### PR TITLE
arch/samv7/sam_progmem: fix page size flash writing for page unaligned addresses

### DIFF
--- a/arch/arm/src/samv7/sam_progmem.c
+++ b/arch/arm/src/samv7/sam_progmem.c
@@ -601,6 +601,7 @@ ssize_t up_progmem_write(size_t address, const void *buffer, size_t buflen)
       dest     = (FAR uint32_t *)address;
       buffer   = (FAR void *)((uintptr_t)buffer + xfrsize);
       buflen  -= xfrsize;
+      offset   = 0;
       page++;
     }
 


### PR DESCRIPTION
## Summary
The `offset` is not reset after a first run of the flash write loop, so even if we have data after writing first flash page unaligned portion all the next write sizes will be limited by `(size_t)SAMV7_PAGE_SIZE - offset` value.

## Impact
SAMv7 based devices

## Testing
PreCI pass
