### PR TITLE
arch: arm: select LIBC_ARCH_ATOMIC when config ARCH_CHIP_RP2040

### DIFF
--- a/arch/arm/Kconfig
+++ b/arch/arm/Kconfig
@@ -232,6 +232,7 @@ config ARCH_CHIP_RP2040
 	select ARCH_HAVE_MULTICPU
 	select ARCH_HAVE_TESTSET
 	select ARM_HAVE_WFE_SEV
+	select LIBC_ARCH_ATOMIC
 	---help---
 		Raspberry Pi RP2040 architectures (ARM dual Cortex-M0+).
 


### PR DESCRIPTION
Use the common atomic operations when needed.

Signed-off-by: Matheus Castello <matheus@castello.eng.br>

## Summary

## Impact

## Testing

