### PR TITLE
sched/signal: Correct kill with cancellation

### DIFF
--- a/sched/signal/sig_default.c
+++ b/sched/signal/sig_default.c
@@ -194,13 +194,6 @@ static void nxsig_abnormal_termination(int signo)
 {
   FAR struct tcb_s *rtcb = (FAR struct tcb_s *)this_task();
 
-  /* Notify the target if the non-cancelable or deferred cancellation set */
-
-  if (nxnotify_cancellation(rtcb))
-    {
-      return;
-    }
-
   /* Careful:  In the multi-threaded task, the signal may be handled on a
    * child pthread.
    */


### PR DESCRIPTION
## Summary
I find that the `kill` doesn't works with pthread cancellation for some workload (without any cancelable syscall) like
```
for(;;)
{
}
```
This patch execute exit routine directly.

## Impact
Should be none
## Testing
Tested with custom apps and ostest
