### PR TITLE
esp32c3/esp32c3_usbserial.c:  Initialize cpuint to ENOMEM.

### DIFF
--- a/arch/risc-v/src/esp32c3/esp32c3_usbserial.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_usbserial.c
@@ -99,6 +99,7 @@ static struct esp32c3_priv_s g_usbserial_priv =
 {
   .periph = ESP32C3_PERIPH_USB,
   .irq    = ESP32C3_IRQ_USB,
+  .cpuint = -ENOMEM,
 };
 
 static struct uart_ops_s g_uart_ops =


### PR DESCRIPTION
## Summary
Initialize cpuint to ENOMEM, otherwise the first attempt to attaching an interrupt will trigger an (debug) assertion.

## Impact
ESP32-C3 CDC Console
## Testing
esp32c3-devkit:usbconsole
