### PR TITLE
arch/arm: Remove EXPERIMENTAL from ARCH_TRUSTZONE_XXX

### DIFF
--- a/arch/arm/Kconfig
+++ b/arch/arm/Kconfig
@@ -822,11 +822,9 @@ config ARCH_TRUSTZONE_SECURE
 
 config ARCH_TRUSTZONE_NONSECURE
 	bool "All CPUs operate non-secure state"
-	depends on EXPERIMENTAL
 
 config ARCH_TRUSTZONE_BOTH
 	bool "CPUs operate in both secure and non-secure states"
-	depends on EXPERIMENTAL
 
 endchoice # TrustZone Configuration
 


### PR DESCRIPTION
## Summary
since it work on the product device

## Impact
No, since the feature depend on EXPERIMENTAL is still off by default.

## Testing
internal device
