### PR TITLE
mpfs: emmcsd: fix uninitialized value

### DIFF
--- a/arch/risc-v/src/mpfs/mpfs_emmcsd.c
+++ b/arch/risc-v/src/mpfs/mpfs_emmcsd.c
@@ -2332,7 +2332,7 @@ static int mpfs_waitresponse(struct sdio_dev_s *dev, uint32_t cmd)
   struct mpfs_dev_s *priv = (struct mpfs_dev_s *)dev;
   uint32_t status;
   int32_t timeout;
-  uint32_t waitbits;
+  uint32_t waitbits = 0;
 
   mcinfo("cmd: %08" PRIx32 "\n", cmd);
 


### PR DESCRIPTION
cppcheck reports the following:

arch/risc-v/src/mpfs/mpfs_emmcsd.c:2375:22: error: Uninitialized variable: waitbits [uninitvar]
  while (!(status & (waitbits | MPFS_EMMCSD_SRS12_EINT))

The finding is positive and this patch initializes it to
zero properly.

Signed-off-by: Eero Nurkkala <eero.nurkkala@offcode.fi>

## Summary

Uninitilized variable is likely to cause random, unwanted effect

## Impact

No impact

## Testing

No testing, obvious error