### PR TITLE
ramtron:Remove errant code and definitions

### DIFF
--- a/drivers/mtd/Kconfig
+++ b/drivers/mtd/Kconfig
@@ -878,22 +878,6 @@ config MTD_RAMTRON
 
 if MTD_RAMTRON
 
-config RAMTRON_WRITEWAIT
-	bool "Wait after write"
-	default n
-	---help---
-		Wait after performing a RAMTRON write operation to assure that the
-		write completed error-free.  The default behavior is to wait for the
-		previous write to complete BEFORE starting the next write.  This
-		option, if selected, forces the driver to wait for the write to
-		complete AFTER each write.  This is a tradoeff:  Selecting this
-		option will significantly reduce RAMTRON performance but has the
-		advantage that it will correctly associate a write failure with a
-		specific write operation.
-
-		One RAMTRON read operations, this option also enables some additional
-		status checking to check for device failures during the read.
-
 config RAMTRON_SETSPEED
 	bool "Adjustable bus speed"
 	default n


### PR DESCRIPTION
## Summary

  After reviewing the data sheet for MB85RS256B, CY15B104Q, and
  FM25V0x the status register definitions in the driver were
  wrong as was the use.

## Impact

Enabling of RAMTRON_WRITEWAIT on master after 5588bc4ef633cdff8e813058eacff77a48ceb11d would fail in read.
Before that it was a crap shoot. Depending on memory contents. As the missing CS toggle allowed the read to just continue.

## Testing

px4 [test rack F4, F7, H7, K66](http://px4-jenkins.dagar.ca:8080/blue/organizations/jenkins/PX4-Autopilot/detail/pr-ramtron/1/pipeline)

