### PR TITLE
tools/rp2040: Compile with C++14

### DIFF
--- a/README.md
+++ b/README.md
@@ -537,7 +537,7 @@ if you want to build the sim:
 
   * ELF toolchain (if you want to build modules for CONFIG_LIBC_MODLIB)
 
-    brew install x86_64-elf-gc
+    brew install x86_64-elf-gcc
 
 # INSTALLATION
 

--- a/tools/rp2040/Makefile.host
+++ b/tools/rp2040/Makefile.host
@@ -24,7 +24,7 @@ default: elf2uf2
 
 # Add CFLAGS=-g on the make command line to build debug versions
 
-CFLAGS = -O2
+CFLAGS = -O2 -std=c++14
 CFLAGS += -I$(PICO_SDK_PATH)/src/common/boot_uf2/include
 
 elf2uf2: $(PICO_SDK_PATH)/tools/elf2uf2/main.cpp


### PR DESCRIPTION
## Summary
`tools/rp2040` needs to be compiled with at least C++11 (`CMakeLists.txt` from version 1.1.2 of the SDK uses C++14), but the makefile doesn't specify a version. On macOS, `clang` from the Command Line Tools defaults to an earlier version of C++, which causes the compilation to fail. This changes the makefile to specify `-std=c++14`, which lets the build succeed on macOS. I've also fixed a typo in `README.md` under the 'Using macOS' section.

## Impact
- Building for Raspberry Pi Pico on macOS succeeds
- Typo in 'Using macOS' section of `README.md` is fixed

## Testing
Compiling for Raspberry Pi Pico now works on my macOS 12.0.1 machine, whereas it didn't before.

