### PR TITLE
charger: fix crash when notify without pollwaiter

### DIFF
--- a/drivers/power/battery_charger.c
+++ b/drivers/power/battery_charger.c
@@ -99,11 +99,16 @@ static const struct file_operations g_batteryops =
  ****************************************************************************/
 
 static int battery_charger_notify(FAR struct battery_charger_priv_s *priv,
-                                   uint32_t mask)
+                                  uint32_t mask)
 {
   FAR struct pollfd *fd = priv->fds;
   int semcnt;
   int ret;
+
+  if (!fd)
+    {
+      return OK;
+    }
 
   ret = nxsem_wait_uninterruptible(&priv->lock);
   if (ret < 0)

--- a/drivers/power/battery_gauge.c
+++ b/drivers/power/battery_gauge.c
@@ -101,11 +101,16 @@ static const struct file_operations g_batteryops =
  ****************************************************************************/
 
 static int battery_gauge_notify(FAR struct battery_gauge_priv_s *priv,
-                                   uint32_t mask)
+                                uint32_t mask)
 {
   FAR struct pollfd *fd = priv->fds;
   int semcnt;
   int ret;
+
+  if (!fd)
+    {
+      return OK;
+    }
 
   ret = nxsem_wait_uninterruptible(&priv->lock);
   if (ret < 0)

--- a/drivers/power/battery_monitor.c
+++ b/drivers/power/battery_monitor.c
@@ -100,11 +100,16 @@ static const struct file_operations g_batteryops =
  ****************************************************************************/
 
 static int battery_monitor_notify(FAR struct battery_monitor_priv_s *priv,
-                                   uint32_t mask)
+                                  uint32_t mask)
 {
   FAR struct pollfd *fd = priv->fds;
   int semcnt;
   int ret;
+
+  if (!fd)
+    {
+      return OK;
+    }
 
   ret = nxsem_wait_uninterruptible(&priv->lock);
   if (ret < 0)


### PR DESCRIPTION
## Summary
charger: fix crash when notify without pollwaiter

Signed-off-by: Jiuzhu Dong <dongjiuzhu1@xiaomi.com>
## Impact
N/A
## Testing
daily test
