### PR TITLE
libc/misc:add err.c to libc 

### DIFF
--- a/arch/or1k/include/mor1kx/irq.h
+++ b/arch/or1k/include/mor1kx/irq.h
@@ -48,7 +48,6 @@
 #include <nuttx/irq.h>
 #ifndef __ASSEMBLY__
 #  include <stdint.h>
-#  include <debug.h>
 #endif
 
 #include <arch/spr.h>

--- a/arch/x86_64/include/intel64/irq.h
+++ b/arch/x86_64/include/intel64/irq.h
@@ -34,7 +34,6 @@
 #  include <stdbool.h>
 #  include <arch/arch.h>
 #  include <time.h>
-#  include <debug.h>
 #  include <nuttx/config.h>
 #endif
 

--- a/arch/x86_64/src/intel64/intel64_handlers.c
+++ b/arch/x86_64/src/intel64/intel64_handlers.c
@@ -30,6 +30,7 @@
 #include <nuttx/signal.h>
 #include <arch/io.h>
 #include <assert.h>
+#include <debug.h>
 #include <inttypes.h>
 #include <syscall.h>
 #include <arch/board/board.h>

--- a/arch/x86_64/src/intel64/intel64_tickless.c
+++ b/arch/x86_64/src/intel64/intel64_tickless.c
@@ -47,6 +47,7 @@
 
 #include <nuttx/config.h>
 
+#include <debug.h>
 #include <stdint.h>
 #include <stdbool.h>
 #include <time.h>

--- a/include/err.h
+++ b/include/err.h
@@ -1,0 +1,57 @@
+/****************************************************************************
+ * include/err.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __INCLUDE_ERR_H
+#define __INCLUDE_ERR_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <stdarg.h>
+#include <nuttx/compiler.h>
+
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
+
+#ifdef CONFIG_LIBC_ERR
+
+/* Print "pid: ", FORMAT, ": ", the standard error string for errno,
+ * and a newline, on stderr.
+ */
+
+void warn(FAR const char *fmt, ...);
+void vwarn(FAR const char *fmt, va_list ap);
+
+/* Likewise, but without ": " and the standard error string.  */
+
+void warnx(FAR const char *fmt, ...);
+void vwarnx(FAR const char *fmt, va_list ap);
+
+/* Likewise, and then exit with STATUS.  */
+
+void err(int status, FAR const char *fmt, ...);
+void verr(int status, FAR const char *fmt, va_list ap);
+void errx(int status, FAR const char *fmt, ...);
+void verrx(int status, FAR const char *, va_list ap);
+
+#endif /* CONFIG_LIBC_ERR */
+#endif /* __INCLUDE_ERR_H */

--- a/libs/libc/misc/Kconfig
+++ b/libs/libc/misc/Kconfig
@@ -61,3 +61,9 @@ config LIBC_ENVPATH
 	---help---
 		Use the contents of the common environment variable to locate executable
 		or library files.  Default: n
+
+config LIBC_ERR
+	bool "Support err() verr() verrx() warn() vwarn() vwarnx()"
+	default y
+	---help---
+		Support err() verr() verrx() warn() vwarn() vwarnx().  Default: y

--- a/libs/libc/misc/Make.defs
+++ b/libs/libc/misc/Make.defs
@@ -56,6 +56,10 @@ ifeq ($(CONFIG_LIBC_ENVPATH),y)
 CSRCS += lib_envpath.c
 endif
 
+ifeq ($(CONFIG_LIBC_ERR),y)
+CSRCS += lib_err.c
+endif
+
 # To ensure uname information is newest,
 # add lib_utsname.o to phony target for force rebuild
 

--- a/libs/libc/misc/lib_err.c
+++ b/libs/libc/misc/lib_err.c
@@ -1,0 +1,156 @@
+/****************************************************************************
+ * libs/libc/misc/lib_err.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <err.h>
+#include <errno.h>
+#include <stdlib.h>
+#include <stdio.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define VA(call)           \
+do                         \
+{                          \
+    va_list ap;            \
+    va_start(ap, fmt);     \
+    call;                  \
+    va_end(ap);            \
+} while(0)
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: vwarn
+ ****************************************************************************/
+
+void vwarn(FAR const char *fmt, va_list ap)
+{
+  int error = errno;
+  struct va_format vaf;
+
+#ifdef va_copy
+  va_list copy;
+
+  va_copy(copy, ap);
+
+  vaf.fmt = fmt;
+  vaf.va  = &copy;
+#else
+  vaf.fmt = fmt;
+  vaf.va  = &ap;
+#endif
+
+#ifdef CONFIG_FILE_STREAM
+  fprintf(stderr, "%d: %pV: %s\n", getpid(), &vaf, strerror(error));
+#else
+  dprintf(STDERR_FILENO, "%d: %pV: %s\n", getpid(), &vaf, strerror(error));
+#endif
+}
+
+/****************************************************************************
+ * Name: vwarnx
+ ****************************************************************************/
+
+void vwarnx(FAR const char *fmt, va_list ap)
+{
+  struct va_format vaf;
+
+#ifdef va_copy
+  va_list copy;
+
+  va_copy(copy, ap);
+
+  vaf.fmt = fmt;
+  vaf.va  = &copy;
+#else
+  vaf.fmt = fmt;
+  vaf.va  = &ap;
+#endif
+
+#ifdef CONFIG_FILE_STREAM
+  fprintf(stderr, "%d: %pV\n", getpid(), &vaf);
+#else
+  dprintf(STDERR_FILENO, "%d: %pV\n", getpid(), &vaf);
+#endif
+}
+
+/****************************************************************************
+ * Name: warn
+ ****************************************************************************/
+
+void warn(FAR const char *fmt, ...)
+{
+  VA(vwarn(fmt, ap));
+}
+
+/****************************************************************************
+ * Name: warnx
+ ****************************************************************************/
+
+void warnx(FAR const char *fmt, ...)
+{
+  VA(vwarnx(fmt, ap));
+}
+
+/****************************************************************************
+ * Name: verr
+ ****************************************************************************/
+
+void verr(int status, FAR const char *fmt, va_list ap)
+{
+  vwarn(fmt, ap);
+  exit(status);
+}
+
+/****************************************************************************
+ * Name: verrx
+ ****************************************************************************/
+
+void verrx(int status, FAR const char *fmt, va_list ap)
+{
+  vwarnx(fmt, ap);
+  exit(status);
+}
+
+/****************************************************************************
+ * Name: err
+ ****************************************************************************/
+
+void err(int status, FAR const char *fmt, ...)
+{
+  VA(verr(status, fmt, ap));
+}
+
+/****************************************************************************
+ * Name: errx
+ ****************************************************************************/
+
+void errx(int status, FAR const char *fmt, ...)
+{
+  VA(verrx(status, fmt, ap));
+}


### PR DESCRIPTION
Signed-off-by: anjiahao <anjiahao@xiaomi.com>

## Summary
add err.c & err.h to libc
## Impact
move <debug.h> form headfile to c file,because <debug.h> define vwarn and verr. confict <err.h>
## Testing
daliy test
