### PR TITLE
boards/nucleo-f302r8: add 3ph Hall sensor support

### DIFF
--- a/boards/arm/stm32/nucleo-f302r8/src/nucleo-f302r8.h
+++ b/boards/arm/stm32/nucleo-f302r8/src/nucleo-f302r8.h
@@ -77,6 +77,17 @@
 
 #define NUCLEOF302R8_PWMTIMER   1
 
+#ifdef CONFIG_SENSORS_HALL3PHASE
+/* GPIO pins used by the 3-phase Hall effect sensor */
+
+#  define GPIO_HALL_PHA (GPIO_INPUT | GPIO_SPEED_2MHz | \
+                         GPIO_PORTA | GPIO_PIN15)
+#  define GPIO_HALL_PHB (GPIO_INPUT | GPIO_SPEED_2MHz | \
+                         GPIO_PORTB | GPIO_PIN3)
+#  define GPIO_HALL_PHC (GPIO_INPUT | GPIO_SPEED_2MHz | \
+                         GPIO_PORTB | GPIO_PIN10)
+#endif
+
 /****************************************************************************
  * Public Data
  ****************************************************************************/

--- a/boards/arm/stm32/nucleo-f302r8/src/stm32_bringup.c
+++ b/boards/arm/stm32/nucleo-f302r8/src/stm32_bringup.c
@@ -27,6 +27,8 @@
 #include <sys/types.h>
 #include <syslog.h>
 
+#include <stm32.h>
+
 #include <nuttx/board.h>
 
 #ifdef CONFIG_USERLED
@@ -39,6 +41,10 @@
 
 #ifdef CONFIG_SENSORS_QENCODER
 #  include "board_qencoder.h"
+#endif
+
+#ifdef CONFIG_SENSORS_HALL3PHASE
+#  include "board_hall3ph.h"
 #endif
 
 #include "nucleo-f302r8.h"
@@ -139,6 +145,20 @@ int stm32_bringup(void)
     {
       syslog(LOG_ERR,
              "ERROR: Failed to register the qencoder: %d\n",
+             ret);
+      return ret;
+    }
+#endif
+
+#ifdef CONFIG_SENSORS_HALL3PHASE
+  /* Initialize and register the 3-phase Hall effect sensor driver */
+
+  ret = board_hall3ph_initialize(0, GPIO_HALL_PHA, GPIO_HALL_PHB,
+                                 GPIO_HALL_PHC);
+  if (ret != OK)
+    {
+      syslog(LOG_ERR,
+             "ERROR: Failed to register the hall : %d\n",
              ret);
       return ret;
     }


### PR DESCRIPTION
## Summary
boards/nucleo-f302r8: add 3ph Hall sensor support

## Impact

## Testing
example/foc