### PR TITLE
GPIO driver: Use generic /dev/gpioN

### DIFF
--- a/Documentation/platforms/risc-v/esp32c3/boards/esp32c3-devkit/index.rst
+++ b/Documentation/platforms/risc-v/esp32c3/boards/esp32c3-devkit/index.rst
@@ -57,15 +57,15 @@ GPIO9 as an interrupt pin.
 
 At the nsh, we can turn the outputs on and off with the following::
 
-  nsh> gpio -o 1 /dev/gpout0
-  nsh> gpio -o 1 /dev/gpout1
+  nsh> gpio -o 1 /dev/gpio0
+  nsh> gpio -o 1 /dev/gpio1
 
-  nsh> gpio -o 0 /dev/gpout0
-  nsh> gpio -o 0 /dev/gpout1
+  nsh> gpio -o 0 /dev/gpio0
+  nsh> gpio -o 0 /dev/gpio1
 
 We can use the interrupt pin to send a signal when the interrupt fires::
 
-    nsh> gpio -w 14 /dev/gpint2
+    nsh> gpio -w 14 /dev/gpio2
 
 The pin is configured as a rising edge interrupt, so after issuing the
 above command, connect it to 3.3V.

--- a/Documentation/platforms/xtensa/esp32/boards/esp32-wrover-kit/index.rst
+++ b/Documentation/platforms/xtensa/esp32/boards/esp32-wrover-kit/index.rst
@@ -102,12 +102,12 @@ This is a test for the GPIO driver. It includes the 3 LEDs and one, arbitrary, G
 For this example, GPIO22 was used.
 At the nsh, we can turn LEDs on and off with the following::
 
-    nsh> gpio -o 1 /dev/gpout0
-    nsh> gpio -o 0 /dev/gpout1
+    nsh> gpio -o 1 /dev/gpio0
+    nsh> gpio -o 0 /dev/gpio0
 
 We can use the interrupt pin to send a signal when the interrupt fires::
 
-    nsh> gpio -w 14 /dev/gpint0
+    nsh> gpio -w 14 /dev/gpio2
 
 The pin is configured to as a rising edge interrupt, so after issuing the
 above command, connect it to 3.3V.

--- a/boards/risc-v/esp32c3/esp32c3-devkit/src/esp32c3_gpio.c
+++ b/boards/risc-v/esp32c3/esp32c3-devkit/src/esp32c3_gpio.c
@@ -282,6 +282,7 @@ static int gpint_enable(FAR struct gpio_dev_s *dev, bool enable)
 
 int esp32c3_gpio_init(void)
 {
+  int pincount = 0;
   int i;
 
 #if BOARD_NGPIOOUT > 0
@@ -292,7 +293,7 @@ int esp32c3_gpio_init(void)
       g_gpout[i].gpio.gp_pintype = GPIO_OUTPUT_PIN;
       g_gpout[i].gpio.gp_ops     = &gpout_ops;
       g_gpout[i].id              = i;
-      gpio_pin_register(&g_gpout[i].gpio, i);
+      gpio_pin_register(&g_gpout[i].gpio, pincount);
 
       /* Configure the pins that will be used as output */
 
@@ -300,6 +301,8 @@ int esp32c3_gpio_init(void)
       esp32c3_configgpio(g_gpiooutputs[i], OUTPUT_FUNCTION_1 |
                          INPUT_FUNCTION_1);
       esp32c3_gpiowrite(g_gpiooutputs[i], 0);
+
+      pincount++;
     }
 #endif
 
@@ -311,11 +314,13 @@ int esp32c3_gpio_init(void)
       g_gpint[i].esp32c3gpio.gpio.gp_pintype = GPIO_INTERRUPT_PIN;
       g_gpint[i].esp32c3gpio.gpio.gp_ops     = &gpint_ops;
       g_gpint[i].esp32c3gpio.id              = i;
-      gpio_pin_register(&g_gpint[i].esp32c3gpio.gpio, i);
+      gpio_pin_register(&g_gpint[i].esp32c3gpio.gpio, pincount);
 
       /* Configure the pins that will be used as interrupt input */
 
       esp32c3_configgpio(g_gpiointinputs[i], INPUT_FUNCTION_1 | PULLDOWN);
+
+      pincount++;
     }
 #endif
 

--- a/boards/xtensa/esp32/esp32-devkitc/src/esp32_gpio.c
+++ b/boards/xtensa/esp32/esp32-devkitc/src/esp32_gpio.c
@@ -326,6 +326,7 @@ static int gpint_enable(FAR struct gpio_dev_s *dev, bool enable)
 
 int esp32_gpio_init(void)
 {
+  int pincount = 0;
   int i;
 
 #if BOARD_NGPIOOUT > 0
@@ -336,7 +337,7 @@ int esp32_gpio_init(void)
       g_gpout[i].gpio.gp_pintype = GPIO_OUTPUT_PIN;
       g_gpout[i].gpio.gp_ops     = &gpout_ops;
       g_gpout[i].id              = i;
-      gpio_pin_register(&g_gpout[i].gpio, i);
+      gpio_pin_register(&g_gpout[i].gpio, pincount);
 
       /* Configure the pins that will be used as output */
 
@@ -344,6 +345,8 @@ int esp32_gpio_init(void)
       esp32_configgpio(g_gpiooutputs[i], OUTPUT_FUNCTION_3 |
                        INPUT_FUNCTION_3);
       esp32_gpiowrite(g_gpiooutputs[i], 0);
+
+      pincount++;
     }
 #endif
 
@@ -355,11 +358,13 @@ int esp32_gpio_init(void)
       g_gpin[i].gpio.gp_pintype = GPIO_INPUT_PIN;
       g_gpin[i].gpio.gp_ops     = &gpin_ops;
       g_gpin[i].id              = i;
-      gpio_pin_register(&g_gpin[i].gpio, i);
+      gpio_pin_register(&g_gpin[i].gpio, pincount);
 
       /* Configure the pins that will be used as INPUT */
 
       esp32_configgpio(g_gpioinputs[i], INPUT_FUNCTION_3);
+
+      pincount++;
     }
 #endif
 
@@ -371,11 +376,13 @@ int esp32_gpio_init(void)
       g_gpint[i].esp32gpio.gpio.gp_pintype = GPIO_INTERRUPT_PIN;
       g_gpint[i].esp32gpio.gpio.gp_ops     = &gpint_ops;
       g_gpint[i].esp32gpio.id              = i;
-      gpio_pin_register(&g_gpint[i].esp32gpio.gpio, i);
+      gpio_pin_register(&g_gpint[i].esp32gpio.gpio, pincount);
 
       /* Configure the pins that will be used as interrupt input */
 
       esp32_configgpio(g_gpiointinputs[i], INPUT_FUNCTION_3 | PULLDOWN);
+
+      pincount++;
     }
 #endif
 

--- a/boards/xtensa/esp32/esp32-wrover-kit/src/esp32_gpio.c
+++ b/boards/xtensa/esp32/esp32-wrover-kit/src/esp32_gpio.c
@@ -326,6 +326,7 @@ static int gpint_enable(FAR struct gpio_dev_s *dev, bool enable)
 
 int esp32_gpio_init(void)
 {
+  int pincount = 0;
   int i;
 
 #if BOARD_NGPIOOUT > 0
@@ -336,7 +337,7 @@ int esp32_gpio_init(void)
       g_gpout[i].gpio.gp_pintype = GPIO_OUTPUT_PIN;
       g_gpout[i].gpio.gp_ops     = &gpout_ops;
       g_gpout[i].id              = i;
-      gpio_pin_register(&g_gpout[i].gpio, i);
+      gpio_pin_register(&g_gpout[i].gpio, pincount);
 
       /* Configure the pins that will be used as output */
 
@@ -344,6 +345,8 @@ int esp32_gpio_init(void)
       esp32_configgpio(g_gpiooutputs[i], OUTPUT_FUNCTION_3 |
                        INPUT_FUNCTION_3);
       esp32_gpiowrite(g_gpiooutputs[i], 0);
+
+      pincount++;
     }
 #endif
 
@@ -355,11 +358,13 @@ int esp32_gpio_init(void)
       g_gpin[i].gpio.gp_pintype = GPIO_INPUT_PIN;
       g_gpin[i].gpio.gp_ops     = &gpin_ops;
       g_gpin[i].id              = i;
-      gpio_pin_register(&g_gpin[i].gpio, i);
+      gpio_pin_register(&g_gpin[i].gpio, pincount);
 
       /* Configure the pins that will be used as INPUT */
 
       esp32_configgpio(g_gpioinputs[i], INPUT_FUNCTION_3);
+
+      pincount++;
     }
 #endif
 
@@ -371,11 +376,13 @@ int esp32_gpio_init(void)
       g_gpint[i].esp32gpio.gpio.gp_pintype = GPIO_INTERRUPT_PIN;
       g_gpint[i].esp32gpio.gpio.gp_ops     = &gpint_ops;
       g_gpint[i].esp32gpio.id              = i;
-      gpio_pin_register(&g_gpint[i].esp32gpio.gpio, i);
+      gpio_pin_register(&g_gpint[i].esp32gpio.gpio, pincount);
 
       /* Configure the pins that will be used as interrupt input */
 
       esp32_configgpio(g_gpiointinputs[i], INPUT_FUNCTION_3 | PULLDOWN);
+
+      pincount++;
     }
 #endif
 

--- a/boards/xtensa/esp32/ttgo_lora_esp32/src/esp32_gpio.c
+++ b/boards/xtensa/esp32/ttgo_lora_esp32/src/esp32_gpio.c
@@ -326,6 +326,7 @@ static int gpint_enable(FAR struct gpio_dev_s *dev, bool enable)
 
 int esp32_gpio_init(void)
 {
+  int pincount = 0;
   int i;
 
 #if BOARD_NGPIOOUT > 0
@@ -336,7 +337,7 @@ int esp32_gpio_init(void)
       g_gpout[i].gpio.gp_pintype = GPIO_OUTPUT_PIN;
       g_gpout[i].gpio.gp_ops     = &gpout_ops;
       g_gpout[i].id              = i;
-      gpio_pin_register(&g_gpout[i].gpio, i);
+      gpio_pin_register(&g_gpout[i].gpio, pincount);
 
       /* Configure the pins that will be used as output */
 
@@ -344,6 +345,8 @@ int esp32_gpio_init(void)
       esp32_configgpio(g_gpiooutputs[i], OUTPUT_FUNCTION_3 |
                        INPUT_FUNCTION_3);
       esp32_gpiowrite(g_gpiooutputs[i], 0);
+
+      pincount++;
     }
 #endif
 
@@ -355,11 +358,13 @@ int esp32_gpio_init(void)
       g_gpin[i].gpio.gp_pintype = GPIO_INPUT_PIN;
       g_gpin[i].gpio.gp_ops     = &gpin_ops;
       g_gpin[i].id              = i;
-      gpio_pin_register(&g_gpin[i].gpio, i);
+      gpio_pin_register(&g_gpin[i].gpio, pincount);
 
       /* Configure the pins that will be used as INPUT */
 
       esp32_configgpio(g_gpioinputs[i], INPUT_FUNCTION_3);
+
+      pincount++;
     }
 #endif
 
@@ -371,11 +376,13 @@ int esp32_gpio_init(void)
       g_gpint[i].esp32gpio.gpio.gp_pintype = GPIO_INTERRUPT_PIN;
       g_gpint[i].esp32gpio.gpio.gp_ops     = &gpint_ops;
       g_gpint[i].esp32gpio.id              = i;
-      gpio_pin_register(&g_gpint[i].esp32gpio.gpio, i);
+      gpio_pin_register(&g_gpint[i].esp32gpio.gpio, pincount);
 
       /* Configure the pins that will be used as interrupt input */
 
       esp32_configgpio(g_gpiointinputs[i], INPUT_FUNCTION_3 | PULLDOWN);
+
+      pincount++;
     }
 #endif
 

--- a/boards/xtensa/esp32s2/esp32s2-saola-1/src/esp32s2_gpio.c
+++ b/boards/xtensa/esp32s2/esp32s2-saola-1/src/esp32s2_gpio.c
@@ -404,6 +404,8 @@ static int gpint_enable(FAR struct gpio_dev_s *dev, bool enable)
 
 int esp32s2_gpio_init(void)
 {
+  int pincount = 0;
+
 #if BOARD_NGPIOOUT > 0
   for (int i = 0; i < BOARD_NGPIOOUT; i++)
     {
@@ -412,7 +414,7 @@ int esp32s2_gpio_init(void)
       g_gpout[i].gpio.gp_pintype = GPIO_OUTPUT_PIN;
       g_gpout[i].gpio.gp_ops     = &gpout_ops;
       g_gpout[i].id              = i;
-      gpio_pin_register(&g_gpout[i].gpio, i);
+      gpio_pin_register(&g_gpout[i].gpio, pincount);
 
       /* Configure the pins that will be used as output */
 
@@ -420,6 +422,8 @@ int esp32s2_gpio_init(void)
       esp32s2_configgpio(g_gpiooutputs[i], OUTPUT_FUNCTION_1 |
                          INPUT_FUNCTION_1);
       esp32s2_gpiowrite(g_gpiooutputs[i], 0);
+
+      pincount++;
     }
 #endif
 
@@ -431,11 +435,13 @@ int esp32s2_gpio_init(void)
       g_gpin[i].gpio.gp_pintype = GPIO_INPUT_PIN_PULLDOWN;
       g_gpin[i].gpio.gp_ops     = &gpin_ops;
       g_gpin[i].id              = i;
-      gpio_pin_register(&g_gpin[i].gpio, i);
+      gpio_pin_register(&g_gpin[i].gpio, pincount);
 
       /* Configure the pins that will be used as interrupt input */
 
       esp32s2_configgpio(g_gpioinputs[i], INPUT_FUNCTION_1 | PULLDOWN);
+
+      pincount++;
     }
 #endif
 
@@ -447,11 +453,13 @@ int esp32s2_gpio_init(void)
       g_gpint[i].esp32s2gpio.gpio.gp_pintype = GPIO_INTERRUPT_PIN;
       g_gpint[i].esp32s2gpio.gpio.gp_ops     = &gpint_ops;
       g_gpint[i].esp32s2gpio.id              = i;
-      gpio_pin_register(&g_gpint[i].esp32s2gpio.gpio, i);
+      gpio_pin_register(&g_gpint[i].esp32s2gpio.gpio, pincount);
 
       /* Configure the pins that will be used as interrupt input */
 
       esp32s2_configgpio(g_gpiointinputs[i], INPUT_FUNCTION_1 | PULLDOWN);
+
+      pincount++;
     }
 #endif
 

--- a/include/nuttx/ioexpander/gpio.h
+++ b/include/nuttx/ioexpander/gpio.h
@@ -107,12 +107,12 @@ typedef CODE int (*pin_interrupt_t)(FAR struct gpio_dev_s *dev, uint8_t pin);
 /* Pin interface vtable definition.  Instances of this vtable are read-only
  * and may reside in FLASH.
  *
- *   - go_read.  Required for all all pin types.
+ *   - go_read.  Required for all pin types.
  *   - go_write.  Required only for the GPIO_OUTPUT_PIN pin type.  Unused
- *     for other pin types may be NULL.
- *   - go_attach and gp_eanble.  Required only the GPIO_INTERRUPT_PIN pin
- *     type.  Unused for other pin types may be NULL.
- *   - go_setpinytype.  Required for all all pin types.
+ *     for other pin types, may be NULL.
+ *   - go_attach and gp_enable.  Required only for the GPIO_INTERRUPT_PIN pin
+ *     type.  Unused for other pin types, may be NULL.
+ *   - go_setpinytype.  Required for all pin types.
  */
 
 struct gpio_dev_s;
@@ -177,14 +177,8 @@ extern "C"
  * Name: gpio_pin_register
  *
  * Description:
- *   Register GPIO pin device driver.
- *
- *   - Input pin types will be registered at /dev/gpinN
- *   - Output pin types will be registered at /dev/gpoutN
- *   - Interrupt pin types will be registered at /dev/gpintN
- *
- *   Where N is the provided minor number in the range of 0-99.
- *
+ *   Register GPIO pin device driver at /dev/gpioN, where N is the provided
+ *   minor number.
  *
  ****************************************************************************/
 
@@ -194,18 +188,12 @@ int gpio_pin_register(FAR struct gpio_dev_s *dev, int minor);
  * Name: gpio_pin_unregister
  *
  * Description:
- *   Unregister GPIO pin device driver.
- *
- *   - Input pin types will be registered at /dev/gpinN
- *   - Output pin types will be registered at /dev/gpoutN
- *   - Interrupt pin types will be registered at /dev/gpintN
- *
- *   Where N is the provided minor number in the range of 0-99.
- *
+ *   Unregister GPIO pin device driver at /dev/gpioN, where N is the provided
+ *   minor number.
  *
  ****************************************************************************/
 
-void gpio_pin_unregister(FAR struct gpio_dev_s *dev, int minor);
+int gpio_pin_unregister(FAR struct gpio_dev_s *dev, int minor);
 
 /****************************************************************************
  * Name: gpio_lower_half


### PR DESCRIPTION
## Summary
This PR changes the names under which GPIO pins are registered as generic /dev/gpioN instead of the specific names for different pintypes (/dev/gpinN, /dev/gpintN, /dev/gpoutN). In my opinion it does not make much sense to distinguish between pintypes in the name, especially because these pintypes can be changed AFTER the driver is registered with the setpintype command. I think these changes would also allow some board-specific lower-half GPIO drivers to be simplified (but that's not included in this PR).

## Impact
All GPIO pins need to be registered with a unique minor number. Previously there could be a /dev/gpin1 and a /dev/gpout1 without issues, but we cannot map both to /dev/gpio1. Most board-level code already used unique numbers, except for some ESP32 boards. I already included the required changes in this PR. All board-specific lower-half GPIO drivers should remain functional.

Applications that rely on GPIO pins being registered as /dev/gpinN, /dev/gpintN and /dev/gpoutN need to be adapted to now refer to /dev/gpioN. For incubator-nuttx-apps I think this is only the case for /examples/timer-gpout.

## Testing
Tested on an S32K144EVB (with the newly implemented GPIO driver). It would be much appreciated if anybody could verify this on another board as well, especially one of the ESP32 boards which I had to adapt.