### PR TITLE
arch/sim: add CONFIG_SIM_STACKSIZE_ADJUSTMENT to reduce variability

### DIFF
--- a/arch/sim/Kconfig
+++ b/arch/sim/Kconfig
@@ -134,6 +134,13 @@ config SIM_WALLTIME_SIGNAL
 
 endchoice
 
+config SIM_STACKSIZE_ADJUSTMENT
+	int "The adjustment of stack size for sim"
+	default 65536
+	---help---
+		The adjustment of stack size for sim. When the task is created,
+		the stack size is increased by this amount.
+
 config SIM_HOSTFS
 	bool "Simulated HostFS"
 	depends on FS_HOSTFS

--- a/arch/sim/src/sim/up_createstack.c
+++ b/arch/sim/src/sim/up_createstack.c
@@ -92,6 +92,8 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
   FAR uint8_t *stack_alloc_ptr;
   int ret = ERROR;
 
+  stack_size += CONFIG_SIM_STACKSIZE_ADJUSTMENT;
+
 #ifdef CONFIG_TLS_ALIGNED
   /* The allocated stack size must not exceed the maximum possible for the
    * TLS feature.

--- a/arch/sim/src/sim/up_initialstate.c
+++ b/arch/sim/src/sim/up_initialstate.c
@@ -57,9 +57,11 @@ void up_initial_state(struct tcb_s *tcb)
   if (tcb->pid == 0)
     {
       tcb->stack_alloc_ptr = (void *)(up_getsp() -
-                                      CONFIG_IDLETHREAD_STACKSIZE);
+                                      CONFIG_IDLETHREAD_STACKSIZE -
+                                      CONFIG_SIM_STACKSIZE_ADJUSTMENT);
       tcb->stack_base_ptr  = tcb->stack_alloc_ptr;
-      tcb->adj_stack_size  = CONFIG_IDLETHREAD_STACKSIZE;
+      tcb->adj_stack_size  = CONFIG_IDLETHREAD_STACKSIZE +
+                             CONFIG_SIM_STACKSIZE_ADJUSTMENT;
 
 #ifdef CONFIG_STACK_COLORATION
       /* If stack debug is enabled, then fill the stack with a

--- a/sched/Kconfig
+++ b/sched/Kconfig
@@ -1808,14 +1808,12 @@ menu "Stack and heap information"
 
 config DEFAULT_TASK_STACKSIZE
 	int "The default stack size for tasks"
-	default 65536 if ARCH_SIM
 	default 2048
 	---help---
 		The default stack size for tasks.
 
 config IDLETHREAD_STACKSIZE
 	int "Idle thread stack size"
-	default DEFAULT_TASK_STACKSIZE if ARCH_SIM
 	default 1024
 	---help---
 		The size of the initial stack used by the IDLE thread.  The IDLE thread


### PR DESCRIPTION

## Summary
Add CONFIG_SIM_STACKSIZE_ADJUSTMENT to reduce variability between sim and other different platform stack size setting

Signed-off-by: Jiuzhu Dong <dongjiuzhu1@xiaomi.com>
## Impact
N/A
## Testing
daily test
