### PR TITLE
Documentation: Fix openocd command instruction

### DIFF
--- a/Documentation/quickstart/debugging.rst
+++ b/Documentation/quickstart/debugging.rst
@@ -59,7 +59,7 @@ start ``openocd`` with the following command:
 
 .. code-block:: console
 
-  $ openocd -f interface/st-link-v2.cfg -f target/stm32f1x.cfg
+  $ openocd -f interface/stlink-v2.cfg -f target/stm32f1x.cfg
 
 This will start a ``gdb`` server. Then, start ``gdb`` with:
 
@@ -138,7 +138,7 @@ Finally, to enable NuttX integration, you need to supply an additional ``openocd
 
 .. code-block:: console
 
-  $ openocd -f interface/st-link-v2.cfg -f target/stm32f1x.cfg -c '$_TARGETNAME configure -rtos nuttx'
+  $ openocd -f interface/stlink-v2.cfg -f target/stm32f1x.cfg -c '$_TARGETNAME configure -rtos nuttx'
   
 Since ``openocd`` also needs to know the memory layout of certain datastructures, you need to have ``gdb``
 run the following commands once the ``nuttx`` binary is loaded:

--- a/Documentation/quickstart/running.rst
+++ b/Documentation/quickstart/running.rst
@@ -52,7 +52,7 @@ Now, to flash the binary to your board, connect the USB cable and do:
 .. code-block:: console
 
   $ cd nuttx/
-  $ openocd -f interface/st-link-v2.cfg -f target/stm32f1x.cfg -c 'init' \
+  $ openocd -f interface/stlink-v2.cfg -f target/stm32f1x.cfg -c 'init' \
     -c 'program nuttx/nuttx.bin verify reset' -c 'shutdown'
 
 Access NuttShell


### PR DESCRIPTION
## Summary
A user reported me an issue while following our documentation
then looking his command line error I noticed the openocd stlink
interface was wrong: st-link-v2.cfg -> stlink-v2.cfg

## Impact
Users will able to get NuttX running in their board

## Testing
N/A
