### PR TITLE
[SECURITY]net/udp/icmp: correct the unreadchable handling

### DIFF
--- a/include/nuttx/net/icmp.h
+++ b/include/nuttx/net/icmp.h
@@ -94,6 +94,26 @@
 #define ICMP_HDRLEN    8                           /* Size of ICMP header */
 #define IPICMP_HDRLEN  (ICMP_HDRLEN + IPv4_HDRLEN) /* Size of IPv4 + ICMP header */
 
+/* Codes for UNREACH. */
+
+#define ICMP_NET_UNREACH             0    /* Network Unreachable    */
+#define ICMP_HOST_UNREACH            1    /* Host Unreachable   */
+#define ICMP_PROT_UNREACH            2    /* Protocol Unreachable   */
+#define ICMP_PORT_UNREACH            3    /* Port Unreachable   */
+#define ICMP_FRAG_NEEDED             4    /* Fragmentation Needed/DF set  */
+#define ICMP_SR_FAILED               5    /* Source Route failed    */
+#define ICMP_NET_UNKNOWN             6
+#define ICMP_HOST_UNKNOWN            7
+#define ICMP_HOST_ISOLATED           8
+#define ICMP_NET_ANO                 9
+#define ICMP_HOST_ANO                10
+#define ICMP_NET_UNR_TOS             11
+#define ICMP_HOST_UNR_TOS            12
+#define ICMP_PKT_FILTERED            13   /* Packet filtered */
+#define ICMP_PREC_VIOLATION          14   /* Precedence violation */
+#define ICMP_PREC_CUTOFF             15   /* Precedence cut off */
+#define NR_ICMP_UNREACH              15   /* instead of hardcoding immediate value */
+
 /****************************************************************************
  * Public Type Definitions
  ****************************************************************************/
@@ -113,8 +133,16 @@ struct icmp_hdr_s
 
   /* ICMP_ECHO_REQUEST and ICMP_ECHO_REPLY data */
 
-  uint16_t id;               /* Used to match requests with replies */
-  uint16_t seqno;            /* "  " "" "   " "      " "  " "     " */
+  union
+    {
+      struct
+        {
+          uint16_t id;      /* Used to match requests with replies */
+          uint16_t seqno;   /* "  " "" "   " "      " "  " "     " */
+        };
+
+      uint32_t data;
+    };
 };
 
 /* The structure holding the ICMP statistics that are gathered if

--- a/include/nuttx/net/icmpv6.h
+++ b/include/nuttx/net/icmpv6.h
@@ -131,6 +131,16 @@
 #define ICMPv6_OPT_SIZE(a)    ((a) > 0 ? ((a) + 2 + 7) & ~7 : 0)
 #define ICMPv6_OPT_OCTECTS(a) ((a) > 0 ? ((a) + 2 + 7) >> 3 : 0)
 
+/* Codes for Destination Unreachable */
+
+#define ICMPv6_NOROUTE        0
+#define ICMPv6_ADM_PROHIBITED 1
+#define ICMPv6_NOT_NEIGHBOUR  2
+#define ICMPv6_ADDR_UNREACH   3
+#define ICMPv6_PORT_UNREACH   4
+#define ICMPv6_POLICY_FAIL    5
+#define ICMPv6_REJECT_ROUTE   6
+
 /****************************************************************************
  * Public Type Definitions
  ****************************************************************************/
@@ -146,6 +156,8 @@ struct icmpv6_hdr_s
   /* Data following the ICMP header contains the data specific to the
    * message type indicated by the Type and Code fields.
    */
+
+  uint32_t data;
 };
 
 /* The ICMPv6 and IPv6 headers */

--- a/net/icmp/Make.defs
+++ b/net/icmp/Make.defs
@@ -23,7 +23,7 @@ ifneq ($(CONFIG_NET_ICMP_NO_STACK),y)
 
 # ICMP source files
 
-NET_CSRCS += icmp_input.c
+NET_CSRCS += icmp_input.c icmp_reply.c
 
 ifeq ($(CONFIG_NET_ICMP_SOCKET),y)
 SOCK_CSRCS += icmp_sockif.c icmp_poll.c icmp_conn.c icmp_sendmsg.c

--- a/net/icmp/icmp.h
+++ b/net/icmp/icmp.h
@@ -362,6 +362,30 @@ int icmp_pollsetup(FAR struct socket *psock, FAR struct pollfd *fds);
 int icmp_pollteardown(FAR struct socket *psock, FAR struct pollfd *fds);
 #endif
 
+/****************************************************************************
+ * Name: icmp_reply
+ *
+ * Description:
+ *   Send an ICMP message in response to a situation
+ *   RFC 1122: 3.2.2 MUST send at least the IP header and 8 bytes of header.
+ *       MAY send more (we do).
+ *       MUST NOT change this header information.
+ *       MUST NOT reply to a multicast/broadcast IP address.
+ *       MUST NOT reply to a multicast/broadcast MAC address.
+ *       MUST reply to only the first fragment.
+ *
+ * Input Parameters:
+ *   dev   - The device driver structure containing the received packet
+ *   type  - ICMP Message Type, eg. ICMP_DEST_UNREACHABLE
+ *   code  - ICMP Message Code, eg. ICMP_PORT_UNREACH
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+void icmp_reply(FAR struct net_driver_s *dev, int type, int code);
+
 #undef EXTERN
 #ifdef __cplusplus
 }

--- a/net/icmp/icmp_reply.c
+++ b/net/icmp/icmp_reply.c
@@ -1,0 +1,171 @@
+/****************************************************************************
+ * net/icmp/icmp_reply.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <stdint.h>
+#include <string.h>
+#include <debug.h>
+
+#include <netinet/in.h>
+#include <net/if.h>
+#include <arpa/inet.h>
+
+#include <nuttx/net/net.h>
+#include <nuttx/net/netdev.h>
+#include <nuttx/net/ip.h>
+#include <nuttx/net/icmp.h>
+
+#include "utils/utils.h"
+#include "netdev/netdev.h"
+#include "devif/devif.h"
+#include "inet/inet.h"
+#include "icmp/icmp.h"
+
+#ifdef CONFIG_NET_ICMP
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define IPv4BUF ((struct ipv4_hdr_s *)&dev->d_buf[NET_LL_HDRLEN(dev)])
+
+/* RFC 1812:
+ * 4.3.2.3, Original Message Header
+ * ...
+ * The ICMP datagram SHOULD contain as much of the original datagram as
+ * possible without the length of the ICMP datagram exceeding 576 bytes.
+ * ...
+ */
+
+#define ICMP_MAXMSGLEN  576
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: icmp_reply
+ *
+ * Description:
+ *   Send an ICMP message in response to a situation
+ *   RFC 1122: 3.2.2 MUST send at least the IP header and 8 bytes of header.
+ *       MAY send more (we do).
+ *       MUST NOT change this header information.
+ *       MUST NOT reply to a multicast/broadcast IP address.
+ *       MUST NOT reply to a multicast/broadcast MAC address.
+ *       MUST reply to only the first fragment.
+ *
+ * Input Parameters:
+ *   dev   - The device driver structure containing the received packet
+ *   type  - ICMP Message Type, eg. ICMP_DEST_UNREACHABLE
+ *   code  - ICMP Message Code, eg. ICMP_PORT_UNREACH
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+void icmp_reply(FAR struct net_driver_s *dev, int type, int code)
+{
+  int ipicmplen = IPv4_HDRLEN + sizeof(struct icmp_hdr_s);
+  FAR struct ipv4_hdr_s *ipv4 = IPv4BUF;
+  FAR struct icmp_hdr_s *icmp = (FAR void *)(ipv4 + 1);
+  uint16_t datalen;
+#ifdef CONFIG_NET_BROADCAST
+  const in_addr_t bcast = INADDR_BROADCAST;
+#endif /* CONFIG_NET_BROADCAST */
+  const in_addr_t any = INADDR_ANY;
+
+  if (net_ipv4addr_hdrcmp(ipv4->destipaddr, &any)
+#  ifdef CONFIG_NET_BROADCAST
+      || net_ipv4addr_hdrcmp(ipv4->destipaddr, &bcast)
+#  endif /* CONFIG_NET_BROADCAST */
+     )
+    {
+      dev->d_len = 0;
+      return;
+    }
+
+  /* Get the data size of the packet. */
+
+  datalen = (ipv4->len[0] << 8) + ipv4->len[1];
+
+  /* RFC says return as much as we can without exceeding 576 bytes. */
+
+  if (datalen > ICMP_MAXMSGLEN - ipicmplen)
+    {
+      datalen = ICMP_MAXMSGLEN - ipicmplen;
+    }
+
+  dev->d_len = ipicmplen + datalen;
+
+  /* Copy fields from original packet */
+
+  memmove(icmp + 1, ipv4, datalen);
+
+  /* Initialize the IP header. */
+
+  ipv4->vhl         = 0x45;
+  ipv4->tos         = 0;
+  ipv4->len[0]      = (dev->d_len >> 8);
+  ipv4->len[1]      = (dev->d_len & 0xff);
+  ++g_ipid;
+  ipv4->ipid[0]     = g_ipid >> 8;
+  ipv4->ipid[1]     = g_ipid & 0xff;
+  ipv4->ipoffset[0] = IP_FLAG_DONTFRAG >> 8;
+  ipv4->ipoffset[1] = IP_FLAG_DONTFRAG & 0xff;
+  ipv4->ttl         = IP_TTL_DEFAULT;
+  ipv4->proto       = IP_PROTO_ICMP;
+
+  /* Calculate IP checksum. */
+
+  ipv4->ipchksum    = 0;
+  ipv4->ipchksum    = ~ipv4_chksum(dev);
+
+  net_ipv4addr_hdrcopy(ipv4->destipaddr, ipv4->srcipaddr);
+  net_ipv4addr_hdrcopy(ipv4->srcipaddr, &dev->d_ipaddr);
+
+  /* Initialize the ICMP header */
+
+  icmp->type        = type;
+  icmp->icode       = code;
+  icmp->data        = 0;
+
+  /* Calculate the ICMP checksum. */
+
+  icmp->icmpchksum  = 0;
+  icmp->icmpchksum  = ~icmp_chksum(dev, datalen + sizeof(*icmp));
+  if (icmp->icmpchksum == 0)
+    {
+      icmp->icmpchksum = 0xffff;
+    }
+
+  ninfo("Outgoing ICMP packet length: %d (%d)\n",
+         dev->d_len, (ipv4->len[0] << 8) | ipv4->len[1]);
+}
+
+#endif /* CONFIG_NET_ICMP */

--- a/net/icmpv6/Make.defs
+++ b/net/icmpv6/Make.defs
@@ -24,7 +24,7 @@ ifneq ($(CONFIG_NET_ICMPv6_NO_STACK),y)
 # ICMPv6 source files
 
 NET_CSRCS += icmpv6_input.c icmpv6_solicit.c icmpv6_advertise.c
-NET_CSRCS += icmpv6_linkipaddr.c
+NET_CSRCS += icmpv6_linkipaddr.c icmpv6_reply.c
 
 ifeq ($(CONFIG_NET_ICMPv6_SOCKET),y)
 SOCK_CSRCS += icmpv6_sockif.c icmpv6_conn.c icmpv6_sendmsg.c

--- a/net/icmpv6/icmpv6.h
+++ b/net/icmpv6/icmpv6.h
@@ -726,6 +726,32 @@ int icmpv6_pollteardown(FAR struct socket *psock, FAR struct pollfd *fds);
 
 void icmpv6_linkipaddr(FAR struct net_driver_s *dev, net_ipv6addr_t ipaddr);
 
+/****************************************************************************
+ * Name: icmpv6_reply
+ *
+ * Description:
+ *   Send an ICMPv6 message in response to a situation
+ *   RFC 1122: 3.2.2 MUST send at least the IP header and 8 bytes of header.
+ *       MAY send more (we do).
+ *       MUST NOT change this header information.
+ *       MUST NOT reply to a multicast/broadcast IP address.
+ *       MUST NOT reply to a multicast/broadcast MAC address.
+ *       MUST reply to only the first fragment.
+ *
+ * Input Parameters:
+ *   dev   - The device driver structure containing the received packet
+ *   type  - ICMPv6 Message Type, eg. ICMPv6_DEST_UNREACHABLE
+ *   code  - ICMPv6 Message Code, eg. ICMPv6_PORT_UNREACH
+ *   data  - Additional 32-bit parameter in the ICMPv6 header
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+void icmpv6_reply(FAR struct net_driver_s *dev,
+                  int type, int code, int data);
+
 #undef EXTERN
 #ifdef __cplusplus
 }

--- a/net/icmpv6/icmpv6_reply.c
+++ b/net/icmpv6/icmpv6_reply.c
@@ -1,0 +1,153 @@
+/****************************************************************************
+ * net/icmpv6/icmpv6_reply.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <stdint.h>
+#include <string.h>
+#include <debug.h>
+
+#include <netinet/in.h>
+#include <net/if.h>
+#include <arpa/inet.h>
+
+#include <nuttx/net/net.h>
+#include <nuttx/net/netdev.h>
+#include <nuttx/net/ip.h>
+#include <nuttx/net/icmpv6.h>
+
+#include "utils/utils.h"
+#include "netdev/netdev.h"
+#include "devif/devif.h"
+#include "inet/inet.h"
+#include "icmpv6/icmpv6.h"
+
+#ifdef CONFIG_NET_ICMPv6
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define IPv6BUF ((struct ipv6_hdr_s *)&dev->d_buf[NET_LL_HDRLEN(dev)])
+
+/* The latest drafts declared increase in minimal mtu up to 1280. */
+
+#define ICMPv6_MINMTULEN  1280
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: icmp_reply
+ *
+ * Description:
+ *   Send an ICMPv6 message in response to a situation
+ *   RFC 1122: 3.2.2 MUST send at least the IP header and 8 bytes of header.
+ *       MAY send more (we do).
+ *       MUST NOT change this header information.
+ *       MUST NOT reply to a multicast/broadcast IP address.
+ *       MUST NOT reply to a multicast/broadcast MAC address.
+ *       MUST reply to only the first fragment.
+ *
+ * Input Parameters:
+ *   dev   - The device driver structure containing the received packet
+ *   type  - ICMPv6 Message Type, eg. ICMPv6_DEST_UNREACHABLE
+ *   code  - ICMPv6 Message Code, eg. ICMPv6_PORT_UNREACH
+ *   data  - Additional 32-bit parameter in the ICMPv6 header
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+void icmpv6_reply(FAR struct net_driver_s *dev, int type, int code, int data)
+{
+  int ipicmplen = IPv6_HDRLEN + sizeof(struct icmpv6_hdr_s);
+  FAR struct ipv6_hdr_s *ipv6 = IPv6BUF;
+  FAR struct icmpv6_hdr_s *icmpv6 = (FAR void *)(ipv6 + 1);
+  uint16_t datalen;
+
+  if (net_ipv6addr_cmp(ipv6->destipaddr, g_ipv6_unspecaddr)
+#  ifdef CONFIG_NET_BROADCAST
+      || net_is_addr_mcast(ipv6->destipaddr)
+#  endif /* CONFIG_NET_BROADCAST */
+     )
+    {
+      dev->d_len = 0;
+      return;
+    }
+
+  /* Get the data size of the packet. */
+
+  datalen = (ipv6->len[0] << 8) + ipv6->len[1];
+
+  /* RFC says return as much as we can without exceeding 1280 bytes. */
+
+  if (datalen > ICMPv6_MINMTULEN - ipicmplen)
+    {
+      datalen = ICMPv6_MINMTULEN - ipicmplen;
+    }
+
+  dev->d_len = ipicmplen + datalen;
+
+  /* Copy fields from original packet */
+
+  memmove(icmpv6 + 1, ipv6, datalen);
+
+  /* Set up the IPv6 header (most is probably already in place) */
+
+  ipv6->vtc      = 0x60;               /* Version/traffic class (MS) */
+  ipv6->tcf      = 0;                  /* Traffic class(LS)/Flow label(MS) */
+  ipv6->flow     = 0;                  /* Flow label (LS) */
+  ipv6->len[0]   = (dev->d_len >> 8);  /* Length excludes the IPv6 header */
+  ipv6->len[1]   = (dev->d_len & 0xff);
+  ipv6->proto    = IP_PROTO_ICMP6;     /* Next header */
+  ipv6->ttl      = 255;                /* Hop limit */
+
+  net_ipv6addr_hdrcopy(ipv6->destipaddr, ipv6->srcipaddr);
+  net_ipv6addr_hdrcopy(ipv6->srcipaddr, dev->d_ipv6addr);
+
+  /* Initialize the ICMPv6 header */
+
+  icmpv6->type   = type;
+  icmpv6->code   = code;
+  icmpv6->data   = htonl(data);
+
+  /* Calculate the ICMPv6 checksum over the ICMPv6 header and payload. */
+
+  icmpv6->chksum = 0;
+  icmpv6->chksum = ~icmpv6_chksum(dev, datalen + sizeof(*icmpv6));
+  if (icmpv6->chksum == 0)
+    {
+      icmpv6->chksum = 0xffff;
+    }
+
+  ninfo("Outgoing ICMPv6 packet length: %d (%d)\n",
+         dev->d_len, (ipv6->len[0] << 8) | ipv6->len[1]);
+}
+
+#endif /* CONFIG_NET_ICMPv6 */

--- a/net/utils/net_icmpchksum.c
+++ b/net/utils/net_icmpchksum.c
@@ -49,7 +49,7 @@
  *
  ****************************************************************************/
 
-#if defined(CONFIG_NET_ICMP) && defined(CONFIG_NET_ICMP_SOCKET)
+#ifdef CONFIG_NET_ICMP
 uint16_t icmp_chksum(FAR struct net_driver_s *dev, int len)
 {
   FAR struct ipv4_hdr_s *ipv4 = IPv4BUF;
@@ -65,7 +65,7 @@ uint16_t icmp_chksum(FAR struct net_driver_s *dev, int len)
   icmp = ICMPBUF(iphdrlen);
   return net_chksum((FAR uint16_t *)&icmp->type, len);
 }
-#endif /* CONFIG_NET_ICMP && CONFIG_NET_ICMP_SOCKET */
+#endif /* CONFIG_NET_ICMP */
 
 /****************************************************************************
  * Name: icmpv6_chksum

--- a/net/utils/utils.h
+++ b/net/utils/utils.h
@@ -361,7 +361,7 @@ uint16_t udp_ipv6_chksum(FAR struct net_driver_s *dev);
  *
  ****************************************************************************/
 
-#if defined(CONFIG_NET_ICMP) && defined(CONFIG_NET_ICMP_SOCKET)
+#ifdef CONFIG_NET_ICMP
 uint16_t icmp_chksum(FAR struct net_driver_s *dev, int len);
 #endif
 


### PR DESCRIPTION
## Summary

net/udp/icmp: correct the unreadchable handling

Reference RFC1122:
https://datatracker.ietf.org/doc/html/rfc1122

https://github.com/lwip-tcpip/lwip/blob/master/src/core/udp.c#L413-L421
https://github.com/torvalds/linux/blob/master/net/ipv4/udp.c#L2469

----------------------------------------------

RFC1122:

4.1.3  SPECIFIC ISSUES

  4.1.3.1  Ports

    If a datagram arrives addressed to a UDP port for which
    there is no pending LISTEN call, UDP SHOULD send an ICMP
    Port Unreachable message.

## Impact

UDP Destination Unreachable handling

## Testing

nmap security scan

before the patch:
```
$ sudo nmap -sU -p 54310-54323 -Pn 192.168.31.240
Starting Nmap 7.80 ( https://nmap.org ) at 2021-11-25 22:09 CST
Warning: File ./nmap-services exists, but Nmap is using /usr/bin/../share/nmap/nmap-services for security and consistency reasons.  set NMAPDIR=. to give priority to files in your local directory (may affect the other data files too).
Nmap scan report for 192.168.31.240
Host is up (0.00062s latency).

PORT      STATE         SERVICE
54310/udp open|filtered unknown
54311/udp open|filtered unknown
54312/udp open|filtered unknown
54313/udp open|filtered unknown
54314/udp open|filtered unknown
54315/udp open|filtered unknown
54316/udp open|filtered unknown
54317/udp open|filtered unknown
54318/udp open|filtered unknown
54319/udp open|filtered unknown
54320/udp open|filtered unknown
54321/udp open|filtered bo2k
54322/udp open|filtered unknown
54323/udp open|filtered unknown
MAC Address: 42:43:44:45:46:47 (Unknown)

Nmap done: 1 IP address (1 host up) scanned in 1.64 seconds
```


after the patch:
```
$ sudo nmap -sU -p 54310-54323 -Pn 192.168.31.240
Starting Nmap 7.80 ( https://nmap.org ) at 2021-11-25 22:07 CST
Warning: File ./nmap-services exists, but Nmap is using /usr/bin/../share/nmap/nmap-services for security and consistency reasons.  set NMAPDIR=. to give priority to files in your local directory (may affect the other data files too).
Nmap scan report for 192.168.31.240
Host is up (0.0038s latency).

PORT      STATE  SERVICE
54310/udp closed unknown
54311/udp closed unknown
54312/udp closed unknown
54313/udp closed unknown
54314/udp closed unknown
54315/udp closed unknown
54316/udp closed unknown
54317/udp closed unknown
54318/udp closed unknown
54319/udp closed unknown
54320/udp closed unknown
54321/udp closed bo2k
54322/udp closed unknown
54323/udp closed unknown
MAC Address: 42:43:44:45:46:47 (Unknown)

Nmap done: 1 IP address (1 host up) scanned in 0.23 seconds
```
