### PR TITLE
esp32_start.c: Initialize the SPI RAM before enabling its cache.

### DIFF
--- a/arch/xtensa/src/esp32/esp32_start.c
+++ b/arch/xtensa/src/esp32/esp32_start.c
@@ -201,7 +201,6 @@ static noreturn_function void __esp32_start(void)
   showprogress("A");
 
 #if defined(CONFIG_ESP32_SPIRAM_BOOT_INIT)
-  esp_spiram_init_cache();
   if (esp_spiram_init() != OK)
     {
 #  if defined(ESP32_SPIRAM_IGNORE_NOTFOUND)
@@ -209,6 +208,10 @@ static noreturn_function void __esp32_start(void)
 #  else
       PANIC();
 #  endif
+    }
+  else
+    {
+      esp_spiram_init_cache();
     }
 
   /* Set external memory bss section to zero */


### PR DESCRIPTION
## Summary
Initialize SPI RAM first and then, if that's successful, its cache.
## Impact
ESP32
## Testing

esp32-devkitc:psram