### PR TITLE
sched_waitpid:delete debugassert

### DIFF
--- a/sched/sched/sched_waitpid.c
+++ b/sched/sched/sched_waitpid.c
@@ -424,7 +424,6 @@ pid_t nx_waitpid(pid_t pid, int *stat_loc, int options)
               /* Recover the exiting child */
 
               child = group_find_child(rtcb->group, info.si_pid);
-              DEBUGASSERT(child != NULL);
 
               /* Discard the child entry, if we have one */
 


### PR DESCRIPTION
Signed-off-by: anjiahao <anjiahao@xiaomi.com>

## Summary
If a task registers SIGCHLD, uses waitpid(-1)
in the handler, and the task also calls waitpid,
it will fail to delete the child function
## Impact

## Testing

