### PR TITLE
sched/vfork: allocate tls_info_s instead task_info_s from stack

### DIFF
--- a/sched/task/task_vfork.c
+++ b/sched/task/task_vfork.c
@@ -96,7 +96,7 @@ FAR struct task_tcb_s *nxtask_setup_vfork(start_t retaddr)
   FAR struct tcb_s *ptcb = this_task();
   FAR struct task_tcb_s *parent;
   FAR struct task_tcb_s *child;
-  FAR struct task_info_s *info;
+  FAR struct tls_info_s *info;
   size_t stack_size;
   uint8_t ttype;
   int priority;
@@ -173,7 +173,7 @@ FAR struct task_tcb_s *nxtask_setup_vfork(start_t retaddr)
 
   /* Setup thread local storage */
 
-  info = up_stack_frame(&child->cmn, sizeof(struct task_info_s));
+  info = up_stack_frame(&child->cmn, sizeof(struct tls_info_s));
   if (info == NULL)
     {
       ret = -ENOMEM;
@@ -181,7 +181,8 @@ FAR struct task_tcb_s *nxtask_setup_vfork(start_t retaddr)
     }
 
   DEBUGASSERT(info == child->cmn.stack_alloc_ptr);
-  memcpy(info, parent->cmn.stack_alloc_ptr, sizeof(struct task_info_s));
+  memcpy(info, parent->cmn.stack_alloc_ptr, sizeof(struct tls_info_s));
+  info->tl_task = child->cmn.group->tg_info;
 
   /* Get the priority of the parent task */
 


### PR DESCRIPTION
## Summary
Minor fix

## Impact
vfork

## Testing
ostest
