### PR TITLE
add board_reset function

### DIFF
--- a/boards/arm/stm32h7/nucleo-h743zi/src/Makefile
+++ b/boards/arm/stm32h7/nucleo-h743zi/src/Makefile
@@ -88,4 +88,8 @@ ifeq ($(CONFIG_PWM),y)
 CSRCS += stm32_pwm.c
 endif
 
+ifeq ($(CONFIG_BOARDCTL_RESET), y)
+CSRCS += stm32_reset.c
+endif
+
 include $(TOPDIR)/boards/Board.mk

--- a/boards/arm/stm32h7/nucleo-h743zi/src/stm32_reset.c
+++ b/boards/arm/stm32h7/nucleo-h743zi/src/stm32_reset.c
@@ -1,0 +1,62 @@
+/****************************************************************************
+ * boards/arm/stm32h7/nucleo-h743zi/src/stm32_reset.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <nuttx/arch.h>
+#include <nuttx/board.h>
+
+#ifdef CONFIG_BOARDCTL_RESET
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: board_reset
+ *
+ * Description:
+ *   Reset board.  Support for this function is required by board-level
+ *   logic if CONFIG_BOARDCTL_RESET is selected.
+ *
+ * Input Parameters:
+ *   status - Status information provided with the reset event.  This
+ *            meaning of this status information is board-specific.  If not
+ *            used by a board, the value zero may be provided in calls to
+ *            board_reset().
+ *
+ * Returned Value:
+ *   If this function returns, then it was not possible to power-off the
+ *   board due to some constraints.  The return value int this case is a
+ *   board-specific reason for the failure to shutdown.
+ *
+ ****************************************************************************/
+
+int board_reset(int status)
+{
+  up_systemreset();
+  return 0;
+}
+
+#endif /* CONFIG_BOARDCTL_RESET */


### PR DESCRIPTION
## Summary
Adds board_reset() function for nucleo-h743zi. 
The function is already implemented for nucleo-h743zi2 and this is a simple copy.l

## Impact

## Testing

