### PR TITLE
libc/getdelim: Remove KERNEL check since it shouldn't be called inside kernel

### DIFF
--- a/libs/libc/stdio/lib_fgets.c
+++ b/libs/libc/stdio/lib_fgets.c
@@ -57,6 +57,6 @@ char *fgets(FAR char *buf, int buflen, FAR FILE *stream)
 
   else
     {
-      return lib_fgets(buf, (size_t)buflen, stream, true, false);
+      return lib_fgets(buf, buflen, stream, true, false);
     }
 }

--- a/libs/libc/stdio/lib_getdelim.c
+++ b/libs/libc/stdio/lib_getdelim.c
@@ -107,7 +107,7 @@ ssize_t getdelim(FAR char **lineptr, size_t *n, int delimiter,
 
   if (lineptr == NULL || n == NULL || stream == NULL)
     {
-      ret = -EINVAL;
+      ret = EINVAL;
       goto errout;
     }
 
@@ -138,7 +138,7 @@ ssize_t getdelim(FAR char **lineptr, size_t *n, int delimiter,
       dest = (FAR char *)lib_malloc(bufsize);
       if (dest == NULL)
         {
-          ret = -ENOMEM;
+          ret = ENOMEM;
           goto errout;
         }
 
@@ -188,13 +188,9 @@ ssize_t getdelim(FAR char **lineptr, size_t *n, int delimiter,
       ch = fgetc(stream);
       if (ch == EOF)
         {
-#ifdef __KERNEL_
-          return -ENODATA;
-#else
           /* errno is not set in this case */
 
           return -1;
-#endif
         }
 
       /* Save the character in the user buffer and increment the number of
@@ -218,12 +214,8 @@ ssize_t getdelim(FAR char **lineptr, size_t *n, int delimiter,
   return ncopied;
 
 errout:
-#ifdef __KERNEL_
-  return ret;
-#else
-  set_errno(-ret);
+  set_errno(ret);
   return -1;
-#endif
 }
 
 /****************************************************************************

--- a/libs/libc/stdio/lib_gets.c
+++ b/libs/libc/stdio/lib_gets.c
@@ -58,5 +58,5 @@ FAR char *gets(FAR char *s)
 {
   /* Let lib_fgets() do the heavy lifting */
 
-  return lib_fgets(s, (size_t)INT_MAX, stdin, false, false);
+  return lib_fgets(s, SIZE_MAX, stdin, false, false);
 }

--- a/libs/libc/stdio/lib_gets_s.c
+++ b/libs/libc/stdio/lib_gets_s.c
@@ -41,7 +41,7 @@
  *   either a terminating newline or EOF, which it replaces with '\0'.  Reads
  *   at most n-1 characters from stdin into the array pointed to by str until
  *   new-line character, end-of-file condition, or read error.   The newline
- *   character, if encountered, is not saved in the arraay.  A NUL character
+ *   character, if encountered, is not saved in the array.  A NUL character
  *   is written immediately after the last character read into the array, or
  *   to str[0] if no characters were read.
  *
@@ -69,5 +69,5 @@ FAR char *gets_s(FAR char *s, rsize_t n)
 
   /* Then let lib_fgets() do the heavy lifting */
 
-  return lib_fgets(s, (size_t)n, stdin, false, true);
+  return lib_fgets(s, n, stdin, false, true);
 }


### PR DESCRIPTION
## Summary
- libc/getdelim: Remove __KERNEL__ check since it shouldn't be called inside kernel
- libc/gets: Remove the unnecessary cast

## Impact

## Testing
Pass CI and ostest
