### PR TITLE
stm32h7 sdmmc: added missing sdio_set_sdio_card_isr() function to initialize SDIO in-band interrupt logic

### DIFF
--- a/arch/arm/src/stm32h7/stm32_sdmmc.c
+++ b/arch/arm/src/stm32h7/stm32_sdmmc.c
@@ -1981,6 +1981,10 @@ static void stm32_reset(FAR struct sdio_dev_s *dev)
   priv->remaining  = 0;      /* Number of bytes remaining in the transfer */
   priv->xfrmask    = 0;      /* Interrupt enables for data transfer */
 
+#ifdef HAVE_SDMMC_SDIO_MODE
+  priv->sdiointmask = 0;     /* SDIO card in-band interrupt mask */
+#endif
+
   priv->widebus    = false;
 
   /* Configure the SDIO peripheral */
@@ -3623,4 +3627,44 @@ void sdio_wrprotect(FAR struct sdio_dev_s *dev, bool wrprotect)
   mcinfo("cdstatus: %02" PRIx8 "\n", priv->cdstatus);
   leave_critical_section(flags);
 }
+
+/****************************************************************************
+ * Name: sdio_set_sdio_card_isr
+ *
+ * Description:
+ *   SDIO card generates interrupt via SDIO_DATA_1 pin.
+ *   Called by board-specific logic to register an ISR for SDIO card.
+ *
+ * Input Parameters:
+ *   func      - callback function.
+ *   arg       - arg to be passed to the function.
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+#ifdef HAVE_SDMMC_SDIO_MODE
+void sdio_set_sdio_card_isr(FAR struct sdio_dev_s *dev,
+                            int (*func)(void *), void *arg)
+{
+  struct stm32_dev_s *priv = (struct stm32_dev_s *)dev;
+
+  priv->do_sdio_card = func;
+
+  if (func != NULL)
+    {
+      priv->sdiointmask = STM32_SDMMC_MASK_SDIOITIE;
+      priv->do_sdio_arg = arg;
+    }
+  else
+    {
+      priv->sdiointmask = 0;
+    }
+
+  sdmmc_putreg32(priv, priv->xfrmask | priv->waitmask | priv->sdiointmask,
+                 STM32_SDMMC_MASK_OFFSET);
+}
+#endif
+
 #endif /* CONFIG_STM32H7_SDMMC1 || CONFIG_STM32H7_SDMMC2 */

--- a/arch/arm/src/stm32h7/stm32_sdmmc.h
+++ b/arch/arm/src/stm32h7/stm32_sdmmc.h
@@ -104,6 +104,27 @@ void sdio_mediachange(FAR struct sdio_dev_s *dev, bool cardinslot);
 
 void sdio_wrprotect(FAR struct sdio_dev_s *dev, bool wrprotect);
 
+/****************************************************************************
+ * Name: sdio_set_sdio_card_isr
+ *
+ * Description:
+ *   SDIO card generates interrupt via SDIO_DATA_1 pin.
+ *   Called by board-specific logic to register an ISR for SDIO card.
+ *
+ * Input Parameters:
+ *   func      - callback function.
+ *   arg       - arg to be passed to the function.
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+#if defined(CONFIG_SDMMC1_SDIO_MODE) || defined(CONFIG_SDMMC2_SDIO_MODE)
+void sdio_set_sdio_card_isr(FAR struct sdio_dev_s *dev,
+                            int (*func)(void *), void *arg);
+#endif
+
 #undef EXTERN
 #if defined(__cplusplus)
 }


### PR DESCRIPTION
## Summary

stm32h7 sdmmc: added missing sdio_set_sdio_card_isr() function to initialize SDIO in-band interrupt logic (similar to stm32/stm32_sdio.c and stm32f7/stm32_sdmmc.c).

## Impact
stm32h7 sdmmc driver

## Testing