### PR TITLE
Add LCD backpack support for ESP32 (devkit-c).

### DIFF
--- a/boards/xtensa/esp32/esp32-devkitc/src/esp32_bringup.c
+++ b/boards/xtensa/esp32/esp32-devkitc/src/esp32_bringup.c
@@ -98,6 +98,10 @@
 #  include "esp32_spi.h"
 #endif
 
+#ifdef CONFIG_LCD_BACKPACK
+#  include "esp32_lcd_backpack.h"
+#endif
+
 #include "esp32-devkitc.h"
 
 /****************************************************************************
@@ -155,6 +159,16 @@ int esp32_bringup(void)
   if (ret < 0)
     {
       syslog(LOG_ERR, "ERROR: Failed to mount procfs at /proc: %d\n", ret);
+    }
+#endif
+
+#ifdef CONFIG_LCD_BACKPACK
+  /* slcd:0, i2c:0, rows=2, cols=16 */
+
+  ret = board_lcd_backpack_init(0, 0, 2, 16);
+  if (ret < 0)
+    {
+      syslog(LOG_ERR, "Failed to initialize PCF8574 LCD, error %d\n", ret);
     }
 #endif
 


### PR DESCRIPTION
## Summary

This commit adds LCD backpack (PCF8574) to ESp32 Devkic-C by changes in board/xtensa/esp32/esp32-devkitc/src/esp32_bringup.c.

## Impact

None.

## Testing

It worked fine.

![image](https://user-images.githubusercontent.com/16869652/134404712-0b8ed251-4998-4e53-9cad-841256b0e90b.png)

![lcd_nuttx_works](https://user-images.githubusercontent.com/16869652/134404800-bce91c62-d3d0-49e4-9e9e-6048324728ec.jpg)

