### PR TITLE
cache_invalidate: fix unalign cacheline invalidate  & add cache coherence config for semihosting option

### DIFF
--- a/arch/arm/Kconfig
+++ b/arch/arm/Kconfig
@@ -975,6 +975,16 @@ config ARM_SEMIHOSTING_HOSTFS
 		This doesn't support some directory operations like readdir because
 		of the limitations of semihosting mechanism.
 
+if ARM_SEMIHOSTING_HOSTFS
+
+config ARM_SEMIHOSTING_HOSTFS_CACHE_COHERENCE
+	bool "Cache coherence in semihosting hostfs"
+	depends on ARCH_DCACHE
+	---help---
+		Flush & Invalidte cache before & after bkpt instruction.
+
+endif
+
 if ARCH_ARMV6M
 source "arch/arm/src/armv6-m/Kconfig"
 endif

--- a/arch/arm/src/arm/arm_cache.S
+++ b/arch/arm/src/arm/arm_cache.S
@@ -123,7 +123,16 @@ up_invalidate_icache_all:
 	.type	up_invalidate_dcache, function
 
 up_invalidate_dcache:
-	bic		r0, r0, #CACHE_DLINESIZE - 1
+	mov		r2, #CACHE_DLINESIZE - 1
+
+	tst		r0, r2
+	bic		r0, r0, r2			/* R0=aligned start address */
+	mcrne		p15, 0, r0, c7, c14, 1		/* Clean & invalidate D entry */
+
+	tst		r1, r2
+	bic		r1, r1, r2			/* R1=aligned end address */
+	mcrne		p15, 0, r1, c7, c14, 1		/* Clean & invalidate D entry */
+
 1:	mcr		p15, 0, r0, c7, c6, 1		/* Invalidate D entry */
 	add		r0, r0, #CACHE_DLINESIZE
 	cmp		r0, r1

--- a/arch/xtensa/Kconfig
+++ b/arch/xtensa/Kconfig
@@ -220,6 +220,16 @@ config XTENSA_EXTMEM_BSS
 		Adds a section and an attribute that allows to force variables into
 		the external memory.
 
+if CONFIG_FS_HOSTFS
+
+config XTENSA_HOSTFS_CACHE_COHERENCE
+	bool "Cache coherence in semihosting hostfs"
+	depends on ARCH_DCACHE
+	---help---
+		Flush & Invalidte cache before & after sim call.
+
+endif
+
 choice
 	prompt "Toolchain Selection"
 	default XTENSA_TOOLCHAIN_ESP

--- a/arch/xtensa/src/common/xtensa_cache.c
+++ b/arch/xtensa/src/common/xtensa_cache.c
@@ -116,11 +116,11 @@ void up_invalidate_icache(uintptr_t start, uintptr_t end)
 {
   /* align to XCHAL_ICACHE_LINESIZE */
 
-  uint32_t addr = start - (start & (XCHAL_ICACHE_LINESIZE - 1));
+  start &= ~(XCHAL_ICACHE_LINESIZE - 1);
 
-  for (; addr < end; addr += XCHAL_ICACHE_LINESIZE)
+  for (; start < end; start += XCHAL_ICACHE_LINESIZE)
     {
-      __asm__ __volatile__ ("ihi %0, 0\n" : : "r"(addr));
+      __asm__ __volatile__ ("ihi %0, 0\n" : : "r"(start));
     }
 
   __asm__ __volatile__ ("isync\n");
@@ -175,11 +175,11 @@ void up_lock_icache(uintptr_t start, uintptr_t end)
 {
   /* align to XCHAL_ICACHE_LINESIZE */
 
-  uint32_t addr = start - (start & (XCHAL_ICACHE_LINESIZE - 1));
+  start &= ~(XCHAL_ICACHE_LINESIZE - 1);
 
-  for (; addr < end; addr += XCHAL_ICACHE_LINESIZE)
+  for (; start < end; start += XCHAL_ICACHE_LINESIZE)
     {
-      __asm__ __volatile__ ("ipfl %0, 0\n": : "r"(addr));
+      __asm__ __volatile__ ("ipfl %0, 0\n": : "r"(start));
     };
 
   __asm__ __volatile__ ("isync\n");
@@ -206,11 +206,11 @@ void up_unlock_icache(uintptr_t start, uintptr_t end)
 {
   /* align to XCHAL_ICACHE_LINESIZE */
 
-  uint32_t addr = start - (start & (XCHAL_ICACHE_LINESIZE - 1));
+  start &= ~(XCHAL_ICACHE_LINESIZE - 1);
 
-  for (; addr < end; addr += XCHAL_ICACHE_LINESIZE)
+  for (; start < end; start += XCHAL_ICACHE_LINESIZE)
     {
-      __asm__ __volatile__ ("ihu %0, 0\n": : "r"(addr));
+      __asm__ __volatile__ ("ihu %0, 0\n": : "r"(start));
     };
 
   __asm__ __volatile__ ("isync\n");
@@ -335,13 +335,24 @@ void up_disable_dcache(void)
 #ifdef CONFIG_XTENSA_DCACHE
 void up_invalidate_dcache(uintptr_t start, uintptr_t end)
 {
-  /* Align to XCHAL_DCACHE_LINESIZE */
-
-  uint32_t addr = start - (start & (XCHAL_DCACHE_LINESIZE - 1));
-
-  for (; addr < end; addr += XCHAL_DCACHE_LINESIZE)
+  if (start & (XCHAL_DCACHE_LINESIZE - 1))
     {
-      __asm__ __volatile__ ("dhi %0, 0\n" : : "r"(addr));
+      /* Align to XCHAL_DCACHE_LINESIZE */
+
+      start &= ~(XCHAL_DCACHE_LINESIZE - 1);
+      __asm__ __volatile__ ("dhwbi %0, 0\n" : : "r"(start));
+      start += XCHAL_DCACHE_LINESIZE;
+    }
+
+  for (; start + XCHAL_DCACHE_LINESIZE <= end;
+       start += XCHAL_DCACHE_LINESIZE)
+    {
+      __asm__ __volatile__ ("dhi %0, 0\n" : : "r"(start));
+    }
+
+  if (start != end)
+    {
+      __asm__ __volatile__ ("dhwbi %0, 0\n" : : "r"(start));
     }
 
   __asm__ __volatile__ ("dsync\n");
@@ -405,11 +416,11 @@ void up_clean_dcache(uintptr_t start, uintptr_t end)
 {
   /* Align to XCHAL_DCACHE_SIZE */
 
-  uint32_t addr = start - (start & (XCHAL_DCACHE_LINESIZE - 1));
+  start &= ~(XCHAL_DCACHE_LINESIZE - 1);
 
-  for (; addr < end; addr += XCHAL_DCACHE_LINESIZE)
+  for (; start < end; start += XCHAL_DCACHE_LINESIZE)
     {
-      __asm__ __volatile__ ("dhwb %0, 0\n" : : "r"(addr));
+      __asm__ __volatile__ ("dhwb %0, 0\n" : : "r"(start));
     }
 
   __asm__ __volatile__ ("dsync\n");
@@ -482,11 +493,11 @@ void up_flush_dcache(uintptr_t start, uintptr_t end)
 {
   /* Align to XCHAL_DCACHE_LINESIZE */
 
-  uint32_t addr = start - (start & (XCHAL_DCACHE_LINESIZE - 1));
+  start &= ~(XCHAL_DCACHE_LINESIZE - 1);
 
-  for (; addr < end; addr += XCHAL_DCACHE_LINESIZE)
+  for (; start < end; start += XCHAL_DCACHE_LINESIZE)
     {
-      __asm__ __volatile__ ("dhwbi %0, 0\n" : : "r"(addr));
+      __asm__ __volatile__ ("dhwbi %0, 0\n" : : "r"(start));
     }
 
   __asm__ __volatile__ ("dsync\n");
@@ -549,11 +560,11 @@ void up_lock_dcache(uintptr_t start, uintptr_t end)
 {
   /* align to XCHAL_DCACHE_LINESIZE */
 
-  uint32_t addr = start - (start & (XCHAL_DCACHE_LINESIZE - 1));
+  start &= ~(XCHAL_DCACHE_LINESIZE - 1);
 
-  for (; addr < end; addr += XCHAL_DCACHE_LINESIZE)
+  for (; start < end; start += XCHAL_DCACHE_LINESIZE)
     {
-      __asm__ __volatile__ ("dpfl %0, 0\n": : "r"(addr));
+      __asm__ __volatile__ ("dpfl %0, 0\n": : "r"(start));
     };
 
   __asm__ __volatile__ ("dsync\n");
@@ -580,11 +591,11 @@ void up_unlock_dcache(uintptr_t start, uintptr_t end)
 {
   /* align to XCHAL_DCACHE_LINESIZE */
 
-  uint32_t addr = start - (start & (XCHAL_DCACHE_LINESIZE - 1));
+  start &= ~(XCHAL_DCACHE_LINESIZE - 1);
 
-  for (; addr < end; addr += XCHAL_DCACHE_LINESIZE)
+  for (; start < end; start += XCHAL_DCACHE_LINESIZE)
     {
-      __asm__ __volatile__ ("dhu %0, 0\n": : "r"(addr));
+      __asm__ __volatile__ ("dhu %0, 0\n": : "r"(start));
     };
 
   __asm__ __volatile__ ("dsync\n");

--- a/arch/xtensa/src/common/xtensa_hostfs.c
+++ b/arch/xtensa/src/common/xtensa_hostfs.c
@@ -23,6 +23,7 @@
  ****************************************************************************/
 
 #include <nuttx/config.h>
+#include <nuttx/cache.h>
 #include <nuttx/fs/hostfs.h>
 
 #include <arch/simcall.h>
@@ -96,6 +97,9 @@ int host_open(const char *pathname, int flags, int mode)
       simcall_flags |= SIMCALL_O_EXCL;
     }
 
+#ifdef CONFIG_XTENSA_HOSTFS_CACHE_COHERENCE
+  up_clean_dcache(pathname, pathname + strlen(pathname) + 1);
+#endif
   return host_call(SIMCALL_SYS_OPEN, (int)pathname, simcall_flags, mode);
 }
 
@@ -106,11 +110,19 @@ int host_close(int fd)
 
 ssize_t host_read(int fd, void *buf, size_t count)
 {
+#ifdef CONFIG_XTENSA_HOSTFS_CACHE_COHERENCE
+  up_invalidate_dcache(buf, buf + count);
+#endif
+
   return host_call(SIMCALL_SYS_READ, fd, (int)buf, count);
 }
 
 ssize_t host_write(int fd, const void *buf, size_t count)
 {
+#ifdef CONFIG_XTENSA_HOSTFS_CACHE_COHERENCE
+  up_clean_dcache(buf, buf + count);
+#endif
+
   return host_call(SIMCALL_SYS_WRITE, fd, (int)buf, count);
 }
 


### PR DESCRIPTION
## Summary
Patch 1:arch:hostfs: add cache coherence config for semihosting option
Patch 2:arch:cache_invalidate: fix unalign cacheline invalidate 
## Impact
## Testing

