### PR TITLE
tools/mkconfig: Handle string with escape character correctly

### DIFF
--- a/tools/cfgdefine.c
+++ b/tools/cfgdefine.c
@@ -86,7 +86,7 @@ static const char *dequote_list[] =
 
 static char *skip_space(char *ptr)
 {
-  while (*ptr && isspace((int)*ptr)) ptr++;
+  while (*ptr && isspace(*ptr)) ptr++;
   return ptr;
 }
 
@@ -94,7 +94,7 @@ static char *skip_space(char *ptr)
 
 static char *find_name_end(char *ptr)
 {
-  while (*ptr && (isalnum((int)*ptr) || *ptr == '_')) ptr++;
+  while (*ptr && (isalnum(*ptr) || *ptr == '_')) ptr++;
   return ptr;
 }
 
@@ -102,7 +102,7 @@ static char *find_name_end(char *ptr)
 
 static char *find_value_end(char *ptr)
 {
-  while (*ptr && !isspace((int)*ptr))
+  while (*ptr && !isspace(*ptr))
     {
       if (*ptr == '"')
         {
@@ -111,7 +111,7 @@ static char *find_value_end(char *ptr)
         }
       else
         {
-          do ptr++; while (*ptr && !isspace((int)*ptr) && *ptr != '"');
+          do ptr++; while (*ptr && !isspace(*ptr) && *ptr != '"');
         }
     }
 
@@ -148,13 +148,7 @@ static char *read_line(FILE *stream)
 
 static void parse_line(char *ptr, char **varname, char **varval)
 {
-  /* Skip over any leading spaces */
-
-  ptr = skip_space(ptr);
-
-  /* The first no-space is the beginning of the variable name */
-
-  *varname = skip_space(ptr);
+  *varname = ptr;
   *varval = NULL;
 
   /* Parse to the end of the variable name */

--- a/tools/cfgdefine.c
+++ b/tools/cfgdefine.c
@@ -106,7 +106,7 @@ static char *find_value_end(char *ptr)
     {
       if (*ptr == '"')
         {
-          do ptr++; while (*ptr && *ptr != '"');
+          do ptr++; while (*ptr && (*ptr != '"' || *(ptr - 1) == '\\'));
           if (*ptr) ptr++;
         }
       else


### PR DESCRIPTION
## Summary
and emove the redundant skip_space and cast.

## Impact
string type of Kconfig with the escape sequence

## Testing
sim:nsh add `CONFIG_INIT_ARGS="\"-c\", \"echo 123;echo 456\""`
```
./nuttx 
login: admin
password: 
User Logged-in!

NuttShell (NSH) NuttX-10.2.0-RC0
MOTD: username=admin password=Administrator
123
456
```