### PR TITLE
net/tcp(unbuffered): fixed an issue with unackseq calculation.

### DIFF
--- a/net/tcp/tcp_input.c
+++ b/net/tcp/tcp_input.c
@@ -694,7 +694,7 @@ found:
 #ifdef CONFIG_NET_TCP_WRITE_BUFFERS
       unackseq = conn->sndseq_max;
 #else
-      unackseq = tcp_addsequence(conn->sndseq, conn->tx_unacked);
+      unackseq = tcp_getsequence(conn->sndseq);
 #endif
 
       /* Get the sequence number of that has just been acknowledged by this


### PR DESCRIPTION
## Summary

Fixed an issue with TCP unackseq calculation.

Wrong unackseq calculation locked conn->tx_unacked at non-zero values
even if all ACKs were received. Thus unbuffered psock_tcp_send() never completed.

This PR is partially related to #4293.

## Impact

TCP