### PR TITLE
net/dup: only start tcp monitor on INET domain

### DIFF
--- a/net/socket/net_dup2.c
+++ b/net/socket/net_dup2.c
@@ -104,7 +104,9 @@ int psock_dup2(FAR struct socket *psock1, FAR struct socket *psock2)
 
   conn = (FAR struct tcp_conn_s *)psock2->s_conn;
 
-  if (psock2->s_type == SOCK_STREAM && conn &&
+  if ((psock2->s_domain == PF_INET ||
+       psock2->s_domain == PF_INET6) &&
+      psock2->s_type == SOCK_STREAM && conn &&
       (conn->tcpstateflags == TCP_ESTABLISHED ||
        conn->tcpstateflags == TCP_SYN_RCVD))
     {


### PR DESCRIPTION
## Summary

net/dup: only start tcp monitor on INET domain

invaild fd dup if the socket with local family work on stream mode.

socket(AF_LOCAL, SOCK_STREAM, 0);

## Impact

socket fd dup

## Testing

 Dup the socket during task exec