### PR TITLE
cortex-m/assert: dump all registers with alias

### DIFF
--- a/arch/arm/src/armv6-m/arm_assert.c
+++ b/arch/arm/src/armv6-m/arm_assert.c
@@ -107,12 +107,14 @@ static inline void up_registerdump(FAR volatile uint32_t *regs)
 
   /* Dump the interrupt registers */
 
-  _alert("R0: %08x %08x %08x %08x %08x %08x %08x %08x\n",
-        regs[REG_R0], regs[REG_R1], regs[REG_R2], regs[REG_R3],
-        regs[REG_R4], regs[REG_R5], regs[REG_R6], regs[REG_R7]);
-  _alert("R8: %08x %08x %08x %08x %08x %08x %08x %08x\n",
-        regs[REG_R8],  regs[REG_R9],  regs[REG_R10], regs[REG_R11],
-        regs[REG_R12], regs[REG_R13], regs[REG_R14], regs[REG_R15]);
+  _alert("R0: %08x R1: %08x R2: %08x  R3: %08x\n",
+         regs[REG_R0], regs[REG_R1], regs[REG_R2], regs[REG_R3]);
+  _alert("R4: %08x R5: %08x R6: %08x  FP: %08x\n",
+         regs[REG_R4], regs[REG_R5], regs[REG_R6], regs[REG_R7]);
+  _alert("R8: %08x SB: %08x SL: %08x R11: %08x\n",
+         regs[REG_R8], regs[REG_R9], regs[REG_R10], regs[REG_R11]);
+  _alert("IP: %08x SP: %08x LR: %08x  PC: %08x\n",
+         regs[REG_R12], regs[REG_R13], regs[REG_R14], regs[REG_R15]);
 #ifdef CONFIG_BUILD_PROTECTED
   _alert("xPSR: %08x PRIMASK: %08x EXEC_RETURN: %08x\n",
         regs[REG_XPSR], regs[REG_PRIMASK], regs[REG_EXC_RETURN]);

--- a/arch/arm/src/armv7-m/arm_assert.c
+++ b/arch/arm/src/armv7-m/arm_assert.c
@@ -110,12 +110,14 @@ static inline void up_registerdump(FAR volatile uint32_t *regs)
 
   /* Dump the interrupt registers */
 
-  _alert("R0: %08x %08x %08x %08x %08x %08x %08x %08x\n",
-        regs[REG_R0], regs[REG_R1], regs[REG_R2], regs[REG_R3],
-        regs[REG_R4], regs[REG_R5], regs[REG_R6], regs[REG_R7]);
-  _alert("R8: %08x %08x %08x %08x %08x %08x %08x %08x\n",
-        regs[REG_R8],  regs[REG_R9],  regs[REG_R10], regs[REG_R11],
-        regs[REG_R12], regs[REG_R13], regs[REG_R14], regs[REG_R15]);
+  _alert("R0: %08x R1: %08x R2: %08x  R3: %08x\n",
+         regs[REG_R0], regs[REG_R1], regs[REG_R2], regs[REG_R3]);
+  _alert("R4: %08x R5: %08x R6: %08x  FP: %08x\n",
+         regs[REG_R4], regs[REG_R5], regs[REG_R6], regs[REG_R7]);
+  _alert("R8: %08x SB: %08x SL: %08x R11: %08x\n",
+         regs[REG_R8], regs[REG_R9], regs[REG_R10], regs[REG_R11]);
+  _alert("IP: %08x SP: %08x LR: %08x  PC: %08x\n",
+         regs[REG_R12], regs[REG_R13], regs[REG_R14], regs[REG_R15]);
 
 #ifdef CONFIG_ARMV7M_USEBASEPRI
   _alert("xPSR: %08x BASEPRI: %08x CONTROL: %08x\n",
@@ -125,7 +127,7 @@ static inline void up_registerdump(FAR volatile uint32_t *regs)
         regs[REG_XPSR], regs[REG_PRIMASK], getcontrol());
 #endif
 
-#ifdef REG_EXC_RETURN
+#ifdef CONFIG_BUILD_PROTECTED
   _alert("EXC_RETURN: %08x\n", regs[REG_EXC_RETURN]);
 #endif
 }

--- a/arch/arm/src/armv8-m/arm_assert.c
+++ b/arch/arm/src/armv8-m/arm_assert.c
@@ -110,12 +110,14 @@ static inline void up_registerdump(FAR volatile uint32_t *regs)
 
   /* Dump the interrupt registers */
 
-  _alert("R0: %08x %08x %08x %08x %08x %08x %08x %08x\n",
-        regs[REG_R0], regs[REG_R1], regs[REG_R2], regs[REG_R3],
-        regs[REG_R4], regs[REG_R5], regs[REG_R6], regs[REG_R7]);
-  _alert("R8: %08x %08x %08x %08x %08x %08x %08x %08x\n",
-        regs[REG_R8],  regs[REG_R9],  regs[REG_R10], regs[REG_R11],
-        regs[REG_R12], regs[REG_R13], regs[REG_R14], regs[REG_R15]);
+  _alert("R0: %08x R1: %08x R2: %08x  R3: %08x\n",
+         regs[REG_R0], regs[REG_R1], regs[REG_R2], regs[REG_R3]);
+  _alert("R4: %08x R5: %08x R6: %08x  FP: %08x\n",
+         regs[REG_R4], regs[REG_R5], regs[REG_R6], regs[REG_R7]);
+  _alert("R8: %08x SB: %08x SL: %08x R11: %08x\n",
+         regs[REG_R8], regs[REG_R9], regs[REG_R10], regs[REG_R11]);
+  _alert("IP: %08x SP: %08x LR: %08x  PC: %08x\n",
+         regs[REG_R12], regs[REG_R13], regs[REG_R14], regs[REG_R15]);
 
 #ifdef CONFIG_ARMV8M_USEBASEPRI
   _alert("xPSR: %08x BASEPRI: %08x CONTROL: %08x\n",
@@ -125,7 +127,7 @@ static inline void up_registerdump(FAR volatile uint32_t *regs)
         regs[REG_XPSR], regs[REG_PRIMASK], getcontrol());
 #endif
 
-#ifdef REG_EXC_RETURN
+#ifdef CONFIG_BUILD_PROTECTED
   _alert("EXC_RETURN: %08x\n", regs[REG_EXC_RETURN]);
 #endif
 }


### PR DESCRIPTION
## Summary

cortex-m/assert: dump all registers with alias

print the register with aliases directly is more friendly to novices who are not familiar with the arm environment

## Impact

N/A

## Testing

```
[ EMERG] [ap] up_registerdump: R0: ffffffff R1: 00000000 R2: ffffffff  R3: 00000000
[ EMERG] [ap] up_registerdump: R4: 3c321cd0 R5: ffffffff R6: 00000000  FP: 3c321b50
[ EMERG] [ap] up_registerdump: R8: 3c321bb8 SB: 00000002 SL: 2c477300 R11: 3c3214b8
[ EMERG] [ap] up_registerdump: IP: feff766c SP: 3c321b50 LR: 2c3cc801  PC: 2c3f3dd8
[ EMERG] [ap] up_registerdump: xPSR: 61000000 BASEPRI: 000000e0 CONTROL: 00000004
```
