### PR TITLE
esp32xx_rtc.c:  misc. fixes.

### DIFF
--- a/arch/risc-v/src/esp32c3/esp32c3_rtc.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_rtc.c
@@ -2464,8 +2464,7 @@ int up_rtc_gettime(struct timespec *tp)
     }
   else
     {
-      time_us = = esp32c3_rtc_get_time_us() +
-                    esp32c3_rtc_get_boot_time();
+      time_us = esp32c3_rtc_get_time_us() + esp32c3_rtc_get_boot_time();
     }
 
   tp->tv_sec  = time_us / USEC_PER_SEC;

--- a/arch/risc-v/src/esp32c3/esp32c3_rtc.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_rtc.c
@@ -29,6 +29,8 @@
 #include <nuttx/arch.h>
 #include <nuttx/spinlock.h>
 
+#include "clock/clock.h"
+
 #include "riscv_arch.h"
 
 #include "hardware/esp32c3_rtccntl.h"
@@ -47,10 +49,11 @@
 #include "hardware/extmem_reg.h"
 #include "hardware/spi_mem_reg.h"
 
-#include "esp32c3_rtc.h"
 #include "esp32c3_clockconfig.h"
 #include "esp32c3_attr.h"
 #include "esp32c3_rt_timer.h"
+
+#include "esp32c3_rtc.h"
 
 /****************************************************************************
  * Pre-processor Definitions

--- a/arch/xtensa/src/esp32/esp32_rtc.c
+++ b/arch/xtensa/src/esp32/esp32_rtc.c
@@ -29,7 +29,8 @@
 #include <nuttx/arch.h>
 #include <nuttx/spinlock.h>
 
-#include "esp32_rtc.h"
+#include "clock/clock.h"
+
 #include "esp32_clockconfig.h"
 #include "esp32_rt_timer.h"
 
@@ -39,6 +40,8 @@
 
 #include "xtensa.h"
 #include "xtensa_attr.h"
+
+#include "esp32_rtc.h"
 
 /****************************************************************************
  * Pre-processor Definitions

--- a/arch/xtensa/src/esp32/esp32_rtc.c
+++ b/arch/xtensa/src/esp32/esp32_rtc.c
@@ -2066,8 +2066,7 @@ int up_rtc_gettime(struct timespec *tp)
     }
   else
     {
-      time_us = = esp32_rtc_get_time_us() +
-                    esp32_rtc_get_boot_time();
+      time_us = esp32_rtc_get_time_us() + esp32_rtc_get_boot_time();
     }
 
   tp->tv_sec  = time_us / USEC_PER_SEC;


### PR DESCRIPTION
## Summary
 - Remove a duplicated assignment.
 - Include `clock/clock.h` needed for `g_basetime`.
## Impact
ESP32 and ESP32-C3 RTC driver
## Testing
esp32-devkitc:rtc
esp32c3-devkit:rtc