### PR TITLE
mm: do kmm_checkcorruption in IRQ when TCB_FLAG_DEBUG_CHECK set

### DIFF
--- a/include/nuttx/sched.h
+++ b/include/nuttx/sched.h
@@ -108,7 +108,8 @@
 #define TCB_FLAG_SYSCALL           (1 << 10)                     /* Bit 9: In a system call */
 #define TCB_FLAG_EXIT_PROCESSING   (1 << 11)                     /* Bit 10: Exitting */
 #define TCB_FLAG_FREE_STACK        (1 << 12)                     /* Bit 12: Free stack after exit */
-                                                                 /* Bits 13-15: Available */
+#define TCB_FLAG_MEM_CHECK         (1 << 13)                     /* Bit 13: Memory check */
+                                                                 /* Bits 14-15: Available */
 
 /* Values for struct task_group tg_flags */
 

--- a/sched/irq/irq_dispatch.c
+++ b/sched/irq/irq_dispatch.c
@@ -27,6 +27,7 @@
 #include <debug.h>
 #include <nuttx/arch.h>
 #include <nuttx/irq.h>
+#include <nuttx/mm/mm.h>
 #include <nuttx/random.h>
 #include <nuttx/sched_note.h>
 
@@ -182,6 +183,14 @@ void irq_dispatch(int irq, FAR void *context)
   /* Notify that we are leaving from the interrupt handler */
 
   sched_note_irqhandler(irq, vector, false);
+#endif
+
+#ifdef CONFIG_DEBUG_MM
+  if ((g_running_tasks[this_cpu()]->flags & TCB_FLAG_MEM_CHECK) || \
+       (this_task()->flags & TCB_FLAG_MEM_CHECK))
+    {
+      kmm_checkcorruption();
+    }
 #endif
 
   /* Record the new "running" task.  g_running_tasks[] is only used by


### PR DESCRIPTION
## Summary

mm: do kmm_checkcorruption in IRQ when TCB_FLAG_DEBUG_CHECK set

This is used for memory corruption check, when "this_task" or  "g_running_tasks" thread flags TCB_FLAG_DEBUG_CHECK set,  then scheduler will check memory blocks in IRQ.

For example:

thread 15 set TCB_FLAG_DEBUG_CHECK:

thread14                         thread 15 overwrite                     thread 16
                  IRQ&switch                                  IRQ&switch
                                                                        checked overwrite

## Impact

Debug method

## Testing

