### PR TITLE
arch/arm/src/stm32l4/stm32l4_pwm.c: fix printf format

### DIFF
--- a/arch/arm/src/stm32l4/stm32l4_pwm.c
+++ b/arch/arm/src/stm32l4/stm32l4_pwm.c
@@ -3166,7 +3166,7 @@ static int pwm_timer(FAR struct pwm_lowerhalf_s *dev,
   DEBUGASSERT(priv != NULL && info != NULL);
 
 #if defined(CONFIG_STM32L4_PWM_MULTICHAN)
-  pwminfo("TIM%u frequency: %u\n",
+  pwminfo("TIM%u frequency: %" PRIu32 "\n",
           priv->timid, info->frequency);
 #else
   pwminfo("TIM%u channel: %u frequency: %" PRIu32 " duty: %08" PRIx32 "\n",


### PR DESCRIPTION
## Summary
Silences the following compiler warnings:

```
chip/stm32l4_pwm.c: In function 'pwm_timer':
chip/stm32l4_pwm.c:3169:11: warning: format '%u' expects argument of type 'unsigned int', but argument 4 has type 'uint32_t {aka const long unsigned int}' [-Wformat=]
   pwminfo("TIM%u frequency: %u\n",
           ^
           priv->timid, info->frequency);
                        ~~~~~~~
```

## Impact
N/A

## Testing
N/A
