### PR TITLE
procfs: fix ps can't log out Group id

### DIFF
--- a/fs/procfs/fs_procfsproc.c
+++ b/fs/procfs/fs_procfsproc.c
@@ -498,8 +498,8 @@ static ssize_t proc_status(FAR struct proc_file_s *procfile,
   DEBUGASSERT(group != NULL);
 
   linesize   = procfs_snprintf(procfile->line, STATUS_LINELEN,
-                               "%-12s%d\n", "PPID:",
-                               group->tg_ppid);
+                               "%-12s%d\n",
+                               "Group:", group->tg_pid);
   copysize   = procfs_memcpy(procfile->line, linesize, buffer, remaining,
                              &offset);
 
@@ -983,6 +983,20 @@ static ssize_t proc_groupstatus(FAR struct proc_file_s *procfile,
 
   linesize   = procfs_snprintf(procfile->line, STATUS_LINELEN, "%-12s%d\n",
                                "Main task:", group->tg_pid);
+  copysize   = procfs_memcpy(procfile->line, linesize, buffer,
+                             remaining, &offset);
+
+  totalsize += copysize;
+  buffer    += copysize;
+  remaining -= copysize;
+
+  if (totalsize >= buflen)
+    {
+      return totalsize;
+    }
+
+  linesize   = procfs_snprintf(procfile->line, STATUS_LINELEN, "%-12s%d\n",
+                               "Parent:", group->tg_ppid);
   copysize   = procfs_memcpy(procfile->line, linesize, buffer,
                              remaining, &offset);
 


### PR DESCRIPTION
## Summary
procfs: fix ps can't log out Group id

Current version:
if defined(CONFIG_SCHED_HAVE_PARENT) && defined(CONFIG_SCHED_CHILD_STATUS) are ture,
but "Group" have no value

  PID GROUP PRI POLICY   TYPE    NPX STATE    EVENT     SIGMASK   STACK   USED  FILLED COMMAND
    0               0 FIFO     Kthread N-- Ready              00000000 2097104 004160   0.1%  Idle Task
    1           100 FIFO     Kthread --- Waiting  Semaphore 00000000 2097120 003024   0.1%  lpwork 0x5988cec0

Root case:
the cmd_ps()  -> ps_callback() in nshlib/nsh_proccmds.c

static const char g_groupid[]   = "Group:";

need key word "Group:"

But the procfs driver always provide:
"PPID:",
in fs/procfs/fs_procfsproc.c

Resolve:
fs/procfs/fs_procfsproc.c set keywords to "Group:"
nshlib/nsh_proccmds.c use keywords "Group:"


## Impact
ps

## Testing

