### PR TITLE
feature: sensor: add set calibration interface

### DIFF
--- a/drivers/sensors/sensor.c
+++ b/drivers/sensors/sensor.c
@@ -445,6 +445,18 @@ static int sensor_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
         }
         break;
 
+      case SNIOC_SET_CALIBVALUE:
+        {
+          if (lower->ops->set_calibvalue == NULL)
+            {
+              ret = -ENOTSUP;
+              break;
+            }
+
+          ret = lower->ops->set_calibvalue(lower, arg);
+        }
+        break;
+
       case SNIOC_GET_NEVENTBUF:
         {
           *val = lower->buffer_number + lower->batch_number;

--- a/include/nuttx/sensors/ioctl.h
+++ b/include/nuttx/sensors/ioctl.h
@@ -297,4 +297,14 @@
 
 #define SNIOC_SELFTEST             _SNIOC(0x0086)
 
+/* Command:      SNIOC_SET_CALIBVALUE
+ * Description:  Set calibration value for sensor.
+ * Argument:     Calibration value for the sensor.
+ * Note:         If setting calibvalue failed, a negated errno value is
+ *               returned, otherwise, OK is returned.
+ *               This cmd is handled by sensor_ops_s::set_calibvalue.
+ */
+
+#define SNIOC_SET_CALIBVALUE       _SNIOC(0x0087)
+
 #endif /* __INCLUDE_NUTTX_SENSORS_IOCTL_H */

--- a/include/nuttx/sensors/sensor.h
+++ b/include/nuttx/sensors/sensor.h
@@ -676,7 +676,7 @@ struct sensor_ops_s
    **************************************************************************/
 
   CODE int (*selftest)(FAR struct sensor_lowerhalf_s *lower,
-                        unsigned long arg);
+                       unsigned long arg);
 
   /**************************************************************************
    * Name: set_calibvalue

--- a/include/nuttx/sensors/sensor.h
+++ b/include/nuttx/sensors/sensor.h
@@ -679,6 +679,26 @@ struct sensor_ops_s
                         unsigned long arg);
 
   /**************************************************************************
+   * Name: set_calibvalue
+   *
+   * The calibration value to be written in or the non-volatile memory of the
+   * sensor or dedicated registers. At each power-on, so that the values read
+   * from the sensor are already corrected. When the device is calibrated,
+   * the absolute accuracy will be better than before.
+   *
+   * Input Parameters:
+   *   lower      - The instance of lower half sensor driver.
+   *   arg        - The parameters associated with calibration value.
+   *
+   * Returned Value:
+   *   Zero (OK) on success; a negated errno value on failure.
+   *
+   **************************************************************************/
+
+  CODE int (*set_calibvalue)(FAR struct sensor_lowerhalf_s *lower,
+                             unsigned long arg);
+
+  /**************************************************************************
    * Name: control
    *
    * With this method, the user can set some special config for the sensor,


### PR DESCRIPTION
Align for selftest interface in struct sensor_ops_s

Signed-off-by: songnannan <songnannan@xiaomi.com>

## Summary
Align for selftest interface in struct sensor_ops_s
## Impact
nothing
## Testing
Test in my own EVB.
