### PR TITLE
feat: driver: support double buffer for display

### DIFF
--- a/drivers/video/fb.c
+++ b/drivers/video/fb.c
@@ -554,6 +554,17 @@ static int fb_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
         }
         break;
 
+      case FBIOPAN_DISPLAY:
+        {
+          FAR struct fb_planeinfo_s *pinfo =
+            (FAR struct fb_planeinfo_s *)((uintptr_t)arg);
+
+          DEBUGASSERT(pinfo != NULL && fb->vtable != NULL &&
+                      fb->vtable->pandisplay != NULL);
+          ret = fb->vtable->pandisplay(fb->vtable, pinfo);
+        }
+        break;
+
       default:
         gerr("ERROR: Unsupported IOCTL command: %d\n", cmd);
         ret = -ENOTTY;

--- a/include/nuttx/video/fb.h
+++ b/include/nuttx/video/fb.h
@@ -283,6 +283,10 @@
 #define FBIOGET_FRAMERATE     _FBIOC(0x0015)  /* Get frame rate
                                                * Argument:            int* */
 
+#define FBIOPAN_DISPLAY       _FBIOC(0x0016)  /* Pan display
+                                               * Argument: read-only struct
+                                               *           fb_planeinfo_s* */
+
 /****************************************************************************
  * Public Types
  ****************************************************************************/
@@ -315,11 +319,15 @@ struct fb_videoinfo_s
 
 struct fb_planeinfo_s
 {
-  FAR void  *fbmem;       /* Start of frame buffer memory */
-  size_t     fblen;       /* Length of frame buffer memory in bytes */
-  fb_coord_t stride;      /* Length of a line in bytes */
-  uint8_t    display;     /* Display number */
-  uint8_t    bpp;         /* Bits per pixel */
+  FAR void  *fbmem;        /* Start of frame buffer memory */
+  size_t     fblen;        /* Length of frame buffer memory in bytes */
+  fb_coord_t stride;       /* Length of a line in bytes */
+  uint8_t    display;      /* Display number */
+  uint8_t    bpp;          /* Bits per pixel */
+  uint32_t   xres_virtual; /* Virtual Horizontal resolution in pixel columns */
+  uint32_t   yres_virtual; /* Virtual Vertical resolution in pixel rows */
+  uint32_t   xoffset;      /* Offset from virtual to visible resolution */
+  uint32_t   yoffset;      /* Offset from virtual to visible resolution */
 };
 
 /* This structure describes an area. */
@@ -583,6 +591,11 @@ struct fb_vtable_s
                FAR const struct fb_overlayblend_s *blend);
 # endif
 #endif
+
+  /* Pan display for multiple buffers. */
+
+  int (*pandisplay)(FAR struct fb_vtable_s *vtable,
+                    FAR struct fb_planeinfo_s *pinfo);
 
   /* Specific Controls ******************************************************/
 


### PR DESCRIPTION
## Summary
This PR is to support multiple buffers, like doube buffer. Reference linux kernel fbmem implement.
reference links:
https://github.com/torvalds/linux/blob/master/drivers/video/fbdev/core/fbmem.c
https://github.com/torvalds/linux/blob/master/drivers/video/fbdev/goldfishfb.c
## Impact
This PR will not affect the manufacturer's adaptation which has been implement.
It just provides one more interface for multiple buffer.
## Testing
It has been verified on the chip of our project.
