### PR TITLE
arch/arm: Add l suffix for INT32_C macro

### DIFF
--- a/arch/arm/include/inttypes.h
+++ b/arch/arm/include/inttypes.h
@@ -108,7 +108,7 @@
 
 #define INT8_C(x)   x
 #define INT16_C(x)  x
-#define INT32_C(x)  x
+#define INT32_C(x)  x ## l
 #define INT64_C(x)  x ## ll
 
 #define UINT8_C(x)  x


### PR DESCRIPTION
## Summary
since int32_t typedef to signed long, fix the error reported by https://github.com/apache/incubator-nuttx-apps/pull/872

## Impact
INT32_C caller

## Testing
https://github.com/apache/incubator-nuttx-apps/pull/872 pass CI.
