### PR TITLE
ci: Use actions/checkout@v2 on build-html job

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -19,7 +19,7 @@ jobs:
   build-html:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
           python-version: '3.8'


### PR DESCRIPTION
## Summary
This PR intends to update the Action `actions/checkout@v2` for the **build-html** CI job

## Impact
No impact, CI only.

## Testing
CI build pass.
