### PR TITLE
stm32l4 dfumode: enable for STM32L4+ chips

### DIFF
--- a/arch/arm/src/stm32l4/stm32l4_dfumode.c
+++ b/arch/arm/src/stm32l4/stm32l4_dfumode.c
@@ -46,6 +46,8 @@ static inline void rcc_reset(void)
 {
   uint32_t regval;
 
+  /* Enable the MSI clock */
+
   regval = getreg32(STM32L4_RCC_CR);
   regval |= RCC_CR_MSION;
   putreg32(regval, STM32L4_RCC_CR);
@@ -63,11 +65,11 @@ static inline void rcc_reset(void)
 
   putreg32(0x00000000, STM32L4_RCC_CFGR);
 
-  /* Reset HSION, HSEON, CSSON and PLLON bits */
+  /* Reset enable bits for other clocks than MSI */
 
   regval  = getreg32(STM32L4_RCC_CR);
   regval &= ~(RCC_CR_HSION | RCC_CR_HSIKERON | RCC_CR_HSEON |
-              RCC_CR_HSIASFS | RCC_CR_CSSON | RCC_CR_PLLON | RCC_CR_PLLON |
+              RCC_CR_HSIASFS | RCC_CR_CSSON | RCC_CR_PLLON |
               RCC_CR_PLLSAI1ON | RCC_CR_PLLSAI2ON);
   putreg32(regval, STM32L4_RCC_CR);
 
@@ -121,7 +123,7 @@ static inline void apb_reset(void)
  *
  ****************************************************************************/
 
-#if defined(CONFIG_STM32L4_STM32L4X6)
+#if defined(CONFIG_STM32L4_STM32L4X6) || defined(CONFIG_STM32L4_STM32L4XR)
 void stm32l4_dfumode(void)
 {
   uint32_t regval;
@@ -131,7 +133,7 @@ void stm32l4_dfumode(void)
   _warn("Entering DFU mode...\n");
 #endif
 
-  /* disable all peripherals, interrupts and switch to HSI */
+  /* disable all peripherals, interrupts and switch to MSI */
 
   rcc_reset();
   apb_reset();

--- a/arch/arm/src/stm32l4/stm32l4_dfumode.h
+++ b/arch/arm/src/stm32l4/stm32l4_dfumode.h
@@ -39,7 +39,7 @@
  *
  ****************************************************************************/
 
-#if defined(CONFIG_STM32L4_STM32L4X6)
+#if defined(CONFIG_STM32L4_STM32L4X6) || defined(CONFIG_STM32L4_STM32L4XR)
 void stm32l4_dfumode(void) noreturn_function;
 #endif
 


### PR DESCRIPTION
## Summary
Allow also STM32L4+ boards to call stm32l4_dfumode() function.

## Impact
Feature port from one MCU subarch to another

## Testing
Tested that DFU mode entry works on STM32L4R5AI

