### PR TITLE
libc/machine: add config LIBC_ARCH_MEMCHR

### DIFF
--- a/libs/libc/machine/Kconfig
+++ b/libs/libc/machine/Kconfig
@@ -48,6 +48,10 @@ config LIBC_ARCH_ATOMIC
 	bool
 	default n
 
+config LIBC_ARCH_MEMCHR
+	bool
+	default n
+
 config LIBC_ARCH_MEMCPY
 	bool
 	default n


### PR DESCRIPTION


## Summary
libc/machine: add config LIBC_ARCH_MEMCHR

Signed-off-by: Jiuzhu Dong <dongjiuzhu1@xiaomi.com>
## Impact
N/A
## Testing
daily test
