### PR TITLE
risc-v/esp32-c3: improvements and fix to esp32c3_rt_timer.c

### DIFF
--- a/arch/risc-v/src/esp32c3/esp32c3_rt_timer.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_rt_timer.c
@@ -718,20 +718,22 @@ int esp32c3_rt_timer_init(void)
 
   nxsem_init(&priv->toutsem, 0, 0);
 
-  priv->pid = kthread_create(RT_TIMER_TASK_NAME,
+  pid = kthread_create(RT_TIMER_TASK_NAME,
                        RT_TIMER_TASK_PRIORITY,
                        RT_TIMER_TASK_STACK_SIZE,
                        rt_timer_thread,
                        NULL);
-  if (priv->pid < 0)
+  if (pid < 0)
     {
       tmrerr("ERROR: Failed to create RT timer task error=%d\n", pid);
       esp32c3_tim_deinit(priv->timer);
-      return priv->pid;
+      return pid;
     }
 
   list_initialize(&priv->runlist);
   list_initialize(&priv->toutlist);
+
+  priv->pid = pid;
 
   flags = enter_critical_section();
 


### PR DESCRIPTION
## Summary

This PR:

1. Removes `_s` of non static variables from esp32c3_rt_timer.c.
2. Fix `pid` variable initialization.

## Impact

Prevent a potential bug in case `kthread_create` fails to create the thread. 

## Testing

Local test.
