### PR TITLE
sem: remove limitation of irq context when do sem_trywait

### DIFF
--- a/mm/mm_heap/mm_sem.c
+++ b/mm/mm_heap/mm_sem.c
@@ -80,9 +80,13 @@ bool mm_takesemaphore(FAR struct mm_heap_s *heap)
 
   if (up_interrupt_context())
     {
+#ifdef CONFIG_DEBUG_MM
+      return _SEM_TRYWAIT(&heap->mm_semaphore) >= 0;
+#else
       /* Can't take semaphore in the interrupt handler */
 
       return false;
+#endif
     }
   else
 #endif

--- a/sched/semaphore/sem_trywait.c
+++ b/sched/semaphore/sem_trywait.c
@@ -69,9 +69,11 @@ int nxsem_trywait(FAR sem_t *sem)
   irqstate_t flags;
   int ret;
 
+#ifndef CONFIG_DEBUG_MM
   /* This API should not be called from interrupt handlers */
 
   DEBUGASSERT(sem != NULL && up_interrupt_context() == false);
+#endif
 
   if (sem != NULL)
     {


### PR DESCRIPTION
## Summary

sem: remove limitation of irq context when do sem_trywait

this change is for using mm_checkcorruption in an interrupt context.

## Impact

allow mm_takesemaphore in IRQ, just try get

## Testing

