### PR TITLE
arch: Dump task name through tcb_s::name instead of argv[0]

### DIFF
--- a/arch/arm/src/common/arm_exit.c
+++ b/arch/arm/src/common/arm_exit.c
@@ -71,7 +71,7 @@ static void _up_dumponexit(FAR struct tcb_s *tcb, FAR void *arg)
   int i;
   int j;
 
-  sinfo("  TCB=%p name=%s pid=%d\n", tcb, tcb->argv[0], tcb->pid);
+  sinfo("  TCB=%p name=%s pid=%d\n", tcb, tcb->name, tcb->pid);
   sinfo("    priority=%d state=%d\n", tcb->sched_priority, tcb->task_state);
 
   filelist = tcb->group->tg_filelist;

--- a/arch/avr/src/common/up_exit.c
+++ b/arch/avr/src/common/up_exit.c
@@ -70,7 +70,7 @@ static void _up_dumponexit(FAR struct tcb_s *tcb, FAR void *arg)
   int i;
   int j;
 
-  sinfo("  TCB=%p name=%s pid=%d\n", tcb, tcb->argv[0], tcb->pid);
+  sinfo("  TCB=%p name=%s pid=%d\n", tcb, tcb->name, tcb->pid);
   sinfo("    priority=%d state=%d\n", tcb->sched_priority, tcb->task_state);
 
   filelist = tcb->group->tg_filelist;

--- a/arch/hc/src/common/up_exit.c
+++ b/arch/hc/src/common/up_exit.c
@@ -70,7 +70,7 @@ static void _up_dumponexit(FAR struct tcb_s *tcb, FAR void *arg)
   int i;
   int j;
 
-  sinfo("  TCB=%p name=%s pid=%d\n", tcb, tcb->argv[0], tcb->pid);
+  sinfo("  TCB=%p name=%s pid=%d\n", tcb, tcb->name, tcb->pid);
   sinfo("    priority=%d state=%d\n", tcb->sched_priority, tcb->task_state);
 
   filelist = tcb->group->tg_filelist;

--- a/arch/mips/src/common/mips_exit.c
+++ b/arch/mips/src/common/mips_exit.c
@@ -72,7 +72,7 @@ static void _up_dumponexit(FAR struct tcb_s *tcb, FAR void *arg)
   int i;
   int j;
 
-  sinfo("  TCB=%p name=%s pid=%d\n", tcb, tcb->argv[0], tcb->pid);
+  sinfo("  TCB=%p name=%s pid=%d\n", tcb, tcb->name, tcb->pid);
   sinfo("    priority=%d state=%d\n", tcb->sched_priority, tcb->task_state);
 
   filelist = tcb->group->tg_filelist;

--- a/arch/misoc/src/lm32/lm32_exit.c
+++ b/arch/misoc/src/lm32/lm32_exit.c
@@ -64,7 +64,7 @@ static void _up_dumponexit(FAR struct tcb_s *tcb, FAR void *arg)
   int i;
   int j;
 
-  sinfo("  TCB=%p name=%s pid=%d\n", tcb, tcb->argv[0], tcb->pid);
+  sinfo("  TCB=%p name=%s pid=%d\n", tcb, tcb->name, tcb->pid);
   sinfo("    priority=%d state=%d\n", tcb->sched_priority, tcb->task_state);
 
   filelist = tcb->group->tg_filelist;

--- a/arch/misoc/src/minerva/minerva_exit.c
+++ b/arch/misoc/src/minerva/minerva_exit.c
@@ -64,7 +64,7 @@ static void _up_dumponexit(FAR struct tcb_s *tcb, FAR void *arg)
   int i;
   int j;
 
-  sinfo("  TCB=%p name=%s pid=%d\n", tcb, tcb->argv[0], tcb->pid);
+  sinfo("  TCB=%p name=%s pid=%d\n", tcb, tcb->name, tcb->pid);
   sinfo("    priority=%d state=%d\n", tcb->sched_priority, tcb->task_state);
 
   filelist = tcb->group->tg_filelist;

--- a/arch/or1k/src/common/up_exit.c
+++ b/arch/or1k/src/common/up_exit.c
@@ -71,7 +71,7 @@ static void _up_dumponexit(FAR struct tcb_s *tcb, FAR void *arg)
   int i;
   int j;
 
-  sinfo("  TCB=%p name=%s pid=%d\n", tcb, tcb->argv[0], tcb->pid);
+  sinfo("  TCB=%p name=%s pid=%d\n", tcb, tcb->name, tcb->pid);
   sinfo("    priority=%d state=%d\n", tcb->sched_priority, tcb->task_state);
 
   filelist = tcb->group->tg_filelist;

--- a/arch/renesas/src/common/up_exit.c
+++ b/arch/renesas/src/common/up_exit.c
@@ -70,7 +70,7 @@ static void _up_dumponexit(FAR struct tcb_s *tcb, FAR void *arg)
   int i;
   int j;
 
-  sinfo("  TCB=%p name=%s\n", tcb, tcb->argv[0]);
+  sinfo("  TCB=%p name=%s\n", tcb, tcb->name);
   sinfo("    priority=%d state=%d\n", tcb->sched_priority, tcb->task_state);
 
   filelist = tcb->group->tg_filelist;

--- a/arch/risc-v/src/common/riscv_exit.c
+++ b/arch/risc-v/src/common/riscv_exit.c
@@ -72,7 +72,7 @@ static void _up_dumponexit(struct tcb_s *tcb, void *arg)
   int i;
   int j;
 
-  sinfo("  TCB=%p name=%s pid=%d\n", tcb, tcb->argv[0], tcb->pid);
+  sinfo("  TCB=%p name=%s pid=%d\n", tcb, tcb->name, tcb->pid);
   sinfo("    priority=%d state=%d\n", tcb->sched_priority, tcb->task_state);
 
   filelist = tcb->group->tg_filelist;

--- a/arch/x86/src/common/up_exit.c
+++ b/arch/x86/src/common/up_exit.c
@@ -70,7 +70,7 @@ static void _up_dumponexit(FAR struct tcb_s *tcb, FAR void *arg)
   int i;
   int j;
 
-  sinfo("  TCB=%p name=%s pid=%d\n", tcb, tcb->argv[0], tcb->pid);
+  sinfo("  TCB=%p name=%s pid=%d\n", tcb, tcb->name, tcb->pid);
   sinfo("    priority=%d state=%d\n", tcb->sched_priority, tcb->task_state);
 
   filelist = tcb->group->tg_filelist;

--- a/arch/x86_64/src/common/up_exit.c
+++ b/arch/x86_64/src/common/up_exit.c
@@ -70,7 +70,7 @@ static void _up_dumponexit(FAR struct tcb_s *tcb, FAR void *arg)
   int i;
   int j;
 
-  sinfo("  TCB=%p name=%s pid=%d\n", tcb, tcb->argv[0], tcb->pid);
+  sinfo("  TCB=%p name=%s pid=%d\n", tcb, tcb->name, tcb->pid);
   sinfo("    priority=%d state=%d\n", tcb->sched_priority, tcb->task_state);
 
   filelist = tcb->group->tg_filelist;

--- a/arch/xtensa/src/common/xtensa_exit.c
+++ b/arch/xtensa/src/common/xtensa_exit.c
@@ -72,7 +72,7 @@ static void _xtensa_dumponexit(struct tcb_s *tcb, void *arg)
   int i;
   int j;
 
-  sinfo("  TCB=%p name=%s pid=%d\n", tcb, tcb->argv[0], tcb->pid);
+  sinfo("  TCB=%p name=%s pid=%d\n", tcb, tcb->name, tcb->pid);
   sinfo("    priority=%d state=%d\n", tcb->sched_priority, tcb->task_state);
 
   filelist = tcb->group->tg_filelist;

--- a/arch/z16/src/common/z16_exit.c
+++ b/arch/z16/src/common/z16_exit.c
@@ -70,7 +70,7 @@ static void _z16_dumponexit(FAR struct tcb_s *tcb, FAR void *arg)
   int i;
   int j;
 
-  sinfo("  TCB=%p name=%s\n", tcb, tcb->argv[0]);
+  sinfo("  TCB=%p name=%s\n", tcb, tcb->name);
   sinfo("    priority=%d state=%d\n", tcb->sched_priority, tcb->task_state);
 
   filelist = tcb->group->tg_filelist;

--- a/arch/z80/src/common/z80_exit.c
+++ b/arch/z80/src/common/z80_exit.c
@@ -72,7 +72,7 @@ static void _up_dumponexit(FAR struct tcb_s *tcb, FAR void *arg)
   int i;
   int j;
 
-  sinfo("  TCB=%p name=%s\n", tcb, tcb->argv[0]);
+  sinfo("  TCB=%p name=%s\n", tcb, tcb->name);
   sinfo("    priority=%d state=%d\n", tcb->sched_priority, tcb->task_state);
 
   filelist = tcb->group->tg_filelist;


### PR DESCRIPTION
## Summary
since argv is defined in task_tcb_s not tcb_s

## Impact
Fix the build break

## Testing
Pass CI
