### PR TITLE
sched: Move argv from tcb_s to task_info_s

### DIFF
--- a/fs/procfs/fs_procfsproc.c
+++ b/fs/procfs/fs_procfsproc.c
@@ -635,7 +635,6 @@ static ssize_t proc_cmdline(FAR struct proc_file_s *procfile,
                             FAR struct tcb_s *tcb, FAR char *buffer,
                             size_t buflen, off_t offset)
 {
-  FAR struct task_tcb_s *ttcb;
   FAR const char *name;
   FAR char **argv;
   size_t remaining;
@@ -689,9 +688,7 @@ static ssize_t proc_cmdline(FAR struct proc_file_s *procfile,
 
   /* Show the task argument list (skipping over the name) */
 
-  ttcb = (FAR struct task_tcb_s *)tcb;
-
-  for (argv = ttcb->argv + 1; *argv; argv++)
+  for (argv = tcb->group->tg_info->argv + 1; *argv; argv++)
     {
       linesize   = procfs_snprintf(procfile->line, STATUS_LINELEN,
                                    " %s", *argv);

--- a/include/nuttx/sched.h
+++ b/include/nuttx/sched.h
@@ -33,11 +33,11 @@
 #include <sched.h>
 #include <signal.h>
 #include <semaphore.h>
-#include <pthread.h>
 #include <time.h>
 
 #include <nuttx/clock.h>
 #include <nuttx/irq.h>
+#include <nuttx/tls.h>
 #include <nuttx/wdog.h>
 #include <nuttx/mm/shm.h>
 #include <nuttx/fs/fs.h>
@@ -347,18 +347,6 @@ struct child_status_s
 };
 #endif
 
-/* struct pthread_cleanup_s *************************************************/
-
-/* This structure describes one element of the pthread cleanup stack */
-
-#ifdef CONFIG_PTHREAD_CLEANUP
-struct pthread_cleanup_s
-{
-  pthread_cleanup_t pc_cleaner;     /* Cleanup callback address */
-  FAR void *pc_arg;                 /* Argument that accompanies the callback */
-};
-#endif
-
 /* struct dspace_s **********************************************************/
 
 /* This structure describes a reference counted D-Space region.
@@ -419,8 +407,6 @@ struct exitinfo_s
   FAR void *arg;
 #endif
 };
-
-struct task_info_s;
 
 /* struct task_group_s ******************************************************/
 
@@ -742,10 +728,6 @@ struct task_tcb_s
   starthook_t starthook;                 /* Task startup function               */
   FAR void *starthookarg;                /* The argument passed to the function */
 #endif
-
-  /* [Re-]start name + start-up parameters **********************************/
-
-  FAR char **argv;                       /* Name+start-up parameters        */
 };
 
 /* struct pthread_tcb_s *****************************************************/

--- a/include/nuttx/tls.h
+++ b/include/nuttx/tls.h
@@ -27,9 +27,8 @@
 
 #include <nuttx/config.h>
 
-#include <nuttx/sched.h>
-#include <nuttx/arch.h>
 #include <sys/types.h>
+#include <pthread.h>
 
 /****************************************************************************
  * Pre-processor Definitions
@@ -102,6 +101,7 @@ struct getopt_s
 struct task_info_s
 {
   sem_t           ta_sem;
+  FAR char      **argv;                         /* Name+start-up parameters     */
 #if CONFIG_TLS_NELEM > 0
   tls_ndxset_t    ta_tlsset;                    /* Set of TLS indexes allocated */
   tls_dtor_t      ta_tlsdtor[CONFIG_TLS_NELEM]; /* List of TLS destructors      */
@@ -114,6 +114,18 @@ struct task_info_s
 #  endif
 #endif
 };
+
+/* struct pthread_cleanup_s *************************************************/
+
+/* This structure describes one element of the pthread cleanup stack */
+
+#ifdef CONFIG_PTHREAD_CLEANUP
+struct pthread_cleanup_s
+{
+  pthread_cleanup_t pc_cleaner;     /* Cleanup callback address */
+  FAR void *pc_arg;                 /* Argument that accompanies the callback */
+};
+#endif
 
 /* When TLS is enabled, up_createstack() will align allocated stacks to the
  * TLS_STACK_ALIGN value.  An instance of the following structure will be

--- a/libs/libc/errno/lib_errno.c
+++ b/libs/libc/errno/lib_errno.c
@@ -24,9 +24,7 @@
 
 #include <nuttx/config.h>
 
-#include <sched.h>
-#include <errno.h>
-
+#include <nuttx/arch.h>
 #include <nuttx/tls.h>
 
 /****************************************************************************

--- a/libs/libc/tls/task_getinfo.c
+++ b/libs/libc/tls/task_getinfo.c
@@ -24,7 +24,7 @@
 
 #include <nuttx/config.h>
 
-#include <nuttx/sched.h>
+#include <nuttx/arch.h>
 #include <nuttx/tls.h>
 
 /****************************************************************************

--- a/libs/libc/tls/tls_destruct.c
+++ b/libs/libc/tls/tls_destruct.c
@@ -24,7 +24,6 @@
 
 #include <nuttx/config.h>
 
-#include <stdint.h>
 #include <assert.h>
 
 #include <nuttx/arch.h>

--- a/libs/libc/tls/tls_getvalue.c
+++ b/libs/libc/tls/tls_getvalue.c
@@ -24,8 +24,8 @@
 
 #include <nuttx/config.h>
 
-#include <stdint.h>
 #include <assert.h>
+#include <errno.h>
 
 #include <nuttx/arch.h>
 #include <nuttx/tls.h>

--- a/libs/libc/tls/tls_setvalue.c
+++ b/libs/libc/tls/tls_setvalue.c
@@ -24,8 +24,8 @@
 
 #include <nuttx/config.h>
 
-#include <stdint.h>
 #include <assert.h>
+#include <errno.h>
 
 #include <nuttx/arch.h>
 #include <nuttx/tls.h>

--- a/sched/init/nx_start.c
+++ b/sched/init/nx_start.c
@@ -457,7 +457,6 @@ void nx_start(void)
       g_idleargv[i][0]  = (FAR char *)g_idlename;
 #endif /* CONFIG_TASK_NAME_SIZE */
       g_idleargv[i][1]  = NULL;
-      g_idletcb[i].argv = &g_idleargv[i][0];
 
       /* Then add the idle task's TCB to the head of the current ready to
        * run list.
@@ -563,6 +562,7 @@ void nx_start(void)
       /* Allocate the IDLE group */
 
       DEBUGVERIFY(group_allocate(&g_idletcb[i], g_idletcb[i].cmn.flags));
+      g_idletcb[i].cmn.group->tg_info->argv = &g_idleargv[i][0];
 
 #ifdef CONFIG_SMP
       /* Create a stack for all CPU IDLE threads (except CPU0 which already

--- a/sched/task/task_setup.c
+++ b/sched/task/task_setup.c
@@ -612,7 +612,7 @@ static int nxtask_setup_stackargs(FAR struct task_tcb_s *tcb,
    */
 
   stackargv[argc + 1] = NULL;
-  tcb->argv = stackargv;
+  tcb->cmn.group->tg_info->argv = stackargv;
 
   return OK;
 }

--- a/sched/task/task_start.c
+++ b/sched/task/task_start.c
@@ -101,7 +101,7 @@ void nxtask_start(void)
    */
 
   argc = 1;
-  while (tcb->argv[argc])
+  while (tcb->cmn.group->tg_info->argv[argc])
     {
       /* Increment the number of args.  Here is a sanity check to
        * prevent running away with an unterminated argv[] list.
@@ -122,14 +122,16 @@ void nxtask_start(void)
 
   if ((tcb->cmn.flags & TCB_FLAG_TTYPE_MASK) == TCB_FLAG_TTYPE_KERNEL)
     {
-      exitcode = tcb->cmn.entry.main(argc, tcb->argv);
+      exitcode = tcb->cmn.entry.main(argc, tcb->cmn.group->tg_info->argv);
     }
   else
     {
 #ifdef CONFIG_BUILD_FLAT
-      nxtask_startup(tcb->cmn.entry.main, argc, tcb->argv);
+      nxtask_startup(tcb->cmn.entry.main, argc,
+                     tcb->cmn.group->tg_info->argv);
 #else
-      up_task_start(tcb->cmn.entry.main, argc, tcb->argv);
+      up_task_start(tcb->cmn.entry.main, argc,
+                    tcb->cmn.group->tg_info->argv);
 #endif
     }
 

--- a/sched/task/task_vfork.c
+++ b/sched/task/task_vfork.c
@@ -94,7 +94,7 @@
 FAR struct task_tcb_s *nxtask_setup_vfork(start_t retaddr)
 {
   FAR struct tcb_s *ptcb = this_task();
-  FAR struct task_tcb_s *parent;
+  FAR struct tcb_s *parent;
   FAR struct task_tcb_s *child;
   FAR struct tls_info_s *info;
   size_t stack_size;
@@ -111,7 +111,7 @@ FAR struct task_tcb_s *nxtask_setup_vfork(start_t retaddr)
       /* Fork'ed from a kernel thread */
 
       ttype = TCB_FLAG_TTYPE_KERNEL;
-      parent = (FAR struct task_tcb_s *)ptcb;
+      parent = ptcb;
     }
   else
     {
@@ -120,12 +120,11 @@ FAR struct task_tcb_s *nxtask_setup_vfork(start_t retaddr)
       ttype = TCB_FLAG_TTYPE_TASK;
       if ((ptcb->flags & TCB_FLAG_TTYPE_MASK) == TCB_FLAG_TTYPE_TASK)
         {
-          parent = (FAR struct task_tcb_s *)ptcb;
+          parent = ptcb;
         }
       else
         {
-          parent = (FAR struct task_tcb_s *)
-              nxsched_get_tcb(ptcb->group->tg_pid);
+          parent = nxsched_get_tcb(ptcb->group->tg_pid);
           if (parent == NULL)
             {
               ret = -ENOENT;
@@ -181,7 +180,7 @@ FAR struct task_tcb_s *nxtask_setup_vfork(start_t retaddr)
     }
 
   DEBUGASSERT(info == child->cmn.stack_alloc_ptr);
-  memcpy(info, parent->cmn.stack_alloc_ptr, sizeof(struct tls_info_s));
+  memcpy(info, parent->stack_alloc_ptr, sizeof(struct tls_info_s));
   info->tl_task = child->cmn.group->tg_info;
 
   up_tls_initialize(info);
@@ -206,7 +205,8 @@ FAR struct task_tcb_s *nxtask_setup_vfork(start_t retaddr)
 
   /* Setup to pass parameters to the new task */
 
-  nxtask_setup_arguments(child, parent->argv[0], &parent->argv[1]);
+  nxtask_setup_arguments(child, parent->group->tg_info->argv[0],
+                         &parent->group->tg_info->argv[1]);
 
   /* Now we have enough in place that we can join the group */
 


### PR DESCRIPTION
## Summary
argv is allocated from stack and then belong to userspace,
so task_info_s is a best location to hold this information.

## Impact
Minor

## Testing
Run sim:asan without error
