### PR TITLE
ci: Freeze pipenv version for avoiding issue on documentation generation

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Generate Documentation
         run: |
           cd Documentation/
-          pip3 install pipenv
+          pip3 install pipenv==2021.5.29
           pipenv install
           pipenv run make html
       - uses: actions/upload-artifact@v2


### PR DESCRIPTION
## Summary
This PR intends to add a quick fix for an issue with the latest release of `pipenv`.

From my investigation seems related to this issue: https://github.com/pypa/pipenv/issues/4828

## Impact
No impact, fix for CI job.

## Testing
CI build pass.
