### PR TITLE
boards/raspberrypi-pico: Update README to fix Pico SDK version

### DIFF
--- a/boards/arm/rp2040/raspberrypi-pico/README.txt
+++ b/boards/arm/rp2040/raspberrypi-pico/README.txt
@@ -36,7 +36,7 @@ Installation
 
 1. Download Raspberry Pi Pico SDK
 
-  $ git clone -b master https://github.com/raspberrypi/pico-sdk.git
+  $ git clone -b 1.1.2 https://github.com/raspberrypi/pico-sdk.git
 
 2. Set PICO_SDK_PATH environment variable
 


### PR DESCRIPTION
## Summary
Update README for Raspberry Pi Pico to fix the Pico SDK version to avoid the build break in the latest SDK.

## Impact
Document only

## Testing

