### PR TITLE
change /dev/syslog & /dev/ramlog for unix standard

### DIFF
--- a/drivers/syslog/Kconfig
+++ b/drivers/syslog/Kconfig
@@ -330,7 +330,7 @@ config SYSLOG_DEVPATH
 	depends on SYSLOG_CHAR
 	---help---
 		The full path to the system logging device.  For the RAMLOG SYSLOG device,
-		this is normally "/dev/ramlog".  For character SYSLOG devices, it should be
+		this is normally "/dev/kmsg".  For character SYSLOG devices, it should be
 		some other existing character device (or file) supported by the configuration
 		(such as "/dev/ttyS1")/
 
@@ -338,7 +338,7 @@ config SYSLOG_CHARDEV
 	bool "SYSLOG character device"
 	default n
 	---help---
-		Enables support for a simple character driver at /dev/syslog whose
+		Enables support for a simple character driver at /dev/log whose
 		write() method will transfer data to the SYSLOG device.  This can be
 		useful if, for example, you want to redirect the output of a program
 		to the SYSLOG.

--- a/drivers/syslog/syslog.h
+++ b/drivers/syslog/syslog.h
@@ -163,7 +163,7 @@ FAR struct syslog_channel_s *syslog_console_channel(void);
  * Name: syslog_register
  *
  * Description:
- *   Register a simple character driver at /dev/syslog whose write() method
+ *   Register a simple character driver at /dev/log whose write() method
  *   will transfer data to the SYSLOG device.  This can be useful if, for
  *   example, you want to redirect the output of a program to the SYSLOG.
  *

--- a/drivers/syslog/syslog_chardev.c
+++ b/drivers/syslog/syslog_chardev.c
@@ -85,7 +85,7 @@ static ssize_t syslog_chardev_write(FAR struct file *filep,
  * Name: syslog_register
  *
  * Description:
- *   Register a simple character driver at /dev/syslog whose write() method
+ *   Register a simple character driver at /dev/log whose write() method
  *   will transfer data to the SYSLOG device.  This can be useful if, for
  *   example, you want to redirect the output of a program to the SYSLOG.
  *
@@ -97,7 +97,7 @@ static ssize_t syslog_chardev_write(FAR struct file *filep,
 
 void syslog_register(void)
 {
-  register_driver("/dev/syslog", &syslog_fops, 0222, NULL);
+  register_driver("/dev/log", &syslog_fops, 0222, NULL);
 }
 
 #endif /* CONFIG_SYSLOG_CHARDEV */

--- a/include/nuttx/syslog/ramlog.h
+++ b/include/nuttx/syslog/ramlog.h
@@ -67,7 +67,7 @@
  */
 
 #if defined(CONFIG_RAMLOG_SYSLOG) && !defined(CONFIG_SYSLOG_DEVPATH)
-#  define CONFIG_SYSLOG_DEVPATH "/dev/ramlog"
+#  define CONFIG_SYSLOG_DEVPATH "/dev/kmsg"
 #endif
 
 #ifndef CONFIG_RAMLOG_NPOLLWAITERS


### PR DESCRIPTION
## Summary
i think use /dev/log & /dev/kmsg is better than /dev/syslog & /dev/ramlog. 
https://unix.stackexchange.com/questions/205883/understand-logging-in-linux/294206#294206
![image](https://user-images.githubusercontent.com/75056955/143161117-9e4f0da6-f228-4429-b167-de818a29d9f5.png)
![image](https://user-images.githubusercontent.com/75056955/143161150-94b68017-3235-4c18-8ae6-7b31be81ba29.png)

## Impact
all applications use "/dev/syslog" & "/dev/ramlog“  as an absolute path
## Testing
daliy
