### PR TITLE
feature: charge: add add chipid ioctl api

### DIFF
--- a/drivers/power/battery_charger.c
+++ b/drivers/power/battery_charger.c
@@ -360,6 +360,16 @@ static int bat_charger_ioctl(FAR struct file *filep, int cmd,
         }
         break;
 
+      case BATIOC_CHIPID:
+        {
+          FAR unsigned int *ptr = (FAR unsigned int *)((uintptr_t)arg);
+          if (ptr)
+            {
+              ret = dev->ops->chipid(dev, ptr);
+            }
+        }
+        break;
+
       default:
         _err("ERROR: Unrecognized cmd: %d\n", cmd);
         ret = -ENOTTY;

--- a/drivers/power/battery_gauge.c
+++ b/drivers/power/battery_gauge.c
@@ -348,6 +348,16 @@ static int bat_gauge_ioctl(FAR struct file *filep,
         }
         break;
 
+      case BATIOC_CHIPID:
+        {
+          FAR unsigned int *ptr = (FAR unsigned int *)((uintptr_t)arg);
+          if (ptr)
+            {
+              ret = dev->ops->chipid(dev, ptr);
+            }
+        }
+        break;
+
       default:
         _err("ERROR: Unrecognized cmd: %d\n", cmd);
         ret = -ENOTTY;

--- a/drivers/power/battery_monitor.c
+++ b/drivers/power/battery_monitor.c
@@ -427,6 +427,16 @@ static int bat_monitor_ioctl(FAR struct file *filep, int cmd,
         }
         break;
 
+      case BATIOC_CHIPID:
+        {
+          FAR unsigned int *ptr = (FAR unsigned int *)((uintptr_t)arg);
+          if (ptr)
+            {
+              ret = dev->ops->chipid(dev, ptr);
+            }
+        }
+        break;
+
       default:
         _err("ERROR: Unrecognized cmd: %d\n", cmd);
         ret = -ENOTTY;

--- a/include/nuttx/power/battery_charger.h
+++ b/include/nuttx/power/battery_charger.h
@@ -78,6 +78,8 @@
  * BATIOC_OPERATE - Perform miscellaneous, device-specific charger operation.
  *   Input value:  An uintptr_t that can hold a pointer to struct
  *                 batio_operate_msg_s.
+ * BATIOC_CHIPID -Get the charger chip id.
+ *   Input value:  A pointer to type unsigned int.
  */
 
 /****************************************************************************
@@ -116,6 +118,10 @@ struct battery_charger_operations_s
   /* Do device specific operation */
 
   int (*operate)(struct battery_charger_dev_s *dev, uintptr_t param);
+
+  /* Get chip id */
+
+  int (*chipid)(struct battery_charger_dev_s *dev, unsigned int *value);
 };
 
 /* This structure defines the battery driver state structure */

--- a/include/nuttx/power/battery_gauge.h
+++ b/include/nuttx/power/battery_gauge.h
@@ -73,6 +73,13 @@
  *   (SoC).  The returned value is a fixed precision percentage of the
  *   batteries full capacity.
  *   Input value:  A pointer to type b16_t.
+ * BATIOC_CURRENT - Return the current of the battery . The returned value
+ *   is a fixed precision number in units of ma.
+ *   Input value:  A pointer to type b16_t.
+ * BATIOC_TEMPERATURE- Return the current temperature of the battery.
+ *   Input value:  A pointer to type b8_t.
+ * BATIOC_CHIPID- Return the chip id of the gauge.
+ *   Input value:  A pointer to type unsigned int.
  */
 
 /****************************************************************************
@@ -107,6 +114,10 @@ struct battery_gauge_operations_s
   /* Battery temp */
 
   int (*temp)(struct battery_gauge_dev_s *dev, b8_t *value);
+
+  /* Battery chipid */
+
+  int (*chipid)(struct battery_gauge_dev_s *dev, unsigned int *value);
 };
 
 /* This structure defines the battery driver state structure */

--- a/include/nuttx/power/battery_ioctl.h
+++ b/include/nuttx/power/battery_ioctl.h
@@ -54,6 +54,7 @@
 #define BATIOC_CHGDSG        _BATIOC(0x000E)
 #define BATIOC_CLEARFAULTS   _BATIOC(0x000F)
 #define BATIOC_COULOMBS      _BATIOC(0x0010)
+#define BATIOC_CHIPID        _BATIOC(0x0011)
 
 /* Special input values for BATIOC_INPUT_CURRENT that may optionally
  * be supported by lower-half driver:

--- a/include/nuttx/power/battery_monitor.h
+++ b/include/nuttx/power/battery_monitor.h
@@ -100,6 +100,8 @@
  * BATIOC_OPERATE - Perform miscellaneous, device-specific charger operation.
  *   Input value:  An uintptr_t that can hold a pointer to struct
  *   batio_operate_msg_s.
+ * BATIOC_CHIPID -Get the chip id.
+ *   Input value:  A pointer to type unsigned int.
  */
 
 /****************************************************************************
@@ -286,6 +288,10 @@ struct battery_monitor_operations_s
   /* Do device specific operation */
 
   int (*operate)(struct battery_monitor_dev_s *dev, uintptr_t param);
+
+  /* Get chip id */
+
+  int (*chipid)(struct battery_charger_dev_s *dev, unsigned int *value);
 };
 
 /* This structure defines the battery driver state structure */


### PR DESCRIPTION
CHAMPION-137

1.add chipid ioctl api to battery monitor code
2.add chipid itctl api to battery charger code
3.add chipid itctl api to battery gauge code

Signed-off-by: weizhifang <weizhifang@xiaomi.com>
Change-Id: Iafb393f370e20a8b58fc5f0b320e5c4674f0e9ab

## Summary

## Impact

## Testing

