### PR TITLE
Added reset code to teensy4 to compile with CONFIG_BOARDCTL_RESET

### DIFF
--- a/boards/arm/imxrt/teensy-4.x/src/Makefile
+++ b/boards/arm/imxrt/teensy-4.x/src/Makefile
@@ -28,6 +28,10 @@ else ifeq ($(CONFIG_BOARD_LATE_INITIALIZE),y)
 CSRCS += imxrt_bringup.c
 endif
 
+ifeq ($(CONFIG_BOARDCTL_RESET),y)
+CSRCS += imxrt_reset.c
+endif
+
 ifeq ($(CONFIG_ARCH_LEDS),y)
 CSRCS += imxrt_autoleds.c
 else
@@ -69,5 +73,7 @@ endif
 ifeq ($(CONFIG_IMXRT_ENC),y)
 CSRCS += imxrt_enc.c
 endif
+
+
 
 include $(TOPDIR)/boards/Board.mk

--- a/boards/arm/imxrt/teensy-4.x/src/imxrt_reset.c
+++ b/boards/arm/imxrt/teensy-4.x/src/imxrt_reset.c
@@ -1,0 +1,61 @@
+/****************************************************************************
+ * boards/arm/imxrt/teensy-4.x/src/imxrt_reset.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+#include <nuttx/board.h>
+#include <nuttx/arch.h>
+
+#ifdef CONFIG_BOARDCTL_RESET
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: board_reset
+ *
+ * Description:
+ *   Reset board.  Support for this function is required by board-level
+ *   logic if CONFIG_BOARDCTL_RESET is selected.
+ *
+ * Input Parameters:
+ *   status - Status information provided with the reset event.  This
+ *            meaning of this status information is board-specific.  If not
+ *            used by a board, the value zero may be provided in calls to
+ *            board_reset().
+ *
+ * Returned Value:
+ *   If this function returns, then it was not possible to power-off the
+ *   board due to some constraints.  The return value int this case is a
+ *   board-specific reason for the failure to shutdown.
+ *
+ ****************************************************************************/
+
+int board_reset(int status)
+{
+  up_systemreset();
+  return 0;
+}
+
+#endif /* CONFIG_BOARDCTL_RESET */


### PR DESCRIPTION

## Summary

Added (boilerplate) reset source code  code to teensy4 board to compile with ```CONFIG_BOARDCTL_RESET```

## Impact

Enabling ```CONFIG_BOARDCTL_RESET```  does not lead to a link failure anymore for the teensy board.
Other boards are not affected. If the ```CONFIG_BOARDCTL_RESET``` is not enabled, there should be no change 
to the system.

## Testing

Enable ```CONFIG_BOARDCTL_RESET``` and try the ```reboot``` command in ```nsh```  This should reboot the device.