### PR TITLE
riscv/bl602: Swap SPI MISO and MOSI

### DIFF
--- a/arch/risc-v/src/bl602/bl602_spi.c
+++ b/arch/risc-v/src/bl602/bl602_spi.c
@@ -1078,6 +1078,32 @@ static void bl602_set_spi_0_act_mode_sel(uint8_t mod)
 }
 
 /****************************************************************************
+ * Name: bl602_swap_spi_0_mosi_with_miso
+ *
+ * Description:
+ *   Swap SPI0 MOSI with MISO
+ *
+ * Input Parameters:
+ *   swap      - Non-zero to swap MOSI and MISO
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+static void bl602_swap_spi_0_mosi_with_miso(uint8_t swap)
+{
+  if (swap)
+    {
+      modifyreg32(BL602_GLB_GLB_PARM, 0, GLB_PARM_REG_SPI_0_SWAP);
+    }
+  else
+    {
+      modifyreg32(BL602_GLB_GLB_PARM, GLB_PARM_REG_SPI_0_SWAP, 0);
+    }
+}
+
+/****************************************************************************
  * Name: bl602_spi_init
  *
  * Description:
@@ -1108,6 +1134,10 @@ static void bl602_spi_init(struct spi_dev_s *dev)
   /* set master mode */
 
   bl602_set_spi_0_act_mode_sel(1);
+
+  /* swap MOSI with MISO to be consistent with BL602 Reference Manual */
+
+  bl602_swap_spi_0_mosi_with_miso(1);
 
   /* spi cfg  reg:
    * cr_spi_deg_en 1


### PR DESCRIPTION
## Summary

BL602 SPI MISO and MOSI pins appear to be swapped when observed with a Logic Analyser.

This contradicts the SPI Pin Functions that were defined in NuttX (board.h). This also contradicts the MISO and MOSI Pin Functions specified in the BL602 Reference Manual.

We fix this by updating the GLB Hardware Register BL602_GLB_GLB_PARM, to swap MISO and MOSI at startup.

[More details here](https://lupyuen.github.io/articles/spi2#appendix-miso-and-mosi-are-swapped)

## Impact

This fix impacts the MISO and MOSI pins on BL602.

Previously MISO and MOSI were incorrectly swapped, contradicting the NuttX pin definitions and the BL602 Reference Manual.

Now MISO and MOSI are consistent with the NuttX pin definitions and BL602 Reference Manual.

## Testing

Tested on Pine64 PineCone BL602 board connected to Semtech SX1262.

Also tested on Pine64 PineDio Stack BL604 board with onboard Semtech SX1262.

[More details here](https://lupyuen.github.io/articles/spi2#appendix-miso-and-mosi-are-swapped)

Note that BL602 SPI Mode needs to be 1 instead of 0 for SPI to work correctly. [(See this)](https://lupyuen.github.io/articles/spi2#appendix-spi-mode-quirk)