### PR TITLE
fix overflow checks in mtdpart

### DIFF
--- a/drivers/mtd/mtd_partition.c
+++ b/drivers/mtd/mtd_partition.c
@@ -777,7 +777,6 @@ FAR struct mtd_dev_s *mtd_partition(FAR struct mtd_dev_s *mtd,
   unsigned int blkpererase;
   off_t erasestart;
   off_t eraseend;
-  off_t devblocks;
   int ret;
 
   DEBUGASSERT(mtd);
@@ -815,8 +814,7 @@ FAR struct mtd_dev_s *mtd_partition(FAR struct mtd_dev_s *mtd,
 
   /* Verify that the sub-region is valid for this geometry */
 
-  devblocks = blkpererase * geo.neraseblocks;
-  if (eraseend > devblocks)
+  if (eraseend > geo.neraseblocks)
     {
       ferr("ERROR: sub-region too big\n");
       return NULL;


### PR DESCRIPTION
When creating a partition, compare erase sector partition limits with parent device erase sector count, not write blocks.

## Summary
you can create partitions larger than the parent device

## Impact
this is bad

## Testing
old code did not detect the error on my board

new code does detect the problem
/* BS removed to protect volunteers */