### PR TITLE
include/stdio:add setlinebuf marco

### DIFF
--- a/include/stdio.h
+++ b/include/stdio.h
@@ -96,6 +96,8 @@
 #  define fsetpos64 fsetpos
 #endif
 
+#define setlinebuf(stream)   setvbuf(stream, NULL, _IOLBF, 0)
+
 /****************************************************************************
  * Public Type Definitions
  ****************************************************************************/


### PR DESCRIPTION
Signed-off-by: anjiahao <anjiahao@xiaomi.com>

## Summary
add `setlinebuf` marco
The setbuffer() function is the same, except that the size of the buffer is up to the caller, rather than being determined by the default BUFSIZ. The setlinebuf() function is exactly equivalent to the call:
setvbuf(stream, NULL, _IOLBF, 0);
![image](https://user-images.githubusercontent.com/75056955/143809821-ac29f4ab-dc7b-4cf3-858b-a1f5db5e7ac7.png)
https://linux.die.net/man/3/setlinebuf
## Impact

## Testing

