### PR TITLE
sched: fix bug in the function nxsched_resume_scheduler

### DIFF
--- a/sched/sched/sched_resumescheduler.c
+++ b/sched/sched/sched_resumescheduler.c
@@ -57,21 +57,7 @@
 
 void nxsched_resume_scheduler(FAR struct tcb_s *tcb)
 {
-#if CONFIG_RR_INTERVAL > 0
 #ifdef CONFIG_SCHED_SPORADIC
-  if ((tcb->flags & TCB_FLAG_POLICY_MASK) == TCB_FLAG_SCHED_RR)
-#endif
-    {
-      /* Reset the task's timeslice. */
-
-      tcb->timeslice = MSEC2TICK(CONFIG_RR_INTERVAL);
-    }
-#endif
-
-#ifdef CONFIG_SCHED_SPORADIC
-#if CONFIG_RR_INTERVAL > 0
-  else
-#endif
   if ((tcb->flags & TCB_FLAG_POLICY_MASK) == TCB_FLAG_SCHED_SPORADIC)
     {
       /* Reset the replenishment cycle if it is appropriate to do so */


### PR DESCRIPTION
Don't reset the task's timeslice if no task switch.

Signed-off-by: walker.zeng <zhaoxiu.zeng@gmail.com>
