### PR TITLE
sched_note: change uint32_t nbi_module into uint8_t array

### DIFF
--- a/include/nuttx/sched_note.h
+++ b/include/nuttx/sched_note.h
@@ -99,6 +99,18 @@
   memset((s), 0, sizeof(struct note_filter_irq_s))
 #endif
 
+/* Note dump module tag definitions */
+
+#ifdef CONFIG_SCHED_INSTRUMENTATION_DUMP
+#  define NOTE_MODULE(a, b, c, d)  \
+  ((uint32_t)((a) & 0xff)        | \
+  ((uint32_t)((b) & 0xff) << 8)  | \
+  ((uint32_t)((c) & 0xff) << 16) | \
+  ((uint32_t)((d) & 0xff) << 24))
+#else
+#  define NOTE_MODULE(a,b,c,d)
+#endif
+
 /****************************************************************************
  * Public Types
  ****************************************************************************/
@@ -346,7 +358,7 @@ struct note_string_s
 struct note_binary_s
 {
   struct note_common_s nbi_cmn; /* Common note parameters */
-  uint32_t nbi_module;          /* Module number */
+  uint8_t  nbi_module[4];       /* Module number */
   uint8_t  nbi_event;           /* Event number */
   uint8_t  nbi_data[1];         /* Binary data */
 };
@@ -612,6 +624,7 @@ void sched_note_filter_irq(struct note_filter_irq_s *oldf,
 
 #else /* CONFIG_SCHED_INSTRUMENTATION */
 
+#  define NOTE_MODULE(a,b,c,d)
 #  define sched_note_start(t)
 #  define sched_note_stop(t)
 #  define sched_note_suspend(t)

--- a/sched/sched/sched_note.c
+++ b/sched/sched/sched_note.c
@@ -864,7 +864,10 @@ void sched_note_dump(uint32_t module, uint8_t event,
   note_common(tcb, &note->nbi_cmn, length,
               NOTE_DUMP_BINARY);
 
-  note->nbi_module = module;
+  note->nbi_module[0] = (uint8_t)(module         & 0xff);
+  note->nbi_module[1] = (uint8_t)((module >> 8)  & 0xff);
+  note->nbi_module[2] = (uint8_t)((module >> 16) & 0xff);
+  note->nbi_module[3] = (uint8_t)((module >> 24) & 0xff);
   note->nbi_event = event;
   memcpy(note->nbi_data, buf, length - sizeof(struct note_binary_s) + 1);
 
@@ -1100,7 +1103,10 @@ void sched_note_vbprintf(uint32_t module, uint8_t event,
   note_common(tcb, &note->nbi_cmn, length,
               NOTE_DUMP_BINARY);
 
-  note->nbi_module = module;
+  note->nbi_module[0] = (uint8_t)(module         & 0xff);
+  note->nbi_module[1] = (uint8_t)((module >> 8)  & 0xff);
+  note->nbi_module[2] = (uint8_t)((module >> 16) & 0xff);
+  note->nbi_module[3] = (uint8_t)((module >> 24) & 0xff);
   note->nbi_event = event;
 
   /* Add the note to circular buffer */


### PR DESCRIPTION
sched_note: change uint32_t nbi_module into uint8_t array, because variables keep the same style that use uint8_t array
sched_note: add note dump module tag definitions

NOTE_MODULE(a, b, c, d)

example:
define TEST_MODULE NOTE_MODULE('t', 'e', 's', 't')
sched_note_dump(TEST_MODULE, event, data, len);

define AUDIO_MODULE NOTE_MODULE('a', 'u', 'd', 'i')
sched_note_dump(AUDIO_MODULE, event, data, len);