### PR TITLE
Userled driver: Rename functions to make it more consistent and avoid confusion

### DIFF
--- a/drivers/leds/userled_lower.c
+++ b/drivers/leds/userled_lower.c
@@ -40,9 +40,9 @@
 
 static userled_set_t
 userled_supported(FAR const struct userled_lowerhalf_s *lower);
-static void userled_led(FAR const struct userled_lowerhalf_s *lower,
-                        int led, bool ledon);
-static void userled_ledset(FAR const struct userled_lowerhalf_s *lower,
+static void userled_setled(FAR const struct userled_lowerhalf_s *lower,
+                           int led, bool ledon);
+static void userled_setall(FAR const struct userled_lowerhalf_s *lower,
                            userled_set_t ledset);
 
 /****************************************************************************
@@ -56,8 +56,8 @@ static uint32_t g_lednum;
 static const struct userled_lowerhalf_s g_userled_lower =
 {
   .ll_supported = userled_supported,
-  .ll_led       = userled_led,
-  .ll_ledset    = userled_ledset,
+  .ll_setled    = userled_setled,
+  .ll_setall    = userled_setall,
 };
 
 /****************************************************************************
@@ -80,28 +80,28 @@ userled_supported(FAR const struct userled_lowerhalf_s *lower)
 }
 
 /****************************************************************************
- * Name: userled_led
+ * Name: userled_setled
  *
  * Description:
  *   Set the current state of one LED
  *
  ****************************************************************************/
 
-static void userled_led(FAR const struct userled_lowerhalf_s *lower,
-                        int led, bool ledon)
+static void userled_setled(FAR const struct userled_lowerhalf_s *lower,
+                           int led, bool ledon)
 {
   board_userled(led, ledon);
 }
 
 /****************************************************************************
- * Name: userled_led
+ * Name: userled_setall
  *
  * Description:
  *   Set the state of all LEDs
  *
  ****************************************************************************/
 
-static void userled_ledset(FAR const struct userled_lowerhalf_s *lower,
+static void userled_setall(FAR const struct userled_lowerhalf_s *lower,
                            userled_set_t ledset)
 {
   board_userled_all(ledset);

--- a/drivers/leds/userled_upper.c
+++ b/drivers/leds/userled_upper.c
@@ -316,8 +316,8 @@ static ssize_t userled_write(FAR struct file *filep, FAR const char *buffer,
   /* Read and return the current state of the LEDs */
 
   lower = priv->lu_lower;
-  DEBUGASSERT(lower && lower->ll_ledset);
-  lower->ll_ledset(lower, ledset);
+  DEBUGASSERT(lower && lower->ll_setall);
+  lower->ll_setall(lower, ledset);
 
   userled_givesem(&priv->lu_exclsem);
   return (ssize_t)sizeof(userled_set_t);
@@ -416,8 +416,8 @@ static int userled_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
                 /* Set the LED state */
 
                 lower = priv->lu_lower;
-                DEBUGASSERT(lower != NULL && lower->ll_led != NULL);
-                lower->ll_led(lower, led, ledon);
+                DEBUGASSERT(lower != NULL && lower->ll_setled != NULL);
+                lower->ll_setled(lower, led, ledon);
                 ret = OK;
               }
           }
@@ -446,8 +446,8 @@ static int userled_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
             /* Set the new LED state */
 
             lower = priv->lu_lower;
-            DEBUGASSERT(lower != NULL && lower->ll_led != NULL);
-            lower->ll_ledset(lower, ledset);
+            DEBUGASSERT(lower != NULL && lower->ll_setall != NULL);
+            lower->ll_setall(lower, ledset);
             ret = OK;
           }
       }
@@ -536,9 +536,9 @@ int userled_register(FAR const char *devname,
   DEBUGASSERT(lower && lower->ll_supported);
   priv->lu_supported = lower->ll_supported(lower);
 
-  DEBUGASSERT(lower && lower->ll_ledset);
+  DEBUGASSERT(lower && lower->ll_setall);
   priv->lu_ledset = 0;
-  lower->ll_ledset(lower, priv->lu_ledset);
+  lower->ll_setall(lower, priv->lu_ledset);
 
   /* And register the LED driver */
 

--- a/include/nuttx/leds/userled.h
+++ b/include/nuttx/leds/userled.h
@@ -65,7 +65,7 @@
 #define ULEDIOC_SETALL     _ULEDIOC(0x0003)
 
 /* Command:     ULEDIOC_GETALL
- * Description: Get the state of one LED.
+ * Description: Get the state of all LEDs.
  * Argument:    A write-able pointer to a userled_set_t memory location in
  *              which to return the LED state.
  * Return:      Zero (OK) on success.  Minus one will be returned on failure
@@ -119,12 +119,12 @@ struct userled_lowerhalf_s
 
   /* Set the current state of one LED */
 
-  CODE void (*ll_led)(FAR const struct userled_lowerhalf_s *lower,
-                      int led, bool ledon);
+  CODE void (*ll_setled)(FAR const struct userled_lowerhalf_s *lower,
+                         int led, bool ledon);
 
   /* Set the state of all LEDs */
 
-  CODE void (*ll_ledset)(FAR const struct userled_lowerhalf_s *lower,
+  CODE void (*ll_setall)(FAR const struct userled_lowerhalf_s *lower,
                          userled_set_t ledset);
 };
 


### PR DESCRIPTION
## Summary
As discussed in the comments of #4635 with @acassis, the naming between the userled interface and drivers is not consistent. This PR aims to make this all a little less confusing by renaming some functions to keep them consistent with the naming of the IOCTL commands defined in include/nuttx/leds/userled.h.

## Impact
This should not change any functionality.

## Testing
Verified that this PR does not break anything by running the LED driver example application on an S32K144EVB board.
