### PR TITLE
net/can/can_recvmsg.c : put can_readahead in critical section

### DIFF
--- a/mm/iob/iob_add_queue.c
+++ b/mm/iob/iob_add_queue.c
@@ -28,6 +28,8 @@
 #include <errno.h>
 #include <debug.h>
 
+#include <nuttx/irq.h>
+#include <nuttx/arch.h>
 #include <nuttx/mm/iob.h>
 
 #include "iob.h"
@@ -66,6 +68,8 @@ static int iob_add_queue_internal(FAR struct iob_s *iob,
   /* Add the container to the end of the queue */
 
   qentry->qe_flink = NULL;
+
+  irqstate_t flags = enter_critical_section();
   if (!iobq->qh_head)
     {
       iobq->qh_head = qentry;
@@ -77,6 +81,8 @@ static int iob_add_queue_internal(FAR struct iob_s *iob,
       iobq->qh_tail->qe_flink = qentry;
       iobq->qh_tail = qentry;
     }
+
+  leave_critical_section(flags);
 
   return 0;
 }

--- a/mm/iob/iob_free_queue_qentry.c
+++ b/mm/iob/iob_free_queue_qentry.c
@@ -24,6 +24,9 @@
 
 #include <nuttx/config.h>
 #include <assert.h>
+
+#include <nuttx/irq.h>
+#include <nuttx/arch.h>
 #include <nuttx/mm/iob.h>
 
 #include "iob.h"
@@ -57,6 +60,7 @@ void iob_free_queue_qentry(FAR struct iob_s *iob,
   FAR struct iob_qentry_s *prev = NULL;
   FAR struct iob_qentry_s *qentry;
 
+  irqstate_t flags = enter_critical_section();
   for (qentry = iobq->qh_head; qentry != NULL;
        prev = qentry, qentry = qentry->qe_flink)
     {
@@ -89,6 +93,8 @@ void iob_free_queue_qentry(FAR struct iob_s *iob,
           break;
         }
     }
+
+  leave_critical_section(flags);
 }
 
 #endif /* CONFIG_IOB_NCHAINS > 0 */

--- a/mm/iob/iob_remove_queue.c
+++ b/mm/iob/iob_remove_queue.c
@@ -26,6 +26,8 @@
 
 #include <debug.h>
 
+#include <nuttx/irq.h>
+#include <nuttx/arch.h>
 #include <nuttx/mm/iob.h>
 
 #include "iob.h"
@@ -62,6 +64,7 @@ FAR struct iob_s *iob_remove_queue(FAR struct iob_queue_s *iobq)
 
   /* Remove the I/O buffer chain from the head of the queue */
 
+  irqstate_t flags = enter_critical_section();
   qentry = iobq->qh_head;
   if (qentry)
     {
@@ -79,6 +82,7 @@ FAR struct iob_s *iob_remove_queue(FAR struct iob_queue_s *iobq)
       iob_free_qentry(qentry);
     }
 
+  leave_critical_section(flags);
   return iob;
 }
 


### PR DESCRIPTION
## Summary

net/can/can_recvmsg.c : put can_readahead in critical section

## Impact

avoid  readahead changed by CAN interrupt , which will lead to data drop , IOB memory leak and NET stack crash

## Testing

