### PR TITLE
stm32h7:DMA_TRBUFF is DMA_SCR_TRBUFF

### DIFF
--- a/arch/arm/src/stm32h7/hardware/stm32_dma.h
+++ b/arch/arm/src/stm32h7/hardware/stm32_dma.h
@@ -319,7 +319,7 @@
 
 #define DMA_SCR_DBM               (1 << 18) /* Bit 15: Double buffer mode */
 #define DMA_SCR_CT                (1 << 19) /* Bit 19: Current target */
-#define DMA_TRBUFF                (1 << 20) /* Bit 20: Enable the DMA to handle bufferable transfers*/
+#define DMA_SCR_TRBUFF            (1 << 20) /* Bit 20: Enable the DMA to handle bufferable transfers */
 #define DMA_SCR_PBURST_SHIFT      (21)      /* Bits 21-22: Peripheral burst transfer configuration */
 #define DMA_SCR_PBURST_MASK       (3 << DMA_SCR_PBURST_SHIFT)
 #  define DMA_SCR_PBURST_SINGLE   (0 << DMA_SCR_PBURST_SHIFT) /* 00: Single transfer */

--- a/arch/arm/src/stm32h7/stm32_dma.c
+++ b/arch/arm/src/stm32h7/stm32_dma.c
@@ -1350,7 +1350,7 @@ static void stm32_sdma_setup(DMA_HANDLE handle, FAR stm32_dmacfg_t *cfg)
   scr    &=  (DMA_SCR_PFCTRL | DMA_SCR_DIR_MASK | DMA_SCR_PINC |
               DMA_SCR_MINC | DMA_SCR_PSIZE_MASK | DMA_SCR_MSIZE_MASK |
               DMA_SCR_PINCOS | DMA_SCR_DBM | DMA_SCR_CIRC |
-              DMA_SCR_PBURST_MASK | DMA_SCR_MBURST_MASK | DMA_TRBUFF);
+              DMA_SCR_PBURST_MASK | DMA_SCR_MBURST_MASK | DMA_SCR_TRBUFF);
   regval |= scr;
   dmachan_putreg(dmachan, STM32_DMA_SCR_OFFSET, regval);
 }

--- a/arch/arm/src/stm32h7/stm32_serial.c
+++ b/arch/arm/src/stm32h7/stm32_serial.c
@@ -468,7 +468,7 @@
                DMA_SCR_PBURST_SINGLE  | \
                DMA_SCR_MBURST_SINGLE  | \
                CONFIG_USART_TXDMAPRIO | \
-               DMA_TRBUFF)
+               DMA_SCR_TRBUFF)
 
 #endif /* SERIAL_HAVE_TXDMA */
 


### PR DESCRIPTION
## Summary

This is just a naming constancy and formatting change.

## Impact

None in the binary.

## Testing
CI
