### PR TITLE
boards/same70-xplained/scripts: fix memory region size for MCUboot app

### DIFF
--- a/boards/arm/samv7/same70-xplained/scripts/flash-dtcm-mcuboot-app.ld
+++ b/boards/arm/samv7/same70-xplained/scripts/flash-dtcm-mcuboot-app.ld
@@ -31,7 +31,7 @@
 
 MEMORY
 {
-  flash (rx) : ORIGIN = 0x00420200, LENGTH = 2048K - 128K - 0x200
+  flash (rx) : ORIGIN = 0x00420200, LENGTH = 896K - 0x200
   sram (rwx) : ORIGIN = 0x20000000, LENGTH = 384K
 }
 

--- a/boards/arm/samv7/same70-xplained/scripts/flash-sram-mcuboot-app.ld
+++ b/boards/arm/samv7/same70-xplained/scripts/flash-sram-mcuboot-app.ld
@@ -28,7 +28,7 @@
 
 MEMORY
 {
-  flash (rx) : ORIGIN = 0x00420200, LENGTH = 2048K - 128K - 0x200
+  flash (rx) : ORIGIN = 0x00420200, LENGTH = 896K - 0x200
   sram (rwx) : ORIGIN = 0x20400000, LENGTH = 384K
 }
 


### PR DESCRIPTION
## Summary
The size of MCUboot compatible application image is configured to 896K in Kconfig. It is calculated wrong in linker file

## Impact
SAME70 Xplained MCUboot compatible applications

## Testing
PreCI pass
