### PR TITLE
binfmt/elf: add bare metal coredump support 

### DIFF
--- a/arch/arm/include/elf.h
+++ b/arch/arm/include/elf.h
@@ -248,4 +248,13 @@
 #define DT_ARM_PREEMPTMAP        0x70000002
 #define DT_ARM_RESERVED2         0x70000003
 
+/* ELF register definitions */
+
+/* Holds the general purpose registers $a1 * through to $pc
+ * at indices 0 to 15.  At index 16 the program status register.
+ * Index 17 should be set to zero.
+ */
+
+typedef unsigned long elf_gregset_t[18];
+
 #endif /* __ARCH_ARM_INCLUDE_ELF_H */

--- a/binfmt/Makefile
+++ b/binfmt/Makefile
@@ -25,6 +25,7 @@ include $(TOPDIR)/Make.defs
 CSRCS  = binfmt_globals.c binfmt_initialize.c binfmt_register.c binfmt_unregister.c
 CSRCS += binfmt_loadmodule.c binfmt_unloadmodule.c binfmt_execmodule.c
 CSRCS += binfmt_exec.c binfmt_copyargv.c binfmt_dumpmodule.c
+CSRCS += binfmt_coredump.c
 
 ifeq ($(CONFIG_BINFMT_LOADABLE),y)
 CSRCS += binfmt_exit.c

--- a/binfmt/binfmt_coredump.c
+++ b/binfmt/binfmt_coredump.c
@@ -1,0 +1,69 @@
+/****************************************************************************
+ * binfmt/binfmt_coredump.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <nuttx/binfmt/binfmt.h>
+#include <errno.h>
+
+#include "binfmt.h"
+
+#ifndef CONFIG_BINFMT_DISABLE
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: core_dump
+ *
+ * Description:
+ *   This function for generating core dump stream.
+ *
+ ****************************************************************************/
+
+int core_dump(FAR struct memory_region_s *regions,
+              FAR struct lib_outstream_s *stream)
+{
+  FAR struct binfmt_s *binfmt;
+  int ret = -ENOENT;
+
+  for (binfmt = g_binfmts; binfmt; binfmt = binfmt->next)
+    {
+      /* Use this handler to try to load the format */
+
+      if (binfmt->coredump)
+        {
+          ret = binfmt->coredump(regions, stream);
+          if (ret == OK)
+            {
+              break;
+            }
+        }
+    }
+
+  return ret;
+}
+
+#endif /* CONFIG_BINFMT_DISABLE */

--- a/binfmt/elf.c
+++ b/binfmt/elf.c
@@ -72,6 +72,10 @@ static int elf_loadbinary(FAR struct binary_s *binp,
                           FAR const char *filename,
                           FAR const struct symtab_s *exports,
                           int nexports);
+#ifdef CONFIG_ELF_COREDUMP
+static int elf_dumpbinary(FAR struct memory_region_s *regions,
+                          FAR struct lib_outstream_s *stream);
+#endif
 #if defined(CONFIG_DEBUG_FEATURES) && defined(CONFIG_DEBUG_BINFMT)
 static void elf_dumploadinfo(FAR struct elf_loadinfo_s *loadinfo);
 #endif
@@ -85,6 +89,9 @@ static struct binfmt_s g_elfbinfmt =
   NULL,             /* next */
   elf_loadbinary,   /* load */
   NULL,             /* unload */
+#ifdef CONFIG_ELF_COREDUMP
+  elf_dumpbinary,   /* coredump */
+#endif
 };
 
 /****************************************************************************
@@ -294,6 +301,30 @@ errout_with_init:
   elf_uninit(&loadinfo);
   return ret;
 }
+
+/****************************************************************************
+ * Name: elf_dumpbinary
+ *
+ * Description:
+ *   Generat the core dump stream as ELF structure.
+ *
+ * Returned Value:
+ *   Zero (OK) on success; a negated errno value on failure.
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_ELF_COREDUMP
+static int elf_dumpbinary(FAR struct memory_region_s *regions,
+                          FAR struct lib_outstream_s *stream)
+{
+  struct elf_dumpinfo_s dumpinfo;
+
+  dumpinfo.regions = regions;
+  dumpinfo.stream  = stream;
+
+  return elf_coredump(&dumpinfo);
+}
+#endif
 
 /****************************************************************************
  * Public Functions

--- a/binfmt/libelf/Kconfig
+++ b/binfmt/libelf/Kconfig
@@ -62,3 +62,14 @@ config ELF_SYMBOL_CACHECOUNT
 	---help---
 		This is a cache that is used to store elf symbol table to
 		reduce access fs. Default: 256
+
+config ELF_COREDUMP
+	bool "ELF Coredump"
+	select DEBUG_TCBINFO
+	default n
+	---help---
+		Generate ELF core dump to provide information about the CPU state and the
+		memory state of program.
+		The memory state embeds a snapshot of all segments mapped in the
+		memory space of the program. The CPU state contains register values
+		when the core dump has been generated.

--- a/binfmt/libelf/Make.defs
+++ b/binfmt/libelf/Make.defs
@@ -30,6 +30,12 @@ CSRCS += libelf_bind.c libelf_init.c libelf_addrenv.c libelf_iobuffer.c
 CSRCS += libelf_load.c libelf_read.c libelf_sections.c libelf_symbols.c
 CSRCS += libelf_uninit.c libelf_unload.c libelf_verify.c
 
+ifeq ($(CONFIG_ELF_COREDUMP),y)
+CSRCS += libelf_coredump.c
+
+CFLAGS += ${shell $(INCDIR) "$(CC)" $(TOPDIR)$(DELIM)sched}
+endif
+
 ifeq ($(CONFIG_BINFMT_CONSTRUCTORS),y)
 CSRCS += libelf_ctors.c libelf_dtors.c
 endif

--- a/binfmt/libelf/libelf_coredump.c
+++ b/binfmt/libelf/libelf_coredump.c
@@ -1,0 +1,370 @@
+/****************************************************************************
+ * binfmt/libelf/libelf_coredump.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <sys/stat.h>
+
+#include <stdio.h>
+#include <stdint.h>
+#include <string.h>
+#include <debug.h>
+#include <errno.h>
+
+#include <nuttx/elf.h>
+#include <nuttx/binfmt/elf.h>
+#include <nuttx/binfmt/binfmt.h>
+#include <nuttx/sched.h>
+#include <sched/sched.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define ELF_PAGESIZE    4096
+#define ELF_BLOCKSIZE   1024
+
+#define ARRAY_SIZE(x)   (sizeof(x) / sizeof((x)[0]))
+#define ROUNDUP(x, y)   ((x + (y - 1)) / (y)) * (y)
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: elf_flush
+ *
+ * Description:
+ *   Flush the out stream
+ *
+ ****************************************************************************/
+
+static int elf_flush(FAR struct elf_dumpinfo_s *cinfo)
+{
+  return cinfo->stream->flush(cinfo->stream);
+}
+
+/****************************************************************************
+ * Name: elf_emit
+ *
+ * Description:
+ *   Send the dump data to binfmt_outstream_s
+ *
+ ****************************************************************************/
+
+static int elf_emit(FAR struct elf_dumpinfo_s *cinfo,
+                    FAR const void *buf, size_t len)
+{
+  FAR const uint8_t *ptr = buf;
+  size_t total = len;
+  int ret;
+
+  while (total > 0)
+    {
+      ret = cinfo->stream->puts(cinfo->stream, ptr, total > ELF_BLOCKSIZE ?
+                                ELF_BLOCKSIZE : total);
+      if (ret < 0)
+        {
+          break;
+        }
+
+      total -= ret;
+      ptr   += ret;
+    }
+
+  return ret < 0 ? ret : len - total;
+}
+
+/****************************************************************************
+ * Name: elf_emit_align
+ *
+ * Description:
+ *   Align the filled data according to the current offset
+ *
+ ****************************************************************************/
+
+static int elf_emit_align(FAR struct elf_dumpinfo_s *cinfo)
+{
+  off_t align = ROUNDUP(cinfo->stream->nput,
+                        ELF_PAGESIZE) - cinfo->stream->nput;
+  unsigned char null[256];
+  off_t total = align;
+  off_t ret;
+
+  memset(null, 0, sizeof(null));
+
+  while (total > 0)
+    {
+      ret = elf_emit(cinfo, null, total > sizeof(null) ?
+                                 sizeof(null) : total);
+      if (ret <= 0)
+        {
+          break;
+        }
+
+      total -= ret;
+    }
+
+  return ret < 0 ? ret : align;
+}
+
+/****************************************************************************
+ * Name: elf_emit_header
+ *
+ * Description:
+ *   Fill the elf header
+ *
+ ****************************************************************************/
+
+static int elf_emit_header(FAR struct elf_dumpinfo_s *cinfo,
+                           int segs)
+{
+  Elf_Ehdr ehdr;
+
+  memset(&ehdr, 0, sizeof(ehdr));
+  memcpy(ehdr.e_ident, ELFMAG, EI_MAGIC_SIZE);
+
+  ehdr.e_ident[EI_CLASS]   = ELF_CLASS;
+  ehdr.e_ident[EI_DATA]    = ELF_DATA;
+  ehdr.e_ident[EI_VERSION] = EV_CURRENT;
+  ehdr.e_ident[EI_OSABI]   = ELF_OSABI;
+
+  ehdr.e_type              = ET_CORE;
+  ehdr.e_machine           = EM_ARCH;
+  ehdr.e_version           = EV_CURRENT;
+  ehdr.e_phoff             = sizeof(Elf_Ehdr);
+  ehdr.e_flags             = EF_FLAG;
+  ehdr.e_ehsize            = sizeof(Elf_Ehdr);
+  ehdr.e_phentsize         = sizeof(Elf_Phdr);
+  ehdr.e_phnum             = segs;
+
+  return elf_emit(cinfo, &ehdr, sizeof(ehdr));
+}
+
+/****************************************************************************
+ * Name: elf_get_note_size
+ *
+ * Description:
+ *   Calculate the note segment size
+ *
+ ****************************************************************************/
+
+static int elf_get_note_size(void)
+{
+  int count = 0;
+  int total;
+  int i;
+
+  for (i = 0; i < g_npidhash; i++)
+    {
+      if (g_pidhash[i])
+        {
+          count++;
+        }
+    }
+
+  total  = count * (sizeof(Elf_Nhdr) + ROUNDUP(CONFIG_TASK_NAME_SIZE, 8) +
+                    sizeof(elf_prstatus_t));
+  total += count * (sizeof(Elf_Nhdr) + ROUNDUP(CONFIG_TASK_NAME_SIZE, 8) +
+                    sizeof(elf_prpsinfo_t));
+  return total;
+}
+
+/****************************************************************************
+ * Name: elf_emit_note_info
+ *
+ * Description:
+ *   Fill the note segment information
+ *
+ ****************************************************************************/
+
+static void elf_emit_note_info(FAR struct elf_dumpinfo_s *cinfo)
+{
+  char name[ROUNDUP(CONFIG_TASK_NAME_SIZE, 8)];
+  FAR struct tcb_s *tcb;
+  elf_prstatus_t status;
+  elf_prpsinfo_t info;
+  Elf_Nhdr nhdr;
+  int i;
+  int j;
+
+  memset(&info,   0x0, sizeof(info));
+  memset(&status, 0x0, sizeof(status));
+
+  for (i = 0; i < g_npidhash; i++)
+    {
+      if (g_pidhash[i] == NULL)
+        {
+          continue;
+        }
+
+      tcb = g_pidhash[i];
+
+      /* Fill Process info */
+
+      nhdr.n_namesz = sizeof(name);
+      nhdr.n_descsz = sizeof(info);
+      nhdr.n_type   = NT_PRPSINFO;
+
+      elf_emit(cinfo, &nhdr, sizeof(nhdr));
+
+      strncpy(name, tcb->name, sizeof(name));
+      elf_emit(cinfo, name, sizeof(name));
+
+      info.pr_pid   = tcb->pid;
+      strncpy(info.pr_fname, tcb->name, sizeof(info.pr_fname));
+      elf_emit(cinfo, &info, sizeof(info));
+
+      /* Fill Process status */
+
+      nhdr.n_descsz = sizeof(status);
+      nhdr.n_type   = NT_PRSTATUS;
+
+      elf_emit(cinfo, &nhdr, sizeof(nhdr));
+      elf_emit(cinfo, name, sizeof(name));
+
+      status.pr_pid = tcb->pid;
+
+      for (j = 0; j < ARRAY_SIZE(status.pr_regs); j++)
+        {
+          status.pr_regs[j] = *(uintptr_t *)((uint8_t *)tcb +
+                                             g_tcbinfo.reg_offs[j]);
+        }
+
+      elf_emit(cinfo, &status, sizeof(status));
+    }
+}
+
+/****************************************************************************
+ * Name: elf_emit_program_header
+ *
+ * Description:
+ *   Fill the program segment header
+ *
+ ****************************************************************************/
+
+static void elf_emit_program_header(FAR struct elf_dumpinfo_s *cinfo,
+                                    int segs)
+{
+  off_t offset = cinfo->stream->nput + (segs + 1) * sizeof(Elf_Phdr);
+  Elf_Phdr phdr;
+  int i;
+
+  memset(&phdr, 0, sizeof(Elf_Phdr));
+
+  phdr.p_type   = PT_NOTE;
+  phdr.p_offset = offset;
+  phdr.p_filesz = elf_get_note_size();
+  offset       += phdr.p_filesz;
+
+  elf_emit(cinfo, &phdr, sizeof(phdr));
+
+  /* Write program headers for segments dump */
+
+  for (i = 0; i < segs; i++)
+    {
+      phdr.p_type   = PT_LOAD;
+      phdr.p_offset = ROUNDUP(offset, ELF_PAGESIZE);
+      phdr.p_vaddr  = cinfo->regions[i].start;
+      phdr.p_paddr  = cinfo->regions[i].start;
+      phdr.p_filesz = cinfo->regions[i].end - cinfo->regions[i].start;
+      phdr.p_memsz  = phdr.p_filesz;
+      phdr.p_flags  = cinfo->regions[i].flags;
+      phdr.p_align  = ELF_PAGESIZE;
+      offset       += ROUNDUP(phdr.p_memsz, ELF_PAGESIZE);
+      elf_emit(cinfo, &phdr, sizeof(phdr));
+    }
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: elf_coredump
+ *
+ * Description:
+ *   Generat the core dump stream as ELF structure.
+ *
+ * Input Parameters:
+ *   dumpinfo - elf coredump informations
+ *
+ * Returned Value:
+ *   Zero (OK) on success; a negated errno value on failure.
+ *
+ ****************************************************************************/
+
+int elf_coredump(FAR struct elf_dumpinfo_s *cinfo)
+{
+  int segs = 0;
+  int i;
+
+  /* Check the memory region */
+
+  if (cinfo->regions)
+    {
+      for (; cinfo->regions[segs].start <
+             cinfo->regions[segs].end; segs++);
+    }
+
+  if (segs == 0)
+    {
+      return -EINVAL;
+    }
+
+  /* Fill notes section */
+
+  elf_emit_header(cinfo, segs + 1);
+
+  /* Fill all the program information about the process for the
+   * notes.  This also sets up the file header.
+   */
+
+  elf_emit_program_header(cinfo, segs);
+
+  /* Fill note information */
+
+  elf_emit_note_info(cinfo);
+
+  /* Align to page */
+
+  elf_emit_align(cinfo);
+
+  /* Start dump the memory */
+
+  for (i = 0; i < segs; i++)
+    {
+      elf_emit(cinfo, (FAR void *)cinfo->regions[i].start,
+               cinfo->regions[i].end -
+               cinfo->regions[i].start);
+
+      /* Align to page */
+
+      elf_emit_align(cinfo);
+    }
+
+  /* Flush the dump */
+
+  return elf_flush(cinfo);
+}

--- a/binfmt/nxflat.c
+++ b/binfmt/nxflat.c
@@ -84,6 +84,7 @@ static struct binfmt_s g_nxflatbinfmt =
   NULL,                /* next */
   nxflat_loadbinary,   /* load */
   nxflat_unloadbinary, /* unload */
+  NULL,                /* coredump */
 };
 
 /****************************************************************************

--- a/include/nuttx/binfmt/binfmt.h
+++ b/include/nuttx/binfmt/binfmt.h
@@ -33,6 +33,7 @@
 
 #include <nuttx/arch.h>
 #include <nuttx/sched.h>
+#include <nuttx/streams.h>
 
 /****************************************************************************
  * Pre-processor Definitions
@@ -102,6 +103,15 @@ struct binary_s
   CODE int (*unload)(FAR struct binary_s *bin);
 };
 
+/* This describes binfmt coredump filed */
+
+struct memory_region_s
+{
+  uintptr_t start;   /* Start address of this region */
+  uintptr_t end;     /* End address of this region */
+  uint32_t  flags;   /* Figure 5-3: Segment Flag Bits: PF_[X|W|R] */
+};
+
 /* This describes one binary format handler */
 
 struct binfmt_s
@@ -120,6 +130,11 @@ struct binfmt_s
   /* Unload module callback */
 
   CODE int (*unload)(FAR struct binary_s *bin);
+
+  /* Unload module callback */
+
+  CODE int (*coredump)(FAR struct memory_region_s *regions,
+                       FAR struct lib_outstream_s *stream);
 };
 
 /****************************************************************************
@@ -174,6 +189,22 @@ int register_binfmt(FAR struct binfmt_s *binfmt);
  ****************************************************************************/
 
 int unregister_binfmt(FAR struct binfmt_s *binfmt);
+
+/****************************************************************************
+ * Name: core_dump
+ *
+ * Description:
+ *   This function for generating core dump stream.
+ *
+ * Returned Value:
+ *   This is a NuttX internal function so it follows the convention that
+ *   0 (OK) is returned on success and a negated errno is returned on
+ *   failure.
+ *
+ ****************************************************************************/
+
+int core_dump(FAR struct memory_region_s *regions,
+              FAR struct lib_outstream_s *stream);
 
 /****************************************************************************
  * Name: load_module

--- a/include/nuttx/binfmt/elf.h
+++ b/include/nuttx/binfmt/elf.h
@@ -135,6 +135,18 @@ struct elf_loadinfo_s
   struct file        file;       /* Descriptor for the file being loaded */
 };
 
+/* This struct provides a description of the dump information of
+ * memory regions.
+ */
+
+#ifdef CONFIG_ELF_COREDUMP
+struct elf_dumpinfo_s
+{
+  FAR struct memory_region_s *regions;
+  FAR struct lib_outstream_s *stream;
+};
+#endif
+
 /****************************************************************************
  * Public Function Prototypes
  ****************************************************************************/
@@ -254,6 +266,24 @@ int elf_bind(FAR struct elf_loadinfo_s *loadinfo,
  ****************************************************************************/
 
 int elf_unload(struct elf_loadinfo_s *loadinfo);
+
+/****************************************************************************
+ * Name: elf_coredump
+ *
+ * Description:
+ *   Generat the core dump stream as ELF structure.
+ *
+ * Input Parameters:
+ *   dumpinfo - elf coredump informations
+ *
+ * Returned Value:
+ *   Zero (OK) on success; a negated errno value on failure.
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_ELF_COREDUMP
+int elf_coredump(FAR struct elf_dumpinfo_s *dumpinfo);
+#endif
 
 #undef EXTERN
 #if defined(__cplusplus)

--- a/include/nuttx/elf.h
+++ b/include/nuttx/elf.h
@@ -26,6 +26,70 @@
  ****************************************************************************/
 
 #include <elf.h>
+#ifdef CONFIG_ELF_COREDUMP
+#include <arch/elf.h>
+#endif
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define ELF_PRARGSZ    (80)  /* Number of chars for args */
+
+/****************************************************************************
+ * Public Types
+ ****************************************************************************/
+
+#ifdef CONFIG_ELF_COREDUMP
+typedef struct elf_prpsinfo_s
+{
+  char           pr_state;    /* Numeric process state */
+  char           pr_sname;    /* Char for pr_state */
+  char           pr_zomb;     /* Zombie */
+  char           pr_nice;     /* Nice val */
+  unsigned long  pr_flag;     /* Flags */
+  unsigned short pr_uid;
+  unsigned short pr_gid;
+  int            pr_pid;
+  int            pr_ppid;
+  int            pr_pgrp;
+  int            pr_sid;
+  char           pr_fname[16];           /* Filename of executable */
+  char           pr_psargs[ELF_PRARGSZ]; /* Initial part of arg list */
+} elf_prpsinfo_t;
+
+typedef struct elf_siginfo_s
+{
+  int            si_signo;    /* Signal number */
+  int            si_code;     /* Extra code */
+  int            si_errno;    /* Errno */
+} elf_siginfo_t;
+
+typedef struct elf_timeval_s
+{
+  long           tv_sec;      /* Seconds */
+  long           tv_usec;     /* Microseconds */
+} elf_timeval_t;
+
+typedef struct elf_prstatus_s
+{
+  elf_siginfo_t  pr_info;     /* Info associated with signal */
+  short          pr_cursig;   /* Current signal */
+  short          pr_padding;  /* Padding align */
+  unsigned long  pr_sigpend;  /* Set of pending signals */
+  unsigned long  pr_sighold;  /* Set of held signals */
+  int            pr_pid;
+  int            pr_ppid;
+  int            pr_pgrp;
+  int            pr_sid;
+  elf_timeval_t  pr_utime;    /* User time */
+  elf_timeval_t  pr_stime;    /* System time */
+  elf_timeval_t  pr_cutime;   /* Cumulative user time */
+  elf_timeval_t  pr_cstime;   /* Cumulative system time */
+  elf_gregset_t  pr_regs;
+  int            pr_fpvalid;  /* True if math co-processor being used */
+} elf_prstatus_t;
+#endif
 
 /****************************************************************************
  * Public Function Prototypes


### PR DESCRIPTION
## Summary

binfmt/elf: add bare metal coredump support 

Add elf coredump support for bare metal files,

The new version of GDB toolchain adds support for bare metal core dump:
http://patches-tcwg.linaro.org/patch/49192/
This makes it possible for the standard coredump to be parsed, we can generate the standard coredump for gdb debugging directly.

GDB version must be more than **12**:

gdb upstream:
`https://github.com/bminor/binutils-gdb`

Compile config:
`./configure  --host=x86_64-linux-gnu --target=arm-none-eabi --with-python --with-mpfr --with-babeltrace --with-lzma --enable-unicode=ucs4 --enable-targets=all`

gdb version:
```
$ ././gdb/gdb --version
...
GNU gdb (GDB) 12.0.50.20211119-git
...
```

coredump file from this patch (armv8-m m55):
```
$ readelf -h armv8-m_m55_coredump
ELF Header:
  Magic:   7f 45 4c 46 01 01 01 00 00 00 00 00 00 00 00 00 
  Class:                             ELF32
  Data:                              2's complement, little endian
  Version:                           1 (current)
  OS/ABI:                            UNIX - System V
  ABI Version:                       0
  Type:                              CORE (Core file)
  Machine:                           ARM
  Version:                           0x1
  Entry point address:               0x0
  Start of program headers:          52 (bytes into file)
  Start of section headers:          0 (bytes into file)
  Flags:                             0x5000400, Version5 EABI, hard-float ABI
  Size of this header:               52 (bytes)
  Size of program headers:           32 (bytes)
  Number of program headers:         3
  Size of section headers:           0 (bytes)
  Number of section headers:         0
  Section header string table index: 0
```

start debug:

```
$ ././gdb/gdb -c armv8-m_m55_coredump  nuttx_elf --data-directory=gdb/data-directory
Copyright (C) 2021 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.
Type "show copying" and "show warranty" for details.
This GDB was configured as "--host=x86_64-linux-gnu --target=arm-none-eabi".
Type "show configuration" for configuration details.
For bug reporting instructions, please see:
<https://www.gnu.org/software/gdb/bugs/>.
Find the GDB manual and other documentation resources online at:
    <http://www.gnu.org/software/gdb/documentation/>.

For help, type "help".
Type "apropos word" to search for commands related to "word"...
Reading symbols from /home/archer/code/l05c/m2/nuttx/nuttx...

warning: core file may not match specified executable file.
[New process 31]
[New process 1]
[New process 2]
[New process 3]
[New process 4]
[New process 5]
[New process 6]
[New process 8]
[New process 9]
[New process 10]
[New process 12]
[New process 13]
[New process 14]
[New process 15]
[New process 16]
[New process 17]
[New process 18]
[New process 20]
[New process 21]
[New process 22]
[New process 23]
[New process 24]
[New process 25]
[New process 31]
Core was generated by `'.
#0  hal_sleep_light_sleep () at ../../platform/hal/hal_sleep.c:506
506	    return ret;
[Current thread is 1 (process 31)]
```


```
(gdb) info thread
  Id   Target Id         Frame 
* 1    process 31        hal_sleep_light_sleep () at ../../platform/hal/hal_sleep.c:506
  2    process 1         arm_switchcontext () at armv8-m/arm_switchcontext.S:79
  3    process 2         arm_switchcontext () at armv8-m/arm_switchcontext.S:79
  4    process 3         arm_switchcontext () at armv8-m/arm_switchcontext.S:79
  5    process 4         arm_switchcontext () at armv8-m/arm_switchcontext.S:79
  6    process 5         arm_switchcontext () at armv8-m/arm_switchcontext.S:79
  7    process 6         arm_switchcontext () at armv8-m/arm_switchcontext.S:79
  8    process 8         arm_switchcontext () at armv8-m/arm_switchcontext.S:79
  9    process 9         arm_switchcontext () at armv8-m/arm_switchcontext.S:79
  10   process 10        arm_switchcontext () at armv8-m/arm_switchcontext.S:79
  11   process 12        arm_switchcontext () at armv8-m/arm_switchcontext.S:79
  12   process 13        arm_switchcontext () at armv8-m/arm_switchcontext.S:79
  13   process 14        arm_switchcontext () at armv8-m/arm_switchcontext.S:79
  14   process 15        arm_switchcontext () at armv8-m/arm_switchcontext.S:79
  15   process 16        arm_switchcontext () at armv8-m/arm_switchcontext.S:79
  16   process 17        arm_switchcontext () at armv8-m/arm_switchcontext.S:79
  17   process 18        arm_switchcontext () at armv8-m/arm_switchcontext.S:79
  18   process 20        arm_switchcontext () at armv8-m/arm_switchcontext.S:79
  19   process 21        arm_switchcontext () at armv8-m/arm_switchcontext.S:79
  20   process 22        arm_switchcontext () at armv8-m/arm_switchcontext.S:79
  21   process 23        arm_switchcontext () at armv8-m/arm_switchcontext.S:79
  22   process 24        arm_switchcontext () at armv8-m/arm_switchcontext.S:79
  23   process 25        arm_switchcontext () at armv8-m/arm_switchcontext.S:79
  24   process 31        arm_switchcontext () at armv8-m/arm_switchcontext.S:79
(gdb) 
```


```
(gdb) thread 16
[Switching to thread 16 (process 17)]
#0  arm_switchcontext () at armv8-m/arm_switchcontext.S:79
79		bx		lr
(gdb) bt
#0  arm_switchcontext () at armv8-m/arm_switchcontext.S:79
#1  0x00211198 in nxsig_timedwait (set=set@entry=0x34043d04, info=info@entry=0x34043d08, timeout=timeout@entry=0x0) at signal/sig_timedwait.c:355
#2  0x0021033c in nx_waitpid (pid=<optimized out>, stat_loc=stat_loc@entry=0x34043d4c, options=options@entry=4) at sched/sched_waitpid.c:427
#3  0x00210392 in waitpid (pid=pid@entry=31, stat_loc=stat_loc@entry=0x34043d4c, options=options@entry=4) at sched/sched_waitpid.c:617
#4  0x0c0f7882 in nsh_builtin (vtbl=vtbl@entry=0x34043ef0, cmd=0x3404415c "hello", argv=argv@entry=0x34043db0, redirfile=redirfile@entry=0x0, oflags=oflags@entry=0) at nsh_builtin.c:182
#5  0x0c0f449c in nsh_execute (oflags=0, redirfile=0x0, argv=0x34043db0, argc=<optimized out>, vtbl=0x34043ef0) at nsh_parse.c:541
#6  nsh_parse_command (vtbl=vtbl@entry=0x34043ef0, cmdline=<optimized out>) at nsh_parse.c:2591
#7  0x0c0f469e in nsh_parse (vtbl=vtbl@entry=0x34043ef0, cmdline=cmdline@entry=0x3404415c "hello") at nsh_parse.c:2675
#8  0x0c0f74f4 in nsh_session (pstate=pstate@entry=0x34043ef0, login=login@entry=1 '\001', argc=argc@entry=1, argv=argv@entry=0x34043ed8) at nsh_session.c:233
#9  0x0c0f844c in nsh_consolemain (argc=argc@entry=1, argv=argv@entry=0x34043ed8) at nsh_consolemain.c:116
#10 0x0c0f8d52 in nsh_main (argc=1, argv=0x34043ed8) at nsh_main.c:170
#11 0x0c0da05c in nxtask_startup (entrypt=0xc0f8d1d <nsh_main>, entrypt@entry=0x1, argc=1, argv=0x34043ed8) at sched/task_startup.c:170
#12 0x00211e68 in nxtask_start () at task/task_start.c:144
#13 0x00000000 in ?? ()
Backtrace stopped: previous frame identical to this frame (corrupt stack?)
```

```
(gdb) frame 7
#7  0x0c0f469e in nsh_parse (vtbl=vtbl@entry=0x34043ef0, cmdline=cmdline@entry=0x3404415c "hello") at nsh_parse.c:2675
2675	          return nsh_parse_command(vtbl, start);
(gdb) info args
vtbl = 0x34043ef0
cmdline = 0x3404415c "hello"
(gdb) info symbol 0x340079e0
g_hpwork in section .psram_bss
```

lookup global symbol:

```
(gdb) p g_
Display all 200 possibilities? (y or n)
g_abbrev_monthname              g_cbfreelist                    g_flowctrl_turnback             g_http10                        g_iob_qpool                     g_nxrecorder_cmds               g_serialops                     g_uart0port
g_abbrev_wdayname               g_cbprealloc                    g_fmtarginvalid                 g_http11                        g_iob_sem                       g_oldpwd                        g_services_db                   g_uart0priv
g_active_netlink_connections    g_cfg80211_rdev                 g_fmtargrange                   g_httpcontsize                  g_ioctl_work                    g_oneshot_ops                   g_sigmask                       g_uart0rxbuffer
g_active_tcp_connections        g_checksum                      g_fmtargrequired                g_httpcrnl                      g_ioexpander                    g_overrun_msg                   g_skb_alloc_size                g_uart0txbuffer
g_adcCalibrated                 g_cmdmap                        g_fmtcmdfailed                  g_httphost                      g_known_ext                     g_passwd                        g_spiarginvalid                 g_uart2port
g_adcIntcpt                     g_count                         g_fmtcmdnotfound                g_httplocation                  g_last_tcp_port                 g_priority                      g_spiargrange                   g_uart2priv
g_adcSlope                      g_current_regs                  g_fmtcmdoutofmemory             g_httpuseragentfields           g_line_separator                g_program_regions               g_spicmdnotfound                g_uart2rxbuffer
g_addrenv_dummy                 g_datemontab                    g_fmtcontext                    g_hw_vif_data                   g_lirc_fops                     g_pthreadhash                   g_spicmds                       g_uart2txbuffer
g_alarmwork                     g_daysbeforemonth               g_fmtdeepnesting                g_hx3203_fileops                g_lo_hostname                   g_ptmx_fops                     g_spiincompleteparam            g_uart_ops
g_arptable                      g_dd                            g_fmtinternalerror              g_i2c_open                      g_lo_ipv4addr                   g_pty_fops                      g_spitoomanyargs                g_uart_rpmsg_ops
g_audio_heap                    g_debug_intersys                g_fmtnomatching                 g_i2carginvalid                 g_lo_ipv4mask                   g_pwd                           g_stacksize                     g_uartbtport
g_audioops                      g_defactions                    g_fmtnosuch                     g_i2cargrange                   g_loop_fops                     g_pwmops                        g_stackused                     g_uartbtpriv
g_baud_table                    g_default_channel_ops           g_fmtsignalrecvd                g_i2cargrequired                g_misc_data                     g_qentry_sem                    g_state                         g_uartbtrxbuffer
g_bes_io_ops                    g_default_pthread_attr          g_fmtsyntax                     g_i2ccmdfailed                  g_mon_lengths                   g_ramlog_channel_ops            g_sub_if_data                   g_uartbttxbuffer
g_bes_lirc_ops                  g_devfreed                      g_fmttoomanyargs                g_i2ccmdnotfound                g_monthname                     g_ramlogfops                    g_success                       g_unknown
g_bes_rptun_ops                 g_devset                        g_free_netlink_connections      g_i2ccmds                       g_net_dev                       g_recv_int_cmd_index            g_sysbuffer                     g_urand_fops
g_bops                          g_dtoa_round                    g_free_sem                      g_i2ctoomanyargs                g_netdevices                    g_redirect1                     g_tasklisttable                 g_usrsock_rpmsg_handler
g_bt_uart_filter_ble_evt_table  g_dtoa_scale_down               g_free_tcp_connections          g_i2cxfrerror                   g_netlink_connections           g_redirect2                     g_tcp_connections               g_wdayname
g_bt_uart_filter_bt_evt_table   g_dtoa_scale_up                 g_freerun_lock                  g_idle_topstack                 g_netlock                       g_rgbledops                     g_tcpsequence                   g_wdogops
g_btnarg                        g_erasetoeol                    g_ftpdaccounts                  g_idlename                      g_noname                        g_rptun_devops                  g_telnet_fops                   g_wdtdev
g_btnhandler                    g_exitstatus                    g_groupid                       g_iob_committed                 g_nsh_extmatch                  g_rtc_lowerhalf                 g_telopts                       g_wdtops
g_btnlower                      g_factory_fops                  g_hcibridge_ops                 g_iob_freelist                  g_nshgreeting                   g_rtc_ops                       g_throttle_sem                  g_wildabbr
g_btnnum                        g_failure                       g_heap                          g_iob_freeqlist                 g_nshprompt                     g_rx_flowctrl                   g_tickless                      g_wiphy_hw_priv
g_builtin_count                 g_fl3236a_fileops               g_holder                        g_iob_pool                      g_nullstring                    g_scheduler                     g_token_separator               g_wrbuffer
g_builtins                      g_flags                         g_home                          g_iob_qcommitted                g_nxplayer_cmds                 g_send_int_cmd_index            g_type                          g_year_lengths
*** List may be truncated, max-completions reached. ***
(gdb) p g_net
g_net_dev              g_netdevices           g_netlink_connections  g_netlink_sockif       g_netlock              g_netstat_linegen      
(gdb) p g_net_dev 
$1 = {{name = "wlan0\000\000\000\000\000\000\000\000\000\000", stats = {rx_packets = 876, tx_packets = 937, rx_bytes = 53378, tx_bytes = 769633, rx_errors = 0, tx_errors = 0, rx_dropped = 0, tx_dropped = 0, multicast = 0, collisions = 0, rx_length_errors = 0, 
      rx_over_errors = 0, rx_crc_errors = 0, rx_frame_errors = 0, rx_fifo_errors = 0, rx_missed_errors = 0, tx_aborted_errors = 0, tx_carrier_errors = 0, tx_fifo_errors = 0, tx_heartbeat_errors = 0, tx_window_errors = 0, rx_compressed = 0, tx_compressed = 0}, 
    netdev_ops = 0x2c2976d8 <ieee80211_dataif_ops>, ifindex = 0, flags = 4099, state = 1, addr_list_lock = {mutex_id = 0x200a7fac <g_net_dev+128>, mutex = {mutex = {sem = {semcount = 1}, pid = -1, type = 2 '\002', nlocks = 0}}}, dev_addrs = {list = {
        next = 0x2005d69c <g_heap+37320>, prev = 0x2005d69c <g_heap+37320>}, count = 1}, mc = {list = {next = 0x200a7fc0 <g_net_dev+148>, prev = 0x200a7fc0 <g_net_dev+148>}, count = 0}, mtu = 1500, type = 1, hard_header_len = 14, 
    perm_addr = "\214\336\371_\323g", '\000' <repeats 25 times>, addr_len = 6 '\006', wmm_en = 1 '\001', ieee80211_ptr = 0x200a8288 <g_sub_if_data+8>, dev_addr = "\214\336\371_\323g", broadcast = "\377\377\377\377\377\377", '\000' <repeats 25 times>, 
    _tx = 0x2005d6e8 <g_heap+37396>, num_tx_queues = 4, real_num_tx_queues = 4, tx_queue_len = 1000, is_used = 1 '\001', trans_start = 100568, destructor = 0x238c89 <free_netdev>, priv = 0x200a8280 <g_sub_if_data>, vif_data = 0x200a6558 <g_hw_vif_data>}, {
    name = "ap0", '\000' <repeats 12 times>, stats = {rx_packets = 0, tx_packets = 0, rx_bytes = 0, tx_bytes = 0, rx_errors = 0, tx_errors = 0, rx_dropped = 0, tx_dropped = 0, multicast = 0, collisions = 0, rx_length_errors = 0, rx_over_errors = 0, 
      rx_crc_errors = 0, rx_frame_errors = 0, rx_fifo_errors = 0, rx_missed_errors = 0, tx_aborted_errors = 0, tx_carrier_errors = 0, tx_fifo_errors = 0, tx_heartbeat_errors = 0, tx_window_errors = 0, rx_compressed = 0, tx_compressed = 0}, 
    netdev_ops = 0x2c2976d8 <ieee80211_dataif_ops>, ifindex = 1, flags = 4098, state = 0, addr_list_lock = {mutex_id = 0x200a80c8 <g_net_dev+412>, mutex = {mutex = {sem = {semcount = 1}, pid = -1, type = 2 '\002', nlocks = 0}}}, dev_addrs = {list = {
        next = 0x20058a84 <g_heap+17840>, prev = 0x20058a84 <g_heap+17840>}, count = 1}, mc = {list = {next = 0x200a80dc <g_net_dev+432>, prev = 0x200a80dc <g_net_dev+432>}, count = 0}, mtu = 1500, type = 1, hard_header_len = 14, 
    perm_addr = "\214\336\371_\323h", '\000' <repeats 25 times>, addr_len = 6 '\006', wmm_en = 1 '\001', ieee80211_ptr = 0x200a8970 <g_sub_if_data+1776>, dev_addr = "\214\336\371_\323h", broadcast = "\377\377\377\377\377\377", '\000' <repeats 25 times>, 
    _tx = 0x20058ad0 <g_heap+17916>, num_tx_queues = 4, real_num_tx_queues = 4, tx_queue_len = 1000, is_used = 1 '\001', trans_start = 0, destructor = 0x238c89 <free_netdev>, priv = 0x200a8968 <g_sub_if_data+1768>, vif_data = 0x200a6df4 <g_hw_vif_data+2204>}, {
    name = '\000' <repeats 15 times>, stats = {rx_packets = 0, tx_packets = 0, rx_bytes = 0, tx_bytes = 0, rx_errors = 0, tx_errors = 0, rx_dropped = 0, tx_dropped = 0, multicast = 0, collisions = 0, rx_length_errors = 0, rx_over_errors = 0, rx_crc_errors = 0, 
      rx_frame_errors = 0, rx_fifo_errors = 0, rx_missed_errors = 0, tx_aborted_errors = 0, tx_carrier_errors = 0, tx_fifo_errors = 0, tx_heartbeat_errors = 0, tx_window_errors = 0, rx_compressed = 0, tx_compressed = 0}, netdev_ops = 0x0, ifindex = 0, 
    flags = 0, state = 0, addr_list_lock = {mutex_id = 0x0, mutex = {mutex = {sem = {semcount = 0}, pid = 0, type = 0 '\000', nlocks = 0}}}, dev_addrs = {list = {next = 0x0, prev = 0x0}, count = 0}, mc = {list = {next = 0x0, prev = 0x0}, count = 0}, mtu = 0, 
    type = 0, hard_header_len = 0, perm_addr = '\000' <repeats 31 times>, addr_len = 0 '\000', wmm_en = 0 '\000', ieee80211_ptr = 0x0, dev_addr = "\000\000\000\000\000", broadcast = '\000' <repeats 31 times>, _tx = 0x0, num_tx_queues = 0, 
    real_num_tx_queues = 0, tx_queue_len = 0, is_used = 0 '\000', trans_start = 0, destructor = 0x0, priv = 0x0, vif_data = 0x0}}

```

## Impact

N/A, new feature

## Testing

Generate elf core dump and debug on gdb