### PR TITLE
feature: sensor: Add sensor type ots.

### DIFF
--- a/drivers/sensors/sensor.c
+++ b/drivers/sensors/sensor.c
@@ -128,6 +128,7 @@ static const struct sensor_info g_sensor_info[] =
   {sizeof(struct sensor_event_ecg),   "ecg"},
   {sizeof(struct sensor_event_ppg),   "ppg"},
   {sizeof(struct sensor_event_impd),  "impd"},
+  {sizeof(struct sensor_event_ots),   "ots"},
 };
 
 static const struct file_operations g_sensor_fops =

--- a/include/nuttx/sensors/sensor.h
+++ b/include/nuttx/sensors/sensor.h
@@ -245,9 +245,18 @@
 
 #define SENSOR_TYPE_IMPEDANCE                       27
 
+/* OTS (Optical tracking sensor)
+ * A sensor of this type returns the OTS measurements in counts. It
+ * integrates an optical chip and a LASER light source in a single miniature
+ * package. It provies wide depth of field range on glossy surface, and
+ * design flexibility into a compact device.
+ */
+
+#define SENSOR_TYPE_OTS                             28
+
 /* The total number of sensor */
 
-#define SENSOR_TYPE_COUNT                           28
+#define SENSOR_TYPE_COUNT                           29
 
 /****************************************************************************
  * Inline Functions
@@ -459,6 +468,13 @@ struct sensor_event_impd    /* Type: Impedance */
   uint64_t timestamp;       /* Unit is microseconds */
   float real;               /* Real part, unit is Ohm(Ω) */
   float imag;               /* Imaginary part, unit is Ohm(Ω) */
+};
+
+struct sensor_event_ots     /* Type: OTS */
+{
+  uint64_t timestamp;       /* Unit is microseconds */
+  int32_t x;                /* Axis X in counts */
+  int32_t y;                /* Axis Y in counts */
 };
 
 /* The sensor lower half driver interface */


### PR DESCRIPTION
Add ots sensor type for ots.

Signed-off-by: songnannan <songnannan@xiaomi.com>

## Summary
Add ots sensor type for optical tracking sensor.
## Impact
Nothing.
## Testing
Test the feature on my own EVB.
