### PR TITLE
S32K1xx arch: Add (optional) support for SPI native/hardware chip select

### DIFF
--- a/arch/arm/src/s32k1xx/Kconfig
+++ b/arch/arm/src/s32k1xx/Kconfig
@@ -624,6 +624,10 @@ menu "LPSPI Configuration"
 config S32K1XX_LPSPI_DWORD
 	bool "DWORD up to 64 bit transfer support"
 	default n
+
+config S32K1XX_LPSPI_HWPCS
+	bool "Use native hardware peripheral chip selects instead of GPIO pins"
+	default n
 	
 endmenu # LPSPI Configuration
 

--- a/arch/arm/src/s32k1xx/hardware/s32k1xx_lpspi.h
+++ b/arch/arm/src/s32k1xx/hardware/s32k1xx_lpspi.h
@@ -299,6 +299,7 @@
 #    define LPSPI_TCR_MSBF             (0 << 23) /* MSB First */
 #define LPSPI_TCR_PCS_SHIFT            (24)      /* Bits 24-25: Peripheral Chip Select */
 #define LPSPI_TCR_PCS_MASK             (3 << LPSPI_TCR_PCS_SHIFT)
+#    define LPSPI_TCR_PCS(n)           (((n) << LPSPI_TCR_PCS_SHIFT) & LPSPI_TCR_PCS_MASK)
 #    define LPSPI_TCR_PCS_0            (0 << LPSPI_TCR_PCS_SHIFT)  /* Transfer using LPSPI_PCS[0] */
 #    define LPSPI_TCR_PCS_1            (1 << LPSPI_TCR_PCS_SHIFT)  /* Transfer using LPSPI_PCS[1] */
 #    define LPSPI_TCR_PCS_2            (2 << LPSPI_TCR_PCS_SHIFT)  /* Transfer using LPSPI_PCS[2] */


### PR DESCRIPTION
## Summary
Adds an option to use native SPI chip selects instead of the software implementation using GPIO (which is more or less the standard in NuttX). This is specifically for the LPSPI peripherals on S32K1XX. With CONFIG_S32K1XX_LPSPI_HWPCS enabled, it is no longer needed to have board-specific logic for SPI chip selects. There is now a generic implementation of the s32k1xx_lpspiNselect functions that only allows switching between devices, but leaves control of the chip selects pins to the LPSPI peripheral.

## Impact
Specific for S32K1xx arch. It is disabled by default, so it does not affect existing configurations.

## Testing
Tested with RDDRONE-BMS772 board (configuration is not available yet in upstream NuttX), which has similarities with the S32K144EVB and contains an System Basis Chip and a Battery Cell Controller that are both accessible over SPI.
