### PR TITLE
esp32-c3/esp32-s2: Fix the sequence of commands to set the alarm value on rt timer.

### DIFF
--- a/arch/risc-v/src/esp32c3/esp32c3_rt_timer.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_rt_timer.c
@@ -169,6 +169,7 @@ static void start_rt_timer(struct rt_timer_s *timer,
         {
           /* Reset the hardware timer alarm */
 
+          ESP32C3_TIM_SETALRM(priv->timer, false);
           ESP32C3_TIM_SETALRVL(priv->timer, USEC_TO_CYCLES(timer->alarm));
           ESP32C3_TIM_SETALRM(priv->timer, true);
         }
@@ -242,6 +243,7 @@ static void stop_rt_timer(struct rt_timer_s *timer)
                                         list);
               alarm = next_timer->alarm;
 
+              ESP32C3_TIM_SETALRM(priv->timer, false);
               ESP32C3_TIM_SETALRVL(priv->timer, USEC_TO_CYCLES(alarm));
               ESP32C3_TIM_SETALRM(priv->timer, true);
             }
@@ -463,6 +465,7 @@ static int rt_timer_isr(int irq, void *context, void *arg)
                                    struct rt_timer_s, list);
               alarm = timer->alarm;
 
+              ESP32C3_TIM_SETALRM(priv->timer, false);
               ESP32C3_TIM_SETALRVL(priv->timer, USEC_TO_CYCLES(alarm));
             }
         }

--- a/arch/xtensa/src/esp32s2/esp32s2_rt_timer.c
+++ b/arch/xtensa/src/esp32s2/esp32s2_rt_timer.c
@@ -176,6 +176,7 @@ static void start_rt_timer(struct rt_timer_s *timer,
         {
           /* Reset the hardware timer alarm */
 
+          ESP32S2_TIM_SETALRM(priv->timer, false);
           ESP32S2_TIM_SETALRVL(priv->timer, USEC_TO_CYCLES(timer->alarm));
           ESP32S2_TIM_SETALRM(priv->timer, true);
         }
@@ -254,6 +255,7 @@ static void stop_rt_timer(struct rt_timer_s *timer)
                                         list);
               alarm = next_timer->alarm;
 
+              ESP32S2_TIM_SETALRM(priv->timer, false);
               ESP32S2_TIM_SETALRVL(priv->timer, USEC_TO_CYCLES(alarm));
               ESP32S2_TIM_SETALRM(priv->timer, true);
             }
@@ -473,6 +475,8 @@ static int rt_timer_isr(int irq, void *context, void *arg)
               timer = container_of(priv->runlist.next,
                                    struct rt_timer_s, list);
               alarm = timer->alarm;
+
+              ESP32S2_TIM_SETALRM(priv->timer, false);
               ESP32S2_TIM_SETALRVL(priv->timer, USEC_TO_CYCLES(alarm));
             }
         }


### PR DESCRIPTION
## Summary

This PR:

1. Is intended to fix an issue manifested when using `rt_timer` clients with small intervals between their timeouts .
In this scenario, sometimes, when the alarm value was set, the counter had already surpassed it but the interrupt
was not triggered.
To solve it, the alarm was disabled before setting and re-enabled after.

## Impact

Fixes an issue.

## Testing

RT timer internal test.

