### PR TITLE
Small clarification in the making-changes.rst documentation.

### DIFF
--- a/Documentation/contributing/making-changes.rst
+++ b/Documentation/contributing/making-changes.rst
@@ -44,15 +44,17 @@ Here's how to do it:
 
     .. code-block:: bash
 
-       $ git clone <your forked incubator-nuttx project clone url>
+       $ git clone <your forked incubator-nuttx project clone url> nuttx
+       $ cd nuttx
        $ git remote add upstream https://github.com/apache/incubator-nuttx.git
 
    Do the same for your forked ``incubator-nuttx-apps`` project:
 
     .. code-block:: bash
 
-       $ cd ../apps
-       $ git clone <your forked incubator-nuttx-apps project clone url>
+       $ cd ..
+       $ git clone <your forked incubator-nuttx-apps project clone url> apps
+       $ cd apps
        $ git remote add upstream https://github.com/apache/incubator-nuttx-apps.git
 
 #. Create a Local Git Branch


### PR DESCRIPTION
## Summary
The git clone commands in the documentation will create "incubator-nuttx" and "incubator-nuttx-apps" directories instead of the "nuttx" and "apps" directories and using the make commands will result in failures because "nuttx" and "apps" directories are not found.

I also added a few "cd" commands for better navigation.

## Impact
I hope this helps newbies which followed the instructions blindly.

## Testing
I've rebuild the documentation locally without problems.
