### PR TITLE
arch/samv7: fix unaligned address write for progmem interface

### DIFF
--- a/arch/arm/src/samd5e5/sam_progmem.c
+++ b/arch/arm/src/samd5e5/sam_progmem.c
@@ -806,7 +806,7 @@ ssize_t up_progmem_write(size_t address, const void *buffer, size_t buflen)
 
           /* Write the page buffer */
 
-          for (i = 0; i < (SAMD5E5_PAGE_SIZE / sizeof(uint32_t)); i++)
+          for (i = 0; i < SAMD5E5_PAGE_WORDS; i++)
             {
               *dest++ = *src++;
             }
@@ -830,7 +830,7 @@ ssize_t up_progmem_write(size_t address, const void *buffer, size_t buflen)
 
           /* Compare page data */
 
-          for (i = 0; i < (SAMD5E5_PAGE_SIZE / sizeof(uint32_t)); i++)
+          for (i = 0; i < SAMD5E5_PAGE_WORDS; i++)
             {
               if (*dest != *src)
                 {
@@ -852,7 +852,7 @@ ssize_t up_progmem_write(size_t address, const void *buffer, size_t buflen)
 
       address += xfrsize;
       dest     = (FAR uint32_t *)address;
-      buffer   = (FAR void *)((uint8_t *)buffer + xfrsize);
+      buffer   = (FAR void *)((uintptr_t)buffer + xfrsize);
       buflen  -= xfrsize;
       offset   = 0;
       page++;

--- a/arch/arm/src/samv7/sam_progmem.c
+++ b/arch/arm/src/samv7/sam_progmem.c
@@ -539,7 +539,7 @@ ssize_t up_progmem_write(size_t address, const void *buffer, size_t buflen)
 
   /* Loop until all of the data has been written */
 
-  dest    = (FAR uint32_t *)address;
+  dest    = (FAR uint32_t *)(address & ~SAMV7_PAGE_MASK);
   written = 0;
 
   while (buflen > 0)
@@ -579,15 +579,15 @@ ssize_t up_progmem_write(size_t address, const void *buffer, size_t buflen)
 
       /* Write the page */
 
-      for (i = 0; i < (SAMV7_PAGE_SIZE / sizeof(uint32_t)); i++)
+      for (i = 0; i < SAMV7_PAGE_WORDS; i++)
         {
           *dest++ = *src++;
-           ARM_DMB();
         }
 
       /* Flush the data cache to memory */
 
-      up_clean_dcache(address, address + SAMV7_PAGE_SIZE);
+      up_clean_dcache(address & ~SAMV7_PAGE_MASK,
+        (address & ~SAMV7_PAGE_MASK) + SAMV7_PAGE_SIZE);
 
       /* Send the write command */
 


### PR DESCRIPTION
## Summary
1. The progmem latch buffer address (aka dest) is not aligned to page size
2. The progmem page write loop does not require DMB instruction
3. Add progmem page alignment to flush the data cache call to take into account new alignment of progmem latch buffer address

## Impact
SAMv7 based devices

## Testing
PreCI pass
