### PR TITLE
Add Board IOCTL for DMA buffer allocation

### DIFF
--- a/boards/Kconfig
+++ b/boards/Kconfig
@@ -3484,6 +3484,15 @@ config BOARDCTL_TESTSET
 		Enables support for the BOARDIOC_SPINLOCK boardctl() command.
 		Architecture specific logic must provide up_testset() interface.
 
+config BOARDCTL_FATDMAMEMORY
+	bool "Architecture-specific fat DMA allocation"
+	default n
+	depends on FAT_DMAMEMORY
+	---help---
+		Enables support for the BOARDCTL_FATDMAMEMORY boardctl() command.
+		Architecture specific logic must provide fat_dma_alloc() and
+		fat_dma_free() interfaces;
+
 config BOARDCTL_IOCTL
 	bool "Board-specific boardctl() commands"
 	default n

--- a/include/sys/boardctl.h
+++ b/include/sys/boardctl.h
@@ -27,6 +27,7 @@
 
 #include <nuttx/config.h>
 #include <stdint.h>
+#include <stddef.h>
 
 #include <nuttx/fs/ioctl.h>
 
@@ -179,8 +180,22 @@
  * ARG:           A pointer to a write-able spinlock object.  On success
  *                the  preceding spinlock state is returned:  0=unlocked,
  *                1=locked.
+ *
  * CONFIGURATION: CONFIG_BOARDCTL_TESTSET
  * DEPENDENCIES:  Architecture-specific logic provides up_testset()
+ *
+ * CMD:           BOARDIOC_FATDMAMEM
+ * DESCRIPTION:   Allocate or free a DMA capable buffer.
+ * ARG:           A pointer to a boardioc_dmafatmemory_ioctl_s object.
+ *                If the pmemory is NULL an allocation of size is
+ *                returned in pmemory.
+ *                If the pmemory is non-NULL the block is freed.
+ *
+ * CONFIGURATION: CONFIG_BOARDCTL_FATDMAMEMORY and CONFIG_FAT_DMAMEMORY
+ * DEPENDENCIES:  Board specific logic, as a requirement of
+ *                CONFIG_FAT_DMAMEMORY provides:
+ *                   void *fat_dma_alloc(size_t size);
+ *                   void fat_dma_free(FAR void *memory, size_t size);
  */
 
 #define BOARDIOC_INIT              _BOARDIOC(0x0001)
@@ -203,6 +218,7 @@
 #define BOARDIOC_UNIQUEKEY         _BOARDIOC(0x0012)
 #define BOARDIOC_SWITCH_BOOT       _BOARDIOC(0x0013)
 #define BOARDIOC_BOOT_IMAGE        _BOARDIOC(0x0014)
+#define BOARDIOC_FATDMAMEM         _BOARDIOC(0x0015)
 
 /* If CONFIG_BOARDCTL_IOCTL=y, then board-specific commands will be support.
  * In this case, all commands not recognized by boardctl() will be forwarded
@@ -401,6 +417,18 @@ struct boardioc_boot_info_s
 {
   FAR const char *path;           /* Path to application firmware image */
   uint32_t        header_size;    /* Size of the image header in bytes */
+};
+#endif
+
+#ifdef CONFIG_BOARDCTL_FATDMAMEMORY
+/* Arguments passed with the BOARDIOC_FATDMAMEM command */
+
+struct boardioc_dmafatmemory_ioctl_s
+{
+  size_t  size;                   /* Allocation size */
+  uint8_t *pmemory;               /* pointer to allocated mem on NULL
+                                   * non-null to be freed
+                                   */
 };
 #endif
 


### PR DESCRIPTION
## Summary

mkfatfs was failing on some stm32F7, stm32H7 and stm32F4.

The diversity of requirements for address space limitation and alignment for SDMMC drivers requires properly aligned and located memory, that only the board config sets and can support.  

For example an H7 SDMMC1 can not DMA to RAM123,4 but SDMMC2 can. 

early and later malloc allocation may get memory from one of the non-accessible memory regions. 

The fat DMA allocator solves this problem OS side as it is facilitated by the board logic and can be configured to choose the correct memory region and granularity.  

This PR will optionally allow the mkfatfs app to use the fat DMA allocator via board_ioctl.

See https://github.com/apache/incubator-nuttx-apps/pull/905

## Impact

None: If disabled.

If enabled on systems with the  fat DMA allocator Fixes mkfatfs 

## Testing
PX4 Test rack [stm32F7, stm32F4, stm32H7](http://px4-jenkins.dagar.ca:8080/blue/organizations/jenkins/PX4-Autopilot/detail/pr-nuttx_mkfatfs_contd/7/pipeline/1095/)

see stanza:
![image](https://user-images.githubusercontent.com/1945821/143592067-22e25694-46f9-4288-9a2b-dd9b39240591.png)

