### PR TITLE
libdsp: Fix compile error with the standard math library

### DIFF
--- a/include/dsp.h
+++ b/include/dsp.h
@@ -70,6 +70,16 @@
 
 /* Some lib constants *******************************************************/
 
+/* These are defined only in the NuttX math library */
+
+#ifndef M_PI_F
+#define M_PI_F    ((float)M_PI)
+#endif
+
+#ifndef M_PI_2_F
+#define M_PI_2_F  ((float)M_PI_2)
+#endif
+
 /* Motor electrical angle is in range 0.0 to 2*PI */
 
 #define MOTOR_ANGLE_E_MAX    (2.0f*M_PI_F)


### PR DESCRIPTION
## Summary

The libdsp uses M_PI_F and M_PI_2_F which are defined only in the NuttX
math library. Fix an compile error when CONFIG_LIBM is disabled and the
other math library is used.

## Impact

none

## Testing

Confirm to pass the following build.
$ ./tools/configure.sh stm32f334-disco:buckboost
$ make menuconfig
(change CONFIG_LIBM from y to n)
$ make
