### PR TITLE
xtensa/esp32: Enable build system to download or build binaries from source

### DIFF
--- a/arch/xtensa/src/esp32/.gitignore
+++ b/arch/xtensa/src/esp32/.gitignore
@@ -1,2 +1,3 @@
 /esp-wireless-drivers-3rdparty
+/esp-nuttx-bootloader
 /*.zip

--- a/arch/xtensa/src/esp32/Bootloader.mk
+++ b/arch/xtensa/src/esp32/Bootloader.mk
@@ -1,0 +1,123 @@
+############################################################################
+# arch/xtensa/src/esp32/Bootloader.mk
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+ifeq ($(CONFIG_ESP32_BOOTLOADER_BUILD_FROM_SOURCE),y)
+
+CHIPDIR            = $(TOPDIR)/arch/xtensa/src/chip
+
+BOOTLOADER_SRCDIR  = $(CHIPDIR)/esp-nuttx-bootloader
+BOOTLOADER_VERSION = main
+BOOTLOADER_URL     = https://github.com/espressif/esp-nuttx-bootloader
+BOOTLOADER_OUTDIR  = out
+
+$(BOOTLOADER_SRCDIR):
+	$(Q) git clone $(BOOTLOADER_URL) $(BOOTLOADER_SRCDIR) -b $(BOOTLOADER_VERSION)
+
+ifeq ($(CONFIG_ESP32_APP_FORMAT_MCUBOOT),y)
+
+BOOTLOADER_CONFIG = $(CHIPDIR)/mcuboot.conf
+
+$(BOOTLOADER_CONFIG): $(TOPDIR)/.config
+	$(Q) echo "Creating Bootloader configuration"
+	$(Q) {                                                                                              \
+		echo "CONFIG_ESP_BOOTLOADER_SIZE=0xF000";                                                       \
+		echo "CONFIG_ESP_APPLICATION_PRIMARY_START_ADDRESS=$(CONFIG_ESP32_OTA_PRIMARY_SLOT_OFFSET)";    \
+		echo "CONFIG_ESP_APPLICATION_SIZE=$(CONFIG_ESP32_OTA_SLOT_SIZE)";                               \
+		echo "CONFIG_ESP_APPLICATION_SECONDARY_START_ADDRESS=$(CONFIG_ESP32_OTA_SECONDARY_SLOT_OFFSET)";\
+		echo "CONFIG_ESP_MCUBOOT_WDT_ENABLE=y";                                                         \
+		echo "CONFIG_ESP_SCRATCH_OFFSET=$(CONFIG_ESP32_OTA_SCRATCH_OFFSET)";                            \
+		echo "CONFIG_ESP_SCRATCH_SIZE=$(CONFIG_ESP32_OTA_SCRATCH_SIZE)";                                \
+	} > $(BOOTLOADER_CONFIG)
+
+bootloader: $(BOOTLOADER_SRCDIR) $(BOOTLOADER_CONFIG)
+	$(Q) echo "Building Bootloader binaries"
+	$(Q) $(BOOTLOADER_SRCDIR)/build_mcuboot.sh -c esp32 -s -f $(BOOTLOADER_CONFIG)
+	$(call COPYFILE, $(BOOTLOADER_SRCDIR)/$(BOOTLOADER_OUTDIR)/mcuboot-esp32.bin, $(TOPDIR))
+
+clean_bootloader:
+	$(call DELDIR, $(BOOTLOADER_SRCDIR))
+	$(call DELFILE, $(BOOTLOADER_CONFIG))
+	$(call DELFILE, $(TOPDIR)/mcuboot-esp32.bin)
+
+else ifeq ($(CONFIG_ESP32_APP_FORMAT_LEGACY),y)
+
+BOOTLOADER_CONFIG = $(CHIPDIR)/sdkconfig
+
+$(BOOTLOADER_CONFIG): $(TOPDIR)/.config
+	$(Q) echo "Creating Bootloader configuration"
+	$(Q) {                                                                                       \
+		[ "$(CONFIG_ESP32_FLASH_2M)"        = "y" ] && echo "CONFIG_ESPTOOLPY_FLASHSIZE_2MB=y";  \
+		[ "$(CONFIG_ESP32_FLASH_4M)"        = "y" ] && echo "CONFIG_ESPTOOLPY_FLASHSIZE_4MB=y";  \
+		[ "$(CONFIG_ESP32_FLASH_8M)"        = "y" ] && echo "CONFIG_ESPTOOLPY_FLASHSIZE_8MB=y";  \
+		[ "$(CONFIG_ESP32_FLASH_16M)"       = "y" ] && echo "CONFIG_ESPTOOLPY_FLASHSIZE_16MB=y"; \
+		[ "$(CONFIG_ESP32_FLASH_MODE_DIO)"  = "y" ] && echo "CONFIG_ESPTOOLPY_FLASHMODE_DIO=y";  \
+		[ "$(CONFIG_ESP32_FLASH_MODE_DOUT)" = "y" ] && echo "CONFIG_ESPTOOLPY_FLASHMODE_DOUT=y"; \
+		[ "$(CONFIG_ESP32_FLASH_MODE_QIO)"  = "y" ] && echo "CONFIG_ESPTOOLPY_FLASHMODE_QIO=y";  \
+		[ "$(CONFIG_ESP32_FLASH_MODE_QOUT)" = "y" ] && echo "CONFIG_ESPTOOLPY_FLASHMODE_QOUT=y"; \
+		[ "$(CONFIG_ESP32_FLASH_FREQ_80M)"  = "y" ] && echo "CONFIG_ESPTOOLPY_FLASHFREQ_80M=y";  \
+		[ "$(CONFIG_ESP32_FLASH_FREQ_40M)"  = "y" ] && echo "CONFIG_ESPTOOLPY_FLASHFREQ_40M=y";  \
+		[ "$(CONFIG_ESP32_FLASH_FREQ_26M)"  = "y" ] && echo "CONFIG_ESPTOOLPY_FLASHFREQ_26M=y";  \
+		[ "$(CONFIG_ESP32_FLASH_FREQ_20M)"  = "y" ] && echo "CONFIG_ESPTOOLPY_FLASHFREQ_20M=y";  \
+		echo "CONFIG_PARTITION_TABLE_CUSTOM=y";                                                  \
+		echo "CONFIG_PARTITION_TABLE_CUSTOM_FILENAME=\"partitions.csv\"";                        \
+	} > $(BOOTLOADER_CONFIG)
+
+bootloader: $(BOOTLOADER_SRCDIR) $(BOOTLOADER_CONFIG)
+	$(Q) echo "Building Bootloader binaries"
+	$(Q) $(BOOTLOADER_SRCDIR)/build_idfboot.sh -c esp32 -s -f $(BOOTLOADER_CONFIG)
+	$(call COPYFILE, $(BOOTLOADER_SRCDIR)/$(BOOTLOADER_OUTDIR)/bootloader-esp32.bin, $(TOPDIR))
+	$(call COPYFILE, $(BOOTLOADER_SRCDIR)/$(BOOTLOADER_OUTDIR)/partition-table-esp32.bin, $(TOPDIR))
+
+clean_bootloader:
+	$(call DELDIR, $(BOOTLOADER_SRCDIR))
+	$(call DELFILE, $(BOOTLOADER_CONFIG))
+	$(call DELFILE, $(TOPDIR)/bootloader-esp32.bin)
+	$(call DELFILE, $(TOPDIR)/partition-table-esp32.bin)
+
+endif
+
+else ifeq ($(CONFIG_ESP32_BOOTLOADER_DOWNLOAD_PREBUILT),y)
+
+BOOTLOADER_VERSION = latest
+BOOTLOADER_URL     = https://github.com/espressif/esp-nuttx-bootloader/releases/download/$(BOOTLOADER_VERSION)
+
+ifeq ($(CONFIG_ESP32_APP_FORMAT_MCUBOOT),y)
+
+bootloader:
+	$(Q) echo "Downloading Bootloader binaries"
+	$(Q) curl -L $(BOOTLOADER_URL)/mcuboot-esp32.bin -o $(TOPDIR)/mcuboot-esp32.bin
+
+clean_bootloader:
+	$(call DELFILE, $(TOPDIR)/mcuboot-esp32.bin)
+
+else ifeq ($(CONFIG_ESP32_APP_FORMAT_LEGACY),y)
+
+bootloader:
+	$(Q) echo "Downloading Bootloader binaries"
+	$(Q) curl -L $(BOOTLOADER_URL)/bootloader-esp32.bin -o $(TOPDIR)/bootloader-esp32.bin
+	$(Q) curl -L $(BOOTLOADER_URL)/partition-table-esp32.bin -o $(TOPDIR)/partition-table-esp32.bin
+
+clean_bootloader:
+	$(call DELFILE, $(TOPDIR)/bootloader-esp32.bin)
+	$(call DELFILE, $(TOPDIR)/partition-table-esp32.bin)
+
+endif
+
+endif

--- a/arch/xtensa/src/esp32/Kconfig
+++ b/arch/xtensa/src/esp32/Kconfig
@@ -1245,6 +1245,30 @@ comment "MCUboot support depends on CONFIG_EXPERIMENTAL"
 endchoice # Application Image Format
 
 choice
+	prompt "Source for bootloader binaries"
+	default ESP32_BOOTLOADER_DOWNLOAD_PREBUILT
+	---help---
+		Select the action to be taken by the build system for the
+		"make bootloader" target.
+
+config ESP32_BOOTLOADER_DOWNLOAD_PREBUILT
+	bool "Download prebuilt binaries"
+	---help---
+		The build system will download the prebuilt binaries from
+		https://github.com/espressif/esp-nuttx-bootloader according to the chosen
+		Application Image Format (ESP32_APP_FORMAT_LEGACY or ESP32_APP_FORMAT_MCUBOOT)
+
+config ESP32_BOOTLOADER_BUILD_FROM_SOURCE
+	bool "Build binaries from source"
+	---help---
+		The build system will build all the required binaries from source. It will clone
+		the https://github.com/espressif/esp-nuttx-bootloader repository and build a
+		custom bootloader according to the chosen Application Image Format
+		(ESP32_APP_FORMAT_LEGACY or ESP32_APP_FORMAT_MCUBOOT) and partition information.
+
+endchoice
+
+choice
 	prompt "Target slot for image flashing"
 	default ESP32_ESPTOOL_TARGET_PRIMARY
 	depends on ESP32_HAVE_OTA_PARTITION

--- a/arch/xtensa/src/esp32/Make.defs
+++ b/arch/xtensa/src/esp32/Make.defs
@@ -18,6 +18,8 @@
 #
 ############################################################################
 
+include chip/Bootloader.mk
+
 # The start-up, "head", file.  May be either a .S or a .c file.
 
 HEAD_ASRC  = xtensa_vectors.S xtensa_window_vector.S xtensa_windowspill.S

--- a/tools/Makefile.unix
+++ b/tools/Makefile.unix
@@ -459,6 +459,26 @@ endif
 download: $(BIN)
 	$(call DOWNLOAD, $<)
 
+# bootloader
+#
+# Some architectures require the provisioning of a bootloader or other
+# functions required for properly executing the NuttX binary.
+# Make.defs files for those architectures should define a bootloader target
+# with the correct operations for that platform. It will generate an error
+# if the bootloader target is not defined.
+
+bootloader:
+	$(Q) $(MAKE) -C $(ARCH_SRC) bootloader
+
+# clean_bootloader
+#
+# Removes all of the files and directories created by the bootloader target.
+# It will generate an error if the clean_bootloader target is not defined on
+# the architecture-specific Makefile.
+
+clean_bootloader:
+	$(Q) $(MAKE) -C $(ARCH_SRC) clean_bootloader
+
 # pass1dep: Create pass1 build dependencies
 # pass2dep: Create pass2 build dependencies
 

--- a/tools/Makefile.win
+++ b/tools/Makefile.win
@@ -418,6 +418,26 @@ endif
 download: $(BIN)
 	$(call DOWNLOAD, $<)
 
+# bootloader
+#
+# Some architectures require the provisioning of a bootloader or other
+# functions required for properly executing the NuttX binary.
+# Make.defs files for those architectures should define a bootloader target
+# with the correct operations for that platform. It will generate an error
+# if the bootloader target is not defined.
+
+bootloader:
+	$(Q) $(MAKE) -C $(ARCH_SRC) bootloader
+
+# clean_bootloader
+#
+# Removes all of the files and directories created by the bootloader target.
+# It will generate an error if the clean_bootloader target is not defined on
+# the architecture-specific Makefile.
+
+clean_bootloader:
+	$(Q) $(MAKE) -C $(ARCH_SRC) clean_bootloader
+
 # pass1dep: Create pass1 build dependencies
 # pass2dep: Create pass2 build dependencies
 


### PR DESCRIPTION
## Summary
This PR intends to add a new feature to the ESP32 build system for easing the provisioning of prebuilt binaries.
Depending on the choice of *Application Image Format*, the user must flash the following binaries to the chip's flash:

**Legacy image format (IDFboot)**
- `bootloader-esp32.bin`
- `partition-table-esp32.bin`

**MCUboot image format**
- `mcuboot-esp32.bin`

This PR adds two new optional **Make** targets: `bootloader` and `clean_bootloader`.
It also brings an implementation for ESP32 chips. Depending on the option selected by the user, this command will execute one the two operations:
1) Download prebuilt binaries (`ESP32_BOOTLOADER_DOWNLOAD_PREBUILT`, **default**)
2) Build binaries from source (`ESP32_BOOTLOADER_BUILD_FROM_SOURCE`)

Host dependencies for building the bootloader from source:
- CMake version 3.13

## Impact
New feature, should have no impact to the standard workflow of the build system.

## Testing
`make bootloader` for `esp32-devkitc:nsh` and `esp32-devkitc:mcuboot_confirm` configurations successfully downloads the prebuilt binaries.
And when selecting `ESP32_BOOTLOADER_BUILD_FROM_SOURCE` successfully builds the binaries from source.
