### PR TITLE
[SECURITY]net/tcp: sanity check for the listen address

### DIFF
--- a/include/nuttx/net/ip.h
+++ b/include/nuttx/net/ip.h
@@ -52,6 +52,7 @@
 
 #include <stdint.h>
 #include <stdbool.h>
+#include <string.h>
 
 #include <arpa/inet.h>
 #include <netinet/in.h>

--- a/net/tcp/tcp.h
+++ b/net/tcp/tcp.h
@@ -852,9 +852,12 @@ void tcp_listen_initialize(void);
  ****************************************************************************/
 
 #if defined(CONFIG_NET_IPv4) && defined(CONFIG_NET_IPv6)
-FAR struct tcp_conn_s *tcp_findlistener(uint16_t portno, uint8_t domain);
+FAR struct tcp_conn_s *tcp_findlistener(FAR union ip_binding_u *uaddr,
+                                        uint16_t portno,
+                                        uint8_t domain);
 #else
-FAR struct tcp_conn_s *tcp_findlistener(uint16_t portno);
+FAR struct tcp_conn_s *tcp_findlistener(FAR union ip_binding_u *uaddr,
+                                        uint16_t portno);
 #endif
 
 /****************************************************************************
@@ -895,9 +898,10 @@ int tcp_listen(FAR struct tcp_conn_s *conn);
  ****************************************************************************/
 
 #if defined(CONFIG_NET_IPv4) && defined(CONFIG_NET_IPv6)
-bool tcp_islistener(uint16_t portno, uint8_t domain);
+bool tcp_islistener(FAR union ip_binding_u *uaddr, uint16_t portno,
+                    uint8_t domain);
 #else
-bool tcp_islistener(uint16_t portno);
+bool tcp_islistener(FAR union ip_binding_u *uaddr, uint16_t portno);
 #endif
 
 /****************************************************************************

--- a/net/tcp/tcp_input.c
+++ b/net/tcp/tcp_input.c
@@ -68,6 +68,7 @@
  ****************************************************************************/
 
 #define IPv4BUF ((FAR struct ipv4_hdr_s *)&dev->d_buf[NET_LL_HDRLEN(dev)])
+#define IPv6BUF ((FAR struct ipv6_hdr_s *)&dev->d_buf[NET_LL_HDRLEN(dev)])
 
 /****************************************************************************
  * Private Functions
@@ -283,8 +284,9 @@ static void tcp_snd_wnd_update(FAR struct tcp_conn_s *conn,
 static void tcp_input(FAR struct net_driver_s *dev, uint8_t domain,
                       unsigned int iplen)
 {
-  FAR struct tcp_hdr_s *tcp;
   FAR struct tcp_conn_s *conn = NULL;
+  FAR struct tcp_hdr_s *tcp;
+  union ip_binding_u uaddr;
   unsigned int tcpiplen;
   unsigned int hdrlen;
   uint16_t tmp16;
@@ -370,10 +372,29 @@ static void tcp_input(FAR struct net_driver_s *dev, uint8_t domain,
        */
 
       tmp16 = tcp->destport;
+#ifdef CONFIG_NET_IPv6
+#  ifdef CONFIG_NET_IPv4
+      if (domain == PF_INET6)
+#  endif
+        {
+          net_ipv6addr_copy(&uaddr.ipv6.laddr, IPv6BUF->destipaddr);
+        }
+#endif
+
+#ifdef CONFIG_NET_IPv4
+#  ifdef CONFIG_NET_IPv6
+      if (domain == PF_INET)
+#  endif
+        {
+          net_ipv4addr_copy(uaddr.ipv4.laddr,
+                            net_ip4addr_conv32(IPv4BUF->destipaddr));
+        }
+#endif
+
 #if defined(CONFIG_NET_IPv4) && defined(CONFIG_NET_IPv6)
-      if (tcp_islistener(tmp16, domain))
+      if (tcp_islistener(&uaddr, tmp16, domain))
 #else
-      if (tcp_islistener(tmp16))
+      if (tcp_islistener(&uaddr, tmp16))
 #endif
         {
           /* We matched the incoming packet with a connection in LISTEN.
@@ -541,10 +562,29 @@ found:
 
           /* Notify the listener for the connection of the reset event */
 
+#ifdef CONFIG_NET_IPv6
+#  ifdef CONFIG_NET_IPv4
+          if (domain == PF_INET6)
+#  endif
+            {
+              net_ipv6addr_copy(&uaddr.ipv6.laddr, IPv6BUF->destipaddr);
+            }
+#endif
+
+#ifdef CONFIG_NET_IPv4
+#  ifdef CONFIG_NET_IPv6
+          if (domain == PF_INET)
+#  endif
+            {
+              net_ipv4addr_copy(uaddr.ipv4.laddr,
+                                net_ip4addr_conv32(IPv4BUF->destipaddr));
+            }
+#endif
+
 #if defined(CONFIG_NET_IPv4) && defined(CONFIG_NET_IPv6)
-          listener = tcp_findlistener(conn->lport, domain);
+          listener = tcp_findlistener(&uaddr, conn->lport, domain);
 #else
-          listener = tcp_findlistener(conn->lport);
+          listener = tcp_findlistener(&uaddr, conn->lport);
 #endif
 
           /* We must free this TCP connection structure; this connection

--- a/net/tcp/tcp_timer.c
+++ b/net/tcp/tcp_timer.c
@@ -250,9 +250,10 @@ void tcp_timer(FAR struct net_driver_s *dev, FAR struct tcp_conn_s *conn,
                   /* Find the listener for this connection. */
 
 #if defined(CONFIG_NET_IPv4) && defined(CONFIG_NET_IPv6)
-                  listener = tcp_findlistener(conn->lport, conn->domain);
+                  listener = tcp_findlistener(&conn->u, conn->lport,
+                                              conn->domain);
 #else
-                  listener = tcp_findlistener(conn->lport);
+                  listener = tcp_findlistener(&conn->u, conn->lport);
 #endif
                   if (listener != NULL)
                     {


### PR DESCRIPTION
## Summary

net/tcp: sanity check for the listen address

TCP stack only checks the visitor's port number on listening port,
which will cause external links to arbitrarily access local resources in the nuttx system:

```
client                                NUTTX server (192.168.1.101)

                                     listen (127.0.0.1):8888
connect (192.168.1.101:8888)   ->    accept (127.0.0.1):8888     (success) <-- here is the issue.

                                     listen (0.0.0.0):8889
connect (192.168.1.101:8889)   ->    accept (0.0.0.0):8889       (success)

                                     listen (192.168.1.101):8890
connect (192.168.1.101:8890)   ->    accept (192.168.1.101):8890 (success)
```

In this PR we added an address check on listener port and reject malicious connections if the address check failure


```
client                                NUTTX server (192.168.1.101)

                                     listen (127.0.0.1):8888
connect (192.168.1.101:8888)   ->    accept (127.0.0.1):8888     (Reject)
```

## Impact

tcp stack accept

## Testing

tcp test connect to the nuttx

```
client                                NUTTX server (192.168.1.101)

                                     listen (127.0.0.1):8888
connect (192.168.1.101:8888)   ->    accept (127.0.0.1):8888     (Reject)
```
