### PR TITLE
arch/arm: Remove -mcpu for fix warning

### DIFF
--- a/arch/arm/src/armv7-m/Toolchain.defs
+++ b/arch/arm/src/armv7-m/Toolchain.defs
@@ -79,7 +79,6 @@ endif
 
 ifeq ($(CONFIG_ARCH_CORTEXM4),y)
   TOOLCHAIN_ARM7EM   := y
-  TOOLCHAIN_MCPU     := -mcpu=cortex-m4
   TOOLCHAIN_MTUNE    := -mtune=cortex-m4
   TOOLCHAIN_MARCH    := -march=armv7e-m
   ifeq ($(CONFIG_ARCH_FPU),y)
@@ -89,7 +88,6 @@ ifeq ($(CONFIG_ARCH_CORTEXM4),y)
   endif
 else ifeq ($(CONFIG_ARCH_CORTEXM7),y)
   TOOLCHAIN_ARM7EM   := y
-  TOOLCHAIN_MCPU     := -mcpu=cortex-m7
   TOOLCHAIN_MTUNE    := -mtune=cortex-m7
   TOOLCHAIN_MARCH    := -march=armv7e-m
   ifeq ($(CONFIG_ARCH_FPU),y)
@@ -103,7 +101,6 @@ else ifeq ($(CONFIG_ARCH_CORTEXM7),y)
   endif
 else # ifeq ($(CONFIG_ARCH_CORTEXM3),y)
   TOOLCHAIN_ARM7EM   := n
-  TOOLCHAIN_MCPU     := -mcpu=cortex-m3
   TOOLCHAIN_MTUNE    := -mtune=cortex-m3
   TOOLCHAIN_MARCH    := -march=armv7-m
   TOOLCHAIN_MFLOAT   := -mfloat-abi=soft
@@ -114,10 +111,10 @@ endif
 ifeq ($(CONFIG_ARMV7M_TOOLCHAIN),BUILDROOT)
 ifeq ($(CONFIG_ARMV7M_OABI_TOOLCHAIN),y)
   CROSSDEV ?= arm-nuttx-elf-
-  ARCHCPUFLAGS = $(TOOLCHAIN_MCPU) $(TOOLCHAIN_MFLOAT)
+  ARCHCPUFLAGS = $(TOOLCHAIN_MARCH) $(TOOLCHAIN_MTUNE) $(TOOLCHAIN_MFLOAT)
 else
   CROSSDEV ?= arm-nuttx-eabi-
-  ARCHCPUFLAGS = $(TOOLCHAIN_MCPU) -mthumb $(TOOLCHAIN_MFLOAT)
+  ARCHCPUFLAGS = $(TOOLCHAIN_MARCH) $(TOOLCHAIN_MTUNE) -mthumb $(TOOLCHAIN_MFLOAT)
 endif
 endif
 
@@ -125,14 +122,14 @@ endif
 
 ifeq ($(CONFIG_ARMV7M_TOOLCHAIN),GNU_EABI)
   CROSSDEV ?= arm-none-eabi-
-  ARCHCPUFLAGS = $(TOOLCHAIN_MCPU) -mthumb $(TOOLCHAIN_MFLOAT)
+  ARCHCPUFLAGS = $(TOOLCHAIN_MARCH) $(TOOLCHAIN_MTUNE) -mthumb $(TOOLCHAIN_MFLOAT)
 endif
 
 # Clang toolchain
 
 ifeq ($(CONFIG_ARMV7M_TOOLCHAIN),CLANG)
   CROSSDEV ?= arm-none-eabi-
-  ARCHCPUFLAGS = -target arm-none-eabi $(TOOLCHAIN_MCPU) $(TOOLCHAIN_MFLOAT)
+  ARCHCPUFLAGS = -target arm-none-eabi $(TOOLCHAIN_MARCH) $(TOOLCHAIN_MTUNE) $(TOOLCHAIN_MFLOAT)
   CC = clang
   CXX = clang++
   CPP = clang -E -P -x c

--- a/arch/arm/src/armv7-m/Toolchain.defs
+++ b/arch/arm/src/armv7-m/Toolchain.defs
@@ -80,6 +80,8 @@ endif
 ifeq ($(CONFIG_ARCH_CORTEXM4),y)
   TOOLCHAIN_ARM7EM   := y
   TOOLCHAIN_MCPU     := -mcpu=cortex-m4
+  TOOLCHAIN_MTUNE    := -mtune=cortex-m4
+  TOOLCHAIN_MARCH    := -march=armv7e-m
   ifeq ($(CONFIG_ARCH_FPU),y)
     TOOLCHAIN_MFLOAT := -mfpu=fpv4-sp-d16 -mfloat-abi=hard
   else
@@ -88,6 +90,8 @@ ifeq ($(CONFIG_ARCH_CORTEXM4),y)
 else ifeq ($(CONFIG_ARCH_CORTEXM7),y)
   TOOLCHAIN_ARM7EM   := y
   TOOLCHAIN_MCPU     := -mcpu=cortex-m7
+  TOOLCHAIN_MTUNE    := -mtune=cortex-m7
+  TOOLCHAIN_MARCH    := -march=armv7e-m
   ifeq ($(CONFIG_ARCH_FPU),y)
   ifeq ($(CONFIG_ARCH_DPFPU),y)
     TOOLCHAIN_MFLOAT := -mfpu=fpv5-d16 -mfloat-abi=hard
@@ -100,6 +104,8 @@ else ifeq ($(CONFIG_ARCH_CORTEXM7),y)
 else # ifeq ($(CONFIG_ARCH_CORTEXM3),y)
   TOOLCHAIN_ARM7EM   := n
   TOOLCHAIN_MCPU     := -mcpu=cortex-m3
+  TOOLCHAIN_MTUNE    := -mtune=cortex-m3
+  TOOLCHAIN_MARCH    := -march=armv7-m
   TOOLCHAIN_MFLOAT   := -mfloat-abi=soft
 endif
 

--- a/arch/arm/src/armv8-m/Toolchain.defs
+++ b/arch/arm/src/armv8-m/Toolchain.defs
@@ -77,11 +77,11 @@ endif
 
 # Parametrization for ARCHCPUFLAGS
 ifeq ($(CONFIG_ARCH_CORTEXM23),y)
-  TOOLCHAIN_MCPU     := -mcpu=cortex-m23
+  TOOLCHAIN_MTUNE    := -mtune=cortex-m23
   TOOLCHAIN_MARCH    := -march=armv8-m.main
   TOOLCHAIN_MFLOAT   := -mfloat-abi=soft
 else ifeq ($(CONFIG_ARCH_CORTEXM33),y)
-  TOOLCHAIN_MCPU     := -mcpu=cortex-m33
+  TOOLCHAIN_MTUNE    := -mtune=cortex-m33
   TOOLCHAIN_MARCH    := -march=armv8-m.main+dsp
   ifeq ($(CONFIG_ARCH_FPU),y)
     TOOLCHAIN_MFLOAT := -mfpu=fpv5-sp-d16 -mfloat-abi=hard
@@ -89,7 +89,7 @@ else ifeq ($(CONFIG_ARCH_CORTEXM33),y)
     TOOLCHAIN_MFLOAT := -mfloat-abi=soft
   endif
 else ifeq ($(CONFIG_ARCH_CORTEXM35P),y)
-  TOOLCHAIN_MCPU     := -mcpu=cortex-m35p
+  TOOLCHAIN_MTUNE    := -mtune=cortex-m35p
   TOOLCHAIN_MARCH    := -march=armv8-m.main+dsp
   ifeq ($(CONFIG_ARCH_FPU),y)
     TOOLCHAIN_MFLOAT := -mfpu=fpv5-sp-d16 -mfloat-abi=hard
@@ -97,7 +97,7 @@ else ifeq ($(CONFIG_ARCH_CORTEXM35P),y)
     TOOLCHAIN_MFLOAT := -mfloat-abi=soft
   endif
 else ifeq ($(CONFIG_ARCH_CORTEXM55),y)
-  TOOLCHAIN_MCPU     := -mcpu=cortex-m55
+  TOOLCHAIN_MTUNE    := -mtune=cortex-m55
   TOOLCHAIN_MARCH    := -march=armv8.1-m.main+dsp
   ifeq ($(CONFIG_ARCH_FPU),y)
     TOOLCHAIN_MFLOAT := -mfpu=fpv5-d16 -mfloat-abi=hard
@@ -112,10 +112,10 @@ endif
 ifeq ($(CONFIG_ARMV8M_TOOLCHAIN),BUILDROOT)
 ifeq ($(CONFIG_ARMV8M_OABI_TOOLCHAIN),y)
   CROSSDEV ?= arm-nuttx-elf-
-  ARCHCPUFLAGS = $(TOOLCHAIN_MCPU) $(TOOLCHAIN_MFLOAT)
+  ARCHCPUFLAGS = $(TOOLCHAIN_MARCH) $(TOOLCHAIN_MTUNE) $(TOOLCHAIN_MFLOAT)
 else
   CROSSDEV ?= arm-nuttx-eabi-
-  ARCHCPUFLAGS = $(TOOLCHAIN_MCPU) -mthumb $(TOOLCHAIN_MFLOAT)
+  ARCHCPUFLAGS = $(TOOLCHAIN_MARCH) $(TOOLCHAIN_MTUNE) -mthumb $(TOOLCHAIN_MFLOAT)
 endif
 endif
 
@@ -123,14 +123,14 @@ endif
 
 ifeq ($(CONFIG_ARMV8M_TOOLCHAIN),GNU_EABI)
   CROSSDEV ?= arm-none-eabi-
-  ARCHCPUFLAGS = $(TOOLCHAIN_MCPU) -mthumb $(TOOLCHAIN_MFLOAT)
+  ARCHCPUFLAGS = $(TOOLCHAIN_MARCH) $(TOOLCHAIN_MTUNE) -mthumb $(TOOLCHAIN_MFLOAT)
 endif
 
 # Clang toolchain
 
 ifeq ($(CONFIG_ARMV8M_TOOLCHAIN),CLANG)
   CROSSDEV ?= arm-none-eabi-
-  ARCHCPUFLAGS = $(TOOLCHAIN_MCPU) -mthumb $(TOOLCHAIN_MFLOAT)
+  ARCHCPUFLAGS = $(TOOLCHAIN_MARCH) $(TOOLCHAIN_MTUNE) -mthumb $(TOOLCHAIN_MFLOAT)
 endif
 
 # Default toolchain

--- a/arch/arm/src/armv8-m/Toolchain.defs
+++ b/arch/arm/src/armv8-m/Toolchain.defs
@@ -78,9 +78,11 @@ endif
 # Parametrization for ARCHCPUFLAGS
 ifeq ($(CONFIG_ARCH_CORTEXM23),y)
   TOOLCHAIN_MCPU     := -mcpu=cortex-m23
+  TOOLCHAIN_MARCH    := -march=armv8-m.main
   TOOLCHAIN_MFLOAT   := -mfloat-abi=soft
 else ifeq ($(CONFIG_ARCH_CORTEXM33),y)
   TOOLCHAIN_MCPU     := -mcpu=cortex-m33
+  TOOLCHAIN_MARCH    := -march=armv8-m.main+dsp
   ifeq ($(CONFIG_ARCH_FPU),y)
     TOOLCHAIN_MFLOAT := -mfpu=fpv5-sp-d16 -mfloat-abi=hard
   else
@@ -88,6 +90,7 @@ else ifeq ($(CONFIG_ARCH_CORTEXM33),y)
   endif
 else ifeq ($(CONFIG_ARCH_CORTEXM35P),y)
   TOOLCHAIN_MCPU     := -mcpu=cortex-m35p
+  TOOLCHAIN_MARCH    := -march=armv8-m.main+dsp
   ifeq ($(CONFIG_ARCH_FPU),y)
     TOOLCHAIN_MFLOAT := -mfpu=fpv5-sp-d16 -mfloat-abi=hard
   else
@@ -95,6 +98,7 @@ else ifeq ($(CONFIG_ARCH_CORTEXM35P),y)
   endif
 else ifeq ($(CONFIG_ARCH_CORTEXM55),y)
   TOOLCHAIN_MCPU     := -mcpu=cortex-m55
+  TOOLCHAIN_MARCH    := -march=armv8.1-m.main+dsp
   ifeq ($(CONFIG_ARCH_FPU),y)
     TOOLCHAIN_MFLOAT := -mfpu=fpv5-d16 -mfloat-abi=hard
   else


### PR DESCRIPTION
## Summary

arch/arm: Remove -mcpu for fix warning

warning: switch '-mcpu=cortex-m55' conflicts with '-march=armv8-m.main' switch

## Impact

all arm compiling

## Testing

