### PR TITLE
boards/raspberrypi-pico: Fix some typos in README.txt

### DIFF
--- a/boards/arm/rp2040/raspberrypi-pico/README.txt
+++ b/boards/arm/rp2040/raspberrypi-pico/README.txt
@@ -5,7 +5,7 @@ This directory contains the port of NuttX to the Raspberry Pi Pico.
 See https://www.raspberrypi.org/products/raspberry-pi-pico/ for information
 about Raspberry Pi Pico.
 
-Currently only the following devices are suppored.
+Currently only the following devices are supported.
 
   Supported:
   - UART  (console port)
@@ -153,7 +153,7 @@ Defconfigs
     USB MSC and CDC/ACM support
     `msconn` and `sercon` commands enable the MSC and CDC/ACM devices.
     The MSC support provides the interface to the SD card with SPI,
-    so the SD card slot connection like spisd configuraion is requied.
+    so the SD card slot connection like spisd configuration is required.
 
 - composite
     USB composite device (MSC + CDC/ACM) support


### PR DESCRIPTION
  This patch fixes some spelling typos in boards/raspberrypi-pico/README.txt
