### PR TITLE
bch: support flush and aligned bch buffer

### DIFF
--- a/drivers/bch/Kconfig
+++ b/drivers/bch/Kconfig
@@ -24,4 +24,8 @@ config BCH_ENCRYPTION_KEY_SIZE
 	default 16
 	depends on BCH_ENCRYPTION
 
+config BCH_BUFFER_ALIGNMENT
+	int "Buffer aligned bytes"
+	default 0
+
 endif # BCH

--- a/drivers/bch/bchdev_driver.c
+++ b/drivers/bch/bchdev_driver.c
@@ -422,6 +422,14 @@ static int bch_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
         }
         break;
 
+      case BIOC_FLUSH:
+        {
+          /* Flush any dirty pages remaining in the cache */
+
+          ret = bchlib_flushsector(bch);
+        }
+        break;
+
 #ifdef CONFIG_BCH_ENCRYPTION
       /* This is a request to set the encryption key? */
 

--- a/drivers/bch/bchlib_setup.c
+++ b/drivers/bch/bchlib_setup.c
@@ -112,7 +112,11 @@ int bchlib_setup(const char *blkdev, bool readonly, FAR void **handle)
 
   /* Allocate the sector I/O buffer */
 
-  bch->buffer = (FAR uint8_t *)kmm_malloc(bch->sectsize);
+#if CONFIG_BCH_BUFFER_ALIGNMENT != 0
+  bch->buffer = kmm_memalign(CONFIG_BCH_BUFFER_ALIGNMENT, bch->sectsize);
+#else
+  bch->buffer = kmm_malloc(bch->sectsize);
+#endif
   if (!bch->buffer)
     {
       ferr("ERROR: Failed to allocate sector buffer\n");


### PR DESCRIPTION
## Summary
1. we can using cmd BIOC_FLUSH to flush sector of buffer to mmc or sdcard.
2. we can specify alignment of buffer by  CONFIG_BCH_BUFFER_ALIGNMENT to good transfer.
## Impact
N/A
## Testing
daily test
