### PR TITLE
sensors/wtgahrs2: Fix syslog format warning

### DIFF
--- a/drivers/sensors/wtgahrs2.c
+++ b/drivers/sensors/wtgahrs2.c
@@ -329,7 +329,7 @@ static void wtgahrs2_gps_data(FAR struct wtgahrs2_dev_s *rtdata,
     {
       rtdata->gps_mask = 0;
       lower->push_event(lower->priv, &rtdata->gps, sizeof(rtdata->gps));
-      sninfo("Time : %llu utc_time: %llu\n",
+      sninfo("Time : %" PRIu64 " utc_time: %" PRIu64 "\n",
              rtdata->gps.timestamp, rtdata->gps.time_utc);
       sninfo("GPS longitude : %fdegree, latitude:%fdegree\n",
               rtdata->gps.longitude, rtdata->gps.latitude);


### PR DESCRIPTION
## Summary
```
sensors/wtgahrs2.c: In function 'wtgahrs2_gps_data':
Error: sensors/wtgahrs2.c:332:14: error: format '%llu' expects argument of type 'long long unsigned int', but argument 3 has type 'uint64_t' {aka 'long unsigned int'} [-Werror=format=]
  332 |       sninfo("Time : %llu utc_time: %llu\n",
      |              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  333 |              rtdata->gps.timestamp, rtdata->gps.time_utc);
      |              ~~~~~~~~~~~~~~~~~~~~~
      |                         |
      |                         uint64_t {aka long unsigned int}
sensors/wtgahrs2.c:332:25: note: format string is defined here
  332 |       sninfo("Time : %llu utc_time: %llu\n",
      |                      ~~~^
      |                         |
      |                         long long unsigned int
      |                      %lu
In file included from sensors/wtgahrs2.c:37:
Error: sensors/wtgahrs2.c:332:14: error: format '%llu' expects argument of type 'long long unsigned int', but argument 4 has type 'uint64_t' {aka 'long unsigned int'} [-Werror=format=]
  332 |       sninfo("Time : %llu utc_time: %llu\n",
      |              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  333 |              rtdata->gps.timestamp, rtdata->gps.time_utc);
      |                                     ~~~~~~~~~~~~~~~~~~~~
      |                                                |
      |                                                uint64_t {aka long unsigned int}
sensors/wtgahrs2.c:332:40: note: format string is defined here
  332 |       sninfo("Time : %llu utc_time: %llu\n",
      |                                     ~~~^
      |                                        |
      |                                        long long unsigned int
      |                                     %lu
```

## Impact
Fix the warning by PR https://github.com/apache/incubator-nuttx/pull/4842

## Testing
Pass CI
