### PR TITLE
ftruncate: sanity check for parameter:length

### DIFF
--- a/fs/vfs/fs_truncate.c
+++ b/fs/vfs/fs_truncate.c
@@ -155,7 +155,12 @@ int file_truncate(FAR struct file *filep, off_t length)
 int ftruncate(int fd, off_t length)
 {
   FAR struct file *filep;
-  int ret;
+  int ret = -EINVAL;
+
+  if (length < 0)
+    {
+      goto errout;
+    }
 
   /* Get the file structure corresponding to the file descriptor. */
 


### PR DESCRIPTION


## Summary
ftruncate: sanity check for parameter:length

Signed-off-by: Jiuzhu Dong <dongjiuzhu1@xiaomi.com>
## Impact
N/A
## Testing
daily test
