### PR TITLE
esp32c3: Fix GPIO Output on pins 18 and 19 USB/JTAG

### DIFF
--- a/arch/risc-v/src/esp32c3/esp32c3_gpio.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_gpio.c
@@ -38,8 +38,16 @@
 #include "esp32c3_irq.h"
 #include "hardware/esp32c3_iomux.h"
 #include "hardware/esp32c3_gpio.h"
+#include "hardware/esp32c3_usb_serial_jtag.h"
 
 #include "esp32c3_gpio.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define USB_JTAG_DM    18
+#define USB_JTAG_DP    19
 
 /****************************************************************************
  * Private Data
@@ -127,6 +135,18 @@ int esp32c3_configgpio(int pin, gpio_pinattr_t attr)
 
   func  = 0;
   cntrl = 0;
+
+  /* If pin 18 or 19 then disable the USB/JTAG function and pull-up */
+
+  if ((pin == USB_JTAG_DM) || (pin == USB_JTAG_DP))
+    {
+      uint32_t regval;
+
+      regval = getreg32(USB_SERIAL_JTAG_CONF0_REG);
+      regval &= ~(USB_SERIAL_JTAG_USB_PAD_ENABLE |
+                  USB_SERIAL_JTAG_DP_PULLUP);
+      putreg32(regval, USB_SERIAL_JTAG_CONF0_REG);
+    }
 
   /* Handle input pins */
 


### PR DESCRIPTION
## Summary
This patch will fix an issue on GPIO 18 and 19 that prevent it to be used as output
## Impact
User will be able to GPIO 18 and 19 accessible as GPIO output
## Testing
ESP32C3-Devkit
