### PR TITLE
local socket bug fix & update

### DIFF
--- a/net/local/local_accept.c
+++ b/net/local/local_accept.c
@@ -170,6 +170,7 @@ int local_accept(FAR struct socket *psock, FAR struct sockaddr *addr,
               conn->lc_psock  = psock;
 #ifdef CONFIG_NET_LOCAL_SCM
               conn->lc_peer   = client;
+              client->lc_peer = conn;
 #endif /* CONFIG_NET_LOCAL_SCM */
 
               strncpy(conn->lc_path, client->lc_path, UNIX_PATH_MAX - 1);

--- a/net/local/local_conn.c
+++ b/net/local/local_conn.c
@@ -176,6 +176,7 @@ void local_free(FAR struct local_conn_s *conn)
   if (local_peerconn(conn) && conn->lc_peer)
     {
       conn->lc_peer->lc_peer = NULL;
+      conn->lc_peer = NULL;
     }
 #endif /* CONFIG_NET_LOCAL_SCM */
 

--- a/net/local/local_connect.c
+++ b/net/local/local_connect.c
@@ -301,9 +301,6 @@ int psock_local_connect(FAR struct socket *psock,
                         UNIX_PATH_MAX - 1);
                 client->lc_path[UNIX_PATH_MAX - 1] = '\0';
                 client->lc_instance_id = local_generate_instance_id();
-#ifdef CONFIG_NET_LOCAL_SCM
-                client->lc_peer = conn;
-#endif /* CONFIG_NET_LOCAL_SCM */
 
                 /* The client is now bound to an address */
 

--- a/net/local/local_recvutils.c
+++ b/net/local/local_recvutils.c
@@ -53,13 +53,13 @@
  *   buf   - Local to store the received data
  *   len   - Length of data to receive [in]
  *           Length of data actually received [out]
+ *           Zero means *len[in] is zero,
+ *           or the sending side has closed the FIFO
  *   once  - Flag to indicate the buf may only be read once
  *
  * Returned Value:
  *   Zero is returned on success; a negated errno value is returned on any
- *   failure.  If -ECONNRESET is received, then the sending side has closed
- *   the FIFO. In this case, the returned data may still be valid (if the
- *   returned len > 0).
+ *   failure.
  *
  ****************************************************************************/
 
@@ -93,8 +93,7 @@ int local_fifo_read(FAR struct file *filep, FAR uint8_t *buf,
            * has closed the FIFO.
            */
 
-          ret = -ECONNRESET;
-          goto errout;
+            break;
         }
       else
         {


### PR DESCRIPTION
## Summary

local socket bug fix & update
local_socket: set lc_peer when accept() instead of connect()
local_socket: recv should return 0 NOT -ECONNRESET if remote closed

## Impact
local_socket

## Testing

