### PR TITLE
netdb: fix access within misaligned address error

### DIFF
--- a/libs/libc/netdb/lib_dnsquery.c
+++ b/libs/libc/netdb/lib_dnsquery.c
@@ -334,6 +334,7 @@ static int dns_recv_response(int sd, FAR union dns_addr_u *addr, int naddr,
   FAR struct dns_answer_s *ans;
   FAR struct dns_header_s *hdr;
   FAR struct dns_question_s *que;
+  struct dns_question_s bak;
   uint16_t nquestions;
   uint16_t nanswers;
   uint16_t temp;
@@ -437,12 +438,13 @@ static int dns_recv_response(int sd, FAR union dns_addr_u *addr, int naddr,
   /* Validate query type and class */
 
   que = (FAR struct dns_question_s *)nameptr;
+  memcpy(&bak, que, sizeof(struct dns_question_s));
 
   /* N.B. Unaligned access may occur here */
 
   temp = HTONS(DNS_CLASS_IN);
-  if (memcmp(&que->type, &qinfo->rectype, sizeof(uint16_t)) != 0 ||
-      memcmp(&que->class, &temp, sizeof(uint16_t)) != 0)
+  if (memcmp(&bak.type, &qinfo->rectype, sizeof(uint16_t)) != 0 ||
+      memcmp(&bak.class, &temp, sizeof(uint16_t)) != 0)
     {
       nerr("ERROR: DNS response with wrong question\n");
       return -EBADMSG;


### PR DESCRIPTION


## Summary

netdb: fix access within misaligned address error

netdb/lib_dnsquery.c:444:14: runtime error: member access within misaligned address 0xef2f5a1b for type 'struct dns_question_s', which requires 2 byte alignment
0xef2f5a1b: note: pointer points here
 63  6f 6d 00 00 01 00 01 c0  0c 00 05 00 01 00 00 00  1c 00 1a 05 6d 75 73 69  63 06 6e 74 65 73 35
              ^
netdb/lib_dnsquery.c:445:14: runtime error: member access within misaligned address 0xef2f5a1b for type 'struct dns_question_s', which requires 2 byte alignment
0xef2f5a1b: note: pointer points here
 63  6f 6d 00 00 01 00 01 c0  0c 00 05 00 01 00 00 00  1c 00 1a 05 6d 75 73 69  63 06 6e 74 65 73 35
              ^

## Impact

## Testing

