### PR TITLE
sched: Fix CPU affinity issues in SMP

### DIFF
--- a/sched/sched/sched_removereadytorun.c
+++ b/sched/sched/sched_removereadytorun.c
@@ -209,20 +209,16 @@ bool nxsched_remove_readytorun(FAR struct tcb_s *rtcb)
 
       if (rtrtcb != NULL && rtrtcb->sched_priority >= nxttcb->sched_priority)
         {
-          FAR struct tcb_s *tmptcb;
-
-          /* The TCB at the head of the ready to run list has the higher
-           * priority.  Remove that task from the head of the g_readytorun
+          /* The TCB rtrtcb has the higher priority and it can be run on
+           * target CPU. Remove that task (rtrtcb) from the g_readytorun
            * list and add to the head of the g_assignedtasks[cpu] list.
            */
 
-          tmptcb = (FAR struct tcb_s *)
-            dq_remfirst((FAR dq_queue_t *)&g_readytorun);
+          dq_rem((FAR dq_entry_t *)rtrtcb, (FAR dq_queue_t *)&g_readytorun);
+          dq_addfirst((FAR dq_entry_t *)rtrtcb, tasklist);
 
-          dq_addfirst((FAR dq_entry_t *)tmptcb, tasklist);
-
-          tmptcb->cpu = cpu;
-          nxttcb = tmptcb;
+          rtrtcb->cpu = cpu;
+          nxttcb = rtrtcb;
         }
 
       /* Will pre-emption be disabled after the switch?  If the lockcount is

--- a/sched/sched/sched_setpriority.c
+++ b/sched/sched/sched_setpriority.c
@@ -58,23 +58,22 @@ static FAR struct tcb_s *nxsched_nexttcb(FAR struct tcb_s *tcb)
 {
   FAR struct tcb_s *nxttcb = (FAR struct tcb_s *)tcb->flink;
   FAR struct tcb_s *rtrtcb;
-  int cpu = this_cpu();
 
   /* Which task should run next?  It will be either the next tcb in the
    * assigned task list (nxttcb) or a TCB in the g_readytorun list.  We can
    * only select a task from that list if the affinity mask includes the
-   * current CPU.
+   * tcb->cpu.
    *
    * If pre-emption is locked or another CPU is in a critical section,
    * then use the 'nxttcb' which will probably be the IDLE thread.
    */
 
-  if (!nxsched_islocked_global() && !irq_cpu_locked(cpu))
+  if (!nxsched_islocked_global() && !irq_cpu_locked(this_cpu()))
     {
-      /* Search for the highest priority task that can run on this CPU. */
+      /* Search for the highest priority task that can run on tcb->cpu. */
 
       for (rtrtcb = (FAR struct tcb_s *)g_readytorun.head;
-           rtrtcb != NULL && !CPU_ISSET(cpu, &rtrtcb->affinity);
+           rtrtcb != NULL && !CPU_ISSET(tcb->cpu, &rtrtcb->affinity);
            rtrtcb = (FAR struct tcb_s *)rtrtcb->flink);
 
       /* Return the TCB from the readyt-to-run list if it is the next


### PR DESCRIPTION
In "nxsched_nexttcb": the task may not running on this_cpu, and rtrtcb->affinity(the affinity of the task in g_readytorun) may not include the current cpu which should be the tcb->cpu.

In "nxsched_remove_readytorun": as the problem in "nxsched_nexttcb", the logical may choose the head of g_readytorun(the greatest priority) task as the next while ignoring the cpu affinity of it.