### PR TITLE
arch: Remove fflush(stdout) from driver code

### DIFF
--- a/arch/arm/src/lc823450/lc823450_mtd.c
+++ b/arch/arm/src/lc823450/lc823450_mtd.c
@@ -645,7 +645,6 @@ int lc823450_mtd_initialize(uint32_t devno)
 
 #ifdef CONFIG_DEBUG
   finfo("/dev/mtdblock%d created\n", devno);
-  fflush(stdout);
 #endif
 
   priv = (FAR struct lc823450_mtd_dev_s *)g_mtdmaster[ch];
@@ -845,7 +844,6 @@ int lc823450_mtd_uninitialize(uint32_t devno)
 
 #ifdef CONFIG_DEBUG
   finfo("/dev/mtdblock%d deleted\n", devno);
-  fflush(stdout);
 #endif
   return OK;
 }

--- a/arch/risc-v/src/esp32c3/esp32c3_pm.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_pm.c
@@ -1579,7 +1579,6 @@ void esp32c3_pmstandby(uint64_t time_in_us)
 
   /* don't power down XTAL — powering it up takes different time on. */
 
-  fflush(stdout);
   esp32c3_sleep_enable_rtc_timer_wakeup(time_in_us);
 #ifdef CONFIG_ESP32C3_RT_TIMER
   /* Get rt-timer timestamp before entering sleep */
@@ -1665,7 +1664,6 @@ void IRAM_ATTR esp32c3_deep_sleep_start(void)
 
 void esp32c3_pmsleep(uint64_t time_in_us)
 {
-  fflush(stdout);
   esp32c3_sleep_enable_rtc_timer_wakeup(time_in_us);
   esp32c3_deep_sleep_start();
 }

--- a/arch/xtensa/src/esp32/esp32_pm.c
+++ b/arch/xtensa/src/esp32/esp32_pm.c
@@ -975,7 +975,6 @@ void esp32_pmstandby(uint64_t time_in_us)
 
   /* don't power down XTAL — powering it up takes different time on. */
 
-  fflush(stdout);
   esp32_sleep_enable_timer_wakeup(time_in_us);
 
 #ifdef CONFIG_ESP32_RT_TIMER
@@ -1128,7 +1127,6 @@ void esp32_deep_sleep_start(void)
 
 void esp32_pmsleep(uint64_t time_in_us)
 {
-  fflush(stdout);
   esp32_sleep_enable_timer_wakeup(time_in_us);
   esp32_deep_sleep_start();
 }


### PR DESCRIPTION
## Summary
it's wrong to call stdio function inside driver

## Impact
Minor

## Testing
Pass CI
