### PR TITLE
riscv/bl602: Enable GPIO output

### DIFF
--- a/arch/risc-v/src/bl602/bl602_gpio.c
+++ b/arch/risc-v/src/bl602/bl602_gpio.c
@@ -129,6 +129,14 @@ int bl602_configgpio(gpio_pinset_t cfgset)
     }
 
   modifyreg32(regaddr, mask, cfg);
+
+  /* Enable pin output if requested */
+
+  if (!(cfgset & GPIO_INPUT))
+    {
+      modifyreg32(BL602_GPIO_CFGCTL34, 0, (1 << pin));
+    }
+
   return OK;
 }
 


### PR DESCRIPTION
## Summary

BL602 GPIO Driver doesn't configure the GPIO Output Enable Register for GPIO Output Pins.

So calling the GPIO Driver `bl602_gpiowrite()` to set the GPIO Output has no effect.

We fix this by updating the GPIO Output Enable Register for GPIO Output Pins in `bl602_configgpio()`.

[More details here](https://lupyuen.github.io/articles/nuttx#appendix-fix-gpio-output)

## Impact

This fix impacts the pins configured for GPIO Output on BL602.

Previously GPIO Output Pins could not be set to High / Low when we call `bl602_gpiowrite()`. 

Now the GPIO Output Pins are set to High / Low correctly when we call `bl602_gpiowrite()`.

## Testing

Tested on Pine64 PineCone BL602 board, with the onboard Blue LED.

[More details here](https://lupyuen.github.io/articles/nuttx#appendix-fix-gpio-output)
