### PR TITLE
xtensa/esp32: Show CPUs activity using LEDs.

### DIFF
--- a/arch/xtensa/src/esp32/esp32_idle.c
+++ b/arch/xtensa/src/esp32/esp32_idle.c
@@ -22,13 +22,17 @@
  * Included Files
  ****************************************************************************/
 
+#include <nuttx/config.h>
+
 #include <assert.h>
 #include <stdint.h>
 #include <debug.h>
-#include <nuttx/config.h>
+
+#include <nuttx/board.h>
 #include <nuttx/arch.h>
 #include <nuttx/spinlock.h>
 #include <nuttx/power/pm.h>
+#include <arch/board/board.h>
 
 #include "esp32_pm.h"
 #include "xtensa.h"
@@ -44,6 +48,18 @@
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
+
+/* Does the board support an IDLE LED to indicate that the board is in the
+ * IDLE state?
+ */
+
+#ifdef CONFIG_ARCH_LEDS_CPU_ACTIVITY
+#  define BEGIN_IDLE() board_autoled_off(LED_CPU)
+#  define END_IDLE()
+#else
+#  define BEGIN_IDLE()
+#  define END_IDLE()
+#endif
 
 /* Values for the RTC Alarm to wake up from the PM_STANDBY mode
  * (which corresponds to ESP32 stop mode).  If this alarm expires,
@@ -266,9 +282,11 @@ void up_idle(void)
    * sleep in a reduced power mode until an interrupt occurs to save power
    */
 
+  BEGIN_IDLE();
 #if XCHAL_HAVE_INTERRUPTS
   __asm__ __volatile__ ("waiti 0");
 #endif
+  END_IDLE();
 
   /* Perform IDLE mode power management */
 

--- a/arch/xtensa/src/esp32/esp32_idle.c
+++ b/arch/xtensa/src/esp32/esp32_idle.c
@@ -85,7 +85,7 @@
  ****************************************************************************/
 
 /****************************************************************************
- * Name: up_idlepm
+ * Name: esp32_idlepm
  *
  * Description:
  *   Perform IDLE state power management.
@@ -93,7 +93,7 @@
  ****************************************************************************/
 
 #ifdef CONFIG_PM
-static void up_idlepm(void)
+static void esp32_idlepm(void)
 {
   irqstate_t flags;
 
@@ -232,7 +232,7 @@ static void up_idlepm(void)
 #endif
 }
 #else
-#  define up_idlepm()
+#  define esp32_idlepm()
 #endif
 
 /****************************************************************************
@@ -272,7 +272,7 @@ void up_idle(void)
 
   /* Perform IDLE mode power management */
 
-  up_idlepm();
+  esp32_idlepm();
 
 #endif
 }

--- a/arch/xtensa/src/esp32/esp32_irq.c
+++ b/arch/xtensa/src/esp32/esp32_irq.c
@@ -32,7 +32,9 @@
 
 #include <nuttx/irq.h>
 #include <nuttx/arch.h>
+#include <nuttx/board.h>
 #include <arch/irq.h>
+#include <arch/board/board.h>
 
 #include "xtensa.h"
 
@@ -922,6 +924,10 @@ uint32_t *xtensa_int_decode(uint32_t cpuints, uint32_t *regs)
   int bit;
 #ifdef CONFIG_SMP
   int cpu;
+#endif
+
+#ifdef CONFIG_ARCH_LEDS_CPU_ACTIVITY
+  board_autoled_on(LED_CPU);
 #endif
 
 #ifdef CONFIG_SMP

--- a/boards/xtensa/esp32/esp32-wrover-kit/include/board.h
+++ b/boards/xtensa/esp32/esp32-wrover-kit/include/board.h
@@ -105,6 +105,10 @@
  * NuttX controls the LEDs:
  */
 
+/* These values index an array that contains the bit definitions for the
+ * correct LEDs (see esp32_autoleds.c).
+ */
+
 #define LED_STARTED       0  /* LED2 */
 #define LED_HEAPALLOCATE  1  /* LED3 */
 #define LED_IRQSENABLED   2  /* LED3 + LED2 */
@@ -113,6 +117,21 @@
 #define LED_SIGNAL        5  /* LED2 + LED3 */
 #define LED_ASSERTION     6  /* LED1 + LED2 + LED3 */
 #define LED_PANIC         7  /* LED1  + N/C  + N/C */
+
+/* The values below are used only to distinguish between the CPUs.
+ * The LEDs are actually mapped as:
+ *    CPU0 -> GPIO_LED1 (Red LED)
+ *    CPU1 -> GPIO_LED2 (Green LED)
+ * Note that from the previous list only LED_HEAPALLOCATE will still be
+ * valid.  This is to avoid collisions and to keep a way to show a successful
+ * heap allocation.  The LED used is still LED3 (Blue LED).
+ */
+
+#ifdef CONFIG_ARCH_LEDS_CPU_ACTIVITY
+#  define LED_CPU0        8
+#  define LED_CPU1        9
+#  define LED_CPU         (LED_CPU0 + up_cpu_index())
+#endif
 
 /* GPIO pins used by the GPIO Subsystem */
 

--- a/boards/xtensa/esp32/esp32-wrover-kit/src/esp32_autoleds.c
+++ b/boards/xtensa/esp32/esp32-wrover-kit/src/esp32_autoleds.c
@@ -42,20 +42,23 @@
 
 /* The following definitions map the encoded LED setting to GPIO settings */
 
-#define LED_STARTED_BITS             (BOARD_LED2_BIT)
-#define LED_HEAPALLOCATE_BITS        (BOARD_LED3_BIT)
-#define LED_IRQSENABLED_BITS         (BOARD_LED3_BIT | BOARD_LED2_BIT)
-#define LED_STACKCREATED_BITS        (BOARD_LED3_BIT)
-#define LED_INIRQ_BITS               (BOARD_LED1_BIT | BOARD_LED3_BIT)
-#define LED_SIGNAL_BITS              (BOARD_LED2_BIT | BOARD_LED3_BIT)
-#define LED_ASSERTION_BITS           (BOARD_LED1_BIT | BOARD_LED2_BIT |\
-                                      BOARD_LED3_BIT)
-#define LED_PANIC_BITS               (BOARD_LED1_BIT)
+#ifndef CONFIG_ARCH_LEDS_CPU_ACTIVITY
+#  define LED_STARTED_BITS         (BOARD_LED2_BIT)
+#  define LED_HEAPALLOCATE_BITS    (BOARD_LED3_BIT)
+#  define LED_IRQSENABLED_BITS     (BOARD_LED3_BIT | BOARD_LED2_BIT)
+#  define LED_STACKCREATED_BITS    (BOARD_LED3_BIT)
+#  define LED_INIRQ_BITS           (BOARD_LED1_BIT | BOARD_LED3_BIT)
+#  define LED_SIGNAL_BITS          (BOARD_LED2_BIT | BOARD_LED3_BIT)
+#  define LED_ASSERTION_BITS       (BOARD_LED1_BIT | BOARD_LED2_BIT |\
+                                    BOARD_LED3_BIT)
+#  define LED_PANIC_BITS           (BOARD_LED1_BIT)
+#endif
 
 /****************************************************************************
  * Private Data
  ****************************************************************************/
 
+#ifndef CONFIG_ARCH_LEDS_CPU_ACTIVITY
 static const unsigned int g_ledbits[8] =
 {
   LED_STARTED_BITS,
@@ -67,6 +70,7 @@ static const unsigned int g_ledbits[8] =
   LED_ASSERTION_BITS,
   LED_PANIC_BITS
 };
+#endif
 
 /****************************************************************************
  * Private Functions
@@ -131,8 +135,25 @@ void board_autoled_initialize(void)
 
 void board_autoled_on(int led)
 {
+#ifdef CONFIG_ARCH_LEDS_CPU_ACTIVITY
+  switch (led)
+    {
+      case LED_CPU0:
+        esp32_gpiowrite(GPIO_LED1, true);
+        break;
+      case LED_CPU1:
+        esp32_gpiowrite(GPIO_LED2, true);
+        break;
+      case LED_HEAPALLOCATE:
+        esp32_gpiowrite(GPIO_LED3, true);
+        break;
+      default:
+        break;
+    }
+#else
   led_clrbits(BOARD_LED1_BIT | BOARD_LED2_BIT | BOARD_LED3_BIT);
   led_setbits(g_ledbits[led]);
+#endif
 }
 
 /****************************************************************************
@@ -141,7 +162,24 @@ void board_autoled_on(int led)
 
 void board_autoled_off(int led)
 {
+#ifdef CONFIG_ARCH_LEDS_CPU_ACTIVITY
+  switch (led)
+    {
+      case LED_CPU0:
+        esp32_gpiowrite(GPIO_LED1, false);
+        break;
+      case LED_CPU1:
+        esp32_gpiowrite(GPIO_LED2, false);
+        break;
+      case LED_HEAPALLOCATE:
+        esp32_gpiowrite(GPIO_LED3, false);
+        break;
+      default:
+        break;
+    }
+#else
   led_clrbits(g_ledbits[led]);
+#endif
 }
 
 #endif /* CONFIG_ARCH_LEDS */


### PR DESCRIPTION
## Summary
Use LEDs to show CPUs activity for ESP32.
## Impact
N/A
## Testing
esp32-wrover-kit with SMP.
