### PR TITLE
tools/ci/cibuild.sh: Update the downloaded ESP Xtensa toolchain.  

### DIFF
--- a/tools/ci/cibuild.sh
+++ b/tools/ci/cibuild.sh
@@ -211,15 +211,15 @@ function xtensa-esp32-gcc-toolchain {
     cd "${prebuilt}"
     case ${os} in
       Darwin)
-        wget --quiet https://dl.espressif.com/dl/xtensa-esp32-elf-gcc8_2_0-esp-2019r2-macos.tar.gz
-        tar xzf xtensa-esp32-elf-gcc8_2_0-esp-2019r2-macos.tar.gz
-        rm xtensa-esp32-elf-gcc8_2_0-esp-2019r2-macos.tar.gz
+        wget --quiet https://dl.espressif.com/dl/xtensa-esp32-elf-gcc8_4_0-esp-2021r1-macos.tar.gz
+        tar xzf xtensa-esp32-elf-gcc8_4_0-esp-2021r1-macos.tar.gz
+        rm xtensa-esp32-elf-gcc8_4_0-esp-2021r1-macos.tar.gz
         ;;
       Linux)
-        wget --quiet https://dl.espressif.com/dl/xtensa-esp32-elf-gcc8_2_0-esp32-2019r1-rc2-linux-amd64.tar.xz
-        xz -d xtensa-esp32-elf-gcc8_2_0-esp32-2019r1-rc2-linux-amd64.tar.xz
-        tar xf xtensa-esp32-elf-gcc8_2_0-esp32-2019r1-rc2-linux-amd64.tar
-        rm xtensa-esp32-elf-gcc8_2_0-esp32-2019r1-rc2-linux-amd64.tar
+        wget --quiet https://dl.espressif.com/dl/xtensa-esp32-elf-gcc8_4_0-esp32-2021r1-linux-amd64.tar.xz
+        xz -d xtensa-esp32-elf-gcc8_4_0-esp32-2021r1-linux-amd64.tar.xz
+        tar xf xtensa-esp32-elf-gcc8_4_0-esp32-2021r1-linux-amd64.tar
+        rm xtensa-esp32-elf-gcc8_4_0-esp32-2021r1-linux-amd64.tar
         ;;
     esac
   fi

--- a/tools/ci/docker/linux/Dockerfile
+++ b/tools/ci/docker/linux/Dockerfile
@@ -103,11 +103,11 @@ RUN mkdir riscv64-unknown-elf-gcc && \
 FROM nuttx-toolchain-base AS nuttx-toolchain-esp32
 # Download the latest ESP32 GCC toolchain prebuilt by Espressif
 RUN mkdir -p xtensa-esp32-elf-gcc && \
-  curl -s -L "https://github.com/espressif/crosstool-NG/releases/download/esp-2020r3/xtensa-esp32-elf-gcc8_4_0-esp-2020r3-linux-amd64.tar.gz" \
+  curl -s -L "https://github.com/espressif/crosstool-NG/releases/download/esp-2021r1/xtensa-esp32-elf-gcc8_4_0-esp-2021r1-linux-amd64.tar.gz" \
   | tar -C xtensa-esp32-elf-gcc --strip-components 1 -xz
 
 RUN mkdir -p xtensa-esp32s2-elf-gcc && \
-  curl -s -L "https://github.com/espressif/crosstool-NG/releases/download/esp-2020r3/xtensa-esp32s2-elf-gcc8_4_0-esp-2020r3-linux-amd64.tar.gz" \
+  curl -s -L "https://github.com/espressif/crosstool-NG/releases/download/esp-2021r1/xtensa-esp32s2-elf-gcc8_4_0-esp-2021r1-linux-amd64.tar.gz" \
   | tar -C xtensa-esp32s2-elf-gcc --strip-components 1 -xz
 
 RUN echo "ESP Binaries: 2021/06/01"


### PR DESCRIPTION
## Summary
Update the downloaded ESP Xtensa toolchain.  
This updates the MacOs version and the (unused, for the CI at least) Linux version.  The Linux version was actually pointing to an old RC.
## Impact
CI
## Testing
Tested the new toolchain version on MacOS.
