### PR TITLE
libc/hex2bin: Handle the line ending(\r, \n and \r\n) dynamically

### DIFF
--- a/include/hex2bin.h
+++ b/include/hex2bin.h
@@ -36,34 +36,6 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-/* Some environments may return CR as end-of-line, others LF, and others
- * both.  If not specified, the logic here assumes either (but not both) as
- * the default.
- */
-
-#if defined(CONFIG_EOL_IS_CR)
-#  undef  CONFIG_EOL_IS_LF
-#  undef  CONFIG_EOL_IS_BOTH_CRLF
-#  undef  CONFIG_EOL_IS_EITHER_CRLF
-#elif defined(CONFIG_EOL_IS_LF)
-#  undef  CONFIG_EOL_IS_CR
-#  undef  CONFIG_EOL_IS_BOTH_CRLF
-#  undef  CONFIG_EOL_IS_EITHER_CRLF
-#elif defined(CONFIG_EOL_IS_BOTH_CRLF)
-#  undef  CONFIG_EOL_IS_CR
-#  undef  CONFIG_EOL_IS_LF
-#  undef  CONFIG_EOL_IS_EITHER_CRLF
-#elif defined(CONFIG_EOL_IS_EITHER_CRLF)
-#  undef  CONFIG_EOL_IS_CR
-#  undef  CONFIG_EOL_IS_LF
-#  undef  CONFIG_EOL_IS_BOTH_CRLF
-#else
-#  undef  CONFIG_EOL_IS_CR
-#  undef  CONFIG_EOL_IS_LF
-#  undef  CONFIG_EOL_IS_BOTH_CRLF
-#  define CONFIG_EOL_IS_EITHER_CRLF 1
-#endif
-
 /****************************************************************************
  * Public Types
  ****************************************************************************/

--- a/libs/libc/hex2bin/lib_hex2bin.c
+++ b/libs/libc/hex2bin/lib_hex2bin.c
@@ -264,38 +264,11 @@ static int readstream(FAR struct lib_instream_s *instream,
 
   while (ch != EOF && nbytes < (MAXRECORD_ASCSIZE - 1))
     {
-#if defined(CONFIG_EOL_IS_LF)
-      if (ch == '\n')
-        {
-          *line = '\0';
-          return nbytes;
-        }
-
-#elif defined(CONFIG_EOL_IS_BOTH_CRLF)
-      if (ch == '\r')
-        {
-          continue;
-        }
-      else if (ch == '\n')
-        {
-          *line = '\0';
-          return nbytes;
-        }
-
-#elif defined(CONFIG_EOL_IS_CR)
-      if (ch == '\r')
-        {
-          *line = '\0';
-          return nbytes;
-        }
-
-#elif defined(CONFIG_EOL_IS_EITHER_CRLF)
       if (ch == '\n' || ch == '\r')
         {
           *line = '\0';
           return nbytes;
         }
-#endif
 
       /* Only hex data goes into the line buffer */
 


### PR DESCRIPTION
## Summary
Change the compiler setting to runtime check

## Impact
Same as before but without manual selection

## Testing

