### PR TITLE
socket rpmsg related bug fix & update

### DIFF
--- a/drivers/rptun/Kconfig
+++ b/drivers/rptun/Kconfig
@@ -21,7 +21,11 @@ config RPTUN_STACKSIZE
 	default DEFAULT_TASK_STACKSIZE
 
 config RPTUN_LOADER
-        bool "rptun loader support"
-        default n
+	bool "rptun loader support"
+	default n
+
+config RPTUN_LOCAL_CPUNAME
+	string "rptun local cpuname"
+	default LIBC_HOSTNAME
 
 endif # RPTUN

--- a/include/netpacket/rpmsg.h
+++ b/include/netpacket/rpmsg.h
@@ -32,7 +32,7 @@
  ****************************************************************************/
 
 #define RPMSG_SOCKET_CPU_SIZE           16
-#define RPMSG_SOCKET_NAME_SIZE          32
+#define RPMSG_SOCKET_NAME_SIZE          16
 
 /****************************************************************************
  * Public Type Definitions

--- a/net/rpmsg/rpmsg_sockif.c
+++ b/net/rpmsg/rpmsg_sockif.c
@@ -1144,7 +1144,7 @@ static ssize_t rpmsg_socket_recvmsg(FAR struct socket *psock,
   FAR struct rpmsg_socket_conn_s *conn = psock->s_conn;
   ssize_t ret;
 
-  if (psock->s_type == SOCK_DGRAM && _SS_ISBOUND(psock->s_flags)
+  if (psock->s_type != SOCK_STREAM && _SS_ISBOUND(psock->s_flags)
           && !_SS_ISCONNECTED(psock->s_flags))
     {
       ret = rpmsg_socket_connect_internal(psock);
@@ -1161,7 +1161,7 @@ static ssize_t rpmsg_socket_recvmsg(FAR struct socket *psock,
 
   rpmsg_socket_lock(&conn->recvlock);
 
-  if (psock->s_type == SOCK_DGRAM)
+  if (psock->s_type != SOCK_STREAM)
     {
       uint32_t datalen;
 

--- a/net/rpmsg/rpmsg_sockif.c
+++ b/net/rpmsg/rpmsg_sockif.c
@@ -52,6 +52,9 @@
 #define RPMSG_SOCKET_CMD_DATA       2
 #define RPMSG_SOCKET_NAME_PREFIX    "rpmsg-socket"
 
+static_assert(RPMSG_SOCKET_NAME_SIZE + 13 <= RPMSG_NAME_SIZE,
+              "socket name size should NOT bigger then RPMSG_NAME_SIZE");
+
 /****************************************************************************
  * Private Types
  ****************************************************************************/
@@ -407,7 +410,7 @@ static void rpmsg_socket_device_created(FAR struct rpmsg_device *rdev,
                                         FAR void *priv)
 {
   FAR struct rpmsg_socket_conn_s *conn = priv;
-  char buf[RPMSG_SOCKET_NAME_SIZE];
+  char buf[RPMSG_NAME_SIZE];
 
   if (conn->ept.rdev)
     {
@@ -457,7 +460,7 @@ static void rpmsg_socket_ns_bind(FAR struct rpmsg_device *rdev,
   FAR struct rpmsg_socket_conn_s *server = priv;
   FAR struct rpmsg_socket_conn_s *tmp;
   FAR struct rpmsg_socket_conn_s *new;
-  char buf[RPMSG_SOCKET_NAME_SIZE];
+  char buf[RPMSG_NAME_SIZE];
   int cnt = 0;
   int ret;
 

--- a/openamp/0005-rpmsg-notify-the-user-when-the-remote-address-is-rec.patch
+++ b/openamp/0005-rpmsg-notify-the-user-when-the-remote-address-is-rec.patch
@@ -1,0 +1,68 @@
+From 9ebf24a656b42d262e66a96b237cabb15508f4ea Mon Sep 17 00:00:00 2001
+From: ligd <liguiding1@xiaomi.com>
+Date: Tue, 19 Oct 2021 19:45:14 +0800
+Subject: [PATCH 1/2] rpmsg: notify the user when the remote address is
+ received
+
+Change-Id: I2f0601fb38944e0cfb8888aa397740161b159e40
+Signed-off-by: ligd <liguiding1@xiaomi.com>
+---
+ lib/include/openamp/rpmsg.h | 4 ++++
+ lib/rpmsg/rpmsg_virtio.c    | 6 ++++++
+ 2 files changed, 10 insertions(+)
+
+diff --git a/lib/include/openamp/rpmsg.h open-amp/lib/include/openamp/rpmsg.h
+index 5c8b45c..93aeec6 100644
+--- a/lib/include/openamp/rpmsg.h
++++ open-amp/lib/include/openamp/rpmsg.h
+@@ -56,6 +56,7 @@ struct rpmsg_device;
+ /* Returns positive value on success or negative error value on failure */
+ typedef int (*rpmsg_ept_cb)(struct rpmsg_endpoint *ept, void *data,
+ 			    size_t len, uint32_t src, void *priv);
++typedef void (*rpmsg_ns_bound_cb)(struct rpmsg_endpoint *ept);
+ typedef void (*rpmsg_ns_unbind_cb)(struct rpmsg_endpoint *ept);
+ typedef void (*rpmsg_ns_bind_cb)(struct rpmsg_device *rdev,
+ 				 const char *name, uint32_t dest);
+@@ -68,6 +69,8 @@ typedef void (*rpmsg_ns_bind_cb)(struct rpmsg_device *rdev,
+  * @dest_addr: address of the default remote endpoint binded.
+  * @cb: user rx callback, return value of this callback is reserved
+  *      for future use, for now, only allow RPMSG_SUCCESS as return value.
++ * @ns_bound_cb: end point service bound callback, called when remote
++ *                ept address is received.
+  * @ns_unbind_cb: end point service unbind callback, called when remote
+  *                ept is destroyed.
+  * @node: end point node.
+@@ -82,6 +85,7 @@ struct rpmsg_endpoint {
+ 	uint32_t addr;
+ 	uint32_t dest_addr;
+ 	rpmsg_ept_cb cb;
++	rpmsg_ns_bound_cb ns_bound_cb;
+ 	rpmsg_ns_unbind_cb ns_unbind_cb;
+ 	struct metal_list node;
+ 	void *priv;
+diff --git a/lib/rpmsg/rpmsg_virtio.c open-amp/lib/rpmsg/rpmsg_virtio.c
+index 2f28a30..51c2565 100644
+--- a/lib/rpmsg/rpmsg_virtio.c
++++ open-amp/lib/rpmsg/rpmsg_virtio.c
+@@ -569,12 +569,18 @@ static int rpmsg_virtio_ns_callback(struct rpmsg_endpoint *ept, void *data,
+ 			metal_mutex_release(&rdev->lock);
+ 			if (_ept->name[0] && rdev->support_ack)
+ 				rpmsg_send_ns_message(_ept, RPMSG_NS_CREATE_ACK);
++			/* notify application that the endpoint has been bound */
++			if (_ept->ns_bound_cb)
++				_ept->ns_bound_cb(_ept);
+ 		}
+ 	} else { /* RPMSG_NS_CREATE_ACK */
+ 		/* save the received destination address */
+ 		if (_ept)
+ 			_ept->dest_addr = dest;
+ 		metal_mutex_release(&rdev->lock);
++		/* notify application that the endpoint has been bound */
++		if (_ept && _ept->ns_bound_cb)
++			_ept->ns_bound_cb(_ept);
+ 	}
+ 
+ 	return RPMSG_SUCCESS;
+-- 
+2.25.1
+

--- a/openamp/open-amp.defs
+++ b/openamp/open-amp.defs
@@ -37,6 +37,7 @@ open-amp.zip:
 	$(Q) patch -p0 < 0002-Negotiate-individual-buffer-size-dynamically.patch
 	$(Q) patch -p0 < 0003-rpmsg-wait-endpoint-ready-in-rpmsg_send-and-rpmsg_se.patch
 	$(Q) patch -p0 < 0004-openamp-add-ns_unbind_notify-support.patch
+	$(Q) patch -p0 < 0005-rpmsg-notify-the-user-when-the-remote-address-is-rec.patch
 
 .openamp_headers: open-amp.zip
 	$(eval headers := $(wildcard open-amp/lib/include/openamp/*.h))


### PR DESCRIPTION
## Summary
socket rpmsg related bug fix & update:
rpmsg_socket: move rpmsg_send out of lock
socket_rpmsg: support SOCK_SEQPACKET
rpmgs_socket: set RPMSG_SOCKET_NAME_SIZE to 16 for handing prefix
socket_rpmsg: fix save rp_name error when accept
socket_rpmsg: use ns_bound to send SYNC packet

## Impact

rpmsg socket

## Testing

