### PR TITLE
add MTDIOCTL_PROGMEM_ERASESTATE support

### DIFF
--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -339,6 +339,11 @@ config ARCH_HAVE_PROGMEM_READ
 	default n
 	depends on ARCH_HAVE_PROGMEM
 
+config ARCH_HAVE_PROGMEM_ERASESTATE
+	bool
+	default n
+	depends on ARCH_HAVE_PROGMEM
+
 config ARCH_HAVE_RESET
 	bool
 	default n

--- a/arch/arm/src/stm32h7/Kconfig
+++ b/arch/arm/src/stm32h7/Kconfig
@@ -333,6 +333,14 @@ config STM32H7_PROGMEM
 		Add progmem support, start block and end block options are provided to
 		obtain an uniform flash memory mapping.
 
+config STM32H7_PROGMEM_ERASESTATE
+	bool "Flash progmem erasestate ictl support"
+	depends on STM32H7_PROGMEM
+	default y
+	select ARCH_HAVE_PROGMEM_ERASESTATE
+	---help---
+		Add progmem erasestate ictl command.
+
 menu "STM32H7 Peripheral Selection"
 
 # These "hidden" settings determine whether a peripheral option is available

--- a/arch/arm/src/stm32h7/stm32_flash.c
+++ b/arch/arm/src/stm32h7/stm32_flash.c
@@ -971,3 +971,8 @@ ssize_t up_progmem_write(size_t addr, const void *buf, size_t count)
   stm32h7_flash_sem_unlock(priv);
   return written;
 }
+
+ssize_t up_progmem_erasestate(void)
+{
+  return FLASH_ERASEDVALUE;
+}

--- a/drivers/mtd/Kconfig
+++ b/drivers/mtd/Kconfig
@@ -136,6 +136,17 @@ config MTD_PROGMEM
 		using the interfaces defined in include/nuttx/progmem.  Those
 		interfaces must be exported by chip-specific logic.
 
+if MTD_PROGMEM
+
+config MTD_PROGMEM_ERASESTATE
+	bool "Enable FLASH MTD device erasestate"
+	depends on ARCH_HAVE_PROGMEM_ERASESTATE
+	---help---
+		Enable the ioctl MTDIOCTL_PROGMEM_ERASESTATE command in the on-chip
+		FLASH interface.
+		
+endif #MTD_PROGMEM
+
 config MTD_CONFIG
 	bool "Enable Dev Config (MTD based) device"
 	default n

--- a/drivers/mtd/mtd_progmem.c
+++ b/drivers/mtd/mtd_progmem.c
@@ -367,6 +367,19 @@ static int progmem_ioctl(FAR struct mtd_dev_s *dev, int cmd,
         }
         break;
 
+#ifdef CONFIG_MTD_PROGMEM_ERASESTATE
+      case MTDIOC_ERASESTATE:
+        {
+          FAR uint8_t *result = (FAR uint8_t *)arg;
+
+          *result = up_progmem_erasestate();
+
+          ret = OK;
+        }
+        break;
+
+#endif /* CONFIG_ARCH_PROGMEM_ERASESTATE */
+
       default:
         ret = -ENOTTY; /* Bad command */
         break;

--- a/include/nuttx/progmem.h
+++ b/include/nuttx/progmem.h
@@ -234,6 +234,18 @@ ssize_t up_progmem_write(size_t addr, FAR const void *buf, size_t count);
 ssize_t up_progmem_read(size_t addr, FAR void *buf, size_t count);
 #endif
 
+/****************************************************************************
+ * Name: up_progmem_erasestate
+ *
+ * Description:
+ *   Return value of erease state.
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_ARCH_HAVE_PROGMEM_ERASESTATE
+ssize_t up_progmem_erasestate(void);
+#endif /* CONFIG_ARCH_HAVE_PROGMEM_ERASESTATE */
+
 #undef EXTERN
 #if defined(__cplusplus)
 }


### PR DESCRIPTION
Signed-off-by: Andres Sanchez <tito97_sp@hotmail.com>

## Summary
Implementation of **MTDIOC_ERASESTATE** ioctl command for **MTD progmem based devices**.
Follows the criteria used in #4166

## Impact
The change affects all the boards that implements PROGMEM devices. This feature can be isolated for each board by means of `CONFIG_ARCH_HAVE_PROGMEM_ERASESTATE` definition.

## Testing
This feature is tested using nucleo-h743zi board
