### PR TITLE
include: Add __socklen_t_defined for compatibility to other C libraries

### DIFF
--- a/include/sys/types.h
+++ b/include/sys/types.h
@@ -219,6 +219,7 @@ typedef int16_t      blksize_t;
 /* Network related */
 
 typedef unsigned int socklen_t;
+#define __socklen_t_defined
 typedef uint16_t     sa_family_t;
 
 /* Used for system times in clock ticks. This type is the natural width of


### PR DESCRIPTION
## Summary
This PR intends to add the definition of `__socklen_t_defined` to NuttX C library implementation to indicate libraries that NuttX provides the `socklen_t` type. Although `__socklen_t_defined` may not be part of the C standard, this improves compatibility to other well-established C library implementations:

- **glibc**: https://sourceware.org/git/?p=glibc.git;a=blob;f=bits/socket.h;h=05ac0249c7da7218cbd11be99a67529161cfa7f7;hb=refs/heads/master#l35
- **uclibc-ng**: https://cgit.uclibc-ng.org/cgi/cgit/uclibc-ng.git/tree/include/unistd.h#n279

## Impact
Resolves Mbed TLS build warnings due to lack of `socklen_t` type.

## Testing
`esp32-devkitc` with `CRYPTO_MBEDTLS`.

