### PR TITLE
tls: restore C89 compatibility for TLS

### DIFF
--- a/arch/arm/src/common/arm_tls.c
+++ b/arch/arm/src/common/arm_tls.c
@@ -65,7 +65,7 @@ int up_tls_size(void)
 
 void up_tls_initialize(FAR struct tls_info_s *info)
 {
-  FAR uint8_t *tls_data = info->tl_data;
+  FAR uint8_t *tls_data = (FAR uint8_t *)(info + 1);
 
   uint32_t tdata_len = sizeof(uint32_t) * (_END_TDATA - _START_TDATA);
   uint32_t tbss_len = sizeof(uint32_t) * (_END_TBSS - _START_TBSS);
@@ -86,5 +86,5 @@ void up_tls_initialize(FAR struct tls_info_s *info)
 
 void *__aeabi_read_tp(void)
 {
-  return tls_get_info()->tl_data;
+  return (void *)(tls_get_info() + 1);
 }

--- a/arch/risc-v/src/common/riscv_tls.c
+++ b/arch/risc-v/src/common/riscv_tls.c
@@ -62,7 +62,7 @@ int up_tls_size(void)
 
 void up_tls_initialize(FAR struct tls_info_s *info)
 {
-  FAR uint8_t *tls_data = info->tl_data;
+  FAR uint8_t *tls_data = (FAR uint8_t *)(info + 1);
 
   uint32_t tdata_len = sizeof(uint32_t) * (_END_TDATA - _START_TDATA);
   uint32_t tbss_len = sizeof(uint32_t) * (_END_TBSS - _START_TBSS);

--- a/arch/risc-v/src/rv32im/riscv_initialstate.c
+++ b/arch/risc-v/src/rv32im/riscv_initialstate.c
@@ -55,11 +55,6 @@
 void up_initial_state(struct tcb_s *tcb)
 {
   struct xcptcontext *xcp = &tcb->xcp;
-
-#ifdef CONFIG_SCHED_THREAD_LOCAL
-  struct tls_info_s *info = tcb->stack_alloc_ptr;
-#endif
-
   uint32_t regval;
 
   /* Initialize the idle thread stack */
@@ -101,7 +96,8 @@ void up_initial_state(struct tcb_s *tcb)
   /* Setup thread local storage pointer */
 
 #ifdef CONFIG_SCHED_THREAD_LOCAL
-  xcp->regs[REG_TP]      = (uint32_t)info->tl_data;
+  xcp->regs[REG_TP]      = (uint32_t)tcb->stack_alloc_ptr +
+                                     sizeof(struct tls_info_s);
 #endif
 
   /* If this task is running PIC, then set the PIC base register to the

--- a/include/nuttx/tls.h
+++ b/include/nuttx/tls.h
@@ -140,7 +140,7 @@ struct pthread_cleanup_s
  * The stack memory is fully accessible to user mode threads.  TLS is not
  * available from interrupt handlers (nor from the IDLE thread).
  *
- * The following diagram represent the typic stack layout:
+ * The following diagram represent the typical stack layout:
  *
  *      Push Down             Push Up
  *   +-------------+      +-------------+ <- Stack memory allocation
@@ -179,9 +179,6 @@ struct tls_info_s
 #endif
 
   int tl_errno;                        /* Per-thread error number */
-#ifdef CONFIG_SCHED_THREAD_LOCAL
-  uint8_t tl_data[0];
-#endif
 };
 
 /****************************************************************************


### PR DESCRIPTION
## Summary
Zero length arrays are not supported by C89. Modify code to avoid usage of zero length arrays.

## Impact
Code refactor only

## Testing
Pass CI
