### PR TITLE
driver: add clk framework

### DIFF
--- a/drivers/Kconfig
+++ b/drivers/Kconfig
@@ -95,6 +95,7 @@ config SPECIFIC_DRIVERS
 source "drivers/crypto/Kconfig"
 source "drivers/loop/Kconfig"
 source "drivers/can/Kconfig"
+source "drivers/clk/Kconfig"
 source "drivers/i2c/Kconfig"
 source "drivers/spi/Kconfig"
 source "drivers/i2s/Kconfig"

--- a/drivers/Makefile
+++ b/drivers/Makefile
@@ -28,6 +28,7 @@ include analog/Make.defs
 include audio/Make.defs
 include bch/Make.defs
 include can/Make.defs
+include clk/Make.defs
 include crypto/Make.defs
 include math/Make.defs
 include motor/Make.defs

--- a/drivers/clk/Kconfig
+++ b/drivers/clk/Kconfig
@@ -1,0 +1,18 @@
+menuconfig CLK
+	bool "Clock management (CLK) driver interfaces"
+	default n
+	---help---
+		The base clock drivers and clock management sets. These interfaces are used
+		to enable/disable clocks and set clock rate for drivers
+
+if CLK
+
+config CLK_RPMSG
+	bool "rpmsg clk driver"
+	default n
+	depends on OPENAMP
+	---help---
+		Rpmsg clk are proxy/master pairs clock that operate clks between client and
+		server processor.
+
+endif

--- a/drivers/clk/Make.defs
+++ b/drivers/clk/Make.defs
@@ -1,0 +1,37 @@
+############################################################################
+# drivers/clk/Make.defs
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+# Include clk core and base clk module
+
+ifeq ($(CONFIG_CLK),y)
+
+CSRCS += clk.c clk_divider.c clk_fixed_factor.c clk_fractional_divider.c
+CSRCS += clk_fixed_rate.c clk_gate.c clk_multiplier.c clk_mux.c clk_phase.c
+
+ifeq ($(CONFIG_CLK_RPMSG),y)
+CSRCS += clk_rpmsg.c
+endif
+# Include clk core and base clk in the build
+
+DEPPATH += --dep-path clk
+VPATH += :clk
+CFLAGS += ${shell $(INCDIR) $(INCDIROPT) "$(CC)" $(TOPDIR)$(DELIM)drivers$(DELIM)clk}
+
+endif

--- a/drivers/clk/clk.c
+++ b/drivers/clk/clk.c
@@ -1,0 +1,1208 @@
+/****************************************************************************
+ * drivers/clk/clk.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/clk/clk.h>
+#include <nuttx/clk/clk_provider.h>
+#include <nuttx/fs/fs.h>
+#include <nuttx/fs/procfs.h>
+#include <nuttx/kmalloc.h>
+#include <nuttx/list.h>
+#include <nuttx/mutex.h>
+
+#include <debug.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <sys/stat.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define CLK_PROCFS_LINELEN                  80
+
+/****************************************************************************
+ * Private Datas
+ ****************************************************************************/
+
+static mutex_t g_clk_list_lock            = MUTEX_INITIALIZER;
+
+static struct list_node g_clk_root_list
+                            = LIST_INITIAL_VALUE(g_clk_root_list);
+static struct list_node g_clk_orphan_list
+                            = LIST_INITIAL_VALUE(g_clk_orphan_list);
+
+/****************************************************************************
+ * Private Function Prototypes
+ ****************************************************************************/
+
+static void clk_list_lock(void);
+static void clk_list_unlock(void);
+
+static int clk_fetch_parent_index(FAR struct clk_s *clk,
+                                  FAR struct clk_s *parent);
+static void clk_init_parent(FAR struct clk_s *clk);
+static void clk_reparent(FAR struct clk_s *clk, FAR struct clk_s *parent);
+
+static uint32_t clk_recalc(FAR struct clk_s *clk, uint32_t parent_rate);
+static void __clk_recalc_rate(FAR struct clk_s *clk);
+
+static void clk_calc_subtree(FAR struct clk_s *clk, uint32_t new_rate,
+                             FAR struct clk_s *new_parent,
+                             uint8_t p_index);
+static FAR struct clk_s *clk_calc_new_rates(FAR struct clk_s *clk,
+                                            uint32_t rate);
+static void clk_change_rate(FAR struct clk_s *clk,
+                            uint32_t best_parent_rate);
+
+static uint32_t __clk_get_rate(FAR struct clk_s *clk);
+static uint32_t __clk_round_rate(FAR struct clk_s *clk, uint32_t rate);
+static int __clk_enable(FAR struct clk_s *clk);
+static int __clk_disable(FAR struct clk_s *clk);
+
+static struct clk_s *__clk_lookup(FAR const char *name,
+                                  FAR struct clk_s *clk);
+static int __clk_register(FAR struct clk_s *clk);
+
+static void clk_disable_unused_subtree(FAR struct clk_s *clk);
+
+/* File system methods */
+
+#if !defined(CONFIG_FS_PROCFS_EXCLUDE_CLK) && defined(CONFIG_FS_PROCFS)
+
+static int clk_procfs_open(FAR struct file *filep, FAR const char *relpath,
+                           int oflags, mode_t mode);
+static int clk_procfs_close(FAR struct file *filep);
+static ssize_t clk_procfs_read(FAR struct file *filep, FAR char *buffer,
+                               size_t buflen);
+static int clk_procfs_dup(FAR const struct file *oldp,
+                          FAR struct file *newp);
+static int clk_procfs_stat(const char *relpath, struct stat *buf);
+
+#endif /* !defined(CONFIG_FS_PROCFS_EXCLUDE_CLK) && defined(CONFIG_FS_PROCFS) */
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+#if !defined(CONFIG_FS_PROCFS_EXCLUDE_CLK) && defined(CONFIG_FS_PROCFS)
+
+const struct procfs_operations clk_procfsoperations =
+{
+  clk_procfs_open,       /* open */
+  clk_procfs_close,      /* close */
+  clk_procfs_read,       /* read */
+  NULL,                  /* write */
+
+  clk_procfs_dup,        /* dup */
+
+  NULL,                  /* opendir */
+  NULL,                  /* closedir */
+  NULL,                  /* readdir */
+  NULL,                  /* rewinddir */
+
+  clk_procfs_stat,       /* stat */
+};
+
+#endif /* !defined(CONFIG_FS_PROCFS_EXCLUDE_CLK) && defined(CONFIG_FS_PROCFS) */
+
+/****************************************************************************
+ * Private Function
+ ****************************************************************************/
+
+#if !defined(CONFIG_FS_PROCFS_EXCLUDE_CLK) && defined(CONFIG_FS_PROCFS)
+
+static int clk_procfs_open(FAR struct file *filep, FAR const char *relpath,
+                           int oflags, mode_t mode)
+{
+  FAR struct procfs_file_s *priv;
+
+  if ((oflags & O_WRONLY) != 0 || (oflags & O_RDONLY) == 0)
+    {
+      return -EACCES;
+    }
+
+  priv = kmm_zalloc(sizeof(struct procfs_file_s));
+  if (!priv)
+    {
+      return -ENOMEM;
+    }
+
+  filep->f_priv = priv;
+  return OK;
+}
+
+static int clk_procfs_close(FAR struct file *filep)
+{
+  FAR struct procfs_file_s *priv = filep->f_priv;
+
+  kmm_free(priv);
+  filep->f_priv = NULL;
+  return OK;
+}
+
+static size_t clk_procfs_printf(FAR char *buffer, size_t buflen,
+                                off_t *pos, FAR const char *fmt,
+                                ...)
+{
+  char tmp[CLK_PROCFS_LINELEN];
+  size_t tmplen;
+  va_list ap;
+
+  va_start(ap, fmt);
+  tmplen = vsnprintf(tmp, sizeof(tmp), fmt, ap);
+  va_end(ap);
+
+  return procfs_memcpy(tmp, tmplen, buffer, buflen, pos);
+}
+
+static size_t clk_procfs_show_subtree(FAR FAR struct clk_s *clk, int level,
+                                      FAR char *buffer, size_t buflen,
+                                      off_t *pos)
+{
+  FAR struct clk_s *child;
+  size_t oldlen = buflen;
+  size_t ret;
+
+  if (strchr(clk_get_name(clk), '/'))
+    {
+      clk_list_unlock();
+    }
+
+  ret = clk_procfs_printf(buffer, buflen, pos, "%*s%-*s %11d %11u %11d\n",
+                          level * 2, "", 40 - level * 2, clk_get_name(clk),
+                          clk_is_enabled(clk), clk_get_rate(clk),
+                          clk_get_phase(clk));
+  buffer += ret;
+  buflen -= ret;
+
+  if (strchr(clk_get_name(clk), '/'))
+    {
+      clk_list_lock();
+    }
+
+  if (buflen > 0)
+    {
+      list_for_every_entry(&clk->children, child, struct clk_s, node)
+        {
+          ret = clk_procfs_show_subtree(child, level + 1,
+                                        buffer, buflen, pos);
+          buffer += ret;
+          buflen -= ret;
+
+          if (buflen == 0)
+            {
+              break; /* No enough space, return */
+            }
+        }
+    }
+
+  return oldlen - buflen;
+}
+
+static size_t clk_procfs_showtree(FAR char *buffer,
+                                  size_t buflen, off_t *pos)
+{
+  FAR struct clk_s *clk;
+  size_t oldlen = buflen;
+  size_t ret;
+
+  clk_list_lock();
+
+  list_for_every_entry(&g_clk_root_list, clk, struct clk_s, node)
+    {
+      ret = clk_procfs_show_subtree(clk, 0, buffer, buflen, pos);
+      buffer += ret;
+      buflen -= ret;
+
+      if (buflen == 0)
+        {
+          goto out; /* No enough space, return */
+        }
+    }
+
+  list_for_every_entry(&g_clk_orphan_list, clk, struct clk_s, node)
+    {
+      ret = clk_procfs_show_subtree(clk, 0, buffer, buflen, pos);
+      buffer += ret;
+      buflen -= ret;
+
+      if (buflen == 0)
+        {
+          goto out; /* No enough space, return */
+        }
+    }
+
+out:
+  clk_list_unlock();
+  return oldlen - buflen;
+}
+
+static ssize_t clk_procfs_read(FAR struct file *filep,
+                               FAR char *buffer, size_t buflen)
+{
+  off_t pos = filep->f_pos;
+  size_t oldlen = buflen;
+  size_t ret;
+
+  ret = clk_procfs_printf(buffer, buflen, &pos,
+                         "%8s%44s%12s%12s\n",
+                         "clock", "enable_cnt", "rate", "phase");
+  buffer += ret;
+  buflen -= ret;
+
+  if (buflen > 0)
+    {
+      ret = clk_procfs_showtree(buffer, buflen, &pos);
+      buffer += ret;
+      buflen -= ret;
+    }
+
+  filep->f_pos += oldlen - buflen;
+  return oldlen - buflen;
+}
+
+static int clk_procfs_dup(FAR const struct file *oldp,
+                          FAR struct file *newp)
+{
+  FAR struct procfs_file_s *oldpriv;
+  FAR struct procfs_file_s *newpriv;
+
+  oldpriv = oldp->f_priv;
+  DEBUGASSERT(oldpriv);
+
+  newpriv = kmm_zalloc(sizeof(struct procfs_file_s));
+  if (!newpriv)
+    {
+      return -ENOMEM;
+    }
+
+  memcpy(newpriv, oldpriv, sizeof(struct procfs_file_s));
+  newp->f_priv = newpriv;
+  return OK;
+}
+
+static int clk_procfs_stat(const char *relpath, struct stat *buf)
+{
+  /* File/directory size, access block size */
+
+  buf->st_mode    = S_IFREG | S_IROTH | S_IRGRP | S_IRUSR;
+  buf->st_size    = 0;
+  buf->st_blksize = 0;
+  buf->st_blocks  = 0;
+  return OK;
+}
+
+#endif /* !defined(CONFIG_FS_PROCFS_EXCLUDE_CLK) && defined(CONFIG_FS_PROCFS) */
+
+static void clk_list_lock(void)
+{
+  nxmutex_lock(&g_clk_list_lock);
+}
+
+static void clk_list_unlock(void)
+{
+  nxmutex_unlock(&g_clk_list_lock);
+}
+
+static int clk_fetch_parent_index(FAR struct clk_s *clk,
+                                  FAR struct clk_s *parent)
+{
+  int i;
+
+  if (!parent)
+    {
+      return -EINVAL;
+    }
+
+  for (i = 0; i < clk->num_parents; i++)
+    {
+      if (!strcmp(clk->parent_names[i], parent->name))
+        {
+          return i;
+        }
+    }
+
+  return -EINVAL;
+}
+
+static void clk_reparent(FAR struct clk_s *clk, FAR struct clk_s *parent)
+{
+  list_delete(&clk->node);
+
+  if (parent)
+    {
+      if (parent->new_child == clk)
+        {
+          parent->new_child = NULL;
+        }
+      list_add_head(&parent->children, &clk->node);
+    }
+
+  clk->parent = parent;
+}
+
+static uint32_t clk_recalc(FAR struct clk_s *clk, uint32_t parent_rate)
+{
+  if (clk->ops->recalc_rate)
+    {
+      return clk->ops->recalc_rate(clk, parent_rate);
+    }
+
+  return parent_rate;
+}
+
+static void __clk_recalc_rate(FAR struct clk_s *clk)
+{
+  uint32_t parent_rate = 0;
+  FAR struct clk_s *child;
+
+  if (clk->parent)
+    {
+      parent_rate = __clk_get_rate(clk->parent);
+    }
+
+  clk->rate = clk_recalc(clk, parent_rate);
+
+  list_for_every_entry(&clk->children, child, struct clk_s, node)
+    {
+      __clk_recalc_rate(child);
+    }
+}
+
+static void clk_calc_subtree(FAR struct clk_s *clk, uint32_t new_rate,
+                             FAR struct clk_s *new_parent, uint8_t p_index)
+{
+  FAR struct clk_s *child;
+
+  clk->new_rate = new_rate;
+  clk->new_parent = new_parent;
+  clk->new_parent_index = p_index;
+
+  clk->new_child = NULL;
+  if (new_parent && new_parent != clk->parent)
+    {
+      new_parent->new_child = clk;
+    }
+
+  list_for_every_entry(&clk->children, child, struct clk_s, node)
+    {
+      child->new_rate = clk_recalc(child, new_rate);
+      clk_calc_subtree(child, child->new_rate, NULL, 0);
+    }
+}
+
+static FAR struct clk_s *clk_calc_new_rates(FAR struct clk_s *clk,
+                                      uint32_t rate)
+{
+  FAR struct clk_s *top = clk;
+  FAR struct clk_s *old_parent;
+  FAR struct clk_s *parent;
+  uint32_t best_parent_rate = 0;
+  uint32_t new_rate = 0;
+  int p_index = 0;
+
+  if (!clk)
+    {
+      return NULL;
+    }
+
+  parent = old_parent = clk->parent;
+  if (parent)
+    {
+      best_parent_rate = __clk_get_rate(parent);
+    }
+
+  if (clk->ops->determine_rate)
+    {
+      new_rate = clk->ops->determine_rate(clk, rate,
+                                          &best_parent_rate, &parent);
+    }
+  else if (clk->ops->round_rate)
+    {
+      new_rate = clk->ops->round_rate(clk, rate, &best_parent_rate);
+    }
+  else if (!parent || !(clk->flags & CLK_SET_RATE_PARENT))
+    {
+      clk->new_rate = clk->rate;
+      return NULL;
+    }
+  else
+    {
+      top = clk_calc_new_rates(parent, rate);
+      new_rate = parent->new_rate;
+      goto out;
+    }
+
+  if (parent)
+    {
+      p_index = clk_fetch_parent_index(clk, parent);
+      if (p_index < 0)
+        {
+          return NULL;
+        }
+    }
+
+  if ((clk->flags & CLK_SET_RATE_PARENT) && parent &&
+      best_parent_rate != __clk_get_rate(parent))
+    {
+      top = clk_calc_new_rates(parent, best_parent_rate);
+    }
+
+out:
+  clk_calc_subtree(clk, new_rate, parent, p_index);
+  return top;
+}
+
+static void clk_change_rate(FAR struct clk_s *clk, uint32_t best_parent_rate)
+{
+  FAR struct clk_s *child;
+  FAR struct clk_s *old_parent;
+  bool skip_set_rate = false;
+
+  list_for_every_entry(&clk->children, child, struct clk_s, node)
+    {
+      if (child->new_parent && child->new_parent != clk)
+        {
+          continue;
+        }
+      if (child->new_rate > __clk_get_rate(child))
+        {
+          clk_change_rate(child, clk->new_rate);
+        }
+    }
+
+  old_parent = clk->parent;
+
+  if (clk->new_parent && clk->new_parent != clk->parent)
+    {
+      if (clk->enable_count)
+        {
+          clk_enable(clk->new_parent);
+          clk_enable(clk);
+        }
+
+      clk_reparent(clk, clk->new_parent);
+
+      if (clk->ops->set_rate_and_parent)
+        {
+          skip_set_rate = true;
+          clk->ops->set_rate_and_parent(clk, clk->new_rate, best_parent_rate,
+                                        clk->new_parent_index);
+        }
+      else if (clk->ops->set_parent)
+        {
+          clk->ops->set_parent(clk, clk->new_parent_index);
+        }
+
+      if (clk->enable_count)
+        {
+          clk_disable(clk);
+          clk_disable(old_parent);
+        }
+    }
+
+  if (!skip_set_rate && clk->ops->set_rate)
+    {
+      clk->ops->set_rate(clk, clk->new_rate, best_parent_rate);
+    }
+
+  clk->rate = clk->new_rate;
+
+  list_for_every_entry(&clk->children, child, struct clk_s, node)
+    {
+      if (child->new_parent && child->new_parent != clk)
+        {
+          continue;
+        }
+      if (child->new_rate != __clk_get_rate(child))
+        {
+          clk_change_rate(child, clk->new_rate);
+        }
+    }
+
+  if (clk->new_child && clk->new_child->new_rate !=
+      __clk_get_rate(clk->new_child))
+    {
+      clk_change_rate(clk->new_child, clk->new_rate);
+    }
+}
+
+static struct clk_s *__clk_lookup(FAR const char *name,
+                                  FAR struct clk_s *clk)
+{
+  FAR struct clk_s *child;
+  FAR struct clk_s *ret;
+
+  if (!strcmp(clk->name, name))
+    {
+      return clk;
+    }
+
+  list_for_every_entry(&clk->children, child, struct clk_s, node)
+    {
+      ret = __clk_lookup(name, child);
+      if (ret)
+        {
+          return ret;
+        }
+    }
+
+  return NULL;
+}
+
+static uint32_t __clk_get_rate(FAR struct clk_s *clk)
+{
+  uint32_t parent_rate;
+
+  if (!clk)
+    {
+      return 0;
+    }
+
+  if (clk->rate == 0)
+    {
+      parent_rate = __clk_get_rate(clk->parent);
+      clk->rate = clk_recalc(clk, parent_rate);
+    }
+
+  return clk->rate;
+}
+
+static uint32_t __clk_round_rate(FAR struct clk_s *clk, uint32_t rate)
+{
+  uint32_t parent_rate = 0;
+  FAR struct clk_s *parent;
+
+  if (!clk)
+    {
+      return 0;
+    }
+
+  parent = clk->parent;
+  if (parent)
+    {
+      parent_rate = __clk_get_rate(parent);
+    }
+
+  if (clk->ops->determine_rate)
+    {
+      return clk->ops->determine_rate(clk, rate, &parent_rate, &parent);
+    }
+  else if (clk->ops->round_rate)
+    {
+      return clk->ops->round_rate(clk, rate, &parent_rate);
+    }
+  else if (clk->flags & CLK_SET_RATE_PARENT)
+    {
+      return __clk_round_rate(clk->parent, rate);
+    }
+  else
+    {
+      return __clk_get_rate(clk);
+    }
+}
+
+static int __clk_enable(FAR struct clk_s *clk)
+{
+  int ret = 0;
+
+  if (!clk)
+    {
+      return 0;
+    }
+
+  if (clk->enable_count == 0)
+    {
+      ret = __clk_enable(clk->parent);
+      if (ret < 0)
+        {
+          return ret;
+        }
+
+      if (clk->ops->enable)
+        {
+          ret = clk->ops->enable(clk);
+          if (ret < 0)
+            {
+              __clk_disable(clk->parent);
+              return ret;
+            }
+        }
+    }
+
+  return ++clk->enable_count;
+}
+
+static int __clk_disable(FAR struct clk_s *clk)
+{
+  if (!clk || clk->enable_count == 0)
+    {
+      return 0;
+    }
+
+  if (clk->flags & CLK_IS_CRITICAL)
+    {
+      return 0;
+    }
+
+  if (--clk->enable_count == 0)
+    {
+      if (clk->ops->disable)
+        {
+          clk->ops->disable(clk);
+        }
+
+      if (clk->parent)
+        {
+          __clk_disable(clk->parent);
+        }
+    }
+
+  return clk->enable_count + 1;
+}
+
+static void clk_init_parent(FAR struct clk_s *clk)
+{
+  uint8_t index;
+
+  if (!clk->num_parents)
+    {
+      return;
+    }
+
+  if (clk->num_parents == 1)
+    {
+      clk->parent = clk_get(clk->parent_names[0]);
+      return;
+    }
+
+  if (!clk->ops->get_parent)
+    {
+      return;
+    };
+
+  index = clk->ops->get_parent(clk);
+  clk->parent = clk_get_parent_by_index(clk, index);
+}
+
+static int __clk_register(FAR struct clk_s *clk)
+{
+  FAR struct clk_s *orphan;
+  FAR struct clk_s *temp;
+  uint8_t i;
+
+  if (!clk)
+    {
+      return -EINVAL;
+    }
+
+  if (clk->ops->set_rate &&
+    !((clk->ops->round_rate || clk->ops->determine_rate) &&
+      clk->ops->recalc_rate))
+    {
+      return -EINVAL;
+    }
+
+  if (clk->ops->set_parent && !clk->ops->get_parent)
+    {
+      return -EINVAL;
+    }
+
+  if (clk->ops->set_rate_and_parent &&
+      !(clk->ops->set_parent && clk->ops->set_rate))
+    {
+      return -EINVAL;
+    }
+
+  clk_init_parent(clk);
+
+  clk_list_lock();
+
+  if (clk->parent)
+    {
+      list_add_head(&clk->parent->children, &clk->node);
+    }
+  else if (!clk->num_parents)
+    {
+      list_add_head(&g_clk_root_list, &clk->node);
+    }
+  else
+    {
+      list_add_head(&g_clk_orphan_list, &clk->node);
+    }
+
+  list_for_every_entry_safe(&g_clk_orphan_list, orphan,
+                            temp, struct clk_s, node)
+    {
+      if (orphan->num_parents && orphan->ops->get_parent)
+        {
+          i = orphan->ops->get_parent(orphan);
+          if (!strcmp(clk->name, orphan->parent_names[i]))
+            {
+              clk_reparent(orphan, clk);
+            }
+        }
+      else if (orphan->num_parents)
+        {
+          for (i = 0; i < orphan->num_parents; i++)
+            {
+              if (!strcmp(clk->name, orphan->parent_names[i]))
+                {
+                  clk_reparent(orphan, clk);
+                  break;
+                }
+            }
+        }
+    }
+
+  clk_list_unlock();
+  return 0;
+}
+
+static void clk_disable_unused_subtree(FAR struct clk_s *clk)
+{
+  FAR struct clk_s *child = NULL;
+
+  list_for_every_entry(&clk->children, child, struct clk_s, node)
+    {
+      clk_disable_unused_subtree(child);
+    }
+
+  if (clk->enable_count)
+    {
+      return;
+    }
+
+  if (clk_is_enabled(clk))
+    {
+      if (clk->flags & CLK_IS_CRITICAL)
+        {
+          __clk_enable(clk);
+        }
+      else if (clk->ops->disable)
+        {
+          clk->ops->disable(clk);
+        }
+    }
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+void clk_disable_unused(void)
+{
+  FAR struct clk_s *root_clk = NULL;
+
+  clk_list_lock();
+
+  list_for_every_entry(&g_clk_root_list, root_clk, struct clk_s, node)
+    {
+      clk_disable_unused_subtree(root_clk);
+    }
+
+  list_for_every_entry(&g_clk_orphan_list, root_clk, struct clk_s, node)
+    {
+      clk_disable_unused_subtree(root_clk);
+    }
+
+  clk_list_unlock();
+}
+
+int clk_disable(FAR struct clk_s *clk)
+{
+  return __clk_disable(clk);
+}
+
+int clk_enable(FAR struct clk_s *clk)
+{
+  return __clk_enable(clk);
+}
+
+uint32_t clk_round_rate(FAR struct clk_s *clk, uint32_t rate)
+{
+  return __clk_round_rate(clk, rate);
+}
+
+int clk_set_rate(FAR struct clk_s *clk, uint32_t rate)
+{
+  uint32_t parent_rate;
+  FAR struct clk_s *top;
+  int ret = 0;
+
+  if (!clk)
+    {
+      return 0;
+    }
+
+  if (rate == __clk_get_rate(clk))
+    {
+      goto out;
+    }
+
+  if ((clk->flags & CLK_SET_RATE_GATE) && clk->enable_count)
+    {
+      ret = -EBUSY;
+      goto out;
+    }
+
+  top = clk_calc_new_rates(clk, rate);
+  if (!top)
+    {
+      ret = -EINVAL;
+      goto out;
+    }
+
+  if (top->new_parent)
+    {
+      parent_rate = __clk_get_rate(top->new_parent);
+    }
+  else if (top->parent)
+    {
+      parent_rate = __clk_get_rate(top->parent);
+    }
+  else
+    {
+      parent_rate = 0;
+    }
+
+  clk_change_rate(top, parent_rate);
+
+out:
+  return ret;
+}
+
+int clk_set_rates(FAR const struct clk_rate_s *rates)
+{
+  FAR struct clk_s *clk;
+  int ret;
+
+  if (!rates)
+    {
+      return 0;
+    }
+
+  while (rates->name)
+    {
+      clk = clk_get(rates->name);
+      if (!clk)
+        {
+          return -EINVAL;
+        }
+
+      ret = clk_set_rate(clk, rates->rate);
+      if (ret < 0)
+        {
+          return ret;
+        }
+
+      rates++;
+    }
+
+  return 0;
+}
+
+int clk_set_phase(FAR struct clk_s *clk, int degrees)
+{
+  int ret = -EINVAL;
+
+  if (!clk)
+    {
+      return 0;
+    }
+
+  degrees %= 360;
+  if (degrees < 0)
+    {
+      degrees += 360;
+    }
+
+  if (clk->ops->set_phase)
+    {
+      ret = clk->ops->set_phase(clk, degrees);
+    }
+
+  return ret;
+}
+
+int clk_get_phase(FAR struct clk_s *clk)
+{
+  if (!clk || !clk->ops->get_phase)
+    {
+      return 0;
+    }
+
+  return clk->ops->get_phase(clk);
+}
+
+FAR const char *clk_get_name(FAR const struct clk_s *clk)
+{
+  return !clk ? NULL : clk->name;
+}
+
+int clk_is_enabled(FAR struct clk_s *clk)
+{
+  if (!clk)
+    {
+      return 0;
+    }
+
+  /* when hardware .is_enabled missing, used software counter */
+
+  if (!clk->ops->is_enabled)
+    {
+      return clk->enable_count;
+    }
+
+  return clk->ops->is_enabled(clk);
+}
+
+FAR struct clk_s *clk_get(FAR const char *name)
+{
+  FAR struct clk_s *root_clk = NULL;
+  FAR struct clk_s *ret = NULL;
+
+  if (!name)
+    {
+      return NULL;
+    }
+
+  clk_list_lock();
+
+  list_for_every_entry(&g_clk_root_list, root_clk, struct clk_s, node)
+    {
+      ret = __clk_lookup(name, root_clk);
+      if (ret)
+        {
+          goto out;
+        }
+    }
+
+  list_for_every_entry(&g_clk_orphan_list, root_clk, struct clk_s, node)
+    {
+      ret = __clk_lookup(name, root_clk);
+      if (ret)
+        {
+          goto out;
+        }
+    }
+
+out:
+  clk_list_unlock();
+
+#ifdef CONFIG_CLK_RPMSG
+  if (ret == NULL)
+    {
+      ret = clk_register_rpmsg(name, CLK_GET_RATE_NOCACHE);
+    }
+#endif
+
+  return ret;
+}
+
+int clk_set_parent(FAR struct clk_s *clk, FAR struct clk_s *parent)
+{
+  FAR struct clk_s *old_parent = NULL;
+  int ret = 0;
+  int index = 0;
+
+  if (!clk)
+    {
+      return 0;
+    }
+
+  if (clk->num_parents > 1 && !clk->ops->set_parent)
+    {
+      return -ENOSYS;
+    }
+
+  if (clk->parent == parent)
+    {
+      goto out;
+    }
+
+  if ((clk->flags & CLK_SET_PARENT_GATE) && clk->enable_count)
+    {
+      ret = -EBUSY;
+      goto out;
+    }
+
+  if (parent)
+    {
+      index = clk_fetch_parent_index(clk, parent);
+      if (index < 0)
+        {
+          ret = index;
+          goto out;
+        }
+    }
+
+  old_parent = clk->parent;
+
+  if (clk->enable_count)
+    {
+      clk_enable(parent);
+      clk_enable(clk);
+    }
+
+  clk_reparent(clk, parent);
+
+  if (parent && clk->ops->set_parent)
+    {
+      ret = clk->ops->set_parent(clk, index);
+    }
+
+  if (ret < 0)
+    {
+      clk_reparent(clk, old_parent);
+
+      if (clk->enable_count)
+        {
+          clk_disable(clk);
+          clk_disable(parent);
+        }
+
+      goto out;
+    }
+
+  if (clk->enable_count)
+    {
+      clk_disable(clk);
+      clk_disable(old_parent);
+    }
+
+  __clk_recalc_rate(clk);
+
+out:
+  return ret;
+}
+
+FAR struct clk_s *clk_get_parent_by_index(FAR struct clk_s *clk,
+                                          uint8_t index)
+{
+  if (!clk || index >= clk->num_parents)
+    {
+      return NULL;
+    }
+
+  return clk_get(clk->parent_names[index]);
+}
+
+FAR struct clk_s *clk_get_parent(FAR struct clk_s *clk)
+{
+  return !clk ? NULL : clk->parent;
+}
+
+uint32_t clk_get_rate(FAR struct clk_s *clk)
+{
+  if (!clk)
+    {
+      return 0;
+    }
+
+  if (clk->flags & CLK_GET_RATE_NOCACHE)
+    {
+      __clk_recalc_rate(clk);
+    }
+
+  return __clk_get_rate(clk);
+}
+
+FAR struct clk_s *clk_register(FAR const char *name,
+                               FAR const char * const *parent_names,
+                               uint8_t num_parents, uint8_t flags,
+                               FAR const struct clk_ops_s *ops,
+                               FAR void *private_data, size_t private_size)
+{
+  FAR struct clk_s *clk;
+  size_t off;
+  size_t len;
+  int i;
+
+  off = len = sizeof(struct clk_s) + num_parents * sizeof(char *);
+  if (!(flags & CLK_PARENT_NAME_IS_STATIC))
+    {
+      for (i = 0; i < num_parents; i++)
+        {
+          len += strlen(parent_names[i]) + 1;
+        }
+    }
+
+  len += private_size;
+
+  if (flags & CLK_NAME_IS_STATIC)
+    {
+      clk = kmm_zalloc(len);
+      if (!clk)
+        {
+          return NULL;
+        }
+
+      clk->name = name;
+    }
+  else
+    {
+      clk = kmm_zalloc(len + strlen(name) + 1);
+      if (!clk)
+        {
+          return NULL;
+        }
+
+      clk->name = (char *)clk + len;
+      strcpy((char *)clk->name, name);
+    }
+
+  clk->ops = ops;
+  clk->num_parents = num_parents;
+  clk->flags = flags;
+
+  clk->private_data = (char *)clk + off;
+  memcpy(clk->private_data, private_data, private_size);
+  off += private_size;
+
+  for (i = 0; i < num_parents; i++)
+    {
+      if (flags & CLK_PARENT_NAME_IS_STATIC)
+        {
+          clk->parent_names[i] = parent_names[i];
+        }
+      else
+        {
+          clk->parent_names[i] = (char *)clk + off;
+          strcpy((char *)clk->parent_names[i], parent_names[i]);
+          off += strlen(parent_names[i]) + 1;
+        }
+    }
+
+  list_initialize(&clk->node);
+  list_initialize(&clk->children);
+
+  if (!__clk_register(clk))
+    {
+      return clk;
+    }
+
+  kmm_free(clk);
+  return NULL;
+}

--- a/drivers/clk/clk.h
+++ b/drivers/clk/clk.h
@@ -1,0 +1,116 @@
+/****************************************************************************
+ * drivers/clk/clk.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __DRIVER_CLK_CLK_H
+#define __DRIVER_CLK_CLK_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <stdint.h>
+#include <strings.h>
+
+#ifdef CONFIG_CLK
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define BIT(nr)                     (1ULL << (nr))
+#define MASK(width)                 (BIT(width) - 1)
+#define MULT_ROUND_UP(r, m)         ((r) * (m) + (m) - 1)
+#define DIV_ROUND_UP(n,d)           (((n) + (d) - 1) / (d))
+#define DIV_ROUND_CLOSEST(n, d)     ((((n) < 0) ^ ((d) < 0)) ? \
+                                    (((n) - (d)/2)/(d)) : (((n) + (d)/2)/(d)))
+#define MIN(x, y)                   (x < y) ? x : y
+
+/****************************************************************************
+ * Inline Functions
+ ****************************************************************************/
+
+static inline void clk_write(uint32_t reg, uint32_t value)
+{
+  reg = reg / (CHAR_BIT / 8);
+  *((volatile uint32_t *) (reg)) = value;
+}
+
+static inline uint32_t clk_read(uint32_t reg)
+{
+  reg = reg / (CHAR_BIT / 8);
+  return *((volatile uint32_t *) (reg));
+}
+
+static inline uint32_t gcd(uint32_t a, uint32_t b)
+{
+  uint32_t r;
+  uint32_t tmp;
+
+  if (a < b)
+    {
+      tmp = a;
+      a = b;
+      b = tmp;
+    }
+
+  if (!b)
+    {
+      return a;
+    }
+
+  while ((r = a % b) != 0)
+    {
+      a = b;
+      b = r;
+    }
+
+  return b;
+}
+
+static inline int is_power_of_2(uint32_t n)
+{
+  return (n != 0 && ((n & (n - 1)) == 0));
+}
+
+static inline uint32_t roundup_pow_of_two(uint32_t n)
+{
+  return 1 << fls(n - 1);
+}
+
+static inline uint32_t rounddown_pow_of_two(uint32_t n)
+{
+  return 1 << (fls(n) - 1);
+}
+
+static inline uint32_t roundup_double(double n)
+{
+  uint32_t intn = (uint32_t)n;
+  if (n == (double)intn)
+    {
+      return intn;
+    }
+
+  return intn + 1;
+}
+
+#endif /* CONFIG_CLK */
+#endif /* __DRIVER_CLK_CLK_H */

--- a/drivers/clk/clk_divider.c
+++ b/drivers/clk/clk_divider.c
@@ -1,0 +1,385 @@
+/****************************************************************************
+ * drivers/clk/clk_divider.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/clk/clk.h>
+#include <nuttx/clk/clk_provider.h>
+
+#include <debug.h>
+#include <stdlib.h>
+
+#include "clk.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define to_clk_divider(_clk) (FAR struct clk_divider_s *) \
+                             (_clk->private_data)
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+static uint32_t _get_maxdiv(uint8_t width, uint16_t flags)
+{
+  if (flags & CLK_DIVIDER_MAX_HALF)
+    {
+      return MASK(width - 1) + 1;
+    }
+
+  if (flags & CLK_DIVIDER_ONE_BASED)
+    {
+      return MASK(width);
+    }
+
+  if (flags & CLK_DIVIDER_DIV_NEED_EVEN)
+    {
+      return MASK(width) - 1;
+    }
+
+  if (flags & CLK_DIVIDER_POWER_OF_TWO)
+    {
+      return 1 << MASK(width);
+    }
+
+  return MASK(width) + 1;
+}
+
+static uint32_t _get_div(uint32_t val, uint16_t flags)
+{
+  if (flags & CLK_DIVIDER_ONE_BASED)
+    {
+      return val;
+    }
+
+  if (flags & CLK_DIVIDER_POWER_OF_TWO)
+    {
+      return 1 << val;
+    }
+
+  return val + 1;
+}
+
+static uint32_t _get_val(uint32_t div, uint16_t flags)
+{
+  if (flags & CLK_DIVIDER_ONE_BASED)
+    {
+      return div;
+    }
+
+  if (flags & CLK_DIVIDER_POWER_OF_TWO)
+    {
+      return ffs(div);
+    }
+
+  return div - 1;
+}
+
+static uint32_t divider_recalc_rate(uint32_t parent_rate,
+                                    uint32_t val, uint16_t flags)
+{
+  uint32_t div;
+
+  div = _get_div(val, flags);
+  if (!div)
+    {
+      return parent_rate;
+    }
+
+  return DIV_ROUND_UP(parent_rate, div);
+}
+
+static uint32_t clk_divider_recalc_rate(FAR struct clk_s *clk,
+                                        uint32_t parent_rate)
+{
+  FAR struct clk_divider_s *divider = to_clk_divider(clk);
+  uint32_t val;
+
+  val = clk_read(divider->reg) >> divider->shift;
+  val &= MASK(divider->width);
+
+  return divider_recalc_rate(parent_rate, val, divider->flags);
+}
+
+static uint32_t _div_round_up(uint32_t parent_rate, uint32_t rate,
+                              uint16_t flags)
+{
+  uint32_t div = DIV_ROUND_UP(parent_rate, rate);
+
+  if (flags & CLK_DIVIDER_POWER_OF_TWO)
+    {
+      div = roundup_pow_of_two(div);
+    }
+
+  return div;
+}
+
+static uint32_t _div_round_closest(uint32_t parent_rate,
+                                   uint32_t rate, uint16_t flags)
+{
+  uint32_t up;
+  uint32_t down;
+  uint32_t up_rate;
+  uint32_t down_rate;
+
+  up = DIV_ROUND_UP(parent_rate, rate);
+  down = parent_rate / rate;
+
+  if (flags & CLK_DIVIDER_POWER_OF_TWO)
+    {
+      up = roundup_pow_of_two(up);
+      down = rounddown_pow_of_two(down);
+    }
+
+  up_rate = DIV_ROUND_UP(parent_rate, up);
+  down_rate = DIV_ROUND_UP(parent_rate, down);
+
+  return (rate - up_rate) <= (down_rate - rate) ? up : down;
+}
+
+static uint32_t _div_round(uint32_t parent_rate, uint32_t rate,
+                           uint16_t flags)
+{
+  if (flags & CLK_DIVIDER_ROUND_CLOSEST)
+    {
+      return _div_round_closest(parent_rate, rate, flags);
+    }
+
+  return _div_round_up(parent_rate, rate, flags);
+}
+
+static bool _is_best_div(uint32_t rate, uint32_t now,
+                         uint32_t best, uint16_t flags)
+{
+  if (flags & CLK_DIVIDER_ROUND_CLOSEST)
+    {
+      return abs(rate - now) < abs(rate - best);
+    }
+
+  return now <= rate && now > best;
+}
+
+static uint32_t _next_div(uint32_t div, uint16_t flags)
+{
+  div++;
+
+  if (flags & CLK_DIVIDER_POWER_OF_TWO)
+    {
+      return roundup_pow_of_two(div);
+    }
+
+  if (flags & CLK_DIVIDER_DIV_NEED_EVEN)
+    {
+      div++;
+    }
+
+  return div;
+}
+
+static uint32_t clk_divider_bestdiv(FAR struct clk_s *clk, uint32_t rate,
+                                    uint32_t *best_parent_rate,
+                                    uint8_t width)
+{
+  uint32_t i;
+  uint32_t bestdiv = 0;
+  uint32_t maxdiv;
+  uint32_t mindiv;
+  uint32_t parent_rate;
+  uint32_t best = 0;
+  uint32_t now;
+  FAR struct clk_divider_s *divider = to_clk_divider(clk);
+
+  if (!rate)
+    {
+      rate = 1;
+    }
+
+  if (divider->flags & CLK_DIVIDER_READ_ONLY)
+    {
+      bestdiv = clk_read(divider->reg) >> divider->shift;
+      bestdiv &= MASK(divider->width);
+      bestdiv = _get_div(bestdiv, divider->flags);
+      return bestdiv;
+    }
+
+  maxdiv = _get_maxdiv(width, divider->flags);
+
+  if (!(clk->flags & CLK_SET_RATE_PARENT))
+    {
+      parent_rate = *best_parent_rate;
+      if (parent_rate > rate)
+        {
+          bestdiv = _div_round(parent_rate, rate, divider->flags);
+          bestdiv = bestdiv > maxdiv ? maxdiv : bestdiv;
+        }
+      else
+        {
+          bestdiv = 1;
+        }
+
+      return bestdiv;
+    }
+
+  mindiv = 0;
+  if (divider->flags & CLK_DIVIDER_MINDIV_MSK)
+    {
+      mindiv = (divider->flags & CLK_DIVIDER_MINDIV_MSK)
+                >> CLK_DIVIDER_MINDIV_OFF;
+      mindiv -= 1;
+    }
+
+  maxdiv = MIN(UINT32_MAX / rate, maxdiv);
+  for (i = _next_div(mindiv, divider->flags); i <= maxdiv;
+       i = _next_div(i, divider->flags))
+    {
+      parent_rate = clk_round_rate(clk_get_parent(clk),
+          rate * i);
+      now = DIV_ROUND_UP(parent_rate, i);
+      if (_is_best_div(rate, now, best, divider->flags))
+        {
+          bestdiv = i;
+          best = now;
+          *best_parent_rate = parent_rate;
+        }
+    }
+
+  if (!bestdiv)
+    {
+      bestdiv = _get_maxdiv(width, divider->flags);
+      *best_parent_rate = clk_round_rate(clk_get_parent(clk), 1);
+    }
+
+  return bestdiv;
+}
+
+static uint32_t divider_round_rate(FAR struct clk_s *clk, uint32_t rate,
+                                   uint32_t *prate, uint8_t width)
+{
+  uint32_t div;
+
+  div = clk_divider_bestdiv(clk, rate, prate, width);
+
+  return DIV_ROUND_UP(*prate, div);
+}
+
+static uint32_t clk_divider_round_rate(FAR struct clk_s *clk, uint32_t rate,
+                                       uint32_t *prate)
+{
+  FAR struct clk_divider_s *divider = to_clk_divider(clk);
+
+  return divider_round_rate(clk, rate, prate, divider->width);
+}
+
+static int32_t divider_get_val(uint32_t rate, uint32_t parent_rate,
+                               uint8_t width, uint16_t flags)
+{
+  uint32_t div;
+  uint32_t value;
+
+  div = DIV_ROUND_UP(parent_rate, rate);
+
+  if ((flags & CLK_DIVIDER_POWER_OF_TWO) && !is_power_of_2(div))
+    {
+      return -EINVAL;
+    }
+
+  value = _get_val(div, flags);
+
+  return MIN(value, MASK(width));
+}
+
+static int clk_divider_set_rate(FAR struct clk_s *clk, uint32_t rate,
+                                uint32_t parent_rate)
+{
+  FAR struct clk_divider_s *divider = to_clk_divider(clk);
+  int32_t value;
+  uint32_t val;
+
+  value = divider_get_val(rate, parent_rate, divider->width, divider->flags);
+
+  if (value < 0)
+    {
+      return value;
+    }
+
+  if (divider->flags & CLK_DIVIDER_HIWORD_MASK)
+    {
+      val = MASK(divider->width) << (divider->shift + 16);
+    }
+  else
+    {
+      val = clk_read(divider->reg);
+      val &= ~(MASK(divider->width) << divider->shift);
+    }
+
+  val |= value << divider->shift;
+  clk_write(divider->reg, val);
+
+  return 0;
+}
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+const struct clk_ops_s g_clk_divider_ops =
+{
+  .recalc_rate = clk_divider_recalc_rate,
+  .round_rate = clk_divider_round_rate,
+  .set_rate = clk_divider_set_rate,
+};
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+FAR struct clk_s *clk_register_divider(FAR const char *name,
+                                       FAR const char *parent_name,
+                                       uint8_t flags, uint32_t reg,
+                                       uint8_t shift, uint8_t width,
+                                       uint16_t clk_divider_flags)
+{
+  struct clk_divider_s div;
+  FAR const char **parent_names;
+  uint8_t num_parents;
+
+  if (clk_divider_flags & CLK_DIVIDER_HIWORD_MASK)
+    {
+      if (width + shift > 16)
+        {
+          return NULL;
+        }
+    }
+
+  parent_names = parent_name ? &parent_name: NULL;
+  num_parents = parent_name ? 1 : 0;
+
+  div.reg = reg;
+  div.shift = shift;
+  div.width = width;
+  div.flags = clk_divider_flags;
+
+  return clk_register(name, parent_names, num_parents, flags,
+                      &g_clk_divider_ops, &div, sizeof(div));
+}

--- a/drivers/clk/clk_fixed_factor.c
+++ b/drivers/clk/clk_fixed_factor.c
@@ -1,0 +1,98 @@
+/****************************************************************************
+ * drivers/clk/clk_fixed_factor.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/clk/clk.h>
+#include <nuttx/clk/clk_provider.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define to_clk_fixed_factor(_clk) (FAR struct clk_fixed_factor_s *) \
+                                  (_clk->private_data)
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+static uint32_t clk_factor_recalc_rate(FAR struct clk_s *clk,
+                                       uint32_t parent_rate)
+{
+  FAR struct clk_fixed_factor_s *fixed = to_clk_fixed_factor(clk);
+  uint64_t rate = parent_rate;
+
+  rate *= fixed->mult;
+  rate /= fixed->div;
+  return rate;
+}
+
+static uint32_t clk_factor_round_rate(FAR struct clk_s *clk,
+                                      uint32_t rate,
+                                      FAR uint32_t *prate)
+{
+  FAR struct clk_fixed_factor_s *fixed = to_clk_fixed_factor(clk);
+
+  if (clk->flags & CLK_SET_RATE_PARENT)
+    {
+      uint32_t best_parent;
+
+      best_parent = ((uint64_t)rate * fixed->div) / fixed->mult;
+      *prate = clk_round_rate(clk_get_parent(clk), best_parent);
+    }
+
+  return ((uint64_t)*prate * fixed->mult) / fixed->div;
+}
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+const struct clk_ops_s g_clk_fixed_factor_ops =
+{
+  .round_rate = clk_factor_round_rate,
+  .recalc_rate = clk_factor_recalc_rate,
+};
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+FAR struct clk_s *clk_register_fixed_factor(FAR const char *name,
+                                            FAR const char *parent_name,
+                                            uint8_t flags, uint8_t mult,
+                                            uint8_t div)
+{
+  struct clk_fixed_factor_s fixed;
+  FAR const char **parent_names;
+  uint8_t num_parents;
+
+  parent_names = parent_name ? &parent_name : NULL;
+  num_parents = parent_name ? 1 : 0;
+
+  fixed.mult = mult;
+  fixed.div = div;
+
+  return clk_register(name, parent_names, num_parents, flags,
+                      &g_clk_fixed_factor_ops, &fixed, sizeof(fixed));
+}

--- a/drivers/clk/clk_fixed_rate.c
+++ b/drivers/clk/clk_fixed_rate.c
@@ -1,0 +1,73 @@
+/****************************************************************************
+ * drivers/clk/clk_fixed_rate.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/clk/clk_provider.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define to_clk_fixed_rate(_clk) (FAR struct clk_fixed_rate_s *) \
+                                (_clk->private_data)
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+static uint32_t clk_fixed_rate_recalc_rate(FAR struct clk_s *clk,
+                                           uint32_t parent_rate)
+{
+  FAR struct clk_fixed_rate_s *fixed = to_clk_fixed_rate(clk);
+  return fixed->fixed_rate;
+}
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+const struct clk_ops_s clk_fixed_rate_ops =
+{
+  .recalc_rate = clk_fixed_rate_recalc_rate,
+};
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+FAR struct clk_s *clk_register_fixed_rate(FAR const char *name,
+                                          FAR const char *parent_name,
+                                          uint8_t flags, uint32_t fixed_rate)
+{
+  struct clk_fixed_rate_s fixed;
+  FAR const char **parent_names;
+  uint8_t num_parents;
+
+  parent_names = parent_name ? &parent_name: NULL;
+  num_parents = parent_name ? 1 : 0;
+
+  fixed.fixed_rate = fixed_rate;
+
+  return clk_register(name, parent_names, num_parents, flags,
+                      &clk_fixed_rate_ops, &fixed, sizeof(fixed));
+}

--- a/drivers/clk/clk_fractional_divider.c
+++ b/drivers/clk/clk_fractional_divider.c
@@ -1,0 +1,181 @@
+/****************************************************************************
+ * drivers/clk/clk_fractional_divider.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/clk/clk_provider.h>
+
+#include "clk.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define to_clk_fd(_clk) (FAR struct clk_fractional_divider_s *) \
+                        (_clk->private_data)
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+static uint32_t clk_fd_recalc_rate(FAR struct clk_s *clk,
+                                   uint32_t parent_rate)
+{
+  FAR struct clk_fractional_divider_s *fd = to_clk_fd(clk);
+  uint32_t mmask = MASK(fd->mwidth) << fd->mshift;
+  uint32_t nmask = MASK(fd->nwidth) << fd->nshift;
+  uint32_t val;
+  uint32_t m;
+  uint32_t n;
+  uint64_t ret;
+
+  val = clk_read(fd->reg);
+
+  m = (val & mmask) >> fd->mshift;
+  n = (val & nmask) >> fd->nshift;
+
+  ret = (uint64_t)parent_rate * m;
+  ret /= (fd->flags & CLK_FRAC_DIV_DOUBLE ? 2 * n : n);
+
+  return ret;
+}
+
+static uint32_t clk_fd_round_rate(FAR struct clk_s *clk,
+                                  uint32_t rate, FAR uint32_t *prate)
+{
+  FAR struct clk_fractional_divider_s *fd = to_clk_fd(clk);
+  uint32_t maxn = BIT(fd->nwidth);
+  uint32_t maxm = BIT(fd->mwidth);
+  uint32_t div;
+  uint32_t m;
+  uint32_t n;
+  uint64_t ret;
+
+  if (!rate || rate >= *prate)
+    {
+      return *prate;
+    }
+
+  if (fd->flags & CLK_FRAC_DIV_DOUBLE)
+    {
+      rate *= 2;
+    }
+
+  div = gcd(*prate, rate);
+
+  do
+    {
+      m = rate / div;
+      n = *prate / div;
+
+      if ((m % 2 != 0) &&
+          (fd->flags & CLK_FRAC_MUL_NEED_EVEN))
+        {
+          m *= 2;
+          n *= 2;
+        }
+
+      div <<= 1;
+    }
+  while (n > maxn || m > maxm);
+
+  ret = (uint64_t)*prate * m;
+  ret /= (fd->flags & CLK_FRAC_DIV_DOUBLE ? 2 * n : n);
+
+  return ret;
+}
+
+static int clk_fd_set_rate(FAR struct clk_s *clk, uint32_t rate,
+                           uint32_t parent_rate)
+{
+  FAR struct clk_fractional_divider_s *fd = to_clk_fd(clk);
+  uint32_t mmask = MASK(fd->mwidth) << fd->mshift;
+  uint32_t nmask = MASK(fd->nwidth) << fd->nshift;
+  uint32_t div;
+  uint32_t n;
+  uint32_t m;
+  uint32_t val;
+
+  if (fd->flags & CLK_FRAC_DIV_DOUBLE)
+    {
+      rate *= 2;
+    }
+
+  div = gcd(parent_rate, rate);
+  m = rate / div;
+  n = parent_rate / div;
+
+  if ((m % 2 != 0) &&
+      (fd->flags & CLK_FRAC_MUL_NEED_EVEN))
+    {
+      m *= 2;
+      n *= 2;
+    }
+
+  val = clk_read(fd->reg);
+  val &= ~(mmask | nmask);
+  val |= (m << fd->mshift) | (n << fd->nshift);
+  clk_write(fd->reg, val);
+
+  return 0;
+}
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+const struct clk_ops_s g_clk_fractional_divider_ops =
+{
+  .recalc_rate = clk_fd_recalc_rate,
+  .round_rate = clk_fd_round_rate,
+  .set_rate = clk_fd_set_rate,
+};
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+FAR struct clk_s *
+clk_register_fractional_divider(FAR const char *name,
+                                FAR const char *parent_name,
+                                uint8_t flags, uint32_t reg,
+                                uint8_t mshift, uint8_t mwidth,
+                                uint8_t nshift, uint8_t nwidth,
+                                uint8_t clk_divider_flags)
+{
+  struct clk_fractional_divider_s fd;
+  FAR const char **parent_names;
+  uint8_t num_parents;
+
+  parent_names = parent_name ? &parent_name : NULL;
+  num_parents = parent_name ? 1 : 0;
+
+  fd.reg = reg;
+  fd.mshift = mshift;
+  fd.mwidth = mwidth;
+  fd.nshift = nshift;
+  fd.nwidth = nwidth;
+  fd.flags = clk_divider_flags;
+
+  return clk_register(name, parent_names, num_parents, flags,
+                      &g_clk_fractional_divider_ops, &fd, sizeof(fd));
+}

--- a/drivers/clk/clk_gate.c
+++ b/drivers/clk/clk_gate.c
@@ -1,0 +1,145 @@
+/****************************************************************************
+ * drivers/clk/clk_gate.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/clk/clk_provider.h>
+
+#include <debug.h>
+
+#include "clk.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define to_clk_gate(_clk) (FAR struct clk_gate_s *)(_clk->private_data)
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+static void clk_gate_endisable(FAR struct clk_s *clk, int32_t enable)
+{
+  FAR struct clk_gate_s *gate = to_clk_gate(clk);
+  int32_t set = gate->flags & CLK_GATE_SET_TO_DISABLE ? 1 : 0;
+  uint32_t val;
+
+  set ^= enable;
+
+  if (gate->flags & CLK_GATE_HIWORD_MASK)
+    {
+      val = BIT(gate->bit_idx + 16);
+      if (set)
+        {
+          val |= BIT(gate->bit_idx);
+        }
+    }
+
+  else
+    {
+      val = clk_read(gate->reg);
+
+      if (set)
+        {
+          val |= BIT(gate->bit_idx);
+        }
+      else
+        {
+          val &= ~BIT(gate->bit_idx);
+        }
+    }
+
+  clk_write(gate->reg, val);
+}
+
+static int clk_gate_enable(FAR struct clk_s *clk)
+{
+  clk_gate_endisable(clk, 1);
+  return 0;
+}
+
+static void clk_gate_disable(FAR struct clk_s *clk)
+{
+  clk_gate_endisable(clk, 0);
+}
+
+static int clk_gate_is_enabled(FAR struct clk_s *clk)
+{
+  FAR struct clk_gate_s *gate = to_clk_gate(clk);
+  uint32_t val;
+
+  val = clk_read(gate->reg);
+
+  if (gate->flags & CLK_GATE_SET_TO_DISABLE)
+    {
+      val ^= BIT(gate->bit_idx);
+    }
+
+  val &= BIT(gate->bit_idx);
+
+  return val ? 1 : 0;
+}
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+const struct clk_ops_s g_clk_gate_ops =
+{
+  .enable = clk_gate_enable,
+  .disable = clk_gate_disable,
+  .is_enabled = clk_gate_is_enabled,
+};
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+FAR struct clk_s *clk_register_gate(FAR const char *name,
+                                    FAR const char *parent_name,
+                                    uint8_t flags, uint32_t reg,
+                                    uint8_t bit_idx,
+                                    uint8_t clk_gate_flags)
+{
+  FAR struct clk_gate_s gate;
+  FAR const char **parent_names;
+  uint8_t num_parents;
+
+  if (clk_gate_flags & CLK_GATE_HIWORD_MASK)
+    {
+      if (bit_idx > 16)
+        {
+          return NULL;
+        }
+    }
+
+  parent_names = parent_name ? &parent_name : NULL;
+  num_parents = parent_name ? 1 : 0;
+
+  gate.reg = reg;
+  gate.bit_idx = bit_idx;
+  gate.flags = clk_gate_flags;
+
+  return clk_register(name, parent_names, num_parents, flags,
+                      &g_clk_gate_ops, &gate, sizeof(gate));
+}

--- a/drivers/clk/clk_multiplier.c
+++ b/drivers/clk/clk_multiplier.c
@@ -1,0 +1,255 @@
+/****************************************************************************
+ * drivers/clk/clk_multiplier.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/clk/clk.h>
+#include <nuttx/clk/clk_provider.h>
+
+#include <debug.h>
+#include <stdlib.h>
+
+#include "clk.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define to_clk_multiplier(_clk) (FAR struct clk_multiplier_s *) \
+                                (_clk->private_data)
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+static uint32_t _get_maxmult(FAR struct clk_multiplier_s *multiplier)
+{
+  if (multiplier->flags & CLK_MULT_ONE_BASED)
+    {
+      return MASK(multiplier->width);
+    }
+
+  if (multiplier->flags & CLK_MULT_MAX_HALF)
+    {
+      return 1 << (multiplier->width - 1);
+    }
+
+  return MASK(multiplier->width) + 1;
+}
+
+static uint32_t _get_mult(FAR struct clk_multiplier_s *multiplier,
+                          uint32_t val)
+{
+  if (multiplier->flags & CLK_MULT_ONE_BASED)
+    {
+      return val;
+    }
+
+  return val + 1;
+}
+
+static uint32_t _get_val(FAR struct clk_multiplier_s *multiplier,
+                         uint32_t mult)
+{
+  if (multiplier->flags & CLK_MULT_ONE_BASED)
+    {
+      return mult;
+    }
+
+  return mult - 1;
+}
+
+static uint32_t clk_multiplier_recalc_rate(FAR struct clk_s *clk,
+                                           uint32_t parent_rate)
+{
+  FAR struct clk_multiplier_s *multiplier = to_clk_multiplier(clk);
+  uint32_t mult;
+  uint32_t val;
+
+  val = clk_read(multiplier->reg) >> multiplier->shift;
+  val &= MASK(multiplier->width);
+
+  mult = _get_mult(multiplier, val);
+  if (!mult)
+    {
+      if (!(multiplier->flags & CLK_MULT_ALLOW_ZERO))
+        {
+          return -EINVAL;
+        }
+
+      return parent_rate;
+    }
+
+  return parent_rate * mult;
+}
+
+static bool __is_best_rate(uint32_t rate, uint32_t new,
+                           uint32_t best, uint16_t flags)
+{
+  if (flags & CLK_MULT_ROUND_CLOSEST)
+    {
+      return abs(rate - new) < abs(rate - best);
+    }
+
+  return new >= rate && new < best;
+}
+
+static uint32_t clk_multiplier_bestmult(FAR struct clk_s *clk, uint32_t rate,
+                                        FAR uint32_t *best_parent_rate)
+{
+  FAR struct clk_multiplier_s *multiplier = to_clk_multiplier(clk);
+  uint32_t i;
+  uint32_t bestmult = 0;
+  uint32_t parent_rate;
+  uint32_t best = 0;
+  uint32_t now;
+  uint32_t maxmult;
+  uint32_t parent_rate_saved = *best_parent_rate;
+
+  if (!rate)
+    {
+      rate = 1;
+    }
+
+  maxmult = _get_maxmult(multiplier);
+
+  if (!(clk->flags & CLK_SET_RATE_PARENT))
+    {
+      parent_rate = *best_parent_rate;
+      bestmult = rate / parent_rate;
+      bestmult = bestmult == 0 ? 1 : bestmult;
+      bestmult = bestmult > maxmult ? maxmult : bestmult;
+      return bestmult;
+    }
+
+  for (i = maxmult; i >= 1; i--)
+    {
+      if (rate == parent_rate_saved * i)
+        {
+          *best_parent_rate = parent_rate_saved;
+          return i;
+        }
+
+      parent_rate = clk_round_rate(clk_get_parent(clk),
+                                   rate / i);
+      now = parent_rate * i;
+      if (__is_best_rate(rate, now, best, multiplier->flags))
+        {
+          bestmult = i;
+          best = now;
+          *best_parent_rate = parent_rate;
+        }
+    }
+
+  if (!bestmult)
+    {
+      bestmult = 1;
+      *best_parent_rate = clk_round_rate(clk_get_parent(clk), 1);
+    }
+
+  return bestmult;
+}
+
+static uint32_t clk_multiplier_round_rate(FAR struct clk_s *clk,
+                                          uint32_t rate, FAR uint32_t *prate)
+{
+  return *prate * clk_multiplier_bestmult(clk, rate, prate);
+}
+
+static int clk_multiplier_set_rate(FAR struct clk_s *clk, uint32_t rate,
+                                   uint32_t parent_rate)
+{
+  FAR struct clk_multiplier_s *multiplier = to_clk_multiplier(clk);
+  uint32_t mult;
+  uint32_t value;
+  uint32_t val;
+
+  mult = rate / parent_rate;
+  value = _get_val(multiplier, mult);
+
+  if (value > MASK(multiplier->width))
+    {
+      value = MASK(multiplier->width);
+    }
+
+  if (multiplier->flags & CLK_MULT_HIWORD_MASK)
+    {
+      val = MASK(multiplier->width) << (multiplier->shift + 16);
+    }
+
+  else
+    {
+      val = clk_read(multiplier->reg);
+      val &= ~(MASK(multiplier->width) << multiplier->shift);
+    }
+
+  val |= value << multiplier->shift;
+  clk_write(multiplier->reg, val);
+
+  return 0;
+}
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+const struct clk_ops_s g_clk_multiplier_ops =
+{
+  .recalc_rate = clk_multiplier_recalc_rate,
+  .round_rate = clk_multiplier_round_rate,
+  .set_rate = clk_multiplier_set_rate,
+};
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+FAR struct clk_s *clk_register_multiplier(FAR const char *name,
+                                          FAR const char *parent_name,
+                                          uint8_t flags, uint32_t reg,
+                                          uint8_t shift,
+                                          uint8_t width,
+                                          uint8_t clk_multiplier_flags)
+{
+  struct clk_multiplier_s mult;
+  FAR const char **parent_names;
+  uint8_t num_parents;
+
+  if (clk_multiplier_flags & CLK_MULT_HIWORD_MASK)
+    {
+      if (width + shift > 16)
+        {
+          return NULL;
+        }
+    }
+
+  parent_names = parent_name ? &parent_name : NULL;
+  num_parents  = parent_name ? 1 : 0;
+
+  mult.reg   = reg;
+  mult.shift = shift;
+  mult.width = width;
+  mult.flags = clk_multiplier_flags;
+
+  return clk_register(name, parent_names, num_parents, flags,
+                      &g_clk_multiplier_ops, &mult, sizeof(mult));
+}

--- a/drivers/clk/clk_mux.c
+++ b/drivers/clk/clk_mux.c
@@ -1,0 +1,199 @@
+/****************************************************************************
+ * drivers/clk/clk_mux.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/clk/clk.h>
+#include <nuttx/clk/clk_provider.h>
+
+#include <stdlib.h>
+
+#include "clk.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define to_clk_mux(_clk) (FAR struct clk_mux_s *)(_clk->private_data)
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+static bool mux_is_better_rate(uint32_t rate, uint32_t now,
+                               uint32_t best, uint8_t flags)
+{
+  if (flags & CLK_MUX_ROUND_CLOSEST)
+    {
+      return abs(now - rate) < abs(best - rate);
+    }
+
+  return now <= rate && now > best;
+}
+
+static uint8_t clk_mux_get_parent(FAR struct clk_s *clk)
+{
+  FAR struct clk_mux_s *mux = to_clk_mux(clk);
+  uint32_t val;
+
+  val = clk_read(mux->reg) >> mux->shift;
+  val &= MASK(mux->width);
+
+  return val;
+}
+
+static int clk_mux_set_parent(FAR struct clk_s *clk, uint8_t index)
+{
+  FAR struct clk_mux_s *mux = to_clk_mux(clk);
+  uint32_t mask = MASK(mux->width);
+  uint32_t val;
+
+  if (mux->flags & CLK_MUX_HIWORD_MASK)
+    {
+      val = mask << (mux->shift + 16);
+    }
+  else
+    {
+      val = clk_read(mux->reg);
+      val &= ~(mask << mux->shift);
+    }
+
+  val |= index << mux->shift;
+  clk_write(mux->reg, val);
+
+  return 0;
+}
+
+static uint32_t
+clk_mux_determine_rate(FAR struct clk_s *clk, uint32_t rate,
+                       uint32_t *best_parent_rate,
+                       struct clk_s **best_parent_p)
+{
+  FAR struct clk_mux_s *mux = to_clk_mux(clk);
+  FAR struct clk_s *parent;
+  struct clk_s *best_parent = NULL;
+  uint8_t i;
+  uint8_t num_parents;
+  uint32_t parent_rate;
+  uint32_t best = 0;
+
+  if (clk->flags & CLK_SET_RATE_NO_REPARENT)
+    {
+      parent = clk->parent;
+      if (clk->flags & CLK_SET_RATE_PARENT)
+        {
+          best = clk_round_rate(parent, rate);
+        }
+      else if (parent)
+        {
+          best = clk_get_rate(parent);
+        }
+      else
+        {
+          best = clk_get_rate(clk);
+        }
+
+      goto out;
+    }
+
+  num_parents = clk->num_parents;
+  for (i = 0; i < num_parents; i++)
+    {
+      parent = clk_get_parent_by_index(clk, i);
+      if (!parent)
+        {
+          continue;
+        }
+
+      if (clk->flags & CLK_SET_RATE_PARENT)
+        {
+          parent_rate = clk_round_rate(parent, rate);
+        }
+
+      else
+        {
+          parent_rate = clk_get_rate(parent);
+        }
+
+      if (mux_is_better_rate(rate, parent_rate, best, mux->flags))
+        {
+          best_parent = parent;
+          best = parent_rate;
+        }
+    }
+
+out:
+  if (best_parent)
+    {
+      *best_parent_p = best_parent;
+    }
+
+  *best_parent_rate = best;
+
+  return best;
+}
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+const struct clk_ops_s g_clk_mux_ops =
+{
+  .get_parent = clk_mux_get_parent,
+  .set_parent = clk_mux_set_parent,
+  .determine_rate = clk_mux_determine_rate,
+};
+
+const struct clk_ops_s g_clk_mux_ro_ops =
+{
+  .get_parent = clk_mux_get_parent,
+};
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+FAR struct clk_s *clk_register_mux(FAR const char *name,
+                                   const char * const *parent_names,
+                                   uint8_t num_parents,
+                                   uint8_t flags, uint32_t reg,
+                                   uint8_t shift, uint8_t width,
+                                   uint8_t clk_mux_flags)
+{
+  struct clk_mux_s mux;
+
+  mux.reg   = reg;
+  mux.shift = shift;
+  mux.width = width;
+  mux.flags = clk_mux_flags;
+
+  if (clk_mux_flags & CLK_MUX_READ_ONLY)
+    {
+      return clk_register(name, parent_names, num_parents, flags,
+                          &g_clk_mux_ro_ops, &mux, sizeof(mux));
+    }
+  else
+    {
+      return clk_register(name, parent_names, num_parents, flags,
+                          &g_clk_mux_ops, &mux, sizeof(mux));
+    }
+}

--- a/drivers/clk/clk_phase.c
+++ b/drivers/clk/clk_phase.c
@@ -1,0 +1,111 @@
+/****************************************************************************
+ * drivers/clk/clk_phase.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/clk/clk_provider.h>
+
+#include "clk.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define to_clk_phase(_clk) (FAR struct clk_phase_s *)(_clk->private_data)
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+static int clk_phase_get_phase(FAR struct clk_s *clk)
+{
+  FAR struct clk_phase_s *phase = to_clk_phase(clk);
+  uint32_t val;
+
+  val = (clk_read(phase->reg) >> phase->shift) & MASK(phase->width);
+  return DIV_ROUND_CLOSEST(360 * val, MASK(phase->width) + 1);
+}
+
+static int clk_phase_set_phase(FAR struct clk_s *clk, int degrees)
+{
+  FAR struct clk_phase_s *phase = to_clk_phase(clk);
+  uint32_t pha;
+  uint32_t val;
+
+  pha = DIV_ROUND_CLOSEST((MASK(phase->width) + 1) * degrees, 360);
+
+  if (pha > MASK(phase->width))
+    {
+      pha = MASK(phase->width);
+    }
+
+  if (phase->flags & CLK_PHASE_HIWORD_MASK)
+    {
+      val = MASK(phase->width) << (phase->shift + 16);
+    }
+  else
+    {
+      val = clk_read(phase->reg);
+      val &= ~(MASK(phase->width) << phase->shift);
+    }
+
+  val |= pha << phase->shift;
+  clk_write(phase->reg, val);
+
+  return 0;
+}
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+const struct clk_ops_s g_clk_phase_ops =
+{
+  .get_phase = clk_phase_get_phase,
+  .set_phase = clk_phase_set_phase,
+};
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+FAR struct clk_s *clk_register_phase(FAR const char *name,
+                                     FAR const char *parent_name,
+                                     uint8_t flags, uint32_t reg,
+                                     uint8_t shift, uint8_t width,
+                                     uint8_t clk_phase_flags)
+{
+  struct clk_phase_s phase;
+  FAR const char **parent_names;
+  uint8_t num_parents;
+
+  parent_names = parent_name ? &parent_name : NULL;
+  num_parents = parent_name ? 1 : 0;
+
+  phase.reg = reg;
+  phase.shift = shift;
+  phase.width = width;
+  phase.flags = clk_phase_flags;
+
+  return clk_register(name, parent_names, num_parents, flags,
+                      &g_clk_phase_ops, &phase, sizeof(phase));
+}

--- a/drivers/clk/clk_rpmsg.c
+++ b/drivers/clk/clk_rpmsg.c
@@ -1,0 +1,853 @@
+/****************************************************************************
+ * drivers/clk/clk_rpmsg.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <string.h>
+
+#include <nuttx/clk/clk.h>
+#include <nuttx/clk/clk_provider.h>
+#include <nuttx/kmalloc.h>
+#include <nuttx/mutex.h>
+#include <nuttx/rptun/openamp.h>
+#include <nuttx/semaphore.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define CLK_RPMSG_EPT_NAME          "rpmsg-clk"
+
+#define CLK_RPMSG_ENABLE            0
+#define CLK_RPMSG_DISABLE           1
+#define CLK_RPMSG_SETRATE           2
+#define CLK_RPMSG_SETPHASE          3
+#define CLK_RPMSG_GETPHASE          4
+#define CLK_RPMSG_GETRATE           5
+#define CLK_RPMSG_ROUNDRATE         6
+#define CLK_RPMSG_ISENABLED         7
+
+#ifndef ARRAY_SIZE
+#  define ARRAY_SIZE(x)             (sizeof(x) / sizeof((x)[0]))
+#endif
+
+/****************************************************************************
+ * Private Types
+ ****************************************************************************/
+
+struct clk_rpmsg_priv_s
+{
+  struct rpmsg_endpoint     ept;
+  struct list_node          clk_list;
+  struct list_node          node;
+  FAR const char            *cpuname;
+};
+
+struct clk_rpmsg_s
+{
+  FAR struct clk_s          *clk;
+  uint32_t                  count;
+  struct list_node          node;
+};
+
+struct clk_rpmsg_cookie_s
+{
+  sem_t                     sem;
+  int64_t                   result;
+};
+
+begin_packed_struct struct clk_rpmsg_header_s
+{
+  uint32_t                  command;
+  uint32_t                  response;
+  int64_t                   result;
+  uint64_t                  cookie;
+} end_packed_struct;
+
+begin_packed_struct struct clk_rpmsg_enable_s
+{
+  struct clk_rpmsg_header_s header;
+  char                      name[0];
+} end_packed_struct;
+
+#define clk_rpmsg_disable_s clk_rpmsg_enable_s
+#define clk_rpmsg_isenabled_s clk_rpmsg_enable_s
+
+begin_packed_struct struct clk_rpmsg_setrate_s
+{
+  struct clk_rpmsg_header_s header;
+  uint64_t                  rate;
+  char                      name[0];
+} end_packed_struct;
+
+#define clk_rpmsg_getrate_s clk_rpmsg_enable_s
+#define clk_rpmsg_roundrate_s clk_rpmsg_setrate_s
+
+begin_packed_struct struct clk_rpmsg_setphase_s
+{
+  struct clk_rpmsg_header_s header;
+  int32_t                   degrees;
+  char                      name[0];
+} end_packed_struct;
+
+#define clk_rpmsg_getphase_s clk_rpmsg_enable_s
+
+/****************************************************************************
+ * Private Function Prototypes
+ ****************************************************************************/
+
+static FAR struct clk_rpmsg_priv_s *clk_rpmsg_get_priv(FAR const char *name);
+static FAR struct rpmsg_endpoint *clk_rpmsg_get_ept(FAR const char **name);
+static FAR struct clk_rpmsg_s *
+clk_rpmsg_get_clk(FAR struct rpmsg_endpoint *ept,
+                  FAR const char *name);
+
+static int clk_rpmsg_enable_handler(FAR struct rpmsg_endpoint *ept,
+                                    FAR void *data, size_t len,
+                                    uint32_t src, FAR void *priv);
+static int clk_rpmsg_disable_handler(FAR struct rpmsg_endpoint *ept,
+                                     FAR void *data, size_t len,
+                                     uint32_t src, FAR void *priv);
+static int clk_rpmsg_getrate_handler(FAR struct rpmsg_endpoint *ept,
+                                     FAR void *data, size_t len,
+                                     uint32_t src, FAR void *priv);
+static int clk_rpmsg_roundrate_handler(FAR struct rpmsg_endpoint *ept,
+                                       FAR void *data, size_t len,
+                                       uint32_t src, FAR void *priv);
+static int clk_rpmsg_setrate_handler(FAR struct rpmsg_endpoint *ept,
+                                     FAR void *data, size_t len,
+                                     uint32_t src, FAR void *priv);
+static int clk_rpmsg_setphase_handler(FAR struct rpmsg_endpoint *ept,
+                                     FAR void *data, size_t len,
+                                     uint32_t src, FAR void *priv);
+static int clk_rpmsg_getphase_handler(FAR struct rpmsg_endpoint *ept,
+                                     FAR void *data, size_t len,
+                                     uint32_t src, FAR void *priv);
+static int clk_rpmsg_isenabled_handler(FAR struct rpmsg_endpoint *ept,
+                                       FAR void *data, size_t len,
+                                       uint32_t src, FAR void *priv);
+
+static void clk_rpmsg_device_created(FAR struct rpmsg_device *rdev,
+                                     FAR void *priv_);
+static void clk_rpmsg_device_destroy(FAR struct rpmsg_device *rdev,
+                                     FAR void *priv_);
+
+static int clk_rpmsg_ept_cb(FAR struct rpmsg_endpoint *ept,
+                            FAR void *data, size_t len,
+                            uint32_t src, FAR void *priv);
+
+static int64_t clk_rpmsg_sendrecv(FAR struct rpmsg_endpoint *ept,
+                                  uint32_t command,
+                                  FAR struct clk_rpmsg_header_s *msg,
+                                  int32_t len);
+
+static int clk_rpmsg_enable(FAR struct clk_s *clk);
+static void clk_rpmsg_disable(FAR struct clk_s *clk);
+static int clk_rpmsg_is_enabled(FAR struct clk_s *clk);
+static uint32_t clk_rpmsg_round_rate(FAR struct clk_s *clk, uint32_t rate,
+                                     FAR uint32_t *parent_rate);
+
+static int clk_rpmsg_set_rate(FAR struct clk_s *clk,
+                              uint32_t rate, uint32_t parent_rate);
+static uint32_t clk_rpmsg_recalc_rate(FAR struct clk_s *clk,
+                                      uint32_t parent_rate);
+static int clk_rpmsg_get_phase(FAR struct clk_s *clk);
+static int clk_rpmsg_set_phase(FAR struct clk_s *clk, int degrees);
+
+/****************************************************************************
+ * Private Datas
+ ****************************************************************************/
+
+static mutex_t g_clk_rpmsg_lock          = MUTEX_INITIALIZER;
+static struct list_node g_clk_rpmsg_priv =
+              LIST_INITIAL_VALUE(g_clk_rpmsg_priv);
+
+static const rpmsg_ept_cb g_clk_rpmsg_handler[] =
+{
+  [CLK_RPMSG_ENABLE]    = clk_rpmsg_enable_handler,
+  [CLK_RPMSG_DISABLE]   = clk_rpmsg_disable_handler,
+  [CLK_RPMSG_SETRATE]   = clk_rpmsg_setrate_handler,
+  [CLK_RPMSG_SETPHASE]  = clk_rpmsg_setphase_handler,
+  [CLK_RPMSG_GETPHASE]  = clk_rpmsg_getphase_handler,
+  [CLK_RPMSG_GETRATE]   = clk_rpmsg_getrate_handler,
+  [CLK_RPMSG_ROUNDRATE] = clk_rpmsg_roundrate_handler,
+  [CLK_RPMSG_ISENABLED] = clk_rpmsg_isenabled_handler,
+};
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+static FAR struct clk_rpmsg_priv_s *clk_rpmsg_get_priv(FAR const char *name)
+{
+  FAR struct clk_rpmsg_priv_s *priv;
+
+  nxmutex_lock(&g_clk_rpmsg_lock);
+
+  list_for_every_entry(&g_clk_rpmsg_priv, priv,
+                       struct clk_rpmsg_priv_s, node)
+    {
+      size_t len = strlen(priv->cpuname);
+
+      if (!strncmp(priv->cpuname, name, len) &&
+         (name[len] == '/' || name[len] == 0))
+        {
+          goto out;
+        }
+    }
+
+  priv = NULL;
+
+out:
+  nxmutex_unlock(&g_clk_rpmsg_lock);
+  return priv;
+}
+
+static FAR struct rpmsg_endpoint *clk_rpmsg_get_ept(FAR const char **name)
+{
+  FAR struct clk_rpmsg_priv_s *priv;
+
+  priv = clk_rpmsg_get_priv(*name);
+  if (priv == NULL)
+    {
+      return NULL;
+    }
+
+  *name += strlen(priv->cpuname) + 1;
+
+  return &priv->ept;
+}
+
+static FAR struct clk_rpmsg_s *
+clk_rpmsg_get_clk(FAR struct rpmsg_endpoint *ept, FAR const char *name)
+{
+  FAR struct clk_rpmsg_priv_s *priv = ept->priv;
+  FAR struct list_node *clk_list = &priv->clk_list;
+  FAR struct clk_rpmsg_s *clkrp;
+
+  list_for_every_entry(clk_list, clkrp, struct clk_rpmsg_s, node)
+    {
+      if (!strcmp(clk_get_name(clkrp->clk), name))
+        {
+          return clkrp;
+        }
+    }
+
+  clkrp = kmm_zalloc(sizeof(*clkrp));
+  if (!clkrp)
+    {
+      return NULL;
+    }
+
+  clkrp->clk = clk_get(name);
+  if (!clkrp->clk)
+    {
+      kmm_free(clkrp);
+      return NULL;
+    }
+
+  list_add_head(clk_list, &clkrp->node);
+
+  return clkrp;
+}
+
+static int clk_rpmsg_enable_handler(FAR struct rpmsg_endpoint *ept,
+                                     FAR void *data, size_t len,
+                                     uint32_t src, FAR void *priv)
+{
+  FAR struct clk_rpmsg_enable_s *msg = data;
+  FAR struct clk_rpmsg_s *clkrp = clk_rpmsg_get_clk(ept, msg->name);
+
+  if (clkrp)
+    {
+      msg->header.result = clk_enable(clkrp->clk);
+      if (!msg->header.result)
+        {
+          clkrp->count++;
+        }
+    }
+  else
+    {
+      msg->header.result = -ENOENT;
+    }
+
+  return rpmsg_send(ept, msg, sizeof(*msg));
+}
+
+static int clk_rpmsg_disable_handler(FAR struct rpmsg_endpoint *ept,
+                                     FAR void *data, size_t len,
+                                     uint32_t src, FAR void *priv)
+{
+  FAR struct clk_rpmsg_disable_s *msg = data;
+  FAR struct clk_rpmsg_s *clkrp = clk_rpmsg_get_clk(ept, msg->name);
+
+  if (clkrp)
+    {
+      clk_disable(clkrp->clk);
+      clkrp->count--;
+      msg->header.result = 0;
+    }
+  else
+    {
+      msg->header.result = -ENOENT;
+    }
+
+  return rpmsg_send(ept, msg, sizeof(*msg));
+}
+
+static int clk_rpmsg_getrate_handler(FAR struct rpmsg_endpoint *ept,
+                                     FAR void *data, size_t len,
+                                     uint32_t src, FAR void *priv)
+{
+  FAR struct clk_rpmsg_getrate_s *msg = data;
+  FAR struct clk_rpmsg_s *clkrp = clk_rpmsg_get_clk(ept, msg->name);
+
+  if (clkrp)
+    {
+      msg->header.result = clk_get_rate(clkrp->clk);
+    }
+  else
+    {
+      msg->header.result = -ENOENT;
+    }
+
+  return rpmsg_send(ept, msg, sizeof(*msg));
+}
+
+static int clk_rpmsg_roundrate_handler(FAR struct rpmsg_endpoint *ept,
+                                       FAR void *data, size_t len,
+                                       uint32_t src, FAR void *priv)
+{
+  FAR struct clk_rpmsg_roundrate_s *msg = data;
+  FAR struct clk_rpmsg_s *clkrp = clk_rpmsg_get_clk(ept, msg->name);
+
+  if (clkrp)
+    {
+      msg->header.result = clk_round_rate(clkrp->clk, msg->rate);
+    }
+  else
+    {
+      msg->header.result = -ENOENT;
+    }
+
+  return rpmsg_send(ept, msg, sizeof(*msg));
+}
+
+static int clk_rpmsg_setrate_handler(FAR struct rpmsg_endpoint *ept,
+                                       FAR void *data, size_t len,
+                                       uint32_t src, FAR void *priv)
+{
+  FAR struct clk_rpmsg_setrate_s *msg = data;
+  FAR struct clk_rpmsg_s *clkrp = clk_rpmsg_get_clk(ept, msg->name);
+
+  if (clkrp)
+    {
+      msg->header.result = clk_set_rate(clkrp->clk, msg->rate);
+    }
+  else
+    {
+      msg->header.result = -ENOENT;
+    }
+
+  return rpmsg_send(ept, msg, sizeof(*msg));
+}
+
+static int clk_rpmsg_setphase_handler(FAR struct rpmsg_endpoint *ept,
+                                       FAR void *data, size_t len,
+                                       uint32_t src, FAR void *priv)
+{
+  FAR struct clk_rpmsg_setphase_s *msg = data;
+  FAR struct clk_rpmsg_s *clkrp = clk_rpmsg_get_clk(ept, msg->name);
+
+  if (clkrp)
+    {
+      msg->header.result = clk_set_phase(clkrp->clk, msg->degrees);
+    }
+  else
+    {
+      msg->header.result = -ENOENT;
+    }
+
+  return rpmsg_send(ept, msg, sizeof(*msg));
+}
+
+static int clk_rpmsg_getphase_handler(FAR struct rpmsg_endpoint *ept,
+                                       FAR void *data, size_t len,
+                                       uint32_t src, FAR void *priv)
+{
+  FAR struct clk_rpmsg_getphase_s *msg = data;
+  FAR struct clk_rpmsg_s *clkrp = clk_rpmsg_get_clk(ept, msg->name);
+
+  if (clkrp)
+    {
+      msg->header.result = clk_get_phase(clkrp->clk);
+    }
+  else
+    {
+      msg->header.result = -ENOENT;
+    }
+
+  return rpmsg_send(ept, msg, sizeof(*msg));
+}
+
+static int clk_rpmsg_isenabled_handler(FAR struct rpmsg_endpoint *ept,
+                                       FAR void *data, size_t len,
+                                       uint32_t src, FAR void *priv)
+{
+  FAR struct clk_rpmsg_isenabled_s *msg = data;
+  FAR struct clk_rpmsg_s *clkrp = clk_rpmsg_get_clk(ept, msg->name);
+
+  if (clkrp)
+    {
+      msg->header.result = clk_is_enabled(clkrp->clk);
+    }
+  else
+    {
+      msg->header.result = -ENOENT;
+    }
+
+  return rpmsg_send(ept, msg, sizeof(*msg));
+}
+
+static int64_t clk_rpmsg_sendrecv(FAR struct rpmsg_endpoint *ept,
+                                  uint32_t command,
+                                  FAR struct clk_rpmsg_header_s *msg,
+                                  int32_t len)
+{
+  struct clk_rpmsg_cookie_s cookie;
+  int ret;
+
+  msg->command  = command;
+  msg->response = 0;
+  msg->cookie   = (uintptr_t)&cookie;
+
+  nxsem_init(&cookie.sem, 0, 0);
+  nxsem_set_protocol(&cookie.sem, SEM_PRIO_NONE);
+  cookie.result  = -EIO;
+
+  ret = rpmsg_send_nocopy(ept, msg, len);
+  if (ret < 0)
+    {
+      return ret;
+    }
+
+  ret = nxsem_wait_uninterruptible(&cookie.sem);
+  if (ret < 0)
+    {
+      return ret;
+    }
+
+  return cookie.result;
+}
+
+static void clk_rpmsg_device_created(FAR struct rpmsg_device *rdev,
+                                     FAR void *priv_)
+{
+  struct clk_rpmsg_priv_s *priv;
+  int ret;
+
+  priv = kmm_zalloc(sizeof(struct clk_rpmsg_priv_s));
+  if (!priv)
+    {
+      return;
+    }
+
+  priv->ept.priv = priv;
+  priv->cpuname  = rpmsg_get_cpuname(rdev);
+
+  list_initialize(&priv->clk_list);
+
+  nxmutex_lock(&g_clk_rpmsg_lock);
+  list_add_head(&g_clk_rpmsg_priv, &priv->node);
+  nxmutex_unlock(&g_clk_rpmsg_lock);
+
+  ret = rpmsg_create_ept(&priv->ept, rdev, CLK_RPMSG_EPT_NAME,
+                         RPMSG_ADDR_ANY, RPMSG_ADDR_ANY,
+                         clk_rpmsg_ept_cb, NULL);
+  if (ret)
+    {
+      free(priv);
+    }
+}
+
+static void clk_rpmsg_device_destroy(FAR struct rpmsg_device *rdev,
+                                     FAR void *priv_)
+{
+  struct clk_rpmsg_s *clkrp;
+  struct clk_rpmsg_s *clkrp_tmp;
+  struct clk_rpmsg_priv_s *priv;
+
+  priv = clk_rpmsg_get_priv(rpmsg_get_cpuname(rdev));
+  if (!priv)
+    {
+      return;
+    }
+
+  list_for_every_entry_safe(&priv->clk_list, clkrp, clkrp_tmp,
+                            struct clk_rpmsg_s, node)
+    {
+      while (clkrp->count--)
+        {
+          clk_disable(clkrp->clk);
+        }
+
+      list_delete(&clkrp->node);
+      kmm_free(clkrp);
+    }
+
+  nxmutex_lock(&g_clk_rpmsg_lock);
+  list_delete(&priv->node);
+  nxmutex_unlock(&g_clk_rpmsg_lock);
+
+  rpmsg_destroy_ept(&priv->ept);
+  kmm_free(priv);
+}
+
+static int clk_rpmsg_ept_cb(FAR struct rpmsg_endpoint *ept, FAR void *data,
+                            size_t len, uint32_t src, FAR void *priv)
+{
+  FAR struct clk_rpmsg_header_s *hdr = data;
+  uint32_t cmd = hdr->command;
+  int ret = -EINVAL;
+
+  if (hdr->response)
+    {
+      FAR struct clk_rpmsg_cookie_s *cookie =
+      (struct clk_rpmsg_cookie_s *)(uintptr_t)hdr->cookie;
+      if (cookie)
+        {
+          cookie->result = hdr->result;
+          nxsem_post(&cookie->sem);
+          ret = 0;
+        }
+    }
+  else if (cmd < ARRAY_SIZE(g_clk_rpmsg_handler)
+           && g_clk_rpmsg_handler[cmd])
+    {
+      hdr->response = 1;
+      ret = g_clk_rpmsg_handler[cmd](ept, data, len, src, priv);
+    }
+
+  return ret;
+}
+
+static int clk_rpmsg_enable(FAR struct clk_s *clk)
+{
+  FAR struct rpmsg_endpoint *ept;
+  FAR struct clk_rpmsg_enable_s *msg;
+  FAR const char *name = clk->name;
+  uint32_t size;
+  uint32_t len;
+
+  ept = clk_rpmsg_get_ept(&name);
+  if (!ept)
+    {
+      return -ENODEV;
+    }
+
+  len = sizeof(*msg) + B2C(strlen(name) + 1);
+
+  msg = rpmsg_get_tx_payload_buffer(ept, &size, true);
+  if (!msg)
+    {
+      return -ENOMEM;
+    }
+
+  DEBUGASSERT(len <= size);
+
+  cstr2bstr(msg->name, name);
+
+  return clk_rpmsg_sendrecv(ept, CLK_RPMSG_ENABLE,
+                           (struct clk_rpmsg_header_s *)msg,
+                            len);
+}
+
+static void clk_rpmsg_disable(FAR struct clk_s *clk)
+{
+  FAR struct rpmsg_endpoint *ept;
+  FAR struct clk_rpmsg_disable_s *msg;
+  FAR const char *name = clk->name;
+  uint32_t size;
+  uint32_t len;
+
+  ept = clk_rpmsg_get_ept(&name);
+  if (!ept)
+    {
+    return;
+    }
+
+  len = sizeof(*msg) + B2C(strlen(name) + 1);
+
+  msg = rpmsg_get_tx_payload_buffer(ept, &size, true);
+  if (!msg)
+    {
+      return;
+    }
+
+  DEBUGASSERT(len <= size);
+
+  cstr2bstr(msg->name, name);
+
+  clk_rpmsg_sendrecv(ept, CLK_RPMSG_DISABLE,
+                    (struct clk_rpmsg_header_s *)msg, len);
+}
+
+static int clk_rpmsg_is_enabled(FAR struct clk_s *clk)
+{
+  FAR struct rpmsg_endpoint *ept;
+  FAR struct clk_rpmsg_enable_s *msg;
+  FAR const char *name = clk->name;
+  uint32_t size;
+  uint32_t len;
+
+  ept = clk_rpmsg_get_ept(&name);
+  if (!ept)
+    {
+      return -ENODEV;
+    }
+
+  len = sizeof(*msg) + B2C(strlen(name) + 1);
+
+  msg = rpmsg_get_tx_payload_buffer(ept, &size, true);
+  if (!msg)
+    {
+      return -ENOMEM;
+    }
+
+  DEBUGASSERT(len <= size);
+
+  cstr2bstr(msg->name, name);
+
+  return clk_rpmsg_sendrecv(ept, CLK_RPMSG_ISENABLED,
+                           (struct clk_rpmsg_header_s *)msg, len);
+}
+
+static uint32_t clk_rpmsg_round_rate(FAR struct clk_s *clk, uint32_t rate,
+                                     FAR uint32_t *parent_rate)
+{
+  FAR struct rpmsg_endpoint *ept;
+  FAR struct clk_rpmsg_roundrate_s *msg;
+  FAR const char *name = clk->name;
+  uint32_t size;
+  uint32_t len;
+  int64_t ret;
+
+  ept = clk_rpmsg_get_ept(&name);
+  if (!ept)
+    {
+      return 0;
+    }
+
+  len = sizeof(*msg) + B2C(strlen(name) + 1);
+
+  msg = rpmsg_get_tx_payload_buffer(ept, &size, true);
+  if (!msg)
+    {
+      return 0;
+    }
+
+  DEBUGASSERT(len <= size);
+
+  msg->rate = rate;
+  cstr2bstr(msg->name, name);
+
+  ret = clk_rpmsg_sendrecv(ept, CLK_RPMSG_ROUNDRATE,
+                          (struct clk_rpmsg_header_s *)msg, len);
+  if (ret < 0)
+    {
+      return 0;
+    }
+
+  return ret;
+}
+
+static int clk_rpmsg_set_rate(FAR struct clk_s *clk, uint32_t rate,
+                              uint32_t parent_rate)
+{
+  FAR struct rpmsg_endpoint *ept;
+  FAR struct clk_rpmsg_setrate_s *msg;
+  FAR const char *name = clk->name;
+  uint32_t size;
+  uint32_t len;
+
+  ept = clk_rpmsg_get_ept(&name);
+  if (!ept)
+    {
+      return -ENODEV;
+    }
+
+  len = sizeof(*msg) + B2C(strlen(name) + 1);
+
+  msg = rpmsg_get_tx_payload_buffer(ept, &size, true);
+  if (!msg)
+    {
+      return -ENOMEM;
+    }
+
+  DEBUGASSERT(len <= size);
+
+  msg->rate = rate;
+  cstr2bstr(msg->name, name);
+
+  return clk_rpmsg_sendrecv(ept, CLK_RPMSG_SETRATE,
+                           (struct clk_rpmsg_header_s *)msg, len);
+}
+
+static uint32_t clk_rpmsg_recalc_rate(FAR struct clk_s *clk,
+                                      uint32_t parent_rate)
+{
+  FAR struct rpmsg_endpoint *ept;
+  FAR struct clk_rpmsg_getrate_s *msg;
+  FAR const char *name = clk->name;
+  uint32_t size;
+  uint32_t len;
+  int64_t ret;
+
+  ept = clk_rpmsg_get_ept(&name);
+  if (!ept)
+    {
+      return 0;
+    }
+
+  len = sizeof(*msg) + B2C(strlen(name) + 1);
+
+  msg = rpmsg_get_tx_payload_buffer(ept, &size, true);
+  if (!msg)
+    {
+      return 0;
+    }
+
+  DEBUGASSERT(len <= size);
+
+  cstr2bstr(msg->name, name);
+
+  ret = clk_rpmsg_sendrecv(ept, CLK_RPMSG_GETRATE,
+                          (struct clk_rpmsg_header_s *)msg, len);
+  if (ret < 0)
+    {
+      return 0;
+    }
+
+  return ret;
+}
+
+static int clk_rpmsg_get_phase(FAR struct clk_s *clk)
+{
+  FAR struct rpmsg_endpoint *ept;
+  FAR struct clk_rpmsg_getphase_s *msg;
+  FAR const char *name = clk->name;
+  uint32_t size;
+  uint32_t len;
+
+  ept = clk_rpmsg_get_ept(&name);
+  if (!ept)
+    {
+      return -ENODEV;
+    }
+
+  len = sizeof(*msg) + B2C(strlen(name) + 1);
+
+  msg = rpmsg_get_tx_payload_buffer(ept, &size, true);
+  if (!msg)
+    {
+      return -ENOMEM;
+    }
+
+  DEBUGASSERT(len <= size);
+
+  cstr2bstr(msg->name, name);
+
+  return clk_rpmsg_sendrecv(ept, CLK_RPMSG_GETPHASE,
+                           (struct clk_rpmsg_header_s *)msg, len);
+}
+
+static int clk_rpmsg_set_phase(FAR struct clk_s *clk, int degrees)
+{
+  FAR struct rpmsg_endpoint *ept;
+  FAR struct clk_rpmsg_setphase_s *msg;
+  FAR const char *name = clk->name;
+  uint32_t size;
+  uint32_t len;
+
+  ept = clk_rpmsg_get_ept(&name);
+  if (!ept)
+    {
+      return -ENODEV;
+    }
+
+  len = sizeof(*msg) + B2C(strlen(name) + 1);
+
+  msg = rpmsg_get_tx_payload_buffer(ept, &size, true);
+  if (!msg)
+    {
+      return -ENOMEM;
+    }
+
+  DEBUGASSERT(len <= size);
+
+  msg->degrees = degrees;
+  cstr2bstr(msg->name, name);
+
+  return clk_rpmsg_sendrecv(ept, CLK_RPMSG_SETPHASE,
+                           (struct clk_rpmsg_header_s *)msg, len);
+}
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+const struct clk_ops_s g_clk_rpmsg_ops =
+{
+  .enable = clk_rpmsg_enable,
+  .disable = clk_rpmsg_disable,
+  .is_enabled = clk_rpmsg_is_enabled,
+  .recalc_rate = clk_rpmsg_recalc_rate,
+  .round_rate = clk_rpmsg_round_rate,
+  .set_rate = clk_rpmsg_set_rate,
+  .set_phase = clk_rpmsg_set_phase,
+  .get_phase = clk_rpmsg_get_phase,
+};
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+FAR struct clk_s *clk_register_rpmsg(FAR const char *name, uint8_t flags)
+{
+  if (strchr(name, '/') == NULL)
+    {
+      return NULL;
+    }
+
+  return clk_register(name, NULL, 0, flags | CLK_IS_CRITICAL,
+                      &g_clk_rpmsg_ops, NULL, 0);
+}
+
+int clk_rpmsg_initialize(void)
+{
+  return rpmsg_register_callback(NULL,
+                                 clk_rpmsg_device_created,
+                                 clk_rpmsg_device_destroy,
+                                 NULL);
+}

--- a/include/nuttx/clk/clk.h
+++ b/include/nuttx/clk/clk.h
@@ -1,0 +1,84 @@
+/****************************************************************************
+ * include/nuttx/clk/clk.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __INCLUDE_NUTTX_CLK_CLK_H
+#define __INCLUDE_NUTTX_CLK_CLK_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <errno.h>
+#include <stdint.h>
+
+/****************************************************************************
+ * Public Types
+ ****************************************************************************/
+
+#ifdef __cplusplus
+#define EXTERN extern "C"
+extern "C"
+{
+#else
+#define EXTERN extern
+#endif
+
+struct clk_s;
+struct clk_ops_s;
+
+struct clk_rate_s
+{
+  FAR const char *name;
+  uint32_t        rate;
+};
+
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
+
+FAR struct clk_s *clk_get(FAR const char *name);
+FAR struct clk_s *clk_get_parent(FAR struct clk_s *clk);
+FAR struct clk_s *clk_get_parent_by_index(FAR struct clk_s *clk,
+                                          uint8_t index);
+
+int clk_set_parent(FAR struct clk_s *clk, FAR struct clk_s *parent);
+int clk_enable(FAR struct clk_s *clk);
+int clk_disable(FAR struct clk_s *clk);
+int clk_is_enabled(FAR struct clk_s *clk);
+
+uint32_t clk_round_rate(FAR struct clk_s *clk, uint32_t rate);
+int      clk_set_rate(FAR struct clk_s *clk, uint32_t rate);
+int      clk_set_rates(FAR const struct clk_rate_s *rates);
+uint32_t clk_get_rate(FAR struct clk_s *clk);
+
+int      clk_set_phase(FAR struct clk_s *clk, int degrees);
+int      clk_get_phase(FAR struct clk_s *clk);
+
+void clk_disable_unused(void);
+FAR const char *clk_get_name(const FAR struct clk_s *clk);
+
+#undef EXTERN
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __INCLUDE_NUTTX_CLK_CLK_H */

--- a/include/nuttx/clk/clk_provider.h
+++ b/include/nuttx/clk/clk_provider.h
@@ -1,0 +1,262 @@
+/****************************************************************************
+ * include/nuttx/clk/clk_provider.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __INCLUDE_NUTTX_CLK_CLK_PROVIDER_H
+#define __INCLUDE_NUTTX_CLK_CLK_PROVIDER_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+#include <nuttx/list.h>
+
+#include <stdint.h>
+#include <stddef.h>
+
+#ifdef CONFIG_CLK
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define CLK_SET_RATE_GATE               0x01
+#define CLK_SET_PARENT_GATE             0x02
+#define CLK_SET_RATE_PARENT             0x04
+#define CLK_SET_RATE_NO_REPARENT        0x08
+#define CLK_GET_RATE_NOCACHE            0x10
+#define CLK_NAME_IS_STATIC              0x20
+#define CLK_PARENT_NAME_IS_STATIC       0x40
+#define CLK_IS_CRITICAL                 0x80
+
+#define CLK_GATE_SET_TO_DISABLE         0x01
+#define CLK_GATE_HIWORD_MASK            0x02
+
+#define CLK_DIVIDER_ONE_BASED           0x01
+#define CLK_DIVIDER_HIWORD_MASK         0x02
+#define CLK_DIVIDER_ROUND_CLOSEST       0x04
+#define CLK_DIVIDER_READ_ONLY           0x08
+#define CLK_DIVIDER_MAX_HALF            0x10
+#define CLK_DIVIDER_DIV_NEED_EVEN       0x20
+#define CLK_DIVIDER_POWER_OF_TWO        0x40
+#define CLK_DIVIDER_MINDIV_OFF          8
+#define CLK_DIVIDER_MINDIV_MSK          0xff00
+
+#define CLK_FRAC_MUL_NEED_EVEN          0x01
+#define CLK_FRAC_DIV_DOUBLE             0x02
+
+#define CLK_MULT_ONE_BASED              0x01
+#define CLK_MULT_ALLOW_ZERO             0x02
+#define CLK_MULT_HIWORD_MASK            0x04
+#define CLK_MULT_MAX_HALF               0x08
+#define CLK_MULT_ROUND_CLOSEST          0x10
+
+#define CLK_MUX_HIWORD_MASK             0x01
+#define CLK_MUX_READ_ONLY               0x02
+#define CLK_MUX_ROUND_CLOSEST           0x04
+
+#define CLK_PHASE_HIWORD_MASK           0x01
+
+/****************************************************************************
+ * Public Types
+ ****************************************************************************/
+
+#undef EXTERN
+#if defined(__cplusplus)
+#  define EXTERN extern "C"
+extern "C"
+{
+#else
+#  define EXTERN extern
+#endif
+
+struct clk_s
+{
+  FAR const char             *name;
+  FAR const struct clk_ops_s *ops;
+  FAR struct clk_s           *parent;
+  uint8_t                     num_parents;
+  uint8_t                     new_parent_index;
+  uint8_t                     enable_count;
+  uint8_t                     flags;
+  uint32_t                    rate;
+  uint32_t                    new_rate;
+  FAR struct clk_s           *new_parent;
+  FAR struct clk_s           *new_child;
+  FAR void                   *private_data;
+  struct list_node            children;
+  struct list_node            node;
+  FAR const char             *parent_names[0];
+};
+
+struct clk_ops_s
+{
+  CODE int       (*enable)(FAR struct clk_s *clk);
+  CODE void      (*disable)(FAR struct clk_s *clk);
+  CODE int       (*is_enabled)(FAR struct clk_s *clk);
+  CODE uint32_t  (*recalc_rate)(FAR struct clk_s *clk, uint32_t parent_rate);
+  CODE uint32_t  (*round_rate)(FAR struct clk_s *clk,
+                               uint32_t rate, uint32_t *parent_rate);
+  CODE uint32_t  (*determine_rate)(FAR struct clk_s *clk, uint32_t rate,
+                                   uint32_t *best_parent_rate,
+                                   struct clk_s **best_parent_clk);
+  CODE int       (*set_parent)(FAR struct clk_s *clk, uint8_t index);
+  CODE uint8_t   (*get_parent)(FAR struct clk_s *clk);
+  CODE int       (*set_rate)(FAR struct clk_s *clk, uint32_t rate,
+                             uint32_t parent_rate);
+  CODE int       (*set_rate_and_parent)(FAR struct clk_s *clk, uint32_t rate,
+                                        uint32_t parent_rate,
+                                        uint8_t index);
+  CODE int       (*get_phase)(FAR struct clk_s *clk);
+  CODE int       (*set_phase)(FAR struct clk_s *clk, int degrees);
+};
+
+struct clk_gate_s
+{
+  uint32_t            reg;
+  uint8_t             bit_idx;
+  uint8_t             flags;
+};
+
+struct clk_fixed_rate_s
+{
+  uint32_t            fixed_rate;
+  uint8_t             flags;
+};
+
+struct clk_fixed_factor_s
+{
+  uint8_t             mult;
+  uint8_t             div;
+};
+
+struct clk_divider_s
+{
+  uint32_t            reg;
+  uint8_t             shift;
+  uint8_t             width;
+  uint16_t            flags;
+};
+
+struct clk_phase_s
+{
+  uint32_t            reg;
+  uint8_t             shift;
+  uint8_t             width;
+  uint8_t             flags;
+};
+
+struct clk_fractional_divider_s
+{
+  uint32_t            reg;
+  uint8_t             mwidth;
+  uint8_t             nwidth;
+  uint8_t             mshift;
+  uint8_t             nshift;
+  uint8_t             flags;
+};
+
+struct clk_multiplier_s
+{
+  uint32_t            reg;
+  uint8_t             shift;
+  uint8_t             width;
+  uint8_t             flags;
+};
+
+struct clk_mux_s
+{
+  uint32_t            reg;
+  uint8_t             width;
+  uint8_t             shift;
+  uint8_t             flags;
+};
+
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
+
+FAR struct clk_s *clk_register(FAR const char *name,
+                               FAR const char * const *parent_names,
+                               uint8_t num_parents, uint8_t flags,
+                               FAR const struct clk_ops_s *ops,
+                               FAR void *private_data, size_t private_size);
+
+FAR struct clk_s *clk_register_gate(FAR const char *name,
+                                    FAR const char *parent_name,
+                                    uint8_t flags, uint32_t reg,
+                                    uint8_t bit_idx,
+                                    uint8_t clk_gate_flags);
+
+FAR struct clk_s *clk_register_fixed_rate(FAR const char *name,
+                                          FAR const char *parent_name,
+                                          uint8_t flags,
+                                          uint32_t fixed_rate);
+
+FAR struct clk_s *clk_register_fixed_factor(FAR const char *name,
+                                            FAR const char *parent_name,
+                                            uint8_t flags, uint8_t mult,
+                                            uint8_t div);
+
+FAR struct clk_s *clk_register_divider(FAR const char *name,
+                                       FAR const char *parent_name,
+                                       uint8_t flags, uint32_t reg,
+                                       uint8_t shift, uint8_t width,
+                                       uint16_t clk_divider_flags);
+
+FAR struct clk_s *clk_register_phase(FAR const char *name,
+                                     FAR const char *parent_name,
+                                     uint8_t flags, uint32_t reg,
+                                     uint8_t shift, uint8_t width,
+                                     uint8_t clk_phase_flags);
+
+FAR struct clk_s *
+clk_register_fractional_divider(FAR const char *name,
+                                FAR const char *parent_name,
+                                uint8_t flags, uint32_t reg,
+                                uint8_t mshift, uint8_t mwidth,
+                                uint8_t nshift, uint8_t nwidth,
+                                uint8_t clk_divider_flags);
+
+FAR struct clk_s *clk_register_multiplier(FAR const char *name,
+                                          FAR const char *parent_name,
+                                          uint8_t flags, uint32_t reg,
+                                          uint8_t shift, uint8_t width,
+                                          uint8_t clk_multiplier_flags);
+
+FAR struct clk_s *clk_register_mux(FAR const char *name,
+                                   const char * const *parent_names,
+                                   uint8_t num_parents, uint8_t flags,
+                                   uint32_t reg, uint8_t shift,
+                                   uint8_t width, uint8_t clk_mux_flags);
+
+#ifdef CONFIG_CLK_RPMSG
+FAR struct clk_s *clk_register_rpmsg(FAR const char *name, uint8_t flags);
+
+int clk_rpmsg_initialize(void);
+#endif
+
+#undef EXTERN
+#if defined(__cplusplus)
+}
+#endif
+
+#endif /* CONFIG_CLK */
+#endif /* __INCLUDE_NUTTX_CLK_CLK_PROVIDER_H */


### PR DESCRIPTION
The clock  framework based on linux driver clock framework,  support base clock drivers and clock management sets. 
And to enable/disable clocks and set clock rate for drivers.

# basic clocks
The framework support many basic hardware clock module, such as  

`divider` 
`clk output = clk_input / divider `

`gate`
`clk output = (on / off )  clk input`

`multiplier `
`clk output = clk_input * multiplier `

 **clk-rpmsg** is  a special clock based on nuttx/openamp framework.
`clk-rpmsg` is fake clock note in local, that operate clocks in remote processor clocks.

These bases clocks can sequential combined to generate new composite clocks.

# API 

Hardware clock module use API in  include/nuttx/clk/clk-provider.h is to register clocks to framework

clk_register_gate
clk_register_fixed_rate
clk_register_divider
clk_register_multiplier

and so on.

the API in  include/nuttx/clk/clk.h is clock consumer API that used by consumers to operates clocks.

clk_get
clk_enable
clk_disable
clk_set_rate
clk_get_rate


# clk procfs

the clk framework support nuttx procfs, thus we can show  clock infomation such as name , rates, phases in procfs  that registered in clock framework.
 
`cat /proc/clks`  show the clock infomation.


Signed-off-by: zhuyanlin <zhuyanlin1@xiaomi.com>

## Summary

## Impact

## Testing

