### PR TITLE
Minor patch to fix the compiler issue in fs/aio and sched/sporadic

### DIFF
--- a/fs/aio/aio_read.c
+++ b/fs/aio/aio_read.c
@@ -31,6 +31,7 @@
 #include <errno.h>
 #include <debug.h>
 
+#include <nuttx/fs/fs.h>
 #include <nuttx/net/net.h>
 
 #include "aio/aio.h"

--- a/fs/aio/aio_write.c
+++ b/fs/aio/aio_write.c
@@ -33,6 +33,8 @@
 #include <errno.h>
 #include <debug.h>
 
+#include <nuttx/fs/fs.h>
+
 #include "aio/aio.h"
 
 #ifdef CONFIG_FS_AIO
@@ -118,7 +120,7 @@ static void aio_write_worker(FAR void *arg)
 
   if (nwritten < 0)
     {
-      ferr("ERROR: write/pwrite/send failed: %d\n", nwritten);
+      ferr("ERROR: write/pwrite/send failed: %zd\n", nwritten);
     }
 
   /* Save the result of the write */

--- a/libs/libc/aio/lio_listio.c
+++ b/libs/libc/aio/lio_listio.c
@@ -28,6 +28,7 @@
 #include <signal.h>
 #include <aio.h>
 #include <assert.h>
+#include <debug.h>
 #include <errno.h>
 
 #include <nuttx/signal.h>

--- a/sched/sched/sched_sporadic.c
+++ b/sched/sched/sched_sporadic.c
@@ -136,7 +136,7 @@ static int sporadic_set_lowpriority(FAR struct tcb_s *tcb)
        * state.
        */
 
-      tcb->base_priority = tcb->low_priority;
+      tcb->base_priority = sporadic->low_priority;
     }
   else
 #endif


### PR DESCRIPTION
## Summary

- Fix error: 'struct tcb_s' has no member named 'low_priority' 
- fs/aio: Fix compile warning 

## Impact
Fix compiler error and warning.

## Testing
ostest
