### PR TITLE
arch/sim/src/sim/up_assert.c: fix implicit declaration warning

### DIFF
--- a/arch/sim/src/sim/up_assert.c
+++ b/arch/sim/src/sim/up_assert.c
@@ -28,6 +28,10 @@
 #include <stdlib.h>
 #include <nuttx/syslog/syslog.h>
 
+#ifdef CONFIG_BOARD_CRASHDUMP
+#  include <nuttx/board.h>
+#endif
+
 #include "up_internal.h"
 
 /****************************************************************************


### PR DESCRIPTION
## Summary
arch/sim/src/sim/up_assert.c: fix implicit declaration warning when CONFIG_BOARD_CRASHDUMP=y
## Impact

## Testing

