### PR TITLE
risc-v/esp32c3: Fix reset triggering crash nested when crash

### DIFF
--- a/arch/risc-v/src/esp32c3/esp32c3_systemreset.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_systemreset.c
@@ -114,6 +114,25 @@ int esp32c3_unregister_shutdown_handler(shutdown_handler_t handler)
 }
 
 /****************************************************************************
+ * Name: up_shutdown_handler
+ *
+ * Description:
+ *   Process all registered shutdown callback functions.
+ *
+ ****************************************************************************/
+
+void up_shutdown_handler(void)
+{
+  for (int i = SHUTDOWN_HANDLERS_NO - 1; i >= 0; i--)
+    {
+      if (shutdown_handlers[i])
+        {
+          shutdown_handlers[i]();
+        }
+    }
+}
+
+/****************************************************************************
  * Name: up_systemreset
  *
  * Description:
@@ -123,14 +142,6 @@ int esp32c3_unregister_shutdown_handler(shutdown_handler_t handler)
 
 void up_systemreset(void)
 {
-  for (int i = SHUTDOWN_HANDLERS_NO - 1; i >= 0; i--)
-    {
-      if (shutdown_handlers[i])
-        {
-          shutdown_handlers[i]();
-        }
-    }
-
   putreg32(RTC_CNTL_SW_SYS_RST, RTC_CNTL_OPTIONS0_REG);
 
   /* Wait for the reset */

--- a/arch/risc-v/src/esp32c3/esp32c3_systemreset.h
+++ b/arch/risc-v/src/esp32c3/esp32c3_systemreset.h
@@ -86,6 +86,16 @@ int esp32c3_register_shutdown_handler(shutdown_handler_t handler);
 
 int esp32c3_unregister_shutdown_handler(shutdown_handler_t handler);
 
+/****************************************************************************
+ * Name: up_shutdown_handler
+ *
+ * Description:
+ *   Process all registered shutdown callback functions.
+ *
+ ****************************************************************************/
+
+void up_shutdown_handler(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/arch/risc-v/src/esp32c3/esp32c3_wifi_adapter.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_wifi_adapter.c
@@ -7192,6 +7192,8 @@ int esp32c3_wifi_bt_coexist_init(void)
 
 void esp_wifi_stop_callback(void)
 {
+  wlinfo("Trying to stop Wi-Fi...");
+
   int ret = esp_wifi_stop();
   if (ret)
     {

--- a/boards/Kconfig
+++ b/boards/Kconfig
@@ -3369,7 +3369,7 @@ config BOARD_RESET_ON_ASSERT
 
 config BOARD_ASSERT_RESET_VALUE
 	int "Board reset argument"
-	default 0
+	default 1
 	depends on BOARDCTL_RESET
 	---help---
 		Parameter that will be passed to board_reset() by when an

--- a/boards/risc-v/esp32c3/esp32c3-devkit/src/esp32c3_reset.c
+++ b/boards/risc-v/esp32c3/esp32c3-devkit/src/esp32c3_reset.c
@@ -30,6 +30,8 @@
 #include <nuttx/arch.h>
 #include <nuttx/board.h>
 
+#include "esp32c3_systemreset.h"
+
 #ifdef CONFIG_BOARDCTL_RESET
 
 /****************************************************************************
@@ -58,7 +60,6 @@
 
 int board_reset(int status)
 {
-#ifdef CONFIG_BOARD_ASSERT_RESET_VALUE
   syslog(LOG_INFO, "reboot status=%d\n", status);
 
   switch (status)
@@ -71,9 +72,6 @@ int board_reset(int status)
       default:
         break;
     }
-#else
-  up_shutdown_handler();
-#endif
 
   up_systemreset();
 

--- a/boards/risc-v/esp32c3/esp32c3-devkit/src/esp32c3_reset.c
+++ b/boards/risc-v/esp32c3/esp32c3-devkit/src/esp32c3_reset.c
@@ -24,6 +24,9 @@
 
 #include <nuttx/config.h>
 
+#include <stdlib.h>
+#include <debug.h>
+#include <assert.h>
 #include <nuttx/arch.h>
 #include <nuttx/board.h>
 
@@ -55,6 +58,23 @@
 
 int board_reset(int status)
 {
+#ifdef CONFIG_BOARD_ASSERT_RESET_VALUE
+  syslog(LOG_INFO, "reboot status=%d\n", status);
+
+  switch (status)
+    {
+      case EXIT_SUCCESS:
+        up_shutdown_handler();
+        break;
+      case CONFIG_BOARD_ASSERT_RESET_VALUE:
+        break;
+      default:
+        break;
+    }
+#else
+  up_shutdown_handler();
+#endif
+
   up_systemreset();
 
   return 0;


### PR DESCRIPTION
## Summary

Fix reset triggering crash nested when crash.

The board code should separate the reset reason, so it had better make "BOARD_ASSERT_RESET_VALUE" not be equal to "EXIT_SUCCESS". 

## Impact

## Testing

