### PR TITLE
arm/cortex-m: enhance the crash dump

### DIFF
--- a/arch/arm/src/armv7-m/arm_assert.c
+++ b/arch/arm/src/armv7-m/arm_assert.c
@@ -137,40 +137,90 @@ static inline void up_registerdump(FAR volatile uint32_t *regs)
  * Name: up_taskdump
  ****************************************************************************/
 
-#if defined(CONFIG_STACK_COLORATION) || defined(CONFIG_SCHED_BACKTRACE)
-static void up_taskdump(FAR struct tcb_s *tcb, FAR void *arg)
+static void up_dump_task(FAR struct tcb_s *tcb, FAR void *arg)
 {
+#ifdef CONFIG_STACK_COLORATION
+  uint32_t stack_filled = 0;
+  uint32_t stack_used;
+#endif
+#ifdef CONFIG_SCHED_CPULOAD
+  struct cpuload_s cpuload;
+  uint32_t fracpart;
+  uint32_t intpart;
+  uint32_t tmp;
+
+  clock_cpuload(tcb->pid, &cpuload);
+
+  if (cpuload.total > 0)
+    {
+      tmp      = (1000 * cpuload.active) / cpuload.total;
+      intpart  = tmp / 10;
+      fracpart = tmp - 10 * intpart;
+    }
+  else
+    {
+      intpart  = 0;
+      fracpart = 0;
+    }
+#endif
+
+#ifdef CONFIG_STACK_COLORATION
+  stack_used = up_check_tcbstack(tcb);
+  if (tcb->adj_stack_size > 0 && stack_used > 0)
+    {
+      /* Use fixed-point math with one decimal place */
+
+      stack_filled = 10 * 100 * stack_used / tcb->adj_stack_size;
+    }
+#endif
+
   /* Dump interesting properties of this task */
 
-  _alert(
-#if CONFIG_TASK_NAME_SIZE > 0
-         "%s: "
-#endif
-         "PID=%d "
+  _alert("  %4d   %4d"
 #ifdef CONFIG_STACK_COLORATION
-         "Stack Used=%lu of %lu\n",
-#else
-         "Stack=%lu\n",
+         "   %7lu"
+#endif
+         "   %7lu"
+#ifdef CONFIG_STACK_COLORATION
+         "   %3" PRId32 ".%1" PRId32 "%%%c"
+#endif
+#ifdef CONFIG_SCHED_CPULOAD
+         "   %3" PRId32 ".%01" PRId32 "%%"
 #endif
 #if CONFIG_TASK_NAME_SIZE > 0
-        tcb->name,
+         "   %s"
 #endif
-        tcb->pid,
+         "\n",
+         tcb->pid, tcb->sched_priority,
 #ifdef CONFIG_STACK_COLORATION
-        (unsigned long)up_check_tcbstack(tcb),
+         (unsigned long)up_check_tcbstack(tcb),
 #endif
-        (unsigned long)tcb->adj_stack_size);
+         (unsigned long)tcb->adj_stack_size
+#ifdef CONFIG_STACK_COLORATION
+        , stack_filled / 10, stack_filled % 10,
+        (stack_filled >= 10 * 80 ? '!' : ' ')
+#endif
+#ifdef CONFIG_SCHED_CPULOAD
+        , intpart, fracpart
+#endif
+#if CONFIG_TASK_NAME_SIZE > 0
+        , tcb->name
+#endif
+        );
+}
 
-  /* Show back trace */
+/****************************************************************************
+ * Name: up_dump_backtrace
+ ****************************************************************************/
 
 #ifdef CONFIG_SCHED_BACKTRACE
+static void up_dump_backtrace(FAR struct tcb_s *tcb, FAR void *arg)
+{
+  /* Show back trace */
+
   sched_dumpstack(tcb->pid);
-#endif
-
-  /* Dump the registers */
-
-  up_registerdump(tcb->xcp.regs);
 }
+#endif
 
 /****************************************************************************
  * Name: up_showtasks
@@ -178,13 +228,71 @@ static void up_taskdump(FAR struct tcb_s *tcb, FAR void *arg)
 
 static inline void up_showtasks(void)
 {
+#if CONFIG_ARCH_INTERRUPTSTACK > 7
+#  ifdef CONFIG_STACK_COLORATION
+  uint32_t stack_used = up_check_intstack();
+  uint32_t stack_filled = 0;
+
+  if ((CONFIG_ARCH_INTERRUPTSTACK & ~7) > 0 && stack_used > 0)
+    {
+      /* Use fixed-point math with one decimal place */
+
+      stack_filled = 10 * 100 *
+                     stack_used / (CONFIG_ARCH_INTERRUPTSTACK & ~7);
+    }
+#  endif
+#endif
+
   /* Dump interesting properties of each task in the crash environment */
 
-  nxsched_foreach(up_taskdump, NULL);
-}
-#else
-#  define up_showtasks()
+  _alert("   PID    PRI"
+#ifdef CONFIG_STACK_COLORATION
+         "      USED"
 #endif
+         "     STACK"
+#ifdef CONFIG_STACK_COLORATION
+         "   FILLED "
+#endif
+#ifdef CONFIG_SCHED_CPULOAD
+         "      CPU"
+#endif
+#if CONFIG_TASK_NAME_SIZE > 0
+         "   COMMAND"
+#endif
+         "\n");
+
+#if CONFIG_ARCH_INTERRUPTSTACK > 7
+  _alert("  ----   ----"
+#  ifdef CONFIG_STACK_COLORATION
+         "   %7lu"
+#  endif
+         "   %7lu"
+#  ifdef CONFIG_STACK_COLORATION
+         "   %3" PRId32 ".%1" PRId32 "%%%c"
+#  endif
+#  ifdef CONFIG_SCHED_CPULOAD
+         "     ----"
+#  endif
+#  if CONFIG_TASK_NAME_SIZE > 0
+         "   irq"
+#  endif
+         "\n"
+#  ifdef CONFIG_STACK_COLORATION
+         , (unsigned long)stack_used
+#  endif
+         , (unsigned long)(CONFIG_ARCH_INTERRUPTSTACK & ~7)
+#  ifdef CONFIG_STACK_COLORATION
+         , stack_filled / 10, stack_filled % 10,
+         (stack_filled >= 10 * 80 ? '!' : ' ')
+#  endif
+        );
+#endif
+
+  nxsched_foreach(up_dump_task, NULL);
+#ifdef CONFIG_SCHED_BACKTRACE
+  nxsched_foreach(up_dump_backtrace, NULL);
+#endif
+}
 
 /****************************************************************************
  * Name: assert_tracecallback
@@ -257,9 +365,6 @@ static void up_dumpstate(void)
   _alert("IRQ stack:\n");
   _alert("  base: %08x\n", istackbase);
   _alert("  size: %08x\n", istacksize);
-#ifdef CONFIG_STACK_COLORATION
-  _alert("  used: %08x\n", up_check_intstack());
-#endif
 
   /* Does the current stack pointer lie within the interrupt
    * stack?
@@ -291,9 +396,6 @@ static void up_dumpstate(void)
   _alert("User stack:\n");
   _alert("  base: %08x\n", ustackbase);
   _alert("  size: %08x\n", ustacksize);
-#ifdef CONFIG_STACK_COLORATION
-  _alert("  used: %08x\n", up_check_tcbstack(rtcb));
-#endif
 
   /* Dump the user stack if the stack pointer lies within the allocated user
    * stack memory.
@@ -316,9 +418,6 @@ static void up_dumpstate(void)
   _alert("sp:         %08x\n", sp);
   _alert("stack base: %08x\n", ustackbase);
   _alert("stack size: %08x\n", ustacksize);
-#ifdef CONFIG_STACK_COLORATION
-  _alert("stack used: %08x\n", up_check_tcbstack(rtcb));
-#endif
 
   /* Dump the user stack if the stack pointer lies within the allocated user
    * stack memory.

--- a/arch/arm/src/armv8-m/arm_assert.c
+++ b/arch/arm/src/armv8-m/arm_assert.c
@@ -137,40 +137,90 @@ static inline void up_registerdump(FAR volatile uint32_t *regs)
  * Name: up_taskdump
  ****************************************************************************/
 
-#if defined(CONFIG_STACK_COLORATION) || defined(CONFIG_SCHED_BACKTRACE)
-static void up_taskdump(FAR struct tcb_s *tcb, FAR void *arg)
+static void up_dump_task(FAR struct tcb_s *tcb, FAR void *arg)
 {
+#ifdef CONFIG_STACK_COLORATION
+  uint32_t stack_filled = 0;
+  uint32_t stack_used;
+#endif
+#ifdef CONFIG_SCHED_CPULOAD
+  struct cpuload_s cpuload;
+  uint32_t fracpart;
+  uint32_t intpart;
+  uint32_t tmp;
+
+  clock_cpuload(tcb->pid, &cpuload);
+
+  if (cpuload.total > 0)
+    {
+      tmp      = (1000 * cpuload.active) / cpuload.total;
+      intpart  = tmp / 10;
+      fracpart = tmp - 10 * intpart;
+    }
+  else
+    {
+      intpart  = 0;
+      fracpart = 0;
+    }
+#endif
+
+#ifdef CONFIG_STACK_COLORATION
+  stack_used = up_check_tcbstack(tcb);
+  if (tcb->adj_stack_size > 0 && stack_used > 0)
+    {
+      /* Use fixed-point math with one decimal place */
+
+      stack_filled = 10 * 100 * stack_used / tcb->adj_stack_size;
+    }
+#endif
+
   /* Dump interesting properties of this task */
 
-  _alert(
-#if CONFIG_TASK_NAME_SIZE > 0
-         "%s: "
-#endif
-         "PID=%d "
+  _alert("  %4d   %4d"
 #ifdef CONFIG_STACK_COLORATION
-         "Stack Used=%lu of %lu\n",
-#else
-         "Stack=%lu\n",
+         "   %7lu"
+#endif
+         "   %7lu"
+#ifdef CONFIG_STACK_COLORATION
+         "   %3" PRId32 ".%1" PRId32 "%%%c"
+#endif
+#ifdef CONFIG_SCHED_CPULOAD
+         "   %3" PRId32 ".%01" PRId32 "%%"
 #endif
 #if CONFIG_TASK_NAME_SIZE > 0
-        tcb->name,
+         "   %s"
 #endif
-        tcb->pid,
+         "\n",
+         tcb->pid, tcb->sched_priority,
 #ifdef CONFIG_STACK_COLORATION
-        (unsigned long)up_check_tcbstack(tcb),
+         (unsigned long)up_check_tcbstack(tcb),
 #endif
-        (unsigned long)tcb->adj_stack_size);
+         (unsigned long)tcb->adj_stack_size
+#ifdef CONFIG_STACK_COLORATION
+        , stack_filled / 10, stack_filled % 10,
+        (stack_filled >= 10 * 80 ? '!' : ' ')
+#endif
+#ifdef CONFIG_SCHED_CPULOAD
+        , intpart, fracpart
+#endif
+#if CONFIG_TASK_NAME_SIZE > 0
+        , tcb->name
+#endif
+        );
+}
 
-  /* Show back trace */
+/****************************************************************************
+ * Name: up_dump_backtrace
+ ****************************************************************************/
 
 #ifdef CONFIG_SCHED_BACKTRACE
+static void up_dump_backtrace(FAR struct tcb_s *tcb, FAR void *arg)
+{
+  /* Show back trace */
+
   sched_dumpstack(tcb->pid);
-#endif
-
-  /* Dump the registers */
-
-  up_registerdump(tcb->xcp.regs);
 }
+#endif
 
 /****************************************************************************
  * Name: up_showtasks
@@ -178,13 +228,71 @@ static void up_taskdump(FAR struct tcb_s *tcb, FAR void *arg)
 
 static inline void up_showtasks(void)
 {
+#if CONFIG_ARCH_INTERRUPTSTACK > 7
+#  ifdef CONFIG_STACK_COLORATION
+  uint32_t stack_used = up_check_intstack();
+  uint32_t stack_filled = 0;
+
+  if ((CONFIG_ARCH_INTERRUPTSTACK & ~7) > 0 && stack_used > 0)
+    {
+      /* Use fixed-point math with one decimal place */
+
+      stack_filled = 10 * 100 *
+                     stack_used / (CONFIG_ARCH_INTERRUPTSTACK & ~7);
+    }
+#  endif
+#endif
+
   /* Dump interesting properties of each task in the crash environment */
 
-  nxsched_foreach(up_taskdump, NULL);
-}
-#else
-#  define up_showtasks()
+  _alert("   PID    PRI"
+#ifdef CONFIG_STACK_COLORATION
+         "      USED"
 #endif
+         "     STACK"
+#ifdef CONFIG_STACK_COLORATION
+         "   FILLED "
+#endif
+#ifdef CONFIG_SCHED_CPULOAD
+         "      CPU"
+#endif
+#if CONFIG_TASK_NAME_SIZE > 0
+         "   COMMAND"
+#endif
+         "\n");
+
+#if CONFIG_ARCH_INTERRUPTSTACK > 7
+  _alert("  ----   ----"
+#  ifdef CONFIG_STACK_COLORATION
+         "   %7lu"
+#  endif
+         "   %7lu"
+#  ifdef CONFIG_STACK_COLORATION
+         "   %3" PRId32 ".%1" PRId32 "%%%c"
+#  endif
+#  ifdef CONFIG_SCHED_CPULOAD
+         "     ----"
+#  endif
+#  if CONFIG_TASK_NAME_SIZE > 0
+         "   irq"
+#  endif
+         "\n"
+#  ifdef CONFIG_STACK_COLORATION
+         , (unsigned long)stack_used
+#  endif
+         , (unsigned long)(CONFIG_ARCH_INTERRUPTSTACK & ~7)
+#  ifdef CONFIG_STACK_COLORATION
+         , stack_filled / 10, stack_filled % 10,
+         (stack_filled >= 10 * 80 ? '!' : ' ')
+#  endif
+        );
+#endif
+
+  nxsched_foreach(up_dump_task, NULL);
+#ifdef CONFIG_SCHED_BACKTRACE
+  nxsched_foreach(up_dump_backtrace, NULL);
+#endif
+}
 
 /****************************************************************************
  * Name: assert_tracecallback
@@ -257,9 +365,6 @@ static void up_dumpstate(void)
   _alert("IRQ stack:\n");
   _alert("  base: %08x\n", istackbase);
   _alert("  size: %08x\n", istacksize);
-#ifdef CONFIG_STACK_COLORATION
-  _alert("  used: %08x\n", up_check_intstack());
-#endif
 
   /* Does the current stack pointer lie within the interrupt
    * stack?
@@ -291,9 +396,6 @@ static void up_dumpstate(void)
   _alert("User stack:\n");
   _alert("  base: %08x\n", ustackbase);
   _alert("  size: %08x\n", ustacksize);
-#ifdef CONFIG_STACK_COLORATION
-  _alert("  used: %08x\n", up_check_tcbstack(rtcb));
-#endif
 
   /* Dump the user stack if the stack pointer lies within the allocated user
    * stack memory.
@@ -316,9 +418,6 @@ static void up_dumpstate(void)
   _alert("sp:         %08x\n", sp);
   _alert("stack base: %08x\n", ustackbase);
   _alert("stack size: %08x\n", ustacksize);
-#ifdef CONFIG_STACK_COLORATION
-  _alert("stack used: %08x\n", up_check_tcbstack(rtcb));
-#endif
 
   /* Dump the user stack if the stack pointer lies within the allocated user
    * stack memory.


### PR DESCRIPTION
## Summary

arm/cortex-m: enhance the crash dump

1. add irq stack information to list
2. add cpu loading into list

before:

```
Idle Task: PID=0 PRI=0 Stack Used=512 of 3048
hpwork: PID=1 PRI=224 Stack Used=304 of 2016
lpwork: PID=2 PRI=100 Stack Used=304 of 2016
rptun: PID=4 PRI=224 Stack Used=856 of 2008
```

after:

```
[ EMERG] [ap] up_showtasks:    PID    PRI      USED     STACK   FILLED       CPU   COMMAND
[ EMERG] [ap] up_showtasks:   ----   ----       928      2048    45.3%      ----   irq
[ EMERG] [ap] up_dump_task:      0      0       512      3048    16.7%     99.4%   Idle Task
[ EMERG] [ap] up_dump_task:      1    224       304      2016    15.0%      0.0%   hpwork
[ EMERG] [ap] up_dump_task:      2    100       304      2016    15.0%      0.0%   lpwork
[ EMERG] [ap] up_dump_task:      4    224       856      2008    42.6%      0.0%   rptun
```

Signed-off-by: chao.an <anchao@xiaomi.com>

## Impact

N/A

## Testing

```
[ EMERG] [ap] up_showtasks:    PID    PRI      USED     STACK   FILLED       CPU   COMMAND
[ EMERG] [ap] up_showtasks:   ----   ----       928      2048    45.3%      ----   irq
[ EMERG] [ap] up_dump_task:      0      0       512      3048    16.7%     99.4%   Idle Task
[ EMERG] [ap] up_dump_task:      1    224       304      2016    15.0%      0.0%   hpwork
[ EMERG] [ap] up_dump_task:      2    100       304      2016    15.0%      0.0%   lpwork
[ EMERG] [ap] up_dump_task:      4    224       856      2008    42.6%      0.0%   rptun
```