### PR TITLE
Support multiple SST26 devices on the same spi bus

### DIFF
--- a/include/nuttx/mtd/mtd.h
+++ b/include/nuttx/mtd/mtd.h
@@ -493,7 +493,8 @@ FAR struct mtd_dev_s *sst25xx_initialize(FAR struct spi_dev_s *dev);
  *
  ****************************************************************************/
 
-FAR struct mtd_dev_s *sst26_initialize_spi(FAR struct spi_dev_s *dev);
+FAR struct mtd_dev_s *sst26_initialize_spi(FAR struct spi_dev_s *dev,
+                                           uint16_t spi_devid);
 
 /****************************************************************************
  * Name: sst39vf_initialize


### PR DESCRIPTION
## Summary
My crazy board has two SST26 on the same spi bus. Framework for multidevices was not activated in this driver

NOTE: I have reorganized the struct fields to improve natural alignment, by moving large fields at the beginning of the struct. No functional impact.

## Impact
Can now support multiple SST26 devices on a spi bus

## Testing
My two chips are now detected. Your automated test cannot test these drivers.

I ran checkpatch and found no issue.
