### PR TITLE
esp32/esp32c3_rng.c: Remove unused functions.

### DIFF
--- a/arch/risc-v/src/esp32c3/esp32c3_rng.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_rng.c
@@ -222,7 +222,7 @@ void devurandom_register(void)
 #ifndef CONFIG_DEV_RANDOM
   esp32c3_rng_initialize();
 #endif
-  register_driver("dev/urandom", &g_rngops, 0444, NULL);
+  register_driver("/dev/urandom", &g_rngops, 0444, NULL);
 }
 #endif
 

--- a/arch/xtensa/src/esp32/esp32_rng.c
+++ b/arch/xtensa/src/esp32/esp32_rng.c
@@ -128,15 +128,6 @@ uint32_t IRAM_ATTR esp_random(void)
 
 static int esp32_rng_initialize(void)
 {
-  static bool first_flag = true;
-
-  if (false == first_flag)
-    {
-      return OK;
-    }
-
-  first_flag = false;
-
   _info("Initializing RNG\n");
 
   memset(&g_rngdev, 0, sizeof(struct rng_dev_s));

--- a/arch/xtensa/src/esp32/esp32_rng.c
+++ b/arch/xtensa/src/esp32/esp32_rng.c
@@ -222,7 +222,7 @@ void devurandom_register(void)
 #ifndef CONFIG_DEV_RANDOM
   esp32_rng_initialize();
 #endif
-  register_driver("dev/urandom", &g_rngops, 0444, NULL);
+  register_driver("/dev/urandom", &g_rngops, 0444, NULL);
 }
 #endif
 


### PR DESCRIPTION
## Summary
- Remove unused functions in esp32_rng.c and esp32c_rng.c
- Remove an initialization gaurd from esp32_rng.c
## Impact
ESP32 and ESP32-C3 RNG driver
## Testing
Building ESP32 and ESP32-C3 defconfigs
