### PR TITLE
fix sim_x11fb compile error

### DIFF
--- a/arch/sim/src/sim/up_lcd.c
+++ b/arch/sim/src/sim/up_lcd.c
@@ -37,6 +37,9 @@
 #include <nuttx/lcd/lcd.h>
 #include "up_internal.h"
 
+#if defined(CONFIG_SIM_X11FB)
+#include <nuttx/wqueue.h>
+#endif
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/


### PR DESCRIPTION
Signed-off-by: anjiahao <anjiahao@xiaomi.com>

## Summary
when i use CONFIG_SIM_X11FB,and `make` ,will compile error
## Impact

## Testing
dailytest

`sim/up_lcd.c:425:14: error: ‘LPWORK’ undeclared (first use in this function)
  425 |   work_queue(LPWORK, &g_updatework, up_updatework, NULL, MSEC2TICK(33));
      |              ^~~~~~
sim/up_lcd.c:425:14: note: each undeclared identifier is reported only once for each function it appears in
sim/up_lcd.c: In function ‘board_lcd_initialize’:
sim/up_lcd.c:457:18: error: ‘LPWORK’ undeclared (first use in this function)
  457 |       work_queue(LPWORK, &g_updatework, up_updatework, NULL, MSEC2TICK(33));
      |                  ^~~~~~
sim/up_lcd.c: At top level:
sim/up_lcd.c:157:22: error: storage size of ‘g_updatework’ isn’t known
  157 | static struct work_s g_updatework;`
