### PR TITLE
[Xtensa/RISC-V] Remove FAR and CODE qualifiers from arch-specific files

### DIFF
--- a/arch/risc-v/include/tls.h
+++ b/arch/risc-v/include/tls.h
@@ -63,7 +63,7 @@
  ****************************************************************************/
 
 #ifdef CONFIG_TLS_ALIGNED
-static inline FAR struct tls_info_s *up_tls_info(void)
+static inline struct tls_info_s *up_tls_info(void)
 {
   DEBUGASSERT(!up_interrupt_context());
   return TLS_INFO((uintptr_t)up_getsp());

--- a/arch/risc-v/src/bl602/bl602_allocateheap.c
+++ b/arch/risc-v/src/bl602/bl602_allocateheap.c
@@ -57,9 +57,9 @@ extern uint8_t _heap_wifi_size;
  *
  ****************************************************************************/
 
-void up_allocate_heap(FAR void **heap_start, size_t *heap_size)
+void up_allocate_heap(void **heap_start, size_t *heap_size)
 {
-  *heap_start = (FAR void *)&_heap_start;
+  *heap_start = (void *)&_heap_start;
   *heap_size  = (size_t)&_heap_size;
 }
 

--- a/arch/risc-v/src/bl602/bl602_hbn.h
+++ b/arch/risc-v/src/bl602/bl602_hbn.h
@@ -64,7 +64,7 @@ extern "C"
 #define BL602_HBN_INT_ACOMP0     (20)    /* HBN interrupt type: ACOMP0 */
 #define BL602_HBN_INT_ACOMP1     (22)    /* HBN interrupt type: ACOMP1 */
 
-typedef CODE int (*bl602_hbn_cb_t)(void *arg);
+typedef int (*bl602_hbn_cb_t)(void *arg);
 
 /****************************************************************************
  * Public Function Prototypes

--- a/arch/risc-v/src/bl602/bl602_hbn.h
+++ b/arch/risc-v/src/bl602/bl602_hbn.h
@@ -64,7 +64,7 @@ extern "C"
 #define BL602_HBN_INT_ACOMP0     (20)    /* HBN interrupt type: ACOMP0 */
 #define BL602_HBN_INT_ACOMP1     (22)    /* HBN interrupt type: ACOMP1 */
 
-typedef CODE int (*bl602_hbn_cb_t)(FAR void *arg);
+typedef CODE int (*bl602_hbn_cb_t)(void *arg);
 
 /****************************************************************************
  * Public Function Prototypes

--- a/arch/risc-v/src/bl602/bl602_i2c.c
+++ b/arch/risc-v/src/bl602/bl602_i2c.c
@@ -114,12 +114,12 @@ struct bl602_i2c_priv_s
  * Private Function Prototypes
  ****************************************************************************/
 
-static int bl602_i2c_transfer(FAR struct i2c_master_s *dev,
-                              FAR struct i2c_msg_s *   msgs,
+static int bl602_i2c_transfer(struct i2c_master_s *dev,
+                              struct i2c_msg_s *   msgs,
                               int                      count);
 
 #ifdef CONFIG_I2C_RESET
-static int bl602_i2c_reset(FAR struct i2c_master_s *dev);
+static int bl602_i2c_reset(struct i2c_master_s *dev);
 #endif
 
 /****************************************************************************
@@ -171,7 +171,7 @@ static struct bl602_i2c_priv_s bl602_i2c0_priv =
  *
  ****************************************************************************/
 
-static void bl602_i2c_send_data(FAR struct bl602_i2c_priv_s *priv)
+static void bl602_i2c_send_data(struct bl602_i2c_priv_s *priv)
 {
   uint32_t          temp = 0;
   uint32_t          val  = 0;
@@ -237,7 +237,7 @@ static void bl602_i2c_recvdata(struct bl602_i2c_priv_s *priv)
  *
  ****************************************************************************/
 
-static void bl602_i2c_sem_init(FAR struct bl602_i2c_priv_s *priv)
+static void bl602_i2c_sem_init(struct bl602_i2c_priv_s *priv)
 {
   nxsem_init(&priv->sem_excl, 0, 1);
 
@@ -512,7 +512,7 @@ static void bl602_i2c_transfer_enable(struct bl602_i2c_priv_s *priv)
  *
  ****************************************************************************/
 
-static void bl602_i2c_start_transfer(FAR struct bl602_i2c_priv_s *priv)
+static void bl602_i2c_start_transfer(struct bl602_i2c_priv_s *priv)
 {
   bl602_i2c_clear_status(I2C0);
   bl602_i2c_config_para(priv);
@@ -675,14 +675,14 @@ static void bl602_i2c_set_freq(int freq)
  *
  ****************************************************************************/
 
-static int bl602_i2c_transfer(FAR struct i2c_master_s *dev,
-                              FAR struct i2c_msg_s *   msgs,
+static int bl602_i2c_transfer(struct i2c_master_s *dev,
+                              struct i2c_msg_s *   msgs,
                               int                      count)
 {
   int                          i;
   int                          j;
   int                          ret  = OK;
-  FAR struct bl602_i2c_priv_s *priv = (FAR struct bl602_i2c_priv_s *)dev;
+  struct bl602_i2c_priv_s *priv = (struct bl602_i2c_priv_s *)dev;
 
   if (count <= 0)
     {
@@ -780,9 +780,9 @@ static int bl602_i2c_transfer(FAR struct i2c_master_s *dev,
  ****************************************************************************/
 
 #ifdef CONFIG_I2C_RESET
-static int bl602_i2c_reset(FAR struct i2c_master_s *dev)
+static int bl602_i2c_reset(struct i2c_master_s *dev)
 {
-  FAR struct bl602_i2c_priv_s *priv = (FAR struct bl602_i2c_priv_s *)dev;
+  struct bl602_i2c_priv_s *priv = (struct bl602_i2c_priv_s *)dev;
 
   bl602_swrst_ahb_slave1(AHB_SLAVE1_I2C);
   bl602_i2c_set_freq(priv->config->clk_freq);
@@ -896,7 +896,7 @@ static void bl602_i2c_callback(struct bl602_i2c_priv_s *priv)
  *
  ****************************************************************************/
 
-static int bl602_i2c_irq(int cpuint, void *context, FAR void *arg)
+static int bl602_i2c_irq(int cpuint, void *context, void *arg)
 {
   uint32_t tmp_val;
 
@@ -1012,10 +1012,10 @@ struct i2c_master_s *bl602_i2cbus_initialize(int port)
  *
  ****************************************************************************/
 
-int bl602_i2cbus_uninitialize(FAR struct i2c_master_s *dev)
+int bl602_i2cbus_uninitialize(struct i2c_master_s *dev)
 {
   irqstate_t flags;
-  FAR struct bl602_i2c_priv_s *priv = (FAR struct bl602_i2c_priv_s *)dev;
+  struct bl602_i2c_priv_s *priv = (struct bl602_i2c_priv_s *)dev;
 
   DEBUGASSERT(dev);
 

--- a/arch/risc-v/src/bl602/bl602_i2c.h
+++ b/arch/risc-v/src/bl602/bl602_i2c.h
@@ -81,7 +81,7 @@ struct i2c_master_s *bl602_i2cbus_initialize(int port);
  *
  ****************************************************************************/
 
-int bl602_i2cbus_uninitialize(FAR struct i2c_master_s *dev);
+int bl602_i2cbus_uninitialize(struct i2c_master_s *dev);
 
 #undef EXTERN
 #if defined(__cplusplus)

--- a/arch/risc-v/src/bl602/bl602_irq.c
+++ b/arch/risc-v/src/bl602/bl602_irq.c
@@ -83,7 +83,7 @@ void up_irqinitialize(void)
   /* Colorize the interrupt stack for debug purposes */
 
   size_t intstack_size = (CONFIG_ARCH_INTERRUPTSTACK & ~15);
-  riscv_stack_color((FAR void *)&g_intstackalloc, intstack_size);
+  riscv_stack_color((void *)&g_intstackalloc, intstack_size);
 #endif
 
   /* currents_regs is non-NULL only while processing an interrupt */

--- a/arch/risc-v/src/bl602/bl602_netdev.c
+++ b/arch/risc-v/src/bl602/bl602_netdev.c
@@ -167,7 +167,7 @@ struct bl602_net_driver_s
 
 struct scan_parse_param_s
 {
-  FAR struct bl602_net_driver_s *priv;
+  struct bl602_net_driver_s *priv;
 
   int                flags;
   struct iw_scan_req scan_req;
@@ -253,42 +253,42 @@ extern struct net_device bl606a0_sta;
 
 /* Common TX logic */
 
-static int bl602_net_transmit(FAR struct bl602_net_driver_s *priv);
-static int bl602_net_txpoll(FAR struct net_driver_s *dev);
+static int bl602_net_transmit(struct bl602_net_driver_s *priv);
+static int bl602_net_txpoll(struct net_driver_s *dev);
 
 /* Interrupt handling */
 
 static void bl602_net_reply(struct bl602_net_driver_s *priv);
-static void bl602_net_receive(FAR struct bl602_net_driver_s *priv);
+static void bl602_net_receive(struct bl602_net_driver_s *priv);
 
 /* Watchdog timer expirations */
 
-static void bl602_net_poll_work(FAR void *arg);
+static void bl602_net_poll_work(void *arg);
 static void bl602_net_poll_expiry(wdparm_t arg);
 
 /* NuttX callback functions */
 
-static int bl602_net_ifup(FAR struct net_driver_s *dev);
-static int bl602_net_ifdown(FAR struct net_driver_s *dev);
+static int bl602_net_ifup(struct net_driver_s *dev);
+static int bl602_net_ifdown(struct net_driver_s *dev);
 
-static void bl602_net_txavail_work(FAR void *arg);
-static int  bl602_net_txavail(FAR struct net_driver_s *dev);
+static void bl602_net_txavail_work(void *arg);
+static int  bl602_net_txavail(struct net_driver_s *dev);
 
 #if defined(CONFIG_NET_MCASTGROUP) || defined(CONFIG_NET_ICMPv6)
-static int bl602_net_addmac(FAR struct net_driver_s *dev,
-                            FAR const uint8_t *mac);
+static int bl602_net_addmac(struct net_driver_s *dev,
+                            const uint8_t *mac);
 # ifdef CONFIG_NET_MCASTGROUP
-static int bl602_net_rmmac(FAR struct net_driver_s *dev,
-                           FAR const uint8_t *mac);
+static int bl602_net_rmmac(struct net_driver_s *dev,
+                           const uint8_t *mac);
 # endif
 # ifdef CONFIG_NET_ICMPv6
-static void bl602_net_ipv6multicast(FAR struct bl602_net_driver_s *priv);
+static void bl602_net_ipv6multicast(struct bl602_net_driver_s *priv);
 # endif
 #endif
 
 #ifdef CONFIG_NETDEV_IOCTL
 static int
-bl602_net_ioctl(FAR struct net_driver_s *dev, int cmd, unsigned long arg);
+bl602_net_ioctl(struct net_driver_s *dev, int cmd, unsigned long arg);
 #endif
 
 /****************************************************************************
@@ -313,7 +313,7 @@ bl602_net_ioctl(FAR struct net_driver_s *dev, int cmd, unsigned long arg);
  *
  ****************************************************************************/
 
-static int bl602_net_transmit(FAR struct bl602_net_driver_s *priv)
+static int bl602_net_transmit(struct bl602_net_driver_s *priv)
 {
   int ret = OK;
   ninfo("tx pkt len:%d\n", priv->net_dev.d_len);
@@ -380,10 +380,10 @@ static int bl602_net_transmit(FAR struct bl602_net_driver_s *priv)
  *
  ****************************************************************************/
 
-static int bl602_net_txpoll(FAR struct net_driver_s *dev)
+static int bl602_net_txpoll(struct net_driver_s *dev)
 {
-  FAR struct bl602_net_driver_s *priv =
-    (FAR struct bl602_net_driver_s *)dev->d_private;
+  struct bl602_net_driver_s *priv =
+    (struct bl602_net_driver_s *)dev->d_private;
 
   if (priv->net_dev.d_len > 0)
     {
@@ -557,7 +557,7 @@ static void bl602_net_reply(struct bl602_net_driver_s *priv)
  *
  ****************************************************************************/
 
-static void bl602_net_receive(FAR struct bl602_net_driver_s *priv)
+static void bl602_net_receive(struct bl602_net_driver_s *priv)
 {
 #ifdef CONFIG_NET_PKT
   /* When packet sockets are enabled, feed the frame into the tap */
@@ -742,8 +742,8 @@ int bl602_net_notify(uint32_t event, uint8_t *data, int len, void *opaque)
 {
   DEBUGASSERT(opaque != NULL);
 
-  FAR struct bl602_net_driver_s *priv =
-    (FAR struct bl602_net_driver_s *)opaque;
+  struct bl602_net_driver_s *priv =
+    (struct bl602_net_driver_s *)opaque;
 
   DEBUGASSERT(priv == &g_bl602_net[0] || priv == &g_bl602_net[1]);
 
@@ -851,9 +851,9 @@ int bl602_net_notify(uint32_t event, uint8_t *data, int len, void *opaque)
  *
  ****************************************************************************/
 
-static void bl602_net_poll_work(FAR void *arg)
+static void bl602_net_poll_work(void *arg)
 {
-  FAR struct bl602_net_driver_s *priv = (FAR struct bl602_net_driver_s *)arg;
+  struct bl602_net_driver_s *priv = (struct bl602_net_driver_s *)arg;
 
   net_lock();
   DEBUGASSERT(priv->net_dev.d_buf == NULL);
@@ -913,7 +913,7 @@ static void bl602_net_poll_work(FAR void *arg)
 
 static void bl602_net_poll_expiry(wdparm_t arg)
 {
-  FAR struct bl602_net_driver_s *priv = (FAR struct bl602_net_driver_s *)arg;
+  struct bl602_net_driver_s *priv = (struct bl602_net_driver_s *)arg;
 
   /* Schedule to perform the interrupt processing on the worker thread. */
 
@@ -941,10 +941,10 @@ static void bl602_net_poll_expiry(wdparm_t arg)
  *
  ****************************************************************************/
 
-static int bl602_net_ifup(FAR struct net_driver_s *dev)
+static int bl602_net_ifup(struct net_driver_s *dev)
 {
-  FAR struct bl602_net_driver_s *priv =
-    (FAR struct bl602_net_driver_s *)dev->d_private;
+  struct bl602_net_driver_s *priv =
+    (struct bl602_net_driver_s *)dev->d_private;
 
 #ifdef CONFIG_NET_IPv4
   ninfo("Bringing up: %ld.%ld.%ld.%ld\n",
@@ -1015,10 +1015,10 @@ static int bl602_net_soft_reset(void)
  *
  ****************************************************************************/
 
-static int bl602_net_ifdown(FAR struct net_driver_s *dev)
+static int bl602_net_ifdown(struct net_driver_s *dev)
 {
-  FAR struct bl602_net_driver_s *priv =
-    (FAR struct bl602_net_driver_s *)dev->d_private;
+  struct bl602_net_driver_s *priv =
+    (struct bl602_net_driver_s *)dev->d_private;
   irqstate_t flags;
 
   net_lock();
@@ -1055,9 +1055,9 @@ static int bl602_net_ifdown(FAR struct net_driver_s *dev)
  *
  ****************************************************************************/
 
-static void bl602_net_txavail_work(FAR void *arg)
+static void bl602_net_txavail_work(void *arg)
 {
-  FAR struct bl602_net_driver_s *priv = (FAR struct bl602_net_driver_s *)arg;
+  struct bl602_net_driver_s *priv = (struct bl602_net_driver_s *)arg;
 
   net_lock();
   DEBUGASSERT(priv->net_dev.d_buf == NULL);
@@ -1128,10 +1128,10 @@ static void bl602_net_txavail_work(FAR void *arg)
  *
  ****************************************************************************/
 
-static int bl602_net_txavail(FAR struct net_driver_s *dev)
+static int bl602_net_txavail(struct net_driver_s *dev)
 {
-  FAR struct bl602_net_driver_s *priv =
-    (FAR struct bl602_net_driver_s *)dev->d_private;
+  struct bl602_net_driver_s *priv =
+    (struct bl602_net_driver_s *)dev->d_private;
 
   if (work_available(&priv->availwork))
     {
@@ -1160,11 +1160,11 @@ static int bl602_net_txavail(FAR struct net_driver_s *dev)
  ****************************************************************************/
 
 #if defined(CONFIG_NET_MCASTGROUP) || defined(CONFIG_NET_ICMPv6)
-static int bl602_net_addmac(FAR struct net_driver_s *dev,
-                            FAR const uint8_t *mac)
+static int bl602_net_addmac(struct net_driver_s *dev,
+                            const uint8_t *mac)
 {
-  FAR struct bl602_net_driver_s *priv =
-    (FAR struct bl602_net_driver_s *)dev->d_private;
+  struct bl602_net_driver_s *priv =
+    (struct bl602_net_driver_s *)dev->d_private;
 
   /* Add the MAC address to the hardware multicast routing table */
 
@@ -1188,11 +1188,11 @@ static int bl602_net_addmac(FAR struct net_driver_s *dev,
  ****************************************************************************/
 
 #ifdef CONFIG_NET_MCASTGROUP
-static int bl602_net_rmmac(FAR struct net_driver_s *dev,
-                           FAR const uint8_t *mac)
+static int bl602_net_rmmac(struct net_driver_s *dev,
+                           const uint8_t *mac)
 {
-  FAR struct bl602_net_driver_s *priv =
-    (FAR struct bl602_net_driver_s *)dev->d_private;
+  struct bl602_net_driver_s *priv =
+    (struct bl602_net_driver_s *)dev->d_private;
 
   /* Add the MAC address to the hardware multicast routing table */
 
@@ -1215,9 +1215,9 @@ static int bl602_net_rmmac(FAR struct net_driver_s *dev,
  ****************************************************************************/
 
 #ifdef CONFIG_NET_ICMPv6
-static void bl602_net_ipv6multicast(FAR struct bl602_net_driver_s *priv)
+static void bl602_net_ipv6multicast(struct bl602_net_driver_s *priv)
 {
-  FAR struct net_driver_s *dev;
+  struct net_driver_s *dev;
   uint16_t                 tmp16;
   uint8_t                  mac[6];
 
@@ -1456,7 +1456,7 @@ static int format_scan_result_to_wapi(struct iwreq *req, int result_cnt)
 }
 
 static wifi_mgmr_t *
-bl602_netdev_get_wifi_mgmr(FAR struct bl602_net_driver_s *priv)
+bl602_netdev_get_wifi_mgmr(struct bl602_net_driver_s *priv)
 {
   if (priv->current_mode == IW_MODE_INFRA)
     {
@@ -1473,7 +1473,7 @@ bl602_netdev_get_wifi_mgmr(FAR struct bl602_net_driver_s *priv)
 }
 
 #ifdef CONFIG_NETDEV_IOCTL
-static int bl602_ioctl_wifi_start(FAR struct bl602_net_driver_s *priv,
+static int bl602_ioctl_wifi_start(struct bl602_net_driver_s *priv,
                                   uintptr_t                      arg)
 {
   UNUSED(arg);
@@ -1547,7 +1547,7 @@ static int bl602_ioctl_wifi_start(FAR struct bl602_net_driver_s *priv,
   return OK;
 }
 
-static int bl602_ioctl_wifi_stop(FAR struct bl602_net_driver_s *priv,
+static int bl602_ioctl_wifi_stop(struct bl602_net_driver_s *priv,
                                  uintptr_t                      arg)
 {
   UNUSED(arg);
@@ -1600,10 +1600,10 @@ static int bl602_ioctl_wifi_stop(FAR struct bl602_net_driver_s *priv,
  ****************************************************************************/
 
 static int
-bl602_net_ioctl(FAR struct net_driver_s *dev, int cmd, unsigned long arg)
+bl602_net_ioctl(struct net_driver_s *dev, int cmd, unsigned long arg)
 {
-  FAR struct bl602_net_driver_s *priv =
-    (FAR struct bl602_net_driver_s *)dev->d_private;
+  struct bl602_net_driver_s *priv =
+    (struct bl602_net_driver_s *)dev->d_private;
   int ret = -ENOSYS;
 
   /* Decode and dispatch the driver-specific IOCTL command */
@@ -2003,7 +2003,7 @@ bl602_net_ioctl(FAR struct net_driver_s *dev, int cmd, unsigned long arg)
 }
 #endif
 
-static int wifi_manager_process(int argc, FAR char *argv[])
+static int wifi_manager_process(int argc, char *argv[])
 {
   bl_pm_init();
   wifi_main_init();
@@ -2213,7 +2213,7 @@ void bl602_net_event(int evt, int val)
 
 int bl602_net_initialize(void)
 {
-  FAR struct bl602_net_driver_s *priv;
+  struct bl602_net_driver_s *priv;
   int                            tmp;
   int                            idx;
   uint8_t                        mac[6];

--- a/arch/risc-v/src/bl602/bl602_oneshot_lowerhalf.c
+++ b/arch/risc-v/src/bl602/bl602_oneshot_lowerhalf.c
@@ -71,7 +71,7 @@ struct bl602_oneshot_lowerhalf_s
   /* Private lower half data follows */
 
   oneshot_callback_t callback; /* Internal handler that receives callback */
-  FAR void *         arg;      /* Argument that is passed to the handler */
+  void *             arg;      /* Argument that is passed to the handler */
   uint8_t            tim;      /* timer tim 0,1 */
   uint8_t            irq;      /* IRQ associated with this timer */
   bool               started;  /* True: Timer has been started */
@@ -81,14 +81,14 @@ struct bl602_oneshot_lowerhalf_s
  * Private Function Prototypes
  ****************************************************************************/
 
-static int bl602_max_delay(FAR struct oneshot_lowerhalf_s *lower,
-                           FAR struct timespec *           ts);
-static int bl602_start(FAR struct oneshot_lowerhalf_s *lower,
+static int bl602_max_delay(struct oneshot_lowerhalf_s *lower,
+                           struct timespec *           ts);
+static int bl602_start(struct oneshot_lowerhalf_s *lower,
                        oneshot_callback_t              callback,
-                       FAR void *                      arg,
-                       FAR const struct timespec *     ts);
-static int bl602_cancel(FAR struct oneshot_lowerhalf_s *lower,
-                        FAR struct timespec *           ts);
+                       void *                      arg,
+                       const struct timespec *     ts);
+static int bl602_cancel(struct oneshot_lowerhalf_s *lower,
+                        struct timespec *           ts);
 
 /****************************************************************************
  * Private Data
@@ -122,13 +122,13 @@ static const struct oneshot_operations_s g_oneshot_ops =
  *
  ****************************************************************************/
 
-static int bl602_oneshot_handler(int irq, FAR void *context, FAR void *arg)
+static int bl602_oneshot_handler(int irq, void *context, void *arg)
 {
-  FAR struct bl602_oneshot_lowerhalf_s *priv =
-    (FAR struct bl602_oneshot_lowerhalf_s *)arg;
+  struct bl602_oneshot_lowerhalf_s *priv =
+    (struct bl602_oneshot_lowerhalf_s *)arg;
 
   oneshot_callback_t callback;
-  FAR void *         cbarg;
+  void *         cbarg;
 
   /* Clear Interrupt Bits */
 
@@ -198,11 +198,11 @@ static int bl602_oneshot_handler(int irq, FAR void *context, FAR void *arg)
  *
  ****************************************************************************/
 
-static int bl602_max_delay(FAR struct oneshot_lowerhalf_s *lower,
-                           FAR struct timespec *           ts)
+static int bl602_max_delay(struct oneshot_lowerhalf_s *lower,
+                           struct timespec *           ts)
 {
-  FAR struct bl602_oneshot_lowerhalf_s *priv =
-    (FAR struct bl602_oneshot_lowerhalf_s *)lower;
+  struct bl602_oneshot_lowerhalf_s *priv =
+    (struct bl602_oneshot_lowerhalf_s *)lower;
   uint64_t usecs;
 
   DEBUGASSERT(priv != NULL && ts != NULL);
@@ -237,13 +237,13 @@ static int bl602_max_delay(FAR struct oneshot_lowerhalf_s *lower,
  *
  ****************************************************************************/
 
-static int bl602_start(FAR struct oneshot_lowerhalf_s *lower,
+static int bl602_start(struct oneshot_lowerhalf_s *lower,
                        oneshot_callback_t              callback,
-                       FAR void *                      arg,
-                       FAR const struct timespec *     ts)
+                       void *                      arg,
+                       const struct timespec *     ts)
 {
-  FAR struct bl602_oneshot_lowerhalf_s *priv =
-    (FAR struct bl602_oneshot_lowerhalf_s *)lower;
+  struct bl602_oneshot_lowerhalf_s *priv =
+    (struct bl602_oneshot_lowerhalf_s *)lower;
   irqstate_t flags;
   uint64_t   usec;
 
@@ -307,11 +307,11 @@ static int bl602_start(FAR struct oneshot_lowerhalf_s *lower,
  *
  ****************************************************************************/
 
-static int bl602_cancel(FAR struct oneshot_lowerhalf_s *lower,
-                        FAR struct timespec *           ts)
+static int bl602_cancel(struct oneshot_lowerhalf_s *lower,
+                        struct timespec *           ts)
 {
-  FAR struct bl602_oneshot_lowerhalf_s *priv =
-    (FAR struct bl602_oneshot_lowerhalf_s *)lower;
+  struct bl602_oneshot_lowerhalf_s *priv =
+    (struct bl602_oneshot_lowerhalf_s *)lower;
   irqstate_t flags;
 
   DEBUGASSERT(priv != NULL);
@@ -359,15 +359,15 @@ static int bl602_cancel(FAR struct oneshot_lowerhalf_s *lower,
  *
  ****************************************************************************/
 
-FAR struct oneshot_lowerhalf_s *oneshot_initialize(int      chan,
+struct oneshot_lowerhalf_s *oneshot_initialize(int      chan,
                                                    uint16_t resolution)
 {
-  FAR struct bl602_oneshot_lowerhalf_s *priv;
+  struct bl602_oneshot_lowerhalf_s *priv;
   struct timer_cfg_s                    timstr;
 
   /* Allocate an instance of the lower half driver */
 
-  priv = (FAR struct bl602_oneshot_lowerhalf_s *)kmm_zalloc(
+  priv = (struct bl602_oneshot_lowerhalf_s *)kmm_zalloc(
     sizeof(struct bl602_oneshot_lowerhalf_s));
 
   if (priv == NULL)

--- a/arch/risc-v/src/bl602/bl602_oneshot_lowerhalf.h
+++ b/arch/risc-v/src/bl602/bl602_oneshot_lowerhalf.h
@@ -78,7 +78,7 @@ struct bl602_oneshot_s
   uint8_t cbndx; /* Timer callback handler index */
 #endif
   volatile bool               running; /* True: the timer is running */
-  FAR struct bl602_tim_dev_s *tch;     /* Pointer returned by
+  struct bl602_tim_dev_s     *tch;     /* Pointer returned by
                                         * bl602_tim_init() */
   volatile oneshot_handler_t handler;  /* Oneshot expiration callback */
   volatile void *            arg;      /* The argument that will accompany

--- a/arch/risc-v/src/bl602/bl602_os_hal.c
+++ b/arch/risc-v/src/bl602/bl602_os_hal.c
@@ -1185,7 +1185,7 @@ uint32_t bl_os_get_tick()
  *
  ****************************************************************************/
 
-static int bl_os_isr_adpt_cb(int irq, void *context, FAR void *arg)
+static int bl_os_isr_adpt_cb(int irq, void *context, void *arg)
 {
   struct irq_adpt *adapter = (struct irq_adpt *)arg;
 

--- a/arch/risc-v/src/bl602/bl602_pwm_lowerhalf.c
+++ b/arch/risc-v/src/bl602/bl602_pwm_lowerhalf.c
@@ -81,8 +81,8 @@ struct bl602_pwm_ch_cfgs
 
 struct bl602_pwm_s
 {
-  FAR const struct pwm_ops_s *ops;         /* PWM operations */
-  uint32_t                    chan_pin[5]; /* Channel pin */
+  const struct pwm_ops_s *ops;         /* PWM operations */
+  uint32_t                chan_pin[5]; /* Channel pin */
 };
 
 /****************************************************************************
@@ -91,12 +91,12 @@ struct bl602_pwm_s
 
 /* PWM driver methods */
 
-static int bl602_pwm_setup(FAR struct pwm_lowerhalf_s *dev);
-static int bl602_pwm_shutdown(FAR struct pwm_lowerhalf_s *dev);
-static int bl602_pwm_start(FAR struct pwm_lowerhalf_s *dev,
-                           FAR const struct pwm_info_s *info);
-static int bl602_pwm_stop(FAR struct pwm_lowerhalf_s *dev);
-static int bl602_pwm_ioctl(FAR struct pwm_lowerhalf_s *dev,
+static int bl602_pwm_setup(struct pwm_lowerhalf_s *dev);
+static int bl602_pwm_shutdown(struct pwm_lowerhalf_s *dev);
+static int bl602_pwm_start(struct pwm_lowerhalf_s *dev,
+                           const struct pwm_info_s *info);
+static int bl602_pwm_stop(struct pwm_lowerhalf_s *dev);
+static int bl602_pwm_ioctl(struct pwm_lowerhalf_s *dev,
                            int cmd, unsigned long arg);
 
 /****************************************************************************
@@ -232,7 +232,7 @@ static int32_t pwm_init(uint8_t id, uint32_t freq)
  *
  ****************************************************************************/
 
-static int bl602_pwm_duty(FAR struct bl602_pwm_s *priv, uint8_t chan,
+static int bl602_pwm_duty(struct bl602_pwm_s *priv, uint8_t chan,
                           ub16_t duty)
 {
   uint16_t period;
@@ -268,7 +268,7 @@ static int bl602_pwm_duty(FAR struct bl602_pwm_s *priv, uint8_t chan,
  *
  ****************************************************************************/
 
-static int bl602_pwm_freq(FAR struct bl602_pwm_s *priv, uint8_t chan,
+static int bl602_pwm_freq(struct bl602_pwm_s *priv, uint8_t chan,
                           uint32_t freq)
 {
   uint16_t period = BL_PWM_CLK / freq;
@@ -298,11 +298,11 @@ static int bl602_pwm_freq(FAR struct bl602_pwm_s *priv, uint8_t chan,
  *
  ****************************************************************************/
 
-static int bl602_pwm_setup(FAR struct pwm_lowerhalf_s *dev)
+static int bl602_pwm_setup(struct pwm_lowerhalf_s *dev)
 {
   int i;
   int ret = OK;
-  FAR struct bl602_pwm_s *priv = (FAR struct bl602_pwm_s *)dev;
+  struct bl602_pwm_s *priv = (struct bl602_pwm_s *)dev;
 
   UNUSED(i);
 
@@ -330,11 +330,11 @@ static int bl602_pwm_setup(FAR struct pwm_lowerhalf_s *dev)
  *
  ****************************************************************************/
 
-static int bl602_pwm_shutdown(FAR struct pwm_lowerhalf_s *dev)
+static int bl602_pwm_shutdown(struct pwm_lowerhalf_s *dev)
 {
   int i;
   int ret = OK;
-  FAR struct bl602_pwm_s *priv = (FAR struct bl602_pwm_s *)dev;
+  struct bl602_pwm_s *priv = (struct bl602_pwm_s *)dev;
 
   UNUSED(i);
 
@@ -360,10 +360,10 @@ static int bl602_pwm_shutdown(FAR struct pwm_lowerhalf_s *dev)
  *
  ****************************************************************************/
 
-static int bl602_pwm_start(FAR struct pwm_lowerhalf_s *dev,
-                           FAR const struct pwm_info_s *info)
+static int bl602_pwm_start(struct pwm_lowerhalf_s *dev,
+                           const struct pwm_info_s *info)
 {
-  FAR struct bl602_pwm_s *priv = (FAR struct bl602_pwm_s *)dev;
+  struct bl602_pwm_s *priv = (struct bl602_pwm_s *)dev;
   int                     ret  = OK;
   int                     i;
 
@@ -393,10 +393,10 @@ static int bl602_pwm_start(FAR struct pwm_lowerhalf_s *dev,
  *
  ****************************************************************************/
 
-static int bl602_pwm_stop(FAR struct pwm_lowerhalf_s *dev)
+static int bl602_pwm_stop(struct pwm_lowerhalf_s *dev)
 {
   int i;
-  FAR struct bl602_pwm_s *priv = (FAR struct bl602_pwm_s *)dev;
+  struct bl602_pwm_s *priv = (struct bl602_pwm_s *)dev;
 
   UNUSED(priv);
   UNUSED(i);
@@ -421,10 +421,10 @@ static int bl602_pwm_stop(FAR struct pwm_lowerhalf_s *dev)
  *
  ****************************************************************************/
 
-static int bl602_pwm_ioctl(FAR struct pwm_lowerhalf_s *dev,
+static int bl602_pwm_ioctl(struct pwm_lowerhalf_s *dev,
                            int cmd, unsigned long arg)
 {
-  FAR struct bl602_pwm_s *priv = (FAR struct bl602_pwm_s *)dev;
+  struct bl602_pwm_s *priv = (struct bl602_pwm_s *)dev;
 
   DEBUGASSERT(dev);
 
@@ -454,7 +454,7 @@ static int bl602_pwm_ioctl(FAR struct pwm_lowerhalf_s *dev,
  *
  ****************************************************************************/
 
-FAR struct pwm_lowerhalf_s *bl602_pwminitialize(int pwm)
+struct pwm_lowerhalf_s *bl602_pwminitialize(int pwm)
 {
   struct bl602_pwm_s *lower = NULL;
 

--- a/arch/risc-v/src/bl602/bl602_pwm_lowerhalf.h
+++ b/arch/risc-v/src/bl602/bl602_pwm_lowerhalf.h
@@ -50,6 +50,6 @@
  *
  ****************************************************************************/
 
-FAR struct pwm_lowerhalf_s *bl602_pwminitialize(int pwm);
+struct pwm_lowerhalf_s *bl602_pwminitialize(int pwm);
 
 #endif /* __ARCH_RISCV_SRC_BL602_BL602_PWM_LOWERHALF_H */

--- a/arch/risc-v/src/bl602/bl602_rtc.h
+++ b/arch/risc-v/src/bl602/bl602_rtc.h
@@ -62,7 +62,7 @@
  *
  ****************************************************************************/
 
-FAR void bl602_hbn_sel(uint8_t clk_type);
+void bl602_hbn_sel(uint8_t clk_type);
 
 /****************************************************************************
  * Name: bl602_hbn_clear_rtc_int
@@ -79,7 +79,7 @@ FAR void bl602_hbn_sel(uint8_t clk_type);
  *
  ****************************************************************************/
 
-FAR void bl602_hbn_clear_rtc_int(void);
+void bl602_hbn_clear_rtc_int(void);
 
 /****************************************************************************
  * Name: bl602_hbn_set_rtc_timer
@@ -98,7 +98,7 @@ FAR void bl602_hbn_clear_rtc_int(void);
  *
  ****************************************************************************/
 
-FAR void bl602_hbn_set_rtc_timer(uint8_t delay_type, uint32_t compval_low,
+void bl602_hbn_set_rtc_timer(uint8_t delay_type, uint32_t compval_low,
                                  uint32_t compval_high,  uint8_t comp_mode);
 
 /****************************************************************************
@@ -115,7 +115,7 @@ FAR void bl602_hbn_set_rtc_timer(uint8_t delay_type, uint32_t compval_low,
  *
  ****************************************************************************/
 
-FAR void bl602_hbn_clear_rtc_counter(void);
+void bl602_hbn_clear_rtc_counter(void);
 
 /****************************************************************************
  * Name: bl602_hbn_enable_rtc_counter
@@ -131,7 +131,7 @@ FAR void bl602_hbn_clear_rtc_counter(void);
  *
  ****************************************************************************/
 
-FAR void bl602_hbn_enable_rtc_counter(void);
+void bl602_hbn_enable_rtc_counter(void);
 
 /****************************************************************************
  * Name: bl602_hbn_get_rtc_timer_val
@@ -148,7 +148,7 @@ FAR void bl602_hbn_enable_rtc_counter(void);
  *
  ****************************************************************************/
 
-FAR void bl602_hbn_get_rtc_timer_val(uint32_t *val_low, uint32_t *val_high);
+void bl602_hbn_get_rtc_timer_val(uint32_t *val_low, uint32_t *val_high);
 
 /****************************************************************************
  * Name: bl602_rtc_lowerhalf_initialize
@@ -165,6 +165,6 @@ FAR void bl602_hbn_get_rtc_timer_val(uint32_t *val_low, uint32_t *val_high);
  *
  ****************************************************************************/
 
-FAR struct rtc_lowerhalf_s *bl602_rtc_lowerhalf_initialize(void);
+struct rtc_lowerhalf_s *bl602_rtc_lowerhalf_initialize(void);
 
 #endif /* __ARCH_RISCV_SRC_BL602_RTC_LOWERHALF_H */

--- a/arch/risc-v/src/bl602/bl602_serial.c
+++ b/arch/risc-v/src/bl602/bl602_serial.c
@@ -293,7 +293,7 @@ static struct uart_dev_s *const g_uart_devs[] =
  *
  ****************************************************************************/
 
-static int __uart_interrupt(int irq, FAR void *context, FAR void *arg)
+static int __uart_interrupt(int irq, void *context, void *arg)
 {
   uart_dev_t *dev           = (uart_dev_t *)arg;
   struct bl602_uart_s *priv = dev->priv;

--- a/arch/risc-v/src/bl602/bl602_spi.c
+++ b/arch/risc-v/src/bl602/bl602_spi.c
@@ -143,41 +143,41 @@ struct bl602_spi_priv_s
  * Private Function Prototypes
  ****************************************************************************/
 
-static int bl602_spi_lock(FAR struct spi_dev_s *dev, bool lock);
+static int bl602_spi_lock(struct spi_dev_s *dev, bool lock);
 
-static void bl602_spi_select(FAR struct spi_dev_s *dev, uint32_t devid,
+static void bl602_spi_select(struct spi_dev_s *dev, uint32_t devid,
                              bool selected);
 
-static uint32_t bl602_spi_setfrequency(FAR struct spi_dev_s *dev,
+static uint32_t bl602_spi_setfrequency(struct spi_dev_s *dev,
                                        uint32_t frequency);
-static void bl602_spi_setmode(FAR struct spi_dev_s *dev,
+static void bl602_spi_setmode(struct spi_dev_s *dev,
                               enum spi_mode_e mode);
-static void bl602_spi_setbits(FAR struct spi_dev_s *dev, int nbits);
+static void bl602_spi_setbits(struct spi_dev_s *dev, int nbits);
 #ifdef CONFIG_SPI_HWFEATURES
-static int bl602_spi_hwfeatures(FAR struct spi_dev_s *dev,
+static int bl602_spi_hwfeatures(struct spi_dev_s *dev,
                                 spi_hwfeatures_t features);
 #endif
-static uint8_t bl602_spi_status(FAR struct spi_dev_s *dev,
+static uint8_t bl602_spi_status(struct spi_dev_s *dev,
                                 uint32_t devid);
 #ifdef CONFIG_SPI_CMDDATA
-static int bl602_spi_cmddata(FAR struct spi_dev_s *dev,
+static int bl602_spi_cmddata(struct spi_dev_s *dev,
                               uint32_t devid, bool cmd);
 #endif
-static uint32_t bl602_spi_send(FAR struct spi_dev_s *dev, uint32_t wd);
-static void bl602_spi_exchange(FAR struct spi_dev_s *dev,
-                               FAR const void *txbuffer,
-                               FAR void *rxbuffer, size_t nwords);
+static uint32_t bl602_spi_send(struct spi_dev_s *dev, uint32_t wd);
+static void bl602_spi_exchange(struct spi_dev_s *dev,
+                               const void *txbuffer,
+                               void *rxbuffer, size_t nwords);
 #ifndef CONFIG_SPI_EXCHANGE
-static void bl602_spi_sndblock(FAR struct spi_dev_s *dev,
-                               FAR const void *txbuffer, size_t nwords);
-static void bl602_spi_recvblock(FAR struct spi_dev_s *dev,
-                                FAR void *rxbuffer, size_t nwords);
+static void bl602_spi_sndblock(struct spi_dev_s *dev,
+                               const void *txbuffer, size_t nwords);
+static void bl602_spi_recvblock(struct spi_dev_s *dev,
+                                void *rxbuffer, size_t nwords);
 #endif
 #ifdef CONFIG_SPI_TRIGGER
-static int bl602_spi_trigger(FAR struct spi_dev_s *dev);
+static int bl602_spi_trigger(struct spi_dev_s *dev);
 #endif
-static void bl602_spi_init(FAR struct spi_dev_s *dev);
-static void bl602_spi_deinit(FAR struct spi_dev_s *dev);
+static void bl602_spi_init(struct spi_dev_s *dev);
+static void bl602_spi_deinit(struct spi_dev_s *dev);
 
 /****************************************************************************
  * Private Data
@@ -395,10 +395,10 @@ static void bl602_clockconfig(struct spi_clock_cfg_s *clockcfg)
  *
  ****************************************************************************/
 
-static int bl602_spi_lock(FAR struct spi_dev_s *dev, bool lock)
+static int bl602_spi_lock(struct spi_dev_s *dev, bool lock)
 {
   int ret;
-  FAR struct bl602_spi_priv_s *priv = (FAR struct bl602_spi_priv_s *)dev;
+  struct bl602_spi_priv_s *priv = (struct bl602_spi_priv_s *)dev;
 
   if (lock)
     {
@@ -435,7 +435,7 @@ static int bl602_spi_lock(FAR struct spi_dev_s *dev, bool lock)
  *
  ****************************************************************************/
 
-static void bl602_spi_select(FAR struct spi_dev_s *dev, uint32_t devid,
+static void bl602_spi_select(struct spi_dev_s *dev, uint32_t devid,
                              bool selected)
 {
   /* we used hardware CS */
@@ -458,10 +458,10 @@ static void bl602_spi_select(FAR struct spi_dev_s *dev, uint32_t devid,
  *
  ****************************************************************************/
 
-static uint32_t bl602_spi_setfrequency(FAR struct spi_dev_s *dev,
+static uint32_t bl602_spi_setfrequency(struct spi_dev_s *dev,
                                        uint32_t frequency)
 {
-  FAR struct bl602_spi_priv_s *priv = (FAR struct bl602_spi_priv_s *)dev;
+  struct bl602_spi_priv_s *priv = (struct bl602_spi_priv_s *)dev;
   struct spi_clock_cfg_s clockcfg;
   size_t count;
   uint8_t ticks;
@@ -526,7 +526,7 @@ static uint32_t bl602_spi_setfrequency(FAR struct spi_dev_s *dev,
  ****************************************************************************/
 
 #ifdef CONFIG_SPI_CS_DELAY_CONTROL
-static int bl602_spi_setdelay(FAR struct spi_dev_s *dev, uint32_t startdelay,
+static int bl602_spi_setdelay(struct spi_dev_s *dev, uint32_t startdelay,
                                 uint32_t stopdelay, uint32_t csdelay)
 {
   spierr("SPI CS delay control not supported\n");
@@ -552,9 +552,9 @@ static int bl602_spi_setdelay(FAR struct spi_dev_s *dev, uint32_t startdelay,
  ****************************************************************************/
 
 static void
-bl602_spi_setmode(FAR struct spi_dev_s *dev, enum spi_mode_e mode)
+bl602_spi_setmode(struct spi_dev_s *dev, enum spi_mode_e mode)
 {
-  FAR struct bl602_spi_priv_s *priv = (FAR struct bl602_spi_priv_s *)dev;
+  struct bl602_spi_priv_s *priv = (struct bl602_spi_priv_s *)dev;
 
   spiinfo("mode=%d\n", mode);
 
@@ -607,9 +607,9 @@ bl602_spi_setmode(FAR struct spi_dev_s *dev, enum spi_mode_e mode)
  *
  ****************************************************************************/
 
-static void bl602_spi_setbits(FAR struct spi_dev_s *dev, int nbits)
+static void bl602_spi_setbits(struct spi_dev_s *dev, int nbits)
 {
-  FAR struct bl602_spi_priv_s *priv = (FAR struct bl602_spi_priv_s *)dev;
+  struct bl602_spi_priv_s *priv = (struct bl602_spi_priv_s *)dev;
 
   spiinfo("nbits=%d\n", nbits);
 
@@ -658,7 +658,7 @@ static void bl602_spi_setbits(FAR struct spi_dev_s *dev, int nbits)
  *
  ****************************************************************************/
 
-static uint8_t bl602_spi_status(FAR struct spi_dev_s *dev, uint32_t devid)
+static uint8_t bl602_spi_status(struct spi_dev_s *dev, uint32_t devid)
 {
   uint8_t status = 0;
 
@@ -690,7 +690,7 @@ static uint8_t bl602_spi_status(FAR struct spi_dev_s *dev, uint32_t devid)
  ****************************************************************************/
 
 #ifdef CONFIG_SPI_CMDDATA
-static int bl602_spi_cmddata(FAR struct spi_dev_s *dev,
+static int bl602_spi_cmddata(struct spi_dev_s *dev,
                               uint32_t devid, bool cmd)
 {
   spierr("SPI cmddata not supported\n");
@@ -717,7 +717,7 @@ static int bl602_spi_cmddata(FAR struct spi_dev_s *dev,
  ****************************************************************************/
 
 #ifdef CONFIG_SPI_HWFEATURES
-static int bl602_spi_hwfeatures(FAR struct spi_dev_s *dev,
+static int bl602_spi_hwfeatures(struct spi_dev_s *dev,
                                 spi_hwfeatures_t features)
 {
   /* Other H/W features are not supported */
@@ -750,9 +750,9 @@ static int bl602_spi_hwfeatures(FAR struct spi_dev_s *dev,
  *
  ****************************************************************************/
 
-static void bl602_spi_dma_exchange(FAR struct bl602_spi_priv_s *priv,
-                                   FAR const void *txbuffer,
-                                   FAR void *rxbuffer, uint32_t nwords)
+static void bl602_spi_dma_exchange(struct bl602_spi_priv_s *priv,
+                                   const void *txbuffer,
+                                   void *rxbuffer, uint32_t nwords)
 {
   spierr("SPI dma not supported\n");
   DEBUGPANIC();
@@ -774,7 +774,7 @@ static void bl602_spi_dma_exchange(FAR struct bl602_spi_priv_s *priv,
  *
  ****************************************************************************/
 
-static uint32_t bl602_spi_poll_send(FAR struct bl602_spi_priv_s *priv,
+static uint32_t bl602_spi_poll_send(struct bl602_spi_priv_s *priv,
                                     uint32_t wd)
 {
   uint32_t val;
@@ -816,7 +816,7 @@ static uint32_t bl602_spi_poll_send(FAR struct bl602_spi_priv_s *priv,
  *
  ****************************************************************************/
 
-static uint32_t bl602_spi_dma_send(FAR struct bl602_spi_priv_s *priv,
+static uint32_t bl602_spi_dma_send(struct bl602_spi_priv_s *priv,
                                    uint32_t wd)
 {
   uint32_t rd = 0;
@@ -842,9 +842,9 @@ static uint32_t bl602_spi_dma_send(FAR struct bl602_spi_priv_s *priv,
  *
  ****************************************************************************/
 
-static uint32_t bl602_spi_send(FAR struct spi_dev_s *dev, uint32_t wd)
+static uint32_t bl602_spi_send(struct spi_dev_s *dev, uint32_t wd)
 {
-  FAR struct bl602_spi_priv_s *priv = (FAR struct bl602_spi_priv_s *)dev;
+  struct bl602_spi_priv_s *priv = (struct bl602_spi_priv_s *)dev;
   uint32_t rd;
 
   if (priv->dma_chan)
@@ -880,9 +880,9 @@ static uint32_t bl602_spi_send(FAR struct spi_dev_s *dev, uint32_t wd)
  *
  ****************************************************************************/
 
-static void bl602_spi_poll_exchange(FAR struct bl602_spi_priv_s *priv,
-                                    FAR const void *txbuffer,
-                                    FAR void *rxbuffer, size_t nwords)
+static void bl602_spi_poll_exchange(struct bl602_spi_priv_s *priv,
+                                    const void *txbuffer,
+                                    void *rxbuffer, size_t nwords)
 {
   int i;
   uint32_t w_wd = 0xffff;
@@ -948,11 +948,11 @@ static void bl602_spi_poll_exchange(FAR struct bl602_spi_priv_s *priv,
  *
  ****************************************************************************/
 
-static void bl602_spi_exchange(FAR struct spi_dev_s *dev,
-                               FAR const void *txbuffer, FAR void *rxbuffer,
+static void bl602_spi_exchange(struct spi_dev_s *dev,
+                               const void *txbuffer, void *rxbuffer,
                                size_t nwords)
 {
-  FAR struct bl602_spi_priv_s *priv = (FAR struct bl602_spi_priv_s *)dev;
+  struct bl602_spi_priv_s *priv = (struct bl602_spi_priv_s *)dev;
 
   if (priv->dma_chan)
     {
@@ -986,8 +986,8 @@ static void bl602_spi_exchange(FAR struct spi_dev_s *dev,
  *
  ****************************************************************************/
 
-static void bl602_spi_sndblock(FAR struct spi_dev_s *dev,
-                               FAR const void *txbuffer, size_t nwords)
+static void bl602_spi_sndblock(struct spi_dev_s *dev,
+                               const void *txbuffer, size_t nwords)
 {
   spiinfo("txbuffer=%p nwords=%d\n", txbuffer, nwords);
 
@@ -1014,8 +1014,8 @@ static void bl602_spi_sndblock(FAR struct spi_dev_s *dev,
  *
  ****************************************************************************/
 
-static void bl602_spi_recvblock(FAR struct spi_dev_s *dev,
-                                FAR void *rxbuffer, size_t nwords)
+static void bl602_spi_recvblock(struct spi_dev_s *dev,
+                                void *rxbuffer, size_t nwords)
 {
   spiinfo("rxbuffer=%p nwords=%d\n", rxbuffer, nwords);
 
@@ -1040,7 +1040,7 @@ static void bl602_spi_recvblock(FAR struct spi_dev_s *dev,
  ****************************************************************************/
 
 #ifdef CONFIG_SPI_TRIGGER
-static int bl602_spi_trigger(FAR struct spi_dev_s *dev)
+static int bl602_spi_trigger(struct spi_dev_s *dev)
 {
   spierr("SPI trigger not supported\n");
   DEBUGPANIC();
@@ -1089,9 +1089,9 @@ static void bl602_set_spi_0_act_mode_sel(uint8_t mod)
  *
  ****************************************************************************/
 
-static void bl602_spi_init(FAR struct spi_dev_s *dev)
+static void bl602_spi_init(struct spi_dev_s *dev)
 {
-  FAR struct bl602_spi_priv_s *priv = (FAR struct bl602_spi_priv_s *)dev;
+  struct bl602_spi_priv_s *priv = (struct bl602_spi_priv_s *)dev;
   const struct bl602_spi_config_s *config = priv->config;
 
   /* Initialize the SPI semaphore that enforces mutually exclusive access */
@@ -1146,9 +1146,9 @@ static void bl602_spi_init(FAR struct spi_dev_s *dev)
  *
  ****************************************************************************/
 
-static void bl602_spi_deinit(FAR struct spi_dev_s *dev)
+static void bl602_spi_deinit(struct spi_dev_s *dev)
 {
-  FAR struct bl602_spi_priv_s *priv = (FAR struct bl602_spi_priv_s *)dev;
+  struct bl602_spi_priv_s *priv = (struct bl602_spi_priv_s *)dev;
 
   bl602_swrst_ahb_slave1(AHB_SLAVE1_SPI);
 
@@ -1173,10 +1173,10 @@ static void bl602_spi_deinit(FAR struct spi_dev_s *dev)
  *
  ****************************************************************************/
 
-FAR struct spi_dev_s *bl602_spibus_initialize(int port)
+struct spi_dev_s *bl602_spibus_initialize(int port)
 {
-  FAR struct spi_dev_s *spi_dev;
-  FAR struct bl602_spi_priv_s *priv;
+  struct spi_dev_s *spi_dev;
+  struct bl602_spi_priv_s *priv;
   irqstate_t flags;
 
   switch (port)
@@ -1190,7 +1190,7 @@ FAR struct spi_dev_s *bl602_spibus_initialize(int port)
     return NULL;
     }
 
-  spi_dev = (FAR struct spi_dev_s *)priv;
+  spi_dev = (struct spi_dev_s *)priv;
 
   flags = enter_critical_section();
 
@@ -1218,10 +1218,10 @@ FAR struct spi_dev_s *bl602_spibus_initialize(int port)
  *
  ****************************************************************************/
 
-int bl602_spibus_uninitialize(FAR struct spi_dev_s *dev)
+int bl602_spibus_uninitialize(struct spi_dev_s *dev)
 {
   irqstate_t flags;
-  FAR struct bl602_spi_priv_s *priv = (FAR struct bl602_spi_priv_s *)dev;
+  struct bl602_spi_priv_s *priv = (struct bl602_spi_priv_s *)dev;
 
   DEBUGASSERT(dev);
 

--- a/arch/risc-v/src/bl602/bl602_spi.h
+++ b/arch/risc-v/src/bl602/bl602_spi.h
@@ -65,7 +65,7 @@ extern "C"
  *
  ****************************************************************************/
 
-FAR struct spi_dev_s *bl602_spibus_initialize(int port);
+struct spi_dev_s *bl602_spibus_initialize(int port);
 
 /****************************************************************************
  * Name: bl602_spibus_uninitialize
@@ -75,7 +75,7 @@ FAR struct spi_dev_s *bl602_spibus_initialize(int port);
  *
  ****************************************************************************/
 
-int bl602_spibus_uninitialize(FAR struct spi_dev_s *dev);
+int bl602_spibus_uninitialize(struct spi_dev_s *dev);
 
 #endif /* CONFIG_BL602_SPI0 */
 

--- a/arch/risc-v/src/bl602/bl602_spiflash.c
+++ b/arch/risc-v/src/bl602/bl602_spiflash.c
@@ -50,7 +50,7 @@
  ****************************************************************************/
 
 #define SPIFLASH_BLOCKSIZE          (0x1000)
-#define MTD2PRIV(_dev)              ((FAR struct bl602_spiflash_s *)_dev)
+#define MTD2PRIV(_dev)              ((struct bl602_spiflash_s *)_dev)
 
 /****************************************************************************
  * Private Types
@@ -81,15 +81,15 @@ struct bl602_spiflash_s
 
 /* MTD driver methods */
 
-static int bl602_erase(FAR struct mtd_dev_s *dev, off_t startblock,
+static int bl602_erase(struct mtd_dev_s *dev, off_t startblock,
                        size_t nblocks);
-static ssize_t bl602_bread(FAR struct mtd_dev_s *dev, off_t startblock,
-                           size_t nblocks, FAR uint8_t *buffer);
-static ssize_t bl602_bwrite(FAR struct mtd_dev_s *dev, off_t startblock,
-                            size_t nblocks, FAR const uint8_t *buffer);
-static ssize_t bl602_read(FAR struct mtd_dev_s *dev, off_t offset,
-                          size_t nbytes, FAR uint8_t *buffer);
-static int bl602_ioctl(FAR struct mtd_dev_s *dev, int cmd,
+static ssize_t bl602_bread(struct mtd_dev_s *dev, off_t startblock,
+                           size_t nblocks, uint8_t *buffer);
+static ssize_t bl602_bwrite(struct mtd_dev_s *dev, off_t startblock,
+                            size_t nblocks, const uint8_t *buffer);
+static ssize_t bl602_read(struct mtd_dev_s *dev, off_t offset,
+                          size_t nbytes, uint8_t *buffer);
+static int bl602_ioctl(struct mtd_dev_s *dev, int cmd,
                        unsigned long arg);
 
 /****************************************************************************
@@ -137,11 +137,11 @@ static struct bl602_spiflash_s g_bl602_spiflash =
  *
  ****************************************************************************/
 
-static int bl602_erase(FAR struct mtd_dev_s *dev, off_t startblock,
+static int bl602_erase(struct mtd_dev_s *dev, off_t startblock,
                        size_t nblocks)
 {
   int ret = 0;
-  FAR struct bl602_spiflash_s *priv = MTD2PRIV(dev);
+  struct bl602_spiflash_s *priv = MTD2PRIV(dev);
   uint32_t addr = priv->config->flash_offset \
                   + startblock * SPIFLASH_BLOCKSIZE;
   uint32_t size = nblocks * SPIFLASH_BLOCKSIZE;
@@ -175,11 +175,11 @@ static int bl602_erase(FAR struct mtd_dev_s *dev, off_t startblock,
  *
  ****************************************************************************/
 
-static ssize_t bl602_read(FAR struct mtd_dev_s *dev, off_t offset,
-                          size_t nbytes, FAR uint8_t *buffer)
+static ssize_t bl602_read(struct mtd_dev_s *dev, off_t offset,
+                          size_t nbytes, uint8_t *buffer)
 {
   int ret = 0;
-  FAR struct bl602_spiflash_s *priv = MTD2PRIV(dev);
+  struct bl602_spiflash_s *priv = MTD2PRIV(dev);
   uint32_t addr = priv->config->flash_offset + offset;
   uint32_t size = nbytes;
 
@@ -210,11 +210,11 @@ static ssize_t bl602_read(FAR struct mtd_dev_s *dev, off_t offset,
  *
  ****************************************************************************/
 
-static ssize_t bl602_bread(FAR struct mtd_dev_s *dev, off_t startblock,
-                           size_t nblocks, FAR uint8_t *buffer)
+static ssize_t bl602_bread(struct mtd_dev_s *dev, off_t startblock,
+                           size_t nblocks, uint8_t *buffer)
 {
   int ret = 0;
-  FAR struct bl602_spiflash_s *priv = MTD2PRIV(dev);
+  struct bl602_spiflash_s *priv = MTD2PRIV(dev);
   uint32_t addr = priv->config->flash_offset \
                   + startblock * SPIFLASH_BLOCKSIZE;
   uint32_t size = nblocks * SPIFLASH_BLOCKSIZE;
@@ -247,11 +247,11 @@ static ssize_t bl602_bread(FAR struct mtd_dev_s *dev, off_t startblock,
  *
  ****************************************************************************/
 
-static ssize_t bl602_bwrite(FAR struct mtd_dev_s *dev, off_t startblock,
-                            size_t nblocks, FAR const uint8_t *buffer)
+static ssize_t bl602_bwrite(struct mtd_dev_s *dev, off_t startblock,
+                            size_t nblocks, const uint8_t *buffer)
 {
   int ret = 0;
-  FAR struct bl602_spiflash_s *priv = MTD2PRIV(dev);
+  struct bl602_spiflash_s *priv = MTD2PRIV(dev);
   uint32_t addr = priv->config->flash_offset \
                   + startblock * SPIFLASH_BLOCKSIZE;
   uint32_t size = nblocks * SPIFLASH_BLOCKSIZE;
@@ -282,18 +282,18 @@ static ssize_t bl602_bwrite(FAR struct mtd_dev_s *dev, off_t startblock,
  *
  ****************************************************************************/
 
-int bl602_ioctl(FAR struct mtd_dev_s *dev, int cmd,
+int bl602_ioctl(struct mtd_dev_s *dev, int cmd,
                        unsigned long arg)
 {
   int ret = -EINVAL;
-  FAR struct bl602_spiflash_s *priv = MTD2PRIV(dev);
+  struct bl602_spiflash_s *priv = MTD2PRIV(dev);
 
   switch (cmd)
     {
       case MTDIOC_GEOMETRY:
         {
           finfo("cmd(0x%x) MTDIOC_GEOMETRY.\n", cmd);
-          FAR struct mtd_geometry_s *geo = (FAR struct mtd_geometry_s *)arg;
+          struct mtd_geometry_s *geo = (struct mtd_geometry_s *)arg;
           if (geo)
             {
               geo->blocksize    = SPIFLASH_BLOCKSIZE;
@@ -309,8 +309,8 @@ int bl602_ioctl(FAR struct mtd_dev_s *dev, int cmd,
         break;
       case BIOC_PARTINFO:
         {
-          FAR struct partition_info_s *info =
-            (FAR struct partition_info_s *)arg;
+          struct partition_info_s *info =
+            (struct partition_info_s *)arg;
           if (info != NULL)
             {
               info->numsectors  = priv->config->flash_size /
@@ -351,10 +351,10 @@ int bl602_ioctl(FAR struct mtd_dev_s *dev, int cmd,
  *
  ****************************************************************************/
 
-FAR struct mtd_dev_s *bl602_spiflash_alloc_mtdpart(void)
+struct mtd_dev_s *bl602_spiflash_alloc_mtdpart(void)
 {
   struct bl602_spiflash_s *priv = &g_bl602_spiflash;
-  FAR struct mtd_dev_s *mtd_part = NULL;
+  struct mtd_dev_s *mtd_part = NULL;
 
   priv->config->flash_offset = CONFIG_BL602_MTD_OFFSET;
   priv->config->flash_size = CONFIG_BL602_MTD_SIZE;
@@ -384,7 +384,7 @@ FAR struct mtd_dev_s *bl602_spiflash_alloc_mtdpart(void)
  *
  ****************************************************************************/
 
-FAR struct mtd_dev_s *bl602_spiflash_get_mtd(void)
+struct mtd_dev_s *bl602_spiflash_get_mtd(void)
 {
   struct bl602_spiflash_s *priv = &g_bl602_spiflash;
 

--- a/arch/risc-v/src/bl602/bl602_spiflash.h
+++ b/arch/risc-v/src/bl602/bl602_spiflash.h
@@ -60,7 +60,7 @@ extern "C"
  *
  ****************************************************************************/
 
-FAR struct mtd_dev_s *bl602_spiflash_alloc_mtdpart(void);
+struct mtd_dev_s *bl602_spiflash_alloc_mtdpart(void);
 
 /****************************************************************************
  * Name: bl602_spiflash_get_mtd
@@ -76,7 +76,7 @@ FAR struct mtd_dev_s *bl602_spiflash_alloc_mtdpart(void);
  *
  ****************************************************************************/
 
-FAR struct mtd_dev_s *bl602_spiflash_get_mtd(void);
+struct mtd_dev_s *bl602_spiflash_get_mtd(void);
 
 #ifdef __cplusplus
 }

--- a/arch/risc-v/src/bl602/bl602_tim_lowerhalf.c
+++ b/arch/risc-v/src/bl602/bl602_tim_lowerhalf.c
@@ -55,10 +55,10 @@
 
 struct bl602_tim_lowerhalf_s
 {
-  FAR const struct timer_ops_s *ops; /* Lower half operations */
+  const struct timer_ops_s *ops; /* Lower half operations */
 
   tccb_t    callback; /* Current upper half interrupt callback */
-  FAR void *arg;      /* Argument passed to upper half callback */
+  void     *arg;      /* Argument passed to upper half callback */
   bool      started;  /* True: Timer has been started */
   uint8_t   irq;      /* IRQ associated with this UART */
   uint8_t   tim;      /* timer tim 0,1 */
@@ -72,15 +72,15 @@ static int bl602_timer_handler(int irq, void *context, void *arg);
 
 /* "Lower half" driver methods */
 
-static int  bl602_tim_start(FAR struct timer_lowerhalf_s *lower);
-static int  bl602_tim_stop(FAR struct timer_lowerhalf_s *lower);
-static int  bl602_tim_getstatus(FAR struct timer_lowerhalf_s *lower,
-                                FAR struct timer_status_s *   status);
-static int  bl602_tim_settimeout(FAR struct timer_lowerhalf_s *lower,
+static int  bl602_tim_start(struct timer_lowerhalf_s *lower);
+static int  bl602_tim_stop(struct timer_lowerhalf_s *lower);
+static int  bl602_tim_getstatus(struct timer_lowerhalf_s *lower,
+                                struct timer_status_s *   status);
+static int  bl602_tim_settimeout(struct timer_lowerhalf_s *lower,
                                  uint32_t                      timeout);
-static void bl602_tim_setcallback(FAR struct timer_lowerhalf_s *lower,
+static void bl602_tim_setcallback(struct timer_lowerhalf_s *lower,
                                   tccb_t                        callback,
-                                  FAR void *                    arg);
+                                  void *                    arg);
 
 /****************************************************************************
  * Private Data
@@ -134,8 +134,8 @@ static struct bl602_tim_lowerhalf_s g_tim2_lowerhalf =
 
 static int bl602_timer_handler(int irq, void *context, void *arg)
 {
-  FAR struct bl602_tim_lowerhalf_s *priv =
-    (FAR struct bl602_tim_lowerhalf_s *)arg;
+  struct bl602_tim_lowerhalf_s *priv =
+    (struct bl602_tim_lowerhalf_s *)arg;
   uint32_t next_interval_us = 0;
 
   /* Clear Interrupt Bits */
@@ -205,10 +205,10 @@ static int bl602_timer_handler(int irq, void *context, void *arg)
  *
  ****************************************************************************/
 
-static int bl602_tim_start(FAR struct timer_lowerhalf_s *lower)
+static int bl602_tim_start(struct timer_lowerhalf_s *lower)
 {
-  FAR struct bl602_tim_lowerhalf_s *priv =
-    (FAR struct bl602_tim_lowerhalf_s *)lower;
+  struct bl602_tim_lowerhalf_s *priv =
+    (struct bl602_tim_lowerhalf_s *)lower;
 
   if (!priv->started)
     {
@@ -246,10 +246,10 @@ static int bl602_tim_start(FAR struct timer_lowerhalf_s *lower)
  *
  ****************************************************************************/
 
-static int bl602_tim_stop(FAR struct timer_lowerhalf_s *lower)
+static int bl602_tim_stop(struct timer_lowerhalf_s *lower)
 {
-  FAR struct bl602_tim_lowerhalf_s *priv =
-    (FAR struct bl602_tim_lowerhalf_s *)lower;
+  struct bl602_tim_lowerhalf_s *priv =
+    (struct bl602_tim_lowerhalf_s *)lower;
 
   /* timer disable */
 
@@ -283,11 +283,11 @@ static int bl602_tim_stop(FAR struct timer_lowerhalf_s *lower)
  *
  ****************************************************************************/
 
-static int bl602_tim_getstatus(FAR struct timer_lowerhalf_s *lower,
-                               FAR struct timer_status_s *   status)
+static int bl602_tim_getstatus(struct timer_lowerhalf_s *lower,
+                               struct timer_status_s *   status)
 {
-  FAR struct bl602_tim_lowerhalf_s *priv =
-    (FAR struct bl602_tim_lowerhalf_s *)lower;
+  struct bl602_tim_lowerhalf_s *priv =
+    (struct bl602_tim_lowerhalf_s *)lower;
   uint32_t current_count;
 
   status->timeout = bl602_timer_getcompvalue(priv->tim, TIMER_COMP_ID_0);
@@ -320,11 +320,11 @@ static int bl602_tim_getstatus(FAR struct timer_lowerhalf_s *lower,
  *
  ****************************************************************************/
 
-static int bl602_tim_settimeout(FAR struct timer_lowerhalf_s *lower,
+static int bl602_tim_settimeout(struct timer_lowerhalf_s *lower,
                                 uint32_t                      timeout)
 {
-  FAR struct bl602_tim_lowerhalf_s *priv =
-    (FAR struct bl602_tim_lowerhalf_s *)lower;
+  struct bl602_tim_lowerhalf_s *priv =
+    (struct bl602_tim_lowerhalf_s *)lower;
 
   bl602_timer_setcompvalue(priv->tim, TIMER_COMP_ID_0, timeout);
 
@@ -351,12 +351,12 @@ static int bl602_tim_settimeout(FAR struct timer_lowerhalf_s *lower,
  *
  ****************************************************************************/
 
-static void bl602_tim_setcallback(FAR struct timer_lowerhalf_s *lower,
+static void bl602_tim_setcallback(struct timer_lowerhalf_s *lower,
                                   tccb_t                        callback,
-                                  FAR void *                    arg)
+                                  void *                    arg)
 {
   struct bl602_tim_lowerhalf_s *priv =
-    (FAR struct bl602_tim_lowerhalf_s *)lower;
+    (struct bl602_tim_lowerhalf_s *)lower;
   irqstate_t flags = enter_critical_section();
 
   /* Save the new callback */
@@ -389,9 +389,9 @@ static void bl602_tim_setcallback(FAR struct timer_lowerhalf_s *lower,
  *
  ****************************************************************************/
 
-int bl602_timer_initialize(FAR const char *devpath, int timer)
+int bl602_timer_initialize(const char *devpath, int timer)
 {
-  FAR struct bl602_tim_lowerhalf_s *lower;
+  struct bl602_tim_lowerhalf_s *lower;
   struct timer_cfg_s                timstr;
 
   switch (timer)
@@ -443,8 +443,8 @@ int bl602_timer_initialize(FAR const char *devpath, int timer)
    * REVISIT: The returned handle is discard here.
    */
 
-  FAR void *drvr =
-    timer_register(devpath, (FAR struct timer_lowerhalf_s *)lower);
+  void *drvr =
+    timer_register(devpath, (struct timer_lowerhalf_s *)lower);
   if (drvr == NULL)
     {
       /* The actual cause of the failure may have been a failure to allocate

--- a/arch/risc-v/src/bl602/bl602_tim_lowerhalf.h
+++ b/arch/risc-v/src/bl602/bl602_tim_lowerhalf.h
@@ -38,6 +38,6 @@
  * Name: bl602_timer_initialize
  ****************************************************************************/
 
-int bl602_timer_initialize(FAR const char *devpath, int timer);
+int bl602_timer_initialize(const char *devpath, int timer);
 
 #endif /* __ARCH_RISCV_SRC_BL602_TIM_LOWERHALF_H */

--- a/arch/risc-v/src/bl602/bl602_timerisr.c
+++ b/arch/risc-v/src/bl602/bl602_timerisr.c
@@ -111,7 +111,7 @@ static void bl602_reload_mtimecmp(void)
  * Name:  bl602_timerisr
  ****************************************************************************/
 
-static int bl602_timerisr(int irq, void *context, FAR void *arg)
+static int bl602_timerisr(int irq, void *context, void *arg)
 {
   bl602_reload_mtimecmp();
 

--- a/arch/risc-v/src/bl602/bl602_wdt_lowerhalf.c
+++ b/arch/risc-v/src/bl602/bl602_wdt_lowerhalf.c
@@ -57,8 +57,8 @@
 
 struct bl602_wdt_lowerhalf_s
 {
-  FAR const struct watchdog_ops_s  *ops; /* Lower half operations */
-  uint32_t lastreset;                    /* The last reset time */
+  const struct watchdog_ops_s  *ops; /* Lower half operations */
+  uint32_t lastreset;                /* The last reset time */
   uint32_t timeout;
   uint8_t started;
 };
@@ -69,12 +69,12 @@ struct bl602_wdt_lowerhalf_s
 
 /* "Lower half" driver methods **********************************************/
 
-static int bl602_start(FAR struct watchdog_lowerhalf_s *lower);
-static int bl602_stop(FAR struct watchdog_lowerhalf_s *lower);
-static int bl602_keepalive(FAR struct watchdog_lowerhalf_s *lower);
-static int bl602_getstatus(FAR struct watchdog_lowerhalf_s *lower,
-                           FAR struct watchdog_status_s *status);
-static int bl602_settimeout(FAR struct watchdog_lowerhalf_s *lower,
+static int bl602_start(struct watchdog_lowerhalf_s *lower);
+static int bl602_stop(struct watchdog_lowerhalf_s *lower);
+static int bl602_keepalive(struct watchdog_lowerhalf_s *lower);
+static int bl602_getstatus(struct watchdog_lowerhalf_s *lower,
+                           struct watchdog_status_s *status);
+static int bl602_settimeout(struct watchdog_lowerhalf_s *lower,
                             uint32_t timeout);
 
 /****************************************************************************
@@ -127,10 +127,10 @@ static struct bl602_wdt_lowerhalf_s g_wdtdev =
  *
  ****************************************************************************/
 
-static int bl602_start(FAR struct watchdog_lowerhalf_s *lower)
+static int bl602_start(struct watchdog_lowerhalf_s *lower)
 {
-  FAR struct bl602_wdt_lowerhalf_s *priv =
-    (FAR struct bl602_wdt_lowerhalf_s *)lower;
+  struct bl602_wdt_lowerhalf_s *priv =
+    (struct bl602_wdt_lowerhalf_s *)lower;
   irqstate_t flags;
 
   DEBUGASSERT(priv);
@@ -169,10 +169,10 @@ static int bl602_start(FAR struct watchdog_lowerhalf_s *lower)
  *
  ****************************************************************************/
 
-static int bl602_stop(FAR struct watchdog_lowerhalf_s *lower)
+static int bl602_stop(struct watchdog_lowerhalf_s *lower)
 {
-  FAR struct bl602_wdt_lowerhalf_s *priv =
-      (FAR struct bl602_wdt_lowerhalf_s *)lower;
+  struct bl602_wdt_lowerhalf_s *priv =
+      (struct bl602_wdt_lowerhalf_s *)lower;
 
   bl602_wdt_disable();
   priv->started = false;
@@ -196,10 +196,10 @@ static int bl602_stop(FAR struct watchdog_lowerhalf_s *lower)
  *
  ****************************************************************************/
 
-static int bl602_keepalive(FAR struct watchdog_lowerhalf_s *lower)
+static int bl602_keepalive(struct watchdog_lowerhalf_s *lower)
 {
-  FAR struct bl602_wdt_lowerhalf_s *priv =
-    (FAR struct bl602_wdt_lowerhalf_s *)lower;
+  struct bl602_wdt_lowerhalf_s *priv =
+    (struct bl602_wdt_lowerhalf_s *)lower;
   irqstate_t flags;
 
   /* Reload the WDT timer */
@@ -230,11 +230,11 @@ static int bl602_keepalive(FAR struct watchdog_lowerhalf_s *lower)
  *
  ****************************************************************************/
 
-static int bl602_getstatus(FAR struct watchdog_lowerhalf_s *lower,
-                           FAR struct watchdog_status_s *status)
+static int bl602_getstatus(struct watchdog_lowerhalf_s *lower,
+                           struct watchdog_status_s *status)
 {
-  FAR struct bl602_wdt_lowerhalf_s *priv =
-    (FAR struct bl602_wdt_lowerhalf_s *)lower;
+  struct bl602_wdt_lowerhalf_s *priv =
+    (struct bl602_wdt_lowerhalf_s *)lower;
   uint32_t ticks;
   uint32_t elapsed;
 
@@ -285,11 +285,11 @@ static int bl602_getstatus(FAR struct watchdog_lowerhalf_s *lower,
  *
  ****************************************************************************/
 
-static int bl602_settimeout(FAR struct watchdog_lowerhalf_s *lower,
+static int bl602_settimeout(struct watchdog_lowerhalf_s *lower,
                            uint32_t timeout)
 {
-  FAR struct bl602_wdt_lowerhalf_s *priv =
-    (FAR struct bl602_wdt_lowerhalf_s *)lower;
+  struct bl602_wdt_lowerhalf_s *priv =
+    (struct bl602_wdt_lowerhalf_s *)lower;
 
   DEBUGASSERT(priv);
 
@@ -334,14 +334,14 @@ static int bl602_settimeout(FAR struct watchdog_lowerhalf_s *lower,
  *
  ****************************************************************************/
 
-int bl602_wdt_initialize(FAR const char *devpath)
+int bl602_wdt_initialize(const char *devpath)
 {
-  FAR struct bl602_wdt_lowerhalf_s *priv = &g_wdtdev;
-  FAR void *handle;
+  struct bl602_wdt_lowerhalf_s *priv = &g_wdtdev;
+  void *handle;
 
   /* Register the watchdog driver as /dev/watchdog0 */
 
   handle = watchdog_register(devpath,
-                             (FAR struct watchdog_lowerhalf_s *)priv);
+                             (struct watchdog_lowerhalf_s *)priv);
   return (handle != NULL) ? OK : -ENODEV;
 }

--- a/arch/risc-v/src/bl602/bl602_wdt_lowerhalf.h
+++ b/arch/risc-v/src/bl602/bl602_wdt_lowerhalf.h
@@ -64,6 +64,6 @@ extern "C"
  *
  ****************************************************************************/
 
-int bl602_wdt_initialize(FAR const char *devpath);
+int bl602_wdt_initialize(const char *devpath);
 
 #endif /* __ARCH_RISCV_SRC_BL602_BL602_WDT_LOWERHALF_H */

--- a/arch/risc-v/src/c906/c906_allocateheap.c
+++ b/arch/risc-v/src/c906/c906_allocateheap.c
@@ -76,7 +76,7 @@
  *
  ****************************************************************************/
 
-void up_allocate_heap(FAR void **heap_start, size_t *heap_size)
+void up_allocate_heap(void **heap_start, size_t *heap_size)
 {
 #if defined(CONFIG_BUILD_PROTECTED) && defined(CONFIG_MM_KERNEL_HEAP)
   /* Get the size and position of the user-space heap.
@@ -88,7 +88,7 @@ void up_allocate_heap(FAR void **heap_start, size_t *heap_size)
 
   /* Return the user-space heap settings */
 
-  *heap_start = (FAR void *)ubase;
+  *heap_start = (void *)ubase;
   *heap_size  = usize;
 
   /* Allow user-mode access to the user heap memory in PMP
@@ -98,7 +98,7 @@ void up_allocate_heap(FAR void **heap_start, size_t *heap_size)
 #else
   /* Return the heap settings */
 
-  *heap_start = (FAR void *)g_idle_topstack;
+  *heap_start = (void *)g_idle_topstack;
   *heap_size = KRAM_END - g_idle_topstack;
 #endif
 }
@@ -114,11 +114,11 @@ void up_allocate_heap(FAR void **heap_start, size_t *heap_size)
  ****************************************************************************/
 
 #if defined(CONFIG_BUILD_PROTECTED) && defined(CONFIG_MM_KERNEL_HEAP)
-void up_allocate_kheap(FAR void **heap_start, size_t *heap_size)
+void up_allocate_kheap(void **heap_start, size_t *heap_size)
 {
   /* Return the kernel heap settings. */
 
-  *heap_start = (FAR void *)g_idle_topstack;
+  *heap_start = (void *)g_idle_topstack;
   *heap_size = KRAM_END - g_idle_topstack;
 }
 #endif

--- a/arch/risc-v/src/c906/c906_irq.c
+++ b/arch/risc-v/src/c906/c906_irq.c
@@ -75,7 +75,7 @@ void up_irqinitialize(void)
 
 #if defined(CONFIG_STACK_COLORATION) && CONFIG_ARCH_INTERRUPTSTACK > 15
   size_t intstack_size = (CONFIG_ARCH_INTERRUPTSTACK & ~15);
-  riscv_stack_color((FAR void *)&g_intstackalloc, intstack_size);
+  riscv_stack_color((void *)&g_intstackalloc, intstack_size);
 #endif
 
   /* Set priority for all global interrupts to 1 (lowest) */

--- a/arch/risc-v/src/c906/c906_serial.c
+++ b/arch/risc-v/src/c906/c906_serial.c
@@ -119,7 +119,7 @@ static int  up_setup(struct uart_dev_s *dev);
 static void up_shutdown(struct uart_dev_s *dev);
 static int  up_attach(struct uart_dev_s *dev);
 static void up_detach(struct uart_dev_s *dev);
-static int  up_interrupt(int irq, void *context, FAR void *arg);
+static int  up_interrupt(int irq, void *context, void *arg);
 static int  up_ioctl(struct file *filep, int cmd, unsigned long arg);
 static int  up_receive(struct uart_dev_s *dev, uint32_t *status);
 static void up_rxint(struct uart_dev_s *dev, bool enable);
@@ -366,7 +366,7 @@ static void up_detach(struct uart_dev_s *dev)
 static volatile uint32_t lsr_data_ready = 0;
 #endif
 
-static int up_interrupt(int irq, void *context, FAR void *arg)
+static int up_interrupt(int irq, void *context, void *arg)
 {
   struct uart_dev_s *dev = (struct uart_dev_s *)arg;
   struct up_dev_s   *priv;

--- a/arch/risc-v/src/c906/c906_timerisr.c
+++ b/arch/risc-v/src/c906/c906_timerisr.c
@@ -93,7 +93,7 @@ static void c906_reload_mtimecmp(void)
  * Name:  c906_timerisr
  ****************************************************************************/
 
-static int c906_timerisr(int irq, void *context, FAR void *arg)
+static int c906_timerisr(int irq, void *context, void *arg)
 {
   c906_reload_mtimecmp();
 

--- a/arch/risc-v/src/common/riscv_allocateheap.c
+++ b/arch/risc-v/src/common/riscv_allocateheap.c
@@ -65,9 +65,9 @@
  *
  ****************************************************************************/
 
-void up_allocate_heap(FAR void **heap_start, size_t *heap_size)
+void up_allocate_heap(void **heap_start, size_t *heap_size)
 {
   board_autoled_on(LED_HEAPALLOCATE);
-  *heap_start = (FAR void *)g_idle_topstack;
+  *heap_start = (void *)g_idle_topstack;
   *heap_size = CONFIG_RAM_END - g_idle_topstack;
 }

--- a/arch/risc-v/src/common/riscv_backtrace.c
+++ b/arch/risc-v/src/common/riscv_backtrace.c
@@ -61,9 +61,9 @@ static inline uintptr_t getfp(void)
  *
  ****************************************************************************/
 
-static int backtrace(FAR uintptr_t *base, FAR uintptr_t *limit,
-                     FAR uintptr_t *fp, FAR uintptr_t *ra,
-                     FAR void **buffer, int size)
+static int backtrace(uintptr_t *base, uintptr_t *limit,
+                     uintptr_t *fp, uintptr_t *ra,
+                     void **buffer, int size)
 {
   int i = 0;
 
@@ -72,14 +72,14 @@ static int backtrace(FAR uintptr_t *base, FAR uintptr_t *limit,
       buffer[i++] = ra;
     }
 
-  for (; i < size; fp = (FAR uintptr_t *)*(fp - 2), i++)
+  for (; i < size; fp = (uintptr_t *)*(fp - 2), i++)
     {
       if (fp > limit || fp < base)
         {
           break;
         }
 
-      ra = (FAR uintptr_t *)*(fp - 1);
+      ra = (uintptr_t *)*(fp - 1);
       if (ra == NULL)
         {
           break;
@@ -119,9 +119,9 @@ static int backtrace(FAR uintptr_t *base, FAR uintptr_t *limit,
  *
  ****************************************************************************/
 
-int up_backtrace(FAR struct tcb_s *tcb, FAR void **buffer, int size)
+int up_backtrace(struct tcb_s *tcb, void **buffer, int size)
 {
-  FAR struct tcb_s *rtcb = running_task();
+  struct tcb_s *rtcb = running_task();
   irqstate_t flags;
   int ret;
 
@@ -135,22 +135,22 @@ int up_backtrace(FAR struct tcb_s *tcb, FAR void **buffer, int size)
       if (up_interrupt_context())
         {
 #if CONFIG_ARCH_INTERRUPTSTACK > 15
-          ret = backtrace((FAR void *)&g_intstackalloc,
-                          (FAR void *)((uint32_t)&g_intstackalloc +
+          ret = backtrace((void *)&g_intstackalloc,
+                          (void *)((uint32_t)&g_intstackalloc +
                                        CONFIG_ARCH_INTERRUPTSTACK),
-                          (FAR void *)getfp(), NULL, buffer, size);
+                          (void *)getfp(), NULL, buffer, size);
 #else
           ret = backtrace(rtcb->stack_base_ptr,
                           rtcb->stack_base_ptr + rtcb->adj_stack_size,
-                          (FAR void *)getfp(), NULL, buffer, size);
+                          (void *)getfp(), NULL, buffer, size);
 #endif
           if (ret < size)
             {
               ret += backtrace(rtcb->stack_base_ptr,
                                rtcb->stack_base_ptr +
                                rtcb->adj_stack_size,
-                               (FAR void *)CURRENT_REGS[REG_FP],
-                               (FAR void *)CURRENT_REGS[REG_EPC],
+                               (void *)CURRENT_REGS[REG_FP],
+                               (void *)CURRENT_REGS[REG_EPC],
                                &buffer[ret], size - ret);
             }
         }
@@ -158,7 +158,7 @@ int up_backtrace(FAR struct tcb_s *tcb, FAR void **buffer, int size)
         {
           ret = backtrace(rtcb->stack_base_ptr,
                           rtcb->stack_base_ptr + rtcb->adj_stack_size,
-                          (FAR void *)getfp(), NULL, buffer, size);
+                          (void *)getfp(), NULL, buffer, size);
         }
     }
   else
@@ -167,8 +167,8 @@ int up_backtrace(FAR struct tcb_s *tcb, FAR void **buffer, int size)
 
       ret = backtrace(tcb->stack_base_ptr,
                       tcb->stack_base_ptr + tcb->adj_stack_size,
-                      (FAR void *)tcb->xcp.regs[REG_FP],
-                      (FAR void *)tcb->xcp.regs[REG_EPC],
+                      (void *)tcb->xcp.regs[REG_FP],
+                      (void *)tcb->xcp.regs[REG_EPC],
                       buffer, size);
 
       leave_critical_section(flags);

--- a/arch/risc-v/src/common/riscv_checkstack.c
+++ b/arch/risc-v/src/common/riscv_checkstack.c
@@ -63,9 +63,9 @@ static size_t do_stackcheck(uintptr_t alloc, size_t size);
 
 static size_t do_stackcheck(uintptr_t alloc, size_t size)
 {
-  FAR uintptr_t start;
-  FAR uintptr_t end;
-  FAR uint32_t *ptr;
+  uintptr_t start;
+  uintptr_t end;
+  uint32_t *ptr;
   size_t mark;
 
   if (size == 0)
@@ -88,7 +88,7 @@ static size_t do_stackcheck(uintptr_t alloc, size_t size)
    * that does not have the magic value is the high water mark.
    */
 
-  for (ptr = (FAR uint32_t *)start, mark = (size >> 2);
+  for (ptr = (uint32_t *)start, mark = (size >> 2);
        *ptr == STACK_COLOR && mark > 0;
        ptr++, mark--);
 
@@ -108,7 +108,7 @@ static size_t do_stackcheck(uintptr_t alloc, size_t size)
       int i;
       int j;
 
-      ptr = (FAR uint32_t *)start;
+      ptr = (uint32_t *)start;
       for (i = 0; i < size; i += 4 * 64)
         {
           for (j = 0; j < 64; j++)
@@ -156,12 +156,12 @@ static size_t do_stackcheck(uintptr_t alloc, size_t size)
  *
  ****************************************************************************/
 
-size_t up_check_tcbstack(FAR struct tcb_s *tcb)
+size_t up_check_tcbstack(struct tcb_s *tcb)
 {
   return do_stackcheck((uintptr_t)tcb->stack_base_ptr, tcb->adj_stack_size);
 }
 
-ssize_t up_check_tcbstack_remain(FAR struct tcb_s *tcb)
+ssize_t up_check_tcbstack_remain(struct tcb_s *tcb)
 {
   return tcb->adj_stack_size - up_check_tcbstack(tcb);
 }

--- a/arch/risc-v/src/common/riscv_createstack.c
+++ b/arch/risc-v/src/common/riscv_createstack.c
@@ -102,7 +102,7 @@
  *
  ****************************************************************************/
 
-int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
+int up_create_stack(struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
 {
 #ifdef CONFIG_TLS_ALIGNED
   /* The allocated stack size must not exceed the maximum possible for the
@@ -234,7 +234,7 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
  ****************************************************************************/
 
 #ifdef CONFIG_STACK_COLORATION
-void riscv_stack_color(FAR void *stackbase, size_t nbytes)
+void riscv_stack_color(void *stackbase, size_t nbytes)
 {
   /* Take extra care that we do not write outsize the stack boundaries */
 

--- a/arch/risc-v/src/common/riscv_exit.c
+++ b/arch/risc-v/src/common/riscv_exit.c
@@ -63,11 +63,11 @@
  ****************************************************************************/
 
 #ifdef CONFIG_DUMP_ON_EXIT
-static void _up_dumponexit(FAR struct tcb_s *tcb, FAR void *arg)
+static void _up_dumponexit(struct tcb_s *tcb, void *arg)
 {
-  FAR struct filelist *filelist;
+  struct filelist *filelist;
 #ifdef CONFIG_FILE_STREAM
-  FAR struct file_struct *filep;
+  struct file_struct *filep;
 #endif
   int i;
   int j;

--- a/arch/risc-v/src/common/riscv_internal.h
+++ b/arch/risc-v/src/common/riscv_internal.h
@@ -168,7 +168,7 @@ void riscv_copyfullstate(uint32_t *dest, uint32_t *src);
 #endif
 
 void riscv_sigdeliver(void);
-int riscv_swint(int irq, FAR void *context, FAR void *arg);
+int riscv_swint(int irq, void *context, void *arg);
 uint32_t riscv_get_newintctx(void);
 
 #ifdef CONFIG_ARCH_FPU
@@ -221,7 +221,7 @@ void riscv_exception(uint32_t mcause, uint32_t *regs);
 /* Debug ********************************************************************/
 
 #ifdef CONFIG_STACK_COLORATION
-void riscv_stack_color(FAR void *stackbase, size_t nbytes);
+void riscv_stack_color(void *stackbase, size_t nbytes);
 #endif
 
 #undef EXTERN

--- a/arch/risc-v/src/common/riscv_pthread_exit.c
+++ b/arch/risc-v/src/common/riscv_pthread_exit.c
@@ -52,7 +52,7 @@
  *   None
  ****************************************************************************/
 
-void up_pthread_exit(pthread_exitroutine_t exit, FAR void *exit_value)
+void up_pthread_exit(pthread_exitroutine_t exit, void *exit_value)
 {
   sys_call2(SYS_pthread_exit, (uintptr_t)exit, (uintptr_t)exit_value);
 

--- a/arch/risc-v/src/common/riscv_releasestack.c
+++ b/arch/risc-v/src/common/riscv_releasestack.c
@@ -75,7 +75,7 @@
  *
  ****************************************************************************/
 
-void up_release_stack(FAR struct tcb_s *dtcb, uint8_t ttype)
+void up_release_stack(struct tcb_s *dtcb, uint8_t ttype)
 {
   /* Is there a stack allocated? */
 

--- a/arch/risc-v/src/common/riscv_stackframe.c
+++ b/arch/risc-v/src/common/riscv_stackframe.c
@@ -90,9 +90,9 @@
  *
  ****************************************************************************/
 
-FAR void *up_stack_frame(FAR struct tcb_s *tcb, size_t frame_size)
+void *up_stack_frame(struct tcb_s *tcb, size_t frame_size)
 {
-  FAR void *ret;
+  void *ret;
 
   /* Align the frame_size */
 
@@ -110,7 +110,7 @@ FAR void *up_stack_frame(FAR struct tcb_s *tcb, size_t frame_size)
 
   /* Save the adjusted stack values in the struct tcb_s */
 
-  tcb->stack_base_ptr   = (FAR uint8_t *)tcb->stack_base_ptr + frame_size;
+  tcb->stack_base_ptr   = (uint8_t *)tcb->stack_base_ptr + frame_size;
   tcb->adj_stack_size -= frame_size;
 
   /* And return the pointer to the allocated region */

--- a/arch/risc-v/src/common/riscv_task_start.c
+++ b/arch/risc-v/src/common/riscv_task_start.c
@@ -60,7 +60,7 @@
  *
  ****************************************************************************/
 
-void up_task_start(main_t taskentry, int argc, FAR char *argv[])
+void up_task_start(main_t taskentry, int argc, char *argv[])
 {
   /* Let sys_call3() do all of the work */
 

--- a/arch/risc-v/src/common/riscv_usestack.c
+++ b/arch/risc-v/src/common/riscv_usestack.c
@@ -82,7 +82,7 @@
  *
  ****************************************************************************/
 
-int up_use_stack(FAR struct tcb_s *tcb, FAR void *stack, size_t stack_size)
+int up_use_stack(struct tcb_s *tcb, void *stack, size_t stack_size)
 {
   uintptr_t top_of_stack;
   size_t size_of_stack;

--- a/arch/risc-v/src/esp32c3/esp32c3_aes.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_aes.c
@@ -588,8 +588,8 @@ int esp32c3_aes_init(void)
 
 #ifdef CONFIG_CRYPTO_AES
 
-int aes_cypher(FAR void *out, FAR const void *in, uint32_t size,
-               FAR const void *iv, FAR const void *key, uint32_t keysize,
+int aes_cypher(void *out, const void *in, uint32_t size,
+               const void *iv, const void *key, uint32_t keysize,
                int mode, int encrypt)
 {
   int ret;

--- a/arch/risc-v/src/esp32c3/esp32c3_allocateheap.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_allocateheap.c
@@ -59,7 +59,7 @@
  *
  ****************************************************************************/
 
-void up_allocate_heap(FAR void **heap_start, size_t *heap_size)
+void up_allocate_heap(void **heap_start, size_t *heap_size)
 {
   /* These values come from the linker scripts (esp32c3.ld and
    * esp32c3.template.ld.)  Check boards/risc-v/esp32c3.
@@ -70,7 +70,7 @@ void up_allocate_heap(FAR void **heap_start, size_t *heap_size)
 
   board_autoled_on(LED_HEAPALLOCATE);
 
-  *heap_start = (FAR void *)&_sheap;
+  *heap_start = (void *)&_sheap;
   *heap_size = (size_t)(ets_rom_layout_p->dram0_rtos_reserved_start -
                         (uintptr_t)&_sheap);
 }

--- a/arch/risc-v/src/esp32c3/esp32c3_ble_adapter.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_ble_adapter.c
@@ -600,7 +600,7 @@ static void interrupt_clear_wrapper(int intr_source, int intr_num)
  *
  ****************************************************************************/
 
-static int esp_int_adpt_cb(int irq, void *context, FAR void *arg)
+static int esp_int_adpt_cb(int irq, void *context, void *arg)
 {
   struct irq_adpt_s *adapter = (struct irq_adpt_s *)arg;
 

--- a/arch/risc-v/src/esp32c3/esp32c3_efuse.h
+++ b/arch/risc-v/src/esp32c3/esp32c3_efuse.h
@@ -178,7 +178,7 @@ void esp32c3_efuse_burn_efuses(void);
  *
  ****************************************************************************/
 
-int esp32c3_efuse_initialize(FAR const char *devpath);
+int esp32c3_efuse_initialize(const char *devpath);
 
 #ifdef __cplusplus
 }

--- a/arch/risc-v/src/esp32c3/esp32c3_efuse_lowerhalf.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_efuse_lowerhalf.c
@@ -37,8 +37,8 @@
 
 struct esp32c3_efuse_lowerhalf_s
 {
-  FAR const struct efuse_ops_s *ops; /* Lower half operations */
-  void *upper;                       /* Pointer to efuse_upperhalf_s */
+  const struct efuse_ops_s *ops; /* Lower half operations */
+  void *upper;                   /* Pointer to efuse_upperhalf_s */
 };
 
 /****************************************************************************
@@ -47,14 +47,14 @@ struct esp32c3_efuse_lowerhalf_s
 
 /* "Lower half" driver methods */
 
-static int esp32c3_efuse_lowerhalf_read(FAR struct efuse_lowerhalf_s *lower,
+static int esp32c3_efuse_lowerhalf_read(struct efuse_lowerhalf_s *lower,
                                         const efuse_desc_t *field[],
                                         uint8_t *data, size_t bits_len);
-static int esp32c3_efuse_lowerhalf_write(FAR struct efuse_lowerhalf_s *lower,
+static int esp32c3_efuse_lowerhalf_write(struct efuse_lowerhalf_s *lower,
                                          const efuse_desc_t *field[],
                                          const uint8_t *data,
                                          size_t bits_len);
-static int esp32c3_efuse_lowerhalf_ioctl(FAR struct efuse_lowerhalf_s *lower,
+static int esp32c3_efuse_lowerhalf_ioctl(struct efuse_lowerhalf_s *lower,
                                          int cmd, unsigned long arg);
 
 /****************************************************************************
@@ -100,7 +100,7 @@ static struct esp32c3_efuse_lowerhalf_s g_esp32c3_efuse_lowerhalf =
  *
  ****************************************************************************/
 
-static int esp32c3_efuse_lowerhalf_read(FAR struct efuse_lowerhalf_s *lower,
+static int esp32c3_efuse_lowerhalf_read(struct efuse_lowerhalf_s *lower,
                                         const efuse_desc_t *field[],
                                         uint8_t *data, size_t bits_len)
 {
@@ -131,7 +131,7 @@ static int esp32c3_efuse_lowerhalf_read(FAR struct efuse_lowerhalf_s *lower,
  *
  ****************************************************************************/
 
-static int esp32c3_efuse_lowerhalf_write(FAR struct efuse_lowerhalf_s *lower,
+static int esp32c3_efuse_lowerhalf_write(struct efuse_lowerhalf_s *lower,
                                          const efuse_desc_t *field[],
                                          const uint8_t *data,
                                          size_t bits_len)
@@ -172,7 +172,7 @@ static int esp32c3_efuse_lowerhalf_write(FAR struct efuse_lowerhalf_s *lower,
  *
  ****************************************************************************/
 
-static int esp32c3_efuse_lowerhalf_ioctl(FAR struct efuse_lowerhalf_s *lower,
+static int esp32c3_efuse_lowerhalf_ioctl(struct efuse_lowerhalf_s *lower,
                                          int cmd, unsigned long arg)
 {
   int ret = OK;
@@ -212,7 +212,7 @@ static int esp32c3_efuse_lowerhalf_ioctl(FAR struct efuse_lowerhalf_s *lower,
  *
  ****************************************************************************/
 
-int esp32c3_efuse_initialize(FAR const char *devpath)
+int esp32c3_efuse_initialize(const char *devpath)
 {
   struct esp32c3_efuse_lowerhalf_s *lower = NULL;
   int ret = OK;
@@ -224,7 +224,7 @@ int esp32c3_efuse_initialize(FAR const char *devpath)
   /* Register the efuse upper driver */
 
   lower->upper = efuse_register(devpath,
-                                (FAR struct efuse_lowerhalf_s *)lower);
+                                (struct efuse_lowerhalf_s *)lower);
 
   if (lower->upper == NULL)
     {

--- a/arch/risc-v/src/esp32c3/esp32c3_freerun.h
+++ b/arch/risc-v/src/esp32c3/esp32c3_freerun.h
@@ -46,11 +46,11 @@
 
 struct esp32c3_freerun_s
 {
-  uint8_t chan;                      /* The timer/counter in use */
-  uint32_t overflow;                 /* Timer counter overflow */
-  uint16_t resolution;               /* Timer resolution */
-  uint64_t max_timeout;              /* Maximum timeout to overflow */
-  FAR struct esp32c3_tim_dev_s *tch; /* Handle returned by esp32c3_tim_init() */
+  uint8_t chan;                  /* The timer/counter in use */
+  uint32_t overflow;             /* Timer counter overflow */
+  uint16_t resolution;           /* Timer resolution */
+  uint64_t max_timeout;          /* Maximum timeout to overflow */
+  struct esp32c3_tim_dev_s *tch; /* Handle returned by esp32c3_tim_init() */
 };
 
 /****************************************************************************

--- a/arch/risc-v/src/esp32c3/esp32c3_gpio.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_gpio.c
@@ -87,7 +87,7 @@ static void gpio_dispatch(int irq, uint32_t status, uint32_t *regs)
  ****************************************************************************/
 
 #ifdef CONFIG_ESP32C3_GPIO_IRQ
-static int gpio_interrupt(int irq, FAR void *context, FAR void *arg)
+static int gpio_interrupt(int irq, void *context, void *arg)
 {
   uint32_t status;
 

--- a/arch/risc-v/src/esp32c3/esp32c3_i2c.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_i2c.c
@@ -268,7 +268,7 @@ static int  esp32c3_i2c_transfer(struct i2c_master_s *dev,
 static inline void esp32c3_i2c_process(struct esp32c3_i2c_priv_s *priv,
                                        uint32_t status);
 #ifdef CONFIG_I2C_POLLED
-static int esp32c3_i2c_polling_waitdone(FAR struct esp32c3_i2c_priv_s *priv);
+static int esp32c3_i2c_polling_waitdone(struct esp32c3_i2c_priv_s *priv);
 #endif
 
 #ifdef CONFIG_I2C_RESET
@@ -836,7 +836,7 @@ static int esp32c3_i2c_sem_waitdone(struct esp32c3_i2c_priv_s *priv)
  *
  ****************************************************************************/
 #ifdef CONFIG_I2C_POLLED
-static int esp32c3_i2c_polling_waitdone(FAR struct esp32c3_i2c_priv_s *priv)
+static int esp32c3_i2c_polling_waitdone(struct esp32c3_i2c_priv_s *priv)
 {
   int ret;
   struct timespec current_time;

--- a/arch/risc-v/src/esp32c3/esp32c3_oneshot.h
+++ b/arch/risc-v/src/esp32c3/esp32c3_oneshot.h
@@ -58,14 +58,14 @@ typedef void (*oneshot_handler_t)(void *arg);
 
 struct esp32c3_oneshot_s
 {
-  uint8_t chan;                         /* The timer/counter in use */
-  volatile bool running;                /* True: the timer is running */
-  FAR struct esp32c3_tim_dev_s    *tim; /* Pointer returned by
-                                         * esp32c3_tim_init() */
-  volatile oneshot_handler_t handler;   /* Oneshot expiration callback */
-  volatile void                 *arg;   /* The argument that will accompany
-                                         * the callback */
-  uint32_t                resolution;   /* us */
+  uint8_t chan;                       /* The timer/counter in use */
+  volatile bool running;              /* True: the timer is running */
+  struct esp32c3_tim_dev_s      *tim; /* Pointer returned by
+                                       * esp32c3_tim_init() */
+  volatile oneshot_handler_t handler; /* Oneshot expiration callback */
+  volatile void                 *arg; /* The argument that will accompany
+                                       * the callback */
+  uint32_t                resolution; /* us */
 };
 
 /****************************************************************************

--- a/arch/risc-v/src/esp32c3/esp32c3_oneshot_lowerhalf.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_oneshot_lowerhalf.c
@@ -57,7 +57,7 @@ struct esp32c3_oneshot_lowerhalf_s
   struct oneshot_lowerhalf_s        lh;   /* Lower half instance */
   struct esp32c3_oneshot_s     oneshot;   /* ESP32-C3-specific oneshot state */
   oneshot_callback_t          callback;   /* Upper half Interrupt callback */
-  FAR void                        *arg;   /* Argument passed to handler */
+  void                        *arg;       /* Argument passed to handler */
   uint16_t                  resolution;
 };
 
@@ -69,16 +69,16 @@ static void esp32c3_oneshot_lh_handler(void *arg);
 
 /* "Lower half" driver methods **********************************************/
 
-static int oneshot_lh_max_delay(FAR struct oneshot_lowerhalf_s *lower,
-                                FAR struct timespec *ts);
-static int oneshot_lh_start(FAR struct oneshot_lowerhalf_s *lower,
+static int oneshot_lh_max_delay(struct oneshot_lowerhalf_s *lower,
+                                struct timespec *ts);
+static int oneshot_lh_start(struct oneshot_lowerhalf_s *lower,
                             oneshot_callback_t callback,
-                            FAR void *arg,
-                            FAR const struct timespec *ts);
-static int oneshot_lh_cancel(FAR struct oneshot_lowerhalf_s *lower,
-                             FAR struct timespec *ts);
-static int oneshot_lh_current(FAR struct oneshot_lowerhalf_s *lower,
-                              FAR struct timespec *ts);
+                            void *arg,
+                            const struct timespec *ts);
+static int oneshot_lh_cancel(struct oneshot_lowerhalf_s *lower,
+                             struct timespec *ts);
+static int oneshot_lh_current(struct oneshot_lowerhalf_s *lower,
+                              struct timespec *ts);
 
 /****************************************************************************
  * Private Data
@@ -112,8 +112,8 @@ static const struct oneshot_operations_s g_esp32c3_timer_ops =
 
 static void esp32c3_oneshot_lh_handler(void *arg)
 {
-  FAR struct esp32c3_oneshot_lowerhalf_s *priv =
-    (FAR struct esp32c3_oneshot_lowerhalf_s *)arg;
+  struct esp32c3_oneshot_lowerhalf_s *priv =
+    (struct esp32c3_oneshot_lowerhalf_s *)arg;
 
   DEBUGASSERT(priv != NULL);
   DEBUGASSERT(priv->callback != NULL);
@@ -148,8 +148,8 @@ static void esp32c3_oneshot_lh_handler(void *arg)
  *
  ****************************************************************************/
 
-static int oneshot_lh_max_delay(FAR struct oneshot_lowerhalf_s *lower,
-                                FAR struct timespec *ts)
+static int oneshot_lh_max_delay(struct oneshot_lowerhalf_s *lower,
+                                struct timespec *ts)
 {
   DEBUGASSERT(ts != NULL);
 
@@ -190,13 +190,13 @@ static int oneshot_lh_max_delay(FAR struct oneshot_lowerhalf_s *lower,
  *
  ****************************************************************************/
 
-static int oneshot_lh_start(FAR struct oneshot_lowerhalf_s *lower,
+static int oneshot_lh_start(struct oneshot_lowerhalf_s *lower,
                             oneshot_callback_t callback,
-                            FAR void *arg,
-                            FAR const struct timespec *ts)
+                            void *arg,
+                            const struct timespec *ts)
 {
-  FAR struct esp32c3_oneshot_lowerhalf_s *priv =
-    (FAR struct esp32c3_oneshot_lowerhalf_s *)lower;
+  struct esp32c3_oneshot_lowerhalf_s *priv =
+    (struct esp32c3_oneshot_lowerhalf_s *)lower;
   int ret;
   irqstate_t flags;
 
@@ -248,11 +248,11 @@ static int oneshot_lh_start(FAR struct oneshot_lowerhalf_s *lower,
  *
  ****************************************************************************/
 
-static int oneshot_lh_cancel(FAR struct oneshot_lowerhalf_s *lower,
-                             FAR struct timespec *ts)
+static int oneshot_lh_cancel(struct oneshot_lowerhalf_s *lower,
+                             struct timespec *ts)
 {
-  FAR struct esp32c3_oneshot_lowerhalf_s *priv =
-    (FAR struct esp32c3_oneshot_lowerhalf_s *)lower;
+  struct esp32c3_oneshot_lowerhalf_s *priv =
+    (struct esp32c3_oneshot_lowerhalf_s *)lower;
   irqstate_t flags;
   int ret;
 
@@ -293,11 +293,11 @@ static int oneshot_lh_cancel(FAR struct oneshot_lowerhalf_s *lower,
  *
  ****************************************************************************/
 
-static int oneshot_lh_current(FAR struct oneshot_lowerhalf_s *lower,
-                              FAR struct timespec *ts)
+static int oneshot_lh_current(struct oneshot_lowerhalf_s *lower,
+                              struct timespec *ts)
 {
-  FAR struct esp32c3_oneshot_lowerhalf_s *priv =
-    (FAR struct esp32c3_oneshot_lowerhalf_s *)lower;
+  struct esp32c3_oneshot_lowerhalf_s *priv =
+    (struct esp32c3_oneshot_lowerhalf_s *)lower;
   uint64_t current_us;
 
   DEBUGASSERT(priv != NULL);
@@ -334,15 +334,15 @@ static int oneshot_lh_current(FAR struct oneshot_lowerhalf_s *lower,
  *
  ****************************************************************************/
 
-FAR struct oneshot_lowerhalf_s *oneshot_initialize(int chan,
+struct oneshot_lowerhalf_s *oneshot_initialize(int chan,
                                                    uint16_t resolution)
 {
-  FAR struct esp32c3_oneshot_lowerhalf_s *priv;
+  struct esp32c3_oneshot_lowerhalf_s *priv;
   int ret;
 
   /* Allocate an instance of the lower half driver */
 
-  priv = (FAR struct esp32c3_oneshot_lowerhalf_s *)kmm_zalloc(
+  priv = (struct esp32c3_oneshot_lowerhalf_s *)kmm_zalloc(
           sizeof(struct esp32c3_oneshot_lowerhalf_s));
 
   if (priv == NULL)

--- a/arch/risc-v/src/esp32c3/esp32c3_partition.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_partition.c
@@ -362,7 +362,7 @@ static int ota_set_bootseq(struct mtd_dev_priv_s *dev, int num)
  *
  ****************************************************************************/
 
-static int esp32c3_part_erase(FAR struct mtd_dev_s *dev, off_t startblock,
+static int esp32c3_part_erase(struct mtd_dev_s *dev, off_t startblock,
                             size_t nblocks)
 {
   struct mtd_dev_priv_s *mtd_priv = (struct mtd_dev_priv_s *)dev;
@@ -387,8 +387,8 @@ static int esp32c3_part_erase(FAR struct mtd_dev_s *dev, off_t startblock,
  *
  ****************************************************************************/
 
-static ssize_t esp32c3_part_read(FAR struct mtd_dev_s *dev, off_t offset,
-                               size_t nbytes, FAR uint8_t *buffer)
+static ssize_t esp32c3_part_read(struct mtd_dev_s *dev, off_t offset,
+                               size_t nbytes, uint8_t *buffer)
 {
   struct mtd_dev_priv_s *mtd_priv = (struct mtd_dev_priv_s *)dev;
 
@@ -412,9 +412,9 @@ static ssize_t esp32c3_part_read(FAR struct mtd_dev_s *dev, off_t offset,
  *
  ****************************************************************************/
 
-static ssize_t esp32c3_part_bread(FAR struct mtd_dev_s *dev,
+static ssize_t esp32c3_part_bread(struct mtd_dev_s *dev,
                                   off_t startblock, size_t nblocks,
-                                  FAR uint8_t *buffer)
+                                  uint8_t *buffer)
 {
   struct mtd_dev_priv_s *mtd_priv = (struct mtd_dev_priv_s *)dev;
 
@@ -438,8 +438,8 @@ static ssize_t esp32c3_part_bread(FAR struct mtd_dev_s *dev,
  *
  ****************************************************************************/
 
-static ssize_t esp32c3_part_write(FAR struct mtd_dev_s *dev, off_t offset,
-                                size_t nbytes, FAR const uint8_t *buffer)
+static ssize_t esp32c3_part_write(struct mtd_dev_s *dev, off_t offset,
+                                size_t nbytes, const uint8_t *buffer)
 {
   struct mtd_dev_priv_s *mtd_priv = (struct mtd_dev_priv_s *)dev;
 
@@ -464,9 +464,9 @@ static ssize_t esp32c3_part_write(FAR struct mtd_dev_s *dev, off_t offset,
  *
  ****************************************************************************/
 
-static ssize_t esp32c3_part_bwrite(FAR struct mtd_dev_s *dev,
+static ssize_t esp32c3_part_bwrite(struct mtd_dev_s *dev,
                                    off_t startblock, size_t nblocks,
-                                   FAR const uint8_t *buffer)
+                                   const uint8_t *buffer)
 {
   struct mtd_dev_priv_s *mtd_priv = (struct mtd_dev_priv_s *)dev;
 
@@ -489,7 +489,7 @@ static ssize_t esp32c3_part_bwrite(FAR struct mtd_dev_s *dev,
  *
  ****************************************************************************/
 
-static int esp32c3_part_ioctl(FAR struct mtd_dev_s *dev, int cmd,
+static int esp32c3_part_ioctl(struct mtd_dev_s *dev, int cmd,
                               unsigned long arg)
 {
   int ret;

--- a/arch/risc-v/src/esp32c3/esp32c3_rng.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_rng.c
@@ -57,9 +57,9 @@
  ****************************************************************************/
 
 static int esp32c3_rng_initialize(void);
-static ssize_t esp32c3_rng_read(FAR struct file *filep, FAR char *buffer,
+static ssize_t esp32c3_rng_read(struct file *filep, char *buffer,
                                 size_t buflen);
-static int esp32c3_rng_open(FAR struct file *filep);
+static int esp32c3_rng_open(struct file *filep);
 
 /****************************************************************************
  * Private Types
@@ -164,7 +164,7 @@ static int esp32c3_rng_initialize(void)
  * Name: esp32c3_rng_open
  ****************************************************************************/
 
-static int esp32c3_rng_open(FAR struct file *filep)
+static int esp32c3_rng_open(struct file *filep)
 {
   /* O_NONBLOCK is not supported */
 
@@ -181,10 +181,10 @@ static int esp32c3_rng_open(FAR struct file *filep)
  * Name: esp32c3_rng_read
  ****************************************************************************/
 
-static ssize_t esp32c3_rng_read(FAR struct file *filep, FAR char *buffer,
+static ssize_t esp32c3_rng_read(struct file *filep, char *buffer,
                               size_t buflen)
 {
-  FAR struct rng_dev_s *priv = (struct rng_dev_s *)&g_rngdev;
+  struct rng_dev_s *priv = (struct rng_dev_s *)&g_rngdev;
   ssize_t read_len;
   uint8_t *rd_buf = (uint8_t *)buffer;
 

--- a/arch/risc-v/src/esp32c3/esp32c3_rt_timer.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_rt_timer.c
@@ -72,7 +72,7 @@ struct esp32c3_rt_priv_s
   sem_t s_toutsem;
   struct list_node s_runlist;
   struct list_node s_toutlist;
-  FAR struct esp32c3_tim_dev_s *timer;
+  struct esp32c3_tim_dev_s *timer;
 };
 
 /****************************************************************************
@@ -105,7 +105,7 @@ static struct esp32c3_rt_priv_s g_rt_priv =
  *
  ****************************************************************************/
 
-static void start_rt_timer(FAR struct rt_timer_s *timer,
+static void start_rt_timer(struct rt_timer_s *timer,
                            uint64_t timeout,
                            bool repeat)
 {
@@ -113,7 +113,7 @@ static void start_rt_timer(FAR struct rt_timer_s *timer,
   struct rt_timer_s *p;
   bool inserted = false;
   uint64_t counter;
-  FAR struct esp32c3_rt_priv_s *priv = &g_rt_priv;
+  struct esp32c3_rt_priv_s *priv = &g_rt_priv;
 
   flags = enter_critical_section();
 
@@ -192,13 +192,13 @@ static void start_rt_timer(FAR struct rt_timer_s *timer,
  *
  ****************************************************************************/
 
-static void stop_rt_timer(FAR struct rt_timer_s *timer)
+static void stop_rt_timer(struct rt_timer_s *timer)
 {
   irqstate_t flags;
   bool ishead;
   struct rt_timer_s *next_timer;
   uint64_t alarm;
-  FAR struct esp32c3_rt_priv_s *priv = &g_rt_priv;
+  struct esp32c3_rt_priv_s *priv = &g_rt_priv;
 
   flags = enter_critical_section();
 
@@ -267,12 +267,12 @@ static void stop_rt_timer(FAR struct rt_timer_s *timer)
  *
  ****************************************************************************/
 
-static void delete_rt_timer(FAR struct rt_timer_s *timer)
+static void delete_rt_timer(struct rt_timer_s *timer)
 {
   int ret;
   irqstate_t flags;
 
-  FAR struct esp32c3_rt_priv_s *priv = &g_rt_priv;
+  struct esp32c3_rt_priv_s *priv = &g_rt_priv;
 
   flags = enter_critical_section();
 
@@ -320,13 +320,13 @@ exit:
  *
  ****************************************************************************/
 
-static int rt_timer_thread(int argc, FAR char *argv[])
+static int rt_timer_thread(int argc, char *argv[])
 {
   int ret;
   irqstate_t flags;
   struct rt_timer_s *timer;
   enum rt_timer_state_e raw_state;
-  FAR struct esp32c3_rt_priv_s *priv = &g_rt_priv;
+  struct esp32c3_rt_priv_s *priv = &g_rt_priv;
 
   while (1)
     {
@@ -418,7 +418,7 @@ static int rt_timer_isr(int irq, void *context, void *arg)
   uint64_t alarm;
   uint64_t counter;
   bool wake = false;
-  FAR struct esp32c3_rt_priv_s *priv = &g_rt_priv;
+  struct esp32c3_rt_priv_s *priv = &g_rt_priv;
 
   /* Clear interrupt register status */
 
@@ -507,8 +507,8 @@ static int rt_timer_isr(int irq, void *context, void *arg)
  *
  ****************************************************************************/
 
-int rt_timer_create(FAR const struct rt_timer_args_s *args,
-                    FAR struct rt_timer_s **timer_handle)
+int rt_timer_create(const struct rt_timer_args_s *args,
+                    struct rt_timer_s **timer_handle)
 {
   struct rt_timer_s *timer;
 
@@ -546,7 +546,7 @@ int rt_timer_create(FAR const struct rt_timer_args_s *args,
  *
  ****************************************************************************/
 
-void rt_timer_start(FAR struct rt_timer_s *timer,
+void rt_timer_start(struct rt_timer_s *timer,
                     uint64_t timeout,
                     bool repeat)
 {
@@ -569,7 +569,7 @@ void rt_timer_start(FAR struct rt_timer_s *timer,
  *
  ****************************************************************************/
 
-void rt_timer_stop(FAR struct rt_timer_s *timer)
+void rt_timer_stop(struct rt_timer_s *timer)
 {
   stop_rt_timer(timer);
 }
@@ -588,7 +588,7 @@ void rt_timer_stop(FAR struct rt_timer_s *timer)
  *
  ****************************************************************************/
 
-void rt_timer_delete(FAR struct rt_timer_s *timer)
+void rt_timer_delete(struct rt_timer_s *timer)
 {
   delete_rt_timer(timer);
 }
@@ -610,7 +610,7 @@ void rt_timer_delete(FAR struct rt_timer_s *timer)
 uint64_t IRAM_ATTR rt_timer_time_us(void)
 {
   uint64_t counter;
-  FAR struct esp32c3_rt_priv_s *priv = &g_rt_priv;
+  struct esp32c3_rt_priv_s *priv = &g_rt_priv;
 
   ESP32C3_TIM_GETCTR(priv->timer, &counter);
   counter = CYCLES_TO_USEC(counter);
@@ -636,7 +636,7 @@ uint64_t IRAM_ATTR rt_timer_get_alarm(void)
 {
   irqstate_t flags;
   uint64_t counter;
-  FAR struct esp32c3_rt_priv_s *priv = &g_rt_priv;
+  struct esp32c3_rt_priv_s *priv = &g_rt_priv;
   uint64_t alarm_value = 0;
 
   flags = enter_critical_section();
@@ -677,7 +677,7 @@ uint64_t IRAM_ATTR rt_timer_get_alarm(void)
 void IRAM_ATTR rt_timer_calibration(uint64_t time_us)
 {
   uint64_t counter;
-  FAR struct esp32c3_rt_priv_s *priv = &g_rt_priv;
+  struct esp32c3_rt_priv_s *priv = &g_rt_priv;
   irqstate_t flags;
 
   flags = enter_critical_section();
@@ -707,7 +707,7 @@ int esp32c3_rt_timer_init(void)
 {
   int pid;
   irqstate_t flags;
-  FAR struct esp32c3_rt_priv_s *priv = &g_rt_priv;
+  struct esp32c3_rt_priv_s *priv = &g_rt_priv;
 
   priv->timer = esp32c3_tim_init(ESP32C3_RT_TIMER);
   if (priv->timer == NULL)
@@ -772,7 +772,7 @@ int esp32c3_rt_timer_init(void)
 void esp32c3_rt_timer_deinit(void)
 {
   irqstate_t flags;
-  FAR struct esp32c3_rt_priv_s *priv = &g_rt_priv;
+  struct esp32c3_rt_priv_s *priv = &g_rt_priv;
 
   flags = enter_critical_section();
 

--- a/arch/risc-v/src/esp32c3/esp32c3_rtc.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_rtc.c
@@ -361,7 +361,7 @@ struct alm_cbinfo_s
 {
   struct rt_timer_s *alarm_hdl;  /* Timer id point to here */
   volatile alm_callback_t ac_cb; /* Client callback function */
-  volatile FAR void *ac_arg;     /* Argument to pass with the callback function */
+  volatile void *ac_arg;         /* Argument to pass with the callback function */
   uint64_t deadline_us;
   uint8_t index;
 };
@@ -428,7 +428,7 @@ static void IRAM_ATTR esp32c3_rtc_clk_cpu_freq_to_pll_mhz(
                                              int cpu_freq_mhz);
 
 #ifdef CONFIG_RTC_DRIVER
-static void IRAM_ATTR esp32c3_rt_cb_handler(FAR void *arg);
+static void IRAM_ATTR esp32c3_rt_cb_handler(void *arg);
 #endif
 
 /****************************************************************************
@@ -1339,11 +1339,11 @@ static void IRAM_ATTR esp32c3_rtc_clk_cpu_freq_to_pll_mhz(
  *
  ****************************************************************************/
 
-static void IRAM_ATTR esp32c3_rt_cb_handler(FAR void *arg)
+static void IRAM_ATTR esp32c3_rt_cb_handler(void *arg)
 {
-  FAR struct alm_cbinfo_s *cbinfo = (struct alm_cbinfo_s *)arg;
+  struct alm_cbinfo_s *cbinfo = (struct alm_cbinfo_s *)arg;
   alm_callback_t cb;
-  FAR void *cb_arg;
+  void *cb_arg;
   int alminfo_id;
 
   DEBUGASSERT(cbinfo != NULL);
@@ -1356,7 +1356,7 @@ static void IRAM_ATTR esp32c3_rt_cb_handler(FAR void *arg)
       /* Alarm callback */
 
       cb = cbinfo->ac_cb;
-      cb_arg = (FAR void *)cbinfo->ac_arg;
+      cb_arg = (void *)cbinfo->ac_arg;
       cbinfo->ac_cb  = NULL;
       cbinfo->ac_arg = NULL;
       cbinfo->deadline_us = 0;
@@ -2355,7 +2355,7 @@ time_t up_rtc_time(void)
  *
  ****************************************************************************/
 
-int up_rtc_settime(FAR const struct timespec *ts)
+int up_rtc_settime(const struct timespec *ts)
 {
   irqstate_t flags;
   uint64_t now_us;
@@ -2450,7 +2450,7 @@ int up_rtc_initialize(void)
  ****************************************************************************/
 
 #ifdef CONFIG_RTC_HIRES
-int up_rtc_gettime(FAR struct timespec *tp)
+int up_rtc_gettime(struct timespec *tp)
 {
   irqstate_t flags;
   uint64_t time_us;
@@ -2493,10 +2493,10 @@ int up_rtc_gettime(FAR struct timespec *tp)
  *
  ****************************************************************************/
 
-int up_rtc_setalarm(FAR struct alm_setalarm_s *alminfo)
+int up_rtc_setalarm(struct alm_setalarm_s *alminfo)
 {
   struct rt_timer_args_s rt_timer_args;
-  FAR struct alm_cbinfo_s *cbinfo;
+  struct alm_cbinfo_s *cbinfo;
   irqstate_t flags;
   int ret = -EBUSY;
   int id;
@@ -2568,7 +2568,7 @@ int up_rtc_setalarm(FAR struct alm_setalarm_s *alminfo)
 
 int up_rtc_cancelalarm(enum alm_id_e alarmid)
 {
-  FAR struct alm_cbinfo_s *cbinfo;
+  struct alm_cbinfo_s *cbinfo;
   irqstate_t flags;
   int ret = -ENODATA;
 
@@ -2615,10 +2615,10 @@ int up_rtc_cancelalarm(enum alm_id_e alarmid)
  *
  ****************************************************************************/
 
-int up_rtc_rdalarm(FAR struct timespec *tp, uint32_t alarmid)
+int up_rtc_rdalarm(struct timespec *tp, uint32_t alarmid)
 {
   irqstate_t flags;
-  FAR struct alm_cbinfo_s *cbinfo;
+  struct alm_cbinfo_s *cbinfo;
   DEBUGASSERT(tp != NULL);
   DEBUGASSERT((RTC_ALARM0 <= alarmid) &&
               (alarmid < RTC_ALARM_LAST));

--- a/arch/risc-v/src/esp32c3/esp32c3_rtc.h
+++ b/arch/risc-v/src/esp32c3/esp32c3_rtc.h
@@ -152,7 +152,7 @@ struct esp32c3_cpu_freq_config_s
 
 /* The form of an alarm callback */
 
-typedef CODE void (*alm_callback_t)(FAR void *arg, unsigned int alarmid);
+typedef CODE void (*alm_callback_t)(void *arg, unsigned int alarmid);
 
 enum alm_id_e
 {
@@ -168,7 +168,7 @@ struct alm_setalarm_s
   int               as_id;     /* enum alm_id_e */
   struct timespec   as_time;   /* Alarm expiration time */
   alm_callback_t    as_cb;     /* Callback (if non-NULL) */
-  FAR void          *as_arg;   /* Argument for callback */
+  void          *as_arg;       /* Argument for callback */
 };
 
 #endif /* CONFIG_RTC_ALARM */
@@ -551,7 +551,7 @@ time_t up_rtc_time(void);
  *
  ****************************************************************************/
 
-int up_rtc_settime(FAR const struct timespec *ts);
+int up_rtc_settime(const struct timespec *ts);
 
 /****************************************************************************
  * Name: up_rtc_initialize
@@ -587,7 +587,7 @@ int up_rtc_initialize(void);
  ****************************************************************************/
 
 #ifdef CONFIG_RTC_HIRES
-int up_rtc_gettime(FAR struct timespec *tp);
+int up_rtc_gettime(struct timespec *tp);
 #endif
 
 #ifdef CONFIG_RTC_ALARM
@@ -606,7 +606,7 @@ int up_rtc_gettime(FAR struct timespec *tp);
  *
  ****************************************************************************/
 
-int up_rtc_setalarm(FAR struct alm_setalarm_s *alminfo);
+int up_rtc_setalarm(struct alm_setalarm_s *alminfo);
 
 /****************************************************************************
  * Name: up_rtc_cancelalarm
@@ -639,7 +639,7 @@ int up_rtc_cancelalarm(enum alm_id_e alarmid);
  *
  ****************************************************************************/
 
-int up_rtc_rdalarm(FAR struct timespec *tp, uint32_t alarmid);
+int up_rtc_rdalarm(struct timespec *tp, uint32_t alarmid);
 
 #endif /* CONFIG_RTC_ALARM */
 

--- a/arch/risc-v/src/esp32c3/esp32c3_rtc.h
+++ b/arch/risc-v/src/esp32c3/esp32c3_rtc.h
@@ -152,7 +152,7 @@ struct esp32c3_cpu_freq_config_s
 
 /* The form of an alarm callback */
 
-typedef CODE void (*alm_callback_t)(void *arg, unsigned int alarmid);
+typedef void (*alm_callback_t)(void *arg, unsigned int alarmid);
 
 enum alm_id_e
 {

--- a/arch/risc-v/src/esp32c3/esp32c3_rtcheap.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_rtcheap.c
@@ -34,7 +34,7 @@
  * Private Data
  ****************************************************************************/
 
-static FAR struct mm_heap_s *g_rtcheap;
+static struct mm_heap_s *g_rtcheap;
 
 /****************************************************************************
  * Public Functions
@@ -60,7 +60,7 @@ void esp32c3_rtcheap_initialize(void)
   extern uint8_t *_srtcheap;
   extern uint8_t *_ertcheap;
 
-  start = (FAR void *)&_srtcheap;
+  start = (void *)&_srtcheap;
   size  = (size_t)((uintptr_t)&_ertcheap - (uintptr_t)&_srtcheap);
   g_rtcheap = mm_initialize("rtcheap", start, size);
 }
@@ -126,7 +126,7 @@ void *esp32c3_rtcheap_zalloc(size_t size)
  *
  ****************************************************************************/
 
-void esp32c3_rtcheap_free(FAR void *mem)
+void esp32c3_rtcheap_free(void *mem)
 {
   mm_free(g_rtcheap, mem);
 }
@@ -163,7 +163,7 @@ void *esp32c3_rtcheap_memalign(size_t alignment, size_t size)
  *
  ****************************************************************************/
 
-bool esp32c3_rtcheap_heapmember(FAR void *mem)
+bool esp32c3_rtcheap_heapmember(void *mem)
 {
   return mm_heapmember(g_rtcheap, mem);
 }
@@ -177,7 +177,7 @@ bool esp32c3_rtcheap_heapmember(FAR void *mem)
  *
  ****************************************************************************/
 
-int esp32c3_rtcheap_mallinfo(FAR struct mallinfo *info)
+int esp32c3_rtcheap_mallinfo(struct mallinfo *info)
 {
   return mm_mallinfo(g_rtcheap, info);
 }

--- a/arch/risc-v/src/esp32c3/esp32c3_rtcheap.h
+++ b/arch/risc-v/src/esp32c3/esp32c3_rtcheap.h
@@ -94,7 +94,7 @@ void *esp32c3_rtcheap_zalloc(size_t size);
  *
  ****************************************************************************/
 
-void esp32c3_rtcheap_free(FAR void *mem);
+void esp32c3_rtcheap_free(void *mem);
 
 /****************************************************************************
  * Name: esp32c3_rtcheap_memalign
@@ -125,7 +125,7 @@ void *esp32c3_rtcheap_memalign(size_t alignment, size_t size);
  *
  ****************************************************************************/
 
-bool esp32c3_rtcheap_heapmember(FAR void *mem);
+bool esp32c3_rtcheap_heapmember(void *mem);
 
 /****************************************************************************
  * Name: esp32c3_rtcheap_mallinfo
@@ -136,7 +136,7 @@ bool esp32c3_rtcheap_heapmember(FAR void *mem);
  *
  ****************************************************************************/
 
-int esp32c3_rtcheap_mallinfo(FAR struct mallinfo *info);
+int esp32c3_rtcheap_mallinfo(struct mallinfo *info);
 
 #undef EXTERN
 #ifdef __cplusplus

--- a/arch/risc-v/src/esp32c3/esp32c3_serial.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_serial.c
@@ -235,7 +235,7 @@ static uart_dev_t g_uart1_dev =
  *
  ****************************************************************************/
 
-static int uart_handler(int irq, FAR void *context, FAR void *arg)
+static int uart_handler(int irq, void *context, void *arg)
 {
   struct uart_dev_s *dev = (struct uart_dev_s *)arg;
   struct esp32c3_uart_s *priv = dev->priv;

--- a/arch/risc-v/src/esp32c3/esp32c3_spi.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_spi.c
@@ -185,53 +185,53 @@ struct esp32c3_spi_priv_s
  * Private Function Prototypes
  ****************************************************************************/
 
-static int esp32c3_spi_lock(FAR struct spi_dev_s *dev, bool lock);
+static int esp32c3_spi_lock(struct spi_dev_s *dev, bool lock);
 #ifndef CONFIG_ESP32C3_SPI_UDCS
-static void esp32c3_spi_select(FAR struct spi_dev_s *dev,
+static void esp32c3_spi_select(struct spi_dev_s *dev,
                                uint32_t devid, bool selected);
 #endif
-static uint32_t esp32c3_spi_setfrequency(FAR struct spi_dev_s *dev,
+static uint32_t esp32c3_spi_setfrequency(struct spi_dev_s *dev,
                                          uint32_t frequency);
-static void esp32c3_spi_setmode(FAR struct spi_dev_s *dev,
+static void esp32c3_spi_setmode(struct spi_dev_s *dev,
                                 enum spi_mode_e mode);
-static void esp32c3_spi_setbits(FAR struct spi_dev_s *dev, int nbits);
+static void esp32c3_spi_setbits(struct spi_dev_s *dev, int nbits);
 #ifdef CONFIG_SPI_HWFEATURES
-static int esp32c3_spi_hwfeatures(FAR struct spi_dev_s *dev,
+static int esp32c3_spi_hwfeatures(struct spi_dev_s *dev,
                                   spi_hwfeatures_t features);
 #endif
-static uint32_t esp32c3_spi_send(FAR struct spi_dev_s *dev, uint32_t wd);
-static void esp32c3_spi_exchange(FAR struct spi_dev_s *dev,
-                                 FAR const void *txbuffer,
-                                 FAR void *rxbuffer, size_t nwords);
+static uint32_t esp32c3_spi_send(struct spi_dev_s *dev, uint32_t wd);
+static void esp32c3_spi_exchange(struct spi_dev_s *dev,
+                                 const void *txbuffer,
+                                 void *rxbuffer, size_t nwords);
 #ifdef CONFIG_ESP32C3_SPI2_DMA
-static int esp32c3_spi_interrupt(int irq, void *context, FAR void *arg);
-static int esp32c3_spi_sem_waitdone(FAR struct esp32c3_spi_priv_s *priv);
-static void esp32c3_spi_dma_exchange(FAR struct esp32c3_spi_priv_s *priv,
-                                     FAR const void *txbuffer,
-                                     FAR void *rxbuffer,
+static int esp32c3_spi_interrupt(int irq, void *context, void *arg);
+static int esp32c3_spi_sem_waitdone(struct esp32c3_spi_priv_s *priv);
+static void esp32c3_spi_dma_exchange(struct esp32c3_spi_priv_s *priv,
+                                     const void *txbuffer,
+                                     void *rxbuffer,
                                      uint32_t nwords);
 #else
-static void esp32c3_spi_poll_exchange(FAR struct esp32c3_spi_priv_s *priv,
-                                      FAR const void *txbuffer,
-                                      FAR void *rxbuffer,
+static void esp32c3_spi_poll_exchange(struct esp32c3_spi_priv_s *priv,
+                                      const void *txbuffer,
+                                      void *rxbuffer,
                                       size_t nwords);
 #endif
 #ifndef CONFIG_SPI_EXCHANGE
-static void esp32c3_spi_sndblock(FAR struct spi_dev_s *dev,
-                                 FAR const void *txbuffer,
+static void esp32c3_spi_sndblock(struct spi_dev_s *dev,
+                                 const void *txbuffer,
                                  size_t nwords);
-static void esp32c3_spi_recvblock(FAR struct spi_dev_s *dev,
-                                  FAR void *rxbuffer,
+static void esp32c3_spi_recvblock(struct spi_dev_s *dev,
+                                  void *rxbuffer,
                                   size_t nwords);
 #endif
 #ifdef CONFIG_SPI_TRIGGER
-static int esp32c3_spi_trigger(FAR struct spi_dev_s *dev);
+static int esp32c3_spi_trigger(struct spi_dev_s *dev);
 #endif
 #ifdef CONFIG_ESP32C3_SPI2_DMA
-static void esp32c3_spi_dma_init(FAR struct spi_dev_s *dev);
+static void esp32c3_spi_dma_init(struct spi_dev_s *dev);
 #endif
-static void esp32c3_spi_init(FAR struct spi_dev_s *dev);
-static void esp32c3_spi_deinit(FAR struct spi_dev_s *dev);
+static void esp32c3_spi_init(struct spi_dev_s *dev);
+static void esp32c3_spi_deinit(struct spi_dev_s *dev);
 
 /****************************************************************************
  * Private Data
@@ -391,10 +391,10 @@ static inline void esp32c3_spi_clr_regbits(uint32_t addr, uint32_t bits)
  *
  ****************************************************************************/
 
-static int esp32c3_spi_lock(FAR struct spi_dev_s *dev, bool lock)
+static int esp32c3_spi_lock(struct spi_dev_s *dev, bool lock)
 {
   int ret;
-  FAR struct esp32c3_spi_priv_s *priv = (FAR struct esp32c3_spi_priv_s *)dev;
+  struct esp32c3_spi_priv_s *priv = (struct esp32c3_spi_priv_s *)dev;
 
   if (lock)
     {
@@ -423,7 +423,7 @@ static int esp32c3_spi_lock(FAR struct spi_dev_s *dev, bool lock)
  ****************************************************************************/
 
 #ifdef CONFIG_ESP32C3_SPI2_DMA
-static int esp32c3_spi_sem_waitdone(FAR struct esp32c3_spi_priv_s *priv)
+static int esp32c3_spi_sem_waitdone(struct esp32c3_spi_priv_s *priv)
 {
   int ret;
   struct timespec abstime;
@@ -463,11 +463,11 @@ static int esp32c3_spi_sem_waitdone(FAR struct esp32c3_spi_priv_s *priv)
  ****************************************************************************/
 
 #ifndef CONFIG_ESP32C3_SPI_UDCS
-static void esp32c3_spi_select(FAR struct spi_dev_s *dev,
+static void esp32c3_spi_select(struct spi_dev_s *dev,
                                uint32_t devid, bool selected)
 {
 #if SPI_HAVE_SWCS
-  FAR struct esp32c3_spi_priv_s *priv = (FAR struct esp32c3_spi_priv_s *)dev;
+  struct esp32c3_spi_priv_s *priv = (struct esp32c3_spi_priv_s *)dev;
   bool value = selected ? false : true;
 
   esp32c3_gpiowrite(priv->config->cs_pin, value);
@@ -493,11 +493,11 @@ static void esp32c3_spi_select(FAR struct spi_dev_s *dev,
  *
  ****************************************************************************/
 
-static uint32_t esp32c3_spi_setfrequency(FAR struct spi_dev_s *dev,
+static uint32_t esp32c3_spi_setfrequency(struct spi_dev_s *dev,
                                          uint32_t frequency)
 {
   uint32_t reg_val;
-  FAR struct esp32c3_spi_priv_s *priv = (FAR struct esp32c3_spi_priv_s *)dev;
+  struct esp32c3_spi_priv_s *priv = (struct esp32c3_spi_priv_s *)dev;
   const uint32_t duty_cycle = 128;
 
   if (priv->frequency == frequency)
@@ -615,10 +615,10 @@ static uint32_t esp32c3_spi_setfrequency(FAR struct spi_dev_s *dev,
  *
  ****************************************************************************/
 
-static void esp32c3_spi_setmode(FAR struct spi_dev_s *dev,
+static void esp32c3_spi_setmode(struct spi_dev_s *dev,
                                 enum spi_mode_e mode)
 {
-  FAR struct esp32c3_spi_priv_s *priv = (FAR struct esp32c3_spi_priv_s *)dev;
+  struct esp32c3_spi_priv_s *priv = (struct esp32c3_spi_priv_s *)dev;
 
   spiinfo("mode=%d\n", mode);
 
@@ -684,9 +684,9 @@ static void esp32c3_spi_setmode(FAR struct spi_dev_s *dev,
  *
  ****************************************************************************/
 
-static void esp32c3_spi_setbits(FAR struct spi_dev_s *dev, int nbits)
+static void esp32c3_spi_setbits(struct spi_dev_s *dev, int nbits)
 {
-  FAR struct esp32c3_spi_priv_s *priv = (FAR struct esp32c3_spi_priv_s *)dev;
+  struct esp32c3_spi_priv_s *priv = (struct esp32c3_spi_priv_s *)dev;
 
   spiinfo("nbits=%d\n", nbits);
 
@@ -710,7 +710,7 @@ static void esp32c3_spi_setbits(FAR struct spi_dev_s *dev, int nbits)
  ****************************************************************************/
 
 #ifdef CONFIG_SPI_HWFEATURES
-static int esp32c3_spi_hwfeatures(FAR struct spi_dev_s *dev,
+static int esp32c3_spi_hwfeatures(struct spi_dev_s *dev,
                                   spi_hwfeatures_t features)
 {
   /* Other H/W features are not supported */
@@ -741,9 +741,9 @@ static int esp32c3_spi_hwfeatures(FAR struct spi_dev_s *dev,
  ****************************************************************************/
 
 #ifdef CONFIG_ESP32C3_SPI2_DMA
-static void esp32c3_spi_dma_exchange(FAR struct esp32c3_spi_priv_s *priv,
-                                     FAR const void *txbuffer,
-                                     FAR void *rxbuffer,
+static void esp32c3_spi_dma_exchange(struct esp32c3_spi_priv_s *priv,
+                                     const void *txbuffer,
+                                     void *rxbuffer,
                                      uint32_t nwords)
 {
   const uint32_t total = nwords * (priv->nbits / 8);
@@ -844,7 +844,7 @@ static void esp32c3_spi_dma_exchange(FAR struct esp32c3_spi_priv_s *priv,
  *
  ****************************************************************************/
 
-static uint32_t esp32c3_spi_poll_send(FAR struct esp32c3_spi_priv_s *priv,
+static uint32_t esp32c3_spi_poll_send(struct esp32c3_spi_priv_s *priv,
                                       uint32_t wd)
 {
   uint32_t val;
@@ -894,9 +894,9 @@ static uint32_t esp32c3_spi_poll_send(FAR struct esp32c3_spi_priv_s *priv,
  *
  ****************************************************************************/
 
-static uint32_t esp32c3_spi_send(FAR struct spi_dev_s *dev, uint32_t wd)
+static uint32_t esp32c3_spi_send(struct spi_dev_s *dev, uint32_t wd)
 {
-  FAR struct esp32c3_spi_priv_s *priv = (FAR struct esp32c3_spi_priv_s *)dev;
+  struct esp32c3_spi_priv_s *priv = (struct esp32c3_spi_priv_s *)dev;
 
   return esp32c3_spi_poll_send(priv, wd);
 }
@@ -922,9 +922,9 @@ static uint32_t esp32c3_spi_send(FAR struct spi_dev_s *dev, uint32_t wd)
  *
  ****************************************************************************/
 
-static void esp32c3_spi_poll_exchange(FAR struct esp32c3_spi_priv_s *priv,
-                                      FAR const void *txbuffer,
-                                      FAR void *rxbuffer,
+static void esp32c3_spi_poll_exchange(struct esp32c3_spi_priv_s *priv,
+                                      const void *txbuffer,
+                                      void *rxbuffer,
                                       size_t nwords)
 {
   const uint32_t total_bytes = nwords * (priv->nbits / 8);
@@ -1051,12 +1051,12 @@ static void esp32c3_spi_poll_exchange(FAR struct esp32c3_spi_priv_s *priv,
  *
  ****************************************************************************/
 
-static void esp32c3_spi_exchange(FAR struct spi_dev_s *dev,
-                                 FAR const void *txbuffer,
-                                 FAR void *rxbuffer,
+static void esp32c3_spi_exchange(struct spi_dev_s *dev,
+                                 const void *txbuffer,
+                                 void *rxbuffer,
                                  size_t nwords)
 {
-  FAR struct esp32c3_spi_priv_s *priv = (FAR struct esp32c3_spi_priv_s *)dev;
+  struct esp32c3_spi_priv_s *priv = (struct esp32c3_spi_priv_s *)dev;
 
 #ifdef CONFIG_ESP32C3_SPI2_DMA
   size_t thld = CONFIG_ESP32C3_SPI2_DMATHRESHOLD;
@@ -1094,8 +1094,8 @@ static void esp32c3_spi_exchange(FAR struct spi_dev_s *dev,
  *
  ****************************************************************************/
 
-static void esp32c3_spi_sndblock(FAR struct spi_dev_s *dev,
-                                 FAR const void *txbuffer,
+static void esp32c3_spi_sndblock(struct spi_dev_s *dev,
+                                 const void *txbuffer,
                                  size_t nwords)
 {
   spiinfo("txbuffer=%p nwords=%d\n", txbuffer, nwords);
@@ -1123,8 +1123,8 @@ static void esp32c3_spi_sndblock(FAR struct spi_dev_s *dev,
  *
  ****************************************************************************/
 
-static void esp32c3_spi_recvblock(FAR struct spi_dev_s *dev,
-                                  FAR void *rxbuffer,
+static void esp32c3_spi_recvblock(struct spi_dev_s *dev,
+                                  void *rxbuffer,
                                   size_t nwords)
 {
   spiinfo("rxbuffer=%p nwords=%d\n", rxbuffer, nwords);
@@ -1150,7 +1150,7 @@ static void esp32c3_spi_recvblock(FAR struct spi_dev_s *dev,
  ****************************************************************************/
 
 #ifdef CONFIG_SPI_TRIGGER
-static int esp32c3_spi_trigger(FAR struct spi_dev_s *dev)
+static int esp32c3_spi_trigger(struct spi_dev_s *dev)
 {
   return -ENOSYS;
 }
@@ -1171,9 +1171,9 @@ static int esp32c3_spi_trigger(FAR struct spi_dev_s *dev)
  ****************************************************************************/
 
 #ifdef CONFIG_ESP32C3_SPI2_DMA
-void esp32c3_spi_dma_init(FAR struct spi_dev_s *dev)
+void esp32c3_spi_dma_init(struct spi_dev_s *dev)
 {
-  FAR struct esp32c3_spi_priv_s *priv = (FAR struct esp32c3_spi_priv_s *)dev;
+  struct esp32c3_spi_priv_s *priv = (struct esp32c3_spi_priv_s *)dev;
 
   /* Enable GDMA clock for the SPI peripheral */
 
@@ -1219,9 +1219,9 @@ void esp32c3_spi_dma_init(FAR struct spi_dev_s *dev)
  *
  ****************************************************************************/
 
-static void esp32c3_spi_init(FAR struct spi_dev_s *dev)
+static void esp32c3_spi_init(struct spi_dev_s *dev)
 {
-  FAR struct esp32c3_spi_priv_s *priv = (FAR struct esp32c3_spi_priv_s *)dev;
+  struct esp32c3_spi_priv_s *priv = (struct esp32c3_spi_priv_s *)dev;
   const struct esp32c3_spi_config_s *config = priv->config;
   uint32_t regval;
 
@@ -1312,9 +1312,9 @@ static void esp32c3_spi_init(FAR struct spi_dev_s *dev)
  *
  ****************************************************************************/
 
-static void esp32c3_spi_deinit(FAR struct spi_dev_s *dev)
+static void esp32c3_spi_deinit(struct spi_dev_s *dev)
 {
-  FAR struct esp32c3_spi_priv_s *priv = (FAR struct esp32c3_spi_priv_s *)dev;
+  struct esp32c3_spi_priv_s *priv = (struct esp32c3_spi_priv_s *)dev;
 
 #ifdef CONFIG_ESP32C3_SPI2_DMA
   modifyreg32(SYSTEM_PERIP_CLK_EN0_REG, priv->config->dma_clk_bit, 0);
@@ -1346,9 +1346,9 @@ static void esp32c3_spi_deinit(FAR struct spi_dev_s *dev)
  ****************************************************************************/
 
 #ifdef CONFIG_ESP32C3_SPI2_DMA
-static int esp32c3_spi_interrupt(int irq, void *context, FAR void *arg)
+static int esp32c3_spi_interrupt(int irq, void *context, void *arg)
 {
-  FAR struct esp32c3_spi_priv_s *priv = (FAR struct esp32c3_spi_priv_s *)arg;
+  struct esp32c3_spi_priv_s *priv = (struct esp32c3_spi_priv_s *)arg;
 
   esp32c3_spi_clr_regbits(SPI_DMA_INT_RAW_REG, SPI_TRANS_DONE_INT_RAW_M);
   nxsem_post(&priv->sem_isr);
@@ -1371,10 +1371,10 @@ static int esp32c3_spi_interrupt(int irq, void *context, FAR void *arg)
  *
  ****************************************************************************/
 
-FAR struct spi_dev_s *esp32c3_spibus_initialize(int port)
+struct spi_dev_s *esp32c3_spibus_initialize(int port)
 {
-  FAR struct spi_dev_s *spi_dev;
-  FAR struct esp32c3_spi_priv_s *priv;
+  struct spi_dev_s *spi_dev;
+  struct esp32c3_spi_priv_s *priv;
   irqstate_t flags;
 
   switch (port)
@@ -1388,7 +1388,7 @@ FAR struct spi_dev_s *esp32c3_spibus_initialize(int port)
         return NULL;
     }
 
-  spi_dev = (FAR struct spi_dev_s *)priv;
+  spi_dev = (struct spi_dev_s *)priv;
 
   flags = enter_critical_section();
 
@@ -1458,10 +1458,10 @@ FAR struct spi_dev_s *esp32c3_spibus_initialize(int port)
  *
  ****************************************************************************/
 
-int esp32c3_spibus_uninitialize(FAR struct spi_dev_s *dev)
+int esp32c3_spibus_uninitialize(struct spi_dev_s *dev)
 {
   irqstate_t flags;
-  FAR struct esp32c3_spi_priv_s *priv = (FAR struct esp32c3_spi_priv_s *)dev;
+  struct esp32c3_spi_priv_s *priv = (struct esp32c3_spi_priv_s *)dev;
 
   DEBUGASSERT(dev);
 

--- a/arch/risc-v/src/esp32c3/esp32c3_spi.h
+++ b/arch/risc-v/src/esp32c3/esp32c3_spi.h
@@ -68,7 +68,7 @@ extern "C"
  *
  ****************************************************************************/
 
-FAR struct spi_dev_s *esp32c3_spibus_initialize(int port);
+struct spi_dev_s *esp32c3_spibus_initialize(int port);
 
 /****************************************************************************
  * Name:  esp32c3_spi[0|1]_select and esp32c3_spi[0|1]_status
@@ -102,10 +102,10 @@ FAR struct spi_dev_s *esp32c3_spibus_initialize(int port);
  ****************************************************************************/
 
 #ifdef CONFIG_ESP32C3_SPI2
-void esp32c3_spi2_select(FAR struct spi_dev_s *dev, uint32_t devid,
+void esp32c3_spi2_select(struct spi_dev_s *dev, uint32_t devid,
                          bool selected);
-uint8_t esp32c3_spi2_status(FAR struct spi_dev_s *dev, uint32_t devid);
-int esp32c3_spi2_cmddata(FAR struct spi_dev_s *dev,
+uint8_t esp32c3_spi2_status(struct spi_dev_s *dev, uint32_t devid);
+int esp32c3_spi2_cmddata(struct spi_dev_s *dev,
                          uint32_t devid,
                          bool cmd);
 #endif
@@ -124,7 +124,7 @@ int esp32c3_spi2_cmddata(FAR struct spi_dev_s *dev,
  *
  ****************************************************************************/
 
-int esp32c3_spibus_uninitialize(FAR struct spi_dev_s *dev);
+int esp32c3_spibus_uninitialize(struct spi_dev_s *dev);
 
 /****************************************************************************
  * Name: esp32c3_spislave_ctrlr_initialize
@@ -141,7 +141,7 @@ int esp32c3_spibus_uninitialize(FAR struct spi_dev_s *dev);
  *
  ****************************************************************************/
 
-FAR struct spi_slave_ctrlr_s *esp32c3_spislave_ctrlr_initialize(int port);
+struct spi_slave_ctrlr_s *esp32c3_spislave_ctrlr_initialize(int port);
 
 /****************************************************************************
  * Name: esp32c3_spislave_ctrlr_uninitialize
@@ -157,7 +157,7 @@ FAR struct spi_slave_ctrlr_s *esp32c3_spislave_ctrlr_initialize(int port);
  *
  ****************************************************************************/
 
-int esp32c3_spislave_ctrlr_uninitialize(FAR struct spi_slave_ctrlr_s *ctrlr);
+int esp32c3_spislave_ctrlr_uninitialize(struct spi_slave_ctrlr_s *ctrlr);
 
 #endif /* CONFIG_ESP32C3_SPI */
 

--- a/arch/risc-v/src/esp32c3/esp32c3_spi_slave.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_spi_slave.c
@@ -189,42 +189,42 @@ struct spislave_priv_s
 
 /* SPI Slave controller interrupt handlers */
 
-static int spislave_cs_interrupt(int irq, void *context, FAR void *arg);
-static int spislave_periph_interrupt(int irq, void *context, FAR void *arg);
+static int spislave_cs_interrupt(int irq, void *context, void *arg);
+static int spislave_periph_interrupt(int irq, void *context, void *arg);
 
 /* SPI Slave controller internal functions */
 
-static void spislave_setmode(FAR struct spi_slave_ctrlr_s *ctrlr,
+static void spislave_setmode(struct spi_slave_ctrlr_s *ctrlr,
                              enum spi_slave_mode_e mode);
-static void spislave_setbits(FAR struct spi_slave_ctrlr_s *ctrlr, int nbits);
-static void spislave_store_result(FAR struct spislave_priv_s *priv,
+static void spislave_setbits(struct spi_slave_ctrlr_s *ctrlr, int nbits);
+static void spislave_store_result(struct spislave_priv_s *priv,
                                   uint32_t recv_bytes);
-static void spislave_prepare_next_rx(FAR struct spislave_priv_s *priv);
-static void spislave_evict_sent_data(FAR struct spislave_priv_s *priv,
+static void spislave_prepare_next_rx(struct spislave_priv_s *priv);
+static void spislave_evict_sent_data(struct spislave_priv_s *priv,
                                      uint32_t sent_bytes);
 #ifdef CONFIG_ESP32C3_SPI2_DMA
-static void spislave_setup_rx_dma(FAR struct spislave_priv_s *priv);
-static void spislave_setup_tx_dma(FAR struct spislave_priv_s *priv);
-static void spislave_prepare_next_tx(FAR struct spislave_priv_s *priv);
+static void spislave_setup_rx_dma(struct spislave_priv_s *priv);
+static void spislave_setup_tx_dma(struct spislave_priv_s *priv);
+static void spislave_prepare_next_tx(struct spislave_priv_s *priv);
 #else
-static void spislave_write_tx_buffer(FAR struct spislave_priv_s *priv);
+static void spislave_write_tx_buffer(struct spislave_priv_s *priv);
 #endif
-static void spislave_initialize(FAR struct spi_slave_ctrlr_s *ctrlr);
-static void spislave_deinitialize(FAR struct spi_slave_ctrlr_s *ctrlr);
+static void spislave_initialize(struct spi_slave_ctrlr_s *ctrlr);
+static void spislave_deinitialize(struct spi_slave_ctrlr_s *ctrlr);
 
 /* SPI Slave controller operations */
 
-static void spislave_bind(FAR struct spi_slave_ctrlr_s *ctrlr,
-                          FAR struct spi_slave_dev_s *dev,
+static void spislave_bind(struct spi_slave_ctrlr_s *ctrlr,
+                          struct spi_slave_dev_s *dev,
                           enum spi_slave_mode_e mode,
                           int nbits);
-static void spislave_unbind(FAR struct spi_slave_ctrlr_s *ctrlr);
-static int spislave_enqueue(FAR struct spi_slave_ctrlr_s *ctrlr,
-                            FAR const void *data,
+static void spislave_unbind(struct spi_slave_ctrlr_s *ctrlr);
+static int spislave_enqueue(struct spi_slave_ctrlr_s *ctrlr,
+                            const void *data,
                             size_t nwords);
-static bool spislave_qfull(FAR struct spi_slave_ctrlr_s *ctrlr);
-static void spislave_qflush(FAR struct spi_slave_ctrlr_s *ctrlr);
-static size_t spislave_qpoll(FAR struct spi_slave_ctrlr_s *ctrlr);
+static bool spislave_qfull(struct spi_slave_ctrlr_s *ctrlr);
+static void spislave_qflush(struct spi_slave_ctrlr_s *ctrlr);
+static size_t spislave_qpoll(struct spi_slave_ctrlr_s *ctrlr);
 
 /****************************************************************************
  * Private Data
@@ -414,10 +414,10 @@ static inline void spislave_dma_rx_fifo_reset(void)
  *
  ****************************************************************************/
 
-static void spislave_setmode(FAR struct spi_slave_ctrlr_s *ctrlr,
+static void spislave_setmode(struct spi_slave_ctrlr_s *ctrlr,
                              enum spi_slave_mode_e mode)
 {
-  FAR struct spislave_priv_s *priv = (FAR struct spislave_priv_s *)ctrlr;
+  struct spislave_priv_s *priv = (struct spislave_priv_s *)ctrlr;
 
   spiinfo("mode=%d\n", mode);
 
@@ -498,9 +498,9 @@ static void spislave_setmode(FAR struct spi_slave_ctrlr_s *ctrlr,
  *
  ****************************************************************************/
 
-static void spislave_setbits(FAR struct spi_slave_ctrlr_s *ctrlr, int nbits)
+static void spislave_setbits(struct spi_slave_ctrlr_s *ctrlr, int nbits)
 {
-  FAR struct spislave_priv_s *priv = (FAR struct spislave_priv_s *)ctrlr;
+  struct spislave_priv_s *priv = (struct spislave_priv_s *)ctrlr;
 
   spiinfo("nbits=%d\n", nbits);
 
@@ -524,9 +524,9 @@ static void spislave_setbits(FAR struct spi_slave_ctrlr_s *ctrlr, int nbits)
  *
  ****************************************************************************/
 
-static int spislave_cs_interrupt(int irq, void *context, FAR void *arg)
+static int spislave_cs_interrupt(int irq, void *context, void *arg)
 {
-  FAR struct spislave_priv_s *priv = (FAR struct spislave_priv_s *)arg;
+  struct spislave_priv_s *priv = (struct spislave_priv_s *)arg;
 
   if (priv->is_processing)
     {
@@ -553,7 +553,7 @@ static int spislave_cs_interrupt(int irq, void *context, FAR void *arg)
  *
  ****************************************************************************/
 
-static void spislave_store_result(FAR struct spislave_priv_s *priv,
+static void spislave_store_result(struct spislave_priv_s *priv,
                                   uint32_t recv_bytes)
 {
   uint32_t remaining_space = SPI_SLAVE_BUFSIZE - priv->rx_length;
@@ -624,7 +624,7 @@ static void spislave_store_result(FAR struct spislave_priv_s *priv,
  *
  ****************************************************************************/
 
-static void spislave_prepare_next_rx(FAR struct spislave_priv_s *priv)
+static void spislave_prepare_next_rx(struct spislave_priv_s *priv)
 {
   if (priv->rx_length < SPI_SLAVE_BUFSIZE)
     {
@@ -650,7 +650,7 @@ static void spislave_prepare_next_rx(FAR struct spislave_priv_s *priv)
  *
  ****************************************************************************/
 
-static void spislave_evict_sent_data(FAR struct spislave_priv_s *priv,
+static void spislave_evict_sent_data(struct spislave_priv_s *priv,
                                      uint32_t sent_bytes)
 {
   if (sent_bytes < priv->tx_length)
@@ -683,7 +683,7 @@ static void spislave_evict_sent_data(FAR struct spislave_priv_s *priv,
  ****************************************************************************/
 
 #ifndef CONFIG_ESP32C3_SPI2_DMA
-static void spislave_write_tx_buffer(FAR struct spislave_priv_s *priv)
+static void spislave_write_tx_buffer(struct spislave_priv_s *priv)
 {
   /* Initialize data_buf_reg with the address of the first data buffer
    * register (W0).
@@ -728,7 +728,7 @@ static void spislave_write_tx_buffer(FAR struct spislave_priv_s *priv)
  ****************************************************************************/
 
 #ifdef CONFIG_ESP32C3_SPI2_DMA
-static void spislave_setup_rx_dma(FAR struct spislave_priv_s *priv)
+static void spislave_setup_rx_dma(struct spislave_priv_s *priv)
 {
   uint32_t length = SPI_SLAVE_BUFSIZE - priv->rx_length;
 
@@ -767,7 +767,7 @@ static void spislave_setup_rx_dma(FAR struct spislave_priv_s *priv)
  ****************************************************************************/
 
 #ifdef CONFIG_ESP32C3_SPI2_DMA
-static void spislave_setup_tx_dma(FAR struct spislave_priv_s *priv)
+static void spislave_setup_tx_dma(struct spislave_priv_s *priv)
 {
   esp32c3_dma_setup(priv->dma_channel, true, dma_txdesc, SPI_DMA_DESC_NUM,
                     priv->tx_buffer, SPI_SLAVE_BUFSIZE);
@@ -803,7 +803,7 @@ static void spislave_setup_tx_dma(FAR struct spislave_priv_s *priv)
  *
  ****************************************************************************/
 
-static void spislave_prepare_next_tx(FAR struct spislave_priv_s *priv)
+static void spislave_prepare_next_tx(struct spislave_priv_s *priv)
 {
   if (priv->tx_length != 0)
     {
@@ -848,9 +848,9 @@ static void spislave_prepare_next_tx(FAR struct spislave_priv_s *priv)
  *
  ****************************************************************************/
 
-static int spislave_periph_interrupt(int irq, void *context, FAR void *arg)
+static int spislave_periph_interrupt(int irq, void *context, void *arg)
 {
-  FAR struct spislave_priv_s *priv = (FAR struct spislave_priv_s *)arg;
+  struct spislave_priv_s *priv = (struct spislave_priv_s *)arg;
 
   uint32_t regval = getreg32(SPI_SLAVE1_REG);
   uint32_t transfer_size = REG_MASK(regval, SPI_SLV_DATA_BITLEN) / 8;
@@ -911,7 +911,7 @@ static int spislave_periph_interrupt(int irq, void *context, FAR void *arg)
  ****************************************************************************/
 
 #ifdef CONFIG_ESP32C3_SPI2_DMA
-void spislave_dma_init(FAR struct spislave_priv_s *priv)
+void spislave_dma_init(struct spislave_priv_s *priv)
 {
   /* Enable GDMA clock for the SPI peripheral */
 
@@ -960,9 +960,9 @@ void spislave_dma_init(FAR struct spislave_priv_s *priv)
  *
  ****************************************************************************/
 
-static void spislave_initialize(FAR struct spi_slave_ctrlr_s *ctrlr)
+static void spislave_initialize(struct spi_slave_ctrlr_s *ctrlr)
 {
-  FAR struct spislave_priv_s *priv = (FAR struct spislave_priv_s *)ctrlr;
+  struct spislave_priv_s *priv = (struct spislave_priv_s *)ctrlr;
   const struct spislave_config_s *config = priv->config;
 
   spiinfo("ctrlr=%p\n", ctrlr);
@@ -1052,9 +1052,9 @@ static void spislave_initialize(FAR struct spi_slave_ctrlr_s *ctrlr)
  *
  ****************************************************************************/
 
-static void spislave_deinitialize(FAR struct spi_slave_ctrlr_s *ctrlr)
+static void spislave_deinitialize(struct spi_slave_ctrlr_s *ctrlr)
 {
-  FAR struct spislave_priv_s *priv = (FAR struct spislave_priv_s *)ctrlr;
+  struct spislave_priv_s *priv = (struct spislave_priv_s *)ctrlr;
 
   esp32c3_gpioirqdisable(ESP32C3_PIN2IRQ(priv->config->cs_pin));
 
@@ -1103,13 +1103,13 @@ static void spislave_deinitialize(FAR struct spi_slave_ctrlr_s *ctrlr)
  *
  ****************************************************************************/
 
-static void spislave_bind(FAR struct spi_slave_ctrlr_s *ctrlr,
-                          FAR struct spi_slave_dev_s *dev,
+static void spislave_bind(struct spi_slave_ctrlr_s *ctrlr,
+                          struct spi_slave_dev_s *dev,
                           enum spi_slave_mode_e mode,
                           int nbits)
 {
-  FAR struct spislave_priv_s *priv = (FAR struct spislave_priv_s *)ctrlr;
-  FAR const void *data = NULL;
+  struct spislave_priv_s *priv = (struct spislave_priv_s *)ctrlr;
+  const void *data = NULL;
   irqstate_t flags;
   size_t num_words;
 
@@ -1169,9 +1169,9 @@ static void spislave_bind(FAR struct spi_slave_ctrlr_s *ctrlr,
  *
  ****************************************************************************/
 
-static void spislave_unbind(FAR struct spi_slave_ctrlr_s *ctrlr)
+static void spislave_unbind(struct spi_slave_ctrlr_s *ctrlr)
 {
-  FAR struct spislave_priv_s *priv = (FAR struct spislave_priv_s *)ctrlr;
+  struct spislave_priv_s *priv = (struct spislave_priv_s *)ctrlr;
   irqstate_t flags;
 
   DEBUGASSERT(priv != NULL);
@@ -1225,11 +1225,11 @@ static void spislave_unbind(FAR struct spi_slave_ctrlr_s *ctrlr)
  *
  ****************************************************************************/
 
-static int spislave_enqueue(FAR struct spi_slave_ctrlr_s *ctrlr,
-                            FAR const void *data,
+static int spislave_enqueue(struct spi_slave_ctrlr_s *ctrlr,
+                            const void *data,
                             size_t len)
 {
-  FAR struct spislave_priv_s *priv = (FAR struct spislave_priv_s *)ctrlr;
+  struct spislave_priv_s *priv = (struct spislave_priv_s *)ctrlr;
   size_t num_bytes = WORDS2BYTES(priv, len);
   size_t bufsize;
   irqstate_t flags;
@@ -1280,9 +1280,9 @@ static int spislave_enqueue(FAR struct spi_slave_ctrlr_s *ctrlr,
  *
  ****************************************************************************/
 
-static bool spislave_qfull(FAR struct spi_slave_ctrlr_s *ctrlr)
+static bool spislave_qfull(struct spi_slave_ctrlr_s *ctrlr)
 {
-  FAR struct spislave_priv_s *priv = (FAR struct spislave_priv_s *)ctrlr;
+  struct spislave_priv_s *priv = (struct spislave_priv_s *)ctrlr;
   irqstate_t flags;
   bool is_full = false;
 
@@ -1314,9 +1314,9 @@ static bool spislave_qfull(FAR struct spi_slave_ctrlr_s *ctrlr)
  *
  ****************************************************************************/
 
-static void spislave_qflush(FAR struct spi_slave_ctrlr_s *ctrlr)
+static void spislave_qflush(struct spi_slave_ctrlr_s *ctrlr)
 {
-  FAR struct spislave_priv_s *priv = (FAR struct spislave_priv_s *)ctrlr;
+  struct spislave_priv_s *priv = (struct spislave_priv_s *)ctrlr;
   irqstate_t flags;
 
   DEBUGASSERT(priv != NULL);
@@ -1345,9 +1345,9 @@ static void spislave_qflush(FAR struct spi_slave_ctrlr_s *ctrlr)
  *
  ****************************************************************************/
 
-static size_t spislave_qpoll(FAR struct spi_slave_ctrlr_s *ctrlr)
+static size_t spislave_qpoll(struct spi_slave_ctrlr_s *ctrlr)
 {
-  FAR struct spislave_priv_s *priv = (FAR struct spislave_priv_s *)ctrlr;
+  struct spislave_priv_s *priv = (struct spislave_priv_s *)ctrlr;
   irqstate_t flags;
   uint32_t tmp;
   uint32_t recv_n;
@@ -1399,10 +1399,10 @@ static size_t spislave_qpoll(FAR struct spi_slave_ctrlr_s *ctrlr)
  *
  ****************************************************************************/
 
-FAR struct spi_slave_ctrlr_s *esp32c3_spislave_ctrlr_initialize(int port)
+struct spi_slave_ctrlr_s *esp32c3_spislave_ctrlr_initialize(int port)
 {
-  FAR struct spi_slave_ctrlr_s *spislave_dev;
-  FAR struct spislave_priv_s *priv;
+  struct spi_slave_ctrlr_s *spislave_dev;
+  struct spislave_priv_s *priv;
   irqstate_t flags;
 
   switch (port)
@@ -1416,7 +1416,7 @@ FAR struct spi_slave_ctrlr_s *esp32c3_spislave_ctrlr_initialize(int port)
         return NULL;
     }
 
-  spislave_dev = (FAR struct spi_slave_ctrlr_s *)priv;
+  spislave_dev = (struct spi_slave_ctrlr_s *)priv;
 
   flags = enter_critical_section();
 
@@ -1484,9 +1484,9 @@ FAR struct spi_slave_ctrlr_s *esp32c3_spislave_ctrlr_initialize(int port)
  *
  ****************************************************************************/
 
-int esp32c3_spislave_ctrlr_uninitialize(FAR struct spi_slave_ctrlr_s *ctrlr)
+int esp32c3_spislave_ctrlr_uninitialize(struct spi_slave_ctrlr_s *ctrlr)
 {
-  FAR struct spislave_priv_s *priv = (FAR struct spislave_priv_s *)ctrlr;
+  struct spislave_priv_s *priv = (struct spislave_priv_s *)ctrlr;
   irqstate_t flags;
 
   DEBUGASSERT(ctrlr != NULL);

--- a/arch/risc-v/src/esp32c3/esp32c3_spiflash.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_spiflash.c
@@ -78,7 +78,7 @@
 #define SPI_FLASH_ERASED_STATE      (0xff)
 #define SPI_FLASH_SIZE              (4 * 1024 * 1024)
 
-#define MTD2PRIV(_dev)              ((FAR struct esp32c3_spiflash_s *)_dev)
+#define MTD2PRIV(_dev)              ((struct esp32c3_spiflash_s *)_dev)
 #define MTD_SIZE(_priv)             ((*(_priv)->data)->chip.chip_size)
 #define MTD_BLKSIZE(_priv)          ((*(_priv)->data)->chip.page_size)
 #define MTD_ERASESIZE(_priv)        ((*(_priv)->data)->chip.sector_size)
@@ -923,12 +923,12 @@ static int esp32c3_ioctl(struct mtd_dev_s *dev, int cmd,
  *
  ****************************************************************************/
 
-FAR struct mtd_dev_s *esp32c3_spiflash_alloc_mtdpart(uint32_t mtd_offset,
+struct mtd_dev_s *esp32c3_spiflash_alloc_mtdpart(uint32_t mtd_offset,
                                                      uint32_t mtd_size)
 {
   struct esp32c3_spiflash_s *priv = &g_esp32c3_spiflash;
   const esp32c3_spiflash_chip_t *chip = &(*priv->data)->chip;
-  FAR struct mtd_dev_s *mtd_part;
+  struct mtd_dev_s *mtd_part;
   uint32_t blocks;
   uint32_t startblock;
   uint32_t size;

--- a/arch/risc-v/src/esp32c3/esp32c3_spiflash.h
+++ b/arch/risc-v/src/esp32c3/esp32c3_spiflash.h
@@ -77,7 +77,7 @@ struct mtd_dev_s *esp32c3_spiflash_mtd(void);
  *
  ****************************************************************************/
 
-FAR struct mtd_dev_s *esp32c3_spiflash_alloc_mtdpart(uint32_t mtd_offset,
+struct mtd_dev_s *esp32c3_spiflash_alloc_mtdpart(uint32_t mtd_offset,
                                                      uint32_t mtd_size);
 
 /****************************************************************************

--- a/arch/risc-v/src/esp32c3/esp32c3_textheap.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_textheap.c
@@ -57,9 +57,9 @@
  *
  ****************************************************************************/
 
-FAR void *up_textheap_memalign(size_t align, size_t size)
+void *up_textheap_memalign(size_t align, size_t size)
 {
-  FAR void *ret = NULL;
+  void *ret = NULL;
 
   /* Prioritise allocating from RTC. If that fails, allocate from the
    * main heap.
@@ -93,7 +93,7 @@ FAR void *up_textheap_memalign(size_t align, size_t size)
  *
  ****************************************************************************/
 
-void up_textheap_free(FAR void *p)
+void up_textheap_free(void *p)
 {
   if (p)
     {

--- a/arch/risc-v/src/esp32c3/esp32c3_tickless.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_tickless.c
@@ -27,10 +27,10 @@
  *
  *   void up_timer_initialize(void): Initializes the timer facilities.
  *     Called early in the initialization sequence (by up_initialize()).
- *   int up_timer_gettime(FAR struct timespec *ts):  Returns the current
+ *   int up_timer_gettime(struct timespec *ts):  Returns the current
  *     time from the platform specific time source.
  *   int up_timer_cancel(void):  Cancels the interval timer.
- *   int up_timer_start(FAR const struct timespec *ts): Start (or re-starts)
+ *   int up_timer_start(const struct timespec *ts): Start (or re-starts)
  *     the interval timer.
  *
  * The RTOS will provide the following interfaces for use by the platform-
@@ -112,7 +112,7 @@ static inline uint64_t up_tmr_getcounter(void);
 static inline uint64_t up_tmr_getalarmvalue(void);
 static inline void up_tmr_counter_advance(uint64_t tick);
 static void IRAM_ATTR up_tmr_setcounter(uint64_t ticks);
-static void IRAM_ATTR up_timer_expire(int irq, void *regs, FAR void *arg);
+static void IRAM_ATTR up_timer_expire(int irq, void *regs, void *arg);
 
 /****************************************************************************
  * Private Data
@@ -275,7 +275,7 @@ static void IRAM_ATTR up_tmr_setcounter(uint64_t ticks)
  *
  ****************************************************************************/
 
-static void IRAM_ATTR up_timer_expire(int irq, void *regs, FAR void *arg)
+static void IRAM_ATTR up_timer_expire(int irq, void *regs, void *arg)
 {
   g_timer_started = false;
   setbits(SYS_TIMER_TARGET0_INT_CLR, SYS_TIMER_SYSTIMER_INT_CLR_REG);
@@ -294,7 +294,7 @@ static void IRAM_ATTR up_timer_expire(int irq, void *regs, FAR void *arg)
  *   up_timer_initialize() was called).  This function is functionally
  *   equivalent to:
  *
- *      int clock_gettime(clockid_t clockid, FAR struct timespec *ts);
+ *      int clock_gettime(clockid_t clockid, struct timespec *ts);
  *
  *   when clockid is CLOCK_MONOTONIC.
  *
@@ -319,7 +319,7 @@ static void IRAM_ATTR up_timer_expire(int irq, void *regs, FAR void *arg)
  *
  ****************************************************************************/
 
-int IRAM_ATTR up_timer_gettime(FAR struct timespec *ts)
+int IRAM_ATTR up_timer_gettime(struct timespec *ts)
 {
   uint64_t ticks;
   irqstate_t flags;
@@ -371,7 +371,7 @@ int IRAM_ATTR up_timer_gettime(FAR struct timespec *ts)
  *
  ****************************************************************************/
 
-int IRAM_ATTR up_timer_cancel(FAR struct timespec *ts)
+int IRAM_ATTR up_timer_cancel(struct timespec *ts)
 {
   uint64_t alarm_value;
   uint64_t counter;
@@ -439,7 +439,7 @@ int IRAM_ATTR up_timer_cancel(FAR struct timespec *ts)
  *
  ****************************************************************************/
 
-int IRAM_ATTR up_timer_start(FAR const struct timespec *ts)
+int IRAM_ATTR up_timer_start(const struct timespec *ts)
 {
   uint64_t cpu_ticks;
   irqstate_t flags;

--- a/arch/risc-v/src/esp32c3/esp32c3_tim.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_tim.c
@@ -45,7 +45,7 @@
 
 struct esp32c3_tim_priv_s
 {
-  FAR struct esp32c3_tim_ops_s *ops;
+  struct esp32c3_tim_ops_s *ops;
   uint8_t                       id;      /* Timer instance */
   uint8_t                       periph;  /* Peripheral ID */
   uint8_t                       irq;     /* Interrupt ID */
@@ -59,34 +59,34 @@ struct esp32c3_tim_priv_s
 
 /* TIM operations ***********************************************************/
 
-static void esp32c3_tim_start(FAR struct esp32c3_tim_dev_s *dev);
-static void esp32c3_tim_stop(FAR struct esp32c3_tim_dev_s *dev);
-static void esp32c3_tim_clear(FAR struct esp32c3_tim_dev_s *dev);
-static void esp32c3_tim_setmode(FAR struct esp32c3_tim_dev_s *dev,
+static void esp32c3_tim_start(struct esp32c3_tim_dev_s *dev);
+static void esp32c3_tim_stop(struct esp32c3_tim_dev_s *dev);
+static void esp32c3_tim_clear(struct esp32c3_tim_dev_s *dev);
+static void esp32c3_tim_setmode(struct esp32c3_tim_dev_s *dev,
                                 enum esp32c3_tim_mode_e mode);
-static void esp32c3_tim_setclksrc(FAR struct esp32c3_tim_dev_s *dev,
+static void esp32c3_tim_setclksrc(struct esp32c3_tim_dev_s *dev,
                                   enum esp32c3_tim_clksrc_e src);
-static void esp32c3_tim_setpre(FAR struct esp32c3_tim_dev_s *dev,
+static void esp32c3_tim_setpre(struct esp32c3_tim_dev_s *dev,
                                uint16_t pre);
-static void esp32c3_tim_getcounter(FAR struct esp32c3_tim_dev_s *dev,
+static void esp32c3_tim_getcounter(struct esp32c3_tim_dev_s *dev,
                                    uint64_t *value);
-static void esp32c3_tim_setcounter(FAR struct esp32c3_tim_dev_s *dev,
+static void esp32c3_tim_setcounter(struct esp32c3_tim_dev_s *dev,
                                    uint64_t value);
-static void esp32c3_tim_reload_now(FAR struct esp32c3_tim_dev_s *dev);
-static void esp32c3_tim_getalarmvalue(FAR struct esp32c3_tim_dev_s *dev,
+static void esp32c3_tim_reload_now(struct esp32c3_tim_dev_s *dev);
+static void esp32c3_tim_getalarmvalue(struct esp32c3_tim_dev_s *dev,
                                       uint64_t *value);
-static void esp32c3_tim_setalarmvalue(FAR struct esp32c3_tim_dev_s *dev,
+static void esp32c3_tim_setalarmvalue(struct esp32c3_tim_dev_s *dev,
                                       uint64_t value);
-static void esp32c3_tim_setalarm(FAR struct esp32c3_tim_dev_s *dev,
+static void esp32c3_tim_setalarm(struct esp32c3_tim_dev_s *dev,
                                  bool enable);
-static void esp32c3_tim_setautoreload(FAR struct esp32c3_tim_dev_s *dev,
+static void esp32c3_tim_setautoreload(struct esp32c3_tim_dev_s *dev,
                                       bool enable);
-static int esp32c3_tim_setisr(FAR struct esp32c3_tim_dev_s *dev,
-                               xcpt_t handler, FAR void * arg);
-static void esp32c3_tim_enableint(FAR struct esp32c3_tim_dev_s *dev);
-static void esp32c3_tim_disableint(FAR struct esp32c3_tim_dev_s *dev);
-static void esp32c3_tim_ackint(FAR struct esp32c3_tim_dev_s *dev);
-static int  esp32c3_tim_checkint(FAR struct esp32c3_tim_dev_s *dev);
+static int esp32c3_tim_setisr(struct esp32c3_tim_dev_s *dev,
+                               xcpt_t handler, void * arg);
+static void esp32c3_tim_enableint(struct esp32c3_tim_dev_s *dev);
+static void esp32c3_tim_disableint(struct esp32c3_tim_dev_s *dev);
+static void esp32c3_tim_ackint(struct esp32c3_tim_dev_s *dev);
+static int  esp32c3_tim_checkint(struct esp32c3_tim_dev_s *dev);
 
 /****************************************************************************
  * Private Data
@@ -195,11 +195,11 @@ struct esp32c3_tim_priv_s g_esp32c3_tim2_priv =
  *
  ****************************************************************************/
 
-static void esp32c3_tim_start(FAR struct esp32c3_tim_dev_s *dev)
+static void esp32c3_tim_start(struct esp32c3_tim_dev_s *dev)
 {
   struct esp32c3_tim_priv_s *priv;
   DEBUGASSERT(dev);
-  priv = (FAR struct esp32c3_tim_priv_s *)dev;
+  priv = (struct esp32c3_tim_priv_s *)dev;
   if (priv->id == ESP32C3_SYSTIM)
     {
       /* Start counter 1 */
@@ -224,11 +224,11 @@ static void esp32c3_tim_start(FAR struct esp32c3_tim_dev_s *dev)
  *
  ****************************************************************************/
 
-static void esp32c3_tim_stop(FAR struct esp32c3_tim_dev_s *dev)
+static void esp32c3_tim_stop(struct esp32c3_tim_dev_s *dev)
 {
   struct esp32c3_tim_priv_s *priv;
   DEBUGASSERT(dev);
-  priv = (FAR struct esp32c3_tim_priv_s *)dev;
+  priv = (struct esp32c3_tim_priv_s *)dev;
   if (priv->id == ESP32C3_SYSTIM)
     {
       /* Stop counter 1 */
@@ -253,7 +253,7 @@ static void esp32c3_tim_stop(FAR struct esp32c3_tim_dev_s *dev)
  *
  ****************************************************************************/
 
-static void esp32c3_tim_clear(FAR struct esp32c3_tim_dev_s *dev)
+static void esp32c3_tim_clear(struct esp32c3_tim_dev_s *dev)
 {
   uint64_t clear_value = 0;
   DEBUGASSERT(dev);
@@ -273,12 +273,12 @@ static void esp32c3_tim_clear(FAR struct esp32c3_tim_dev_s *dev)
  *
  ****************************************************************************/
 
-static void esp32c3_tim_setmode(FAR struct esp32c3_tim_dev_s *dev,
+static void esp32c3_tim_setmode(struct esp32c3_tim_dev_s *dev,
                                enum esp32c3_tim_mode_e mode)
 {
   struct esp32c3_tim_priv_s *priv;
   DEBUGASSERT(dev);
-  priv = (FAR struct esp32c3_tim_priv_s *)dev;
+  priv = (struct esp32c3_tim_priv_s *)dev;
   if (mode == ESP32C3_TIM_MODE_DOWN)
     {
       modifyreg32(TIMG_T0CONFIG_REG(priv->id), TIMG_T0_INCREASE_M, 0);
@@ -301,12 +301,12 @@ static void esp32c3_tim_setmode(FAR struct esp32c3_tim_dev_s *dev,
  *
  ****************************************************************************/
 
-static void esp32c3_tim_setclksrc(FAR struct esp32c3_tim_dev_s *dev,
+static void esp32c3_tim_setclksrc(struct esp32c3_tim_dev_s *dev,
                                  enum esp32c3_tim_clksrc_e src)
 {
   struct esp32c3_tim_priv_s *priv;
   DEBUGASSERT(dev);
-  priv = (FAR struct esp32c3_tim_priv_s *)dev;
+  priv = (struct esp32c3_tim_priv_s *)dev;
   if (src == ESP32C3_TIM_APB_CLK)
     {
       modifyreg32(TIMG_T0CONFIG_REG(priv->id), TIMG_T0_USE_XTAL_M, 0);
@@ -331,13 +331,13 @@ static void esp32c3_tim_setclksrc(FAR struct esp32c3_tim_dev_s *dev,
  *
  ****************************************************************************/
 
-static void esp32c3_tim_setpre(FAR struct esp32c3_tim_dev_s *dev,
+static void esp32c3_tim_setpre(struct esp32c3_tim_dev_s *dev,
                                uint16_t pre)
 {
   uint32_t mask = (uint32_t)pre << TIMG_T0_DIVIDER_S;
   struct esp32c3_tim_priv_s *priv;
   DEBUGASSERT(dev);
-  priv = (FAR struct esp32c3_tim_priv_s *)dev;
+  priv = (struct esp32c3_tim_priv_s *)dev;
   modifyreg32(TIMG_T0CONFIG_REG(priv->id), TIMG_T0_DIVIDER_M, mask);
 }
 
@@ -354,13 +354,13 @@ static void esp32c3_tim_setpre(FAR struct esp32c3_tim_dev_s *dev,
  *
  ****************************************************************************/
 
-static void esp32c3_tim_getcounter(FAR struct esp32c3_tim_dev_s *dev,
+static void esp32c3_tim_getcounter(struct esp32c3_tim_dev_s *dev,
                                 uint64_t *value)
 {
   uint32_t value_32;
   struct esp32c3_tim_priv_s *priv;
   DEBUGASSERT(dev);
-  priv = (FAR struct esp32c3_tim_priv_s *)dev;
+  priv = (struct esp32c3_tim_priv_s *)dev;
   *value = 0;
   if (priv->id == ESP32C3_SYSTIM)
     {
@@ -423,14 +423,14 @@ static void esp32c3_tim_getcounter(FAR struct esp32c3_tim_dev_s *dev,
  *
  ****************************************************************************/
 
-static void esp32c3_tim_setcounter(FAR struct esp32c3_tim_dev_s *dev,
+static void esp32c3_tim_setcounter(struct esp32c3_tim_dev_s *dev,
                                   uint64_t value)
 {
   uint64_t low_64 = value & LOW_32_MASK;
   uint64_t high_64;
   struct esp32c3_tim_priv_s *priv;
   DEBUGASSERT(dev);
-  priv = (FAR struct esp32c3_tim_priv_s *)dev;
+  priv = (struct esp32c3_tim_priv_s *)dev;
 
   if (priv->id == ESP32C3_SYSTIM)
     {
@@ -469,11 +469,11 @@ static void esp32c3_tim_setcounter(FAR struct esp32c3_tim_dev_s *dev,
  *
  ****************************************************************************/
 
-static void esp32c3_tim_reload_now(FAR struct esp32c3_tim_dev_s *dev)
+static void esp32c3_tim_reload_now(struct esp32c3_tim_dev_s *dev)
 {
   struct esp32c3_tim_priv_s *priv;
   DEBUGASSERT(dev);
-  priv = (FAR struct esp32c3_tim_priv_s *)dev;
+  priv = (struct esp32c3_tim_priv_s *)dev;
 
   if (priv->id == ESP32C3_SYSTIM)
     {
@@ -502,13 +502,13 @@ static void esp32c3_tim_reload_now(FAR struct esp32c3_tim_dev_s *dev)
  *
  ****************************************************************************/
 
-static void esp32c3_tim_getalarmvalue(FAR struct esp32c3_tim_dev_s *dev,
+static void esp32c3_tim_getalarmvalue(struct esp32c3_tim_dev_s *dev,
                                    uint64_t *value)
 {
   uint32_t value_32;
   struct esp32c3_tim_priv_s *priv;
   DEBUGASSERT(dev);
-  priv = (FAR struct esp32c3_tim_priv_s *)dev;
+  priv = (struct esp32c3_tim_priv_s *)dev;
   *value = 0;
   if (priv->id == ESP32C3_SYSTIM)
     {
@@ -553,12 +553,12 @@ static void esp32c3_tim_getalarmvalue(FAR struct esp32c3_tim_dev_s *dev,
  *
  ****************************************************************************/
 
-static void esp32c3_tim_setalarmvalue(FAR struct esp32c3_tim_dev_s *dev,
+static void esp32c3_tim_setalarmvalue(struct esp32c3_tim_dev_s *dev,
                                       uint64_t value)
 {
   struct esp32c3_tim_priv_s *priv;
   DEBUGASSERT(dev);
-  priv = (FAR struct esp32c3_tim_priv_s *)dev;
+  priv = (struct esp32c3_tim_priv_s *)dev;
 
   if (priv->id == ESP32C3_SYSTIM)
     {
@@ -600,12 +600,12 @@ static void esp32c3_tim_setalarmvalue(FAR struct esp32c3_tim_dev_s *dev,
  *
  ****************************************************************************/
 
-static void esp32c3_tim_setalarm(FAR struct esp32c3_tim_dev_s *dev,
+static void esp32c3_tim_setalarm(struct esp32c3_tim_dev_s *dev,
                                  bool enable)
 {
   struct esp32c3_tim_priv_s *priv;
   DEBUGASSERT(dev);
-  priv = (FAR struct esp32c3_tim_priv_s *)dev;
+  priv = (struct esp32c3_tim_priv_s *)dev;
 
   if (priv->id == ESP32C3_SYSTIM)
     {
@@ -651,12 +651,12 @@ static void esp32c3_tim_setalarm(FAR struct esp32c3_tim_dev_s *dev,
  *
  ****************************************************************************/
 
-static void esp32c3_tim_setautoreload(FAR struct esp32c3_tim_dev_s *dev,
+static void esp32c3_tim_setautoreload(struct esp32c3_tim_dev_s *dev,
                                    bool enable)
 {
   struct esp32c3_tim_priv_s *priv;
   DEBUGASSERT(dev);
-  priv = (FAR struct esp32c3_tim_priv_s *)dev;
+  priv = (struct esp32c3_tim_priv_s *)dev;
 
   if (enable)
     {
@@ -688,15 +688,15 @@ static void esp32c3_tim_setautoreload(FAR struct esp32c3_tim_dev_s *dev,
  *
  ****************************************************************************/
 
-static int esp32c3_tim_setisr(FAR struct esp32c3_tim_dev_s *dev,
-                               xcpt_t handler, FAR void *arg)
+static int esp32c3_tim_setisr(struct esp32c3_tim_dev_s *dev,
+                               xcpt_t handler, void *arg)
 {
-  FAR struct esp32c3_tim_priv_s *priv = NULL;
+  struct esp32c3_tim_priv_s *priv = NULL;
   int ret = OK;
 
   DEBUGASSERT(dev);
 
-  priv = (FAR struct esp32c3_tim_priv_s *)dev;
+  priv = (struct esp32c3_tim_priv_s *)dev;
 
   /* Disable interrupt when callback is removed. */
 
@@ -777,11 +777,11 @@ errout:
  *
  ****************************************************************************/
 
-static void esp32c3_tim_enableint(FAR struct esp32c3_tim_dev_s *dev)
+static void esp32c3_tim_enableint(struct esp32c3_tim_dev_s *dev)
 {
   struct esp32c3_tim_priv_s *priv;
   DEBUGASSERT(dev);
-  priv = (FAR struct esp32c3_tim_priv_s *)dev;
+  priv = (struct esp32c3_tim_priv_s *)dev;
   if (priv->id == ESP32C3_SYSTIM)
     {
       modifyreg32(SYS_TIMER_SYSTIMER_INT_ENA_REG, 0,
@@ -804,11 +804,11 @@ static void esp32c3_tim_enableint(FAR struct esp32c3_tim_dev_s *dev)
  *
  ****************************************************************************/
 
-static void esp32c3_tim_disableint(FAR struct esp32c3_tim_dev_s *dev)
+static void esp32c3_tim_disableint(struct esp32c3_tim_dev_s *dev)
 {
   struct esp32c3_tim_priv_s *priv;
   DEBUGASSERT(dev);
-  priv = (FAR struct esp32c3_tim_priv_s *)dev;
+  priv = (struct esp32c3_tim_priv_s *)dev;
   if (priv->id == ESP32C3_SYSTIM)
     {
       modifyreg32(SYS_TIMER_SYSTIMER_INT_ENA_REG,
@@ -831,11 +831,11 @@ static void esp32c3_tim_disableint(FAR struct esp32c3_tim_dev_s *dev)
  *
  ****************************************************************************/
 
-static void esp32c3_tim_ackint(FAR struct esp32c3_tim_dev_s *dev)
+static void esp32c3_tim_ackint(struct esp32c3_tim_dev_s *dev)
 {
   struct esp32c3_tim_priv_s *priv;
   DEBUGASSERT(dev);
-  priv = (FAR struct esp32c3_tim_priv_s *)dev;
+  priv = (struct esp32c3_tim_priv_s *)dev;
   if (priv->id == ESP32C3_SYSTIM)
     {
       modifyreg32(SYS_TIMER_SYSTIMER_INT_CLR_REG, 0,
@@ -861,7 +861,7 @@ static void esp32c3_tim_ackint(FAR struct esp32c3_tim_dev_s *dev)
  *
  ****************************************************************************/
 
-static int esp32c3_tim_checkint(FAR struct esp32c3_tim_dev_s *dev)
+static int esp32c3_tim_checkint(struct esp32c3_tim_dev_s *dev)
 {
   struct esp32c3_tim_priv_s *priv = (struct esp32c3_tim_priv_s *)dev;
   uint32_t reg_value;
@@ -905,9 +905,9 @@ static int esp32c3_tim_checkint(FAR struct esp32c3_tim_dev_s *dev)
  *
  ****************************************************************************/
 
-FAR struct esp32c3_tim_dev_s *esp32c3_tim_init(int timer)
+struct esp32c3_tim_dev_s *esp32c3_tim_init(int timer)
 {
-  FAR struct esp32c3_tim_priv_s *tim = NULL;
+  struct esp32c3_tim_priv_s *tim = NULL;
 
   /* First, take the data structure associated with the timer instance */
 
@@ -967,7 +967,7 @@ FAR struct esp32c3_tim_dev_s *esp32c3_tim_init(int timer)
     }
 
   errout:
-  return (FAR struct esp32c3_tim_dev_s *)tim;
+  return (struct esp32c3_tim_dev_s *)tim;
 }
 
 /****************************************************************************
@@ -981,12 +981,12 @@ FAR struct esp32c3_tim_dev_s *esp32c3_tim_init(int timer)
  *
  ****************************************************************************/
 
-void esp32c3_tim_deinit(FAR struct esp32c3_tim_dev_s *dev)
+void esp32c3_tim_deinit(struct esp32c3_tim_dev_s *dev)
 {
-  FAR struct esp32c3_tim_priv_s *tim = NULL;
+  struct esp32c3_tim_priv_s *tim = NULL;
 
   DEBUGASSERT(dev);
 
-  tim = (FAR struct esp32c3_tim_priv_s *)dev;
+  tim = (struct esp32c3_tim_priv_s *)dev;
   tim->inuse = false;
 }

--- a/arch/risc-v/src/esp32c3/esp32c3_tim.h
+++ b/arch/risc-v/src/esp32c3/esp32c3_tim.h
@@ -99,36 +99,36 @@ struct esp32c3_tim_ops_s
 {
   /* Timer tasks */
 
-  CODE void (*start)(struct esp32c3_tim_dev_s *dev);
-  CODE void (*stop)(struct esp32c3_tim_dev_s *dev);
-  CODE void (*clear)(struct esp32c3_tim_dev_s *dev);
+  void (*start)(struct esp32c3_tim_dev_s *dev);
+  void (*stop)(struct esp32c3_tim_dev_s *dev);
+  void (*clear)(struct esp32c3_tim_dev_s *dev);
 
   /* Timer operations */
 
-  CODE void (*setmode)(struct esp32c3_tim_dev_s *dev,
+  void (*setmode)(struct esp32c3_tim_dev_s *dev,
                        enum esp32c3_tim_mode_e mode);
-  CODE void (*setclksrc)(struct esp32c3_tim_dev_s *dev,
+  void (*setclksrc)(struct esp32c3_tim_dev_s *dev,
                          enum esp32c3_tim_clksrc_e src);
-  CODE void (*setpre)(struct esp32c3_tim_dev_s *dev, uint16_t pre);
-  CODE void (*getcounter)(struct esp32c3_tim_dev_s *dev,
+  void (*setpre)(struct esp32c3_tim_dev_s *dev, uint16_t pre);
+  void (*getcounter)(struct esp32c3_tim_dev_s *dev,
                           uint64_t *value);
-  CODE void (*setcounter)(struct esp32c3_tim_dev_s *dev, uint64_t value);
-  CODE void (*reloadnow)(struct esp32c3_tim_dev_s *dev);
-  CODE void (*getalarmvalue)(struct esp32c3_tim_dev_s *dev,
+  void (*setcounter)(struct esp32c3_tim_dev_s *dev, uint64_t value);
+  void (*reloadnow)(struct esp32c3_tim_dev_s *dev);
+  void (*getalarmvalue)(struct esp32c3_tim_dev_s *dev,
                              uint64_t *value);
-  CODE void (*setalarmvalue)(struct esp32c3_tim_dev_s *dev,
+  void (*setalarmvalue)(struct esp32c3_tim_dev_s *dev,
                              uint64_t value);
-  CODE void (*setalarm)(struct esp32c3_tim_dev_s *dev, bool enable);
-  CODE void (*setautoreload)(struct esp32c3_tim_dev_s *dev, bool enable);
+  void (*setalarm)(struct esp32c3_tim_dev_s *dev, bool enable);
+  void (*setautoreload)(struct esp32c3_tim_dev_s *dev, bool enable);
 
   /* Timer interrupts */
 
-  CODE int (*setisr)(struct esp32c3_tim_dev_s *dev, xcpt_t handler,
+  int (*setisr)(struct esp32c3_tim_dev_s *dev, xcpt_t handler,
                      void * arg);
-  CODE void (*enableint)(struct esp32c3_tim_dev_s *dev);
-  CODE void (*disableint)(struct esp32c3_tim_dev_s *dev);
-  CODE void (*ackint)(struct esp32c3_tim_dev_s *dev);
-  CODE int  (*checkint)(struct esp32c3_tim_dev_s *dev);
+  void (*enableint)(struct esp32c3_tim_dev_s *dev);
+  void (*disableint)(struct esp32c3_tim_dev_s *dev);
+  void (*ackint)(struct esp32c3_tim_dev_s *dev);
+  int  (*checkint)(struct esp32c3_tim_dev_s *dev);
 };
 
 /****************************************************************************

--- a/arch/risc-v/src/esp32c3/esp32c3_tim.h
+++ b/arch/risc-v/src/esp32c3/esp32c3_tim.h
@@ -99,43 +99,43 @@ struct esp32c3_tim_ops_s
 {
   /* Timer tasks */
 
-  CODE void (*start)(FAR struct esp32c3_tim_dev_s *dev);
-  CODE void (*stop)(FAR struct esp32c3_tim_dev_s *dev);
-  CODE void (*clear)(FAR struct esp32c3_tim_dev_s *dev);
+  CODE void (*start)(struct esp32c3_tim_dev_s *dev);
+  CODE void (*stop)(struct esp32c3_tim_dev_s *dev);
+  CODE void (*clear)(struct esp32c3_tim_dev_s *dev);
 
   /* Timer operations */
 
-  CODE void (*setmode)(FAR struct esp32c3_tim_dev_s *dev,
+  CODE void (*setmode)(struct esp32c3_tim_dev_s *dev,
                        enum esp32c3_tim_mode_e mode);
-  CODE void (*setclksrc)(FAR struct esp32c3_tim_dev_s *dev,
+  CODE void (*setclksrc)(struct esp32c3_tim_dev_s *dev,
                          enum esp32c3_tim_clksrc_e src);
-  CODE void (*setpre)(FAR struct esp32c3_tim_dev_s *dev, uint16_t pre);
-  CODE void (*getcounter)(FAR struct esp32c3_tim_dev_s *dev,
+  CODE void (*setpre)(struct esp32c3_tim_dev_s *dev, uint16_t pre);
+  CODE void (*getcounter)(struct esp32c3_tim_dev_s *dev,
                           uint64_t *value);
-  CODE void (*setcounter)(FAR struct esp32c3_tim_dev_s *dev, uint64_t value);
-  CODE void (*reloadnow)(FAR struct esp32c3_tim_dev_s *dev);
-  CODE void (*getalarmvalue)(FAR struct esp32c3_tim_dev_s *dev,
+  CODE void (*setcounter)(struct esp32c3_tim_dev_s *dev, uint64_t value);
+  CODE void (*reloadnow)(struct esp32c3_tim_dev_s *dev);
+  CODE void (*getalarmvalue)(struct esp32c3_tim_dev_s *dev,
                              uint64_t *value);
-  CODE void (*setalarmvalue)(FAR struct esp32c3_tim_dev_s *dev,
+  CODE void (*setalarmvalue)(struct esp32c3_tim_dev_s *dev,
                              uint64_t value);
-  CODE void (*setalarm)(FAR struct esp32c3_tim_dev_s *dev, bool enable);
-  CODE void (*setautoreload)(FAR struct esp32c3_tim_dev_s *dev, bool enable);
+  CODE void (*setalarm)(struct esp32c3_tim_dev_s *dev, bool enable);
+  CODE void (*setautoreload)(struct esp32c3_tim_dev_s *dev, bool enable);
 
   /* Timer interrupts */
 
-  CODE int (*setisr)(FAR struct esp32c3_tim_dev_s *dev, xcpt_t handler,
-                     FAR void * arg);
-  CODE void (*enableint)(FAR struct esp32c3_tim_dev_s *dev);
-  CODE void (*disableint)(FAR struct esp32c3_tim_dev_s *dev);
-  CODE void (*ackint)(FAR struct esp32c3_tim_dev_s *dev);
-  CODE int  (*checkint)(FAR struct esp32c3_tim_dev_s *dev);
+  CODE int (*setisr)(struct esp32c3_tim_dev_s *dev, xcpt_t handler,
+                     void * arg);
+  CODE void (*enableint)(struct esp32c3_tim_dev_s *dev);
+  CODE void (*disableint)(struct esp32c3_tim_dev_s *dev);
+  CODE void (*ackint)(struct esp32c3_tim_dev_s *dev);
+  CODE int  (*checkint)(struct esp32c3_tim_dev_s *dev);
 };
 
 /****************************************************************************
  * Public Function Prototypes
  ****************************************************************************/
 
-FAR struct esp32c3_tim_dev_s *esp32c3_tim_init(int timer);
-void esp32c3_tim_deinit(FAR struct esp32c3_tim_dev_s *dev);
+struct esp32c3_tim_dev_s *esp32c3_tim_init(int timer);
+void esp32c3_tim_deinit(struct esp32c3_tim_dev_s *dev);
 
 #endif /* __ARCH_RISCV_SRC_ESP32C3_ESP32C3_TIM_H */

--- a/arch/risc-v/src/esp32c3/esp32c3_tim_lowerhalf.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_tim_lowerhalf.c
@@ -54,12 +54,12 @@
 
 struct esp32c3_timer_lowerhalf_s
 {
-  FAR const struct timer_ops_s *ops;        /* Lower half operations */
-  FAR struct esp32c3_tim_dev_s *tim;        /* esp32c3 timer driver */
-  tccb_t                        callback;   /* Current user interrupt callback */
-  FAR void                     *arg;        /* Argument passed to upper half callback */
-  bool                          started;    /* True: Timer has been started */
-  void *upper;                              /* Pointer to watchdog_upperhalf_s */
+  const struct timer_ops_s *ops;      /* Lower half operations */
+  struct esp32c3_tim_dev_s *tim;      /* esp32c3 timer driver */
+  tccb_t                    callback; /* Current user interrupt callback */
+  void                     *arg;      /* Argument passed to upper half callback */
+  bool                      started;  /* True: Timer has been started */
+  void                     *upper;    /* Pointer to watchdog_upperhalf_s */
 };
 
 /****************************************************************************
@@ -70,16 +70,16 @@ static int esp32c3_timer_handler(int irq, void *context, void *arg);
 
 /* "Lower half" driver methods **********************************************/
 
-static int esp32c3_timer_start(FAR struct timer_lowerhalf_s *lower);
-static int esp32c3_timer_stop(FAR struct timer_lowerhalf_s *lower);
-static int esp32c3_timer_getstatus(FAR struct timer_lowerhalf_s *lower,
-                                   FAR struct timer_status_s *status);
-static int esp32c3_timer_settimeout(FAR struct timer_lowerhalf_s *lower,
+static int esp32c3_timer_start(struct timer_lowerhalf_s *lower);
+static int esp32c3_timer_stop(struct timer_lowerhalf_s *lower);
+static int esp32c3_timer_getstatus(struct timer_lowerhalf_s *lower,
+                                   struct timer_status_s *status);
+static int esp32c3_timer_settimeout(struct timer_lowerhalf_s *lower,
                                     uint32_t timeout);
-static int esp32c3_timer_maxtimeout(FAR struct timer_lowerhalf_s *lower,
+static int esp32c3_timer_maxtimeout(struct timer_lowerhalf_s *lower,
                                     uint32_t *timeout);
-static void esp32c3_timer_setcallback(FAR struct timer_lowerhalf_s *lower,
-                                      tccb_t callback, FAR void *arg);
+static void esp32c3_timer_setcallback(struct timer_lowerhalf_s *lower,
+                                      tccb_t callback, void *arg);
 
 /****************************************************************************
  * Private Data
@@ -130,8 +130,8 @@ static struct esp32c3_timer_lowerhalf_s g_esp32c3_timer1_lowerhalf =
 
 static int esp32c3_timer_handler(int irq, void *context, void *arg)
 {
-  FAR struct esp32c3_timer_lowerhalf_s *priv =
-    (FAR struct esp32c3_timer_lowerhalf_s *)arg;
+  struct esp32c3_timer_lowerhalf_s *priv =
+    (struct esp32c3_timer_lowerhalf_s *)arg;
   uint32_t next_interval_us = 0;
 
   if (priv->callback(&next_interval_us, priv->upper))
@@ -168,10 +168,10 @@ static int esp32c3_timer_handler(int irq, void *context, void *arg)
  *
  ****************************************************************************/
 
-static int esp32c3_timer_start(FAR struct timer_lowerhalf_s *lower)
+static int esp32c3_timer_start(struct timer_lowerhalf_s *lower)
 {
-  FAR struct esp32c3_timer_lowerhalf_s *priv =
-    (FAR struct esp32c3_timer_lowerhalf_s *)lower;
+  struct esp32c3_timer_lowerhalf_s *priv =
+    (struct esp32c3_timer_lowerhalf_s *)lower;
   int ret = OK;
   uint16_t pre;
   irqstate_t flags;
@@ -263,10 +263,10 @@ errout:
  *
  ****************************************************************************/
 
-static int esp32c3_timer_stop(FAR struct timer_lowerhalf_s *lower)
+static int esp32c3_timer_stop(struct timer_lowerhalf_s *lower)
 {
-  FAR struct esp32c3_timer_lowerhalf_s *priv =
-    (FAR struct esp32c3_timer_lowerhalf_s *)lower;
+  struct esp32c3_timer_lowerhalf_s *priv =
+    (struct esp32c3_timer_lowerhalf_s *)lower;
   int ret = OK;
   irqstate_t flags;
 
@@ -309,11 +309,11 @@ errout:
  *
  ****************************************************************************/
 
-static int esp32c3_timer_getstatus(FAR struct timer_lowerhalf_s *lower,
-                                 FAR struct timer_status_s *status)
+static int esp32c3_timer_getstatus(struct timer_lowerhalf_s *lower,
+                                 struct timer_status_s *status)
 {
-  FAR struct esp32c3_timer_lowerhalf_s *priv =
-    (FAR struct esp32c3_timer_lowerhalf_s *)lower;
+  struct esp32c3_timer_lowerhalf_s *priv =
+    (struct esp32c3_timer_lowerhalf_s *)lower;
   int ret = OK;
   uint64_t current_counter_value;
   uint64_t alarm_value;
@@ -371,11 +371,11 @@ static int esp32c3_timer_getstatus(FAR struct timer_lowerhalf_s *lower,
  *
  ****************************************************************************/
 
-static int esp32c3_timer_settimeout(FAR struct timer_lowerhalf_s *lower,
+static int esp32c3_timer_settimeout(struct timer_lowerhalf_s *lower,
                                   uint32_t timeout)
 {
-  FAR struct esp32c3_timer_lowerhalf_s *priv =
-    (FAR struct esp32c3_timer_lowerhalf_s *)lower;
+  struct esp32c3_timer_lowerhalf_s *priv =
+    (struct esp32c3_timer_lowerhalf_s *)lower;
   int ret = OK;
 
   DEBUGASSERT(priv);
@@ -403,7 +403,7 @@ static int esp32c3_timer_settimeout(FAR struct timer_lowerhalf_s *lower,
  *
  ****************************************************************************/
 
-static int esp32c3_timer_maxtimeout(FAR struct timer_lowerhalf_s *lower,
+static int esp32c3_timer_maxtimeout(struct timer_lowerhalf_s *lower,
                                   uint32_t *max_timeout)
 {
   DEBUGASSERT(max_timeout);
@@ -433,11 +433,11 @@ static int esp32c3_timer_maxtimeout(FAR struct timer_lowerhalf_s *lower,
  *
  ****************************************************************************/
 
-static void esp32c3_timer_setcallback(FAR struct timer_lowerhalf_s *lower,
-                                    tccb_t callback, FAR void *arg)
+static void esp32c3_timer_setcallback(struct timer_lowerhalf_s *lower,
+                                    tccb_t callback, void *arg)
 {
-  FAR struct esp32c3_timer_lowerhalf_s *priv =
-    (FAR struct esp32c3_timer_lowerhalf_s *)lower;
+  struct esp32c3_timer_lowerhalf_s *priv =
+    (struct esp32c3_timer_lowerhalf_s *)lower;
   irqstate_t flags;
   int ret = OK;
 
@@ -492,7 +492,7 @@ static void esp32c3_timer_setcallback(FAR struct timer_lowerhalf_s *lower,
  *
  ****************************************************************************/
 
-int esp32c3_timer_initialize(FAR const char *devpath, uint8_t timer)
+int esp32c3_timer_initialize(const char *devpath, uint8_t timer)
 {
   struct esp32c3_timer_lowerhalf_s *lower = NULL;
   int ret = OK;
@@ -542,7 +542,7 @@ int esp32c3_timer_initialize(FAR const char *devpath, uint8_t timer)
    */
 
   lower->upper = timer_register(devpath,
-                                (FAR struct timer_lowerhalf_s *)lower);
+                                (struct timer_lowerhalf_s *)lower);
   if (lower->upper == NULL)
     {
       /* The actual cause of the failure may have been a failure to allocate

--- a/arch/risc-v/src/esp32c3/esp32c3_tim_lowerhalf.h
+++ b/arch/risc-v/src/esp32c3/esp32c3_tim_lowerhalf.h
@@ -35,6 +35,6 @@
  * Name: esp32c3_timer_initialize
  ****************************************************************************/
 
-int esp32c3_timer_initialize(FAR const char *devpath, uint8_t timer);
+int esp32c3_timer_initialize(const char *devpath, uint8_t timer);
 
 #endif /* __ARCH_RISCV_SRC_ESP32C3_ESP32C3_TIM_LOWERHALF_H */

--- a/arch/risc-v/src/esp32c3/esp32c3_timerisr.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_timerisr.c
@@ -51,7 +51,7 @@
  * Name: systimer_isr
  ****************************************************************************/
 
-static int systimer_isr(int irq, FAR void *context, FAR void *arg)
+static int systimer_isr(int irq, void *context, void *arg)
 {
   setbits(SYS_TIMER_TARGET0_INT_CLR, SYS_TIMER_SYSTIMER_INT_CLR_REG);
 

--- a/arch/risc-v/src/esp32c3/esp32c3_wdt.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_wdt.c
@@ -98,7 +98,7 @@ static int32_t esp32c3_wdt_config_stage(struct esp32c3_wdt_dev_s *dev,
                                         enum esp32c3_wdt_stage_e stage,
                                         enum esp32c3_wdt_stage_action_e cfg);
 static void esp32c3_wdt_update_conf(struct esp32c3_wdt_dev_s *dev);
-static uint16_t esp32c3_wdt_rtc_clk(FAR struct esp32c3_wdt_dev_s *dev);
+static uint16_t esp32c3_wdt_rtc_clk(struct esp32c3_wdt_dev_s *dev);
 static int32_t esp32c3_wdt_setisr(struct esp32c3_wdt_dev_s *dev,
                                   xcpt_t handler, void *arg);
 static void esp32c3_wdt_enableint(struct esp32c3_wdt_dev_s *dev);
@@ -657,7 +657,7 @@ static void esp32c3_wdt_feed(struct esp32c3_wdt_dev_s *dev)
  *
  ****************************************************************************/
 
-static uint16_t esp32c3_wdt_rtc_clk(FAR struct esp32c3_wdt_dev_s *dev)
+static uint16_t esp32c3_wdt_rtc_clk(struct esp32c3_wdt_dev_s *dev)
 {
   enum esp32c3_rtc_slow_freq_e slow_clk_rtc;
   uint32_t period_13q19;

--- a/arch/risc-v/src/esp32c3/esp32c3_wifi_adapter.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_wifi_adapter.c
@@ -719,7 +719,7 @@ static int32_t wifi_errno_trans(int ret)
  *
  ****************************************************************************/
 
-static int esp_int_adpt_cb(int irq, void *context, FAR void *arg)
+static int esp_int_adpt_cb(int irq, void *context, void *arg)
 {
   struct irq_adpt *adapter = (struct irq_adpt *)arg;
 
@@ -2155,7 +2155,7 @@ static int esp_event_id_map(int event_id)
  *
  ****************************************************************************/
 
-static void esp_evt_work_cb(FAR void *arg)
+static void esp_evt_work_cb(void *arg)
 {
   int ret;
   irqstate_t flags;
@@ -4972,7 +4972,7 @@ void esp_wifi_free_eb(void *eb)
  *
  ****************************************************************************/
 
-int esp_wifi_notify_subscribe(pid_t pid, FAR struct sigevent *event)
+int esp_wifi_notify_subscribe(pid_t pid, struct sigevent *event)
 {
   int id;
   struct wifi_notify *notify;
@@ -5297,7 +5297,7 @@ errout_set_mode:
  *
  ****************************************************************************/
 
-int esp_wifi_sta_send_data(FAR void *pbuf, size_t len)
+int esp_wifi_sta_send_data(void *pbuf, size_t len)
 {
   int ret;
 
@@ -6376,7 +6376,7 @@ errout_set_mode:
  *
  ****************************************************************************/
 
-int esp_wifi_softap_send_data(FAR void *pbuf, size_t len)
+int esp_wifi_softap_send_data(void *pbuf, size_t len)
 {
   int ret;
 

--- a/arch/risc-v/src/esp32c3/esp32c3_wifi_adapter.h
+++ b/arch/risc-v/src/esp32c3/esp32c3_wifi_adapter.h
@@ -140,7 +140,7 @@ void esp_wifi_free_eb(void *eb);
  *
  ****************************************************************************/
 
-int esp_wifi_notify_subscribe(pid_t pid, FAR struct sigevent *event);
+int esp_wifi_notify_subscribe(pid_t pid, struct sigevent *event);
 
 #ifdef ESP32C3_WLAN_HAS_STA
 
@@ -194,7 +194,7 @@ int esp_wifi_sta_stop(void);
  *
  ****************************************************************************/
 
-int esp_wifi_sta_send_data(FAR void *pbuf, size_t len);
+int esp_wifi_sta_send_data(void *pbuf, size_t len);
 
 /****************************************************************************
  * Name: esp_wifi_sta_register_recv_cb

--- a/arch/risc-v/src/esp32c3/esp32c3_wifi_utils.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_wifi_utils.c
@@ -448,7 +448,7 @@ void esp_wifi_scan_event_parse(void)
                * in pointer field.
                */
 
-              iwe->u.essid.pointer = (FAR void *)sizeof(iwe->u.essid);
+              iwe->u.essid.pointer = (void *)sizeof(iwe->u.essid);
               memcpy(&iwe->u.essid + 1,
                     ap_list_buffer[bss_count].ssid, essid_len);
 

--- a/arch/risc-v/src/fe310/fe310_irq.c
+++ b/arch/risc-v/src/fe310/fe310_irq.c
@@ -62,7 +62,7 @@ void up_irqinitialize(void)
 
 #if defined(CONFIG_STACK_COLORATION) && CONFIG_ARCH_INTERRUPTSTACK > 15
   size_t intstack_size = (CONFIG_ARCH_INTERRUPTSTACK & ~15);
-  riscv_stack_color((FAR void *)&g_intstackalloc, intstack_size);
+  riscv_stack_color((void *)&g_intstackalloc, intstack_size);
 #endif
 
   /* Set priority for all global interrupts to 1 (lowest) */

--- a/arch/risc-v/src/fe310/fe310_serial.c
+++ b/arch/risc-v/src/fe310/fe310_serial.c
@@ -119,7 +119,7 @@ static int  up_setup(struct uart_dev_s *dev);
 static void up_shutdown(struct uart_dev_s *dev);
 static int  up_attach(struct uart_dev_s *dev);
 static void up_detach(struct uart_dev_s *dev);
-static int  up_interrupt(int irq, void *context, FAR void *arg);
+static int  up_interrupt(int irq, void *context, void *arg);
 static int  up_ioctl(struct file *filep, int cmd, unsigned long arg);
 static int  up_receive(struct uart_dev_s *dev, unsigned int *status);
 static void up_rxint(struct uart_dev_s *dev, bool enable);
@@ -364,7 +364,7 @@ static void up_detach(struct uart_dev_s *dev)
  *
  ****************************************************************************/
 
-static int up_interrupt(int irq, void *context, FAR void *arg)
+static int up_interrupt(int irq, void *context, void *arg)
 {
   struct uart_dev_s *dev = (struct uart_dev_s *)arg;
   struct up_dev_s   *priv;

--- a/arch/risc-v/src/fe310/fe310_timerisr.c
+++ b/arch/risc-v/src/fe310/fe310_timerisr.c
@@ -91,7 +91,7 @@ static void fe310_reload_mtimecmp(void)
  * Name:  fe310_timerisr
  ****************************************************************************/
 
-static int fe310_timerisr(int irq, void *context, FAR void *arg)
+static int fe310_timerisr(int irq, void *context, void *arg)
 {
   fe310_reload_mtimecmp();
 

--- a/arch/risc-v/src/k210/k210_allocateheap.c
+++ b/arch/risc-v/src/k210/k210_allocateheap.c
@@ -60,10 +60,10 @@
  *
  ****************************************************************************/
 
-void up_allocate_heap(FAR void **heap_start, size_t *heap_size)
+void up_allocate_heap(void **heap_start, size_t *heap_size)
 {
   board_autoled_on(LED_HEAPALLOCATE);
-  *heap_start = (FAR void *)K210_HEAP_START;
+  *heap_start = (void *)K210_HEAP_START;
   *heap_size = CONFIG_RAM_END - K210_HEAP_START;
 }
 
@@ -78,7 +78,7 @@ void up_allocate_heap(FAR void **heap_start, size_t *heap_size)
  ****************************************************************************/
 
 #if defined(CONFIG_BUILD_PROTECTED) && defined(CONFIG_MM_KERNEL_HEAP)
-void up_allocate_kheap(FAR void **heap_start, size_t *heap_size)
+void up_allocate_kheap(void **heap_start, size_t *heap_size)
 {
   /* Get the unaligned size and position of the user-space heap.
    * This heap begins after the user-space .bss section at an offset
@@ -103,7 +103,7 @@ void up_allocate_kheap(FAR void **heap_start, size_t *heap_size)
    * that was not dedicated to the user heap).
    */
 
-  *heap_start = (FAR void *)USERSPACE->us_bssend;
+  *heap_start = (void *)USERSPACE->us_bssend;
   *heap_size  = ubase - (uintptr_t)USERSPACE->us_bssend;
 }
 #endif

--- a/arch/risc-v/src/k210/k210_cpuidlestack.c
+++ b/arch/risc-v/src/k210/k210_cpuidlestack.c
@@ -40,7 +40,7 @@
 #define STACK_ISALIGNED(a)   ((uintptr_t)(a) & ~SMP_STACK_MASK)
 
 #if CONFIG_SMP_NCPUS > 1
-static FAR const uintptr_t g_cpu_stackalloc[CONFIG_SMP_NCPUS] =
+static const uintptr_t g_cpu_stackalloc[CONFIG_SMP_NCPUS] =
 {
     0
   , K210_IDLESTACK1_BASE
@@ -94,7 +94,7 @@ static FAR const uintptr_t g_cpu_stackalloc[CONFIG_SMP_NCPUS] =
  *
  ****************************************************************************/
 
-int up_cpu_idlestack(int cpu, FAR struct tcb_s *tcb, size_t stack_size)
+int up_cpu_idlestack(int cpu, struct tcb_s *tcb, size_t stack_size)
 {
 #if CONFIG_SMP_NCPUS > 1
   uintptr_t stack_alloc;
@@ -108,7 +108,7 @@ int up_cpu_idlestack(int cpu, FAR struct tcb_s *tcb, size_t stack_size)
   DEBUGASSERT(stack_alloc != 0 && STACK_ISALIGNED(stack_alloc));
 
   tcb->adj_stack_size  = SMP_STACK_SIZE;
-  tcb->stack_alloc_ptr = (FAR void *)stack_alloc;
+  tcb->stack_alloc_ptr = (void *)stack_alloc;
   tcb->stack_base_ptr  = tcb->stack_alloc_ptr;
 #endif
   return OK;

--- a/arch/risc-v/src/k210/k210_cpupause.c
+++ b/arch/risc-v/src/k210/k210_cpupause.c
@@ -123,7 +123,7 @@ bool up_cpu_pausereq(int cpu)
 
 int up_cpu_paused(int cpu)
 {
-  FAR struct tcb_s *tcb = this_task();
+  struct tcb_s *tcb = this_task();
 
   /* Update scheduler parameters */
 
@@ -187,7 +187,7 @@ int up_cpu_paused(int cpu)
  *
  ****************************************************************************/
 
-int riscv_pause_handler(int irq, void *c, FAR void *arg)
+int riscv_pause_handler(int irq, void *c, void *arg)
 {
   int cpu = up_cpu_index();
 

--- a/arch/risc-v/src/k210/k210_cpustart.c
+++ b/arch/risc-v/src/k210/k210_cpustart.c
@@ -64,7 +64,7 @@
  ****************************************************************************/
 
 extern volatile bool g_serial_ok;
-extern int riscv_pause_handler(int irq, void *c, FAR void *arg);
+extern int riscv_pause_handler(int irq, void *c, void *arg);
 
 /****************************************************************************
  * Public Functions
@@ -113,7 +113,7 @@ void k210_cpu_boot(int cpu)
   DPRINTF("CPU%d Started\n", this_cpu());
 
 #ifdef CONFIG_STACK_COLORATION
-  FAR struct tcb_s *tcb = this_task();
+  struct tcb_s *tcb = this_task();
 
   /* If stack debug is enabled, then fill the stack with a
    * recognizable value that we can use later to test for high

--- a/arch/risc-v/src/k210/k210_irq.c
+++ b/arch/risc-v/src/k210/k210_irq.c
@@ -52,7 +52,7 @@ volatile uint64_t *g_current_regs[1];
 #endif
 
 #ifdef CONFIG_SMP
-extern int riscv_pause_handler(int irq, void *c, FAR void *arg);
+extern int riscv_pause_handler(int irq, void *c, void *arg);
 #endif
 
 /****************************************************************************
@@ -88,7 +88,7 @@ void up_irqinitialize(void)
 #else
   intstack_size = ((CONFIG_ARCH_INTERRUPTSTACK * CONFIG_SMP_NCPUS) & ~15);
 #endif
-  riscv_stack_color((FAR void *)&g_intstackalloc, intstack_size);
+  riscv_stack_color((void *)&g_intstackalloc, intstack_size);
 #endif
 
   /* Set priority for all global interrupts to 1 (lowest) */

--- a/arch/risc-v/src/k210/k210_serial.c
+++ b/arch/risc-v/src/k210/k210_serial.c
@@ -119,7 +119,7 @@ static int  up_setup(struct uart_dev_s *dev);
 static void up_shutdown(struct uart_dev_s *dev);
 static int  up_attach(struct uart_dev_s *dev);
 static void up_detach(struct uart_dev_s *dev);
-static int  up_interrupt(int irq, void *context, FAR void *arg);
+static int  up_interrupt(int irq, void *context, void *arg);
 static int  up_ioctl(struct file *filep, int cmd, unsigned long arg);
 static int  up_receive(struct uart_dev_s *dev, unsigned int *status);
 static void up_rxint(struct uart_dev_s *dev, bool enable);
@@ -364,7 +364,7 @@ static void up_detach(struct uart_dev_s *dev)
  *
  ****************************************************************************/
 
-static int up_interrupt(int irq, void *context, FAR void *arg)
+static int up_interrupt(int irq, void *context, void *arg)
 {
   struct uart_dev_s *dev = (struct uart_dev_s *)arg;
   struct up_dev_s   *priv;

--- a/arch/risc-v/src/k210/k210_timerisr.c
+++ b/arch/risc-v/src/k210/k210_timerisr.c
@@ -93,7 +93,7 @@ static void k210_reload_mtimecmp(void)
  * Name:  k210_timerisr
  ****************************************************************************/
 
-static int k210_timerisr(int irq, void *context, FAR void *arg)
+static int k210_timerisr(int irq, void *context, void *arg)
 {
   k210_reload_mtimecmp();
 

--- a/arch/risc-v/src/litex/litex_irq.c
+++ b/arch/risc-v/src/litex/litex_irq.c
@@ -61,7 +61,7 @@ void up_irqinitialize(void)
 
 #if defined(CONFIG_STACK_COLORATION) && CONFIG_ARCH_INTERRUPTSTACK > 15
   size_t intstack_size = (CONFIG_ARCH_INTERRUPTSTACK & ~15);
-  riscv_stack_color((FAR void *)&g_intstackalloc, intstack_size);
+  riscv_stack_color((void *)&g_intstackalloc, intstack_size);
 #endif
 
   /* litex vexriscv dont have priority and threshold control */

--- a/arch/risc-v/src/litex/litex_serial.c
+++ b/arch/risc-v/src/litex/litex_serial.c
@@ -143,7 +143,7 @@ static int  up_setup(struct uart_dev_s *dev);
 static void up_shutdown(struct uart_dev_s *dev);
 static int  up_attach(struct uart_dev_s *dev);
 static void up_detach(struct uart_dev_s *dev);
-static int  up_interrupt(int irq, void *context, FAR void *arg);
+static int  up_interrupt(int irq, void *context, void *arg);
 static int  up_ioctl(struct file *filep, int cmd, unsigned long arg);
 static int  up_receive(struct uart_dev_s *dev, unsigned int *status);
 static void up_rxint(struct uart_dev_s *dev, bool enable);
@@ -386,7 +386,7 @@ static void up_detach(struct uart_dev_s *dev)
  *
  ****************************************************************************/
 
-static int up_interrupt(int irq, void *context, FAR void *arg)
+static int up_interrupt(int irq, void *context, void *arg)
 {
   struct uart_dev_s *dev = (struct uart_dev_s *)arg;
   struct up_dev_s   *priv;

--- a/arch/risc-v/src/litex/litex_timerisr.c
+++ b/arch/risc-v/src/litex/litex_timerisr.c
@@ -134,7 +134,7 @@ static void litex_reload_mtimecmp(void)
  * Name:  litex_timerisr
  ****************************************************************************/
 
-static int litex_timerisr(int irq, void *context, FAR void *arg)
+static int litex_timerisr(int irq, void *context, void *arg)
 {
   litex_reload_mtimecmp();
 

--- a/arch/risc-v/src/mpfs/mpfs_allocateheap.c
+++ b/arch/risc-v/src/mpfs/mpfs_allocateheap.c
@@ -76,7 +76,7 @@
  *
  ****************************************************************************/
 
-void up_allocate_heap(FAR void **heap_start, size_t *heap_size)
+void up_allocate_heap(void **heap_start, size_t *heap_size)
 {
 #if defined(CONFIG_BUILD_PROTECTED) && defined(CONFIG_MM_KERNEL_HEAP)
   /* Get the size and position of the user-space heap.
@@ -88,7 +88,7 @@ void up_allocate_heap(FAR void **heap_start, size_t *heap_size)
 
   /* Return the user-space heap settings */
 
-  *heap_start = (FAR void *)ubase;
+  *heap_start = (void *)ubase;
   *heap_size  = usize;
 
   /* Allow user-mode access to the user heap memory in PMP
@@ -98,7 +98,7 @@ void up_allocate_heap(FAR void **heap_start, size_t *heap_size)
 #else
   /* Return the heap settings */
 
-  *heap_start = (FAR void *)g_idle_topstack;
+  *heap_start = (void *)g_idle_topstack;
   *heap_size = KRAM_END - g_idle_topstack;
 #endif
 }
@@ -114,11 +114,11 @@ void up_allocate_heap(FAR void **heap_start, size_t *heap_size)
  ****************************************************************************/
 
 #if defined(CONFIG_BUILD_PROTECTED) && defined(CONFIG_MM_KERNEL_HEAP)
-void up_allocate_kheap(FAR void **heap_start, size_t *heap_size)
+void up_allocate_kheap(void **heap_start, size_t *heap_size)
 {
   /* Return the kernel heap settings. */
 
-  *heap_start = (FAR void *)g_idle_topstack;
+  *heap_start = (void *)g_idle_topstack;
   *heap_size = KRAM_END - g_idle_topstack;
 }
 #endif

--- a/arch/risc-v/src/mpfs/mpfs_corepwm.c
+++ b/arch/risc-v/src/mpfs/mpfs_corepwm.c
@@ -75,13 +75,13 @@ struct mpfs_pwmchan_s
 
 struct mpfs_pwmtimer_s
 {
-  FAR const struct pwm_ops_s *ops;     /* PWM operations */
-  uint8_t nchannels;                   /* Number of channels on this PWM block */
-  uint8_t pwmid;                       /* PWM ID {1,...} */
+  const struct pwm_ops_s *ops; /* PWM operations */
+  uint8_t nchannels;           /* Number of channels on this PWM block */
+  uint8_t pwmid;               /* PWM ID {1,...} */
   struct mpfs_pwmchan_s channels[MPFS_MAX_PWM_CHANNELS];
-  uint32_t frequency;                  /* Current frequency setting */
-  uintptr_t base;                      /* The base address of the pwm block */
-  uint32_t pwmclk;                     /* The frequency of the pwm clock */
+  uint32_t frequency;          /* Current frequency setting */
+  uintptr_t base;              /* The base address of the pwm block */
+  uint32_t pwmclk;             /* The frequency of the pwm clock */
 };
 
 /****************************************************************************
@@ -95,26 +95,26 @@ static void pwm_putreg(struct mpfs_pwmtimer_s *priv, int offset,
                        uint32_t value);
 
 #ifdef CONFIG_DEBUG_PWM_INFO
-static void pwm_dumpregs(struct mpfs_pwmtimer_s *priv, FAR const char *msg);
+static void pwm_dumpregs(struct mpfs_pwmtimer_s *priv, const char *msg);
 #else
 #  define pwm_dumpregs(priv,msg)
 #endif
 
 /* Timer management */
 
-static int pwm_timer(FAR struct mpfs_pwmtimer_s *priv,
-                     FAR const struct pwm_info_s *info);
+static int pwm_timer(struct mpfs_pwmtimer_s *priv,
+                     const struct pwm_info_s *info);
 
 /* PWM driver methods */
 
-static int pwm_setup(FAR struct pwm_lowerhalf_s *dev);
-static int pwm_shutdown(FAR struct pwm_lowerhalf_s *dev);
+static int pwm_setup(struct pwm_lowerhalf_s *dev);
+static int pwm_shutdown(struct pwm_lowerhalf_s *dev);
 
-static int pwm_start(FAR struct pwm_lowerhalf_s *dev,
-                     FAR const struct pwm_info_s *info);
+static int pwm_start(struct pwm_lowerhalf_s *dev,
+                     const struct pwm_info_s *info);
 
-static int pwm_stop(FAR struct pwm_lowerhalf_s *dev);
-static int pwm_ioctl(FAR struct pwm_lowerhalf_s *dev,
+static int pwm_stop(struct pwm_lowerhalf_s *dev);
+static int pwm_ioctl(struct pwm_lowerhalf_s *dev,
                      int cmd, unsigned long arg);
 
 /****************************************************************************
@@ -326,7 +326,7 @@ static void pwm_putreg(struct mpfs_pwmtimer_s *priv, int offset,
 #ifdef CONFIG_DEBUG_PWM_INFO
 #define MPFS_PWMREG_STEP (MPFS_COREPWM_PWM2_POS_EDGE_OFFSET -  MPFS_COREPWM_PWM1_POS_EDGE_OFFSET)
 
-static void pwm_dumpregs(struct mpfs_pwmtimer_s *priv, FAR const char *msg)
+static void pwm_dumpregs(struct mpfs_pwmtimer_s *priv, const char *msg)
 {
   pwminfo("%s:\n", msg);
   pwminfo("  PRESCALE: %08x PERIOD: %08x\n",
@@ -366,8 +366,8 @@ static void pwm_dumpregs(struct mpfs_pwmtimer_s *priv, FAR const char *msg)
  *
  ****************************************************************************/
 
-static int pwm_timer(FAR struct mpfs_pwmtimer_s *priv,
-                     FAR const struct pwm_info_s *info)
+static int pwm_timer(struct mpfs_pwmtimer_s *priv,
+                     const struct pwm_info_s *info)
 {
   int      i;
 
@@ -497,7 +497,7 @@ static int pwm_timer(FAR struct mpfs_pwmtimer_s *priv,
  *
  ****************************************************************************/
 
-static int pwm_update_duty(FAR struct mpfs_pwmtimer_s *priv,
+static int pwm_update_duty(struct mpfs_pwmtimer_s *priv,
                            uint8_t channel, ub16_t duty16)
 {
   uint32_t              period;
@@ -553,9 +553,9 @@ static int pwm_update_duty(FAR struct mpfs_pwmtimer_s *priv,
  *
  ****************************************************************************/
 
-static int pwm_setup(FAR struct pwm_lowerhalf_s *dev)
+static int pwm_setup(struct pwm_lowerhalf_s *dev)
 {
-  FAR struct mpfs_pwmtimer_s *priv = (FAR struct mpfs_pwmtimer_s *)dev;
+  struct mpfs_pwmtimer_s *priv = (struct mpfs_pwmtimer_s *)dev;
 
   pwminfo("PWMID%u\n", priv->pwmid);
   pwm_dumpregs(priv, "Initially");
@@ -579,9 +579,9 @@ static int pwm_setup(FAR struct pwm_lowerhalf_s *dev)
  *
  ****************************************************************************/
 
-static int pwm_shutdown(FAR struct pwm_lowerhalf_s *dev)
+static int pwm_shutdown(struct pwm_lowerhalf_s *dev)
 {
-  FAR struct mpfs_pwmtimer_s *priv = (FAR struct mpfs_pwmtimer_s *)dev;
+  struct mpfs_pwmtimer_s *priv = (struct mpfs_pwmtimer_s *)dev;
 
   pwminfo("PWM%u\n", priv->pwmid);
 
@@ -607,11 +607,11 @@ static int pwm_shutdown(FAR struct pwm_lowerhalf_s *dev)
  *
  ****************************************************************************/
 
-static int pwm_start(FAR struct pwm_lowerhalf_s *dev,
-                     FAR const struct pwm_info_s *info)
+static int pwm_start(struct pwm_lowerhalf_s *dev,
+                     const struct pwm_info_s *info)
 {
   int ret = OK;
-  FAR struct mpfs_pwmtimer_s *priv = (FAR struct mpfs_pwmtimer_s *)dev;
+  struct mpfs_pwmtimer_s *priv = (struct mpfs_pwmtimer_s *)dev;
 
   /* if frequency has not changed we just update duty */
 
@@ -671,9 +671,9 @@ static int pwm_start(FAR struct pwm_lowerhalf_s *dev,
  *
  ****************************************************************************/
 
-static int pwm_stop(FAR struct pwm_lowerhalf_s *dev)
+static int pwm_stop(struct pwm_lowerhalf_s *dev)
 {
-  FAR struct mpfs_pwmtimer_s *priv = (FAR struct mpfs_pwmtimer_s *)dev;
+  struct mpfs_pwmtimer_s *priv = (struct mpfs_pwmtimer_s *)dev;
 
   pwminfo("PWM%u pwm_stop\n", priv->pwmid);
 
@@ -725,11 +725,11 @@ static int pwm_stop(FAR struct pwm_lowerhalf_s *dev)
  *
  ****************************************************************************/
 
-static int pwm_ioctl(FAR struct pwm_lowerhalf_s *dev, int cmd,
+static int pwm_ioctl(struct pwm_lowerhalf_s *dev, int cmd,
                      unsigned long arg)
 {
 #ifdef CONFIG_DEBUG_PWM_INFO
-  FAR struct mpfs_pwmtimer_s *priv = (FAR struct mpfs_pwmtimer_s *)dev;
+  struct mpfs_pwmtimer_s *priv = (struct mpfs_pwmtimer_s *)dev;
 
   /* There are no platform-specific ioctl commands */
 
@@ -759,9 +759,9 @@ static int pwm_ioctl(FAR struct pwm_lowerhalf_s *dev, int cmd,
  *
  ****************************************************************************/
 
-FAR struct pwm_lowerhalf_s *mpfs_corepwm_init(int pwmid)
+struct pwm_lowerhalf_s *mpfs_corepwm_init(int pwmid)
 {
-  FAR struct mpfs_pwmtimer_s *lower;
+  struct mpfs_pwmtimer_s *lower;
 
   pwminfo("PWM%u\n", pwmid);
 
@@ -782,6 +782,6 @@ FAR struct pwm_lowerhalf_s *mpfs_corepwm_init(int pwmid)
       return NULL;
   }
 
-  return (FAR struct pwm_lowerhalf_s *)lower;
+  return (struct pwm_lowerhalf_s *)lower;
 }
 

--- a/arch/risc-v/src/mpfs/mpfs_corepwm.h
+++ b/arch/risc-v/src/mpfs/mpfs_corepwm.h
@@ -87,7 +87,7 @@ extern "C"
  *
  ****************************************************************************/
 
-FAR struct pwm_lowerhalf_s *mpfs_corepwm_init(int pwmid);
+struct pwm_lowerhalf_s *mpfs_corepwm_init(int pwmid);
 
 #undef EXTERN
 #if defined(__cplusplus)

--- a/arch/risc-v/src/mpfs/mpfs_emmcsd.c
+++ b/arch/risc-v/src/mpfs/mpfs_emmcsd.c
@@ -324,58 +324,58 @@ struct mpfs_dev_s
 /* Mutual exclusion */
 
 #if defined(CONFIG_SDIO_MUXBUS)
-static int  mpfs_lock(FAR struct sdio_dev_s *dev, bool lock);
+static int  mpfs_lock(struct sdio_dev_s *dev, bool lock);
 #endif
 
 /* Initialization/setup */
 
-static void mpfs_reset(FAR struct sdio_dev_s *dev);
-static sdio_capset_t mpfs_capabilities(FAR struct sdio_dev_s *dev);
-static sdio_statset_t mpfs_status(FAR struct sdio_dev_s *dev);
-static void mpfs_widebus(FAR struct sdio_dev_s *dev, bool enable);
-static void mpfs_clock(FAR struct sdio_dev_s *dev,
+static void mpfs_reset(struct sdio_dev_s *dev);
+static sdio_capset_t mpfs_capabilities(struct sdio_dev_s *dev);
+static sdio_statset_t mpfs_status(struct sdio_dev_s *dev);
+static void mpfs_widebus(struct sdio_dev_s *dev, bool enable);
+static void mpfs_clock(struct sdio_dev_s *dev,
                        enum sdio_clock_e rate);
-static int  mpfs_attach(FAR struct sdio_dev_s *dev);
+static int  mpfs_attach(struct sdio_dev_s *dev);
 
 /* Command / Status / Data Transfer */
 
-static int  mpfs_sendcmd(FAR struct sdio_dev_s *dev, uint32_t cmd,
+static int  mpfs_sendcmd(struct sdio_dev_s *dev, uint32_t cmd,
                          uint32_t arg);
 #ifdef CONFIG_SDIO_BLOCKSETUP
-static void mpfs_blocksetup(FAR struct sdio_dev_s *dev,
+static void mpfs_blocksetup(struct sdio_dev_s *dev,
               unsigned int blocksize, unsigned int nblocks);
 #endif
-static int  mpfs_recvsetup(FAR struct sdio_dev_s *dev, FAR uint8_t *buffer,
+static int  mpfs_recvsetup(struct sdio_dev_s *dev, uint8_t *buffer,
                            size_t nbytes);
-static int  mpfs_sendsetup(FAR struct sdio_dev_s *dev,
-                           FAR const uint8_t *buffer, size_t nbytes);
-static int  mpfs_cancel(FAR struct sdio_dev_s *dev);
+static int  mpfs_sendsetup(struct sdio_dev_s *dev,
+                           const uint8_t *buffer, size_t nbytes);
+static int  mpfs_cancel(struct sdio_dev_s *dev);
 
-static int  mpfs_waitresponse(FAR struct sdio_dev_s *dev, uint32_t cmd);
-static int  mpfs_recvshortcrc(FAR struct sdio_dev_s *dev, uint32_t cmd,
+static int  mpfs_waitresponse(struct sdio_dev_s *dev, uint32_t cmd);
+static int  mpfs_recvshortcrc(struct sdio_dev_s *dev, uint32_t cmd,
                               uint32_t *rshort);
-static int  mpfs_recvlong(FAR struct sdio_dev_s *dev, uint32_t cmd,
+static int  mpfs_recvlong(struct sdio_dev_s *dev, uint32_t cmd,
                           uint32_t rlong[4]);
-static int  mpfs_recvshort(FAR struct sdio_dev_s *dev, uint32_t cmd,
+static int  mpfs_recvshort(struct sdio_dev_s *dev, uint32_t cmd,
                            uint32_t *rshort);
 
 /* Event handler */
 
-static void mpfs_waitenable(FAR struct sdio_dev_s *dev,
+static void mpfs_waitenable(struct sdio_dev_s *dev,
                             sdio_eventset_t eventset, uint32_t timeout);
-static sdio_eventset_t mpfs_eventwait(FAR struct sdio_dev_s *dev);
-static void mpfs_callbackenable(FAR struct sdio_dev_s *dev,
+static sdio_eventset_t mpfs_eventwait(struct sdio_dev_s *dev);
+static void mpfs_callbackenable(struct sdio_dev_s *dev,
                                 sdio_eventset_t eventset);
-static int  mpfs_registercallback(FAR struct sdio_dev_s *dev,
+static int  mpfs_registercallback(struct sdio_dev_s *dev,
                                   worker_t callback, void *arg);
 
 /* DMA */
 
 #if defined(CONFIG_SDIO_DMA)
-static int  mpfs_dmarecvsetup(FAR struct sdio_dev_s *dev,
-                              FAR uint8_t *buffer, size_t buflen);
-static int  mpfs_dmasendsetup(FAR struct sdio_dev_s *dev,
-                              FAR const uint8_t *buffer, size_t buflen);
+static int  mpfs_dmarecvsetup(struct sdio_dev_s *dev,
+                              uint8_t *buffer, size_t buflen);
+static int  mpfs_dmasendsetup(struct sdio_dev_s *dev,
+                              const uint8_t *buffer, size_t buflen);
 #endif
 
 /* Initialization/uninitialization/reset ************************************/
@@ -1164,7 +1164,7 @@ static int mpfs_emmcsd_interrupt(int irq, void *context, void *arg)
  ****************************************************************************/
 
 #if defined(CONFIG_SDIO_MUXBUS)
-static int mpfs_lock(FAR struct sdio_dev_s *dev, bool lock)
+static int mpfs_lock(struct sdio_dev_s *dev, bool lock)
 {
   /* The multiplex bus is part of board support package. */
 
@@ -1375,9 +1375,9 @@ static void mpfs_sdcard_init(struct mpfs_dev_s *priv)
  *
  ****************************************************************************/
 
-static bool mpfs_device_reset(FAR struct sdio_dev_s *dev)
+static bool mpfs_device_reset(struct sdio_dev_s *dev)
 {
-  FAR struct mpfs_dev_s *priv = (FAR struct mpfs_dev_s *)dev;
+  struct mpfs_dev_s *priv = (struct mpfs_dev_s *)dev;
   irqstate_t flags;
   uint32_t regval;
   uint32_t cap;
@@ -1608,7 +1608,7 @@ static bool mpfs_device_reset(FAR struct sdio_dev_s *dev)
  *
  ****************************************************************************/
 
-static void mpfs_reset(FAR struct sdio_dev_s *dev)
+static void mpfs_reset(struct sdio_dev_s *dev)
 {
   mpfs_device_reset(dev);
 }
@@ -1627,7 +1627,7 @@ static void mpfs_reset(FAR struct sdio_dev_s *dev)
  *
  ****************************************************************************/
 
-static sdio_capset_t mpfs_capabilities(FAR struct sdio_dev_s *dev)
+static sdio_capset_t mpfs_capabilities(struct sdio_dev_s *dev)
 {
   struct mpfs_dev_s *priv = (struct mpfs_dev_s *)dev;
   sdio_capset_t caps = 0;
@@ -1665,7 +1665,7 @@ static sdio_capset_t mpfs_capabilities(FAR struct sdio_dev_s *dev)
  *
  ****************************************************************************/
 
-static sdio_statset_t mpfs_status(FAR struct sdio_dev_s *dev)
+static sdio_statset_t mpfs_status(struct sdio_dev_s *dev)
 {
   struct mpfs_dev_s *priv = (struct mpfs_dev_s *)dev;
   return priv->cdstatus;
@@ -1688,7 +1688,7 @@ static sdio_statset_t mpfs_status(FAR struct sdio_dev_s *dev)
  *
  ****************************************************************************/
 
-static void mpfs_widebus(FAR struct sdio_dev_s *dev, bool wide)
+static void mpfs_widebus(struct sdio_dev_s *dev, bool wide)
 {
   struct mpfs_dev_s *priv = (struct mpfs_dev_s *)dev;
   priv->widebus = wide;
@@ -1721,7 +1721,7 @@ static void mpfs_widebus(FAR struct sdio_dev_s *dev, bool wide)
  *
  ****************************************************************************/
 
-static void mpfs_clock(FAR struct sdio_dev_s *dev, enum sdio_clock_e rate)
+static void mpfs_clock(struct sdio_dev_s *dev, enum sdio_clock_e rate)
 {
   struct mpfs_dev_s *priv = (struct mpfs_dev_s *)dev;
   uint32_t clckr;
@@ -1779,7 +1779,7 @@ static void mpfs_clock(FAR struct sdio_dev_s *dev, enum sdio_clock_e rate)
  *
  ****************************************************************************/
 
-static int mpfs_attach(FAR struct sdio_dev_s *dev)
+static int mpfs_attach(struct sdio_dev_s *dev)
 {
   struct mpfs_dev_s *priv = (struct mpfs_dev_s *)dev;
   int ret;
@@ -1832,7 +1832,7 @@ static int mpfs_attach(FAR struct sdio_dev_s *dev)
  *
  ****************************************************************************/
 
-static int mpfs_sendcmd(FAR struct sdio_dev_s *dev, uint32_t cmd,
+static int mpfs_sendcmd(struct sdio_dev_s *dev, uint32_t cmd,
                          uint32_t arg)
 {
   struct mpfs_dev_s *priv = (struct mpfs_dev_s *)dev;
@@ -1941,7 +1941,7 @@ static int mpfs_sendcmd(FAR struct sdio_dev_s *dev, uint32_t cmd,
  ****************************************************************************/
 
 #ifdef CONFIG_SDIO_BLOCKSETUP
-static void mpfs_blocksetup(FAR struct sdio_dev_s *dev,
+static void mpfs_blocksetup(struct sdio_dev_s *dev,
                              unsigned int blocksize, unsigned int nblocks)
 {
   struct mpfs_dev_s *priv = (struct mpfs_dev_s *)dev;
@@ -1975,7 +1975,7 @@ static void mpfs_blocksetup(FAR struct sdio_dev_s *dev,
  *
  ****************************************************************************/
 
-static int mpfs_recvsetup(FAR struct sdio_dev_s *dev, FAR uint8_t *buffer,
+static int mpfs_recvsetup(struct sdio_dev_s *dev, uint8_t *buffer,
                            size_t nbytes)
 {
   struct mpfs_dev_s *priv = (struct mpfs_dev_s *)dev;
@@ -2030,7 +2030,7 @@ static int mpfs_recvsetup(FAR struct sdio_dev_s *dev, FAR uint8_t *buffer,
  *
  ****************************************************************************/
 
-static int mpfs_sendsetup(FAR struct sdio_dev_s *dev, FAR const
+static int mpfs_sendsetup(struct sdio_dev_s *dev, const
                            uint8_t *buffer, size_t nbytes)
 {
   struct mpfs_dev_s *priv = (struct mpfs_dev_s *)dev;
@@ -2084,8 +2084,8 @@ static int mpfs_sendsetup(FAR struct sdio_dev_s *dev, FAR const
  ****************************************************************************/
 
 #ifdef CONFIG_SDIO_DMA
-static int mpfs_dmarecvsetup(FAR struct sdio_dev_s *dev,
-                              FAR uint8_t *buffer, size_t buflen)
+static int mpfs_dmarecvsetup(struct sdio_dev_s *dev,
+                              uint8_t *buffer, size_t buflen)
 {
   struct mpfs_dev_s *priv = (struct mpfs_dev_s *)dev;
 #ifndef CONFIG_SDIO_BLOCKSETUP
@@ -2144,8 +2144,8 @@ static int mpfs_dmarecvsetup(FAR struct sdio_dev_s *dev,
  ****************************************************************************/
 
 #ifdef CONFIG_SDIO_DMA
-static int mpfs_dmasendsetup(FAR struct sdio_dev_s *dev,
-                              FAR const uint8_t *buffer, size_t buflen)
+static int mpfs_dmasendsetup(struct sdio_dev_s *dev,
+                              const uint8_t *buffer, size_t buflen)
 {
   struct mpfs_dev_s *priv = (struct mpfs_dev_s *)dev;
 #ifndef CONFIG_SDIO_BLOCKSETUP
@@ -2213,7 +2213,7 @@ static int mpfs_dmasendsetup(FAR struct sdio_dev_s *dev,
  *
  ****************************************************************************/
 
-static int mpfs_cancel(FAR struct sdio_dev_s *dev)
+static int mpfs_cancel(struct sdio_dev_s *dev)
 {
   struct mpfs_dev_s *priv = (struct mpfs_dev_s *)dev;
 
@@ -2257,7 +2257,7 @@ static int mpfs_cancel(FAR struct sdio_dev_s *dev)
  *
  ****************************************************************************/
 
-static int mpfs_waitresponse(FAR struct sdio_dev_s *dev, uint32_t cmd)
+static int mpfs_waitresponse(struct sdio_dev_s *dev, uint32_t cmd)
 {
   struct mpfs_dev_s *priv = (struct mpfs_dev_s *)dev;
   uint32_t status;
@@ -2394,7 +2394,7 @@ static int mpfs_check_recverror(struct mpfs_dev_s *priv)
  *
  ****************************************************************************/
 
-static int mpfs_recvshortcrc(FAR struct sdio_dev_s *dev, uint32_t cmd,
+static int mpfs_recvshortcrc(struct sdio_dev_s *dev, uint32_t cmd,
                               uint32_t *rshort)
 {
   struct mpfs_dev_s *priv = (struct mpfs_dev_s *)dev;
@@ -2432,7 +2432,7 @@ static int mpfs_recvshortcrc(FAR struct sdio_dev_s *dev, uint32_t cmd,
  *
  ****************************************************************************/
 
-static int mpfs_recvshort(FAR struct sdio_dev_s *dev, uint32_t cmd,
+static int mpfs_recvshort(struct sdio_dev_s *dev, uint32_t cmd,
                            uint32_t *rshort)
 {
   struct mpfs_dev_s *priv = (struct mpfs_dev_s *)dev;
@@ -2468,7 +2468,7 @@ static int mpfs_recvshort(FAR struct sdio_dev_s *dev, uint32_t cmd,
  *
  ****************************************************************************/
 
-static int mpfs_recvlong(FAR struct sdio_dev_s *dev, uint32_t cmd,
+static int mpfs_recvlong(struct sdio_dev_s *dev, uint32_t cmd,
                           uint32_t rlong[4])
 {
   struct mpfs_dev_s *priv = (struct mpfs_dev_s *)dev;
@@ -2522,7 +2522,7 @@ static int mpfs_recvlong(FAR struct sdio_dev_s *dev, uint32_t cmd,
  *
  ****************************************************************************/
 
-static void mpfs_waitenable(FAR struct sdio_dev_s *dev,
+static void mpfs_waitenable(struct sdio_dev_s *dev,
                             sdio_eventset_t eventset, uint32_t timeout)
 {
   struct mpfs_dev_s *priv = (struct mpfs_dev_s *)dev;
@@ -2608,7 +2608,7 @@ static void mpfs_waitenable(FAR struct sdio_dev_s *dev,
  *
  ****************************************************************************/
 
-static sdio_eventset_t mpfs_eventwait(FAR struct sdio_dev_s *dev)
+static sdio_eventset_t mpfs_eventwait(struct sdio_dev_s *dev)
 {
   struct mpfs_dev_s *priv = (struct mpfs_dev_s *)dev;
   sdio_eventset_t wkupevent = 0;
@@ -2698,7 +2698,7 @@ errout_with_waitints:
  *
  ****************************************************************************/
 
-static void mpfs_callbackenable(FAR struct sdio_dev_s *dev,
+static void mpfs_callbackenable(struct sdio_dev_s *dev,
                                  sdio_eventset_t eventset)
 {
   struct mpfs_dev_s *priv = (struct mpfs_dev_s *)dev;
@@ -2732,7 +2732,7 @@ static void mpfs_callbackenable(FAR struct sdio_dev_s *dev,
  *
  ****************************************************************************/
 
-static int mpfs_registercallback(FAR struct sdio_dev_s *dev,
+static int mpfs_registercallback(struct sdio_dev_s *dev,
                                   worker_t callback, void *arg)
 {
   struct mpfs_dev_s *priv = (struct mpfs_dev_s *)dev;
@@ -2849,7 +2849,7 @@ static void mpfs_callback(void *arg)
  *
  ****************************************************************************/
 
-FAR struct sdio_dev_s *sdio_initialize(int slotno)
+struct sdio_dev_s *sdio_initialize(int slotno)
 {
   struct mpfs_dev_s *priv = NULL;
   priv = &g_emmcsd_dev;
@@ -2895,7 +2895,7 @@ FAR struct sdio_dev_s *sdio_initialize(int slotno)
  *
  ****************************************************************************/
 
-void sdio_mediachange(FAR struct sdio_dev_s *dev, bool cardinslot)
+void sdio_mediachange(struct sdio_dev_s *dev, bool cardinslot)
 {
   struct mpfs_dev_s *priv = (struct mpfs_dev_s *)dev;
   sdio_statset_t cdstatus;
@@ -2943,7 +2943,7 @@ void sdio_mediachange(FAR struct sdio_dev_s *dev, bool cardinslot)
  *
  ****************************************************************************/
 
-void sdio_wrprotect(FAR struct sdio_dev_s *dev, bool wrprotect)
+void sdio_wrprotect(struct sdio_dev_s *dev, bool wrprotect)
 {
   struct mpfs_dev_s *priv = (struct mpfs_dev_s *)dev;
   irqstate_t flags;

--- a/arch/risc-v/src/mpfs/mpfs_emmcsd.h
+++ b/arch/risc-v/src/mpfs/mpfs_emmcsd.h
@@ -63,7 +63,7 @@ extern "C"
  ****************************************************************************/
 
 struct sdio_dev_s; /* See include/nuttx/sdio.h */
-FAR struct sdio_dev_s *sdio_initialize(int slotno);
+struct sdio_dev_s *sdio_initialize(int slotno);
 
 /****************************************************************************
  * Name: sdio_mediachange
@@ -84,7 +84,7 @@ FAR struct sdio_dev_s *sdio_initialize(int slotno);
  *
  ****************************************************************************/
 
-void sdio_mediachange(FAR struct sdio_dev_s *dev, bool cardinslot);
+void sdio_mediachange(struct sdio_dev_s *dev, bool cardinslot);
 
 /****************************************************************************
  * Name: sdio_wrprotect
@@ -102,7 +102,7 @@ void sdio_mediachange(FAR struct sdio_dev_s *dev, bool cardinslot);
  *
  ****************************************************************************/
 
-void sdio_wrprotect(FAR struct sdio_dev_s *dev, bool wrprotect);
+void sdio_wrprotect(struct sdio_dev_s *dev, bool wrprotect);
 
 #undef EXTERN
 #if defined(__cplusplus)

--- a/arch/risc-v/src/mpfs/mpfs_irq.c
+++ b/arch/risc-v/src/mpfs/mpfs_irq.c
@@ -107,7 +107,7 @@ void up_irqinitialize(void)
 
 #if defined(CONFIG_STACK_COLORATION) && CONFIG_ARCH_INTERRUPTSTACK > 15
   size_t intstack_size = (CONFIG_ARCH_INTERRUPTSTACK & ~15);
-  riscv_stack_color((FAR void *)&g_intstackalloc, intstack_size);
+  riscv_stack_color((void *)&g_intstackalloc, intstack_size);
 #endif
 
   /* Set priority for all global interrupts to 1 (lowest) */

--- a/arch/risc-v/src/mpfs/mpfs_spi.h
+++ b/arch/risc-v/src/mpfs/mpfs_spi.h
@@ -73,7 +73,7 @@ struct spi_dev_s *mpfs_spibus_initialize(int port);
  *
  ****************************************************************************/
 
-int mpfs_spibus_uninitialize(FAR struct spi_dev_s *dev);
+int mpfs_spibus_uninitialize(struct spi_dev_s *dev);
 
 #ifdef __cplusplus
 }

--- a/arch/risc-v/src/mpfs/mpfs_timerisr.c
+++ b/arch/risc-v/src/mpfs/mpfs_timerisr.c
@@ -87,7 +87,7 @@ static void mpfs_reload_mtimecmp(void)
  * Name:  mpfs_timerisr
  ****************************************************************************/
 
-static int mpfs_timerisr(int irq, void *context, FAR void *arg)
+static int mpfs_timerisr(int irq, void *context, void *arg)
 {
   mpfs_reload_mtimecmp();
 

--- a/arch/risc-v/src/rv32im/riscv_assert.c
+++ b/arch/risc-v/src/rv32im/riscv_assert.c
@@ -89,7 +89,7 @@ static void riscv_stackdump(uint32_t sp, uint32_t stack_top)
  ****************************************************************************/
 
 #ifdef CONFIG_ARCH_STACKDUMP
-static inline void riscv_registerdump(FAR volatile uint32_t *regs)
+static inline void riscv_registerdump(volatile uint32_t *regs)
 {
   /* Are user registers available from interrupt processing? */
 
@@ -125,7 +125,7 @@ static inline void riscv_registerdump(FAR volatile uint32_t *regs)
  ****************************************************************************/
 
 #if defined(CONFIG_STACK_COLORATION) || defined(CONFIG_SCHED_BACKTRACE)
-static void riscv_taskdump(FAR struct tcb_s *tcb, FAR void *arg)
+static void riscv_taskdump(struct tcb_s *tcb, void *arg)
 {
   /* Dump interesting properties of this task */
 
@@ -310,7 +310,7 @@ static void riscv_assert(void)
  ****************************************************************************/
 
 #ifdef CONFIG_ARCH_USBDUMP
-static int usbtrace_syslog(FAR const char *fmt, ...)
+static int usbtrace_syslog(const char *fmt, ...)
 {
   va_list ap;
 
@@ -322,7 +322,7 @@ static int usbtrace_syslog(FAR const char *fmt, ...)
   return OK;
 }
 
-static int assert_tracecallback(FAR struct usbtrace_s *trace, FAR void *arg)
+static int assert_tracecallback(struct usbtrace_s *trace, void *arg)
 {
   usbtrace_trprintf(usbtrace_syslog, trace->event, trace->value);
   return 0;

--- a/arch/risc-v/src/rv32im/riscv_swint.c
+++ b/arch/risc-v/src/rv32im/riscv_swint.c
@@ -121,7 +121,7 @@ static void dispatch_syscall(void)
  *
  ****************************************************************************/
 
-int riscv_swint(int irq, FAR void *context, FAR void *arg)
+int riscv_swint(int irq, void *context, void *arg)
 {
   uint32_t *regs = (uint32_t *)context;
 
@@ -266,7 +266,7 @@ int riscv_swint(int irq, FAR void *context, FAR void *arg)
       default:
         {
 #ifdef CONFIG_BUILD_KERNEL
-          FAR struct tcb_s *rtcb = nxsched_self();
+          struct tcb_s *rtcb = nxsched_self();
           int index = rtcb->xcp.nsyscalls;
 
           /* Verify that the SYS call number is within range */

--- a/arch/risc-v/src/rv32m1/rv32m1_gpio.c
+++ b/arch/risc-v/src/rv32m1/rv32m1_gpio.c
@@ -59,14 +59,14 @@ struct rv32m1_ctrlbase_s
   const uint32_t portgate;  /* Port Clock Control Gate */
   const uint32_t gpiogate;  /* GPIO Clock Control Gate */
   const uint32_t irq;       /* IRQ Number */
-  FAR sq_queue_t *isrchain; /* Interrupt Service Routine Chain */
+  sq_queue_t *isrchain;     /* Interrupt Service Routine Chain */
 };
 
 struct rv32m1_isr_s
 {
   sq_entry_t link;
   xcpt_t     isr;
-  FAR void   *arg;
+  void   *arg;
   uint32_t   pin;
 };
 
@@ -316,19 +316,19 @@ static void rv32m1_gpio_portconfig(uint32_t cfgset)
  ****************************************************************************/
 
 LOCATE_ITCM
-static int rv32m1_gpio_interrupt(int irq, FAR void *context, FAR void *arg)
+static int rv32m1_gpio_interrupt(int irq, void *context, void *arg)
 {
-  const FAR struct rv32m1_ctrlbase_s *ctrl;
-  const FAR sq_queue_t *isrchain;
-  const FAR sq_entry_t *e;
-  const FAR struct rv32m1_isr_s *priv;
+  const struct rv32m1_ctrlbase_s *ctrl;
+  const sq_queue_t *isrchain;
+  const sq_entry_t *e;
+  const struct rv32m1_isr_s *priv;
 
   uint32_t portbase;
 
   uint32_t risf; /* the Read([red]) Interrupt status Flag */
   uint32_t wisf; /* The Interrupt status Flag to write back */
 
-  ctrl = (const FAR struct rv32m1_ctrlbase_s *)arg;
+  ctrl = (const struct rv32m1_ctrlbase_s *)arg;
   portbase = ctrl->portbase;
   isrchain = ctrl->isrchain;
 
@@ -611,7 +611,7 @@ void rv32m1_gpio_irqdisable(uint32_t cfgset)
  * Name: rv32m1_gpio_irqattach
  ****************************************************************************/
 
-int rv32m1_gpio_irqattach(uint32_t cfgset, xcpt_t isr, FAR void *arg)
+int rv32m1_gpio_irqattach(uint32_t cfgset, xcpt_t isr, void *arg)
 {
   unsigned int port;
   unsigned int pin;
@@ -621,10 +621,10 @@ int rv32m1_gpio_irqattach(uint32_t cfgset, xcpt_t isr, FAR void *arg)
 
   irqstate_t flags;
 
-  FAR sq_queue_t *isrchain;
-  FAR sq_entry_t *e;
+  sq_queue_t *isrchain;
+  sq_entry_t *e;
 
-  FAR struct rv32m1_isr_s *priv;
+  struct rv32m1_isr_s *priv;
 
   if (!isr)
     {
@@ -661,7 +661,7 @@ int rv32m1_gpio_irqattach(uint32_t cfgset, xcpt_t isr, FAR void *arg)
       e = sq_next(e);
     }
 
-  priv = (FAR struct rv32m1_isr_s *)kmm_malloc(sizeof(*priv));
+  priv = (struct rv32m1_isr_s *)kmm_malloc(sizeof(*priv));
   if (priv)
     {
       /* If it is the first time to attach an isr, the generic gpio
@@ -698,7 +698,7 @@ done:
  * Name: rv32m1_gpio_irqdetach
  ****************************************************************************/
 
-int rv32m1_gpio_irqdetach(uint32_t cfgset, xcpt_t isr, FAR void *arg)
+int rv32m1_gpio_irqdetach(uint32_t cfgset, xcpt_t isr, void *arg)
 {
   uint32_t port;
   uint32_t pin;
@@ -707,11 +707,11 @@ int rv32m1_gpio_irqdetach(uint32_t cfgset, xcpt_t isr, FAR void *arg)
 
   irqstate_t flags;
 
-  FAR sq_queue_t *isrchain;
-  FAR sq_entry_t *cur;
-  FAR sq_entry_t *pre;
+  sq_queue_t *isrchain;
+  sq_entry_t *cur;
+  sq_entry_t *pre;
 
-  FAR struct rv32m1_isr_s *priv;
+  struct rv32m1_isr_s *priv;
 
   if (!isr)
     {

--- a/arch/risc-v/src/rv32m1/rv32m1_gpio.h
+++ b/arch/risc-v/src/rv32m1/rv32m1_gpio.h
@@ -281,13 +281,13 @@ EXTERN void rv32m1_gpio_irqdisable(uint32_t cfgset);
  * Name: rv32m1_gpio_irqattach
  ****************************************************************************/
 
-EXTERN int rv32m1_gpio_irqattach(uint32_t cfgset, xcpt_t isr, FAR void *arg);
+EXTERN int rv32m1_gpio_irqattach(uint32_t cfgset, xcpt_t isr, void *arg);
 
 /****************************************************************************
  * Name: rv32m1_gpio_irqdetach
  ****************************************************************************/
 
-EXTERN int rv32m1_gpio_irqdetach(uint32_t cfgset, xcpt_t isr, FAR void *arg);
+EXTERN int rv32m1_gpio_irqdetach(uint32_t cfgset, xcpt_t isr, void *arg);
 
 /****************************************************************************
  * Name: rv32m1_gpio_clearpending

--- a/arch/risc-v/src/rv32m1/rv32m1_irq.c
+++ b/arch/risc-v/src/rv32m1/rv32m1_irq.c
@@ -48,7 +48,7 @@
  ****************************************************************************/
 
 LOCATE_ITCM
-static int rv32m1_intmuxisr(int irq, void *context, FAR void *arg)
+static int rv32m1_intmuxisr(int irq, void *context, void *arg)
 {
   UNUSED(irq);
   UNUSED(context);
@@ -97,7 +97,7 @@ void up_irqinitialize(void)
 
 #if defined(CONFIG_STACK_COLORATION) && CONFIG_ARCH_INTERRUPTSTACK > 15
   size_t intstack_size = (CONFIG_ARCH_INTERRUPTSTACK & ~15);
-  riscv_stack_color((FAR void *)((uintptr_t)&g_intstacktop - intstack_size),
+  riscv_stack_color((void *)((uintptr_t)&g_intstacktop - intstack_size),
                  intstack_size);
 #endif
 

--- a/arch/risc-v/src/rv32m1/rv32m1_serial.c
+++ b/arch/risc-v/src/rv32m1/rv32m1_serial.c
@@ -143,7 +143,7 @@ static int  up_setup(struct uart_dev_s *dev);
 static void up_shutdown(struct uart_dev_s *dev);
 static int  up_attach(struct uart_dev_s *dev);
 static void up_detach(struct uart_dev_s *dev);
-static int  up_interrupt(int irq, void *context, FAR void *arg);
+static int  up_interrupt(int irq, void *context, void *arg);
 static int  up_ioctl(struct file *filep, int cmd, unsigned long arg);
 static int  up_receive(struct uart_dev_s *dev, unsigned int *status);
 static void up_rxint(struct uart_dev_s *dev, bool enable);
@@ -767,7 +767,7 @@ static void up_detach(struct uart_dev_s *dev)
  ****************************************************************************/
 
 LOCATE_ITCM
-static int up_interrupt(int irq, void *context, FAR void *arg)
+static int up_interrupt(int irq, void *context, void *arg)
 {
   struct uart_dev_s *dev = (struct uart_dev_s *)arg;
   struct up_dev_s   *priv;

--- a/arch/risc-v/src/rv32m1/rv32m1_serial.c
+++ b/arch/risc-v/src/rv32m1/rv32m1_serial.c
@@ -491,7 +491,7 @@ static void up_set_format(struct uart_dev_s *dev)
           /* Get the closer one. i.e. the minimum difference */
 
           tdiff = priv->baud - baud;
-          tsbr ++;
+          tsbr++;
         }
 
       /* Pick up the best osr and sbr with the minimum diff */

--- a/arch/risc-v/src/rv32m1/rv32m1_timerisr.c
+++ b/arch/risc-v/src/rv32m1/rv32m1_timerisr.c
@@ -58,7 +58,7 @@
  ****************************************************************************/
 
 LOCATE_ITCM
-static int rv32m1_timerisr(int irq, void *context, FAR void *arg)
+static int rv32m1_timerisr(int irq, void *context, void *arg)
 {
   /* Write '1' to clear the pending flag */
 

--- a/arch/risc-v/src/rv64gc/riscv_assert.c
+++ b/arch/risc-v/src/rv64gc/riscv_assert.c
@@ -90,7 +90,7 @@ static void up_stackdump(uint64_t sp, uintptr_t stack_top)
  * Name: up_registerdump
  ****************************************************************************/
 
-static inline void up_registerdump(FAR volatile uintptr_t *regs)
+static inline void up_registerdump(volatile uintptr_t *regs)
 {
   /* Are user registers available from interrupt processing? */
 
@@ -132,7 +132,7 @@ static inline void up_registerdump(FAR volatile uintptr_t *regs)
  ****************************************************************************/
 
 #if defined(CONFIG_STACK_COLORATION) || defined(CONFIG_SCHED_BACKTRACE)
-static void up_taskdump(FAR struct tcb_s *tcb, FAR void *arg)
+static void up_taskdump(struct tcb_s *tcb, void *arg)
 {
   /* Dump interesting properties of this task */
 
@@ -319,7 +319,7 @@ static void _up_assert(void)
  ****************************************************************************/
 
 #ifdef CONFIG_ARCH_USBDUMP
-static int usbtrace_syslog(FAR const char *fmt, ...)
+static int usbtrace_syslog(const char *fmt, ...)
 {
   va_list ap;
 
@@ -331,7 +331,7 @@ static int usbtrace_syslog(FAR const char *fmt, ...)
   return OK;
 }
 
-static int assert_tracecallback(FAR struct usbtrace_s *trace, FAR void *arg)
+static int assert_tracecallback(struct usbtrace_s *trace, void *arg)
 {
   usbtrace_trprintf(usbtrace_syslog, trace->event, trace->value);
   return 0;

--- a/arch/risc-v/src/rv64gc/riscv_schedulesigaction.c
+++ b/arch/risc-v/src/rv64gc/riscv_schedulesigaction.c
@@ -267,7 +267,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
                    * been delivered.
                    */
 
-                  tcb->xcp.sigdeliver        = (FAR void *)sigdeliver;
+                  tcb->xcp.sigdeliver        = (void *)sigdeliver;
                   tcb->xcp.saved_epc         = tcb->xcp.regs[REG_EPC];
                   tcb->xcp.saved_int_ctx     = tcb->xcp.regs[REG_INT_CTX];
 
@@ -292,7 +292,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
                    * been delivered.
                    */
 
-                  tcb->xcp.sigdeliver       = (FAR void *)sigdeliver;
+                  tcb->xcp.sigdeliver       = (void *)sigdeliver;
                   tcb->xcp.saved_epc        = CURRENT_REGS[REG_EPC];
                   tcb->xcp.saved_int_ctx    = CURRENT_REGS[REG_INT_CTX];
 
@@ -352,7 +352,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
            * by the signal trampoline after the signal has been delivered.
            */
 
-          tcb->xcp.sigdeliver        = (FAR void *)sigdeliver;
+          tcb->xcp.sigdeliver        = (void *)sigdeliver;
           tcb->xcp.saved_epc         = tcb->xcp.regs[REG_EPC];
           tcb->xcp.saved_int_ctx     = tcb->xcp.regs[REG_INT_CTX];
 

--- a/arch/risc-v/src/rv64gc/riscv_signal_dispatch.c
+++ b/arch/risc-v/src/rv64gc/riscv_signal_dispatch.c
@@ -64,7 +64,7 @@
  ****************************************************************************/
 
 void up_signal_dispatch(_sa_sigaction_t sighand, int signo,
-                        FAR siginfo_t *info, FAR void *ucontext)
+                        siginfo_t *info, void *ucontext)
 {
   /* Let sys_call4() do all of the work */
 

--- a/arch/risc-v/src/rv64gc/riscv_swint.c
+++ b/arch/risc-v/src/rv64gc/riscv_swint.c
@@ -133,7 +133,7 @@ static void dispatch_syscall(void)
  *
  ****************************************************************************/
 
-int riscv_swint(int irq, FAR void *context, FAR void *arg)
+int riscv_swint(int irq, void *context, void *arg)
 {
   uint64_t *regs = (uint64_t *)context;
 
@@ -254,7 +254,7 @@ int riscv_swint(int irq, FAR void *context, FAR void *arg)
       /* R0=SYS_task_start:  This a user task start
        *
        *   void up_task_start(main_t taskentry, int argc,
-       *                      FAR char *argv[]) noreturn_function;
+       *                      char *argv[]) noreturn_function;
        *
        * At this point, the following values are saved in context:
        *
@@ -318,7 +318,7 @@ int riscv_swint(int irq, FAR void *context, FAR void *arg)
       /* R0=SYS_pthread_exit:  This pthread_exit call in user-space
        *
        *   void up_pthread_exit(pthread_exitroutine_t exit,
-       *                        FAR void *exit_value)
+       *                        void *exit_value)
        *
        * At this point, the following values are saved in context:
        *
@@ -348,7 +348,7 @@ int riscv_swint(int irq, FAR void *context, FAR void *arg)
       /* R0=SYS_signal_handler:  This a user signal handler callback
        *
        * void signal_handler(_sa_sigaction_t sighand, int signo,
-       *                     FAR siginfo_t *info, FAR void *ucontext);
+       *                     siginfo_t *info, void *ucontext);
        *
        * At this point, the following values are saved in context:
        *
@@ -421,7 +421,7 @@ int riscv_swint(int irq, FAR void *context, FAR void *arg)
       default:
         {
 #ifdef CONFIG_LIB_SYSCALL
-          FAR struct tcb_s *rtcb = nxsched_self();
+          struct tcb_s *rtcb = nxsched_self();
           int index = rtcb->xcp.nsyscalls;
 
           /* Verify that the SYS call number is within range */

--- a/arch/risc-v/src/rv64gc/svcall.h
+++ b/arch/risc-v/src/rv64gc/svcall.h
@@ -94,7 +94,7 @@
 #ifdef CONFIG_BUILD_PROTECTED
 /* SYS call 4:
  *
- * void up_task_start(main_t taskentry, int argc, FAR char *argv[])
+ * void up_task_start(main_t taskentry, int argc, char *argv[])
  *        noreturn_function;
  */
 
@@ -102,7 +102,7 @@
 /* SYS call 6:
  *
  * void signal_handler(_sa_sigaction_t sighand, int signo,
- *                     FAR siginfo_t *info, FAR void *ucontext);
+ *                     siginfo_t *info, void *ucontext);
  */
 
 #define SYS_signal_handler        (6)
@@ -127,7 +127,7 @@
 
 /* SYS call 8:
  *
- * void up_pthread_exit(pthread_exitroutine_t exit, FAR void *exit_value)
+ * void up_pthread_exit(pthread_exitroutine_t exit, void *exit_value)
  */
 
 #define SYS_pthread_exit          (8)

--- a/arch/xtensa/include/arch.h
+++ b/arch/xtensa/include/arch.h
@@ -143,7 +143,7 @@ void *xtensa_imm_zalloc(size_t size);
  *
  ****************************************************************************/
 
-void xtensa_imm_free(FAR void *mem);
+void xtensa_imm_free(void *mem);
 
 /****************************************************************************
  * Name: xtensa_imm_memalign
@@ -174,7 +174,7 @@ void *xtensa_imm_memalign(size_t alignment, size_t size);
  *
  ****************************************************************************/
 
-bool xtensa_imm_heapmember(FAR void *mem);
+bool xtensa_imm_heapmember(void *mem);
 
 /****************************************************************************
  * Name: xtensa_imm_mallinfo
@@ -185,7 +185,7 @@ bool xtensa_imm_heapmember(FAR void *mem);
  *
  ****************************************************************************/
 
-int xtensa_imm_mallinfo(FAR struct mallinfo *info);
+int xtensa_imm_mallinfo(struct mallinfo *info);
 #endif
 
 #undef EXTERN

--- a/arch/xtensa/include/tls.h
+++ b/arch/xtensa/include/tls.h
@@ -63,7 +63,7 @@
  ****************************************************************************/
 
 #ifdef CONFIG_TLS_ALIGNED
-static inline FAR struct tls_info_s *up_tls_info(void)
+static inline struct tls_info_s *up_tls_info(void)
 {
   DEBUGASSERT(!up_interrupt_context());
   return TLS_INFO((uintptr_t)up_getsp());

--- a/arch/xtensa/src/common/xtensa.h
+++ b/arch/xtensa/src/common/xtensa.h
@@ -344,7 +344,7 @@ void xtensa_pminitialize(void);
 /* Debug ********************************************************************/
 
 #ifdef CONFIG_STACK_COLORATION
-void up_stack_color(FAR void *stackbase, size_t nbytes);
+void up_stack_color(void *stackbase, size_t nbytes);
 #endif
 
 #endif /* __ASSEMBLY__ */

--- a/arch/xtensa/src/common/xtensa_assert.c
+++ b/arch/xtensa/src/common/xtensa_assert.c
@@ -63,7 +63,7 @@
  ****************************************************************************/
 
 #ifdef CONFIG_ARCH_USBDUMP
-static int usbtrace_syslog(FAR const char *fmt, ...)
+static int usbtrace_syslog(const char *fmt, ...)
 {
   va_list ap;
 
@@ -75,7 +75,7 @@ static int usbtrace_syslog(FAR const char *fmt, ...)
   return OK;
 }
 
-static int assert_tracecallback(FAR struct usbtrace_s *trace, FAR void *arg)
+static int assert_tracecallback(struct usbtrace_s *trace, void *arg)
 {
   usbtrace_trprintf(usbtrace_syslog, trace->event, trace->value);
   return 0;

--- a/arch/xtensa/src/common/xtensa_backtrace.c
+++ b/arch/xtensa/src/common/xtensa_backtrace.c
@@ -105,9 +105,9 @@ static void get_window_regs(struct xtensa_windowregs_s *frame)
  ****************************************************************************/
 
 #ifndef __XTENSA_CALL0_ABI__
-static int backtrace_window(FAR uintptr_t *base, FAR uintptr_t *limit,
+static int backtrace_window(uintptr_t *base, uintptr_t *limit,
                      struct xtensa_windowregs_s *frame,
-                     FAR void **buffer, int size)
+                     void **buffer, int size)
 {
   uint32_t windowstart;
   uint32_t ra;
@@ -152,9 +152,9 @@ static int backtrace_window(FAR uintptr_t *base, FAR uintptr_t *limit,
  *
  ****************************************************************************/
 
-static int backtrace_stack(FAR uintptr_t *base, FAR uintptr_t *limit,
-                     FAR uintptr_t *sp, FAR uintptr_t *ra,
-                     FAR void **buffer, int size)
+static int backtrace_stack(uintptr_t *base, uintptr_t *limit,
+                     uintptr_t *sp, uintptr_t *ra,
+                     void **buffer, int size)
 {
   int i = 0;
 
@@ -163,14 +163,14 @@ static int backtrace_stack(FAR uintptr_t *base, FAR uintptr_t *limit,
       buffer[i++] = MAKE_PC_FROM_RA((uintptr_t)ra);
     }
 
-  for (; i < size; sp = (FAR uintptr_t *)*(sp - 3), i++)
+  for (; i < size; sp = (uintptr_t *)*(sp - 3), i++)
     {
       if (sp > limit || sp < base)
         {
           break;
         }
 
-      ra = (FAR uintptr_t *)*(sp - 4);
+      ra = (uintptr_t *)*(sp - 4);
       if (ra == NULL)
         {
           break;
@@ -210,9 +210,9 @@ static int backtrace_stack(FAR uintptr_t *base, FAR uintptr_t *limit,
  *
  ****************************************************************************/
 
-int up_backtrace(FAR struct tcb_s *tcb, FAR void **buffer, int size)
+int up_backtrace(struct tcb_s *tcb, void **buffer, int size)
 {
-  FAR struct tcb_s *rtcb = running_task();
+  struct tcb_s *rtcb = running_task();
   irqstate_t flags;
   int ret;
 
@@ -234,20 +234,20 @@ int up_backtrace(FAR struct tcb_s *tcb, FAR void **buffer, int size)
 #endif
           xtensa_window_spill();
 
-          ret = bactrace_stack((FAR void *)istackbase,
-                          (FAR void *)((uint32_t)&g_intstackalloc +
+          ret = bactrace_stack((void *)istackbase,
+                          (void *)((uint32_t)&g_intstackalloc +
                                        CONFIG_ARCH_INTERRUPTSTACK),
-                          (FAR void *)up_getsp(), NULL, buffer, size);
+                          (void *)up_getsp(), NULL, buffer, size);
 #else
           ret = backtrace_stack(rtcb->stack_base_ptr,
                           rtcb->stack_base_ptr + rtcb->adj_stack_size,
-                          (FAR void *)up_getsp(), NULL, buffer, size);
+                          (void *)up_getsp(), NULL, buffer, size);
 #endif
           ret += backtrace_stack(rtcb->stack_base_ptr,
                           rtcb->stack_base_ptr +
                           rtcb->adj_stack_size,
-                          (FAR void *)CURRENT_REGS[REG_A1],
-                          (FAR void *)CURRENT_REGS[REG_A0],
+                          (void *)CURRENT_REGS[REG_A1],
+                          (void *)CURRENT_REGS[REG_A0],
                           &buffer[ret], size - ret);
         }
       else
@@ -273,7 +273,7 @@ int up_backtrace(FAR struct tcb_s *tcb, FAR void **buffer, int size)
 #endif
           ret += backtrace_stack(rtcb->stack_base_ptr,
                           rtcb->stack_base_ptr + rtcb->adj_stack_size,
-                          (FAR void *)up_getsp(), NULL, buffer, size - ret);
+                          (void *)up_getsp(), NULL, buffer, size - ret);
         }
     }
   else
@@ -284,8 +284,8 @@ int up_backtrace(FAR struct tcb_s *tcb, FAR void **buffer, int size)
 
       ret = backtrace_stack(tcb->stack_base_ptr,
                       tcb->stack_base_ptr + tcb->adj_stack_size,
-                      (FAR void *)tcb->xcp.regs[REG_A1],
-                      (FAR void *)tcb->xcp.regs[REG_A0],
+                      (void *)tcb->xcp.regs[REG_A1],
+                      (void *)tcb->xcp.regs[REG_A0],
                       buffer, size);
 
       leave_critical_section(flags);

--- a/arch/xtensa/src/common/xtensa_checkstack.c
+++ b/arch/xtensa/src/common/xtensa_checkstack.c
@@ -72,9 +72,9 @@ static size_t do_stackcheck(uintptr_t alloc, size_t size);
 
 static size_t do_stackcheck(uintptr_t alloc, size_t size)
 {
-  FAR uintptr_t start;
-  FAR uintptr_t end;
-  FAR uint32_t *ptr;
+  uintptr_t start;
+  uintptr_t end;
+  uint32_t *ptr;
   size_t mark;
 
   if (size == 0)
@@ -99,7 +99,7 @@ static size_t do_stackcheck(uintptr_t alloc, size_t size)
    * we encounter that does not have the magic value is the high water mark.
    */
 
-  for (ptr = (FAR uint32_t *)start, mark = (size >> 2);
+  for (ptr = (uint32_t *)start, mark = (size >> 2);
        *ptr == STACK_COLOR && mark > 0;
        ptr++, mark--);
 
@@ -119,7 +119,7 @@ static size_t do_stackcheck(uintptr_t alloc, size_t size)
       int i;
       int j;
 
-      ptr = (FAR uint32_t *)start;
+      ptr = (uint32_t *)start;
       for (i = 0; i < size; i += 4 * 64)
         {
           for (j = 0; j < 64; j++)
@@ -167,12 +167,12 @@ static size_t do_stackcheck(uintptr_t alloc, size_t size)
  *
  ****************************************************************************/
 
-size_t up_check_tcbstack(FAR struct tcb_s *tcb)
+size_t up_check_tcbstack(struct tcb_s *tcb)
 {
   return do_stackcheck((uintptr_t)tcb->stack_base_ptr, tcb->adj_stack_size);
 }
 
-ssize_t up_check_tcbstack_remain(FAR struct tcb_s *tcb)
+ssize_t up_check_tcbstack_remain(struct tcb_s *tcb)
 {
   return tcb->adj_stack_size - up_check_tcbstack(tcb);
 }

--- a/arch/xtensa/src/common/xtensa_cpupause.c
+++ b/arch/xtensa/src/common/xtensa_cpupause.c
@@ -97,7 +97,7 @@ bool up_cpu_pausereq(int cpu)
 
 int up_cpu_paused(int cpu)
 {
-  FAR struct tcb_s *tcb = this_task();
+  struct tcb_s *tcb = this_task();
 
   /* Update scheduler parameters */
 

--- a/arch/xtensa/src/common/xtensa_createstack.c
+++ b/arch/xtensa/src/common/xtensa_createstack.c
@@ -97,7 +97,7 @@
  *
  ****************************************************************************/
 
-int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
+int up_create_stack(struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
 {
 #if XCHAL_CP_NUM > 0
   struct xcptcontext *xcp;
@@ -271,12 +271,12 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
  ****************************************************************************/
 
 #ifdef CONFIG_STACK_COLORATION
-void up_stack_color(FAR void *stackbase, size_t nbytes)
+void up_stack_color(void *stackbase, size_t nbytes)
 {
   uintptr_t start;
   uintptr_t end;
   size_t nwords;
-  FAR uint32_t *ptr;
+  uint32_t *ptr;
 
   /* Take extra care that we do not write outside the stack boundaries */
 
@@ -287,7 +287,7 @@ void up_stack_color(FAR void *stackbase, size_t nbytes)
   /* Get the adjusted size based on the top and bottom of the stack */
 
   nwords = (end - start) >> 2;
-  ptr  = (FAR uint32_t *)start;
+  ptr  = (uint32_t *)start;
 
   /* Set the entire stack to the coloration value */
 

--- a/arch/xtensa/src/common/xtensa_dumpstate.c
+++ b/arch/xtensa/src/common/xtensa_dumpstate.c
@@ -56,7 +56,7 @@ static uint32_t s_last_regs[XCPTCONTEXT_REGS];
  ****************************************************************************/
 
 #ifdef CONFIG_STACK_COLORATION
-static void up_taskdump(FAR struct tcb_s *tcb, FAR void *arg)
+static void up_taskdump(struct tcb_s *tcb, void *arg)
 {
   /* Dump interesting properties of this task */
 

--- a/arch/xtensa/src/common/xtensa_exit.c
+++ b/arch/xtensa/src/common/xtensa_exit.c
@@ -63,11 +63,11 @@
  ****************************************************************************/
 
 #ifdef CONFIG_DUMP_ON_EXIT
-static void _xtensa_dumponexit(FAR struct tcb_s *tcb, FAR void *arg)
+static void _xtensa_dumponexit(struct tcb_s *tcb, void *arg)
 {
-  FAR struct filelist *filelist;
+  struct filelist *filelist;
 #ifdef CONFIG_FILE_STREAM
-  FAR struct file_struct *filep;
+  struct file_struct *filep;
 #endif
   int i;
   int j;

--- a/arch/xtensa/src/common/xtensa_releasestack.c
+++ b/arch/xtensa/src/common/xtensa_releasestack.c
@@ -68,7 +68,7 @@
  *
  ****************************************************************************/
 
-void up_release_stack(FAR struct tcb_s *dtcb, uint8_t ttype)
+void up_release_stack(struct tcb_s *dtcb, uint8_t ttype)
 {
   /* Is there a stack allocated? */
 

--- a/arch/xtensa/src/common/xtensa_stackframe.c
+++ b/arch/xtensa/src/common/xtensa_stackframe.c
@@ -82,9 +82,9 @@
  *
  ****************************************************************************/
 
-FAR void *up_stack_frame(FAR struct tcb_s *tcb, size_t frame_size)
+void *up_stack_frame(struct tcb_s *tcb, size_t frame_size)
 {
-  FAR void *ret;
+  void *ret;
 
   /* Align the frame_size */
 
@@ -102,7 +102,7 @@ FAR void *up_stack_frame(FAR struct tcb_s *tcb, size_t frame_size)
 
   /* Save the adjusted stack values in the struct tcb_s */
 
-  tcb->stack_base_ptr   = (FAR uint8_t *)tcb->stack_base_ptr + frame_size;
+  tcb->stack_base_ptr   = (uint8_t *)tcb->stack_base_ptr + frame_size;
   tcb->adj_stack_size -= frame_size;
 
   /* And return the pointer to the allocated region */

--- a/arch/xtensa/src/common/xtensa_testset.c
+++ b/arch/xtensa/src/common/xtensa_testset.c
@@ -49,7 +49,7 @@
  *
  ****************************************************************************/
 
-static inline uint32_t xtensa_compareset(FAR volatile uint32_t *addr,
+static inline uint32_t xtensa_compareset(volatile uint32_t *addr,
                                          uint32_t compare,
                                          uint32_t set)
 {
@@ -88,13 +88,13 @@ static inline uint32_t xtensa_compareset(FAR volatile uint32_t *addr,
  *
  ****************************************************************************/
 
-spinlock_t up_testset(volatile FAR spinlock_t *lock)
+spinlock_t up_testset(volatile spinlock_t *lock)
 {
   spinlock_t prev;
 
   /* Perform the 32-bit compare and set operation */
 
-  prev = xtensa_compareset((FAR volatile uint32_t *)lock,
+  prev = xtensa_compareset((volatile uint32_t *)lock,
                            SP_UNLOCKED, SP_LOCKED);
 
   /* xtensa_compareset() should return either SP_UNLOCKED if the spinlock

--- a/arch/xtensa/src/esp32/esp32_aes.c
+++ b/arch/xtensa/src/esp32/esp32_aes.c
@@ -580,8 +580,8 @@ int esp32_aes_init(void)
 
 #ifdef CONFIG_CRYPTO_AES
 
-int aes_cypher(FAR void *out, FAR const void *in, uint32_t size,
-               FAR const void *iv, FAR const void *key, uint32_t keysize,
+int aes_cypher(void *out, const void *in, uint32_t size,
+               const void *iv, const void *key, uint32_t keysize,
                int mode, int encrypt)
 {
   int ret;

--- a/arch/xtensa/src/esp32/esp32_allocateheap.c
+++ b/arch/xtensa/src/esp32/esp32_allocateheap.c
@@ -64,11 +64,11 @@
  *
  ****************************************************************************/
 
-void up_allocate_heap(FAR void **heap_start, size_t *heap_size)
+void up_allocate_heap(void **heap_start, size_t *heap_size)
 {
   board_autoled_on(LED_HEAPALLOCATE);
 
-  *heap_start = (FAR void *)&_sheap;
+  *heap_start = (void *)&_sheap;
   DEBUGASSERT(HEAP_REGION1_END > (uintptr_t)*heap_start);
   *heap_size = (size_t)(HEAP_REGION1_END - (uintptr_t)*heap_start);
 }
@@ -113,28 +113,28 @@ void xtensa_add_region(void)
     }
 
 #ifndef CONFIG_SMP
-  start = (FAR void *)(HEAP_REGION2_START + XTENSA_IMEM_REGION_SIZE);
+  start = (void *)(HEAP_REGION2_START + XTENSA_IMEM_REGION_SIZE);
   size  = (size_t)(uintptr_t)&_eheap - (size_t)start;
   umm_addregion(start, size);
 
 #else
 #ifdef CONFIG_ESP32_QEMU_IMAGE
-  start = (FAR void *)HEAP_REGION2_START;
+  start = (void *)HEAP_REGION2_START;
   size  = (size_t)(uintptr_t)&_eheap - (size_t)start;
   umm_addregion(start, size);
 #else
-  start = (FAR void *)HEAP_REGION2_START;
+  start = (void *)HEAP_REGION2_START;
   size  = (size_t)(HEAP_REGION2_END - HEAP_REGION2_START);
   umm_addregion(start, size);
 
-  start = (FAR void *)HEAP_REGION3_START + XTENSA_IMEM_REGION_SIZE;
+  start = (void *)HEAP_REGION3_START + XTENSA_IMEM_REGION_SIZE;
   size  = (size_t)(uintptr_t)&_eheap - (size_t)start;
   umm_addregion(start, size);
 #endif
 #endif
 
 #ifndef CONFIG_ESP32_QEMU_IMAGE
-  start = (FAR void *)HEAP_REGION0_START;
+  start = (void *)HEAP_REGION0_START;
   size  = (size_t)(HEAP_REGION0_END - HEAP_REGION0_START);
   umm_addregion(start, size);
 #endif
@@ -142,10 +142,10 @@ void xtensa_add_region(void)
 #ifdef CONFIG_ESP32_SPIRAM
 #  if defined(CONFIG_HEAP2_BASE) && defined(CONFIG_HEAP2_SIZE)
 #    ifdef CONFIG_XTENSA_EXTMEM_BSS
-      start = (FAR void *)(&_ebss_extmem);
+      start = (void *)(&_ebss_extmem);
       size = CONFIG_HEAP2_SIZE - (size_t)(&_ebss_extmem - &_sbss_extmem);
 #    else
-      start = (FAR void *)CONFIG_HEAP2_BASE;
+      start = (void *)CONFIG_HEAP2_BASE;
       size = CONFIG_HEAP2_SIZE;
 #    endif
 #  ifdef CONFIG_ESP32_SPIRAM_BANKSWITCH_ENABLE

--- a/arch/xtensa/src/esp32/esp32_cpuidlestack.c
+++ b/arch/xtensa/src/esp32/esp32_cpuidlestack.c
@@ -86,7 +86,7 @@ uint32_t g_cpu1_idlestack[CPU1_IDLETHREAD_STACKWORDS]
  *
  ****************************************************************************/
 
-int up_cpu_idlestack(int cpu, FAR struct tcb_s *tcb, size_t stack_size)
+int up_cpu_idlestack(int cpu, struct tcb_s *tcb, size_t stack_size)
 {
   /* XTENSA uses a push-down stack:  the stack grows toward lower* addresses
    * in memory.  The stack pointer register points to the lowest, valid

--- a/arch/xtensa/src/esp32/esp32_cpustart.c
+++ b/arch/xtensa/src/esp32/esp32_cpustart.c
@@ -72,7 +72,7 @@ extern void ets_set_appcpu_boot_addr(uint32_t start);
  ****************************************************************************/
 
 #if 0 /* Was useful in solving some startup problems */
-static inline void xtensa_registerdump(FAR struct tcb_s *tcb)
+static inline void xtensa_registerdump(struct tcb_s *tcb)
 {
   _info("CPU%d:\n", up_cpu_index());
 
@@ -130,7 +130,7 @@ static inline void xtensa_attach_fromcpu0_interrupt(void)
 
 void xtensa_appcpu_start(void)
 {
-  FAR struct tcb_s *tcb = this_task();
+  struct tcb_s *tcb = this_task();
   register uint32_t sp;
 
 #ifdef CONFIG_STACK_COLORATION

--- a/arch/xtensa/src/esp32/esp32_efuse.h
+++ b/arch/xtensa/src/esp32/esp32_efuse.h
@@ -60,4 +60,4 @@ int esp_efuse_write_field(const efuse_desc_t *field[],
 
 void esp_efuse_burn_efuses(void);
 
-int esp32_efuse_initialize(FAR const char *devpath);
+int esp32_efuse_initialize(const char *devpath);

--- a/arch/xtensa/src/esp32/esp32_efuse_lowerhalf.c
+++ b/arch/xtensa/src/esp32/esp32_efuse_lowerhalf.c
@@ -37,8 +37,8 @@
 
 struct esp32_efuse_lowerhalf_s
 {
-  FAR const struct efuse_ops_s *ops; /* Lower half operations */
-  void *upper;                       /* Pointer to efuse_upperhalf_s */
+  const struct efuse_ops_s *ops; /* Lower half operations */
+  void *upper;                   /* Pointer to efuse_upperhalf_s */
 };
 
 /****************************************************************************
@@ -47,14 +47,14 @@ struct esp32_efuse_lowerhalf_s
 
 /* "Lower half" driver methods **********************************************/
 
-static int      esp32_efuse_read_field(FAR struct efuse_lowerhalf_s *lower,
+static int      esp32_efuse_read_field(struct efuse_lowerhalf_s *lower,
                                        const efuse_desc_t *field[],
-                                       FAR uint8_t *data, size_t size);
-static int      esp32_efuse_write_field(FAR struct efuse_lowerhalf_s *lower,
+                                       uint8_t *data, size_t size);
+static int      esp32_efuse_write_field(struct efuse_lowerhalf_s *lower,
                                         const efuse_desc_t *field[],
-                                        FAR const uint8_t *data,
+                                        const uint8_t *data,
                                         size_t size);
-static int      efuse_ioctl(FAR struct efuse_lowerhalf_s *lower, int cmd,
+static int      efuse_ioctl(struct efuse_lowerhalf_s *lower, int cmd,
                             unsigned long arg);
 
 /****************************************************************************
@@ -82,7 +82,7 @@ static struct esp32_efuse_lowerhalf_s g_esp32_efuse_lowerhalf =
  * Private functions
  ****************************************************************************/
 
-static int esp32_efuse_read_field(FAR struct efuse_lowerhalf_s *lower,
+static int esp32_efuse_read_field(struct efuse_lowerhalf_s *lower,
                                   const efuse_desc_t *field[],
                                   uint8_t *data, size_t bits_len)
 {
@@ -95,7 +95,7 @@ static int esp32_efuse_read_field(FAR struct efuse_lowerhalf_s *lower,
   return ret;
 }
 
-static int esp32_efuse_write_field(FAR struct efuse_lowerhalf_s *lower,
+static int esp32_efuse_write_field(struct efuse_lowerhalf_s *lower,
                                    const efuse_desc_t *field[],
                                    const uint8_t *data, size_t bits_len)
 {
@@ -121,7 +121,7 @@ static int esp32_efuse_write_field(FAR struct efuse_lowerhalf_s *lower,
  * Name: efuse_ioctl
  ****************************************************************************/
 
-static int efuse_ioctl(FAR struct efuse_lowerhalf_s *lower,
+static int efuse_ioctl(struct efuse_lowerhalf_s *lower,
                        int cmd, unsigned long arg)
 {
   int ret = OK;
@@ -162,7 +162,7 @@ static int efuse_ioctl(FAR struct efuse_lowerhalf_s *lower,
  *
  ****************************************************************************/
 
-int esp32_efuse_initialize(FAR const char *devpath)
+int esp32_efuse_initialize(const char *devpath)
 {
   struct esp32_efuse_lowerhalf_s *lower = NULL;
   int ret = OK;
@@ -174,7 +174,7 @@ int esp32_efuse_initialize(FAR const char *devpath)
   /* Register the efuser upper driver */
 
   lower->upper = efuse_register(devpath,
-                                (FAR struct efuse_lowerhalf_s *)lower);
+                                (struct efuse_lowerhalf_s *)lower);
 
   if (lower->upper == NULL)
     {

--- a/arch/xtensa/src/esp32/esp32_emac.c
+++ b/arch/xtensa/src/esp32/esp32_emac.c
@@ -373,7 +373,7 @@ static void emac_init_buffer(struct esp32_emac_s *priv)
 
   for (i = 0; i < EMAC_BUF_NUM; i++)
     {
-      sq_addlast((FAR sq_entry_t *)buffer, &priv->freeb);
+      sq_addlast((sq_entry_t *)buffer, &priv->freeb);
       buffer += EMAC_BUF_LEN;
     }
 }
@@ -435,7 +435,7 @@ static inline void emac_free_buffer(struct esp32_emac_s *priv,
 {
   /* Free the buffer by adding it to the end of the free buffer list */
 
-  sq_addlast((FAR sq_entry_t *)buffer, &priv->freeb);
+  sq_addlast((sq_entry_t *)buffer, &priv->freeb);
 }
 
 /****************************************************************************
@@ -1271,7 +1271,7 @@ static int phy_enable_interrupt(void)
  *
  ****************************************************************************/
 
-static void emac_txtimeout_work(FAR void *arg)
+static void emac_txtimeout_work(void *arg)
 {
   struct esp32_emac_s *priv = (struct esp32_emac_s *)arg;
 
@@ -1341,7 +1341,7 @@ static void emac_txtimeout_expiry(wdparm_t arg)
  *
  ****************************************************************************/
 
-static void emac_rx_interrupt_work(FAR void *arg)
+static void emac_rx_interrupt_work(void *arg)
 {
   struct esp32_emac_s *priv = (struct esp32_emac_s *)arg;
   struct net_driver_s *dev = &priv->dev;
@@ -1496,7 +1496,7 @@ static void emac_rx_interrupt_work(FAR void *arg)
  *
  ****************************************************************************/
 
-static void emac_tx_interrupt_work(FAR void *arg)
+static void emac_tx_interrupt_work(void *arg)
 {
   struct esp32_emac_s *priv = (struct esp32_emac_s *)arg;
 
@@ -1526,7 +1526,7 @@ static void emac_tx_interrupt_work(FAR void *arg)
  *
  ****************************************************************************/
 
-static int emac_interrupt(int irq, FAR void *context, FAR void *arg)
+static int emac_interrupt(int irq, void *context, void *arg)
 {
   struct esp32_emac_s *priv = (struct esp32_emac_s *)arg;
   uint32_t value = emac_get_reg(EMAC_DMA_SR_OFFSET);
@@ -1677,7 +1677,7 @@ static int emac_txpoll(struct net_driver_s *dev)
 
 static void emac_dopoll(struct esp32_emac_s *priv)
 {
-  FAR struct net_driver_s *dev = &priv->dev;
+  struct net_driver_s *dev = &priv->dev;
 
   if (!TX_IS_BUSY(priv))
     {
@@ -1722,7 +1722,7 @@ static void emac_dopoll(struct esp32_emac_s *priv)
  *
  ****************************************************************************/
 
-static void emac_txavail_work(FAR void *arg)
+static void emac_txavail_work(void *arg)
 {
   struct esp32_emac_s *priv = (struct esp32_emac_s *)arg;
 
@@ -1758,11 +1758,11 @@ static void emac_txavail_work(FAR void *arg)
  *
  ****************************************************************************/
 
-static void emac_poll_work(FAR void *arg)
+static void emac_poll_work(void *arg)
 {
   int ret;
   struct esp32_emac_s *priv = (struct esp32_emac_s *)arg;
-  FAR struct net_driver_s *dev = &priv->dev;
+  struct net_driver_s *dev = &priv->dev;
 
   ninfo("ifup: %d\n", priv->ifup);
 
@@ -1826,7 +1826,7 @@ static void emac_poll_work(FAR void *arg)
 
 static void emac_poll_expiry(wdparm_t arg)
 {
-  FAR struct esp32_emac_s *priv = (FAR struct esp32_emac_s *)arg;
+  struct esp32_emac_s *priv = (struct esp32_emac_s *)arg;
 
   /* Schedule to perform the interrupt processing on the worker thread. */
 
@@ -2026,7 +2026,7 @@ static int emac_txavail(struct net_driver_s *dev)
  ****************************************************************************/
 
 #if defined(CONFIG_NET_MCASTGROUP) || defined(CONFIG_NET_ICMPv6)
-static int emac_addmac(struct net_driver_s *dev, FAR const uint8_t *mac)
+static int emac_addmac(struct net_driver_s *dev, const uint8_t *mac)
 {
   ninfo("MAC: %02x:%02x:%02x:%02x:%02x:%02x\n",
         mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);
@@ -2055,7 +2055,7 @@ static int emac_addmac(struct net_driver_s *dev, FAR const uint8_t *mac)
  ****************************************************************************/
 
 #ifdef CONFIG_NET_MCASTGROUP
-static int emac_rmmac(struct net_driver_s *dev, FAR const uint8_t *mac)
+static int emac_rmmac(struct net_driver_s *dev, const uint8_t *mac)
 {
   ninfo("MAC: %02x:%02x:%02x:%02x:%02x:%02x\n",
         mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);
@@ -2096,7 +2096,7 @@ static int emac_rmmac(struct net_driver_s *dev, FAR const uint8_t *mac)
 static int emac_ioctl(struct net_driver_s *dev, int cmd, unsigned long arg)
 {
 #if defined(CONFIG_NETDEV_PHY_IOCTL) && defined(CONFIG_ARCH_PHY_INTERRUPT)
-  FAR struct esp32_emacmac_s *priv = NET2PRIV(dev);
+  struct esp32_emacmac_s *priv = NET2PRIV(dev);
 #endif
   int ret;
 

--- a/arch/xtensa/src/esp32/esp32_freerun.h
+++ b/arch/xtensa/src/esp32/esp32_freerun.h
@@ -46,11 +46,11 @@
 
 struct esp32_freerun_s
 {
-  uint8_t chan;                    /* The timer/counter in use */
-  uint32_t overflow;               /* Timer counter overflow */
-  uint16_t resolution;             /* Timer resolution */
-  uint64_t max_timeout;            /* Maximum timeout to overflow */
-  FAR struct esp32_tim_dev_s *tch; /* Handle returned by esp32_tim_init() */
+  uint8_t chan;                /* The timer/counter in use */
+  uint32_t overflow;           /* Timer counter overflow */
+  uint16_t resolution;         /* Timer resolution */
+  uint64_t max_timeout;        /* Maximum timeout to overflow */
+  struct esp32_tim_dev_s *tch; /* Handle returned by esp32_tim_init() */
 };
 
 /****************************************************************************

--- a/arch/xtensa/src/esp32/esp32_gpio.c
+++ b/arch/xtensa/src/esp32/esp32_gpio.c
@@ -135,7 +135,7 @@ static void gpio_dispatch(int irq, uint32_t status, uint32_t *regs)
  ****************************************************************************/
 
 #ifdef CONFIG_ESP32_GPIO_IRQ
-static int gpio_interrupt(int irq, FAR void *context, FAR void *arg)
+static int gpio_interrupt(int irq, void *context, void *arg)
 {
   uint32_t status;
 

--- a/arch/xtensa/src/esp32/esp32_himem.c
+++ b/arch/xtensa/src/esp32/esp32_himem.c
@@ -103,13 +103,13 @@
 
 /* Character driver methods */
 
-static int     himem_open(FAR struct file *filep);
-static int     himem_close(FAR struct file *filep);
-static ssize_t himem_read(FAR struct file *filep, FAR char *buffer,
+static int     himem_open(struct file *filep);
+static int     himem_close(struct file *filep);
+static ssize_t himem_read(struct file *filep, char *buffer,
                           size_t buflen);
-static ssize_t himem_write(FAR struct file *filep, FAR const char *buffer,
+static ssize_t himem_write(struct file *filep, const char *buffer,
                            size_t buflen);
-static int     himem_ioctl(FAR struct file *filep, int cmd,
+static int     himem_ioctl(struct file *filep, int cmd,
                            unsigned long arg);
 
 /* This structure is used only for access control */
@@ -222,7 +222,7 @@ size_t esp_himem_reserved_area_size(void)
 
 int esp_himem_init(void)
 {
-  FAR struct himem_access_s *priv;
+  struct himem_access_s *priv;
   int paddr_start = (4096 * 1024) - (CACHE_BLOCKSIZE *
                      SPIRAM_BANKSWITCH_RESERVE);
   int paddr_end;
@@ -236,7 +236,7 @@ int esp_himem_init(void)
 
   /* Allocate a new himem access instance */
 
-  priv = (FAR struct himem_access_s *)
+  priv = (struct himem_access_s *)
     kmm_zalloc(sizeof(struct himem_access_s));
 
   if (!priv)
@@ -652,7 +652,7 @@ int esp_himem_unmap(esp_himem_rangehandle_t range, void *ptr,
  *
  ****************************************************************************/
 
-static int himem_open(FAR struct file *filep)
+static int himem_open(struct file *filep)
 {
   return OK;
 }
@@ -665,7 +665,7 @@ static int himem_open(FAR struct file *filep)
  *
  ****************************************************************************/
 
-static int himem_close(FAR struct file *filep)
+static int himem_close(struct file *filep)
 {
   return OK;
 }
@@ -674,7 +674,7 @@ static int himem_close(FAR struct file *filep)
  * Name: himem_read
  ****************************************************************************/
 
-static ssize_t himem_read(FAR struct file *filep, FAR char *buffer,
+static ssize_t himem_read(struct file *filep, char *buffer,
                           size_t buflen)
 {
   return -ENOSYS;
@@ -684,7 +684,7 @@ static ssize_t himem_read(FAR struct file *filep, FAR char *buffer,
  * Name: himem_write
  ****************************************************************************/
 
-static ssize_t himem_write(FAR struct file *filep, FAR const char *buffer,
+static ssize_t himem_write(struct file *filep, const char *buffer,
                           size_t buflen)
 {
   return -ENOSYS;
@@ -694,7 +694,7 @@ static ssize_t himem_write(FAR struct file *filep, FAR const char *buffer,
  * Name: himem_ioctl
  ****************************************************************************/
 
-static int himem_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
+static int himem_ioctl(struct file *filep, int cmd, unsigned long arg)
 {
   int ret   = OK;
 
@@ -704,8 +704,8 @@ static int himem_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
 
       case HIMEMIOC_ALLOC_BLOCKS:
         {
-          FAR struct esp_himem_par *param =
-                     (FAR struct esp_himem_par *)((uintptr_t)arg);
+          struct esp_himem_par *param =
+                     (struct esp_himem_par *)((uintptr_t)arg);
 
           DEBUGASSERT(param != NULL);
 
@@ -724,8 +724,8 @@ static int himem_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
 
       case HIMEMIOC_FREE_BLOCKS:
         {
-          FAR struct esp_himem_par *param =
-                     (FAR struct esp_himem_par *)((uintptr_t)arg);
+          struct esp_himem_par *param =
+                     (struct esp_himem_par *)((uintptr_t)arg);
 
           DEBUGASSERT(param != NULL);
 
@@ -742,8 +742,8 @@ static int himem_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
 
       case HIMEMIOC_ALLOC_MAP_RANGE:
         {
-          FAR struct esp_himem_par *param =
-                     (FAR struct esp_himem_par *)((uintptr_t)arg);
+          struct esp_himem_par *param =
+                     (struct esp_himem_par *)((uintptr_t)arg);
 
           DEBUGASSERT(param != NULL);
 
@@ -762,8 +762,8 @@ static int himem_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
 
       case HIMEMIOC_FREE_MAP_RANGE:
         {
-          FAR struct esp_himem_par *param =
-                     (FAR struct esp_himem_par *)((uintptr_t)arg);
+          struct esp_himem_par *param =
+                     (struct esp_himem_par *)((uintptr_t)arg);
 
           DEBUGASSERT(param != NULL);
 
@@ -780,8 +780,8 @@ static int himem_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
 
       case HIMEMIOC_MAP:
         {
-          FAR struct esp_himem_par *param =
-                     (FAR struct esp_himem_par *)((uintptr_t)arg);
+          struct esp_himem_par *param =
+                     (struct esp_himem_par *)((uintptr_t)arg);
 
           DEBUGASSERT(param != NULL);
 
@@ -804,8 +804,8 @@ static int himem_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
 
       case HIMEMIOC_UNMAP:
         {
-          FAR struct esp_himem_par *param =
-                     (FAR struct esp_himem_par *)((uintptr_t)arg);
+          struct esp_himem_par *param =
+                     (struct esp_himem_par *)((uintptr_t)arg);
 
           DEBUGASSERT(param != NULL);
 
@@ -824,8 +824,8 @@ static int himem_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
 
       case HIMEMIOC_GET_PHYS_SIZE:
         {
-          FAR struct esp_himem_par *param =
-                     (FAR struct esp_himem_par *)((uintptr_t)arg);
+          struct esp_himem_par *param =
+                     (struct esp_himem_par *)((uintptr_t)arg);
 
           DEBUGASSERT(param != NULL);
 
@@ -837,8 +837,8 @@ static int himem_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
 
       case HIMEMIOC_GET_FREE_SIZE:
         {
-          FAR struct esp_himem_par *param =
-                     (FAR struct esp_himem_par *)((uintptr_t)arg);
+          struct esp_himem_par *param =
+                     (struct esp_himem_par *)((uintptr_t)arg);
 
           DEBUGASSERT(param != NULL);
 

--- a/arch/xtensa/src/esp32/esp32_i2c.c
+++ b/arch/xtensa/src/esp32/esp32_i2c.c
@@ -488,7 +488,7 @@ static void esp32_i2c_senddata(FAR struct esp32_i2c_priv_s *priv)
 
   /* Transfer the data from the msg buffer to the TX FIFO */
 
-  for (i = 0; i < n; i ++)
+  for (i = 0; i < n; i++)
     {
       esp32_i2c_set_reg(priv, I2C_DATA_OFFSET,
                         msg->buffer[priv->bytes + i]);

--- a/arch/xtensa/src/esp32/esp32_i2c.c
+++ b/arch/xtensa/src/esp32/esp32_i2c.c
@@ -235,20 +235,20 @@ struct esp32_i2c_priv_s
  * Private Function Prototypes
  ****************************************************************************/
 
-static void esp32_i2c_init_clock(FAR struct esp32_i2c_priv_s *priv,
+static void esp32_i2c_init_clock(struct esp32_i2c_priv_s *priv,
                                  uint32_t clock);
-static void esp32_i2c_init(FAR struct esp32_i2c_priv_s *priv);
-static void esp32_i2c_deinit(FAR struct esp32_i2c_priv_s *priv);
-static int esp32_i2c_transfer(FAR struct i2c_master_s *dev,
-                              FAR struct i2c_msg_s *msgs,
+static void esp32_i2c_init(struct esp32_i2c_priv_s *priv);
+static void esp32_i2c_deinit(struct esp32_i2c_priv_s *priv);
+static int esp32_i2c_transfer(struct i2c_master_s *dev,
+                              struct i2c_msg_s *msgs,
                               int count);
 static inline void esp32_i2c_process(struct esp32_i2c_priv_s *priv,
                                      uint32_t status);
 #ifdef CONFIG_I2C_POLLED
-static int esp32_i2c_polling_waitdone(FAR struct esp32_i2c_priv_s *priv);
+static int esp32_i2c_polling_waitdone(struct esp32_i2c_priv_s *priv);
 #endif
 #ifdef CONFIG_I2C_RESET
-static int esp32_i2c_reset(FAR struct i2c_master_s *dev);
+static int esp32_i2c_reset(struct i2c_master_s *dev);
 #endif
 
 #ifdef CONFIG_I2C_TRACE
@@ -416,7 +416,7 @@ static inline void esp32_i2c_reset_reg_bits(struct esp32_i2c_priv_s *priv,
  *
  ****************************************************************************/
 
-static void esp32_i2c_reset_fifo(FAR struct esp32_i2c_priv_s *priv)
+static void esp32_i2c_reset_fifo(struct esp32_i2c_priv_s *priv)
 {
   esp32_i2c_set_reg_bits(priv, I2C_FIFO_CONF_OFFSET, I2C_TX_FIFO_RST);
   esp32_i2c_reset_reg_bits(priv, I2C_FIFO_CONF_OFFSET, I2C_TX_FIFO_RST);
@@ -433,7 +433,7 @@ static void esp32_i2c_reset_fifo(FAR struct esp32_i2c_priv_s *priv)
  *
  ****************************************************************************/
 
-static void esp32_i2c_sendstart(FAR struct esp32_i2c_priv_s *priv)
+static void esp32_i2c_sendstart(struct esp32_i2c_priv_s *priv)
 {
   struct i2c_msg_s *msg = &priv->msgv[priv->msgid];
 
@@ -471,7 +471,7 @@ static void esp32_i2c_sendstart(FAR struct esp32_i2c_priv_s *priv)
  *
  ****************************************************************************/
 
-static void esp32_i2c_senddata(FAR struct esp32_i2c_priv_s *priv)
+static void esp32_i2c_senddata(struct esp32_i2c_priv_s *priv)
 {
   int i;
   struct i2c_msg_s *msg = &priv->msgv[priv->msgid];
@@ -600,7 +600,7 @@ static void esp32_i2c_sendstop(struct esp32_i2c_priv_s *priv)
  *
  ****************************************************************************/
 
-static void esp32_i2c_init_clock(FAR struct esp32_i2c_priv_s *priv,
+static void esp32_i2c_init_clock(struct esp32_i2c_priv_s *priv,
                                  uint32_t clk_freq)
 {
   uint32_t half_cycles = APB_CLK_FREQ / clk_freq / 2;
@@ -632,7 +632,7 @@ static void esp32_i2c_init_clock(FAR struct esp32_i2c_priv_s *priv,
  *
  ****************************************************************************/
 
-static void esp32_i2c_init(FAR struct esp32_i2c_priv_s *priv)
+static void esp32_i2c_init(struct esp32_i2c_priv_s *priv)
 {
   const struct esp32_i2c_config_s *config = priv->config;
 
@@ -682,7 +682,7 @@ static void esp32_i2c_init(FAR struct esp32_i2c_priv_s *priv)
  *
  ****************************************************************************/
 
-static void esp32_i2c_deinit(FAR struct esp32_i2c_priv_s *priv)
+static void esp32_i2c_deinit(struct esp32_i2c_priv_s *priv)
 {
   const struct esp32_i2c_config_s *config = priv->config;
 
@@ -700,7 +700,7 @@ static void esp32_i2c_deinit(FAR struct esp32_i2c_priv_s *priv)
  *
  ****************************************************************************/
 
-static void esp32_i2c_reset_fsmc(FAR struct esp32_i2c_priv_s *priv)
+static void esp32_i2c_reset_fsmc(struct esp32_i2c_priv_s *priv)
 {
   esp32_i2c_deinit(priv);
   esp32_i2c_init(priv);
@@ -718,7 +718,7 @@ static void esp32_i2c_reset_fsmc(FAR struct esp32_i2c_priv_s *priv)
  *   priv          - Pointer to the internal driver state structure.
  ****************************************************************************/
 #ifndef CONFIG_I2C_POLLED
-static int esp32_i2c_sem_waitdone(FAR struct esp32_i2c_priv_s *priv)
+static int esp32_i2c_sem_waitdone(struct esp32_i2c_priv_s *priv)
 {
   int ret;
   struct timespec abstime;
@@ -766,7 +766,7 @@ static int esp32_i2c_sem_waitdone(FAR struct esp32_i2c_priv_s *priv)
  *
  ****************************************************************************/
 #ifdef CONFIG_I2C_POLLED
-static int esp32_i2c_polling_waitdone(FAR struct esp32_i2c_priv_s *priv)
+static int esp32_i2c_polling_waitdone(struct esp32_i2c_priv_s *priv)
 {
   int ret;
   struct timespec current_time;
@@ -869,7 +869,7 @@ static int esp32_i2c_polling_waitdone(FAR struct esp32_i2c_priv_s *priv)
  *
  ****************************************************************************/
 
-static int esp32_i2c_sem_wait(FAR struct esp32_i2c_priv_s *priv)
+static int esp32_i2c_sem_wait(struct esp32_i2c_priv_s *priv)
 {
   return nxsem_wait_uninterruptible(&priv->sem_excl);
 }
@@ -895,7 +895,7 @@ static void esp32_i2c_sem_post(struct esp32_i2c_priv_s *priv)
  *
  ****************************************************************************/
 
-static void esp32_i2c_sem_destroy(FAR struct esp32_i2c_priv_s *priv)
+static void esp32_i2c_sem_destroy(struct esp32_i2c_priv_s *priv)
 {
   nxsem_destroy(&priv->sem_excl);
 #ifndef CONFIG_I2C_POLLED
@@ -911,7 +911,7 @@ static void esp32_i2c_sem_destroy(FAR struct esp32_i2c_priv_s *priv)
  *
  ****************************************************************************/
 
-static inline void esp32_i2c_sem_init(FAR struct esp32_i2c_priv_s *priv)
+static inline void esp32_i2c_sem_init(struct esp32_i2c_priv_s *priv)
 {
   nxsem_init(&priv->sem_excl, 0, 1);
 
@@ -937,13 +937,13 @@ static inline void esp32_i2c_sem_init(FAR struct esp32_i2c_priv_s *priv)
  *
  ****************************************************************************/
 
-static int esp32_i2c_transfer(FAR struct i2c_master_s *dev,
-                              FAR struct i2c_msg_s *msgs,
+static int esp32_i2c_transfer(struct i2c_master_s *dev,
+                              struct i2c_msg_s *msgs,
                               int count)
 {
   int i;
   int ret = OK;
-  FAR struct esp32_i2c_priv_s *priv = (FAR struct esp32_i2c_priv_s *)dev;
+  struct esp32_i2c_priv_s *priv = (struct esp32_i2c_priv_s *)dev;
 
   DEBUGASSERT(count > 0);
 
@@ -1163,10 +1163,10 @@ out:
  ****************************************************************************/
 
 #ifdef CONFIG_I2C_RESET
-static int esp32_i2c_reset(FAR struct i2c_master_s *dev)
+static int esp32_i2c_reset(struct i2c_master_s *dev)
 {
   irqstate_t flags;
-  FAR struct esp32_i2c_priv_s *priv = (FAR struct esp32_i2c_priv_s *)dev;
+  struct esp32_i2c_priv_s *priv = (struct esp32_i2c_priv_s *)dev;
 
   DEBUGASSERT(dev);
 
@@ -1380,7 +1380,7 @@ static void esp32_i2c_tracedump(struct esp32_i2c_priv_s *priv)
  ****************************************************************************/
 
 #ifndef CONFIG_I2C_POLLED
-static int esp32_i2c_irq(int cpuint, void *context, FAR void *arg)
+static int esp32_i2c_irq(int cpuint, void *context, void *arg)
 {
   struct esp32_i2c_priv_s *priv = (struct esp32_i2c_priv_s *)arg;
 
@@ -1528,7 +1528,7 @@ static inline void esp32_i2c_process(struct esp32_i2c_priv_s *priv,
  *
  ****************************************************************************/
 
-FAR struct i2c_master_s *esp32_i2cbus_initialize(int port)
+struct i2c_master_s *esp32_i2cbus_initialize(int port)
 {
   irqstate_t flags;
   struct esp32_i2c_priv_s *priv;
@@ -1598,7 +1598,7 @@ FAR struct i2c_master_s *esp32_i2cbus_initialize(int port)
 
   leave_critical_section(flags);
 
-  return (FAR struct i2c_master_s *)priv;
+  return (struct i2c_master_s *)priv;
 }
 
 /****************************************************************************
@@ -1609,10 +1609,10 @@ FAR struct i2c_master_s *esp32_i2cbus_initialize(int port)
  *
  ****************************************************************************/
 
-int esp32_i2cbus_uninitialize(FAR struct i2c_master_s *dev)
+int esp32_i2cbus_uninitialize(struct i2c_master_s *dev)
 {
   irqstate_t flags;
-  FAR struct esp32_i2c_priv_s *priv = (FAR struct esp32_i2c_priv_s *)dev;
+  struct esp32_i2c_priv_s *priv = (struct esp32_i2c_priv_s *)dev;
 
   DEBUGASSERT(dev);
 

--- a/arch/xtensa/src/esp32/esp32_i2c.h
+++ b/arch/xtensa/src/esp32/esp32_i2c.h
@@ -64,7 +64,7 @@ extern "C"
  *
  ****************************************************************************/
 
-FAR struct i2c_master_s *esp32_i2cbus_initialize(int port);
+struct i2c_master_s *esp32_i2cbus_initialize(int port);
 
 /****************************************************************************
  * Name: esp32_i2cbus_uninitialize
@@ -81,7 +81,7 @@ FAR struct i2c_master_s *esp32_i2cbus_initialize(int port);
  *
  ****************************************************************************/
 
-int esp32_i2cbus_uninitialize(FAR struct i2c_master_s *dev);
+int esp32_i2cbus_uninitialize(struct i2c_master_s *dev);
 
 #ifdef __cplusplus
 }

--- a/arch/xtensa/src/esp32/esp32_imm.c
+++ b/arch/xtensa/src/esp32/esp32_imm.c
@@ -41,7 +41,7 @@
  * Private Data
  ****************************************************************************/
 
-FAR struct mm_heap_s *g_iheap;
+struct mm_heap_s *g_iheap;
 
 /****************************************************************************
  * Public Functions
@@ -60,7 +60,7 @@ void xtensa_imm_initialize(void)
   void  *start;
   size_t size;
 
-  start = (FAR void *)ESP32_IMEM_START;
+  start = (void *)ESP32_IMEM_START;
   size  = CONFIG_XTENSA_IMEM_REGION_SIZE;
   g_iheap = mm_initialize("esp32-imem", start, size);
 }
@@ -126,7 +126,7 @@ void *xtensa_imm_zalloc(size_t size)
  *
  ****************************************************************************/
 
-void xtensa_imm_free(FAR void *mem)
+void xtensa_imm_free(void *mem)
 {
   mm_free(g_iheap, mem);
 }
@@ -163,7 +163,7 @@ void *xtensa_imm_memalign(size_t alignment, size_t size)
  *
  ****************************************************************************/
 
-bool xtensa_imm_heapmember(FAR void *mem)
+bool xtensa_imm_heapmember(void *mem)
 {
   return mm_heapmember(g_iheap, mem);
 }
@@ -177,7 +177,7 @@ bool xtensa_imm_heapmember(FAR void *mem)
  *
  ****************************************************************************/
 
-int xtensa_imm_mallinfo(FAR struct mallinfo *info)
+int xtensa_imm_mallinfo(struct mallinfo *info)
 {
   return mm_mallinfo(g_iheap, info);
 }

--- a/arch/xtensa/src/esp32/esp32_intercpu_interrupt.c
+++ b/arch/xtensa/src/esp32/esp32_intercpu_interrupt.c
@@ -80,12 +80,12 @@ static int esp32_fromcpu_interrupt(int fromcpu)
  *
  ****************************************************************************/
 
-int esp32_fromcpu0_interrupt(int irq, FAR void *context, FAR void *arg)
+int esp32_fromcpu0_interrupt(int irq, void *context, void *arg)
 {
   return esp32_fromcpu_interrupt(0);
 }
 
-int esp32_fromcpu1_interrupt(int irq, FAR void *context, FAR void *arg)
+int esp32_fromcpu1_interrupt(int irq, void *context, void *arg)
 {
   return esp32_fromcpu_interrupt(1);
 }

--- a/arch/xtensa/src/esp32/esp32_oneshot.h
+++ b/arch/xtensa/src/esp32/esp32_oneshot.h
@@ -60,7 +60,7 @@ struct esp32_oneshot_s
 {
   uint8_t chan;                       /* The timer/counter in use */
   volatile bool running;              /* True: the timer is running */
-  FAR struct esp32_tim_dev_s    *tim; /* Pointer returned by
+  struct esp32_tim_dev_s    *tim;     /* Pointer returned by
                                        * esp32_tim_init() */
   volatile oneshot_handler_t handler; /* Oneshot expiration callback */
   volatile void                 *arg; /* The argument that will accompany

--- a/arch/xtensa/src/esp32/esp32_oneshot_lowerhalf.c
+++ b/arch/xtensa/src/esp32/esp32_oneshot_lowerhalf.c
@@ -58,7 +58,7 @@ struct esp32_oneshot_lowerhalf_s
   struct oneshot_lowerhalf_s        lh;  /* Lower half instance */
   struct esp32_oneshot_s       oneshot;  /* ESP32-specific oneshot state */
   oneshot_callback_t          callback;  /* Upper half Interrupt callback */
-  FAR void                        *arg;  /* Argument passed to handler */
+  void                        *arg;      /* Argument passed to handler */
   uint16_t                  resolution;
 };
 
@@ -70,16 +70,16 @@ static void esp32_oneshot_lh_handler(void *arg);
 
 /* "Lower half" driver methods **********************************************/
 
-static int esp32_max_lh_delay(FAR struct oneshot_lowerhalf_s *lower,
-                              FAR struct timespec *ts);
-static int esp32_lh_start(FAR struct oneshot_lowerhalf_s *lower,
+static int esp32_max_lh_delay(struct oneshot_lowerhalf_s *lower,
+                              struct timespec *ts);
+static int esp32_lh_start(struct oneshot_lowerhalf_s *lower,
                           oneshot_callback_t callback,
-                          FAR void *arg,
-                          FAR const struct timespec *ts);
-static int esp32_lh_cancel(FAR struct oneshot_lowerhalf_s *lower,
-                           FAR struct timespec *ts);
-static int esp32_lh_current(FAR struct oneshot_lowerhalf_s *lower,
-                            FAR struct timespec *ts);
+                          void *arg,
+                          const struct timespec *ts);
+static int esp32_lh_cancel(struct oneshot_lowerhalf_s *lower,
+                           struct timespec *ts);
+static int esp32_lh_current(struct oneshot_lowerhalf_s *lower,
+                            struct timespec *ts);
 
 /****************************************************************************
  * Private Data
@@ -113,8 +113,8 @@ static const struct oneshot_operations_s g_esp32_timer_ops =
 
 static void esp32_oneshot_lh_handler(void *arg)
 {
-  FAR struct esp32_oneshot_lowerhalf_s *priv =
-    (FAR struct esp32_oneshot_lowerhalf_s *)arg;
+  struct esp32_oneshot_lowerhalf_s *priv =
+    (struct esp32_oneshot_lowerhalf_s *)arg;
 
   DEBUGASSERT(priv != NULL);
   DEBUGASSERT(priv->callback != NULL);
@@ -149,8 +149,8 @@ static void esp32_oneshot_lh_handler(void *arg)
  *
  ****************************************************************************/
 
-static int esp32_max_lh_delay(FAR struct oneshot_lowerhalf_s *lower,
-                              FAR struct timespec *ts)
+static int esp32_max_lh_delay(struct oneshot_lowerhalf_s *lower,
+                              struct timespec *ts)
 {
   DEBUGASSERT(ts != NULL);
 
@@ -191,13 +191,13 @@ static int esp32_max_lh_delay(FAR struct oneshot_lowerhalf_s *lower,
  *
  ****************************************************************************/
 
-static int esp32_lh_start(FAR struct oneshot_lowerhalf_s *lower,
+static int esp32_lh_start(struct oneshot_lowerhalf_s *lower,
                           oneshot_callback_t callback,
-                          FAR void *arg,
-                          FAR const struct timespec *ts)
+                          void *arg,
+                          const struct timespec *ts)
 {
-  FAR struct esp32_oneshot_lowerhalf_s *priv =
-    (FAR struct esp32_oneshot_lowerhalf_s *)lower;
+  struct esp32_oneshot_lowerhalf_s *priv =
+    (struct esp32_oneshot_lowerhalf_s *)lower;
   int ret;
   irqstate_t flags;
 
@@ -247,11 +247,11 @@ static int esp32_lh_start(FAR struct oneshot_lowerhalf_s *lower,
  *
  ****************************************************************************/
 
-static int esp32_lh_cancel(FAR struct oneshot_lowerhalf_s *lower,
-                           FAR struct timespec *ts)
+static int esp32_lh_cancel(struct oneshot_lowerhalf_s *lower,
+                           struct timespec *ts)
 {
-  FAR struct esp32_oneshot_lowerhalf_s *priv =
-    (FAR struct esp32_oneshot_lowerhalf_s *)lower;
+  struct esp32_oneshot_lowerhalf_s *priv =
+    (struct esp32_oneshot_lowerhalf_s *)lower;
   irqstate_t flags;
   int ret;
 
@@ -292,11 +292,11 @@ static int esp32_lh_cancel(FAR struct oneshot_lowerhalf_s *lower,
  *
  ****************************************************************************/
 
-static int esp32_lh_current(FAR struct oneshot_lowerhalf_s *lower,
-                            FAR struct timespec *ts)
+static int esp32_lh_current(struct oneshot_lowerhalf_s *lower,
+                            struct timespec *ts)
 {
-  FAR struct esp32_oneshot_lowerhalf_s *priv =
-    (FAR struct esp32_oneshot_lowerhalf_s *)lower;
+  struct esp32_oneshot_lowerhalf_s *priv =
+    (struct esp32_oneshot_lowerhalf_s *)lower;
   uint64_t current_us;
 
   DEBUGASSERT(priv != NULL);
@@ -333,15 +333,15 @@ static int esp32_lh_current(FAR struct oneshot_lowerhalf_s *lower,
  *
  ****************************************************************************/
 
-FAR struct oneshot_lowerhalf_s *oneshot_initialize(int chan,
+struct oneshot_lowerhalf_s *oneshot_initialize(int chan,
                                                    uint16_t resolution)
 {
-  FAR struct esp32_oneshot_lowerhalf_s *priv;
+  struct esp32_oneshot_lowerhalf_s *priv;
   int ret;
 
   /* Allocate an instance of the lower half driver */
 
-  priv = (FAR struct esp32_oneshot_lowerhalf_s *)kmm_zalloc(
+  priv = (struct esp32_oneshot_lowerhalf_s *)kmm_zalloc(
           sizeof(struct esp32_oneshot_lowerhalf_s));
 
   if (priv == NULL)

--- a/arch/xtensa/src/esp32/esp32_partition.c
+++ b/arch/xtensa/src/esp32/esp32_partition.c
@@ -362,7 +362,7 @@ static int ota_set_bootseq(struct mtd_dev_priv *dev, int num)
  *
  ****************************************************************************/
 
-static int esp32_part_erase(FAR struct mtd_dev_s *dev, off_t startblock,
+static int esp32_part_erase(struct mtd_dev_s *dev, off_t startblock,
                             size_t nblocks)
 {
   struct mtd_dev_priv *mtd_priv = (struct mtd_dev_priv *)dev;
@@ -387,8 +387,8 @@ static int esp32_part_erase(FAR struct mtd_dev_s *dev, off_t startblock,
  *
  ****************************************************************************/
 
-static ssize_t esp32_part_read(FAR struct mtd_dev_s *dev, off_t offset,
-                               size_t nbytes, FAR uint8_t *buffer)
+static ssize_t esp32_part_read(struct mtd_dev_s *dev, off_t offset,
+                               size_t nbytes, uint8_t *buffer)
 {
   struct mtd_dev_priv *mtd_priv = (struct mtd_dev_priv *)dev;
 
@@ -412,8 +412,8 @@ static ssize_t esp32_part_read(FAR struct mtd_dev_s *dev, off_t offset,
  *
  ****************************************************************************/
 
-static ssize_t esp32_part_bread(FAR struct mtd_dev_s *dev, off_t startblock,
-                                size_t nblocks, FAR uint8_t *buffer)
+static ssize_t esp32_part_bread(struct mtd_dev_s *dev, off_t startblock,
+                                size_t nblocks, uint8_t *buffer)
 {
   struct mtd_dev_priv *mtd_priv = (struct mtd_dev_priv *)dev;
 
@@ -437,8 +437,8 @@ static ssize_t esp32_part_bread(FAR struct mtd_dev_s *dev, off_t startblock,
  *
  ****************************************************************************/
 
-static ssize_t esp32_part_write(FAR struct mtd_dev_s *dev, off_t offset,
-                                size_t nbytes, FAR const uint8_t *buffer)
+static ssize_t esp32_part_write(struct mtd_dev_s *dev, off_t offset,
+                                size_t nbytes, const uint8_t *buffer)
 {
   struct mtd_dev_priv *mtd_priv = (struct mtd_dev_priv *)dev;
 
@@ -463,8 +463,8 @@ static ssize_t esp32_part_write(FAR struct mtd_dev_s *dev, off_t offset,
  *
  ****************************************************************************/
 
-static ssize_t esp32_part_bwrite(FAR struct mtd_dev_s *dev, off_t startblock,
-                                 size_t nblocks, FAR const uint8_t *buffer)
+static ssize_t esp32_part_bwrite(struct mtd_dev_s *dev, off_t startblock,
+                                 size_t nblocks, const uint8_t *buffer)
 {
   struct mtd_dev_priv *mtd_priv = (struct mtd_dev_priv *)dev;
 
@@ -487,7 +487,7 @@ static ssize_t esp32_part_bwrite(FAR struct mtd_dev_s *dev, off_t startblock,
  *
  ****************************************************************************/
 
-static int esp32_part_ioctl(FAR struct mtd_dev_s *dev, int cmd,
+static int esp32_part_ioctl(struct mtd_dev_s *dev, int cmd,
                             unsigned long arg)
 {
   int ret;

--- a/arch/xtensa/src/esp32/esp32_rng.c
+++ b/arch/xtensa/src/esp32/esp32_rng.c
@@ -59,9 +59,9 @@
  ****************************************************************************/
 
 static int esp32_rng_initialize(void);
-static ssize_t esp32_rng_read(FAR struct file *filep, FAR char *buffer,
+static ssize_t esp32_rng_read(struct file *filep, char *buffer,
                               size_t buflen);
-static int esp32_rng_open(FAR struct file *filep);
+static int esp32_rng_open(struct file *filep);
 
 /****************************************************************************
  * Private Types
@@ -166,7 +166,7 @@ static int esp32_rng_initialize(void)
  * Name: esp32_rng_open
  ****************************************************************************/
 
-static int esp32_rng_open(FAR struct file *filep)
+static int esp32_rng_open(struct file *filep)
 {
   /* O_NONBLOCK is not supported */
 
@@ -183,10 +183,10 @@ static int esp32_rng_open(FAR struct file *filep)
  * Name: esp32_rng_read
  ****************************************************************************/
 
-static ssize_t esp32_rng_read(FAR struct file *filep, FAR char *buffer,
+static ssize_t esp32_rng_read(struct file *filep, char *buffer,
                               size_t buflen)
 {
-  FAR struct rng_dev_s *priv = (struct rng_dev_s *)&g_rngdev;
+  struct rng_dev_s *priv = (struct rng_dev_s *)&g_rngdev;
   ssize_t read_len;
   uint8_t *rd_buf = (uint8_t *)buffer;
 
@@ -241,7 +241,7 @@ static ssize_t esp32_rng_read(FAR struct file *filep, FAR char *buffer,
 void devrandom_register(void)
 {
   esp32_rng_initialize();
-  register_driver("/dev/random", FAR & g_rngops, 0444, NULL);
+  register_driver("/dev/random", &g_rngops, 0444, NULL);
 }
 #endif
 
@@ -265,7 +265,7 @@ void devurandom_register(void)
 #ifndef CONFIG_DEV_RANDOM
   esp32_rng_initialize();
 #endif
-  register_driver("dev/urandom", FAR & g_rngops, 0444, NULL);
+  register_driver("dev/urandom", &g_rngops, 0444, NULL);
 }
 #endif
 

--- a/arch/xtensa/src/esp32/esp32_rt_timer.c
+++ b/arch/xtensa/src/esp32/esp32_rt_timer.c
@@ -93,7 +93,7 @@ static struct esp32_tim_dev_s *s_esp32_tim_dev;
  *
  ****************************************************************************/
 
-static void start_rt_timer(FAR struct rt_timer_s *timer,
+static void start_rt_timer(struct rt_timer_s *timer,
                            uint64_t timeout,
                            bool repeat)
 {
@@ -178,7 +178,7 @@ static void start_rt_timer(FAR struct rt_timer_s *timer,
  *
  ****************************************************************************/
 
-static void stop_rt_timer(FAR struct rt_timer_s *timer)
+static void stop_rt_timer(struct rt_timer_s *timer)
 {
   irqstate_t flags;
   bool ishead;
@@ -252,7 +252,7 @@ static void stop_rt_timer(FAR struct rt_timer_s *timer)
  *
  ****************************************************************************/
 
-static void delete_rt_timer(FAR struct rt_timer_s *timer)
+static void delete_rt_timer(struct rt_timer_s *timer)
 {
   irqstate_t flags;
 
@@ -294,7 +294,7 @@ exit:
  *
  ****************************************************************************/
 
-static int rt_timer_thread(int argc, FAR char *argv[])
+static int rt_timer_thread(int argc, char *argv[])
 {
   int ret;
   irqstate_t flags;
@@ -464,8 +464,8 @@ static int rt_timer_isr(int irq, void *context, void *arg)
  *
  ****************************************************************************/
 
-int rt_timer_create(FAR const struct rt_timer_args_s *args,
-                    FAR struct rt_timer_s **timer_handle)
+int rt_timer_create(const struct rt_timer_args_s *args,
+                    struct rt_timer_s **timer_handle)
 {
   struct rt_timer_s *timer;
 
@@ -503,7 +503,7 @@ int rt_timer_create(FAR const struct rt_timer_args_s *args,
  *
  ****************************************************************************/
 
-void rt_timer_start(FAR struct rt_timer_s *timer,
+void rt_timer_start(struct rt_timer_s *timer,
                     uint64_t timeout,
                     bool repeat)
 {
@@ -526,7 +526,7 @@ void rt_timer_start(FAR struct rt_timer_s *timer,
  *
  ****************************************************************************/
 
-void rt_timer_stop(FAR struct rt_timer_s *timer)
+void rt_timer_stop(struct rt_timer_s *timer)
 {
   stop_rt_timer(timer);
 }
@@ -545,7 +545,7 @@ void rt_timer_stop(FAR struct rt_timer_s *timer)
  *
  ****************************************************************************/
 
-void rt_timer_delete(FAR struct rt_timer_s *timer)
+void rt_timer_delete(struct rt_timer_s *timer)
 {
   delete_rt_timer(timer);
 }

--- a/arch/xtensa/src/esp32/esp32_rt_timer.h
+++ b/arch/xtensa/src/esp32/esp32_rt_timer.h
@@ -107,8 +107,8 @@ extern "C"
  *
  ****************************************************************************/
 
-int rt_timer_create(FAR const struct rt_timer_args_s *args,
-                    FAR struct rt_timer_s **timer_handle);
+int rt_timer_create(const struct rt_timer_args_s *args,
+                    struct rt_timer_s **timer_handle);
 
 /****************************************************************************
  * Name: rt_timer_start
@@ -126,7 +126,7 @@ int rt_timer_create(FAR const struct rt_timer_args_s *args,
  *
  ****************************************************************************/
 
-void rt_timer_start(FAR struct rt_timer_s *timer,
+void rt_timer_start(struct rt_timer_s *timer,
                     uint64_t timeout,
                     bool repeat);
 
@@ -144,7 +144,7 @@ void rt_timer_start(FAR struct rt_timer_s *timer,
  *
  ****************************************************************************/
 
-void rt_timer_stop(FAR struct rt_timer_s *timer);
+void rt_timer_stop(struct rt_timer_s *timer);
 
 /****************************************************************************
  * Name: rt_timer_delete
@@ -160,7 +160,7 @@ void rt_timer_stop(FAR struct rt_timer_s *timer);
  *
  ****************************************************************************/
 
-void rt_timer_delete(FAR struct rt_timer_s *timer);
+void rt_timer_delete(struct rt_timer_s *timer);
 
 /****************************************************************************
  * Name: rt_timer_time_us

--- a/arch/xtensa/src/esp32/esp32_rtc.c
+++ b/arch/xtensa/src/esp32/esp32_rtc.c
@@ -232,7 +232,7 @@ struct alm_cbinfo_s
 {
   struct rt_timer_s *alarm_hdl;  /* Timer id point to here */
   volatile alm_callback_t ac_cb; /* Client callback function */
-  volatile FAR void *ac_arg;     /* Argument to pass with the callback function */
+  volatile void *ac_arg;         /* Argument to pass with the callback function */
   uint64_t deadline_us;
   uint8_t index;
 };
@@ -266,7 +266,7 @@ static void IRAM_ATTR esp32_rtc_clk_8m_enable(bool clk_8m_en, bool d256_en);
 static uint32_t IRAM_ATTR esp32_rtc_clk_slow_freq_get_hz(void);
 
 #ifdef CONFIG_RTC_DRIVER
-static void IRAM_ATTR esp32_rt_cb_handler(FAR void *arg);
+static void IRAM_ATTR esp32_rt_cb_handler(void *arg);
 #endif
 
 /****************************************************************************
@@ -760,11 +760,11 @@ static void esp32_select_rtc_slow_clk(enum esp32_slow_clk_sel_e slow_clk)
  *
  ****************************************************************************/
 
-static void IRAM_ATTR esp32_rt_cb_handler(FAR void *arg)
+static void IRAM_ATTR esp32_rt_cb_handler(void *arg)
 {
-  FAR struct alm_cbinfo_s *cbinfo = (struct alm_cbinfo_s *)arg;
+  struct alm_cbinfo_s *cbinfo = (struct alm_cbinfo_s *)arg;
   alm_callback_t cb;
-  FAR void *cb_arg;
+  void *cb_arg;
   int alminfo_id;
 
   DEBUGASSERT(cbinfo != NULL);
@@ -777,7 +777,7 @@ static void IRAM_ATTR esp32_rt_cb_handler(FAR void *arg)
       /* Alarm callback */
 
       cb = cbinfo->ac_cb;
-      cb_arg = (FAR void *)cbinfo->ac_arg;
+      cb_arg = (void *)cbinfo->ac_arg;
       cbinfo->ac_cb  = NULL;
       cbinfo->ac_arg = NULL;
       cbinfo->deadline_us = 0;
@@ -1957,7 +1957,7 @@ time_t up_rtc_time(void)
  *
  ****************************************************************************/
 
-int up_rtc_settime(FAR const struct timespec *ts)
+int up_rtc_settime(const struct timespec *ts)
 {
   irqstate_t flags;
   uint64_t now_us;
@@ -2052,7 +2052,7 @@ int up_rtc_initialize(void)
  ****************************************************************************/
 
 #ifdef CONFIG_RTC_HIRES
-int up_rtc_gettime(FAR struct timespec *tp)
+int up_rtc_gettime(struct timespec *tp)
 {
   irqstate_t flags;
   uint64_t time_us;
@@ -2095,10 +2095,10 @@ int up_rtc_gettime(FAR struct timespec *tp)
  *
  ****************************************************************************/
 
-int up_rtc_setalarm(FAR struct alm_setalarm_s *alminfo)
+int up_rtc_setalarm(struct alm_setalarm_s *alminfo)
 {
   struct rt_timer_args_s rt_timer_args;
-  FAR struct alm_cbinfo_s *cbinfo;
+  struct alm_cbinfo_s *cbinfo;
   irqstate_t flags;
   int ret = -EBUSY;
   int id;
@@ -2170,7 +2170,7 @@ int up_rtc_setalarm(FAR struct alm_setalarm_s *alminfo)
 
 int up_rtc_cancelalarm(enum alm_id_e alarmid)
 {
-  FAR struct alm_cbinfo_s *cbinfo;
+  struct alm_cbinfo_s *cbinfo;
   irqstate_t flags;
   int ret = -ENODATA;
 
@@ -2217,10 +2217,10 @@ int up_rtc_cancelalarm(enum alm_id_e alarmid)
  *
  ****************************************************************************/
 
-int up_rtc_rdalarm(FAR struct timespec *tp, uint32_t alarmid)
+int up_rtc_rdalarm(struct timespec *tp, uint32_t alarmid)
 {
   irqstate_t flags;
-  FAR struct alm_cbinfo_s *cbinfo;
+  struct alm_cbinfo_s *cbinfo;
   DEBUGASSERT(tp != NULL);
   DEBUGASSERT((RTC_ALARM0 <= alarmid) &&
               (alarmid < RTC_ALARM_LAST));

--- a/arch/xtensa/src/esp32/esp32_rtc.h
+++ b/arch/xtensa/src/esp32/esp32_rtc.h
@@ -134,7 +134,7 @@ enum esp32_rtc_cal_sel_e
 
 /* The form of an alarm callback */
 
-typedef CODE void (*alm_callback_t)(void *arg, unsigned int alarmid);
+typedef void (*alm_callback_t)(void *arg, unsigned int alarmid);
 
 enum alm_id_e
 {

--- a/arch/xtensa/src/esp32/esp32_rtc.h
+++ b/arch/xtensa/src/esp32/esp32_rtc.h
@@ -134,7 +134,7 @@ enum esp32_rtc_cal_sel_e
 
 /* The form of an alarm callback */
 
-typedef CODE void (*alm_callback_t)(FAR void *arg, unsigned int alarmid);
+typedef CODE void (*alm_callback_t)(void *arg, unsigned int alarmid);
 
 enum alm_id_e
 {
@@ -150,7 +150,7 @@ struct alm_setalarm_s
   int               as_id;     /* enum alm_id_e */
   struct timespec   as_time;   /* Alarm expiration time */
   alm_callback_t    as_cb;     /* Callback (if non-NULL) */
-  FAR void          *as_arg;   /* Argument for callback */
+  void          *as_arg;       /* Argument for callback */
 };
 
 #endif /* CONFIG_RTC_ALARM */
@@ -562,7 +562,7 @@ time_t up_rtc_time(void);
  *
  ****************************************************************************/
 
-int up_rtc_settime(FAR const struct timespec *ts);
+int up_rtc_settime(const struct timespec *ts);
 
 /****************************************************************************
  * Name: up_rtc_initialize
@@ -598,7 +598,7 @@ int up_rtc_initialize(void);
  ****************************************************************************/
 
 #ifdef CONFIG_RTC_HIRES
-int up_rtc_gettime(FAR struct timespec *tp);
+int up_rtc_gettime(struct timespec *tp);
 #endif
 
 #ifdef CONFIG_RTC_ALARM
@@ -617,7 +617,7 @@ int up_rtc_gettime(FAR struct timespec *tp);
  *
  ****************************************************************************/
 
-int up_rtc_setalarm(FAR struct alm_setalarm_s *alminfo);
+int up_rtc_setalarm(struct alm_setalarm_s *alminfo);
 
 /****************************************************************************
  * Name: up_rtc_cancelalarm
@@ -650,7 +650,7 @@ int up_rtc_cancelalarm(enum alm_id_e alarmid);
  *
  ****************************************************************************/
 
-int up_rtc_rdalarm(FAR struct timespec *tp, uint32_t alarmid);
+int up_rtc_rdalarm(struct timespec *tp, uint32_t alarmid);
 
 #endif /* CONFIG_RTC_ALARM */
 

--- a/arch/xtensa/src/esp32/esp32_rtc_lowerhalf.c
+++ b/arch/xtensa/src/esp32/esp32_rtc_lowerhalf.c
@@ -46,7 +46,7 @@
 struct esp32_cbinfo_s
 {
   volatile rtc_alarm_callback_t cb;  /* Callback when the alarm expires */
-  volatile FAR void *priv;           /* Private argurment to accompany callback */
+  volatile void *priv;               /* Private argurment to accompany callback */
 };
 #endif
 
@@ -60,7 +60,7 @@ struct esp32_lowerhalf_s
    * operations vtable (which may lie in FLASH or ROM)
    */
 
-  FAR const struct rtc_ops_s *ops;
+  const struct rtc_ops_s *ops;
 #ifdef CONFIG_RTC_ALARM
   /* Alarm callback information */
 
@@ -74,22 +74,22 @@ struct esp32_lowerhalf_s
 
 /* Prototypes for static methods in struct rtc_ops_s */
 
-static int rtc_lh_rdtime(FAR struct rtc_lowerhalf_s *lower,
-                         FAR struct rtc_time *rtctime);
-static int rtc_lh_settime(FAR struct rtc_lowerhalf_s *lower,
-                          FAR const struct rtc_time *rtctime);
-static bool rtc_lh_havesettime(FAR struct rtc_lowerhalf_s *lower);
+static int rtc_lh_rdtime(struct rtc_lowerhalf_s *lower,
+                         struct rtc_time *rtctime);
+static int rtc_lh_settime(struct rtc_lowerhalf_s *lower,
+                          const struct rtc_time *rtctime);
+static bool rtc_lh_havesettime(struct rtc_lowerhalf_s *lower);
 
 #ifdef CONFIG_RTC_ALARM
-static void rtc_lh_alarm_callback(FAR void *arg, unsigned int alarmid);
-static int rtc_lh_setalarm(FAR struct rtc_lowerhalf_s *lower,
-                           FAR const struct lower_setalarm_s *alarminfo);
-static int rtc_lh_setrelative(FAR struct rtc_lowerhalf_s *lower,
-                           FAR const struct lower_setrelative_s *alarminfo);
-static int rtc_lh_cancelalarm(FAR struct rtc_lowerhalf_s *lower,
+static void rtc_lh_alarm_callback(void *arg, unsigned int alarmid);
+static int rtc_lh_setalarm(struct rtc_lowerhalf_s *lower,
+                           const struct lower_setalarm_s *alarminfo);
+static int rtc_lh_setrelative(struct rtc_lowerhalf_s *lower,
+                           const struct lower_setrelative_s *alarminfo);
+static int rtc_lh_cancelalarm(struct rtc_lowerhalf_s *lower,
                               int alarmid);
-static int rtc_lh_rdalarm(FAR struct rtc_lowerhalf_s *lower,
-                          FAR struct lower_rdalarm_s *alarminfo);
+static int rtc_lh_rdalarm(struct rtc_lowerhalf_s *lower,
+                          struct lower_rdalarm_s *alarminfo);
 #endif
 
 /****************************************************************************
@@ -145,12 +145,12 @@ static struct esp32_lowerhalf_s g_rtc_lowerhalf =
  ****************************************************************************/
 
 #ifdef CONFIG_RTC_ALARM
-static void rtc_lh_alarm_callback(FAR void *arg, unsigned int alarmid)
+static void rtc_lh_alarm_callback(void *arg, unsigned int alarmid)
 {
-  FAR struct esp32_lowerhalf_s *lower;
-  FAR struct esp32_cbinfo_s *cbinfo;
+  struct esp32_lowerhalf_s *lower;
+  struct esp32_cbinfo_s *cbinfo;
   rtc_alarm_callback_t cb;
-  FAR void *priv;
+  void *priv;
 
   DEBUGASSERT((RTC_ALARM0 <= alarmid) && (alarmid < RTC_ALARM_LAST));
 
@@ -162,7 +162,7 @@ static void rtc_lh_alarm_callback(FAR void *arg, unsigned int alarmid)
    */
 
   cb           = (rtc_alarm_callback_t)cbinfo->cb;
-  priv         = (FAR void *)cbinfo->priv;
+  priv         = (void *)cbinfo->priv;
 
   cbinfo->cb   = NULL;
   cbinfo->priv = NULL;
@@ -192,11 +192,11 @@ static void rtc_lh_alarm_callback(FAR void *arg, unsigned int alarmid)
  *
  ****************************************************************************/
 
-static int rtc_lh_rdtime(FAR struct rtc_lowerhalf_s *lower,
-                         FAR struct rtc_time *rtctime)
+static int rtc_lh_rdtime(struct rtc_lowerhalf_s *lower,
+                         struct rtc_time *rtctime)
 {
 #if defined(CONFIG_RTC_HIRES)
-  FAR struct timespec ts;
+  struct timespec ts;
   int ret;
 
   /* Get the higher resolution time */
@@ -212,7 +212,7 @@ static int rtc_lh_rdtime(FAR struct rtc_lowerhalf_s *lower,
    * compatible.
    */
 
-  if (!gmtime_r(&ts.tv_sec, (FAR struct tm *)rtctime))
+  if (!gmtime_r(&ts.tv_sec, (struct tm *)rtctime))
     {
       ret = -get_errno();
       goto errout;
@@ -233,7 +233,7 @@ errout:
 
   /* Convert the one second epoch time to a struct tm */
 
-  if (gmtime_r(&timer, (FAR struct tm *)rtctime) == 0)
+  if (gmtime_r(&timer, (struct tm *)rtctime) == 0)
     {
       int errcode = get_errno();
       DEBUGASSERT(errcode > 0);
@@ -262,8 +262,8 @@ errout:
  *
  ****************************************************************************/
 
-static int rtc_lh_settime(FAR struct rtc_lowerhalf_s *lower,
-                          FAR const struct rtc_time *rtctime)
+static int rtc_lh_settime(struct rtc_lowerhalf_s *lower,
+                          const struct rtc_time *rtctime)
 {
   struct timespec ts;
 
@@ -271,7 +271,7 @@ static int rtc_lh_settime(FAR struct rtc_lowerhalf_s *lower,
    * rtc_time is cast compatible with struct tm.
    */
 
-  ts.tv_sec  = mktime((FAR struct tm *)rtctime);
+  ts.tv_sec  = mktime((struct tm *)rtctime);
   ts.tv_nsec = 0;
 
   /* Now set the time (with a accuracy of seconds) */
@@ -293,7 +293,7 @@ static int rtc_lh_settime(FAR struct rtc_lowerhalf_s *lower,
  *
  ****************************************************************************/
 
-static bool rtc_lh_havesettime(FAR struct rtc_lowerhalf_s *lower)
+static bool rtc_lh_havesettime(struct rtc_lowerhalf_s *lower)
 {
   if (esp32_rtc_get_boot_time() == 0)
     {
@@ -321,11 +321,11 @@ static bool rtc_lh_havesettime(FAR struct rtc_lowerhalf_s *lower)
  ****************************************************************************/
 
 #ifdef CONFIG_RTC_ALARM
-static int rtc_lh_setalarm(FAR struct rtc_lowerhalf_s *lower,
-                           FAR const struct lower_setalarm_s *alarminfo)
+static int rtc_lh_setalarm(struct rtc_lowerhalf_s *lower,
+                           const struct lower_setalarm_s *alarminfo)
 {
-  FAR struct esp32_lowerhalf_s *priv;
-  FAR struct esp32_cbinfo_s *cbinfo;
+  struct esp32_lowerhalf_s *priv;
+  struct esp32_cbinfo_s *cbinfo;
   struct alm_setalarm_s lowerinfo;
   int ret;
 
@@ -333,7 +333,7 @@ static int rtc_lh_setalarm(FAR struct rtc_lowerhalf_s *lower,
   DEBUGASSERT((RTC_ALARM0 <= alarminfo->id) &&
               (alarminfo->id < RTC_ALARM_LAST));
 
-  priv = (FAR struct esp32_lowerhalf_s *)lower;
+  priv = (struct esp32_lowerhalf_s *)lower;
 
   /* Remember the callback information */
 
@@ -349,7 +349,7 @@ static int rtc_lh_setalarm(FAR struct rtc_lowerhalf_s *lower,
 
   /* Convert the RTC time to a timespec (1 second accuracy) */
 
-  lowerinfo.as_time.tv_sec  = mktime((FAR struct tm *)&alarminfo->time);
+  lowerinfo.as_time.tv_sec  = mktime((struct tm *)&alarminfo->time);
   lowerinfo.as_time.tv_nsec = 0;
 
   /* And set the alarm */
@@ -383,8 +383,8 @@ static int rtc_lh_setalarm(FAR struct rtc_lowerhalf_s *lower,
  ****************************************************************************/
 
 #ifdef CONFIG_RTC_ALARM
-static int rtc_lh_setrelative(FAR struct rtc_lowerhalf_s *lower,
-                            FAR const struct lower_setrelative_s *alarminfo)
+static int rtc_lh_setrelative(struct rtc_lowerhalf_s *lower,
+                            const struct lower_setrelative_s *alarminfo)
 {
   struct lower_setalarm_s setalarm;
   time_t seconds;
@@ -400,7 +400,7 @@ static int rtc_lh_setrelative(FAR struct rtc_lowerhalf_s *lower,
       flags = spin_lock_irqsave(NULL);
 
       seconds = alarminfo->reltime;
-      gmtime_r(&seconds, (FAR struct tm *)&setalarm.time);
+      gmtime_r(&seconds, (struct tm *)&setalarm.time);
 
       /* The set the alarm using this absolute time */
 
@@ -434,15 +434,15 @@ static int rtc_lh_setrelative(FAR struct rtc_lowerhalf_s *lower,
  ****************************************************************************/
 
 #ifdef CONFIG_RTC_ALARM
-static int rtc_lh_cancelalarm(FAR struct rtc_lowerhalf_s *lower, int alarmid)
+static int rtc_lh_cancelalarm(struct rtc_lowerhalf_s *lower, int alarmid)
 {
-  FAR struct esp32_lowerhalf_s *priv;
-  FAR struct esp32_cbinfo_s *cbinfo;
+  struct esp32_lowerhalf_s *priv;
+  struct esp32_cbinfo_s *cbinfo;
 
   DEBUGASSERT(lower != NULL);
   DEBUGASSERT((RTC_ALARM0 <= alarmid) && (alarmid < RTC_ALARM_LAST));
 
-  priv = (FAR struct esp32_lowerhalf_s *)lower;
+  priv = (struct esp32_lowerhalf_s *)lower;
 
   /* Nullify callback information to reduce window for race conditions */
 
@@ -473,8 +473,8 @@ static int rtc_lh_cancelalarm(FAR struct rtc_lowerhalf_s *lower, int alarmid)
  ****************************************************************************/
 
 #ifdef CONFIG_RTC_ALARM
-static int rtc_lh_rdalarm(FAR struct rtc_lowerhalf_s *lower,
-                          FAR struct lower_rdalarm_s *alarminfo)
+static int rtc_lh_rdalarm(struct rtc_lowerhalf_s *lower,
+                          struct lower_rdalarm_s *alarminfo)
 {
   struct timespec ts;
   int ret;
@@ -487,8 +487,8 @@ static int rtc_lh_rdalarm(FAR struct rtc_lowerhalf_s *lower,
   flags = spin_lock_irqsave(NULL);
 
   ret = up_rtc_rdalarm(&ts, alarminfo->id);
-  localtime_r((FAR const time_t *)&ts.tv_sec,
-              (FAR struct tm *)alarminfo->time);
+  localtime_r((const time_t *)&ts.tv_sec,
+              (struct tm *)alarminfo->time);
 
   spin_unlock_irqrestore(NULL, flags);
 
@@ -515,9 +515,9 @@ static int rtc_lh_rdalarm(FAR struct rtc_lowerhalf_s *lower,
  *
  ****************************************************************************/
 
-FAR struct rtc_lowerhalf_s *esp32_rtc_lowerhalf(void)
+struct rtc_lowerhalf_s *esp32_rtc_lowerhalf(void)
 {
-  return (FAR struct rtc_lowerhalf_s *)&g_rtc_lowerhalf;
+  return (struct rtc_lowerhalf_s *)&g_rtc_lowerhalf;
 }
 
 /****************************************************************************
@@ -539,7 +539,7 @@ FAR struct rtc_lowerhalf_s *esp32_rtc_lowerhalf(void)
 int esp32_rtc_driverinit(void)
 {
   int ret;
-  FAR struct rtc_lowerhalf_s *lower;
+  struct rtc_lowerhalf_s *lower;
 
   /* Instantiate the ESP32 lower-half RTC driver */
 

--- a/arch/xtensa/src/esp32/esp32_serial.c
+++ b/arch/xtensa/src/esp32/esp32_serial.c
@@ -280,7 +280,7 @@ static int  esp32_setup(struct uart_dev_s *dev);
 static void esp32_shutdown(struct uart_dev_s *dev);
 static int  esp32_attach(struct uart_dev_s *dev);
 static void esp32_detach(struct uart_dev_s *dev);
-static int  esp32_interrupt(int cpuint, void *context, FAR void *arg);
+static int  esp32_interrupt(int cpuint, void *context, void *arg);
 static int  esp32_ioctl(struct file *filep, int cmd, unsigned long arg);
 static int  esp32_receive(struct uart_dev_s *dev, unsigned int *status);
 static void esp32_rxint(struct uart_dev_s *dev, bool enable);
@@ -300,7 +300,7 @@ static void dma_config(uint8_t dma_chan);
 static void dma_attach(uint8_t dma_chan);
 static inline void dma_enable_int(uint8_t dma_chan);
 static inline void dma_disable_int(uint8_t dma_chan);
-static int esp32_interrupt_dma(int cpuint, void *context, FAR void *arg);
+static int esp32_interrupt_dma(int cpuint, void *context, void *arg);
 #endif
 
 /****************************************************************************
@@ -1178,7 +1178,7 @@ static void dma_attach(uint8_t dma_chan)
  *
  ****************************************************************************/
 
-static int esp32_interrupt_dma(int irq, void *context, FAR void *arg)
+static int esp32_interrupt_dma(int irq, void *context, void *arg)
 {
   uint32_t value;
   uint32_t status;
@@ -1315,7 +1315,7 @@ static void dma_config(uint8_t dma_chan)
  *
  ****************************************************************************/
 
-static int esp32_interrupt(int cpuint, void *context, FAR void *arg)
+static int esp32_interrupt(int cpuint, void *context, void *arg)
 {
   struct uart_dev_s *dev = (struct uart_dev_s *)arg;
   struct esp32_dev_s *priv;

--- a/arch/xtensa/src/esp32/esp32_smp.h
+++ b/arch/xtensa/src/esp32/esp32_smp.h
@@ -64,8 +64,8 @@ extern uint32_t g_cpu1_idlestack[CPU1_IDLETHREAD_STACKWORDS];
  *
  ****************************************************************************/
 
-int esp32_fromcpu0_interrupt(int irq, FAR void *context, FAR void *arg);
-int esp32_fromcpu1_interrupt(int irq, FAR void *context, FAR void *arg);
+int esp32_fromcpu0_interrupt(int irq, void *context, void *arg);
+int esp32_fromcpu1_interrupt(int irq, void *context, void *arg);
 
 #endif /* CONFIG_SMP */
 #endif /* __ARCH_XTENSA_SRC_ESP32_ESP32_SMP_H */

--- a/arch/xtensa/src/esp32/esp32_spi.c
+++ b/arch/xtensa/src/esp32/esp32_spi.c
@@ -168,37 +168,37 @@ struct esp32_spi_priv_s
  * Private Function Prototypes
  ****************************************************************************/
 
-static int esp32_spi_lock(FAR struct spi_dev_s *dev, bool lock);
+static int esp32_spi_lock(struct spi_dev_s *dev, bool lock);
 #ifndef CONFIG_ESP32_SPI_UDCS
-static void esp32_spi_select(FAR struct spi_dev_s *dev,
+static void esp32_spi_select(struct spi_dev_s *dev,
                              uint32_t devid, bool selected);
 #endif
-static uint32_t esp32_spi_setfrequency(FAR struct spi_dev_s *dev,
+static uint32_t esp32_spi_setfrequency(struct spi_dev_s *dev,
                                        uint32_t frequency);
-static void esp32_spi_setmode(FAR struct spi_dev_s *dev,
+static void esp32_spi_setmode(struct spi_dev_s *dev,
                               enum spi_mode_e mode);
-static void esp32_spi_setbits(FAR struct spi_dev_s *dev, int nbits);
+static void esp32_spi_setbits(struct spi_dev_s *dev, int nbits);
 #ifdef CONFIG_SPI_HWFEATURES
-static int esp32_spi_hwfeatures(FAR struct spi_dev_s *dev,
+static int esp32_spi_hwfeatures(struct spi_dev_s *dev,
                                 spi_hwfeatures_t features);
 #endif
-static uint32_t esp32_spi_send(FAR struct spi_dev_s *dev, uint32_t wd);
-static void esp32_spi_exchange(FAR struct spi_dev_s *dev,
-                               FAR const void *txbuffer,
-                               FAR void *rxbuffer, size_t nwords);
+static uint32_t esp32_spi_send(struct spi_dev_s *dev, uint32_t wd);
+static void esp32_spi_exchange(struct spi_dev_s *dev,
+                               const void *txbuffer,
+                               void *rxbuffer, size_t nwords);
 #ifndef CONFIG_SPI_EXCHANGE
-static void esp32_spi_sndblock(FAR struct spi_dev_s *dev,
-                               FAR const void *txbuffer,
+static void esp32_spi_sndblock(struct spi_dev_s *dev,
+                               const void *txbuffer,
                                size_t nwords);
-static void esp32_spi_recvblock(FAR struct spi_dev_s *dev,
-                                FAR void *rxbuffer,
+static void esp32_spi_recvblock(struct spi_dev_s *dev,
+                                void *rxbuffer,
                                 size_t nwords);
 #endif
 #ifdef CONFIG_SPI_TRIGGER
-static int esp32_spi_trigger(FAR struct spi_dev_s *dev);
+static int esp32_spi_trigger(struct spi_dev_s *dev);
 #endif
-static void esp32_spi_init(FAR struct spi_dev_s *dev);
-static void esp32_spi_deinit(FAR struct spi_dev_s *dev);
+static void esp32_spi_init(struct spi_dev_s *dev);
+static void esp32_spi_deinit(struct spi_dev_s *dev);
 
 /****************************************************************************
  * Private Data
@@ -467,10 +467,10 @@ static inline bool esp32_spi_iomux(struct esp32_spi_priv_s *priv)
  *
  ****************************************************************************/
 
-static int esp32_spi_lock(FAR struct spi_dev_s *dev, bool lock)
+static int esp32_spi_lock(struct spi_dev_s *dev, bool lock)
 {
   int ret;
-  FAR struct esp32_spi_priv_s *priv = (FAR struct esp32_spi_priv_s *)dev;
+  struct esp32_spi_priv_s *priv = (struct esp32_spi_priv_s *)dev;
 
   if (lock)
     {
@@ -492,7 +492,7 @@ static int esp32_spi_lock(FAR struct spi_dev_s *dev, bool lock)
  *
  ****************************************************************************/
 
-static int esp32_spi_sem_waitdone(FAR struct esp32_spi_priv_s *priv)
+static int esp32_spi_sem_waitdone(struct esp32_spi_priv_s *priv)
 {
   int ret;
   struct timespec abstime;
@@ -531,11 +531,11 @@ static int esp32_spi_sem_waitdone(FAR struct esp32_spi_priv_s *priv)
  ****************************************************************************/
 
 #ifndef CONFIG_ESP32_SPI_UDCS
-static void esp32_spi_select(FAR struct spi_dev_s *dev,
+static void esp32_spi_select(struct spi_dev_s *dev,
                              uint32_t devid, bool selected)
 {
 #ifdef CONFIG_ESP32_SPI_SWCS
-  FAR struct esp32_spi_priv_s *priv = (FAR struct esp32_spi_priv_s *)dev;
+  struct esp32_spi_priv_s *priv = (struct esp32_spi_priv_s *)dev;
   bool value = selected ? false : true;
 
   esp32_gpiowrite(priv->config->cs_pin, value);
@@ -561,11 +561,11 @@ static void esp32_spi_select(FAR struct spi_dev_s *dev,
  *
  ****************************************************************************/
 
-static uint32_t esp32_spi_setfrequency(FAR struct spi_dev_s *dev,
+static uint32_t esp32_spi_setfrequency(struct spi_dev_s *dev,
                                        uint32_t frequency)
 {
   uint32_t reg_val;
-  FAR struct esp32_spi_priv_s *priv = (FAR struct esp32_spi_priv_s *)dev;
+  struct esp32_spi_priv_s *priv = (struct esp32_spi_priv_s *)dev;
   const uint32_t duty_cycle = 128;
 
   if (priv->frequency == frequency)
@@ -655,13 +655,13 @@ static uint32_t esp32_spi_setfrequency(FAR struct spi_dev_s *dev,
  *
  ****************************************************************************/
 
-static void esp32_spi_setmode(FAR struct spi_dev_s *dev,
+static void esp32_spi_setmode(struct spi_dev_s *dev,
                               enum spi_mode_e mode)
 {
   uint32_t ck_idle_edge;
   uint32_t ck_out_edge;
   uint32_t delay_mode;
-  FAR struct esp32_spi_priv_s *priv = (FAR struct esp32_spi_priv_s *)dev;
+  struct esp32_spi_priv_s *priv = (struct esp32_spi_priv_s *)dev;
 
   spiinfo("mode=%d\n", mode);
 
@@ -737,9 +737,9 @@ static void esp32_spi_setmode(FAR struct spi_dev_s *dev,
  *
  ****************************************************************************/
 
-static void esp32_spi_setbits(FAR struct spi_dev_s *dev, int nbits)
+static void esp32_spi_setbits(struct spi_dev_s *dev, int nbits)
 {
-  FAR struct esp32_spi_priv_s *priv = (FAR struct esp32_spi_priv_s *)dev;
+  struct esp32_spi_priv_s *priv = (struct esp32_spi_priv_s *)dev;
 
   spiinfo("nbits=%d\n", nbits);
 
@@ -763,7 +763,7 @@ static void esp32_spi_setbits(FAR struct spi_dev_s *dev, int nbits)
  ****************************************************************************/
 
 #ifdef CONFIG_SPI_HWFEATURES
-static int esp32_spi_hwfeatures(FAR struct spi_dev_s *dev,
+static int esp32_spi_hwfeatures(struct spi_dev_s *dev,
                                 spi_hwfeatures_t features)
 {
   /* Other H/W features are not supported */
@@ -793,9 +793,9 @@ static int esp32_spi_hwfeatures(FAR struct spi_dev_s *dev,
  *
  ****************************************************************************/
 
-static void esp32_spi_dma_exchange(FAR struct esp32_spi_priv_s *priv,
-                                   FAR const void *txbuffer,
-                                   FAR void *rxbuffer,
+static void esp32_spi_dma_exchange(struct esp32_spi_priv_s *priv,
+                                   const void *txbuffer,
+                                   void *rxbuffer,
                                    uint32_t nwords)
 {
   const uint32_t total = nwords * (priv->nbits / 8);
@@ -947,7 +947,7 @@ static void esp32_spi_dma_exchange(FAR struct esp32_spi_priv_s *priv,
  *
  ****************************************************************************/
 
-static uint32_t esp32_spi_poll_send(FAR struct esp32_spi_priv_s *priv,
+static uint32_t esp32_spi_poll_send(struct esp32_spi_priv_s *priv,
                                     uint32_t wd)
 {
   uint32_t val;
@@ -991,9 +991,9 @@ static uint32_t esp32_spi_poll_send(FAR struct esp32_spi_priv_s *priv,
  *
  ****************************************************************************/
 
-static uint32_t esp32_spi_send(FAR struct spi_dev_s *dev, uint32_t wd)
+static uint32_t esp32_spi_send(struct spi_dev_s *dev, uint32_t wd)
 {
-  FAR struct esp32_spi_priv_s *priv = (FAR struct esp32_spi_priv_s *)dev;
+  struct esp32_spi_priv_s *priv = (struct esp32_spi_priv_s *)dev;
 
   return esp32_spi_poll_send(priv, wd);
 }
@@ -1019,9 +1019,9 @@ static uint32_t esp32_spi_send(FAR struct spi_dev_s *dev, uint32_t wd)
  *
  ****************************************************************************/
 
-static void esp32_spi_poll_exchange(FAR struct esp32_spi_priv_s *priv,
-                                    FAR const void *txbuffer,
-                                    FAR void *rxbuffer,
+static void esp32_spi_poll_exchange(struct esp32_spi_priv_s *priv,
+                                    const void *txbuffer,
+                                    void *rxbuffer,
                                     size_t nwords)
 {
   const uintptr_t spi_user_reg = SPI_USER_REG(priv->config->id);
@@ -1147,12 +1147,12 @@ static void esp32_spi_poll_exchange(FAR struct esp32_spi_priv_s *priv,
  *
  ****************************************************************************/
 
-static void esp32_spi_exchange(FAR struct spi_dev_s *dev,
-                               FAR const void *txbuffer,
-                               FAR void *rxbuffer,
+static void esp32_spi_exchange(struct spi_dev_s *dev,
+                               const void *txbuffer,
+                               void *rxbuffer,
                                size_t nwords)
 {
-  FAR struct esp32_spi_priv_s *priv = (FAR struct esp32_spi_priv_s *)dev;
+  struct esp32_spi_priv_s *priv = (struct esp32_spi_priv_s *)dev;
 
 #ifdef CONFIG_ESP32_SPI_DMATHRESHOLD
   size_t thld = CONFIG_ESP32_SPI_DMATHRESHOLD;
@@ -1192,8 +1192,8 @@ static void esp32_spi_exchange(FAR struct spi_dev_s *dev,
  *
  ****************************************************************************/
 
-static void esp32_spi_sndblock(FAR struct spi_dev_s *dev,
-                               FAR const void *txbuffer,
+static void esp32_spi_sndblock(struct spi_dev_s *dev,
+                               const void *txbuffer,
                                size_t nwords)
 {
   spiinfo("txbuffer=%p nwords=%d\n", txbuffer, nwords);
@@ -1221,8 +1221,8 @@ static void esp32_spi_sndblock(FAR struct spi_dev_s *dev,
  *
  ****************************************************************************/
 
-static void esp32_spi_recvblock(FAR struct spi_dev_s *dev,
-                                FAR void *rxbuffer,
+static void esp32_spi_recvblock(struct spi_dev_s *dev,
+                                void *rxbuffer,
                                 size_t nwords)
 {
   spiinfo("rxbuffer=%p nwords=%d\n", rxbuffer, nwords);
@@ -1248,7 +1248,7 @@ static void esp32_spi_recvblock(FAR struct spi_dev_s *dev,
  ****************************************************************************/
 
 #ifdef CONFIG_SPI_TRIGGER
-static int esp32_spi_trigger(FAR struct spi_dev_s *dev)
+static int esp32_spi_trigger(struct spi_dev_s *dev)
 {
   return -ENOSYS;
 }
@@ -1268,9 +1268,9 @@ static int esp32_spi_trigger(FAR struct spi_dev_s *dev)
  *
  ****************************************************************************/
 
-static void esp32_spi_init(FAR struct spi_dev_s *dev)
+static void esp32_spi_init(struct spi_dev_s *dev)
 {
-  FAR struct esp32_spi_priv_s *priv = (FAR struct esp32_spi_priv_s *)dev;
+  struct esp32_spi_priv_s *priv = (struct esp32_spi_priv_s *)dev;
   const struct esp32_spi_config_s *config = priv->config;
   uint32_t regval;
 
@@ -1372,9 +1372,9 @@ static void esp32_spi_init(FAR struct spi_dev_s *dev)
  *
  ****************************************************************************/
 
-static void esp32_spi_deinit(FAR struct spi_dev_s *dev)
+static void esp32_spi_deinit(struct spi_dev_s *dev)
 {
-  FAR struct esp32_spi_priv_s *priv = (FAR struct esp32_spi_priv_s *)dev;
+  struct esp32_spi_priv_s *priv = (struct esp32_spi_priv_s *)dev;
 
   if (priv->config->use_dma)
     {
@@ -1404,9 +1404,9 @@ static void esp32_spi_deinit(FAR struct spi_dev_s *dev)
  *
  ****************************************************************************/
 
-static int esp32_spi_interrupt(int irq, void *context, FAR void *arg)
+static int esp32_spi_interrupt(int irq, void *context, void *arg)
 {
-  FAR struct esp32_spi_priv_s *priv = (FAR struct esp32_spi_priv_s *)arg;
+  struct esp32_spi_priv_s *priv = (struct esp32_spi_priv_s *)arg;
 
   esp32_spi_reset_regbits(SPI_SLAVE_REG(priv->config->id), SPI_TRANS_DONE_M);
   nxsem_post(&priv->sem_isr);
@@ -1428,11 +1428,11 @@ static int esp32_spi_interrupt(int irq, void *context, FAR void *arg)
  *
  ****************************************************************************/
 
-FAR struct spi_dev_s *esp32_spibus_initialize(int port)
+struct spi_dev_s *esp32_spibus_initialize(int port)
 {
   int ret;
-  FAR struct spi_dev_s *spi_dev;
-  FAR struct esp32_spi_priv_s *priv;
+  struct spi_dev_s *spi_dev;
+  struct esp32_spi_priv_s *priv;
   irqstate_t flags;
 
   switch (port)
@@ -1451,7 +1451,7 @@ FAR struct spi_dev_s *esp32_spibus_initialize(int port)
         return NULL;
     }
 
-  spi_dev = (FAR struct spi_dev_s *)priv;
+  spi_dev = (struct spi_dev_s *)priv;
 
   flags = enter_critical_section();
 
@@ -1505,10 +1505,10 @@ FAR struct spi_dev_s *esp32_spibus_initialize(int port)
  *
  ****************************************************************************/
 
-int esp32_spibus_uninitialize(FAR struct spi_dev_s *dev)
+int esp32_spibus_uninitialize(struct spi_dev_s *dev)
 {
   irqstate_t flags;
-  FAR struct esp32_spi_priv_s *priv = (FAR struct esp32_spi_priv_s *)dev;
+  struct esp32_spi_priv_s *priv = (struct esp32_spi_priv_s *)dev;
 
   DEBUGASSERT(dev);
 

--- a/arch/xtensa/src/esp32/esp32_spi.h
+++ b/arch/xtensa/src/esp32/esp32_spi.h
@@ -72,7 +72,7 @@ extern "C"
  *
  ****************************************************************************/
 
-FAR struct spi_dev_s *esp32_spibus_initialize(int port);
+struct spi_dev_s *esp32_spibus_initialize(int port);
 
 /****************************************************************************
  * Name:  esp32_spi0/1/...select and esp32_spi0/1/...status
@@ -105,17 +105,17 @@ FAR struct spi_dev_s *esp32_spibus_initialize(int port);
  ****************************************************************************/
 
 #ifdef CONFIG_ESP32_SPI2
-void esp32_spi2_select(FAR struct spi_dev_s *dev, uint32_t devid,
+void esp32_spi2_select(struct spi_dev_s *dev, uint32_t devid,
                        bool selected);
-uint8_t esp32_spi2_status(FAR struct spi_dev_s *dev, uint32_t devid);
-int esp32_spi2_cmddata(FAR struct spi_dev_s *dev, uint32_t devid, bool cmd);
+uint8_t esp32_spi2_status(struct spi_dev_s *dev, uint32_t devid);
+int esp32_spi2_cmddata(struct spi_dev_s *dev, uint32_t devid, bool cmd);
 #endif
 
 #ifdef CONFIG_ESP32_SPI3
-void esp32_spi3_select(FAR struct spi_dev_s *dev, uint32_t devid,
+void esp32_spi3_select(struct spi_dev_s *dev, uint32_t devid,
                        bool selected);
-uint8_t esp32_spi3_status(FAR struct spi_dev_s *dev, uint32_t devid);
-int esp32_spi3_cmddata(FAR struct spi_dev_s *dev, uint32_t devid, bool cmd);
+uint8_t esp32_spi3_status(struct spi_dev_s *dev, uint32_t devid);
+int esp32_spi3_cmddata(struct spi_dev_s *dev, uint32_t devid, bool cmd);
 #endif
 
 /****************************************************************************
@@ -126,7 +126,7 @@ int esp32_spi3_cmddata(FAR struct spi_dev_s *dev, uint32_t devid, bool cmd);
  *
  ****************************************************************************/
 
-int esp32_spibus_uninitialize(FAR struct spi_dev_s *dev);
+int esp32_spibus_uninitialize(struct spi_dev_s *dev);
 
 /****************************************************************************
  * Name: esp32_spislv_ctrlr_initialize
@@ -142,7 +142,7 @@ int esp32_spibus_uninitialize(FAR struct spi_dev_s *dev);
  *
  ****************************************************************************/
 
-FAR struct spi_slave_ctrlr_s *esp32_spislv_ctrlr_initialize(int port);
+struct spi_slave_ctrlr_s *esp32_spislv_ctrlr_initialize(int port);
 
 /****************************************************************************
  * Name: esp32_spislv_ctrlr_uninitialize
@@ -158,7 +158,7 @@ FAR struct spi_slave_ctrlr_s *esp32_spislv_ctrlr_initialize(int port);
  *
  ****************************************************************************/
 
-int esp32_spislv_ctrlr_uninitialize(FAR struct spi_slave_ctrlr_s *ctrlr);
+int esp32_spislv_ctrlr_uninitialize(struct spi_slave_ctrlr_s *ctrlr);
 
 #endif /* CONFIG_ESP32_SPI */
 

--- a/arch/xtensa/src/esp32/esp32_spi_slave.c
+++ b/arch/xtensa/src/esp32/esp32_spi_slave.c
@@ -169,23 +169,23 @@ struct esp32_spislv_priv_s
  * Private Function Prototypes
  ****************************************************************************/
 
-static void esp32_spislv_setmode(FAR struct spi_slave_ctrlr_s *ctrlr,
+static void esp32_spislv_setmode(struct spi_slave_ctrlr_s *ctrlr,
                                  enum spi_mode_e mode);
-static void esp32_spislv_setbits(FAR struct spi_slave_ctrlr_s *ctrlr,
+static void esp32_spislv_setbits(struct spi_slave_ctrlr_s *ctrlr,
                                  int nbits);
-static int esp32_spislv_interrupt(int irq, void *context, FAR void *arg);
-static void esp32_spislv_initialize(FAR struct spi_slave_ctrlr_s *ctrlr);
+static int esp32_spislv_interrupt(int irq, void *context, void *arg);
+static void esp32_spislv_initialize(struct spi_slave_ctrlr_s *ctrlr);
 static void esp32_spislv_bind(struct spi_slave_ctrlr_s *ctrlr,
                               struct spi_slave_dev_s *dev,
                               enum spi_slave_mode_e mode,
                               int nbits);
 static void esp32_spislv_unbind(struct spi_slave_ctrlr_s *ctrlr);
 static int esp32_spislv_enqueue(struct spi_slave_ctrlr_s *ctrlr,
-                                FAR const void *data,
+                                const void *data,
                                 size_t nwords);
 static bool esp32_spislv_qfull(struct spi_slave_ctrlr_s *ctrlr);
 static void esp32_spislv_qflush(struct spi_slave_ctrlr_s *ctrlr);
-static size_t esp32_spislv_qpoll(FAR struct spi_slave_ctrlr_s *ctrlr);
+static size_t esp32_spislv_qpoll(struct spi_slave_ctrlr_s *ctrlr);
 
 /****************************************************************************
  * Private Data
@@ -458,7 +458,7 @@ static inline bool esp32_spi_iomux(struct esp32_spislv_priv_s *priv)
  *
  ****************************************************************************/
 
-static void esp32_spislv_setmode(FAR struct spi_slave_ctrlr_s *ctrlr,
+static void esp32_spislv_setmode(struct spi_slave_ctrlr_s *ctrlr,
                                  enum spi_mode_e mode)
 {
   uint32_t ck_idle_edge;
@@ -587,7 +587,7 @@ static void esp32_spislv_setmode(FAR struct spi_slave_ctrlr_s *ctrlr,
  *
  ****************************************************************************/
 
-static void esp32_spislv_setbits(FAR struct spi_slave_ctrlr_s *ctrlr,
+static void esp32_spislv_setbits(struct spi_slave_ctrlr_s *ctrlr,
                                  int nbits)
 {
   struct esp32_spislv_priv_s *priv = (struct esp32_spislv_priv_s *)ctrlr;
@@ -614,7 +614,7 @@ static void esp32_spislv_setbits(FAR struct spi_slave_ctrlr_s *ctrlr,
  *
  ****************************************************************************/
 
-static int esp32_io_interrupt(int irq, void *context, FAR void *arg)
+static int esp32_io_interrupt(int irq, void *context, void *arg)
 {
   struct esp32_spislv_priv_s *priv = (struct esp32_spislv_priv_s *)arg;
 
@@ -755,7 +755,7 @@ static void esp32_spislv_rx(struct esp32_spislv_priv_s *priv)
  *
  ****************************************************************************/
 
-static int esp32_spislv_interrupt(int irq, void *context, FAR void *arg)
+static int esp32_spislv_interrupt(int irq, void *context, void *arg)
 {
   struct esp32_spislv_priv_s *priv = (struct esp32_spislv_priv_s *)arg;
   uint32_t n;
@@ -846,7 +846,7 @@ static int esp32_spislv_interrupt(int irq, void *context, FAR void *arg)
  *
  ****************************************************************************/
 
-static void esp32_spislv_initialize(FAR struct spi_slave_ctrlr_s *ctrlr)
+static void esp32_spislv_initialize(struct spi_slave_ctrlr_s *ctrlr)
 {
   struct esp32_spislv_priv_s *priv = (struct esp32_spislv_priv_s *)ctrlr;
   const struct esp32_spislv_config_s *config = priv->config;
@@ -958,7 +958,7 @@ static void esp32_spislv_initialize(FAR struct spi_slave_ctrlr_s *ctrlr)
  *
  ****************************************************************************/
 
-static void esp32_spislv_deinit(FAR struct spi_slave_ctrlr_s *ctrlr)
+static void esp32_spislv_deinit(struct spi_slave_ctrlr_s *ctrlr)
 {
   struct esp32_spislv_priv_s *priv = (struct esp32_spislv_priv_s *)ctrlr;
 
@@ -1101,7 +1101,7 @@ static void esp32_spislv_unbind(struct spi_slave_ctrlr_s *ctrlr)
  ****************************************************************************/
 
 static int esp32_spislv_enqueue(struct spi_slave_ctrlr_s *ctrlr,
-                                FAR const void *data,
+                                const void *data,
                                 size_t nwords)
 {
   struct esp32_spislv_priv_s *priv = (struct esp32_spislv_priv_s *)ctrlr;
@@ -1217,7 +1217,7 @@ static void esp32_spislv_qflush(struct spi_slave_ctrlr_s *ctrlr)
  *
  ****************************************************************************/
 
-static size_t esp32_spislv_qpoll(FAR struct spi_slave_ctrlr_s *ctrlr)
+static size_t esp32_spislv_qpoll(struct spi_slave_ctrlr_s *ctrlr)
 {
   struct esp32_spislv_priv_s *priv = (struct esp32_spislv_priv_s *)ctrlr;
   irqstate_t flags;
@@ -1249,11 +1249,11 @@ static size_t esp32_spislv_qpoll(FAR struct spi_slave_ctrlr_s *ctrlr)
  *
  ****************************************************************************/
 
-FAR struct spi_slave_ctrlr_s *esp32_spislv_ctrlr_initialize(int port)
+struct spi_slave_ctrlr_s *esp32_spislv_ctrlr_initialize(int port)
 {
   int ret;
-  FAR struct spi_slave_ctrlr_s *spislv_dev;
-  FAR struct esp32_spislv_priv_s *priv;
+  struct spi_slave_ctrlr_s *spislv_dev;
+  struct esp32_spislv_priv_s *priv;
   irqstate_t flags;
 
   switch (port)
@@ -1272,7 +1272,7 @@ FAR struct spi_slave_ctrlr_s *esp32_spislv_ctrlr_initialize(int port)
         return NULL;
     }
 
-  spislv_dev = (FAR struct spi_slave_ctrlr_s *)priv;
+  spislv_dev = (struct spi_slave_ctrlr_s *)priv;
 
   flags = enter_critical_section();
 
@@ -1333,7 +1333,7 @@ FAR struct spi_slave_ctrlr_s *esp32_spislv_ctrlr_initialize(int port)
  *
  ****************************************************************************/
 
-int esp32_spislv_ctrlr_uninitialize(FAR struct spi_slave_ctrlr_s *ctrlr)
+int esp32_spislv_ctrlr_uninitialize(struct spi_slave_ctrlr_s *ctrlr)
 {
   irqstate_t flags;
   struct esp32_spislv_priv_s *priv = (struct esp32_spislv_priv_s *)ctrlr;

--- a/arch/xtensa/src/esp32/esp32_spiflash.c
+++ b/arch/xtensa/src/esp32/esp32_spiflash.c
@@ -71,7 +71,7 @@
 #define SPI_FLASH_ENCRYPT_WORDS     (32 / 4)
 #define SPI_FLASH_ERASED_STATE      (0xff)
 
-#define MTD2PRIV(_dev)              ((FAR struct esp32_spiflash_s *)_dev)
+#define MTD2PRIV(_dev)              ((struct esp32_spiflash_s *)_dev)
 #define MTD_SIZE(_priv)             ((_priv)->chip->chip_size)
 #define MTD_BLKSIZE(_priv)          ((_priv)->chip->page_size)
 #define MTD_ERASESIZE(_priv)        ((_priv)->chip->sector_size)
@@ -192,63 +192,63 @@ static inline void spi_reset_regbits(struct esp32_spiflash_s *priv,
 /* Misc. helpers */
 
 static inline void IRAM_ATTR
-  esp32_spiflash_opstart(FAR struct spiflash_cachestate_s *state);
+  esp32_spiflash_opstart(struct spiflash_cachestate_s *state);
 static inline void IRAM_ATTR
-  esp32_spiflash_opdone(FAR const struct spiflash_cachestate_s *state);
+  esp32_spiflash_opdone(const struct spiflash_cachestate_s *state);
 
 static bool IRAM_ATTR spiflash_pagecached(uint32_t phypage);
 static void IRAM_ATTR spiflash_flushmapped(size_t start, size_t size);
 
 /* Flash helpers */
 
-static void IRAM_ATTR esp32_set_read_opt(FAR struct esp32_spiflash_s *priv);
+static void IRAM_ATTR esp32_set_read_opt(struct esp32_spiflash_s *priv);
 static void IRAM_ATTR esp32_set_write_opt(struct esp32_spiflash_s *priv);
-static int  IRAM_ATTR  esp32_read_status(FAR struct esp32_spiflash_s *priv,
+static int  IRAM_ATTR  esp32_read_status(struct esp32_spiflash_s *priv,
                                          uint32_t *status);
-static int IRAM_ATTR esp32_wait_idle(FAR struct esp32_spiflash_s *priv);
-static int IRAM_ATTR esp32_enable_write(FAR struct esp32_spiflash_s *priv);
-static int IRAM_ATTR esp32_erasesector(FAR struct esp32_spiflash_s *priv,
+static int IRAM_ATTR esp32_wait_idle(struct esp32_spiflash_s *priv);
+static int IRAM_ATTR esp32_enable_write(struct esp32_spiflash_s *priv);
+static int IRAM_ATTR esp32_erasesector(struct esp32_spiflash_s *priv,
                                        uint32_t addr, uint32_t size);
-static int IRAM_ATTR esp32_writedata(FAR struct esp32_spiflash_s *priv,
+static int IRAM_ATTR esp32_writedata(struct esp32_spiflash_s *priv,
                                      uint32_t addr,
                                      const uint8_t *buffer, uint32_t size);
-static int IRAM_ATTR esp32_readdata(FAR struct esp32_spiflash_s *priv,
+static int IRAM_ATTR esp32_readdata(struct esp32_spiflash_s *priv,
                                     uint32_t addr,
                                     uint8_t *buffer, uint32_t size);
 #if 0
-static int esp32_read_highstatus(FAR struct esp32_spiflash_s *priv,
+static int esp32_read_highstatus(struct esp32_spiflash_s *priv,
                                  uint32_t *status);
 #endif
 #if 0
-static int esp32_write_status(FAR struct esp32_spiflash_s *priv,
+static int esp32_write_status(struct esp32_spiflash_s *priv,
                               uint32_t status);
 #endif
 
 /* MTD driver methods */
 
-static int esp32_erase(FAR struct mtd_dev_s *dev, off_t startblock,
+static int esp32_erase(struct mtd_dev_s *dev, off_t startblock,
                        size_t nblocks);
-static ssize_t esp32_read(FAR struct mtd_dev_s *dev, off_t offset,
-                          size_t nbytes, FAR uint8_t *buffer);
-static ssize_t esp32_read_decrypt(FAR struct mtd_dev_s *dev,
+static ssize_t esp32_read(struct mtd_dev_s *dev, off_t offset,
+                          size_t nbytes, uint8_t *buffer);
+static ssize_t esp32_read_decrypt(struct mtd_dev_s *dev,
                                   off_t offset,
                                   size_t nbytes,
-                                  FAR uint8_t *buffer);
-static ssize_t esp32_bread(FAR struct mtd_dev_s *dev, off_t startblock,
-                           size_t nblocks, FAR uint8_t *buffer);
-static ssize_t esp32_bread_decrypt(FAR struct mtd_dev_s *dev,
+                                  uint8_t *buffer);
+static ssize_t esp32_bread(struct mtd_dev_s *dev, off_t startblock,
+                           size_t nblocks, uint8_t *buffer);
+static ssize_t esp32_bread_decrypt(struct mtd_dev_s *dev,
                                    off_t startblock,
                                    size_t nblocks,
-                                   FAR uint8_t *buffer);
-static ssize_t esp32_write(FAR struct mtd_dev_s *dev, off_t offset,
-                           size_t nbytes, FAR const uint8_t *buffer);
-static ssize_t esp32_bwrite(FAR struct mtd_dev_s *dev, off_t startblock,
-                            size_t nblocks, FAR const uint8_t *buffer);
-static ssize_t esp32_bwrite_encrypt(FAR struct mtd_dev_s *dev,
+                                   uint8_t *buffer);
+static ssize_t esp32_write(struct mtd_dev_s *dev, off_t offset,
+                           size_t nbytes, const uint8_t *buffer);
+static ssize_t esp32_bwrite(struct mtd_dev_s *dev, off_t startblock,
+                            size_t nblocks, const uint8_t *buffer);
+static ssize_t esp32_bwrite_encrypt(struct mtd_dev_s *dev,
                                     off_t startblock,
                                     size_t nblocks,
-                                    FAR const uint8_t *buffer);
-static int esp32_ioctl(FAR struct mtd_dev_s *dev, int cmd,
+                                    const uint8_t *buffer);
+static int esp32_ioctl(struct mtd_dev_s *dev, int cmd,
                        unsigned long arg);
 
 /****************************************************************************
@@ -406,7 +406,7 @@ static inline void spi_reset_regbits(struct esp32_spiflash_s *priv,
  ****************************************************************************/
 
 static inline void IRAM_ATTR
-  esp32_spiflash_opstart(FAR struct spiflash_cachestate_s *state)
+  esp32_spiflash_opstart(struct spiflash_cachestate_s *state)
 {
 #ifdef CONFIG_SMP
   int other;
@@ -439,7 +439,7 @@ static inline void IRAM_ATTR
  ****************************************************************************/
 
 static inline void IRAM_ATTR
-  esp32_spiflash_opdone(FAR const struct spiflash_cachestate_s *state)
+  esp32_spiflash_opdone(const struct spiflash_cachestate_s *state)
 {
 #ifdef CONFIG_SMP
   int other;
@@ -558,7 +558,7 @@ static void IRAM_ATTR spiflash_flushmapped(size_t start, size_t size)
  *
  ****************************************************************************/
 
-static void IRAM_ATTR esp32_set_read_opt(FAR struct esp32_spiflash_s *priv)
+static void IRAM_ATTR esp32_set_read_opt(struct esp32_spiflash_s *priv)
 {
   uint32_t regval;
   uint32_t ctrl;
@@ -698,7 +698,7 @@ static void IRAM_ATTR esp32_set_write_opt(struct esp32_spiflash_s *priv)
  *
  ****************************************************************************/
 
-static int IRAM_ATTR esp32_read_status(FAR struct esp32_spiflash_s *priv,
+static int IRAM_ATTR esp32_read_status(struct esp32_spiflash_s *priv,
                                        uint32_t *status)
 {
   esp32_spiflash_chip_t *chip = priv->chip;
@@ -752,7 +752,7 @@ static int IRAM_ATTR esp32_read_status(FAR struct esp32_spiflash_s *priv,
  *
  ****************************************************************************/
 
-static int IRAM_ATTR esp32_wait_idle(FAR struct esp32_spiflash_s *priv)
+static int IRAM_ATTR esp32_wait_idle(struct esp32_spiflash_s *priv)
 {
   uint32_t status;
 
@@ -790,7 +790,7 @@ static int IRAM_ATTR esp32_wait_idle(FAR struct esp32_spiflash_s *priv)
  ****************************************************************************/
 
 #if 0
-static int esp32_read_highstatus(FAR struct esp32_spiflash_s *priv,
+static int esp32_read_highstatus(struct esp32_spiflash_s *priv,
                                  uint32_t *status)
 {
   uint32_t regval;
@@ -827,7 +827,7 @@ static int esp32_read_highstatus(FAR struct esp32_spiflash_s *priv,
  ****************************************************************************/
 
 #if 0
-static int esp32_write_status(FAR struct esp32_spiflash_s *priv,
+static int esp32_write_status(struct esp32_spiflash_s *priv,
                               uint32_t status)
 {
   if (esp32_wait_idle(priv))
@@ -865,7 +865,7 @@ static int esp32_write_status(FAR struct esp32_spiflash_s *priv,
  *
  ****************************************************************************/
 
-static int IRAM_ATTR esp32_enable_write(FAR struct esp32_spiflash_s *priv)
+static int IRAM_ATTR esp32_enable_write(struct esp32_spiflash_s *priv)
 {
   uint32_t flags;
   uint32_t regval;
@@ -911,7 +911,7 @@ static int IRAM_ATTR esp32_enable_write(FAR struct esp32_spiflash_s *priv)
  *
  ****************************************************************************/
 
-static int IRAM_ATTR esp32_erasesector(FAR struct esp32_spiflash_s *priv,
+static int IRAM_ATTR esp32_erasesector(struct esp32_spiflash_s *priv,
                                        uint32_t addr, uint32_t size)
 {
   uint32_t offset;
@@ -976,7 +976,7 @@ static int IRAM_ATTR esp32_erasesector(FAR struct esp32_spiflash_s *priv,
  *
  ****************************************************************************/
 
-static int IRAM_ATTR esp32_writeonce(FAR struct esp32_spiflash_s *priv,
+static int IRAM_ATTR esp32_writeonce(struct esp32_spiflash_s *priv,
                                      uint32_t addr,
                                      const uint32_t *buffer,
                                      uint32_t size)
@@ -1046,7 +1046,7 @@ static int IRAM_ATTR esp32_writeonce(FAR struct esp32_spiflash_s *priv,
  *
  ****************************************************************************/
 
-static int IRAM_ATTR esp32_writedata(FAR struct esp32_spiflash_s *priv,
+static int IRAM_ATTR esp32_writedata(struct esp32_spiflash_s *priv,
                                      uint32_t addr,
                                      const uint8_t *buffer,
                                      uint32_t size)
@@ -1114,7 +1114,7 @@ static int IRAM_ATTR esp32_writedata(FAR struct esp32_spiflash_s *priv,
  ****************************************************************************/
 
 static int IRAM_ATTR esp32_writedata_encrypted(
-  FAR struct esp32_spiflash_s *priv,
+  struct esp32_spiflash_s *priv,
   uint32_t addr,
   const uint8_t *buffer,
   uint32_t size)
@@ -1203,7 +1203,7 @@ exit:
  *
  ****************************************************************************/
 
-static int IRAM_ATTR esp32_readonce(FAR struct esp32_spiflash_s *priv,
+static int IRAM_ATTR esp32_readonce(struct esp32_spiflash_s *priv,
                                     uint32_t addr,
                                     uint32_t *buffer,
                                     uint32_t size)
@@ -1265,7 +1265,7 @@ static int IRAM_ATTR esp32_readonce(FAR struct esp32_spiflash_s *priv,
  *
  ****************************************************************************/
 
-static int IRAM_ATTR esp32_readdata(FAR struct esp32_spiflash_s *priv,
+static int IRAM_ATTR esp32_readdata(struct esp32_spiflash_s *priv,
                                     uint32_t addr,
                                     uint8_t *buffer,
                                     uint32_t size)
@@ -1318,7 +1318,7 @@ static int IRAM_ATTR esp32_readdata(FAR struct esp32_spiflash_s *priv,
  *
  ****************************************************************************/
 
-static int IRAM_ATTR esp32_mmap(FAR struct esp32_spiflash_s *priv,
+static int IRAM_ATTR esp32_mmap(struct esp32_spiflash_s *priv,
                                 struct spiflash_map_req *req)
 {
   int ret;
@@ -1402,7 +1402,7 @@ static int IRAM_ATTR esp32_mmap(FAR struct esp32_spiflash_s *priv,
  *
  ****************************************************************************/
 
-static void IRAM_ATTR esp32_ummap(FAR struct esp32_spiflash_s *priv,
+static void IRAM_ATTR esp32_ummap(struct esp32_spiflash_s *priv,
                                   const struct spiflash_map_req *req)
 {
   int i;
@@ -1447,7 +1447,7 @@ static void IRAM_ATTR esp32_ummap(FAR struct esp32_spiflash_s *priv,
  ****************************************************************************/
 
 static int IRAM_ATTR esp32_readdata_encrypted(
-  FAR struct esp32_spiflash_s *priv,
+  struct esp32_spiflash_s *priv,
   uint32_t addr,
   uint8_t *buffer,
   uint32_t size)
@@ -1488,11 +1488,11 @@ static int IRAM_ATTR esp32_readdata_encrypted(
  *
  ****************************************************************************/
 
-static int esp32_erase(FAR struct mtd_dev_s *dev, off_t startblock,
+static int esp32_erase(struct mtd_dev_s *dev, off_t startblock,
                        size_t nblocks)
 {
   int ret;
-  FAR struct esp32_spiflash_s *priv = MTD2PRIV(dev);
+  struct esp32_spiflash_s *priv = MTD2PRIV(dev);
   uint32_t addr = startblock * MTD_ERASESIZE(priv);
   uint32_t size = nblocks * MTD_ERASESIZE(priv);
 
@@ -1544,11 +1544,11 @@ static int esp32_erase(FAR struct mtd_dev_s *dev, off_t startblock,
  *
  ****************************************************************************/
 
-static ssize_t esp32_read(FAR struct mtd_dev_s *dev, off_t offset,
-                          size_t nbytes, FAR uint8_t *buffer)
+static ssize_t esp32_read(struct mtd_dev_s *dev, off_t offset,
+                          size_t nbytes, uint8_t *buffer)
 {
   int ret;
-  FAR struct esp32_spiflash_s *priv = MTD2PRIV(dev);
+  struct esp32_spiflash_s *priv = MTD2PRIV(dev);
 
 #ifdef CONFIG_ESP32_SPIFLASH_DEBUG
   finfo("esp32_read(%p, 0x%x, %d, %p)\n", dev, offset, nbytes, buffer);
@@ -1598,11 +1598,11 @@ error_with_buffer:
  *
  ****************************************************************************/
 
-static ssize_t esp32_bread(FAR struct mtd_dev_s *dev, off_t startblock,
-                           size_t nblocks, FAR uint8_t *buffer)
+static ssize_t esp32_bread(struct mtd_dev_s *dev, off_t startblock,
+                           size_t nblocks, uint8_t *buffer)
 {
   int ret;
-  FAR struct esp32_spiflash_s *priv = MTD2PRIV(dev);
+  struct esp32_spiflash_s *priv = MTD2PRIV(dev);
   uint32_t addr = MTD_BLK2SIZE(priv, startblock);
   uint32_t size = MTD_BLK2SIZE(priv, nblocks);
 
@@ -1642,14 +1642,14 @@ static ssize_t esp32_bread(FAR struct mtd_dev_s *dev, off_t startblock,
  *
  ****************************************************************************/
 
-static ssize_t esp32_read_decrypt(FAR struct mtd_dev_s *dev,
+static ssize_t esp32_read_decrypt(struct mtd_dev_s *dev,
                                   off_t offset,
                                   size_t nbytes,
-                                  FAR uint8_t *buffer)
+                                  uint8_t *buffer)
 {
   int ret;
   uint8_t *tmpbuff = buffer;
-  FAR struct esp32_spiflash_s *priv = MTD2PRIV(dev);
+  struct esp32_spiflash_s *priv = MTD2PRIV(dev);
 
 #ifdef CONFIG_ESP32_SPIFLASH_DEBUG
   finfo("esp32_read_decrypt(%p, 0x%x, %d, %p)\n",
@@ -1699,13 +1699,13 @@ error_with_buffer:
  *
  ****************************************************************************/
 
-static ssize_t esp32_bread_decrypt(FAR struct mtd_dev_s *dev,
+static ssize_t esp32_bread_decrypt(struct mtd_dev_s *dev,
                                    off_t startblock,
                                    size_t nblocks,
-                                   FAR uint8_t *buffer)
+                                   uint8_t *buffer)
 {
   int ret;
-  FAR struct esp32_spiflash_s *priv = MTD2PRIV(dev);
+  struct esp32_spiflash_s *priv = MTD2PRIV(dev);
   uint32_t addr = MTD_BLK2SIZE(priv, startblock);
   uint32_t size = MTD_BLK2SIZE(priv, nblocks);
 
@@ -1744,11 +1744,11 @@ static ssize_t esp32_bread_decrypt(FAR struct mtd_dev_s *dev,
  *
  ****************************************************************************/
 
-static ssize_t esp32_write(FAR struct mtd_dev_s *dev, off_t offset,
-                           size_t nbytes, FAR const uint8_t *buffer)
+static ssize_t esp32_write(struct mtd_dev_s *dev, off_t offset,
+                           size_t nbytes, const uint8_t *buffer)
 {
   int ret;
-  FAR struct esp32_spiflash_s *priv = MTD2PRIV(dev);
+  struct esp32_spiflash_s *priv = MTD2PRIV(dev);
 
   ASSERT(buffer);
 
@@ -1805,11 +1805,11 @@ error_with_buffer:
  *
  ****************************************************************************/
 
-static ssize_t esp32_bwrite(FAR struct mtd_dev_s *dev, off_t startblock,
-                            size_t nblocks, FAR const uint8_t *buffer)
+static ssize_t esp32_bwrite(struct mtd_dev_s *dev, off_t startblock,
+                            size_t nblocks, const uint8_t *buffer)
 {
   ssize_t ret;
-  FAR struct esp32_spiflash_s *priv = MTD2PRIV(dev);
+  struct esp32_spiflash_s *priv = MTD2PRIV(dev);
   uint32_t addr = MTD_BLK2SIZE(priv, startblock);
   uint32_t size = MTD_BLK2SIZE(priv, nblocks);
 
@@ -1849,13 +1849,13 @@ static ssize_t esp32_bwrite(FAR struct mtd_dev_s *dev, off_t startblock,
  *
  ****************************************************************************/
 
-static ssize_t esp32_bwrite_encrypt(FAR struct mtd_dev_s *dev,
+static ssize_t esp32_bwrite_encrypt(struct mtd_dev_s *dev,
                                     off_t startblock,
                                     size_t nblocks,
-                                    FAR const uint8_t *buffer)
+                                    const uint8_t *buffer)
 {
   ssize_t ret;
-  FAR struct esp32_spiflash_s *priv = MTD2PRIV(dev);
+  struct esp32_spiflash_s *priv = MTD2PRIV(dev);
   uint32_t addr = MTD_BLK2SIZE(priv, startblock);
   uint32_t size = MTD_BLK2SIZE(priv, nblocks);
 
@@ -1904,11 +1904,11 @@ error_with_buffer:
  *
  ****************************************************************************/
 
-static int esp32_ioctl(FAR struct mtd_dev_s *dev, int cmd,
+static int esp32_ioctl(struct mtd_dev_s *dev, int cmd,
                        unsigned long arg)
 {
   int ret = -EINVAL;
-  FAR struct esp32_spiflash_s *priv = MTD2PRIV(dev);
+  struct esp32_spiflash_s *priv = MTD2PRIV(dev);
 
   finfo("cmd: %d \n", cmd);
 
@@ -1916,7 +1916,7 @@ static int esp32_ioctl(FAR struct mtd_dev_s *dev, int cmd,
     {
       case MTDIOC_GEOMETRY:
         {
-          FAR struct mtd_geometry_s *geo = (FAR struct mtd_geometry_s *)arg;
+          struct mtd_geometry_s *geo = (struct mtd_geometry_s *)arg;
           if (geo)
             {
               geo->blocksize    = MTD_BLKSIZE(priv);
@@ -1932,8 +1932,8 @@ static int esp32_ioctl(FAR struct mtd_dev_s *dev, int cmd,
 
       case BIOC_PARTINFO:
         {
-          FAR struct partition_info_s *info =
-            (FAR struct partition_info_s *)arg;
+          struct partition_info_s *info =
+            (struct partition_info_s *)arg;
           if (info != NULL)
             {
               info->numsectors  = MTD_SIZE(priv) / MTD_BLKSIZE(priv);
@@ -1947,7 +1947,7 @@ static int esp32_ioctl(FAR struct mtd_dev_s *dev, int cmd,
 
       case MTDIOC_ERASESTATE:
         {
-          FAR uint8_t *result = (FAR uint8_t *)arg;
+          uint8_t *result = (uint8_t *)arg;
           *result = SPI_FLASH_ERASED_STATE;
 
           ret = OK;
@@ -1982,12 +1982,12 @@ static int esp32_ioctl(FAR struct mtd_dev_s *dev, int cmd,
  *
  ****************************************************************************/
 
-FAR struct mtd_dev_s *esp32_spiflash_alloc_mtdpart(uint32_t mtd_offset,
+struct mtd_dev_s *esp32_spiflash_alloc_mtdpart(uint32_t mtd_offset,
                                                    uint32_t mtd_size)
 {
   struct esp32_spiflash_s *priv = &g_esp32_spiflash1;
   esp32_spiflash_chip_t *chip = priv->chip;
-  FAR struct mtd_dev_s *mtd_part;
+  struct mtd_dev_s *mtd_part;
   uint32_t blocks;
   uint32_t startblock;
   uint32_t size;
@@ -2043,7 +2043,7 @@ FAR struct mtd_dev_s *esp32_spiflash_alloc_mtdpart(uint32_t mtd_offset,
  *
  ****************************************************************************/
 
-FAR struct mtd_dev_s *esp32_spiflash_get_mtd(void)
+struct mtd_dev_s *esp32_spiflash_get_mtd(void)
 {
   struct esp32_spiflash_s *priv = &g_esp32_spiflash1;
 
@@ -2064,7 +2064,7 @@ FAR struct mtd_dev_s *esp32_spiflash_get_mtd(void)
  *
  ****************************************************************************/
 
-FAR struct mtd_dev_s *esp32_spiflash_encrypt_get_mtd(void)
+struct mtd_dev_s *esp32_spiflash_encrypt_get_mtd(void)
 {
   struct esp32_spiflash_s *priv = &g_esp32_spiflash1_encrypt;
 

--- a/arch/xtensa/src/esp32/esp32_spiflash.h
+++ b/arch/xtensa/src/esp32/esp32_spiflash.h
@@ -63,7 +63,7 @@ extern "C"
  *
  ****************************************************************************/
 
-FAR struct mtd_dev_s *esp32_spiflash_alloc_mtdpart(uint32_t mtd_offset,
+struct mtd_dev_s *esp32_spiflash_alloc_mtdpart(uint32_t mtd_offset,
                                                    uint32_t mtd_size);
 
 /****************************************************************************
@@ -80,7 +80,7 @@ FAR struct mtd_dev_s *esp32_spiflash_alloc_mtdpart(uint32_t mtd_offset,
  *
  ****************************************************************************/
 
-FAR struct mtd_dev_s *esp32_spiflash_get_mtd(void);
+struct mtd_dev_s *esp32_spiflash_get_mtd(void);
 
 /****************************************************************************
  * Name: esp32_spiflash_encrypt_get_mtd
@@ -96,7 +96,7 @@ FAR struct mtd_dev_s *esp32_spiflash_get_mtd(void);
  *
  ****************************************************************************/
 
-FAR struct mtd_dev_s *esp32_spiflash_encrypt_get_mtd(void);
+struct mtd_dev_s *esp32_spiflash_encrypt_get_mtd(void);
 
 #ifdef __cplusplus
 }

--- a/arch/xtensa/src/esp32/esp32_textheap.c
+++ b/arch/xtensa/src/esp32/esp32_textheap.c
@@ -60,9 +60,9 @@
  *
  ****************************************************************************/
 
-FAR void *up_textheap_memalign(size_t align, size_t size)
+void *up_textheap_memalign(size_t align, size_t size)
 {
-  FAR void *ret = NULL;
+  void *ret = NULL;
 
   /* Prioritise allocating from RTC. If that fails, allocate from the
    * main heap.
@@ -88,7 +88,7 @@ FAR void *up_textheap_memalign(size_t align, size_t size)
  *
  ****************************************************************************/
 
-void up_textheap_free(FAR void *p)
+void up_textheap_free(void *p)
 {
   if (p)
     {

--- a/arch/xtensa/src/esp32/esp32_tickless.c
+++ b/arch/xtensa/src/esp32/esp32_tickless.c
@@ -27,10 +27,10 @@
  *
  *   void up_timer_initialize(void): Initializes the timer facilities.
  *     Called early in the initialization sequence (by up_initialize()).
- *   int up_timer_gettime(FAR struct timespec *ts):  Returns the current
+ *   int up_timer_gettime(struct timespec *ts):  Returns the current
  *     time from the platform specific time source.
  *   int up_timer_cancel(void):  Cancels the interval timer.
- *   int up_timer_start(FAR const struct timespec *ts): Start (or re-starts)
+ *   int up_timer_start(const struct timespec *ts): Start (or re-starts)
  *     the interval timer.
  *
  * The RTOS will provide the following interfaces for use by the platform-
@@ -92,7 +92,7 @@ static inline uint64_t up_tmr_total_count(void);
 static inline uint64_t up_tmr_getcount(void);
 static void IRAM_ATTR up_tmr_setcompare(uint32_t ticks);
 static void IRAM_ATTR up_tmr_setcount(uint64_t ticks);
-static int up_timer_expire(int irq, void *regs, FAR void *arg);
+static int up_timer_expire(int irq, void *regs, void *arg);
 
 /****************************************************************************
  * Private Data
@@ -234,7 +234,7 @@ static void IRAM_ATTR up_tmr_setcount(uint64_t ticks)
  *
  ****************************************************************************/
 
-static int up_timer_expire(int irq, void *regs, FAR void *arg)
+static int up_timer_expire(int irq, void *regs, void *arg)
 {
   irqstate_t flags;
   bool do_sched = false;
@@ -295,7 +295,7 @@ static int up_timer_expire(int irq, void *regs, FAR void *arg)
  *   up_timer_initialize() was called).  This function is functionally
  *   equivalent to:
  *
- *      int clock_gettime(clockid_t clockid, FAR struct timespec *ts);
+ *      int clock_gettime(clockid_t clockid, struct timespec *ts);
  *
  *   when clockid is CLOCK_MONOTONIC.
  *
@@ -320,7 +320,7 @@ static int up_timer_expire(int irq, void *regs, FAR void *arg)
  *
  ****************************************************************************/
 
-int IRAM_ATTR up_timer_gettime(FAR struct timespec *ts)
+int IRAM_ATTR up_timer_gettime(struct timespec *ts)
 {
   uint64_t ticks;
   irqstate_t flags;
@@ -371,7 +371,7 @@ int IRAM_ATTR up_timer_gettime(FAR struct timespec *ts)
  *
  ****************************************************************************/
 
-int IRAM_ATTR up_timer_cancel(FAR struct timespec *ts)
+int IRAM_ATTR up_timer_cancel(struct timespec *ts)
 {
   uint64_t rst_ticks;
   uint64_t cur_ticks;
@@ -437,7 +437,7 @@ int IRAM_ATTR up_timer_cancel(FAR struct timespec *ts)
  *
  ****************************************************************************/
 
-int IRAM_ATTR up_timer_start(FAR const struct timespec *ts)
+int IRAM_ATTR up_timer_start(const struct timespec *ts)
 {
   uint64_t cpu_ticks;
   irqstate_t flags;

--- a/arch/xtensa/src/esp32/esp32_tim.c
+++ b/arch/xtensa/src/esp32/esp32_tim.c
@@ -43,7 +43,7 @@
 
 struct esp32_tim_priv_s
 {
-  FAR struct esp32_tim_ops_s *ops;
+  struct esp32_tim_ops_s *ops;
   uint32_t                    base;     /* Timer register base address */
   uint8_t                     periph;   /* Peripheral ID */
   uint8_t                     irq;      /* Interrupt ID */
@@ -59,12 +59,12 @@ struct esp32_tim_priv_s
 
 /* TIM registers access *****************************************************/
 
-static uint32_t esp32_tim_getreg(FAR struct esp32_tim_dev_s *dev,
+static uint32_t esp32_tim_getreg(struct esp32_tim_dev_s *dev,
                                  uint32_t offset);
-static void esp32_tim_putreg(FAR struct esp32_tim_dev_s *dev,
+static void esp32_tim_putreg(struct esp32_tim_dev_s *dev,
                              uint32_t offset,
                              uint32_t value);
-static void esp32_tim_modifyreg32(FAR struct esp32_tim_dev_s *dev,
+static void esp32_tim_modifyreg32(struct esp32_tim_dev_s *dev,
                                   uint32_t offset,
                                   uint32_t clearbits,
                                   uint32_t setbits);
@@ -73,29 +73,29 @@ static void esp32_tim_modifyreg32(FAR struct esp32_tim_dev_s *dev,
 
 /* TIM operations ***********************************************************/
 
-static void esp32_tim_start(FAR struct esp32_tim_dev_s *dev);
-static void esp32_tim_stop(FAR struct esp32_tim_dev_s *dev);
-static void esp32_tim_clear(FAR struct esp32_tim_dev_s *dev);
-static void esp32_tim_setmode(FAR struct esp32_tim_dev_s *dev, uint8_t mode);
-static void esp32_tim_setpre(FAR struct esp32_tim_dev_s *dev, uint16_t pre);
-static void esp32_tim_getcounter(FAR struct esp32_tim_dev_s *dev,
+static void esp32_tim_start(struct esp32_tim_dev_s *dev);
+static void esp32_tim_stop(struct esp32_tim_dev_s *dev);
+static void esp32_tim_clear(struct esp32_tim_dev_s *dev);
+static void esp32_tim_setmode(struct esp32_tim_dev_s *dev, uint8_t mode);
+static void esp32_tim_setpre(struct esp32_tim_dev_s *dev, uint16_t pre);
+static void esp32_tim_getcounter(struct esp32_tim_dev_s *dev,
                                  uint64_t *value);
-static void esp32_tim_setcounter(FAR struct esp32_tim_dev_s *dev,
+static void esp32_tim_setcounter(struct esp32_tim_dev_s *dev,
                                  uint64_t value);
-static void esp32_tim_reload_now(FAR struct esp32_tim_dev_s *dev);
-static void esp32_tim_getalarmvalue(FAR struct esp32_tim_dev_s *dev,
+static void esp32_tim_reload_now(struct esp32_tim_dev_s *dev);
+static void esp32_tim_getalarmvalue(struct esp32_tim_dev_s *dev,
                                     uint64_t *value);
-static void esp32_tim_setalarmvalue(FAR struct esp32_tim_dev_s *dev,
+static void esp32_tim_setalarmvalue(struct esp32_tim_dev_s *dev,
                                     uint64_t value);
-static void esp32_tim_setalarm(FAR struct esp32_tim_dev_s *dev, bool enable);
-static void esp32_tim_setautoreload(FAR struct esp32_tim_dev_s *dev,
+static void esp32_tim_setalarm(struct esp32_tim_dev_s *dev, bool enable);
+static void esp32_tim_setautoreload(struct esp32_tim_dev_s *dev,
                                     bool enable);
-static  int esp32_tim_setisr(FAR struct esp32_tim_dev_s *dev, xcpt_t handler,
-                             FAR void * arg);
-static void esp32_tim_enableint(FAR struct esp32_tim_dev_s *dev);
-static void esp32_tim_disableint(FAR struct esp32_tim_dev_s *dev);
-static void esp32_tim_ackint(FAR struct esp32_tim_dev_s *dev);
-static int  esp32_tim_checkint(FAR struct esp32_tim_dev_s *dev);
+static  int esp32_tim_setisr(struct esp32_tim_dev_s *dev, xcpt_t handler,
+                             void * arg);
+static void esp32_tim_enableint(struct esp32_tim_dev_s *dev);
+static void esp32_tim_disableint(struct esp32_tim_dev_s *dev);
+static void esp32_tim_ackint(struct esp32_tim_dev_s *dev);
+static int  esp32_tim_checkint(struct esp32_tim_dev_s *dev);
 
 /****************************************************************************
  * Private Data
@@ -200,7 +200,7 @@ struct esp32_tim_priv_s g_esp32_tim3_priv =
  *
  ****************************************************************************/
 
-static uint32_t esp32_tim_getreg(FAR struct esp32_tim_dev_s *dev,
+static uint32_t esp32_tim_getreg(struct esp32_tim_dev_s *dev,
                                  uint32_t offset)
 {
   DEBUGASSERT(dev);
@@ -216,7 +216,7 @@ static uint32_t esp32_tim_getreg(FAR struct esp32_tim_dev_s *dev,
  *
  ****************************************************************************/
 
-static void esp32_tim_putreg(FAR struct esp32_tim_dev_s *dev,
+static void esp32_tim_putreg(struct esp32_tim_dev_s *dev,
                              uint32_t offset,
                              uint32_t value)
 {
@@ -233,7 +233,7 @@ static void esp32_tim_putreg(FAR struct esp32_tim_dev_s *dev,
  *
  ****************************************************************************/
 
-static void esp32_tim_modifyreg32(FAR struct esp32_tim_dev_s *dev,
+static void esp32_tim_modifyreg32(struct esp32_tim_dev_s *dev,
                                   uint32_t offset,
                                   uint32_t clearbits,
                                   uint32_t setbits)
@@ -252,7 +252,7 @@ static void esp32_tim_modifyreg32(FAR struct esp32_tim_dev_s *dev,
  *
  ****************************************************************************/
 
-static void esp32_tim_start(FAR struct esp32_tim_dev_s *dev)
+static void esp32_tim_start(struct esp32_tim_dev_s *dev)
 {
   DEBUGASSERT(dev);
   esp32_tim_modifyreg32(dev, TIM_CONFIG_OFFSET, 0, TIMG_T0_EN);
@@ -266,7 +266,7 @@ static void esp32_tim_start(FAR struct esp32_tim_dev_s *dev)
  *
  ****************************************************************************/
 
-static void esp32_tim_stop(FAR struct esp32_tim_dev_s *dev)
+static void esp32_tim_stop(struct esp32_tim_dev_s *dev)
 {
   DEBUGASSERT(dev);
   esp32_tim_modifyreg32(dev, TIM_CONFIG_OFFSET, TIMG_T0_EN, 0);
@@ -280,7 +280,7 @@ static void esp32_tim_stop(FAR struct esp32_tim_dev_s *dev)
  *
  ****************************************************************************/
 
-static void esp32_tim_clear(FAR struct esp32_tim_dev_s *dev)
+static void esp32_tim_clear(struct esp32_tim_dev_s *dev)
 {
   uint64_t clear_value = 0;
   DEBUGASSERT(dev);
@@ -296,7 +296,7 @@ static void esp32_tim_clear(FAR struct esp32_tim_dev_s *dev)
  *
  ****************************************************************************/
 
-static void esp32_tim_setmode(FAR struct esp32_tim_dev_s *dev, uint8_t mode)
+static void esp32_tim_setmode(struct esp32_tim_dev_s *dev, uint8_t mode)
 {
   DEBUGASSERT(dev);
 
@@ -320,7 +320,7 @@ static void esp32_tim_setmode(FAR struct esp32_tim_dev_s *dev, uint8_t mode)
  *
  ****************************************************************************/
 
-static void esp32_tim_setpre(FAR struct esp32_tim_dev_s *dev, uint16_t pre)
+static void esp32_tim_setpre(struct esp32_tim_dev_s *dev, uint16_t pre)
 {
   uint32_t mask = (uint32_t)pre << TIMG_T0_DIVIDER_S;
   DEBUGASSERT(dev);
@@ -335,7 +335,7 @@ static void esp32_tim_setpre(FAR struct esp32_tim_dev_s *dev, uint16_t pre)
  *
  ****************************************************************************/
 
-static void esp32_tim_getcounter(FAR struct esp32_tim_dev_s *dev,
+static void esp32_tim_getcounter(struct esp32_tim_dev_s *dev,
                                 uint64_t *value)
 {
   uint32_t value_32;
@@ -369,7 +369,7 @@ static void esp32_tim_getcounter(FAR struct esp32_tim_dev_s *dev,
  *
  ****************************************************************************/
 
-static void esp32_tim_setcounter(FAR struct esp32_tim_dev_s *dev,
+static void esp32_tim_setcounter(struct esp32_tim_dev_s *dev,
                                 uint64_t value)
 {
   uint64_t low_64 = value & LOW_32_MASK;
@@ -391,7 +391,7 @@ static void esp32_tim_setcounter(FAR struct esp32_tim_dev_s *dev,
  *
  ****************************************************************************/
 
-static void esp32_tim_reload_now(FAR struct esp32_tim_dev_s *dev)
+static void esp32_tim_reload_now(struct esp32_tim_dev_s *dev)
 {
   DEBUGASSERT(dev);
 
@@ -408,7 +408,7 @@ static void esp32_tim_reload_now(FAR struct esp32_tim_dev_s *dev)
  *
  ****************************************************************************/
 
-static void esp32_tim_getalarmvalue(FAR struct esp32_tim_dev_s *dev,
+static void esp32_tim_getalarmvalue(struct esp32_tim_dev_s *dev,
                                    uint64_t *value)
 {
   uint32_t value_32;
@@ -435,7 +435,7 @@ static void esp32_tim_getalarmvalue(FAR struct esp32_tim_dev_s *dev,
  *
  ****************************************************************************/
 
-static void esp32_tim_setalarmvalue(FAR struct esp32_tim_dev_s *dev,
+static void esp32_tim_setalarmvalue(struct esp32_tim_dev_s *dev,
                                    uint64_t value)
 {
   uint64_t low_64 = value & LOW_32_MASK;
@@ -457,7 +457,7 @@ static void esp32_tim_setalarmvalue(FAR struct esp32_tim_dev_s *dev,
  *
  ****************************************************************************/
 
-static void esp32_tim_setalarm(FAR struct esp32_tim_dev_s *dev, bool enable)
+static void esp32_tim_setalarm(struct esp32_tim_dev_s *dev, bool enable)
 {
   DEBUGASSERT(dev);
 
@@ -482,7 +482,7 @@ static void esp32_tim_setalarm(FAR struct esp32_tim_dev_s *dev, bool enable)
  *
  ****************************************************************************/
 
-static void esp32_tim_setautoreload(FAR struct esp32_tim_dev_s *dev,
+static void esp32_tim_setautoreload(struct esp32_tim_dev_s *dev,
                                    bool enable)
 {
   DEBUGASSERT(dev);
@@ -507,15 +507,15 @@ static void esp32_tim_setautoreload(FAR struct esp32_tim_dev_s *dev,
  *
  ****************************************************************************/
 
-static int esp32_tim_setisr(FAR struct esp32_tim_dev_s *dev, xcpt_t handler,
-                            FAR void *arg)
+static int esp32_tim_setisr(struct esp32_tim_dev_s *dev, xcpt_t handler,
+                            void *arg)
 {
-  FAR struct esp32_tim_priv_s *tim = NULL;
+  struct esp32_tim_priv_s *tim = NULL;
   int ret = OK;
 
   DEBUGASSERT(dev);
 
-  tim = (FAR struct esp32_tim_priv_s *)dev;
+  tim = (struct esp32_tim_priv_s *)dev;
 
   /* Disable interrupt when callback is removed */
 
@@ -587,7 +587,7 @@ errout:
  *
  ****************************************************************************/
 
-static void esp32_tim_enableint(FAR struct esp32_tim_dev_s *dev)
+static void esp32_tim_enableint(struct esp32_tim_dev_s *dev)
 {
   DEBUGASSERT(dev);
 
@@ -620,7 +620,7 @@ static void esp32_tim_enableint(FAR struct esp32_tim_dev_s *dev)
  *
  ****************************************************************************/
 
-static void esp32_tim_disableint(FAR struct esp32_tim_dev_s *dev)
+static void esp32_tim_disableint(struct esp32_tim_dev_s *dev)
 {
   DEBUGASSERT(dev);
 
@@ -651,7 +651,7 @@ static void esp32_tim_disableint(FAR struct esp32_tim_dev_s *dev)
  *
  ****************************************************************************/
 
-static void esp32_tim_ackint(FAR struct esp32_tim_dev_s *dev)
+static void esp32_tim_ackint(struct esp32_tim_dev_s *dev)
 {
   DEBUGASSERT(dev);
 
@@ -679,7 +679,7 @@ static void esp32_tim_ackint(FAR struct esp32_tim_dev_s *dev)
  *
  ****************************************************************************/
 
-static int esp32_tim_checkint(FAR struct esp32_tim_dev_s *dev)
+static int esp32_tim_checkint(struct esp32_tim_dev_s *dev)
 {
   int ret = 0;
   uint32_t reg_value;
@@ -724,9 +724,9 @@ static int esp32_tim_checkint(FAR struct esp32_tim_dev_s *dev)
  *
  ****************************************************************************/
 
-FAR struct esp32_tim_dev_s *esp32_tim_init(int timer)
+struct esp32_tim_dev_s *esp32_tim_init(int timer)
 {
-  FAR struct esp32_tim_priv_s *tim = NULL;
+  struct esp32_tim_priv_s *tim = NULL;
 
   /* First, take the data structure associated with the timer instance */
 
@@ -784,7 +784,7 @@ FAR struct esp32_tim_dev_s *esp32_tim_init(int timer)
     }
 
   errout:
-  return (FAR struct esp32_tim_dev_s *)tim;
+  return (struct esp32_tim_dev_s *)tim;
 }
 
 /****************************************************************************
@@ -795,13 +795,13 @@ FAR struct esp32_tim_dev_s *esp32_tim_init(int timer)
  *
  ****************************************************************************/
 
-void esp32_tim_deinit(FAR struct esp32_tim_dev_s *dev)
+void esp32_tim_deinit(struct esp32_tim_dev_s *dev)
 {
-  FAR struct esp32_tim_priv_s *tim = NULL;
+  struct esp32_tim_priv_s *tim = NULL;
 
   DEBUGASSERT(dev);
 
-  tim = (FAR struct esp32_tim_priv_s *)dev;
+  tim = (struct esp32_tim_priv_s *)dev;
 
   tim->inuse = false;
 }

--- a/arch/xtensa/src/esp32/esp32_tim.h
+++ b/arch/xtensa/src/esp32/esp32_tim.h
@@ -82,32 +82,32 @@ struct esp32_tim_ops_s
 {
   /* Timer tasks */
 
-  CODE void (*start)(struct esp32_tim_dev_s *dev);
-  CODE void (*stop)(struct esp32_tim_dev_s *dev);
-  CODE void (*clear)(struct esp32_tim_dev_s *dev);
+  void (*start)(struct esp32_tim_dev_s *dev);
+  void (*stop)(struct esp32_tim_dev_s *dev);
+  void (*clear)(struct esp32_tim_dev_s *dev);
 
   /* Timer operations */
 
-  CODE void (*setmode)(struct esp32_tim_dev_s *dev, uint8_t mode);
-  CODE void (*setpre)(struct esp32_tim_dev_s *dev, uint16_t pre);
-  CODE void (*getcounter)(struct esp32_tim_dev_s *dev, uint64_t *value);
-  CODE void (*setcounter)(struct esp32_tim_dev_s *dev, uint64_t value);
-  CODE void (*reloadnow)(struct esp32_tim_dev_s *dev);
-  CODE void (*getalarmvalue)(struct esp32_tim_dev_s *dev,
+  void (*setmode)(struct esp32_tim_dev_s *dev, uint8_t mode);
+  void (*setpre)(struct esp32_tim_dev_s *dev, uint16_t pre);
+  void (*getcounter)(struct esp32_tim_dev_s *dev, uint64_t *value);
+  void (*setcounter)(struct esp32_tim_dev_s *dev, uint64_t value);
+  void (*reloadnow)(struct esp32_tim_dev_s *dev);
+  void (*getalarmvalue)(struct esp32_tim_dev_s *dev,
                             uint64_t *value);
-  CODE void (*setalarmvalue)(struct esp32_tim_dev_s *dev,
+  void (*setalarmvalue)(struct esp32_tim_dev_s *dev,
                              uint64_t value);
-  CODE void (*setalarm)(struct esp32_tim_dev_s *dev, bool enable);
-  CODE void (*setautoreload)(struct esp32_tim_dev_s *dev, bool enable);
+  void (*setalarm)(struct esp32_tim_dev_s *dev, bool enable);
+  void (*setautoreload)(struct esp32_tim_dev_s *dev, bool enable);
 
   /* Timer interrupts */
 
-  CODE int (*setisr)(struct esp32_tim_dev_s *dev, xcpt_t handler,
+  int (*setisr)(struct esp32_tim_dev_s *dev, xcpt_t handler,
                      void * arg);
-  CODE void (*enableint)(struct esp32_tim_dev_s *dev);
-  CODE void (*disableint)(struct esp32_tim_dev_s *dev);
-  CODE void (*ackint)(struct esp32_tim_dev_s *dev);
-  CODE int (*checkint)(struct esp32_tim_dev_s *dev);
+  void (*enableint)(struct esp32_tim_dev_s *dev);
+  void (*disableint)(struct esp32_tim_dev_s *dev);
+  void (*ackint)(struct esp32_tim_dev_s *dev);
+  int (*checkint)(struct esp32_tim_dev_s *dev);
 };
 
 /****************************************************************************

--- a/arch/xtensa/src/esp32/esp32_tim.h
+++ b/arch/xtensa/src/esp32/esp32_tim.h
@@ -82,39 +82,39 @@ struct esp32_tim_ops_s
 {
   /* Timer tasks */
 
-  CODE void (*start)(FAR struct esp32_tim_dev_s *dev);
-  CODE void (*stop)(FAR struct esp32_tim_dev_s *dev);
-  CODE void (*clear)(FAR struct esp32_tim_dev_s *dev);
+  CODE void (*start)(struct esp32_tim_dev_s *dev);
+  CODE void (*stop)(struct esp32_tim_dev_s *dev);
+  CODE void (*clear)(struct esp32_tim_dev_s *dev);
 
   /* Timer operations */
 
-  CODE void (*setmode)(FAR struct esp32_tim_dev_s *dev, uint8_t mode);
-  CODE void (*setpre)(FAR struct esp32_tim_dev_s *dev, uint16_t pre);
-  CODE void (*getcounter)(FAR struct esp32_tim_dev_s *dev, uint64_t *value);
-  CODE void (*setcounter)(FAR struct esp32_tim_dev_s *dev, uint64_t value);
-  CODE void (*reloadnow)(FAR struct esp32_tim_dev_s *dev);
-  CODE void (*getalarmvalue)(FAR struct esp32_tim_dev_s *dev,
+  CODE void (*setmode)(struct esp32_tim_dev_s *dev, uint8_t mode);
+  CODE void (*setpre)(struct esp32_tim_dev_s *dev, uint16_t pre);
+  CODE void (*getcounter)(struct esp32_tim_dev_s *dev, uint64_t *value);
+  CODE void (*setcounter)(struct esp32_tim_dev_s *dev, uint64_t value);
+  CODE void (*reloadnow)(struct esp32_tim_dev_s *dev);
+  CODE void (*getalarmvalue)(struct esp32_tim_dev_s *dev,
                             uint64_t *value);
-  CODE void (*setalarmvalue)(FAR struct esp32_tim_dev_s *dev,
+  CODE void (*setalarmvalue)(struct esp32_tim_dev_s *dev,
                              uint64_t value);
-  CODE void (*setalarm)(FAR struct esp32_tim_dev_s *dev, bool enable);
-  CODE void (*setautoreload)(FAR struct esp32_tim_dev_s *dev, bool enable);
+  CODE void (*setalarm)(struct esp32_tim_dev_s *dev, bool enable);
+  CODE void (*setautoreload)(struct esp32_tim_dev_s *dev, bool enable);
 
   /* Timer interrupts */
 
-  CODE int (*setisr)(FAR struct esp32_tim_dev_s *dev, xcpt_t handler,
-                     FAR void * arg);
-  CODE void (*enableint)(FAR struct esp32_tim_dev_s *dev);
-  CODE void (*disableint)(FAR struct esp32_tim_dev_s *dev);
-  CODE void (*ackint)(FAR struct esp32_tim_dev_s *dev);
-  CODE int (*checkint)(FAR struct esp32_tim_dev_s *dev);
+  CODE int (*setisr)(struct esp32_tim_dev_s *dev, xcpt_t handler,
+                     void * arg);
+  CODE void (*enableint)(struct esp32_tim_dev_s *dev);
+  CODE void (*disableint)(struct esp32_tim_dev_s *dev);
+  CODE void (*ackint)(struct esp32_tim_dev_s *dev);
+  CODE int (*checkint)(struct esp32_tim_dev_s *dev);
 };
 
 /****************************************************************************
  * Public Function Prototypes
  ****************************************************************************/
 
-FAR struct esp32_tim_dev_s *esp32_tim_init(int timer);
-void esp32_tim_deinit(FAR struct esp32_tim_dev_s *dev);
+struct esp32_tim_dev_s *esp32_tim_init(int timer);
+void esp32_tim_deinit(struct esp32_tim_dev_s *dev);
 
 #endif /* __ARCH_XTENSA_SRC_ESP32_ESP32_TIM_H */

--- a/arch/xtensa/src/esp32/esp32_tim_lowerhalf.c
+++ b/arch/xtensa/src/esp32/esp32_tim_lowerhalf.c
@@ -53,12 +53,12 @@
 
 struct esp32_timer_lowerhalf_s
 {
-  FAR const struct timer_ops_s *ops;        /* Lower half operations */
-  FAR struct esp32_tim_dev_s   *tim;        /* esp32 timer driver */
-  tccb_t                        callback;   /* Current user interrupt callback */
-  FAR void                     *arg;        /* Argument passed to upper half callback */
-  bool                          started;    /* True: Timer has been started */
-  void *upper;                              /* Pointer to watchdog_upperhalf_s */
+  const struct timer_ops_s *ops;        /* Lower half operations */
+  struct esp32_tim_dev_s   *tim;        /* esp32 timer driver */
+  tccb_t                    callback;   /* Current user interrupt callback */
+  void                     *arg;        /* Argument passed to upper half callback */
+  bool                      started;    /* True: Timer has been started */
+  void                     *upper;      /* Pointer to watchdog_upperhalf_s */
 };
 
 /****************************************************************************
@@ -69,16 +69,16 @@ static int esp32_timer_handler(int irq, void *context, void *arg);
 
 /* "Lower half" driver methods **********************************************/
 
-static int esp32_timer_start(FAR struct timer_lowerhalf_s *lower);
-static int esp32_timer_stop(FAR struct timer_lowerhalf_s *lower);
-static int esp32_timer_getstatus(FAR struct timer_lowerhalf_s *lower,
-                                  FAR struct timer_status_s *status);
-static int esp32_timer_settimeout(FAR struct timer_lowerhalf_s *lower,
+static int esp32_timer_start(struct timer_lowerhalf_s *lower);
+static int esp32_timer_stop(struct timer_lowerhalf_s *lower);
+static int esp32_timer_getstatus(struct timer_lowerhalf_s *lower,
+                                 struct timer_status_s *status);
+static int esp32_timer_settimeout(struct timer_lowerhalf_s *lower,
                                   uint32_t timeout);
-static int esp32_timer_maxtimeout(FAR struct timer_lowerhalf_s *lower,
+static int esp32_timer_maxtimeout(struct timer_lowerhalf_s *lower,
                                   uint32_t *timeout);
-static void esp32_timer_setcallback(FAR struct timer_lowerhalf_s *lower,
-                              tccb_t callback, FAR void *arg);
+static void esp32_timer_setcallback(struct timer_lowerhalf_s *lower,
+                                    tccb_t callback, void *arg);
 
 /****************************************************************************
  * Private Data
@@ -151,8 +151,8 @@ static struct esp32_timer_lowerhalf_s g_esp32_timer3_lowerhalf =
 
 static int esp32_timer_handler(int irq, void *context, void *arg)
 {
-  FAR struct esp32_timer_lowerhalf_s *priv =
-    (FAR struct esp32_timer_lowerhalf_s *)arg;
+  struct esp32_timer_lowerhalf_s *priv =
+    (struct esp32_timer_lowerhalf_s *)arg;
   uint32_t next_interval_us = 0;
 
   if (priv->callback(&next_interval_us, priv->upper))
@@ -189,10 +189,10 @@ static int esp32_timer_handler(int irq, void *context, void *arg)
  *
  ****************************************************************************/
 
-static int esp32_timer_start(FAR struct timer_lowerhalf_s *lower)
+static int esp32_timer_start(struct timer_lowerhalf_s *lower)
 {
-  FAR struct esp32_timer_lowerhalf_s *priv =
-    (FAR struct esp32_timer_lowerhalf_s *)lower;
+  struct esp32_timer_lowerhalf_s *priv =
+    (struct esp32_timer_lowerhalf_s *)lower;
   int ret = OK;
   uint16_t pre;
   irqstate_t flags;
@@ -282,10 +282,10 @@ errout:
  *
  ****************************************************************************/
 
-static int esp32_timer_stop(FAR struct timer_lowerhalf_s *lower)
+static int esp32_timer_stop(struct timer_lowerhalf_s *lower)
 {
-  FAR struct esp32_timer_lowerhalf_s *priv =
-    (FAR struct esp32_timer_lowerhalf_s *)lower;
+  struct esp32_timer_lowerhalf_s *priv =
+    (struct esp32_timer_lowerhalf_s *)lower;
   int ret = OK;
   irqstate_t flags;
 
@@ -328,11 +328,11 @@ errout:
  *
  ****************************************************************************/
 
-static int esp32_timer_getstatus(FAR struct timer_lowerhalf_s *lower,
-                                 FAR struct timer_status_s *status)
+static int esp32_timer_getstatus(struct timer_lowerhalf_s *lower,
+                                 struct timer_status_s *status)
 {
-  FAR struct esp32_timer_lowerhalf_s *priv =
-    (FAR struct esp32_timer_lowerhalf_s *)lower;
+  struct esp32_timer_lowerhalf_s *priv =
+    (struct esp32_timer_lowerhalf_s *)lower;
   int      ret = OK;
   uint64_t current_counter_value;
   uint64_t alarm_value;
@@ -390,11 +390,11 @@ static int esp32_timer_getstatus(FAR struct timer_lowerhalf_s *lower,
  *
  ****************************************************************************/
 
-static int esp32_timer_settimeout(FAR struct timer_lowerhalf_s *lower,
+static int esp32_timer_settimeout(struct timer_lowerhalf_s *lower,
                                   uint32_t timeout)
 {
-  FAR struct esp32_timer_lowerhalf_s *priv =
-    (FAR struct esp32_timer_lowerhalf_s *)lower;
+  struct esp32_timer_lowerhalf_s *priv =
+    (struct esp32_timer_lowerhalf_s *)lower;
   int      ret = OK;
 
   DEBUGASSERT(priv);
@@ -422,7 +422,7 @@ static int esp32_timer_settimeout(FAR struct timer_lowerhalf_s *lower,
  *
  ****************************************************************************/
 
-static int esp32_timer_maxtimeout(FAR struct timer_lowerhalf_s *lower,
+static int esp32_timer_maxtimeout(struct timer_lowerhalf_s *lower,
                                   uint32_t *max_timeout)
 {
   DEBUGASSERT(max_timeout);
@@ -452,11 +452,11 @@ static int esp32_timer_maxtimeout(FAR struct timer_lowerhalf_s *lower,
  *
  ****************************************************************************/
 
-static void esp32_timer_setcallback(FAR struct timer_lowerhalf_s *lower,
-                                    tccb_t callback, FAR void *arg)
+static void esp32_timer_setcallback(struct timer_lowerhalf_s *lower,
+                                    tccb_t callback, void *arg)
 {
-  FAR struct esp32_timer_lowerhalf_s *priv =
-    (FAR struct esp32_timer_lowerhalf_s *)lower;
+  struct esp32_timer_lowerhalf_s *priv =
+    (struct esp32_timer_lowerhalf_s *)lower;
   irqstate_t flags;
   int ret = OK;
 
@@ -508,7 +508,7 @@ static void esp32_timer_setcallback(FAR struct timer_lowerhalf_s *lower,
  *
  ****************************************************************************/
 
-int esp32_timer_initialize(FAR const char *devpath, uint8_t timer)
+int esp32_timer_initialize(const char *devpath, uint8_t timer)
 {
   struct esp32_timer_lowerhalf_s *lower = NULL;
   int                             ret   = OK;
@@ -582,7 +582,7 @@ int esp32_timer_initialize(FAR const char *devpath, uint8_t timer)
    */
 
   lower->upper  = timer_register(devpath,
-                                 (FAR struct timer_lowerhalf_s *)lower);
+                                 (struct timer_lowerhalf_s *)lower);
   if (lower->upper  == NULL)
     {
       /* The actual cause of the failure may have been a failure to allocate

--- a/arch/xtensa/src/esp32/esp32_tim_lowerhalf.h
+++ b/arch/xtensa/src/esp32/esp32_tim_lowerhalf.h
@@ -37,6 +37,6 @@
  * Name: esp32_timer_initialize
  ****************************************************************************/
 
-int esp32_timer_initialize(FAR const char *devpath, uint8_t timer);
+int esp32_timer_initialize(const char *devpath, uint8_t timer);
 
 #endif /* __ARCH_XTENSA_SRC_ESP32_ESP32_TIM_LOWERHALF_H */

--- a/arch/xtensa/src/esp32/esp32_timerisr.c
+++ b/arch/xtensa/src/esp32/esp32_timerisr.c
@@ -65,7 +65,7 @@ static uint32_t g_tick_divisor;
  *
  ****************************************************************************/
 
-static int esp32_timerisr(int irq, uint32_t *regs, FAR void *arg)
+static int esp32_timerisr(int irq, uint32_t *regs, void *arg)
 {
   uint32_t divisor;
   uint32_t compare;

--- a/arch/xtensa/src/esp32/esp32_user.c
+++ b/arch/xtensa/src/esp32/esp32_user.c
@@ -347,7 +347,7 @@ uint32_t *xtensa_user(int exccause, uint32_t *regs)
       uint8_t t;
 
       binfo("XCHAL_EXCCAUSE_LOAD_STORE_ERROR at %p, pc=%p\n",
-            (FAR void *)regs[REG_EXCVADDR],
+            (void *)regs[REG_EXCVADDR],
             pc);
 
       if (decode_s8i(pc, &imm8, &s, &t))

--- a/arch/xtensa/src/esp32/esp32_wdt.c
+++ b/arch/xtensa/src/esp32/esp32_wdt.c
@@ -49,7 +49,7 @@
 
 struct esp32_wdt_priv_s
   {
-    FAR struct esp32_wdt_ops_s *ops;
+    struct esp32_wdt_ops_s *ops;
     uint32_t                    base;    /* WDT register base address */
     uint8_t                     cpu;     /* CPU ID */
     uint8_t                     periph;  /* Peripheral ID */
@@ -64,34 +64,34 @@ struct esp32_wdt_priv_s
 
 /* WDT registers access *****************************************************/
 
-static void esp32_wdt_putreg(FAR struct esp32_wdt_dev_s *dev,
+static void esp32_wdt_putreg(struct esp32_wdt_dev_s *dev,
                              uint32_t offset,
                              uint32_t value);
-static void esp32_wdt_modifyreg32(FAR struct esp32_wdt_dev_s *dev,
+static void esp32_wdt_modifyreg32(struct esp32_wdt_dev_s *dev,
                                   uint32_t offset,
                                   uint32_t clearbits,
                                   uint32_t setbits);
-static uint32_t esp32_wdt_getreg(FAR struct esp32_wdt_dev_s *dev,
+static uint32_t esp32_wdt_getreg(struct esp32_wdt_dev_s *dev,
                                  uint32_t offset);
 
 /* WDT operations ***********************************************************/
 
-static int esp32_wdt_start(FAR struct esp32_wdt_dev_s *dev);
-static int esp32_wdt_stop(FAR struct esp32_wdt_dev_s *dev);
-static int esp32_wdt_enablewp(FAR struct esp32_wdt_dev_s *dev);
-static int esp32_wdt_disablewp(FAR struct esp32_wdt_dev_s *dev);
-static int esp32_wdt_pre(FAR struct esp32_wdt_dev_s *dev, uint16_t value);
-static int esp32_wdt_settimeout(FAR struct esp32_wdt_dev_s *dev,
+static int esp32_wdt_start(struct esp32_wdt_dev_s *dev);
+static int esp32_wdt_stop(struct esp32_wdt_dev_s *dev);
+static int esp32_wdt_enablewp(struct esp32_wdt_dev_s *dev);
+static int esp32_wdt_disablewp(struct esp32_wdt_dev_s *dev);
+static int esp32_wdt_pre(struct esp32_wdt_dev_s *dev, uint16_t value);
+static int esp32_wdt_settimeout(struct esp32_wdt_dev_s *dev,
                                 uint32_t value, uint8_t stage);
-static int esp32_wdt_feed_dog(FAR struct esp32_wdt_dev_s *dev);
-static int esp32_wdt_set_stg_conf(FAR struct esp32_wdt_dev_s *dev,
+static int esp32_wdt_feed_dog(struct esp32_wdt_dev_s *dev);
+static int esp32_wdt_set_stg_conf(struct esp32_wdt_dev_s *dev,
                                    uint8_t stage, uint8_t conf);
-static uint16_t esp32_rtc_clk(FAR struct esp32_wdt_dev_s *dev);
-static int esp32_wdt_setisr(FAR struct esp32_wdt_dev_s *dev, xcpt_t handler,
-                            FAR void * arg);
-static int esp32_wdt_enableint(FAR struct esp32_wdt_dev_s *dev);
-static int esp32_wdt_disableint(FAR struct esp32_wdt_dev_s *dev);
-static int esp32_wdt_ackint(FAR struct esp32_wdt_dev_s *dev);
+static uint16_t esp32_rtc_clk(struct esp32_wdt_dev_s *dev);
+static int esp32_wdt_setisr(struct esp32_wdt_dev_s *dev, xcpt_t handler,
+                            void * arg);
+static int esp32_wdt_enableint(struct esp32_wdt_dev_s *dev);
+static int esp32_wdt_disableint(struct esp32_wdt_dev_s *dev);
+static int esp32_wdt_ackint(struct esp32_wdt_dev_s *dev);
 
 /****************************************************************************
  * Private Data
@@ -184,7 +184,7 @@ struct esp32_wdt_priv_s g_esp32_rwdt_priv =
  *
  ****************************************************************************/
 
-static void esp32_wdt_putreg(FAR struct esp32_wdt_dev_s *dev,
+static void esp32_wdt_putreg(struct esp32_wdt_dev_s *dev,
                              uint32_t offset,
                              uint32_t value)
 {
@@ -201,7 +201,7 @@ static void esp32_wdt_putreg(FAR struct esp32_wdt_dev_s *dev,
  *
  ****************************************************************************/
 
-static void esp32_wdt_modifyreg32(FAR struct esp32_wdt_dev_s *dev,
+static void esp32_wdt_modifyreg32(struct esp32_wdt_dev_s *dev,
                                   uint32_t offset,
                                   uint32_t clearbits,
                                   uint32_t setbits)
@@ -220,7 +220,7 @@ static void esp32_wdt_modifyreg32(FAR struct esp32_wdt_dev_s *dev,
  *
  ****************************************************************************/
 
-static uint32_t esp32_wdt_getreg(FAR struct esp32_wdt_dev_s *dev,
+static uint32_t esp32_wdt_getreg(struct esp32_wdt_dev_s *dev,
                                  uint32_t offset)
 {
   DEBUGASSERT(dev);
@@ -236,7 +236,7 @@ static uint32_t esp32_wdt_getreg(FAR struct esp32_wdt_dev_s *dev,
  *
  ****************************************************************************/
 
-static int esp32_wdt_start(FAR struct esp32_wdt_dev_s *dev)
+static int esp32_wdt_start(struct esp32_wdt_dev_s *dev)
 {
   DEBUGASSERT(dev);
 
@@ -272,7 +272,7 @@ static int esp32_wdt_start(FAR struct esp32_wdt_dev_s *dev)
  *
  ****************************************************************************/
 
-static int esp32_wdt_set_stg_conf(FAR struct esp32_wdt_dev_s *dev,
+static int esp32_wdt_set_stg_conf(struct esp32_wdt_dev_s *dev,
                                    uint8_t stage, uint8_t conf)
 {
   int ret = OK;
@@ -393,7 +393,7 @@ static int esp32_wdt_set_stg_conf(FAR struct esp32_wdt_dev_s *dev,
  *
  ****************************************************************************/
 
-static int esp32_wdt_stop(FAR struct esp32_wdt_dev_s *dev)
+static int esp32_wdt_stop(struct esp32_wdt_dev_s *dev)
 {
   DEBUGASSERT(dev);
 
@@ -426,7 +426,7 @@ static int esp32_wdt_stop(FAR struct esp32_wdt_dev_s *dev)
  *
  ****************************************************************************/
 
-static int esp32_wdt_enablewp(FAR struct esp32_wdt_dev_s *dev)
+static int esp32_wdt_enablewp(struct esp32_wdt_dev_s *dev)
 {
   DEBUGASSERT(dev);
 
@@ -459,7 +459,7 @@ static int esp32_wdt_enablewp(FAR struct esp32_wdt_dev_s *dev)
  *
  ****************************************************************************/
 
-static int esp32_wdt_disablewp(FAR struct esp32_wdt_dev_s *dev)
+static int esp32_wdt_disablewp(struct esp32_wdt_dev_s *dev)
 {
   DEBUGASSERT(dev);
 
@@ -490,7 +490,7 @@ static int esp32_wdt_disablewp(FAR struct esp32_wdt_dev_s *dev)
  *
  ****************************************************************************/
 
-static int esp32_wdt_pre(FAR struct esp32_wdt_dev_s *dev, uint16_t pre)
+static int esp32_wdt_pre(struct esp32_wdt_dev_s *dev, uint16_t pre)
 {
   uint32_t mask = (uint32_t)pre << TIMG_WDT_CLK_PRESCALE_S;
 
@@ -511,7 +511,7 @@ static int esp32_wdt_pre(FAR struct esp32_wdt_dev_s *dev, uint16_t pre)
  *
  ****************************************************************************/
 
-static uint16_t esp32_rtc_clk(FAR struct esp32_wdt_dev_s *dev)
+static uint16_t esp32_rtc_clk(struct esp32_wdt_dev_s *dev)
 {
   enum esp32_rtc_slow_freq_e slow_clk_rtc;
   uint32_t period_13q19;
@@ -568,7 +568,7 @@ static uint16_t esp32_rtc_clk(FAR struct esp32_wdt_dev_s *dev)
  *
  ****************************************************************************/
 
-static int esp32_wdt_settimeout(FAR struct esp32_wdt_dev_s *dev,
+static int esp32_wdt_settimeout(struct esp32_wdt_dev_s *dev,
                                 uint32_t value, uint8_t stage)
 {
   int ret = OK;
@@ -673,7 +673,7 @@ static int esp32_wdt_settimeout(FAR struct esp32_wdt_dev_s *dev,
  *
  ****************************************************************************/
 
-static int esp32_wdt_feed_dog(FAR struct esp32_wdt_dev_s *dev)
+static int esp32_wdt_feed_dog(struct esp32_wdt_dev_s *dev)
 {
   DEBUGASSERT(dev);
 
@@ -704,15 +704,15 @@ static int esp32_wdt_feed_dog(FAR struct esp32_wdt_dev_s *dev)
  *
  ****************************************************************************/
 
-static int esp32_wdt_setisr(FAR struct esp32_wdt_dev_s *dev, xcpt_t handler,
-                            FAR void *arg)
+static int esp32_wdt_setisr(struct esp32_wdt_dev_s *dev, xcpt_t handler,
+                            void *arg)
 {
-  FAR struct esp32_wdt_priv_s *wdt = NULL;
+  struct esp32_wdt_priv_s *wdt = NULL;
   int ret = OK;
 
   DEBUGASSERT(dev);
 
-  wdt = (FAR struct esp32_wdt_priv_s *)dev;
+  wdt = (struct esp32_wdt_priv_s *)dev;
 
   /* Disable interrupt when callback is removed */
 
@@ -779,7 +779,7 @@ errout:
  *
  ****************************************************************************/
 
-static int esp32_wdt_enableint(FAR struct esp32_wdt_dev_s *dev)
+static int esp32_wdt_enableint(struct esp32_wdt_dev_s *dev)
 {
   DEBUGASSERT(dev);
 
@@ -826,7 +826,7 @@ static int esp32_wdt_enableint(FAR struct esp32_wdt_dev_s *dev)
  *
  ****************************************************************************/
 
-static int esp32_wdt_disableint(FAR struct esp32_wdt_dev_s *dev)
+static int esp32_wdt_disableint(struct esp32_wdt_dev_s *dev)
 {
   DEBUGASSERT(dev);
 
@@ -871,7 +871,7 @@ static int esp32_wdt_disableint(FAR struct esp32_wdt_dev_s *dev)
  *
  ****************************************************************************/
 
-static int esp32_wdt_ackint(FAR struct esp32_wdt_dev_s *dev)
+static int esp32_wdt_ackint(struct esp32_wdt_dev_s *dev)
 {
   DEBUGASSERT(dev);
 
@@ -904,9 +904,9 @@ static int esp32_wdt_ackint(FAR struct esp32_wdt_dev_s *dev)
  *
  ****************************************************************************/
 
-FAR struct esp32_wdt_dev_s *esp32_wdt_init(uint8_t wdt_id)
+struct esp32_wdt_dev_s *esp32_wdt_init(uint8_t wdt_id)
 {
-  FAR struct esp32_wdt_priv_s *wdt = NULL;
+  struct esp32_wdt_priv_s *wdt = NULL;
 
   /* Get wdt instance */
 
@@ -970,7 +970,7 @@ FAR struct esp32_wdt_dev_s *esp32_wdt_init(uint8_t wdt_id)
     }
 
   errout:
-    return (FAR struct esp32_wdt_dev_s *)wdt;
+    return (struct esp32_wdt_dev_s *)wdt;
 }
 
 /****************************************************************************
@@ -999,13 +999,13 @@ void esp32_wdt_early_deinit(void)
  *
  ****************************************************************************/
 
-int esp32_wdt_deinit(FAR struct esp32_wdt_dev_s *dev)
+int esp32_wdt_deinit(struct esp32_wdt_dev_s *dev)
 {
-  FAR struct esp32_wdt_priv_s *wdt = NULL;
+  struct esp32_wdt_priv_s *wdt = NULL;
 
   DEBUGASSERT(dev);
 
-  wdt = (FAR struct esp32_wdt_priv_s *)dev;
+  wdt = (struct esp32_wdt_priv_s *)dev;
 
   wdt->inuse = false;
 
@@ -1021,7 +1021,7 @@ int esp32_wdt_deinit(FAR struct esp32_wdt_dev_s *dev)
  *
  ****************************************************************************/
 
-bool esp32_wdt_is_running(FAR struct esp32_wdt_dev_s *dev)
+bool esp32_wdt_is_running(struct esp32_wdt_dev_s *dev)
 {
   uint32_t status = 0;
   DEBUGASSERT(dev);

--- a/arch/xtensa/src/esp32/esp32_wdt.h
+++ b/arch/xtensa/src/esp32/esp32_wdt.h
@@ -70,28 +70,28 @@ struct esp32_wdt_ops_s
 {
   /* WDT tasks */
 
-  CODE int (*start)(struct esp32_wdt_dev_s *dev);
-  CODE int (*stop)(struct esp32_wdt_dev_s *dev);
+  int (*start)(struct esp32_wdt_dev_s *dev);
+  int (*stop)(struct esp32_wdt_dev_s *dev);
 
   /* WDT configuration */
 
-  CODE int (*enablewp)(struct esp32_wdt_dev_s *dev);
-  CODE int (*disablewp)(struct esp32_wdt_dev_s *dev);
-  CODE int (*pre)(struct esp32_wdt_dev_s *dev, uint16_t value);
-  CODE int (*settimeout)(struct esp32_wdt_dev_s *dev,
+  int (*enablewp)(struct esp32_wdt_dev_s *dev);
+  int (*disablewp)(struct esp32_wdt_dev_s *dev);
+  int (*pre)(struct esp32_wdt_dev_s *dev, uint16_t value);
+  int (*settimeout)(struct esp32_wdt_dev_s *dev,
                          uint32_t value, uint8_t stage);
-  CODE int (*feed)(struct esp32_wdt_dev_s *dev);
-  CODE int (*stg_conf)(struct esp32_wdt_dev_s *dev,
+  int (*feed)(struct esp32_wdt_dev_s *dev);
+  int (*stg_conf)(struct esp32_wdt_dev_s *dev,
                                    uint8_t stage, uint8_t conf);
-  CODE uint16_t (*rtc_clk)(struct esp32_wdt_dev_s *dev);
+  uint16_t (*rtc_clk)(struct esp32_wdt_dev_s *dev);
 
   /* WDT interrupts */
 
-  CODE int (*setisr)(struct esp32_wdt_dev_s *dev, xcpt_t handler,
+  int (*setisr)(struct esp32_wdt_dev_s *dev, xcpt_t handler,
                      void * arg);
-  CODE int (*enableint)(struct esp32_wdt_dev_s *dev);
-  CODE int (*disableint)(struct esp32_wdt_dev_s *dev);
-  CODE int (*ackint)(struct esp32_wdt_dev_s *dev);
+  int (*enableint)(struct esp32_wdt_dev_s *dev);
+  int (*disableint)(struct esp32_wdt_dev_s *dev);
+  int (*ackint)(struct esp32_wdt_dev_s *dev);
 };
 
 /****************************************************************************

--- a/arch/xtensa/src/esp32/esp32_wdt.h
+++ b/arch/xtensa/src/esp32/esp32_wdt.h
@@ -70,37 +70,37 @@ struct esp32_wdt_ops_s
 {
   /* WDT tasks */
 
-  CODE int (*start)(FAR struct esp32_wdt_dev_s *dev);
-  CODE int (*stop)(FAR struct esp32_wdt_dev_s *dev);
+  CODE int (*start)(struct esp32_wdt_dev_s *dev);
+  CODE int (*stop)(struct esp32_wdt_dev_s *dev);
 
   /* WDT configuration */
 
-  CODE int (*enablewp)(FAR struct esp32_wdt_dev_s *dev);
-  CODE int (*disablewp)(FAR struct esp32_wdt_dev_s *dev);
-  CODE int (*pre)(FAR struct esp32_wdt_dev_s *dev, uint16_t value);
-  CODE int (*settimeout)(FAR struct esp32_wdt_dev_s *dev,
+  CODE int (*enablewp)(struct esp32_wdt_dev_s *dev);
+  CODE int (*disablewp)(struct esp32_wdt_dev_s *dev);
+  CODE int (*pre)(struct esp32_wdt_dev_s *dev, uint16_t value);
+  CODE int (*settimeout)(struct esp32_wdt_dev_s *dev,
                          uint32_t value, uint8_t stage);
-  CODE int (*feed)(FAR struct esp32_wdt_dev_s *dev);
-  CODE int (*stg_conf)(FAR struct esp32_wdt_dev_s *dev,
+  CODE int (*feed)(struct esp32_wdt_dev_s *dev);
+  CODE int (*stg_conf)(struct esp32_wdt_dev_s *dev,
                                    uint8_t stage, uint8_t conf);
-  CODE uint16_t (*rtc_clk)(FAR struct esp32_wdt_dev_s *dev);
+  CODE uint16_t (*rtc_clk)(struct esp32_wdt_dev_s *dev);
 
   /* WDT interrupts */
 
-  CODE int (*setisr)(FAR struct esp32_wdt_dev_s *dev, xcpt_t handler,
-                     FAR void * arg);
-  CODE int (*enableint)(FAR struct esp32_wdt_dev_s *dev);
-  CODE int (*disableint)(FAR struct esp32_wdt_dev_s *dev);
-  CODE int (*ackint)(FAR struct esp32_wdt_dev_s *dev);
+  CODE int (*setisr)(struct esp32_wdt_dev_s *dev, xcpt_t handler,
+                     void * arg);
+  CODE int (*enableint)(struct esp32_wdt_dev_s *dev);
+  CODE int (*disableint)(struct esp32_wdt_dev_s *dev);
+  CODE int (*ackint)(struct esp32_wdt_dev_s *dev);
 };
 
 /****************************************************************************
  * Public Function Prototypes
  ****************************************************************************/
 
-FAR struct esp32_wdt_dev_s *esp32_wdt_init(uint8_t wdt_id);
+struct esp32_wdt_dev_s *esp32_wdt_init(uint8_t wdt_id);
 void esp32_wdt_early_deinit(void);
-int esp32_wdt_deinit(FAR struct esp32_wdt_dev_s *dev);
-bool esp32_wdt_is_running(FAR struct esp32_wdt_dev_s *dev);
+int esp32_wdt_deinit(struct esp32_wdt_dev_s *dev);
+bool esp32_wdt_is_running(struct esp32_wdt_dev_s *dev);
 
 #endif /* __ARCH_XTENSA_SRC_ESP32_ESP32_WDT_H */

--- a/arch/xtensa/src/esp32/esp32_wdt_lowerhalf.c
+++ b/arch/xtensa/src/esp32/esp32_wdt_lowerhalf.c
@@ -72,14 +72,14 @@
 
 struct esp32_wdt_lowerhalf_s
 {
-  FAR const struct watchdog_ops_s *ops;        /* Lower half operations */
-  FAR struct esp32_wdt_dev_s   *wdt;           /* esp32 watchdog driver */
-  uint32_t timeout;                            /* The current timeout */
-  enum wdt_peripherals peripheral;             /* Indicates if it is from RTC or Timer Module */
-  uint32_t lastreset;                          /* The last reset time */
-  bool     started;                            /* True: Timer has been started */
-  xcpt_t handler;                              /* User Handler */
-  void   *upper;                               /* Pointer to watchdog_upperhalf_s */
+  const struct watchdog_ops_s *ops; /* Lower half operations */
+  struct esp32_wdt_dev_s   *wdt;    /* esp32 watchdog driver */
+  uint32_t timeout;                 /* The current timeout */
+  enum wdt_peripherals peripheral;  /* Indicates if it is from RTC or Timer Module */
+  uint32_t lastreset;               /* The last reset time */
+  bool     started;                 /* True: Timer has been started */
+  xcpt_t handler;                   /* User Handler */
+  void   *upper;                    /* Pointer to watchdog_upperhalf_s */
 };
 
 /****************************************************************************
@@ -88,18 +88,18 @@ struct esp32_wdt_lowerhalf_s
 
 /* Interrupt handling *******************************************************/
 
-static int      esp32_wdt_handler(int irq, FAR void *context, FAR void *arg);
+static int      esp32_wdt_handler(int irq, void *context, void *arg);
 
 /* "Lower half" driver methods **********************************************/
 
-static int      esp32_wdt_start(FAR struct watchdog_lowerhalf_s *lower);
-static int      esp32_wdt_stop(FAR struct watchdog_lowerhalf_s *lower);
-static int      esp32_wdt_keepalive(FAR struct watchdog_lowerhalf_s *lower);
-static int      esp32_wdt_getstatus(FAR struct watchdog_lowerhalf_s *lower,
-                                    FAR struct watchdog_status_s *status);
-static int      esp32_wdt_settimeout(FAR struct watchdog_lowerhalf_s *lower,
+static int      esp32_wdt_start(struct watchdog_lowerhalf_s *lower);
+static int      esp32_wdt_stop(struct watchdog_lowerhalf_s *lower);
+static int      esp32_wdt_keepalive(struct watchdog_lowerhalf_s *lower);
+static int      esp32_wdt_getstatus(struct watchdog_lowerhalf_s *lower,
+                                    struct watchdog_status_s *status);
+static int      esp32_wdt_settimeout(struct watchdog_lowerhalf_s *lower,
                                      uint32_t timeout);
-static xcpt_t   esp32_wdt_capture(FAR struct watchdog_lowerhalf_s *lower,
+static xcpt_t   esp32_wdt_capture(struct watchdog_lowerhalf_s *lower,
                                   xcpt_t handler);
 
 /****************************************************************************
@@ -163,10 +163,10 @@ static struct esp32_wdt_lowerhalf_s g_esp32_rwdt_lowerhalf =
  *
  ****************************************************************************/
 
-static int esp32_wdt_start(FAR struct watchdog_lowerhalf_s *lower)
+static int esp32_wdt_start(struct watchdog_lowerhalf_s *lower)
 {
-  FAR struct esp32_wdt_lowerhalf_s *priv =
-    (FAR struct esp32_wdt_lowerhalf_s *)lower;
+  struct esp32_wdt_lowerhalf_s *priv =
+    (struct esp32_wdt_lowerhalf_s *)lower;
   int ret = OK;
   irqstate_t flags;
 
@@ -248,10 +248,10 @@ static int esp32_wdt_start(FAR struct watchdog_lowerhalf_s *lower)
  *
  ****************************************************************************/
 
-static int esp32_wdt_stop(FAR struct watchdog_lowerhalf_s *lower)
+static int esp32_wdt_stop(struct watchdog_lowerhalf_s *lower)
 {
-  FAR struct esp32_wdt_lowerhalf_s *priv =
-  (FAR struct esp32_wdt_lowerhalf_s *)lower;
+  struct esp32_wdt_lowerhalf_s *priv =
+  (struct esp32_wdt_lowerhalf_s *)lower;
   irqstate_t flags;
 
   /* Unlock WDT */
@@ -296,10 +296,10 @@ static int esp32_wdt_stop(FAR struct watchdog_lowerhalf_s *lower)
  *
  ****************************************************************************/
 
-static int esp32_wdt_keepalive(FAR struct watchdog_lowerhalf_s *lower)
+static int esp32_wdt_keepalive(struct watchdog_lowerhalf_s *lower)
 {
-  FAR struct esp32_wdt_lowerhalf_s *priv =
-    (FAR struct esp32_wdt_lowerhalf_s *)lower;
+  struct esp32_wdt_lowerhalf_s *priv =
+    (struct esp32_wdt_lowerhalf_s *)lower;
   irqstate_t flags;
 
   wdinfo("Entry\n");
@@ -335,11 +335,11 @@ static int esp32_wdt_keepalive(FAR struct watchdog_lowerhalf_s *lower)
  *
  ****************************************************************************/
 
-static int esp32_wdt_getstatus(FAR struct watchdog_lowerhalf_s *lower,
-                           FAR struct watchdog_status_s *status)
+static int esp32_wdt_getstatus(struct watchdog_lowerhalf_s *lower,
+                           struct watchdog_status_s *status)
 {
-  FAR struct esp32_wdt_lowerhalf_s *priv =
-    (FAR struct esp32_wdt_lowerhalf_s *)lower;
+  struct esp32_wdt_lowerhalf_s *priv =
+    (struct esp32_wdt_lowerhalf_s *)lower;
   uint32_t ticks;
   uint32_t elapsed;
 
@@ -404,11 +404,11 @@ static int esp32_wdt_getstatus(FAR struct watchdog_lowerhalf_s *lower,
  *
  ****************************************************************************/
 
-static int esp32_wdt_settimeout(FAR struct watchdog_lowerhalf_s *lower,
+static int esp32_wdt_settimeout(struct watchdog_lowerhalf_s *lower,
                             uint32_t timeout)
 {
-  FAR struct esp32_wdt_lowerhalf_s *priv =
-    (FAR struct esp32_wdt_lowerhalf_s *)lower;
+  struct esp32_wdt_lowerhalf_s *priv =
+    (struct esp32_wdt_lowerhalf_s *)lower;
   uint16_t rtc_cycles = 0;
   uint32_t rtc_ms_max = 0;
 
@@ -497,11 +497,11 @@ static int esp32_wdt_settimeout(FAR struct watchdog_lowerhalf_s *lower,
  *
  ****************************************************************************/
 
-static xcpt_t esp32_wdt_capture(FAR struct watchdog_lowerhalf_s *lower,
+static xcpt_t esp32_wdt_capture(struct watchdog_lowerhalf_s *lower,
                             xcpt_t handler)
 {
-  FAR struct esp32_wdt_lowerhalf_s *priv =
-  (FAR struct esp32_wdt_lowerhalf_s *)lower;
+  struct esp32_wdt_lowerhalf_s *priv =
+  (struct esp32_wdt_lowerhalf_s *)lower;
   irqstate_t flags;
   xcpt_t oldhandler;
 
@@ -576,9 +576,9 @@ static xcpt_t esp32_wdt_capture(FAR struct watchdog_lowerhalf_s *lower,
 
 /* Interrupt handling *******************************************************/
 
-static int    esp32_wdt_handler(int irq, FAR void *context, FAR void *arg)
+static int    esp32_wdt_handler(int irq, void *context, void *arg)
 {
-  FAR struct esp32_wdt_lowerhalf_s *priv = arg;
+  struct esp32_wdt_lowerhalf_s *priv = arg;
 
   ESP32_WDT_UNLOCK(priv->wdt);
 
@@ -622,7 +622,7 @@ static int    esp32_wdt_handler(int irq, FAR void *context, FAR void *arg)
  *
  ****************************************************************************/
 
-int esp32_wdt_initialize(FAR const char *devpath, uint8_t wdt)
+int esp32_wdt_initialize(const char *devpath, uint8_t wdt)
 {
   struct esp32_wdt_lowerhalf_s *lower = NULL;
   int                             ret = OK;
@@ -699,7 +699,7 @@ int esp32_wdt_initialize(FAR const char *devpath, uint8_t wdt)
    */
 
   lower->upper = watchdog_register(devpath,
-                             (FAR struct watchdog_lowerhalf_s *)lower);
+                             (struct watchdog_lowerhalf_s *)lower);
   if (lower->upper == NULL)
     {
       /* The actual cause of the failure may have been a failure to allocate

--- a/arch/xtensa/src/esp32/esp32_wdt_lowerhalf.h
+++ b/arch/xtensa/src/esp32/esp32_wdt_lowerhalf.h
@@ -47,6 +47,6 @@ enum wdt_peripherals
  * Name: esp32_timer_initialize
  ****************************************************************************/
 
-int esp32_wdt_initialize(FAR const char *devpath, uint8_t timer);
+int esp32_wdt_initialize(const char *devpath, uint8_t timer);
 
 #endif /* __ARCH_XTENSA_SRC_ESP32_ESP32_WDT_LOWERHALF_H */

--- a/arch/xtensa/src/esp32/esp32_wifi_adapter.c
+++ b/arch/xtensa/src/esp32/esp32_wifi_adapter.c
@@ -673,7 +673,7 @@ static int32_t wifi_errno_trans(int ret)
  *
  ****************************************************************************/
 
-static int esp_int_adpt_cb(int irq, void *context, FAR void *arg)
+static int esp_int_adpt_cb(int irq, void *context, void *arg)
 {
   struct irq_adpt *adapter = (struct irq_adpt *)arg;
 
@@ -2094,7 +2094,7 @@ static int esp_event_id_map(int event_id)
  *
  ****************************************************************************/
 
-static void esp_evt_work_cb(FAR void *arg)
+static void esp_evt_work_cb(void *arg)
 {
   int ret;
   irqstate_t flags;
@@ -4787,7 +4787,7 @@ void esp_wifi_free_eb(void *eb)
  *
  ****************************************************************************/
 
-int esp_wifi_notify_subscribe(pid_t pid, FAR struct sigevent *event)
+int esp_wifi_notify_subscribe(pid_t pid, struct sigevent *event)
 {
   int id;
   struct wifi_notify *notify;

--- a/arch/xtensa/src/esp32/esp32_wifi_adapter.h
+++ b/arch/xtensa/src/esp32/esp32_wifi_adapter.h
@@ -134,7 +134,7 @@ void esp_wifi_free_eb(void *eb);
  *
  ****************************************************************************/
 
-int esp_wifi_notify_subscribe(pid_t pid, FAR struct sigevent *event);
+int esp_wifi_notify_subscribe(pid_t pid, struct sigevent *event);
 
 #ifdef ESP32_WLAN_HAS_STA
 

--- a/arch/xtensa/src/esp32/esp32_wifi_utils.c
+++ b/arch/xtensa/src/esp32/esp32_wifi_utils.c
@@ -442,7 +442,7 @@ void esp_wifi_scan_event_parse(void)
                * in pointer field.
                */
 
-              iwe->u.essid.pointer = (FAR void *)sizeof(iwe->u.essid);
+              iwe->u.essid.pointer = (void *)sizeof(iwe->u.essid);
               memcpy(&iwe->u.essid + 1,
                     ap_list_buffer[bss_count].ssid, essid_len);
               wlinfo("INFO: ssid %s\n", ap_list_buffer[bss_count].ssid);

--- a/arch/xtensa/src/esp32/esp32_wlan.c
+++ b/arch/xtensa/src/esp32/esp32_wlan.c
@@ -128,7 +128,7 @@ struct wlan_ops
   int (*rssi)(struct iwreq *iwr, bool set);
   int (*connect)(void);
   int (*disconnect)(void);
-  int (*event)(pid_t pid, FAR struct sigevent *event);
+  int (*event)(pid_t pid, struct sigevent *event);
   int (*stop)(void);
 };
 
@@ -231,17 +231,17 @@ static const struct wlan_ops g_softap_ops =
 
 /* Common TX logic */
 
-static void wlan_transmit(FAR struct wlan_priv_s *priv);
-static void wlan_rxpoll(FAR void *arg);
-static int  wlan_txpoll(FAR struct net_driver_s *dev);
-static void wlan_dopoll(FAR struct wlan_priv_s *priv);
+static void wlan_transmit(struct wlan_priv_s *priv);
+static void wlan_rxpoll(void *arg);
+static int  wlan_txpoll(struct net_driver_s *dev);
+static void wlan_dopoll(struct wlan_priv_s *priv);
 
 /* Watchdog timer expirations */
 
-static void wlan_txtimeout_work(FAR void *arg);
+static void wlan_txtimeout_work(void *arg);
 static void wlan_txtimeout_expiry(wdparm_t arg);
 
-static void wlan_poll_work(FAR void *arg);
+static void wlan_poll_work(void *arg);
 static void wlan_poll_expiry(wdparm_t arg);
 
 /* NuttX callback functions */
@@ -249,15 +249,15 @@ static void wlan_poll_expiry(wdparm_t arg);
 static int wlan_ifup(struct net_driver_s *dev);
 static int wlan_ifdown(struct net_driver_s *dev);
 
-static void wlan_txavail_work(FAR void *arg);
+static void wlan_txavail_work(void *arg);
 static int wlan_txavail(struct net_driver_s *dev);
 
 #if defined(CONFIG_NET_MCASTGROUP) || defined(CONFIG_NET_ICMPv6)
-static int wlan_addmac(struct net_driver_s *dev, FAR const uint8_t *mac);
+static int wlan_addmac(struct net_driver_s *dev, const uint8_t *mac);
 #endif
 
 #ifdef CONFIG_NET_MCASTGROUP
-static int wlan_rmmac(struct net_driver_s *dev, FAR const uint8_t *mac);
+static int wlan_rmmac(struct net_driver_s *dev, const uint8_t *mac);
 #endif
 
 #ifdef CONFIG_NETDEV_IOCTL
@@ -446,7 +446,7 @@ static inline void wlan_add_txpkt_head(struct wlan_priv_s *priv,
  *
  ****************************************************************************/
 
-static struct wlan_pktbuf *wlan_recvframe(FAR struct wlan_priv_s *priv)
+static struct wlan_pktbuf *wlan_recvframe(struct wlan_priv_s *priv)
 {
   irqstate_t flags;
   sq_entry_t *entry;
@@ -479,7 +479,7 @@ static struct wlan_pktbuf *wlan_recvframe(FAR struct wlan_priv_s *priv)
  *
  ****************************************************************************/
 
-static struct wlan_pktbuf *wlan_txframe(FAR struct wlan_priv_s *priv)
+static struct wlan_pktbuf *wlan_txframe(struct wlan_priv_s *priv)
 {
   irqstate_t flags;
   sq_entry_t *entry;
@@ -513,7 +513,7 @@ static struct wlan_pktbuf *wlan_txframe(FAR struct wlan_priv_s *priv)
  *
  ****************************************************************************/
 
-static void wlan_transmit(FAR struct wlan_priv_s *priv)
+static void wlan_transmit(struct wlan_priv_s *priv)
 {
   struct wlan_pktbuf *pktbuf;
   int ret;
@@ -550,7 +550,7 @@ static void wlan_transmit(FAR struct wlan_priv_s *priv)
  *
  ****************************************************************************/
 
-static void wlan_tx_done(FAR struct wlan_priv_s *priv)
+static void wlan_tx_done(struct wlan_priv_s *priv)
 {
   wd_cancel(&priv->txtimeout);
 
@@ -575,7 +575,7 @@ static void wlan_tx_done(FAR struct wlan_priv_s *priv)
  *
  ****************************************************************************/
 
-static int wlan_rx_done(FAR struct wlan_priv_s *priv, void *buffer,
+static int wlan_rx_done(struct wlan_priv_s *priv, void *buffer,
                         uint16_t len, void *eb)
 {
   struct wlan_pktbuf *pktbuf;
@@ -645,12 +645,12 @@ out:
  *
  ****************************************************************************/
 
-static void wlan_rxpoll(FAR void *arg)
+static void wlan_rxpoll(void *arg)
 {
   struct wlan_pktbuf *pktbuf;
   struct eth_hdr_s *eth_hdr;
-  FAR struct wlan_priv_s *priv = (FAR struct wlan_priv_s *)arg;
-  FAR struct net_driver_s *dev = &priv->dev;
+  struct wlan_priv_s *priv = (struct wlan_priv_s *)arg;
+  struct net_driver_s *dev = &priv->dev;
 #ifdef WLAN_RX_THRESHOLD
   uint32_t rbytes = 0;
 #endif
@@ -868,10 +868,10 @@ static void wlan_rxpoll(FAR void *arg)
  *
  ****************************************************************************/
 
-static int wlan_txpoll(FAR struct net_driver_s *dev)
+static int wlan_txpoll(struct net_driver_s *dev)
 {
   struct wlan_pktbuf *pktbuf;
-  FAR struct wlan_priv_s *priv = (FAR struct wlan_priv_s *)dev->d_private;
+  struct wlan_priv_s *priv = (struct wlan_priv_s *)dev->d_private;
 
   DEBUGASSERT(dev->d_buf != NULL);
 
@@ -941,9 +941,9 @@ static int wlan_txpoll(FAR struct net_driver_s *dev)
  *
  ****************************************************************************/
 
-static void wlan_dopoll(FAR struct wlan_priv_s *priv)
+static void wlan_dopoll(struct wlan_priv_s *priv)
 {
-  FAR struct net_driver_s *dev = &priv->dev;
+  struct net_driver_s *dev = &priv->dev;
   struct wlan_pktbuf *pktbuf;
   uint8_t *txbuf;
   int ret;
@@ -1059,10 +1059,10 @@ static void wlan_txtimeout_expiry(wdparm_t arg)
  *
  ****************************************************************************/
 
-static void wlan_poll_work(FAR void *arg)
+static void wlan_poll_work(void *arg)
 {
   int32_t delay = WLAN_WDDELAY;
-  FAR struct wlan_priv_s *priv = (FAR struct wlan_priv_s *)arg;
+  struct wlan_priv_s *priv = (struct wlan_priv_s *)arg;
   struct net_driver_s *dev = &priv->dev;
   struct wlan_pktbuf *pktbuf;
 
@@ -1129,7 +1129,7 @@ exit:
 
 static void wlan_poll_expiry(wdparm_t arg)
 {
-  FAR struct wlan_priv_s *priv = (FAR struct wlan_priv_s *)arg;
+  struct wlan_priv_s *priv = (struct wlan_priv_s *)arg;
 
   if (priv->ifup)
     {
@@ -1154,9 +1154,9 @@ static void wlan_poll_expiry(wdparm_t arg)
  *
  ****************************************************************************/
 
-static void wlan_txavail_work(FAR void *arg)
+static void wlan_txavail_work(void *arg)
 {
-  FAR struct wlan_priv_s *priv = (FAR struct wlan_priv_s *)arg;
+  struct wlan_priv_s *priv = (struct wlan_priv_s *)arg;
 
   /* Try to send all cached TX packets even if net is down */
 
@@ -1197,10 +1197,10 @@ static void wlan_txavail_work(FAR void *arg)
  *
  ****************************************************************************/
 
-static int wlan_ifup(FAR struct net_driver_s *dev)
+static int wlan_ifup(struct net_driver_s *dev)
 {
   int ret;
-  FAR struct wlan_priv_s *priv = (FAR struct wlan_priv_s *)dev->d_private;
+  struct wlan_priv_s *priv = (struct wlan_priv_s *)dev->d_private;
 
 #ifdef CONFIG_NET_IPv4
   ninfo("Bringing up: %d.%d.%d.%d\n",
@@ -1264,10 +1264,10 @@ static int wlan_ifup(FAR struct net_driver_s *dev)
  *
  ****************************************************************************/
 
-static int wlan_ifdown(FAR struct net_driver_s *dev)
+static int wlan_ifdown(struct net_driver_s *dev)
 {
   int ret;
-  FAR struct wlan_priv_s *priv = (FAR struct wlan_priv_s *)dev->d_private;
+  struct wlan_priv_s *priv = (struct wlan_priv_s *)dev->d_private;
 
   net_lock();
 
@@ -1316,9 +1316,9 @@ static int wlan_ifdown(FAR struct net_driver_s *dev)
  *
  ****************************************************************************/
 
-static int wlan_txavail(FAR struct net_driver_s *dev)
+static int wlan_txavail(struct net_driver_s *dev)
 {
-  FAR struct wlan_priv_s *priv = (FAR struct wlan_priv_s *)dev->d_private;
+  struct wlan_priv_s *priv = (struct wlan_priv_s *)dev->d_private;
 
   if (work_available(&priv->txwork))
     {
@@ -1347,9 +1347,9 @@ static int wlan_txavail(FAR struct net_driver_s *dev)
  ****************************************************************************/
 
 #if defined(CONFIG_NET_MCASTGROUP) || defined(CONFIG_NET_ICMPv6)
-static int wlan_addmac(FAR struct net_driver_s *dev, FAR const uint8_t *mac)
+static int wlan_addmac(struct net_driver_s *dev, const uint8_t *mac)
 {
-  FAR struct wlan_priv_s *priv = (FAR struct wlan_priv_s *)dev->d_private;
+  struct wlan_priv_s *priv = (struct wlan_priv_s *)dev->d_private;
 
   /* Add the MAC address to the hardware multicast routing table */
 
@@ -1374,9 +1374,9 @@ static int wlan_addmac(FAR struct net_driver_s *dev, FAR const uint8_t *mac)
  ****************************************************************************/
 
 #ifdef CONFIG_NET_MCASTGROUP
-static int wlan_rmmac(FAR struct net_driver_s *dev, FAR const uint8_t *mac)
+static int wlan_rmmac(struct net_driver_s *dev, const uint8_t *mac)
 {
-  FAR struct wlan_priv_s *priv = (FAR struct wlan_priv_s *)dev->d_private;
+  struct wlan_priv_s *priv = (struct wlan_priv_s *)dev->d_private;
 
   /* Add the MAC address to the hardware multicast routing table */
 
@@ -1399,9 +1399,9 @@ static int wlan_rmmac(FAR struct net_driver_s *dev, FAR const uint8_t *mac)
  ****************************************************************************/
 
 #ifdef CONFIG_NET_ICMPv6
-static void wlan_ipv6multicast(FAR struct wlan_priv_s *priv)
+static void wlan_ipv6multicast(struct wlan_priv_s *priv)
 {
-  FAR struct net_driver_s *dev;
+  struct net_driver_s *dev;
   uint16_t tmp16;
   uint8_t mac[6];
 
@@ -1471,7 +1471,7 @@ static void wlan_ipv6multicast(FAR struct wlan_priv_s *priv)
  ****************************************************************************/
 
 #ifdef CONFIG_NETDEV_IOCTL
-static int wlan_ioctl(FAR struct net_driver_s *dev,
+static int wlan_ioctl(struct net_driver_s *dev,
                       int cmd,
                       unsigned long arg)
 {
@@ -1659,8 +1659,8 @@ static int esp32_net_initialize(int devno, uint8_t *mac_addr,
                                 const struct wlan_ops *ops)
 {
   int ret;
-  FAR struct wlan_priv_s *priv;
-  FAR struct net_driver_s *netdev;
+  struct wlan_priv_s *priv;
+  struct net_driver_s *netdev;
 
   priv = &g_wlan_priv[devno];
   if (priv->ref)
@@ -1728,7 +1728,7 @@ static int esp32_net_initialize(int devno, uint8_t *mac_addr,
 #ifdef ESP32_WLAN_HAS_STA
 static int wlan_sta_rx_done(void *buffer, uint16_t len, void *eb)
 {
-  FAR struct wlan_priv_s *priv = &g_wlan_priv[ESP32_WLAN_STA_DEVNO];
+  struct wlan_priv_s *priv = &g_wlan_priv[ESP32_WLAN_STA_DEVNO];
 
   return wlan_rx_done(priv, buffer, len, eb);
 }
@@ -1753,7 +1753,7 @@ static int wlan_sta_rx_done(void *buffer, uint16_t len, void *eb)
 
 static void wlan_sta_tx_done(uint8_t *data, uint16_t *len, bool status)
 {
-  FAR struct wlan_priv_s *priv = &g_wlan_priv[ESP32_WLAN_STA_DEVNO];
+  struct wlan_priv_s *priv = &g_wlan_priv[ESP32_WLAN_STA_DEVNO];
 
   wlan_tx_done(priv);
 }
@@ -1779,7 +1779,7 @@ static void wlan_sta_tx_done(uint8_t *data, uint16_t *len, bool status)
 #ifdef ESP32_WLAN_HAS_SOFTAP
 static int wlan_softap_rx_done(void *buffer, uint16_t len, void *eb)
 {
-  FAR struct wlan_priv_s *priv = &g_wlan_priv[ESP32_WLAN_SOFTAP_DEVNO];
+  struct wlan_priv_s *priv = &g_wlan_priv[ESP32_WLAN_SOFTAP_DEVNO];
 
   return wlan_rx_done(priv, buffer, len, eb);
 }
@@ -1804,7 +1804,7 @@ static int wlan_softap_rx_done(void *buffer, uint16_t len, void *eb)
 
 static void wlan_softap_tx_done(uint8_t *data, uint16_t *len, bool status)
 {
-  FAR struct wlan_priv_s *priv = &g_wlan_priv[ESP32_WLAN_SOFTAP_DEVNO];
+  struct wlan_priv_s *priv = &g_wlan_priv[ESP32_WLAN_SOFTAP_DEVNO];
 
   wlan_tx_done(priv);
 }

--- a/arch/xtensa/src/esp32s2/esp32s2_allocateheap.c
+++ b/arch/xtensa/src/esp32s2/esp32s2_allocateheap.c
@@ -57,13 +57,13 @@
  *
  ****************************************************************************/
 
-void up_allocate_heap(FAR void **heap_start, size_t *heap_size)
+void up_allocate_heap(void **heap_start, size_t *heap_size)
 {
   extern uint32_t *_dram0_rtos_reserved_start;
 
   board_autoled_on(LED_HEAPALLOCATE);
 
-  *heap_start = (FAR void *)&_sheap;
+  *heap_start = (void *)&_sheap;
   *heap_size = (size_t)((uintptr_t)&_dram0_rtos_reserved_start -
                         (uintptr_t)&_sheap);
 }

--- a/arch/xtensa/src/esp32s2/esp32s2_gpio.c
+++ b/arch/xtensa/src/esp32s2/esp32s2_gpio.c
@@ -105,7 +105,7 @@ static void gpio_dispatch(int irq, uint32_t status, uint32_t *regs)
  ****************************************************************************/
 
 #ifdef CONFIG_ESP32S2_GPIO_IRQ
-static int gpio_interrupt(int irq, FAR void *context, FAR void *arg)
+static int gpio_interrupt(int irq, void *context, void *arg)
 {
   uint32_t status;
 

--- a/arch/xtensa/src/esp32s2/esp32s2_serial.c
+++ b/arch/xtensa/src/esp32s2/esp32s2_serial.c
@@ -229,7 +229,7 @@ static uart_dev_t g_uart1_dev =
  *
  ****************************************************************************/
 
-static int uart_handler(int irq, FAR void *context, FAR void *arg)
+static int uart_handler(int irq, void *context, void *arg)
 {
   struct uart_dev_s *dev = (struct uart_dev_s *)arg;
   struct esp32s2_uart_s *priv = dev->priv;

--- a/arch/xtensa/src/esp32s2/esp32s2_tim.c
+++ b/arch/xtensa/src/esp32s2/esp32s2_tim.c
@@ -50,7 +50,7 @@
 
 struct esp32s2_tim_priv_s
 {
-  FAR struct esp32s2_tim_ops_s    *ops;
+  struct esp32s2_tim_ops_s    *ops;
   uint8_t                          gid;  /* Group instance */
   uint8_t                          tid;  /* Timer instance */
   uint8_t                      int_pri;
@@ -66,34 +66,34 @@ struct esp32s2_tim_priv_s
 
 /* TIM operations ***********************************************************/
 
-static void esp32s2_tim_start(FAR struct esp32s2_tim_dev_s *dev);
-static void esp32s2_tim_stop(FAR struct esp32s2_tim_dev_s *dev);
-static void esp32s2_tim_clear(FAR struct esp32s2_tim_dev_s *dev);
-static void esp32s2_tim_setmode(FAR struct esp32s2_tim_dev_s *dev,
+static void esp32s2_tim_start(struct esp32s2_tim_dev_s *dev);
+static void esp32s2_tim_stop(struct esp32s2_tim_dev_s *dev);
+static void esp32s2_tim_clear(struct esp32s2_tim_dev_s *dev);
+static void esp32s2_tim_setmode(struct esp32s2_tim_dev_s *dev,
                                 enum esp32s2_tim_mode_e mode);
-static void esp32s2_tim_setclksrc(FAR struct esp32s2_tim_dev_s *dev,
+static void esp32s2_tim_setclksrc(struct esp32s2_tim_dev_s *dev,
                                   enum esp32s2_tim_clksrc_e src);
-static void esp32s2_tim_setpre(FAR struct esp32s2_tim_dev_s *dev,
+static void esp32s2_tim_setpre(struct esp32s2_tim_dev_s *dev,
                                uint16_t pre);
-static void esp32s2_tim_getcounter(FAR struct esp32s2_tim_dev_s *dev,
+static void esp32s2_tim_getcounter(struct esp32s2_tim_dev_s *dev,
                                    uint64_t *value);
-static void esp32s2_tim_setcounter(FAR struct esp32s2_tim_dev_s *dev,
+static void esp32s2_tim_setcounter(struct esp32s2_tim_dev_s *dev,
                                    uint64_t value);
-static void esp32s2_tim_reload_now(FAR struct esp32s2_tim_dev_s *dev);
-static void esp32s2_tim_getalarmvalue(FAR struct esp32s2_tim_dev_s *dev,
+static void esp32s2_tim_reload_now(struct esp32s2_tim_dev_s *dev);
+static void esp32s2_tim_getalarmvalue(struct esp32s2_tim_dev_s *dev,
                                       uint64_t *value);
-static void esp32s2_tim_setalarmvalue(FAR struct esp32s2_tim_dev_s *dev,
+static void esp32s2_tim_setalarmvalue(struct esp32s2_tim_dev_s *dev,
                                       uint64_t value);
-static void esp32s2_tim_setalarm(FAR struct esp32s2_tim_dev_s *dev,
+static void esp32s2_tim_setalarm(struct esp32s2_tim_dev_s *dev,
                                  bool enable);
-static void esp32s2_tim_setautoreload(FAR struct esp32s2_tim_dev_s *dev,
+static void esp32s2_tim_setautoreload(struct esp32s2_tim_dev_s *dev,
                                       bool enable);
-static int esp32s2_tim_setisr(FAR struct esp32s2_tim_dev_s *dev,
-                              xcpt_t handler, FAR void * arg);
-static void esp32s2_tim_enableint(FAR struct esp32s2_tim_dev_s *dev);
-static void esp32s2_tim_disableint(FAR struct esp32s2_tim_dev_s *dev);
-static void esp32s2_tim_ackint(FAR struct esp32s2_tim_dev_s *dev);
-static int  esp32s2_tim_checkint(FAR struct esp32s2_tim_dev_s *dev);
+static int esp32s2_tim_setisr(struct esp32s2_tim_dev_s *dev,
+                              xcpt_t handler, void * arg);
+static void esp32s2_tim_enableint(struct esp32s2_tim_dev_s *dev);
+static void esp32s2_tim_disableint(struct esp32s2_tim_dev_s *dev);
+static void esp32s2_tim_ackint(struct esp32s2_tim_dev_s *dev);
+static int  esp32s2_tim_checkint(struct esp32s2_tim_dev_s *dev);
 
 /****************************************************************************
  * Private Data
@@ -203,9 +203,9 @@ struct esp32s2_tim_priv_s g_esp32s2_tim3_priv =
  *
  ****************************************************************************/
 
-static void esp32s2_tim_start(FAR struct esp32s2_tim_dev_s *dev)
+static void esp32s2_tim_start(struct esp32s2_tim_dev_s *dev)
 {
-  struct esp32s2_tim_priv_s *priv = (FAR struct esp32s2_tim_priv_s *)dev;
+  struct esp32s2_tim_priv_s *priv = (struct esp32s2_tim_priv_s *)dev;
 
   DEBUGASSERT(dev);
 
@@ -230,9 +230,9 @@ static void esp32s2_tim_start(FAR struct esp32s2_tim_dev_s *dev)
  *
  ****************************************************************************/
 
-static void esp32s2_tim_stop(FAR struct esp32s2_tim_dev_s *dev)
+static void esp32s2_tim_stop(struct esp32s2_tim_dev_s *dev)
 {
-  struct esp32s2_tim_priv_s *priv = (FAR struct esp32s2_tim_priv_s *)dev;
+  struct esp32s2_tim_priv_s *priv = (struct esp32s2_tim_priv_s *)dev;
 
   DEBUGASSERT(dev);
 
@@ -257,7 +257,7 @@ static void esp32s2_tim_stop(FAR struct esp32s2_tim_dev_s *dev)
  *
  ****************************************************************************/
 
-static void esp32s2_tim_clear(FAR struct esp32s2_tim_dev_s *dev)
+static void esp32s2_tim_clear(struct esp32s2_tim_dev_s *dev)
 {
   uint64_t clear_value = 0;
 
@@ -279,10 +279,10 @@ static void esp32s2_tim_clear(FAR struct esp32s2_tim_dev_s *dev)
  *
  ****************************************************************************/
 
-static void esp32s2_tim_setmode(FAR struct esp32s2_tim_dev_s *dev,
+static void esp32s2_tim_setmode(struct esp32s2_tim_dev_s *dev,
                                 enum esp32s2_tim_mode_e mode)
 {
-  struct esp32s2_tim_priv_s *priv  = (FAR struct esp32s2_tim_priv_s *)dev;
+  struct esp32s2_tim_priv_s *priv  = (struct esp32s2_tim_priv_s *)dev;
 
   DEBUGASSERT(dev);
 
@@ -325,10 +325,10 @@ static void esp32s2_tim_setmode(FAR struct esp32s2_tim_dev_s *dev,
  *
  ****************************************************************************/
 
-static void esp32s2_tim_setclksrc(FAR struct esp32s2_tim_dev_s *dev,
+static void esp32s2_tim_setclksrc(struct esp32s2_tim_dev_s *dev,
                                   enum esp32s2_tim_clksrc_e src)
 {
-  struct esp32s2_tim_priv_s *priv = (FAR struct esp32s2_tim_priv_s *)dev;
+  struct esp32s2_tim_priv_s *priv = (struct esp32s2_tim_priv_s *)dev;
 
   DEBUGASSERT(dev);
 
@@ -356,10 +356,10 @@ static void esp32s2_tim_setclksrc(FAR struct esp32s2_tim_dev_s *dev,
  *
  ****************************************************************************/
 
-static void esp32s2_tim_setpre(FAR struct esp32s2_tim_dev_s *dev,
+static void esp32s2_tim_setpre(struct esp32s2_tim_dev_s *dev,
                                uint16_t pre)
 {
-  struct esp32s2_tim_priv_s *priv = (FAR struct esp32s2_tim_priv_s *)dev;
+  struct esp32s2_tim_priv_s *priv = (struct esp32s2_tim_priv_s *)dev;
   uint32_t mask = (uint32_t)pre << TIMG_T0_DIVIDER_S;
 
   DEBUGASSERT(dev);
@@ -387,11 +387,11 @@ static void esp32s2_tim_setpre(FAR struct esp32s2_tim_dev_s *dev,
  *
  ****************************************************************************/
 
-static void esp32s2_tim_getcounter(FAR struct esp32s2_tim_dev_s *dev,
+static void esp32s2_tim_getcounter(struct esp32s2_tim_dev_s *dev,
                                    uint64_t *value)
 {
   uint32_t value_32;
-  struct esp32s2_tim_priv_s *priv = (FAR struct esp32s2_tim_priv_s *)dev;
+  struct esp32s2_tim_priv_s *priv = (struct esp32s2_tim_priv_s *)dev;
 
   DEBUGASSERT(dev);
 
@@ -443,10 +443,10 @@ static void esp32s2_tim_getcounter(FAR struct esp32s2_tim_dev_s *dev,
  *
  ****************************************************************************/
 
-static void esp32s2_tim_setcounter(FAR struct esp32s2_tim_dev_s *dev,
+static void esp32s2_tim_setcounter(struct esp32s2_tim_dev_s *dev,
                                   uint64_t value)
 {
-  struct esp32s2_tim_priv_s *priv = (FAR struct esp32s2_tim_priv_s *)dev;
+  struct esp32s2_tim_priv_s *priv = (struct esp32s2_tim_priv_s *)dev;
   uint64_t low_64 = value & UINT32_MAX;
   uint64_t high_64 = (value >> SHIFT_32);
 
@@ -478,9 +478,9 @@ static void esp32s2_tim_setcounter(FAR struct esp32s2_tim_dev_s *dev,
  *
  ****************************************************************************/
 
-static void esp32s2_tim_reload_now(FAR struct esp32s2_tim_dev_s *dev)
+static void esp32s2_tim_reload_now(struct esp32s2_tim_dev_s *dev)
 {
-  struct esp32s2_tim_priv_s *priv = (FAR struct esp32s2_tim_priv_s *)dev;
+  struct esp32s2_tim_priv_s *priv = (struct esp32s2_tim_priv_s *)dev;
 
   DEBUGASSERT(dev);
 
@@ -508,11 +508,11 @@ static void esp32s2_tim_reload_now(FAR struct esp32s2_tim_dev_s *dev)
  *
  ****************************************************************************/
 
-static void esp32s2_tim_getalarmvalue(FAR struct esp32s2_tim_dev_s *dev,
+static void esp32s2_tim_getalarmvalue(struct esp32s2_tim_dev_s *dev,
                                       uint64_t *value)
 {
   uint32_t value_32;
-  struct esp32s2_tim_priv_s *priv = (FAR struct esp32s2_tim_priv_s *)dev;
+  struct esp32s2_tim_priv_s *priv = (struct esp32s2_tim_priv_s *)dev;
 
   DEBUGASSERT(dev);
 
@@ -551,10 +551,10 @@ static void esp32s2_tim_getalarmvalue(FAR struct esp32s2_tim_dev_s *dev,
  *
  ****************************************************************************/
 
-static void esp32s2_tim_setalarmvalue(FAR struct esp32s2_tim_dev_s *dev,
+static void esp32s2_tim_setalarmvalue(struct esp32s2_tim_dev_s *dev,
                                       uint64_t value)
 {
-  struct esp32s2_tim_priv_s *priv = (FAR struct esp32s2_tim_priv_s *)dev;
+  struct esp32s2_tim_priv_s *priv = (struct esp32s2_tim_priv_s *)dev;
   uint64_t low_64  = value & UINT32_MAX;
   uint64_t high_64 = (value >> SHIFT_32);
 
@@ -587,10 +587,10 @@ static void esp32s2_tim_setalarmvalue(FAR struct esp32s2_tim_dev_s *dev,
  *
  ****************************************************************************/
 
-static void esp32s2_tim_setalarm(FAR struct esp32s2_tim_dev_s *dev,
+static void esp32s2_tim_setalarm(struct esp32s2_tim_dev_s *dev,
                                  bool enable)
 {
-  struct esp32s2_tim_priv_s *priv = (FAR struct esp32s2_tim_priv_s *)dev;
+  struct esp32s2_tim_priv_s *priv = (struct esp32s2_tim_priv_s *)dev;
 
   DEBUGASSERT(dev);
 
@@ -632,10 +632,10 @@ static void esp32s2_tim_setalarm(FAR struct esp32s2_tim_dev_s *dev,
  *
  ****************************************************************************/
 
-static void esp32s2_tim_setautoreload(FAR struct esp32s2_tim_dev_s *dev,
+static void esp32s2_tim_setautoreload(struct esp32s2_tim_dev_s *dev,
                                    bool enable)
 {
-  struct esp32s2_tim_priv_s *priv = (FAR struct esp32s2_tim_priv_s *)dev;
+  struct esp32s2_tim_priv_s *priv = (struct esp32s2_tim_priv_s *)dev;
 
   DEBUGASSERT(dev);
 
@@ -683,10 +683,10 @@ static void esp32s2_tim_setautoreload(FAR struct esp32s2_tim_dev_s *dev,
  *
  ****************************************************************************/
 
-static int esp32s2_tim_setisr(FAR struct esp32s2_tim_dev_s *dev,
-                              xcpt_t handler, FAR void *arg)
+static int esp32s2_tim_setisr(struct esp32s2_tim_dev_s *dev,
+                              xcpt_t handler, void *arg)
 {
-  FAR struct esp32s2_tim_priv_s *priv = (FAR struct esp32s2_tim_priv_s *)dev;
+  struct esp32s2_tim_priv_s *priv = (struct esp32s2_tim_priv_s *)dev;
   int ret = OK;
 
   DEBUGASSERT(dev);
@@ -772,9 +772,9 @@ errout:
  *
  ****************************************************************************/
 
-static void esp32s2_tim_enableint(FAR struct esp32s2_tim_dev_s *dev)
+static void esp32s2_tim_enableint(struct esp32s2_tim_dev_s *dev)
 {
-  struct esp32s2_tim_priv_s *priv = (FAR struct esp32s2_tim_priv_s *)dev;
+  struct esp32s2_tim_priv_s *priv = (struct esp32s2_tim_priv_s *)dev;
 
   DEBUGASSERT(dev);
 
@@ -801,9 +801,9 @@ static void esp32s2_tim_enableint(FAR struct esp32s2_tim_dev_s *dev)
  *
  ****************************************************************************/
 
-static void esp32s2_tim_disableint(FAR struct esp32s2_tim_dev_s *dev)
+static void esp32s2_tim_disableint(struct esp32s2_tim_dev_s *dev)
 {
-  struct esp32s2_tim_priv_s *priv = (FAR struct esp32s2_tim_priv_s *)dev;
+  struct esp32s2_tim_priv_s *priv = (struct esp32s2_tim_priv_s *)dev;
 
   DEBUGASSERT(dev);
 
@@ -830,9 +830,9 @@ static void esp32s2_tim_disableint(FAR struct esp32s2_tim_dev_s *dev)
  *
  ****************************************************************************/
 
-static void esp32s2_tim_ackint(FAR struct esp32s2_tim_dev_s *dev)
+static void esp32s2_tim_ackint(struct esp32s2_tim_dev_s *dev)
 {
-  struct esp32s2_tim_priv_s *priv = (FAR struct esp32s2_tim_priv_s *)dev;
+  struct esp32s2_tim_priv_s *priv = (struct esp32s2_tim_priv_s *)dev;
 
   DEBUGASSERT(dev);
 
@@ -860,7 +860,7 @@ static void esp32s2_tim_ackint(FAR struct esp32s2_tim_dev_s *dev)
  *
  ****************************************************************************/
 
-static int esp32s2_tim_checkint(FAR struct esp32s2_tim_dev_s *dev)
+static int esp32s2_tim_checkint(struct esp32s2_tim_dev_s *dev)
 {
   struct esp32s2_tim_priv_s *priv = (struct esp32s2_tim_priv_s *)dev;
   uint32_t reg_value;
@@ -903,9 +903,9 @@ static int esp32s2_tim_checkint(FAR struct esp32s2_tim_dev_s *dev)
  *
  ****************************************************************************/
 
-FAR struct esp32s2_tim_dev_s *esp32s2_tim_init(int timer)
+struct esp32s2_tim_dev_s *esp32s2_tim_init(int timer)
 {
-  FAR struct esp32s2_tim_priv_s *tim = NULL;
+  struct esp32s2_tim_priv_s *tim = NULL;
 
   /* First, take the data structure associated with the timer instance */
 
@@ -963,7 +963,7 @@ FAR struct esp32s2_tim_dev_s *esp32s2_tim_init(int timer)
     }
 
 errout:
-  return (FAR struct esp32s2_tim_dev_s *)tim;
+  return (struct esp32s2_tim_dev_s *)tim;
 }
 
 /****************************************************************************
@@ -977,12 +977,12 @@ errout:
  *
  ****************************************************************************/
 
-void esp32s2_tim_deinit(FAR struct esp32s2_tim_dev_s *dev)
+void esp32s2_tim_deinit(struct esp32s2_tim_dev_s *dev)
 {
-  FAR struct esp32s2_tim_priv_s *tim = NULL;
+  struct esp32s2_tim_priv_s *tim = NULL;
 
   DEBUGASSERT(dev);
 
-  tim = (FAR struct esp32s2_tim_priv_s *)dev;
+  tim = (struct esp32s2_tim_priv_s *)dev;
   tim->inuse = false;
 }

--- a/arch/xtensa/src/esp32s2/esp32s2_tim.h
+++ b/arch/xtensa/src/esp32s2/esp32s2_tim.h
@@ -96,36 +96,36 @@ struct esp32s2_tim_ops_s
 {
   /* Timer tasks */
 
-  CODE void (*start)(struct esp32s2_tim_dev_s *dev);
-  CODE void (*stop)(struct esp32s2_tim_dev_s *dev);
-  CODE void (*clear)(struct esp32s2_tim_dev_s *dev);
+  void (*start)(struct esp32s2_tim_dev_s *dev);
+  void (*stop)(struct esp32s2_tim_dev_s *dev);
+  void (*clear)(struct esp32s2_tim_dev_s *dev);
 
   /* Timer operations */
 
-  CODE void (*setmode)(struct esp32s2_tim_dev_s *dev,
+  void (*setmode)(struct esp32s2_tim_dev_s *dev,
                        enum esp32s2_tim_mode_e mode);
-  CODE void (*setpre)(struct esp32s2_tim_dev_s *dev, uint16_t pre);
-  CODE void (*getcounter)(struct esp32s2_tim_dev_s *dev,
+  void (*setpre)(struct esp32s2_tim_dev_s *dev, uint16_t pre);
+  void (*getcounter)(struct esp32s2_tim_dev_s *dev,
                           uint64_t *value);
-  CODE void (*setclksrc)(struct esp32s2_tim_dev_s *dev,
+  void (*setclksrc)(struct esp32s2_tim_dev_s *dev,
                          enum esp32s2_tim_clksrc_e src);
-  CODE void (*setcounter)(struct esp32s2_tim_dev_s *dev, uint64_t value);
-  CODE void (*reloadnow)(struct esp32s2_tim_dev_s *dev);
-  CODE void (*getalarmvalue)(struct esp32s2_tim_dev_s *dev,
+  void (*setcounter)(struct esp32s2_tim_dev_s *dev, uint64_t value);
+  void (*reloadnow)(struct esp32s2_tim_dev_s *dev);
+  void (*getalarmvalue)(struct esp32s2_tim_dev_s *dev,
                              uint64_t *value);
-  CODE void (*setalarmvalue)(struct esp32s2_tim_dev_s *dev,
+  void (*setalarmvalue)(struct esp32s2_tim_dev_s *dev,
                              uint64_t value);
-  CODE void (*setalarm)(struct esp32s2_tim_dev_s *dev, bool enable);
-  CODE void (*setautoreload)(struct esp32s2_tim_dev_s *dev, bool enable);
+  void (*setalarm)(struct esp32s2_tim_dev_s *dev, bool enable);
+  void (*setautoreload)(struct esp32s2_tim_dev_s *dev, bool enable);
 
   /* Timer interrupts */
 
-  CODE int (*setisr)(struct esp32s2_tim_dev_s *dev, xcpt_t handler,
+  int (*setisr)(struct esp32s2_tim_dev_s *dev, xcpt_t handler,
                      void * arg);
-  CODE void (*enableint)(struct esp32s2_tim_dev_s *dev);
-  CODE void (*disableint)(struct esp32s2_tim_dev_s *dev);
-  CODE void (*ackint)(struct esp32s2_tim_dev_s *dev);
-  CODE int (*checkint)(struct esp32s2_tim_dev_s *dev);
+  void (*enableint)(struct esp32s2_tim_dev_s *dev);
+  void (*disableint)(struct esp32s2_tim_dev_s *dev);
+  void (*ackint)(struct esp32s2_tim_dev_s *dev);
+  int (*checkint)(struct esp32s2_tim_dev_s *dev);
 };
 
 /****************************************************************************

--- a/arch/xtensa/src/esp32s2/esp32s2_tim.h
+++ b/arch/xtensa/src/esp32s2/esp32s2_tim.h
@@ -96,43 +96,43 @@ struct esp32s2_tim_ops_s
 {
   /* Timer tasks */
 
-  CODE void (*start)(FAR struct esp32s2_tim_dev_s *dev);
-  CODE void (*stop)(FAR struct esp32s2_tim_dev_s *dev);
-  CODE void (*clear)(FAR struct esp32s2_tim_dev_s *dev);
+  CODE void (*start)(struct esp32s2_tim_dev_s *dev);
+  CODE void (*stop)(struct esp32s2_tim_dev_s *dev);
+  CODE void (*clear)(struct esp32s2_tim_dev_s *dev);
 
   /* Timer operations */
 
-  CODE void (*setmode)(FAR struct esp32s2_tim_dev_s *dev,
+  CODE void (*setmode)(struct esp32s2_tim_dev_s *dev,
                        enum esp32s2_tim_mode_e mode);
-  CODE void (*setpre)(FAR struct esp32s2_tim_dev_s *dev, uint16_t pre);
-  CODE void (*getcounter)(FAR struct esp32s2_tim_dev_s *dev,
+  CODE void (*setpre)(struct esp32s2_tim_dev_s *dev, uint16_t pre);
+  CODE void (*getcounter)(struct esp32s2_tim_dev_s *dev,
                           uint64_t *value);
-  CODE void (*setclksrc)(FAR struct esp32s2_tim_dev_s *dev,
+  CODE void (*setclksrc)(struct esp32s2_tim_dev_s *dev,
                          enum esp32s2_tim_clksrc_e src);
-  CODE void (*setcounter)(FAR struct esp32s2_tim_dev_s *dev, uint64_t value);
-  CODE void (*reloadnow)(FAR struct esp32s2_tim_dev_s *dev);
-  CODE void (*getalarmvalue)(FAR struct esp32s2_tim_dev_s *dev,
+  CODE void (*setcounter)(struct esp32s2_tim_dev_s *dev, uint64_t value);
+  CODE void (*reloadnow)(struct esp32s2_tim_dev_s *dev);
+  CODE void (*getalarmvalue)(struct esp32s2_tim_dev_s *dev,
                              uint64_t *value);
-  CODE void (*setalarmvalue)(FAR struct esp32s2_tim_dev_s *dev,
+  CODE void (*setalarmvalue)(struct esp32s2_tim_dev_s *dev,
                              uint64_t value);
-  CODE void (*setalarm)(FAR struct esp32s2_tim_dev_s *dev, bool enable);
-  CODE void (*setautoreload)(FAR struct esp32s2_tim_dev_s *dev, bool enable);
+  CODE void (*setalarm)(struct esp32s2_tim_dev_s *dev, bool enable);
+  CODE void (*setautoreload)(struct esp32s2_tim_dev_s *dev, bool enable);
 
   /* Timer interrupts */
 
-  CODE int (*setisr)(FAR struct esp32s2_tim_dev_s *dev, xcpt_t handler,
-                     FAR void * arg);
-  CODE void (*enableint)(FAR struct esp32s2_tim_dev_s *dev);
-  CODE void (*disableint)(FAR struct esp32s2_tim_dev_s *dev);
-  CODE void (*ackint)(FAR struct esp32s2_tim_dev_s *dev);
-  CODE int (*checkint)(FAR struct esp32s2_tim_dev_s *dev);
+  CODE int (*setisr)(struct esp32s2_tim_dev_s *dev, xcpt_t handler,
+                     void * arg);
+  CODE void (*enableint)(struct esp32s2_tim_dev_s *dev);
+  CODE void (*disableint)(struct esp32s2_tim_dev_s *dev);
+  CODE void (*ackint)(struct esp32s2_tim_dev_s *dev);
+  CODE int (*checkint)(struct esp32s2_tim_dev_s *dev);
 };
 
 /****************************************************************************
  * Public Function Prototypes
  ****************************************************************************/
 
-FAR struct esp32s2_tim_dev_s *esp32s2_tim_init(int timer);
-void esp32s2_tim_deinit(FAR struct esp32s2_tim_dev_s *dev);
+struct esp32s2_tim_dev_s *esp32s2_tim_init(int timer);
+void esp32s2_tim_deinit(struct esp32s2_tim_dev_s *dev);
 
 #endif /* __ARCH_XTENSA_SRC_ESP32S2_ESP32S2_TIM_H */

--- a/arch/xtensa/src/esp32s2/esp32s2_tim_lowerhalf.c
+++ b/arch/xtensa/src/esp32s2/esp32s2_tim_lowerhalf.c
@@ -51,32 +51,32 @@
 
 struct esp32s2_timer_lowerhalf_s
 {
-  FAR const struct timer_ops_s *ops;        /* Lower half operations */
-  FAR struct esp32s2_tim_dev_s *tim;        /* esp32s2 timer driver */
-  tccb_t                        callback;   /* Interrupt callback */
-  FAR void                     *arg;        /* Argument passed to upper half callback */
-  bool                          started;    /* True: Timer has been started */
-  FAR void                     *upper;      /* Pointer to watchdog_upperhalf_s */
+  const struct timer_ops_s *ops;        /* Lower half operations */
+  struct esp32s2_tim_dev_s *tim;        /* esp32s2 timer driver */
+  tccb_t                    callback;   /* Interrupt callback */
+  void                     *arg;        /* Argument passed to upper half callback */
+  bool                      started;    /* True: Timer has been started */
+  void                     *upper;      /* Pointer to watchdog_upperhalf_s */
 };
 
 /****************************************************************************
  * Private Function Prototypes
  ****************************************************************************/
 
-static int esp32s2_timer_handler(int irq, FAR void *context, void *arg);
+static int esp32s2_timer_handler(int irq, void *context, void *arg);
 
 /* "Lower half" driver methods **********************************************/
 
-static int esp32s2_timer_start(FAR struct timer_lowerhalf_s *lower);
-static int esp32s2_timer_stop(FAR struct timer_lowerhalf_s *lower);
-static int esp32s2_timer_getstatus(FAR struct timer_lowerhalf_s *lower,
-                                   FAR struct timer_status_s *status);
-static int esp32s2_timer_settimeout(FAR struct timer_lowerhalf_s *lower,
+static int esp32s2_timer_start(struct timer_lowerhalf_s *lower);
+static int esp32s2_timer_stop(struct timer_lowerhalf_s *lower);
+static int esp32s2_timer_getstatus(struct timer_lowerhalf_s *lower,
+                                   struct timer_status_s *status);
+static int esp32s2_timer_settimeout(struct timer_lowerhalf_s *lower,
                                     uint32_t timeout);
-static int esp32s2_timer_maxtimeout(FAR struct timer_lowerhalf_s *lower,
+static int esp32s2_timer_maxtimeout(struct timer_lowerhalf_s *lower,
                                     uint32_t *timeout);
-static void esp32s2_timer_setcallback(FAR struct timer_lowerhalf_s *lower,
-                                      tccb_t callback, FAR void *arg);
+static void esp32s2_timer_setcallback(struct timer_lowerhalf_s *lower,
+                                      tccb_t callback, void *arg);
 
 /****************************************************************************
  * Private Data
@@ -147,10 +147,10 @@ static struct esp32s2_timer_lowerhalf_s g_esp32s2_timer3_lowerhalf =
  *
  ****************************************************************************/
 
-static int esp32s2_timer_handler(int irq, FAR void *context, void *arg)
+static int esp32s2_timer_handler(int irq, void *context, void *arg)
 {
-  FAR struct esp32s2_timer_lowerhalf_s *priv =
-    (FAR struct esp32s2_timer_lowerhalf_s *)arg;
+  struct esp32s2_timer_lowerhalf_s *priv =
+    (struct esp32s2_timer_lowerhalf_s *)arg;
   uint32_t next_interval_us = 0;
 
   if (priv->callback(&next_interval_us, priv->upper))
@@ -187,10 +187,10 @@ static int esp32s2_timer_handler(int irq, FAR void *context, void *arg)
  *
  ****************************************************************************/
 
-static int esp32s2_timer_start(FAR struct timer_lowerhalf_s *lower)
+static int esp32s2_timer_start(struct timer_lowerhalf_s *lower)
 {
-  FAR struct esp32s2_timer_lowerhalf_s *priv =
-    (FAR struct esp32s2_timer_lowerhalf_s *)lower;
+  struct esp32s2_timer_lowerhalf_s *priv =
+    (struct esp32s2_timer_lowerhalf_s *)lower;
   int ret = OK;
   uint16_t pre;
   irqstate_t flags;
@@ -282,10 +282,10 @@ errout:
  *
  ****************************************************************************/
 
-static int esp32s2_timer_stop(FAR struct timer_lowerhalf_s *lower)
+static int esp32s2_timer_stop(struct timer_lowerhalf_s *lower)
 {
-  FAR struct esp32s2_timer_lowerhalf_s *priv =
-    (FAR struct esp32s2_timer_lowerhalf_s *)lower;
+  struct esp32s2_timer_lowerhalf_s *priv =
+    (struct esp32s2_timer_lowerhalf_s *)lower;
   int ret = OK;
   irqstate_t flags;
 
@@ -331,11 +331,11 @@ errout:
  *
  ****************************************************************************/
 
-static int esp32s2_timer_getstatus(FAR struct timer_lowerhalf_s *lower,
-                                   FAR struct timer_status_s *status)
+static int esp32s2_timer_getstatus(struct timer_lowerhalf_s *lower,
+                                   struct timer_status_s *status)
 {
-  FAR struct esp32s2_timer_lowerhalf_s *priv =
-    (FAR struct esp32s2_timer_lowerhalf_s *)lower;
+  struct esp32s2_timer_lowerhalf_s *priv =
+    (struct esp32s2_timer_lowerhalf_s *)lower;
   int ret = OK;
   uint64_t current_counter_value;
   uint64_t alarm_value;
@@ -393,11 +393,11 @@ static int esp32s2_timer_getstatus(FAR struct timer_lowerhalf_s *lower,
  *
  ****************************************************************************/
 
-static int esp32s2_timer_settimeout(FAR struct timer_lowerhalf_s *lower,
+static int esp32s2_timer_settimeout(struct timer_lowerhalf_s *lower,
                                     uint32_t timeout)
 {
-  FAR struct esp32s2_timer_lowerhalf_s *priv =
-    (FAR struct esp32s2_timer_lowerhalf_s *)lower;
+  struct esp32s2_timer_lowerhalf_s *priv =
+    (struct esp32s2_timer_lowerhalf_s *)lower;
   int ret = OK;
 
   DEBUGASSERT(priv);
@@ -425,7 +425,7 @@ static int esp32s2_timer_settimeout(FAR struct timer_lowerhalf_s *lower,
  *
  ****************************************************************************/
 
-static int esp32s2_timer_maxtimeout(FAR struct timer_lowerhalf_s *lower,
+static int esp32s2_timer_maxtimeout(struct timer_lowerhalf_s *lower,
                                   uint32_t *max_timeout)
 {
   DEBUGASSERT(max_timeout);
@@ -452,11 +452,11 @@ static int esp32s2_timer_maxtimeout(FAR struct timer_lowerhalf_s *lower,
  *
  ****************************************************************************/
 
-static void esp32s2_timer_setcallback(FAR struct timer_lowerhalf_s *lower,
-                                      tccb_t callback, FAR void *arg)
+static void esp32s2_timer_setcallback(struct timer_lowerhalf_s *lower,
+                                      tccb_t callback, void *arg)
 {
-  FAR struct esp32s2_timer_lowerhalf_s *priv =
-    (FAR struct esp32s2_timer_lowerhalf_s *)lower;
+  struct esp32s2_timer_lowerhalf_s *priv =
+    (struct esp32s2_timer_lowerhalf_s *)lower;
   irqstate_t flags;
   int ret = OK;
 
@@ -511,7 +511,7 @@ static void esp32s2_timer_setcallback(FAR struct timer_lowerhalf_s *lower,
  *
  ****************************************************************************/
 
-int esp32s2_timer_initialize(FAR const char *devpath, uint8_t timer)
+int esp32s2_timer_initialize(const char *devpath, uint8_t timer)
 {
   struct esp32s2_timer_lowerhalf_s *lower = NULL;
   int ret = OK;
@@ -577,7 +577,7 @@ int esp32s2_timer_initialize(FAR const char *devpath, uint8_t timer)
    */
 
   lower->upper = timer_register(devpath,
-                                (FAR struct timer_lowerhalf_s *)lower);
+                                (struct timer_lowerhalf_s *)lower);
   if (lower->upper == NULL)
     {
       /* The actual cause of the failure may have been a failure to allocate

--- a/arch/xtensa/src/esp32s2/esp32s2_tim_lowerhalf.h
+++ b/arch/xtensa/src/esp32s2/esp32s2_tim_lowerhalf.h
@@ -37,6 +37,6 @@
  * Name: esp32s2_timer_initialize
  ****************************************************************************/
 
-int esp32s2_timer_initialize(FAR const char *devpath, uint8_t timer);
+int esp32s2_timer_initialize(const char *devpath, uint8_t timer);
 
 #endif /* __ARCH_XTENSA_SRC_ESP32S2_ESP32S2_TIM_LOWERHALF_H */

--- a/arch/xtensa/src/esp32s2/esp32s2_timerisr.c
+++ b/arch/xtensa/src/esp32s2/esp32s2_timerisr.c
@@ -111,7 +111,7 @@ static inline void xtensa_setcompare(uint32_t compare)
  *
  ****************************************************************************/
 
-static int esp32s2_timerisr(int irq, uint32_t *regs, FAR void *arg)
+static int esp32s2_timerisr(int irq, uint32_t *regs, void *arg)
 {
   uint32_t divisor;
   uint32_t compare;

--- a/arch/xtensa/src/esp32s2/esp32s2_user.c
+++ b/arch/xtensa/src/esp32s2/esp32s2_user.c
@@ -317,7 +317,7 @@ uint32_t *xtensa_user(int exccause, uint32_t *regs)
       uint8_t t;
 
       binfo("XCHAL_EXCCAUSE_LOAD_STORE_ERROR at %p, pc=%p\n",
-            (FAR void *)regs[REG_EXCVADDR],
+            (void *)regs[REG_EXCVADDR],
             pc);
 
       if (decode_s8i(pc, &imm8, &s, &t))


### PR DESCRIPTION
## Summary
This PR intends to remove all references to the `FAR` and `CODE` qualifiers from **Xtensa** and **RISC-V** files.
`FAR` and `CODE` are defined to nothing on both architectures.

## Impact
Should have no impact.

## Testing
CI build pass.
