### PR TITLE
sched: Move g_tcbinfo to include/nuttx/sched.h

### DIFF
--- a/fs/procfs/fs_procfstcbinfo.c
+++ b/fs/procfs/fs_procfstcbinfo.c
@@ -87,8 +87,6 @@ static int     tcbinfo_stat(FAR const char *relpath, FAR struct stat *buf);
  * Public Data
  ****************************************************************************/
 
-extern struct tcbinfo_s g_tcbinfo;
-
 /* See fs_mount.c -- this structure is explicitly externed there.
  * We use the old-fashioned kind of initializers so that this will compile
  * with any compiler.

--- a/include/nuttx/sched.h
+++ b/include/nuttx/sched.h
@@ -832,6 +832,10 @@ EXTERN uint32_t g_crit_max[1];
 #endif
 #endif /* CONFIG_SCHED_CRITMONITOR */
 
+#ifdef CONFIG_DEBUG_TCBINFO
+EXTERN struct tcbinfo_s g_tcbinfo;
+#endif
+
 /****************************************************************************
  * Public Function Prototypes
  ****************************************************************************/


### PR DESCRIPTION
## Summary

## Impact
Minor change

## Testing
Pass CI
