### PR TITLE
sched_note.c: Suppress warnings

### DIFF
--- a/sched/sched/sched_note.c
+++ b/sched/sched/sched_note.c
@@ -86,10 +86,12 @@ static struct note_filter_s g_note_filter =
     }
 };
 
+#ifdef CONFIG_SCHED_INSTRUMENTATION_IRQHANDLER
 #ifdef CONFIG_SMP
 static unsigned int g_note_disabled_irq_nest[CONFIG_SMP_NCPUS];
 #else
 static unsigned int g_note_disabled_irq_nest[1];
+#endif
 #endif
 #endif
 


### PR DESCRIPTION
## Summary
Condition g_note_disabled_irq_nest with INSTRUMENTATION_IRQHANDLER to avoid warnings.
## Impact
Note driver
## Testing
ESP32 with note driver enabled.
