### PR TITLE
boards/same70-xplained: disable systick before loading MCUboot application

### DIFF
--- a/arch/arm/src/samv7/sam_progmem.c
+++ b/arch/arm/src/samv7/sam_progmem.c
@@ -546,7 +546,7 @@ ssize_t up_progmem_write(size_t address, const void *buffer, size_t buflen)
     {
       /* How much can we write into this page? */
 
-      xfrsize = MIN((size_t)SAMV7_PAGE_SIZE - offset, buflen) ;
+      xfrsize = MIN((size_t)SAMV7_PAGE_SIZE - offset, buflen);
 
       /* Do we need to use the intermediate buffer? */
 

--- a/boards/arm/samv7/same70-xplained/src/sam_boot_image.c
+++ b/boards/arm/samv7/same70-xplained/src/sam_boot_image.c
@@ -57,6 +57,9 @@ struct arm_vector_table
  ****************************************************************************/
 
 static void cleanup_arm_nvic(void);
+#ifdef CONFIG_ARMV7M_SYSTICK
+static void systick_disable(void);
+#endif
 
 /****************************************************************************
  * Private Functions
@@ -100,6 +103,29 @@ static void cleanup_arm_nvic(void)
     }
 }
 
+#ifdef CONFIG_ARMV7M_SYSTICK
+/****************************************************************************
+ * Name:  systick_disable
+ *
+ * Description:
+ *   Disable the SysTick system timer
+ *
+ * Input Parameters:
+ *   None
+ *
+ *  Returned Value:
+ *    None
+ *
+ ****************************************************************************/
+
+static void systick_disable(void)
+{
+  putreg32(0, NVIC_SYSTICK_CTRL);
+  putreg32(NVIC_SYSTICK_RELOAD_MASK, NVIC_SYSTICK_RELOAD);
+  putreg32(0, NVIC_SYSTICK_CURRENT);
+}
+#endif
+
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
@@ -131,6 +157,10 @@ int board_boot_image(FAR const char *path, uint32_t hdr_size)
       syslog(LOG_ERR, "Failed to read ARM vector table: %d", bytes);
       return bytes < 0 ? bytes : -1;
     }
+
+#ifdef CONFIG_ARMV7M_SYSTICK
+  systick_disable();
+#endif
 
   cleanup_arm_nvic();
 

--- a/boards/arm/samv7/same70-xplained/src/sam_usbdev.c
+++ b/boards/arm/samv7/same70-xplained/src/sam_usbdev.c
@@ -52,7 +52,7 @@
  * Name:  sam_usbinitialize
  *
  * Description:
- *   Called from stm32_boardinitialize very early in initialization to setup
+ *   Called from sam_boardinitialize very early in initialization to setup
  *   USB-related GPIO pins for the SAME70-XPLD board.
  *
  ****************************************************************************/


### PR DESCRIPTION
## Summary
Disable systick before booting application image by MCUboot bootloader

## Impact
SAME70 Xplained MCUboot bootloader

## Testing
PreCI pass
