### PR TITLE
esp32/Kconfig: Make ESP32_BT_RESERVE_DRAM default to 0 again if Bluetooth is not enabled. 

### DIFF
--- a/arch/xtensa/src/esp32/Kconfig
+++ b/arch/xtensa/src/esp32/Kconfig
@@ -541,7 +541,8 @@ menu "Memory Configuration"
 
 config ESP32_BT_RESERVE_DRAM
 	int "Reserved BT DRAM"
-	default 65536
+	default 0 if !ESP32_BLE
+	default 65536 if ESP32_BLE
 
 config ESP32_TRACEMEM_RESERVE_DRAM
 	int "Reserved trace memory DRAM"


### PR DESCRIPTION
## Summary
Make ESP32_BT_RESERVE_DRAM default to 0 again if Bluetooth is not enabled.  When Bluetooth is enbaled then it defaults to 64KB.  This will not waste those 64KB of memory when Bluetooth is not needed.
## Impact
ESP32.
## Testing

esp32 defconfigs.