### PR TITLE
esp32 & esp32c3: Partition supports BIO cmd

### DIFF
--- a/arch/risc-v/src/esp32c3/esp32c3_partition.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_partition.c
@@ -497,12 +497,6 @@ static int esp32c3_part_ioctl(struct mtd_dev_s *dev, int cmd,
 
   finfo("INFO: cmd=%d(0x%x) arg=0x%" PRIx32 "\n", cmd, cmd, arg);
 
-  if (!_MTDIOCVALID(cmd))
-    {
-      ferr("ERROR: cmd=%d(0x%x) is error\n", cmd, cmd);
-      return -EINVAL;
-    }
-
   switch (_IOC_NR(cmd))
     {
       case OTA_IMG_GET_BOOT:

--- a/arch/xtensa/src/esp32/esp32_partition.c
+++ b/arch/xtensa/src/esp32/esp32_partition.c
@@ -495,12 +495,6 @@ static int esp32_part_ioctl(struct mtd_dev_s *dev, int cmd,
 
   finfo("INFO: cmd=%d(%x) arg=%x\n", cmd, cmd, arg);
 
-  if (!_MTDIOCVALID(cmd))
-    {
-      finfo("INFO: cmd=%d(%x) is error\n", cmd, cmd);
-      return -ENOTTY;
-    }
-
   switch (_IOC_NR(cmd))
     {
       case OTA_IMG_GET_BOOT:


### PR DESCRIPTION
## Summary

Partition of esp32 and esp32c3 supports BIO command.

## Impact

## Testing

