### PR TITLE
Fix syslog_write failed

### DIFF
--- a/drivers/syslog/syslog_channel.c
+++ b/drivers/syslog/syslog_channel.c
@@ -161,8 +161,14 @@ static ssize_t syslog_default_write(FAR struct syslog_channel_s *channel,
                                     FAR const char *buffer, size_t buflen)
 {
 #if defined(CONFIG_ARCH_LOWPUTC)
+  size_t nwritten;
+
   nxsem_wait(&g_syslog_default_sem);
-  up_puts(buffer);
+  for (nwritten = 0; nwritten < buflen; nwritten++)
+    {
+      up_putc(buffer[nwritten]);
+    }
+
   nxsem_post(&g_syslog_default_sem);
 #endif
 

--- a/drivers/syslog/syslog_stream.c
+++ b/drivers/syslog/syslog_stream.c
@@ -56,11 +56,6 @@ static int syslogstream_flush(FAR struct lib_syslogstream_s *stream)
 
   if (iob != NULL && iob->io_len > 0)
     {
-      /* Ensure the buffer is zero terminated */
-
-      DEBUGASSERT(iob->io_len < CONFIG_IOB_BUFSIZE);
-      iob->io_data[iob->io_len] = '\0';
-
       /* Yes write the buffered data */
 
       do
@@ -105,7 +100,7 @@ static void syslogstream_addchar(FAR struct lib_syslogstream_s *stream,
 
   /* Is the buffer full? */
 
-  if (iob->io_len >= CONFIG_IOB_BUFSIZE - 1)
+  if (iob->io_len >= CONFIG_IOB_BUFSIZE)
     {
       /* Yes.. then flush the buffer */
 


### PR DESCRIPTION


## Summary

Fix syslog_write failed, in previous commit use up_puts in syslog_default_write, but this will caused,
user directly call syslog_write failed


    Revert "drivers/syslog: Call up_puts in syslog_default_write instad up_putc"
    
    This reverts commit 174b2403258cbf0e063ac389beeedcd09b8a0b1a.
    
    Revert "drivers/syslog: Ensure the buffer zero terminate"
    
    This reverts commit 1692aa7894858a8957d2d2e091891b15cbf22ae8.


## Impact

## Testing

