### PR TITLE
mpfs: emmcsd: boost waitresponse perf

### DIFF
--- a/arch/risc-v/src/mpfs/mpfs_emmcsd.c
+++ b/arch/risc-v/src/mpfs/mpfs_emmcsd.c
@@ -2332,7 +2332,6 @@ static int mpfs_waitresponse(struct sdio_dev_s *dev, uint32_t cmd)
   struct mpfs_dev_s *priv = (struct mpfs_dev_s *)dev;
   uint32_t status;
   int32_t timeout;
-  uint32_t waitbits = 0;
 
   mcinfo("cmd: %08" PRIx32 "\n", cmd);
 
@@ -2363,22 +2362,17 @@ static int mpfs_waitresponse(struct sdio_dev_s *dev, uint32_t cmd)
 
   /* Then wait for the response (or timeout) */
 
-  if (cmd & MMCSD_DATAXFR_MASK)
-    {
-      waitbits = MPFS_EMMCSD_SRS12_CC;
-    }
-
   do
     {
       status = getreg32(MPFS_EMMCSD_SRS12);
     }
-  while (!(status & (waitbits | MPFS_EMMCSD_SRS12_EINT))
+  while (!(status & (MPFS_EMMCSD_SRS12_CC | MPFS_EMMCSD_SRS12_EINT))
          && --timeout);
 
   if (timeout == 0 || (status & MPFS_EMMCSD_SRS12_ECT))
     {
-      mcerr("ERROR: Timeout cmd: %08" PRIx32 " stat: %08" PRIx32 " wb: %08"
-            PRIx32 "\n", cmd, status, waitbits);
+      mcerr("ERROR: Timeout cmd: %08" PRIx32 " stat: %08" PRIx32 "\n", cmd,
+            status);
       return -EBUSY;
     }
 


### PR DESCRIPTION
When waiting for a response to a sent command, the command
complete bit (MPFS_EMMCSD_SRS12_CC) should always guarantee
the completion of that particular command. There's no need
to have some combinations skipping the check of the command
complete bit. Thus, remove the 'waitbits' parameter as it's
unnecessary.

Signed-off-by: Eero Nurkkala <eero.nurkkala@offcode.fi>

## Summary

Fix to cppcheck finding at f8832f7d86ddd0c77f40cc7523d096fcafbc4e60 caused regression. Some commands now timeout because waitbits is different.

## Impact

Fix the regression properly.

## Testing

Tested on PolarFire Icicle board with both eMMC and SD-cards. FAT filesystems were mounted and used.
