### PR TITLE
wdog/wd_start: remove the "delay+1" operation, which will cause the a…

### DIFF
--- a/sched/wdog/wd_start.c
+++ b/sched/wdog/wd_start.c
@@ -204,15 +204,11 @@ int wd_start(FAR struct wdog_s *wdog, sclock_t delay,
   up_getpicbase(&wdog->picbase);
   wdog->arg = arg;
 
-  /* Calculate delay+1, forcing the delay into a range that we can handle */
+  /* Forcing the delay into a range that we can handle */
 
   if (delay <= 0)
     {
       delay = 1;
-    }
-  else if (++delay <= 0)
-    {
-      delay--;
     }
 
 #ifdef CONFIG_SCHED_TICKLESS


### PR DESCRIPTION
wdog/wd_start.c: remove the "delay+1" operation, which will cause the actual delay time to be one tick longer than expected delay time.

## Summary
The sleep() time is not correct because of the incorrect delay calculation in wdog/wd_start : 192. The delay time will be one tick (system clock tick) longer than expected delay time.

## Impact

## Testing
Measure the sleep time after call sleep() using clock() function in linux simulation environment.
### Test code:
```c
int main(int argc, FAR char *argv[])
{
  int count = 0;
  clock_t clock1 = 0;
  clock_t clock2 = 0;

  printf("\n");
  while(count < 20)
    {
      clock1 = clock();
      sleep(1);
      clock2 = clock();
      printf("count:%d, clock1: %ld, clock2: %ld.\n", count, clock1, clock2);
      count++;
    }

  printf("Test End!\n");
  return 0;
}
```
### Test result before revision:
```shell
nsh> hello

count:0, clock1: 4294967254, clock2: 4294967355.
count:1, clock1: 4294967355, clock2: 4294967456.
count:2, clock1: 4294967456, clock2: 4294967557.
count:3, clock1: 4294967557, clock2: 4294967658.
count:4, clock1: 4294967658, clock2: 4294967759.
count:5, clock1: 4294967759, clock2: 4294967860.
count:6, clock1: 4294967860, clock2: 4294967961.
count:7, clock1: 4294967961, clock2: 4294968062.
count:8, clock1: 4294968062, clock2: 4294968163.
count:9, clock1: 4294968163, clock2: 4294968264.
count:10, clock1: 4294968264, clock2: 4294968365.
count:11, clock1: 4294968365, clock2: 4294968466.
count:12, clock1: 4294968466, clock2: 4294968567.
count:13, clock1: 4294968567, clock2: 4294968668.
count:14, clock1: 4294968668, clock2: 4294968769.
count:15, clock1: 4294968769, clock2: 4294968870.
count:16, clock1: 4294968870, clock2: 4294968971.
count:17, clock1: 4294968971, clock2: 4294969072.
count:18, clock1: 4294969072, clock2: 4294969173.
count:19, clock1: 4294969173, clock2: 4294969274.
Test End!
nsh> 

```
We can see that the sleep time is always one tick (system clock tick) longer than expected sleep time.

### Test result after revision:
```shell
nsh> hello

count:0, clock1: 4294967334, clock2: 4294967434.
count:1, clock1: 4294967434, clock2: 4294967534.
count:2, clock1: 4294967534, clock2: 4294967634.
count:3, clock1: 4294967634, clock2: 4294967734.
count:4, clock1: 4294967734, clock2: 4294967834.
count:5, clock1: 4294967834, clock2: 4294967934.
count:6, clock1: 4294967934, clock2: 4294968034.
count:7, clock1: 4294968034, clock2: 4294968134.
count:8, clock1: 4294968134, clock2: 4294968234.
count:9, clock1: 4294968234, clock2: 4294968334.
count:10, clock1: 4294968334, clock2: 4294968434.
count:11, clock1: 4294968434, clock2: 4294968534.
count:12, clock1: 4294968534, clock2: 4294968634.
count:13, clock1: 4294968634, clock2: 4294968734.
count:14, clock1: 4294968734, clock2: 4294968834.
count:15, clock1: 4294968834, clock2: 4294968934.
count:16, clock1: 4294968934, clock2: 4294969034.
count:17, clock1: 4294969034, clock2: 4294969134.
count:18, clock1: 4294969134, clock2: 4294969234.
count:19, clock1: 4294969234, clock2: 4294969334.
Test End!
nsh> 
```
The sleep time is correct.


