### PR TITLE
Qencoder: add support for the encoder index pin and implementation for stm32/qenco

### DIFF
--- a/arch/arm/src/stm32/Kconfig
+++ b/arch/arm/src/stm32/Kconfig
@@ -11166,6 +11166,10 @@ config STM32_QENCODER_DISABLE_EXTEND16BTIMERS
 	bool "Disable QEncoder timers extension from 16-bit to 32-bit"
 	default n
 
+config STM32_QENCODER_INDEX_PIN
+	bool "Enable QEncoder timers support for index pin"
+	default n
+
 config STM32_TIM1_QE
 	bool "TIM1 QE"
 	default n

--- a/arch/arm/src/stm32/stm32_qencoder.h
+++ b/arch/arm/src/stm32/stm32_qencoder.h
@@ -124,5 +124,24 @@
 
 int stm32_qeinitialize(FAR const char *devpath, int tim);
 
+#ifdef CONFIG_STM32_QENCODER_INDEX_PIN
+/****************************************************************************
+ * Name: stm32_qe_index_init
+ *
+ * Description:
+ *   Register the encoder index pin to a given Qencoder timer
+ *
+ * Input Parameters:
+ *   tim  - The qenco timer number
+ *   gpio - gpio pin configuration
+ *
+ * Returned Value:
+ *   Zero on success; A negated errno value is returned on failure.
+ *
+ ****************************************************************************/
+
+int stm32_qe_index_init(int tim, uint32_t gpio);
+#endif
+
 #endif /* CONFIG_SENSORS_QENCODER */
 #endif /* __ARCH_ARM_SRC_STM32_STM32_QENCODER_H */

--- a/boards/arm/stm32/b-g431b-esc1/src/b-g431b-esc1.h
+++ b/boards/arm/stm32/b-g431b-esc1/src/b-g431b-esc1.h
@@ -70,6 +70,13 @@
 
 #define GPIO_BTN_USER  (GPIO_INPUT|GPIO_FLOAT|GPIO_EXTI|GPIO_PORTC|GPIO_PIN10)
 
+#ifdef CONFIG_SENSORS_QENCODER
+/* Qenco index pin */
+
+#  define QENCODER_TIM4_INDEX_GPIO (GPIO_INPUT | GPIO_FLOAT |\
+                                    GPIO_EXTI | GPIO_PORTB | GPIO_PIN8)
+#endif
+
 #ifdef CONFIG_SENSORS_HALL3PHASE
 /* GPIO pins used by the 3-phase Hall effect sensor */
 

--- a/boards/arm/stm32/b-g431b-esc1/src/stm32_foc.c
+++ b/boards/arm/stm32/b-g431b-esc1/src/stm32_foc.c
@@ -40,6 +40,10 @@
 
 #include "stm32_foc.h"
 
+#ifdef CONFIG_SENSORS_QENCODER
+#  include "stm32_qencoder.h"
+#endif
+
 #include "arm_arch.h"
 
 #include "b-g431b-esc1.h"
@@ -535,6 +539,24 @@ int stm32_foc_setup(void)
 
   if (g_foc_dev == NULL)
     {
+#if defined(CONFIG_SENSORS_QENCODER) || defined(CONFIG_SENSORS_HALL3PHASE)
+      /* Disable USB Type-C and Power Delivery Dead Battery */
+
+      modifyreg32(STM32_PWR_CR3, 0, PWR_CR3_UCPD1_DBDIS);
+#endif
+
+#if defined(CONFIG_SENSORS_QENCODER) && defined(CONFIG_STM32_QENCODER_INDEX_PIN)
+      /* Configure encoder index GPIO */
+
+      ret = stm32_qe_index_init(4, QENCODER_TIM4_INDEX_GPIO);
+      if (ret < 0)
+        {
+          mtrerr("Failed to register encoder index pin %d\n", ret);
+          ret = -EACCES;
+          goto errout;
+        }
+#endif
+
       /* Initialize arch specific FOC lower-half */
 
       foc = stm32_foc_initialize(0, &g_stm32_foc_board);
@@ -584,12 +606,6 @@ int stm32_adc_setup(void)
 
   if (initialized == false)
     {
-#if defined(CONFIG_SENSORS_QENCODER) || defined(CONFIG_SENSORS_HALL3PHASE)
-      /* Disable USB Type-C and Power Delivery Dead Battery */
-
-      modifyreg32(STM32_PWR_CR3, 0, PWR_CR3_UCPD1_DBDIS);
-#endif
-
       if (g_foc_dev == NULL)
         {
           mtrerr("Failed to get g_foc_dev device\n");

--- a/drivers/sensors/qencoder.c
+++ b/drivers/sensors/qencoder.c
@@ -328,6 +328,24 @@ static int qe_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
         }
         break;
 
+      /* QEIOC_SETINDEX - Set the index pin position
+       *   Argument: uint32
+       */
+
+      case QEIOC_SETINDEX:
+        {
+          uint32_t indexpos = (uint32_t)arg;
+          if (lower->ops->setindex != NULL)
+            {
+              ret = lower->ops->setindex(lower, indexpos);
+            }
+          else
+            {
+              ret = -ENOTTY;
+            }
+        }
+        break;
+
       /* Any unrecognized IOCTL commands might be platform-specific ioctl
        * commands
        */

--- a/include/nuttx/sensors/qencoder.h
+++ b/include/nuttx/sensors/qencoder.h
@@ -57,9 +57,10 @@
 #define QEIOC_POSITION     _QEIOC(0x0001) /* Arg: int32_t* pointer */
 #define QEIOC_RESET        _QEIOC(0x0002) /* Arg: None */
 #define QEIOC_SETPOSMAX    _QEIOC(0x0003) /* Arg: uint32_t */
+#define QEIOC_SETINDEX     _QEIOC(0x0004) /* Arg: uint32_t */
 
 #define QE_FIRST           0x0001         /* First required command */
-#define QE_NCMDS           3              /* Two required commands */
+#define QE_NCMDS           4              /* 4 required commands */
 
 /* User defined ioctl commands are also supported. These will be forwarded
  * by the upper-half QE driver to the lower-half QE driver via the ioctl()
@@ -119,6 +120,10 @@ struct qe_ops_s
   /* Reset the position measurement to zero. */
 
   CODE int (*reset)(FAR struct qe_lowerhalf_s *lower);
+
+  /* Set the index pin position */
+
+  CODE int (*setindex)(FAR struct qe_lowerhalf_s *lower, uint32_t pos);
 
   /* Lower-half logic may support platform-specific ioctl commands */
 


### PR DESCRIPTION
## Summary
- drivers/qencoder: add an interface to configure the encoder index pin position
- arch/arm/stm32/stm32_qencoder: add support for Qenco index pin
- boards/b-g431b-esc1: register Qenco index pin

## Impact
New feature for qenco

## Testing
b-g431b-esc1
