### PR TITLE
net/arp: clean the arp table when netdev carrier off

### DIFF
--- a/include/nuttx/net/arp.h
+++ b/include/nuttx/net/arp.h
@@ -82,9 +82,10 @@
 
 struct arp_entry_s
 {
-  in_addr_t         at_ipaddr;   /* IP address */
-  struct ether_addr at_ethaddr;  /* Hardware address */
-  clock_t           at_time;     /* Time of last usage */
+  in_addr_t                at_ipaddr;   /* IP address */
+  struct ether_addr        at_ethaddr;  /* Hardware address */
+  clock_t                  at_time;     /* Time of last usage */
+  FAR struct net_driver_s *at_dev;      /* The device driver structure */
 };
 
 /****************************************************************************

--- a/net/arp/arp.h
+++ b/net/arp/arp.h
@@ -359,6 +359,22 @@ int arp_find(in_addr_t ipaddr, FAR struct ether_addr *ethaddr);
 void arp_delete(in_addr_t ipaddr);
 
 /****************************************************************************
+ * Name: arp_cleanup
+ *
+ * Description:
+ *   Clear the ARP table on the network device
+ *
+ * Input Parameters:
+ *   dev  - The device driver structure
+ *
+ * Assumptions
+ *   The network is locked to assure exclusive access to the ARP table.
+ *
+ ****************************************************************************/
+
+void arp_cleanup(FAR struct net_driver_s *dev);
+
+/****************************************************************************
  * Name: arp_update
  *
  * Description:
@@ -366,6 +382,7 @@ void arp_delete(in_addr_t ipaddr);
  *   address of an existing association.
  *
  * Input Parameters:
+ *   dev     - The device driver structure
  *   ipaddr  - The IP address as an inaddr_t
  *   ethaddr - Refers to a HW address uint8_t[IFHWADDRLEN]
  *
@@ -378,7 +395,8 @@ void arp_delete(in_addr_t ipaddr);
  *
  ****************************************************************************/
 
-int arp_update(in_addr_t ipaddr, FAR uint8_t *ethaddr);
+int arp_update(FAR struct net_driver_s *dev, in_addr_t ipaddr,
+               FAR uint8_t *ethaddr);
 
 /****************************************************************************
  * Name: arp_hdr_update
@@ -388,6 +406,7 @@ int arp_update(in_addr_t ipaddr, FAR uint8_t *ethaddr);
  *   address of an existing association.
  *
  * Input Parameters:
+ *   dev     - The device driver structure
  *   pipaddr - Refers to an IP address uint16_t[2] in network order
  *   ethaddr - Refers to a HW address uint8_t[IFHWADDRLEN]
  *
@@ -400,7 +419,8 @@ int arp_update(in_addr_t ipaddr, FAR uint8_t *ethaddr);
  *
  ****************************************************************************/
 
-void arp_hdr_update(FAR uint16_t *pipaddr, FAR uint8_t *ethaddr);
+void arp_hdr_update(FAR struct net_driver_s *dev, FAR uint16_t *pipaddr,
+                    FAR uint8_t *ethaddr);
 
 /****************************************************************************
  * Name: arp_snapshot
@@ -462,8 +482,9 @@ void arp_dump(FAR struct arp_hdr_s *arp);
 #  define arp_notify(i)
 #  define arp_find(i,e) (-ENOSYS)
 #  define arp_delete(i)
-#  define arp_update(i,m);
-#  define arp_hdr_update(i,m);
+#  define arp_cleanup(d)
+#  define arp_update(d,i,m);
+#  define arp_hdr_update(d,i,m);
 #  define arp_snapshot(s,n) (0)
 #  define arp_dump(arp)
 

--- a/net/arp/arp_arpin.c
+++ b/net/arp/arp_arpin.c
@@ -121,7 +121,7 @@ void arp_arpin(FAR struct net_driver_s *dev)
              * with this host in the future.
              */
 
-            arp_hdr_update(arp->ah_sipaddr, arp->ah_shwaddr);
+            arp_hdr_update(dev, arp->ah_sipaddr, arp->ah_shwaddr);
 
             arp->ah_opcode = HTONS(ARP_REPLY);
             memcpy(arp->ah_dhwaddr, arp->ah_shwaddr, ETHER_ADDR_LEN);
@@ -152,7 +152,7 @@ void arp_arpin(FAR struct net_driver_s *dev)
           {
             /* Yes... Insert the address mapping in the ARP table */
 
-            arp_hdr_update(arp->ah_sipaddr, arp->ah_shwaddr);
+            arp_hdr_update(dev, arp->ah_sipaddr, arp->ah_shwaddr);
 
             /* Then notify any logic waiting for the ARP result */
 

--- a/net/arp/arp_ipin.c
+++ b/net/arp/arp_ipin.c
@@ -90,7 +90,7 @@ void arp_ipin(FAR struct net_driver_s *dev)
   srcipaddr = net_ip4addr_conv32(IPBUF->eh_srcipaddr);
   if (net_ipv4addr_maskcmp(srcipaddr, dev->d_ipaddr, dev->d_netmask))
     {
-      arp_hdr_update(IPBUF->eh_srcipaddr, ETHBUF->src);
+      arp_hdr_update(dev, IPBUF->eh_srcipaddr, ETHBUF->src);
     }
 }
 

--- a/net/netdev/netdev_carrier.c
+++ b/net/netdev/netdev_carrier.c
@@ -37,6 +37,7 @@
 
 #include "netdev/netdev.h"
 #include "netlink/netlink.h"
+#include "arp/arp.h"
 
 /****************************************************************************
  * Public Functions
@@ -94,6 +95,7 @@ int netdev_carrier_off(FAR struct net_driver_s *dev)
       /* Notify clients that the network has been taken down */
 
       devif_dev_event(dev, NULL, NETDEV_DOWN);
+      arp_cleanup(dev);
 
       return OK;
     }


### PR DESCRIPTION
## Summary

net/arp: clean the arp table when netdev carrier off

Fix the arp address changed if netdev renew, since the
arp table should be cleared when the netdev carrier off

Signed-off-by: songlinzhang <songlinzhang@xiaomi.com>

## Impact

netdev carrier off 

## Testing

wlan ifup/down/ renew test