### PR TITLE
risc-v/esp32c3: Add hardware brownout check and reset

### DIFF
--- a/arch/risc-v/src/esp32c3/Kconfig
+++ b/arch/risc-v/src/esp32c3/Kconfig
@@ -351,6 +351,14 @@ config ESP32C3_BLE
 	---help---
 		Enable BLE support
 
+config ESP32C3_BROWNOUT_DET
+	bool "Brownout Detect"
+	default y
+	---help---
+		The ESP32-C3 has a built-in brownout detector which can detect if the voltage is lower than
+		a specific value. If this happens, it will reset the chip in order to prevent unintended
+		behaviour.
+
 endmenu # ESP32-C3 Peripheral Support
 
 menuconfig ESP32C3_WIFI_BT_COEXIST
@@ -1058,5 +1066,49 @@ config ESP32C3_PARTITION_TABLE_OFFSET
 	depends on ESP32C3_APP_FORMAT_LEGACY
 
 endmenu # Application Image Configuration
+
+menu "Brownout Detect Configuration"
+	depends on ESP32C3_BROWNOUT_DET
+
+choice ESP32C3_BROWNOUT_DET_LVL_SEL
+	prompt "Brownout voltage level"
+	default ESP32C3_BROWNOUT_DET_LVL_SEL_7
+	---help---
+		The brownout detector will reset the chip when the supply voltage is approximately
+		below this level. Note that there may be some variation of brownout voltage level
+		between each chip.
+
+		#The voltage levels here are estimates, more work needs to be done to figure out the exact voltages
+		#of the brownout threshold levels.
+
+	config ESP32C3_BROWNOUT_DET_LVL_SEL_7
+		bool "2.51V"
+
+	config ESP32C3_BROWNOUT_DET_LVL_SEL_6
+		bool "2.64V"
+
+	config ESP32C3_BROWNOUT_DET_LVL_SEL_5
+		bool "2.76V"
+
+	config ESP32C3_BROWNOUT_DET_LVL_SEL_4
+		bool "2.92V"
+
+	config ESP32C3_BROWNOUT_DET_LVL_SEL_3
+		bool "3.10V"
+
+	config ESP32C3_BROWNOUT_DET_LVL_SEL_2
+		bool "3.27V"
+endchoice
+
+config ESP32C3_BROWNOUT_DET_LVL
+	int
+	default 2 if ESP32C3_BROWNOUT_DET_LVL_SEL_2
+	default 3 if ESP32C3_BROWNOUT_DET_LVL_SEL_3
+	default 4 if ESP32C3_BROWNOUT_DET_LVL_SEL_4
+	default 5 if ESP32C3_BROWNOUT_DET_LVL_SEL_5
+	default 6 if ESP32C3_BROWNOUT_DET_LVL_SEL_6
+	default 7 if ESP32C3_BROWNOUT_DET_LVL_SEL_7
+
+endmenu # ESP32C3_BROWNOUT_DET
 
 endif # ARCH_CHIP_ESP32C3

--- a/arch/risc-v/src/esp32c3/Make.defs
+++ b/arch/risc-v/src/esp32c3/Make.defs
@@ -172,6 +172,10 @@ ifeq ($(CONFIG_ESP32C3_RTC_HEAP),y)
 CHIP_CSRCS += esp32c3_rtcheap.c
 endif
 
+ifeq ($(CONFIG_ESP32C3_BROWNOUT_DET),y)
+CHIP_CSRCS += esp32c3_brownout.c
+endif
+
 ifeq ($(CONFIG_ESP32C3_WIRELESS),y)
 WIRELESS_DRV_UNPACK  = esp-wireless-drivers-3rdparty
 WIRELESS_DRV_ID      = 055f1ef

--- a/arch/risc-v/src/esp32c3/esp32c3_brownout.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_brownout.c
@@ -1,0 +1,66 @@
+/****************************************************************************
+ * arch/risc-v/src/esp32c3/esp32c3_brownout.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include "esp32c3.h"
+#include "hardware/esp32c3_rtccntl.h"
+#include "hardware/regi2c_ctrl.h"
+#include "hardware/regi2c_brownout.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define ESP32C3_BROWNOUT_VAL        CONFIG_ESP32C3_BROWNOUT_DET_LVL
+#define ESP32C3_BROWNOUT_RST_SEL    1
+#define ESP32C3_BROWNOUT_RST_WAIT   0x3ff
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name:  esp32c3_brownout_init
+ *
+ * Description:
+ *   Initialize hardware brownout check and reset.
+ *
+ ****************************************************************************/
+
+void esp32c3_brownout_init(void)
+{
+  uint32_t regval;
+
+  REGI2C_WRITE_MASK(I2C_BOD, I2C_BOD_THRESHOLD, ESP32C3_BROWNOUT_VAL);
+
+  regval = RTC_CNTL_BROWN_OUT_ENA |
+           (ESP32C3_BROWNOUT_RST_SEL << RTC_CNTL_BROWN_OUT_RST_SEL_S) |
+           RTC_CNTL_BROWN_OUT_RST_ENA |
+           (ESP32C3_BROWNOUT_RST_WAIT << RTC_CNTL_BROWN_OUT_RST_WAIT_S) |
+           RTC_CNTL_BROWN_OUT_PD_RF_ENA |
+           RTC_CNTL_BROWN_OUT_CLOSE_FLASH_ENA;
+
+  putreg32(regval, RTC_CNTL_BROWN_OUT_REG);
+}

--- a/arch/risc-v/src/esp32c3/esp32c3_brownout.h
+++ b/arch/risc-v/src/esp32c3/esp32c3_brownout.h
@@ -1,0 +1,65 @@
+/****************************************************************************
+ * arch/risc-v/src/esp32c3/esp32c3_brownout.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __ARCH_RISCV_SRC_ESP32C3_ESP32C3_BROWNOUT_H
+#define __ARCH_RISCV_SRC_ESP32C3_ESP32C3_BROWNOUT_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#ifndef __ASSEMBLY__
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+#ifdef __cplusplus
+#define EXTERN extern "C"
+extern "C"
+{
+#else
+#define EXTERN extern
+#endif
+
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name:  esp32c3_brownout_init
+ *
+ * Description:
+ *   Initialize hardware brownout check and reset.
+ *
+ ****************************************************************************/
+
+void esp32c3_brownout_init(void);
+
+#if defined(__cplusplus)
+}
+#endif
+#undef EXTERN
+
+#endif /* __ASSEMBLY__ */
+
+#endif /* __ARCH_RISCV_SRC_ESP32C3_ESP32C3_BROWNOUT_H */

--- a/arch/risc-v/src/esp32c3/esp32c3_start.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_start.c
@@ -38,6 +38,10 @@
 #include "hardware/esp32c3_cache_memory.h"
 #include "hardware/extmem_reg.h"
 
+#ifdef CONFIG_ESP32C3_BROWNOUT_DET
+#  include "esp32c3_brownout.h"
+#endif
+
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
@@ -239,6 +243,12 @@ void __esp32c3_start(void)
   /* Set CPU frequency */
 
   esp32c3_clockconfig();
+
+#ifdef CONFIG_ESP32C3_BROWNOUT_DET
+  /* Initialize hardware brownout check and reset */
+
+  esp32c3_brownout_init();
+#endif
 
   /* Configure the UART so we can get debug output */
 

--- a/arch/risc-v/src/esp32c3/hardware/regi2c_brownout.h
+++ b/arch/risc-v/src/esp32c3/hardware/regi2c_brownout.h
@@ -1,0 +1,31 @@
+/****************************************************************************
+ * arch/risc-v/src/esp32c3/hardware/regi2c_brownout.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __ARCH_RISCV_SRC_ESP32C3_HARDWARE_REGI2C_BROWNOUT_H_
+#define __ARCH_RISCV_SRC_ESP32C3_HARDWARE_REGI2C_BROWNOUT_H_
+
+#define I2C_BOD                     0x61
+#define I2C_BOD_HOSTID              0
+
+#define I2C_BOD_THRESHOLD           0x5
+#define I2C_BOD_THRESHOLD_MSB       2
+#define I2C_BOD_THRESHOLD_LSB       0
+
+#endif /* __ARCH_RISCV_SRC_ESP32C3_HARDWARE_REGI2C_BROWNOUT_H_ */


### PR DESCRIPTION
## Summary

Add hardware brownout check and reset.

## Impact

## Testing

