### PR TITLE
esp32/esp32c3: Fix MMU pages number calculation error

### DIFF
--- a/arch/risc-v/src/esp32c3/esp32c3_spiflash.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_spiflash.c
@@ -290,7 +290,7 @@ static int IRAM_ATTR esp32c3_mmap(struct spiflash_map_req_s *req)
     }
 
   flash_page = MMU_ADDR2PAGE(req->src_addr);
-  page_cnt   = MMU_BYTES2PAGES(req->size);
+  page_cnt   = MMU_BYTES2PAGES(MMU_ADDR2OFF(req->src_addr) + req->size);
 
   if (start_page + page_cnt < DROM0_PAGES_END)
     {

--- a/arch/xtensa/src/esp32/esp32_spiflash.c
+++ b/arch/xtensa/src/esp32/esp32_spiflash.c
@@ -1344,7 +1344,7 @@ static int IRAM_ATTR esp32_mmap(struct esp32_spiflash_s *priv,
     }
 
   flash_page = MMU_ADDR2PAGE(req->src_addr);
-  page_cnt = MMU_BYTES2PAGES(req->size);
+  page_cnt = MMU_BYTES2PAGES(MMU_ADDR2OFF(req->src_addr) + req->size);
 
   if (start_page + page_cnt < DROM0_PAGES_END)
     {


### PR DESCRIPTION
## Summary

Fix MMU pages number calculation error.

If the starting mapping address is not 64KB aligned, we must allocation space by 64KB align, so the rest is also added.

## Impact

## Testing

