### PR TITLE
sched/dumpstack: raise the stack dump level to emergency

### DIFF
--- a/libs/libc/sched/sched_dumpstack.c
+++ b/libs/libc/sched/sched_dumpstack.c
@@ -69,8 +69,7 @@ void sched_dumpstack(pid_t tid)
                       DUMP_FORMAT, DUMP_WIDTH, address[i]);
       if (i == size - 1 || ret % DUMP_LINESIZE == 0)
         {
-          syslog(LOG_INFO, "[BackTrace|%2d|%d]: %s\n",
-                           tid, i / DUMP_NITEM, line);
+          syslog(LOG_EMERG, "backtrace|%2d: %s\n", tid, line);
           ret = 0;
         }
     }


### PR DESCRIPTION
## Summary

sched/dumpstack: raise the stack dump level to emergency

since sometimes dumpstack will be used in extreme situations(eg. assert)

Signed-off-by: chao.an <anchao@xiaomi.com>

## Impact

crash dump/dumpstack

## Testing

dumpstack print:
```
[ EMERG] up_assert: Assertion failed at file:armv8-m/arm_usagefault.c line: 113 task: init
[ EMERG] backtrace|10:  0x2c325bde 0x2c319b98 0x2c3261cc 0x2c316b20 0x2c32699c 0x2c303a50 0x2c326072 0x2c3206ea
[ EMERG] backtrace|10:  0x2c3428cc 0x2c33ed14 0x2c342e8e 0x2c34403a 0x2c344ac0 0x2c319b60 0x2c3080ba

```