### PR TITLE
net/tcp(unbuffered): retransmit only one the earliest not acknowledged segment

### DIFF
--- a/net/tcp/tcp.h
+++ b/net/tcp/tcp.h
@@ -172,6 +172,9 @@ struct tcp_conn_s
   uint8_t  rcvseq[4];     /* The sequence number that we expect to
                            * receive next */
   uint8_t  sndseq[4];     /* The sequence number that was last sent by us */
+#if !defined(CONFIG_NET_TCP_WRITE_BUFFERS)
+  uint32_t rexmit_seq;    /* The sequence number to be retrasmitted */
+#endif
   uint8_t  crefs;         /* Reference counts on this instance */
 #if defined(CONFIG_NET_IPv4) && defined(CONFIG_NET_IPv6)
   uint8_t  domain;        /* IP domain: PF_INET or PF_INET6 */

--- a/net/tcp/tcp_appsend.c
+++ b/net/tcp/tcp_appsend.c
@@ -316,7 +316,23 @@ void tcp_rexmit(FAR struct net_driver_s *dev, FAR struct tcp_conn_s *conn,
 #ifdef CONFIG_NET_TCP_WRITE_BUFFERS
   if (dev->d_sndlen > 0)
 #else
-  if (dev->d_sndlen > 0 && conn->tx_unacked > 0)
+  if ((result & TCP_REXMIT) != 0 &&
+      dev->d_sndlen > 0 && conn->tx_unacked > 0)
+    {
+      uint32_t saveseq;
+
+      /* According to RFC 6298 (5.4), retransmit the earliest segment
+       * that has not been acknowledged by the TCP receiver.
+       */
+
+      saveseq = tcp_getsequence(conn->sndseq);
+      tcp_setsequence(conn->sndseq, conn->rexmit_seq);
+
+      tcp_send(dev, conn, TCP_ACK | TCP_PSH, dev->d_sndlen + hdrlen);
+
+      tcp_setsequence(conn->sndseq, saveseq);
+    }
+  else if (dev->d_sndlen > 0 && conn->tx_unacked > 0)
 #endif
     {
       uint32_t seq;


### PR DESCRIPTION
## Summary

As it turned out, the existing TCP unbuffered send implementation does a full rewind from the most recent sent segment back to the earliest not acknowledged one, thus many TCP segments are re-sent every time when TCP retrasmission timeout occurs.

According to RFC 6298 (5.4) only one the earliest not acknowledged segment should be retransmitted instead.

This PR implements TCP retrasmission according to RFC 6298 (5.4) ~if CONFIG_NET_TCP_SPLIT is disabled (this is by default).
If CONFIG_NET_TCP_SPLIT is enabled, TCP retrasmission works as before (full rewind). So far it is not clear how to adapt CONFIG_NET_TCP_SPLIT algorithm to conform to RFC 6298 (5.4).~ (CONFIG_NET_TCP_SPLIT is already removed by PR #4660).

## Impact

TCP

## Testing