### PR TITLE
bcm43xxx: wrong devif_timer() invocations and sporadic stalls of TX poll timer

### DIFF
--- a/drivers/wireless/ieee80211/bcm43xxx/bcmf_driver.h
+++ b/drivers/wireless/ieee80211/bcm43xxx/bcmf_driver.h
@@ -66,6 +66,7 @@ struct bcmf_dev_s
   bool bc_bifup;             /* true:ifup false:ifdown */
   struct wdog_s bc_txpoll;   /* TX poll timer */
   struct work_s bc_irqwork;  /* For deferring interrupt work to the work queue */
+  struct work_s bc_rxwork;   /* For deferring rx work to the work queue */
   struct work_s bc_pollwork; /* For deferring poll work to the work queue */
 
   /* This holds the information visible to the NuttX network */


### PR DESCRIPTION
## Summary

- Fixed an issue with wrong devif_timer() invocations on bcmf_netdev_notify_tx_done events that provoked massive TCP spurious retransmissions;

- Fixed an issue with sporadic stalls of TX poll timer.

## Impact

bcm43xxx driver
Photon board
EMW3162 board