### PR TITLE
riscv/esp32c3: Initialize the BLE Mac

### DIFF
--- a/arch/risc-v/src/esp32c3/esp32c3_ble_adapter.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_ble_adapter.c
@@ -1328,7 +1328,7 @@ static void *malloc_internal_wrapper(size_t size)
 
 static int read_mac_wrapper(uint8_t mac[6])
 {
-  return 0;
+  return esp_read_mac(mac, ESP_MAC_BT);
 }
 
 /****************************************************************************

--- a/arch/risc-v/src/esp32c3/esp32c3_wifi_adapter.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_wifi_adapter.c
@@ -84,9 +84,6 @@
 #  error "on_exit() API must be enabled for deallocating Wi-Fi resources"
 #endif
 
-#define MAC_ADDR0_REG (DR_REG_EFUSE_BASE + 0x044)
-#define MAC_ADDR1_REG (DR_REG_EFUSE_BASE + 0x048)
-
 #define PHY_RF_MASK   ((1 << PHY_BT_MODULE) | (1 << PHY_WIFI_MODULE))
 
 #ifdef CONFIG_ESP32C3_WIFI_SAVE_PARAM
@@ -2650,66 +2647,6 @@ static void wifi_apb80m_release(void)
 static int wifi_phy_update_country_info(const char *country)
 {
   return -1;
-}
-
-/****************************************************************************
- * Name: esp_read_mac
- *
- * Description:
- *   Read MAC address from efuse
- *
- * Input Parameters:
- *   mac  - MAC address buffer pointer
- *   type - MAC address type
- *
- * Returned Value:
- *   0 if success or -1 if fail
- *
- ****************************************************************************/
-
-esp_err_t esp_read_mac(uint8_t *mac, esp_mac_type_t type)
-{
-  uint32_t regval[2];
-  uint8_t tmp;
-  uint8_t *data = (uint8_t *)regval;
-  int i;
-
-  if (type > ESP_MAC_WIFI_SOFTAP)
-    {
-      wlerr("ERROR: Input type is error=%d\n", type);
-      return -1;
-    }
-
-  regval[0] = getreg32(MAC_ADDR0_REG);
-  regval[1] = getreg32(MAC_ADDR1_REG);
-
-  for (i = 0; i < MAC_LEN; i++)
-    {
-      mac[i] = data[5 - i];
-    }
-
-  if (type == ESP_MAC_WIFI_SOFTAP)
-    {
-      tmp = mac[0];
-      for (i = 0; i < 64; i++)
-        {
-          mac[0] = tmp | 0x02;
-          mac[0] ^= i << 2;
-
-          if (mac[0] != tmp)
-            {
-              break;
-            }
-        }
-
-      if (i >= 64)
-        {
-          wlerr("ERROR: Failed to generate softAP MAC\n");
-          return -1;
-        }
-    }
-
-  return 0;
 }
 
 /****************************************************************************

--- a/arch/risc-v/src/esp32c3/esp32c3_wifi_adapter.h
+++ b/arch/risc-v/src/esp32c3/esp32c3_wifi_adapter.h
@@ -62,7 +62,6 @@ extern "C"
 
 #define SSID_MAX_LEN                (32)
 #define PWD_MAX_LEN                 (64)
-#define MAC_LEN                     (6)
 
 /* Wi-Fi event ID */
 

--- a/arch/risc-v/src/esp32c3/esp32c3_wifi_utils.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_wifi_utils.c
@@ -33,6 +33,7 @@
 
 #include "esp32c3_wifi_adapter.h"
 #include "esp32c3_wifi_utils.h"
+#include "esp32c3_wireless.h"
 #include "espidf_wifi.h"
 
 /****************************************************************************

--- a/arch/risc-v/src/esp32c3/esp32c3_wireless.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_wireless.c
@@ -33,16 +33,20 @@
 #include "hardware/esp32c3_system.h"
 #include "hardware/esp32c3_soc.h"
 #include "hardware/esp32c3_syscon.h"
+#include "hardware/esp32c3_efuse.h"
+#include "esp32c3_wireless.h"
 #include "esp32c3.h"
 #include "esp32c3_irq.h"
 #include "esp32c3_attr.h"
 #include "esp32c3_wireless.h"
-
 #include "espidf_wifi.h"
 
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
+
+#define MAC_ADDR0_REG EFUSE_RD_MAC_SPI_SYS_0_REG
+#define MAC_ADDR1_REG EFUSE_RD_MAC_SPI_SYS_1_REG
 
 /* Software Interrupt */
 
@@ -503,4 +507,81 @@ int esp32c3_wl_deinit(void)
   leave_critical_section(flags);
 
   return OK;
+}
+
+/****************************************************************************
+ * Name: esp_read_mac
+ *
+ * Description:
+ *   Read MAC address from efuse
+ *
+ * Input Parameters:
+ *   mac  - MAC address buffer pointer
+ *   type - MAC address type
+ *
+ * Returned Value:
+ *   0 if success or -1 if fail
+ *
+ ****************************************************************************/
+
+int esp_read_mac(uint8_t *mac, esp_mac_type_t type)
+{
+  uint32_t regval[2];
+  uint8_t tmp;
+  uint8_t *data = (uint8_t *)regval;
+  int i;
+
+  if (type > ESP_MAC_BT)
+    {
+      wlerr("ERROR: Input type is error=%d\n", type);
+      return -1;
+    }
+
+  regval[0] = getreg32(MAC_ADDR0_REG);
+  regval[1] = getreg32(MAC_ADDR1_REG);
+
+  for (i = 0; i < MAC_LEN; i++)
+    {
+      mac[i] = data[5 - i];
+    }
+
+  if (type == ESP_MAC_WIFI_SOFTAP)
+    {
+      tmp = mac[0];
+      for (i = 0; i < 64; i++)
+        {
+          mac[0] = tmp | 0x02;
+          mac[0] ^= i << 2;
+
+          if (mac[0] != tmp)
+            {
+              break;
+            }
+        }
+
+      if (i >= 64)
+        {
+          wlerr("ERROR: Failed to generate softAP MAC\n");
+          return -1;
+        }
+    }
+
+  if (type == ESP_MAC_BT)
+    {
+      tmp = mac[0];
+      for (i = 0; i < 64; i++)
+        {
+          mac[0] = tmp | 0x02;
+          mac[0] ^= i << 2;
+
+          if (mac[0] != tmp)
+            {
+              break;
+            }
+        }
+
+      mac[5] += 1;
+    }
+
+  return 0;
 }

--- a/arch/risc-v/src/esp32c3/esp32c3_wireless.h
+++ b/arch/risc-v/src/esp32c3/esp32c3_wireless.h
@@ -31,6 +31,8 @@
 #include <semaphore.h>
 #include <nuttx/list.h>
 
+#include "espidf_wifi.h"
+
 #ifndef __ASSEMBLY__
 
 #undef EXTERN
@@ -55,6 +57,12 @@ struct esp32c3_wl_semcache_s
   sem_t *sem;
   uint32_t count;
 };
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define MAC_LEN       (6)
 
 /****************************************************************************
  * Public Function Prototypes
@@ -159,6 +167,23 @@ int esp32c3_wl_init(void);
  ****************************************************************************/
 
 int esp32c3_wl_deinit(void);
+
+/****************************************************************************
+ * Name: esp_read_mac
+ *
+ * Description:
+ *   Read MAC address from efuse
+ *
+ * Input Parameters:
+ *   mac  - MAC address buffer pointer
+ *   type - MAC address type
+ *
+ * Returned Value:
+ *   0 if success or -1 if fail
+ *
+ ****************************************************************************/
+
+int esp_read_mac(uint8_t *mac, esp_mac_type_t type);
 
 #ifdef __cplusplus
 }

--- a/arch/risc-v/src/esp32c3/esp32c3_wlan.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_wlan.c
@@ -47,6 +47,7 @@
 #include "esp32c3_wlan.h"
 #include "esp32c3_wifi_utils.h"
 #include "esp32c3_wifi_adapter.h"
+#include "esp32c3_wireless.h"
 #include "esp32c3_systemreset.h"
 
 /****************************************************************************


### PR DESCRIPTION
## Summary

Initialize the BLE static Address when initializing the Bluetooth Controller.

## Impact

## Testing

