### PR TITLE
S32K1XX arch: gpioread may also be used for output pins

### DIFF
--- a/arch/arm/src/s32k1xx/s32k1xx_pingpio.c
+++ b/arch/arm/src/s32k1xx/s32k1xx_pingpio.c
@@ -96,7 +96,6 @@ bool s32k1xx_gpioread(uint32_t pinset)
   bool         ret = false;
 
   DEBUGASSERT((pinset & _PIN_MODE_MASK) == _PIN_MODE_GPIO);
-  DEBUGASSERT((pinset & _PIN_IO_MASK) == _PIN_INPUT);
 
   /* Get the port number and pin number */
 


### PR DESCRIPTION
## Summary
The s32k1xx_gpioread function contains a DEBUGASSERT that checks if the pin from which the logic level is to be read is actually an **input** pin. However, on S32K1XX the Port Data Input Register may also be accessed for pins that are configured as an **output**, so this check is not needed. Without this check it becomes possible to use s32k1xx_gpioread to check if the pin actually has the desired output state, which is a nice feature.

## Impact
N/A

## Testing
N/A
