### PR TITLE
sched:watchdog: remove tick check in wd_timer

### DIFF
--- a/sched/wdog/wd_start.c
+++ b/sched/wdog/wd_start.c
@@ -370,14 +370,6 @@ unsigned int wd_timer(int ticks, bool noswitches)
   wdog = (FAR struct wdog_s *)g_wdactivelist.head;
   while (wdog != NULL && ticks > 0)
     {
-#ifndef CONFIG_SCHED_TICKLESS_ALARM
-      /* There is logic to handle the case where ticks is greater than
-       * the watchdog lag, but if the scheduling is working properly
-       * that should never happen.
-       */
-
-      DEBUGASSERT(ticks <= wdog->lag);
-#endif
       /* Decrement the lag for this watchdog. */
 
       decr = MIN(wdog->lag, ticks);


### PR DESCRIPTION
In scene with CONFIG_SCHED_TICKLESS but no CONFIG_SCHED_TICKLESS_ALARM
The system may crash by assert
`up_assert: Assertion failed at file:wdog/wd_start.c line: 379 task: rptun`

Signed-off-by: zhuyanlin <zhuyanlin1@xiaomi.com>

## Summary

## Impact

## Testing

