### PR TITLE
Use ethernet MAC programmed in imxrt OCOTP MAC0/MAC1 (teensy board)

### DIFF
--- a/arch/arm/src/imxrt/imxrt_enet.c
+++ b/arch/arm/src/imxrt/imxrt_enet.c
@@ -2560,6 +2560,28 @@ int imxrt_netinitialize(int intf)
   priv->dev.d_private = g_enet;         /* Used to recover private state from dev */
 
 #ifdef CONFIG_NET_ETHERNET
+
+#ifdef CONFIG_NET_USE_OTP_ETHERNET_MAC
+
+  /* Boards like the teensy have a unique (official)
+   * MAC address stored in OTP.
+   * TODO: hardcoded mem locations: use proper registers and header file
+   * offsets: 0x620: MAC0, 0x630: MAC1
+   */
+
+  uidl   = getreg32(IMXRT_OCOTP_BASE + 0x620);
+  uidml  = getreg32(IMXRT_OCOTP_BASE + 0x630);
+  mac    = priv->dev.d_mac.ether.ether_addr_octet;
+
+  mac[0] = (uidml & 0x0000ff00) >> 8;
+  mac[1] = (uidml & 0x000000ff) >> 0;
+  mac[2] = (uidl & 0xff000000) >> 24;
+  mac[3] = (uidl & 0x00ff0000) >> 16;
+  mac[4] = (uidl & 0x0000ff00) >> 8;
+  mac[5] = (uidl & 0x000000ff) >> 0;
+
+#else
+
   /* Determine a semi-unique MAC address from MCU UID
    * We use UID Low and Mid Low registers to get 64 bits, from which we keep
    * 48 bits.  We then force unicast and locally administered bits
@@ -2581,6 +2603,9 @@ int imxrt_netinitialize(int intf)
   mac[3] = (uidl &  0x00ff0000) >> 16;
   mac[4] = (uidl &  0x0000ff00) >> 8;
   mac[5] = (uidl &  0x000000ff);
+
+#endif
+
 #endif
 
 #ifdef CONFIG_IMXRT_ENET_PHYINIT

--- a/boards/arm/imxrt/teensy-4.x/Kconfig
+++ b/boards/arm/imxrt/teensy-4.x/Kconfig
@@ -30,4 +30,13 @@ config IMXRT_FLEXCAN3_AS_CAN0
 		This configuration option ensures that if more that one CAN bus is set on
 		that CAN 3 (with FD capability) will be initialized as can0.
 
+config NET_USE_OTP_ETHERNET_MAC
+	bool "Use Ethernet MAC address stored in OCOTP_MAC0 and OCOTP_MAC1"
+	---help---
+		The teensy 4.1 board has an "offical" unique MAC address stored in OCOTP (One-Time-Programmable) memory.
+		When enabling this option, it is read and used when the ethernet peripheral is initialized.
+		If so, the 'ifconfig  eth0' HWaddr should start with 04:e9:e5:...
+		(the vendor ID of 'PJRC.COM, LLC') when this feature is enabled.
+		It may also be used with other boards that have the OCOTP programmed with a valid MAC.
+
 endif


### PR DESCRIPTION

## Summary

This PR makes it possible to use the MAC address that is stored in the OCOTP memory (if programmed) for the imxrt Teensy board.

## Impact

Adds a config flag in the Teensy board menu to enable the use of the OCOTP MAC address. Other boards are not affected.

## Testing

When enabling the option CONFIG_NET_USE_OTP_ETHERNET_MAC the Ethernet  MAC address should begin with 04:e9:e5
When disabling the option, a (semi-random) unicast and locally administered address should be assigned as Ethernet MAC address.

