### PR TITLE
arch/xtensa: correct the interrupt stack on irq handler

### DIFF
--- a/arch/xtensa/src/common/xtensa_assert.c
+++ b/arch/xtensa/src/common/xtensa_assert.c
@@ -189,6 +189,8 @@ void up_assert(const char *filename, int lineno)
 
 void xtensa_panic(int xptcode, uint32_t *regs)
 {
+  CURRENT_REGS = regs;
+
   /* We get here when a un-dispatch-able, irrecoverable exception occurs */
 
   board_autoled_on(LED_ASSERTION);
@@ -203,7 +205,6 @@ void xtensa_panic(int xptcode, uint32_t *regs)
   _alert("Unhandled Exception %d\n", xptcode);
 #endif
 
-  CURRENT_REGS = regs;
   xtensa_assert(); /* Should not return */
   for (; ; );
 }
@@ -290,6 +291,8 @@ void xtensa_panic(int xptcode, uint32_t *regs)
 
 void xtensa_user_panic(int exccause, uint32_t *regs)
 {
+  CURRENT_REGS = regs;
+
   /* We get here when a un-dispatch-able, irrecoverable exception occurs */
 
   board_autoled_on(LED_ASSERTION);
@@ -305,7 +308,6 @@ void xtensa_user_panic(int exccause, uint32_t *regs)
   _alert("User Exception: EXCCAUSE=%04x\n", exccause);
 #endif
 
-  CURRENT_REGS = regs;
   xtensa_assert(); /* Should not return */
   for (; ; );
 }

--- a/arch/xtensa/src/common/xtensa_int_handlers.S
+++ b/arch/xtensa/src/common/xtensa_int_handlers.S
@@ -104,14 +104,15 @@ g_intstacktop:
 	addi	\aout, \aout, 1				/* Return aout + 1 */
 	.endm
 
-/************************************************************************************
+/****************************************************************************
  * Name: setintstack
  *
  * Description:
- *   Set the current stack pointer to the "top" the interrupt stack.  Single CPU
- *   case.  Must be provided by MCU-specific logic in the SMP case.
+ *   Set the current stack pointer to the "top" the interrupt stack.
+ *   Single CPU case.
+ *   Must be provided by MCU-specific logic in the SMP case.
  *
- ************************************************************************************/
+ ****************************************************************************/
 
 #if !defined(CONFIG_SMP) && CONFIG_ARCH_INTERRUPTSTACK > 15
 	.macro	setintstack tmp1 tmp2
@@ -423,6 +424,12 @@ _xtensa_level2_handler:
 
 	mov  a12, sp
 
+	/* Switch to an interrupt stack if we have one */
+
+#if CONFIG_ARCH_INTERRUPTSTACK > 15
+	setintstack a13 a14
+#endif
+
 	/* Set up PS for C, enable interrupts above this level and clear EXCM. */
 
 	ps_setup	2 a0
@@ -494,6 +501,12 @@ _xtensa_level3_handler:
 	 */
 
 	mov  a12, sp
+
+	/* Switch to an interrupt stack if we have one */
+
+#if CONFIG_ARCH_INTERRUPTSTACK > 15
+	setintstack a13 a14
+#endif
 
 	/* Set up PS for C, enable interrupts above this level and clear EXCM. */
 
@@ -567,6 +580,12 @@ _xtensa_level4_handler:
 
 	mov  a12, sp
 
+	/* Switch to an interrupt stack if we have one */
+
+#if CONFIG_ARCH_INTERRUPTSTACK > 15
+	setintstack a13 a14
+#endif
+
 	/* Set up PS for C, enable interrupts above this level and clear EXCM. */
 
 	ps_setup	4 a0
@@ -639,6 +658,12 @@ _xtensa_level5_handler:
 
 	mov  a12, sp
 
+	/* Switch to an interrupt stack if we have one */
+
+#if CONFIG_ARCH_INTERRUPTSTACK > 15
+	setintstack a13 a14
+#endif
+
 	/* Set up PS for C, enable interrupts above this level and clear EXCM. */
 
 	ps_setup	5 a0
@@ -710,6 +735,12 @@ _xtensa_level6_handler:
 	 */
 
 	mov  a12, sp
+
+	/* Switch to an interrupt stack if we have one */
+
+#if CONFIG_ARCH_INTERRUPTSTACK > 15
+	setintstack a13 a14
+#endif
 
 	/* Set up PS for C, enable interrupts above this level and clear EXCM. */
 

--- a/arch/xtensa/src/common/xtensa_panic.S
+++ b/arch/xtensa/src/common/xtensa_panic.S
@@ -67,6 +67,26 @@
 #include "chip.h"
 
 /****************************************************************************
+ * Assembly Language Macros
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: setintstack
+ *
+ * Description:
+ *   Set the current stack pointer to the "top" the interrupt stack.
+ *   Single CPU case.
+ *   Must be provided by MCU-specific logic in the SMP case.
+ *
+ ****************************************************************************/
+
+#if !defined(CONFIG_SMP) && CONFIG_ARCH_INTERRUPTSTACK > 15
+	.macro	setintstack tmp1 tmp2
+	movi		a1, g_intstacktop
+	.endm
+#endif
+
+/****************************************************************************
  * Public Functions
  ****************************************************************************/
 
@@ -108,6 +128,12 @@ _xtensa_panic:
 
 	mov		a2, sp							/* Address of state save on stack */
 	call0	_xtensa_context_save			/* Save full register state */
+
+	/* Switch to an interrupt stack if we have one */
+
+#if CONFIG_ARCH_INTERRUPTSTACK > 15
+	setintstack a13 a14
+#endif
 
 	/* Save exc cause and vaddr into exception frame */
 

--- a/arch/xtensa/src/common/xtensa_user_handler.S
+++ b/arch/xtensa/src/common/xtensa_user_handler.S
@@ -225,6 +225,12 @@ _xtensa_user_handler:
 	mov		a2, sp							/* Address of state save on stack */
 	call0	_xtensa_context_save			/* Save full register state */
 
+	/* Save current SP before (possibly) overwriting it,
+	* it's the register save area.
+	*/
+
+	mov	a12, sp
+
 	/* Switch to an interrupt stack if we have one */
 
 #if CONFIG_ARCH_INTERRUPTSTACK > 15
@@ -271,17 +277,18 @@ _xtensa_user_handler:
 
 #ifdef __XTENSA_CALL0_ABI__
 	rsr		a2, EXCCAUSE					/* Argument 1 (a2) = EXCCAUSE */
-	mov		a3, sp							/* Argument 2 (a3) = pointer to register save area */
+	mov		a3, a12							/* Argument 2 (a3) = pointer to register save area */
 	calx0	xtensa_user						/* Call xtensa_user */
 #else
 	rsr		a6, EXCCAUSE					/* Argument 1 (a6) = EXCCAUSE */
-	mov		a7, sp							/* Argument 2 (a7) = pointer to register save area */
+	mov		a7, a12							/* Argument 2 (a7) = pointer to register save area */
 	call4	xtensa_user						/* Call xtensa_user */
-	mov		a2, a6
+	mov		a12, a6
 #endif
 
 	/* Restore registers in preparation to return from interrupt */
 
+	mov		a2, a12							/* a2 = address of new state save area */
 	call0	_xtensa_context_restore			/* (Preserves a2) */
 
 	/* Restore only level-specific regs (the rest were already restored) */

--- a/arch/xtensa/src/common/xtensa_user_handler.S
+++ b/arch/xtensa/src/common/xtensa_user_handler.S
@@ -71,6 +71,22 @@
  ****************************************************************************/
 
 /****************************************************************************
+ * Name: setintstack
+ *
+ * Description:
+ *   Set the current stack pointer to the "top" the interrupt stack.
+ *   Single CPU case.
+ *   Must be provided by MCU-specific logic in the SMP case.
+ *
+ ****************************************************************************/
+
+#if !defined(CONFIG_SMP) && CONFIG_ARCH_INTERRUPTSTACK > 15
+	.macro	setintstack tmp1 tmp2
+	movi		a1, g_intstacktop
+	.endm
+#endif
+
+/****************************************************************************
  * Macro: ps_setup
  *
  * Description:
@@ -208,6 +224,12 @@ _xtensa_user_handler:
 	s32i	a2, sp, (4 * REG_A2)
 	mov		a2, sp							/* Address of state save on stack */
 	call0	_xtensa_context_save			/* Save full register state */
+
+	/* Switch to an interrupt stack if we have one */
+
+#if CONFIG_ARCH_INTERRUPTSTACK > 15
+	setintstack a13 a14
+#endif
 
 	/* Save exc cause and vaddr into exception frame */
 
@@ -361,6 +383,12 @@ _xtensa_syscall_handler:
 	mov		a2, sp							/* Address of state save on stack */
 	call0	_xtensa_context_save			/* Save full register state */
 
+	/* Switch to an interrupt stack if we have one */
+
+#if CONFIG_ARCH_INTERRUPTSTACK > 15
+	setintstack a13 a14
+#endif
+
 	/* Set up PS for C, enable interrupts above this level and clear EXCM. */
 
 	ps_setup	1 a0
@@ -483,6 +511,12 @@ _xtensa_coproc_handler:
 	s32i	a2, sp, (4 * REG_A2)
 	mov		a2, sp							/* Address of state save on stack */
 	call0	_xtensa_context_save			/* Save full register state */
+
+	/* Switch to an interrupt stack if we have one */
+
+#if CONFIG_ARCH_INTERRUPTSTACK > 15
+	setintstack a13 a14
+#endif
 
 	/* Save exc cause and vaddr into exception frame */
 


### PR DESCRIPTION
## Summary

arch/xtensa: correct the interrupt stack on irq handler
arch: xtensa: save current SP before overwrting 
arch/xtensa: set the current reg before print syslog 

## Impact

enhance the exception handler process

## Testing

dumpstack/assert works as expected

```
[   52.024061] [ 1] [ EMERG] [[audio] ] up_taskdump: Idle Task: PID=0 Stack Used=656 of 4064
[   52.025062] [ 1] [ ALERT] [[audio] ] up_backtrace: 293, ret: 3, base: 0x3de007e0, 0x3de017c0, A1: 0x3de01750, A0: 0xacb067e1
[   52.026451] [ 1] [ EMERG] [[audio] ] backtrace:
[   52.027017] [ 1] [ EMERG] [[audio] ] [ 0] [<0x2cb067e1>] nx_start+0x1e5/0x220
[   52.028000] [ 1] [ EMERG] [[audio] ] [ 0] [<0x2cb176a9>] _start+0x9/0xc
[   52.028873] [ 1] [ EMERG] [[audio] ] [ 0] [<0x3de00260>] _xtensa_reset_handler+0x5c/0x1fc
[   52.029973] [ 1] [ EMERG] [[audio] ] up_taskdump: hpwork: PID=1 Stack Used=296 of 4256
[   52.030891] [ 1] [ ALERT] [[audio] ] up_backtrace: 293, ret: 5, base: 0x3de10920, 0x3de119c0, A1: 0x3de11910, A0: 0xacb16da4
[   52.032265] [ 1] [ EMERG] [[audio] ] backtrace:
[   52.032831] [ 1] [ EMERG] [[audio] ] [ 1] [<0x2cb16da4>] up_block_task+0x74/0xa8
[   52.033817] [ 1] [ EMERG] [[audio] ] [ 1] [<0x2cb08de8>] nxsem_wait+0x68/0x98
[   52.034736] [ 1] [ EMERG] [[audio] ] [ 1] [<0x2cb08e23>] nxsem_wait_uninterruptible+0xb/0x14
[   52.035808] [ 1] [ EMERG] [[audio] ] [ 1] [<0x2cb0b24f>] work_thread+0x23/0x50
[   52.036746] [ 1] [ EMERG] [[audio] ] [ 1] [<0x2cb0a743>] nxtask_start+0x57/0x7c
[   52.037705] [ 1] [ EMERG] [[audio] ] up_taskdump: rexecd: PID=10 Stack Used=544 of 4256
[   52.038635] [ 1] [ ALERT] [[audio] ] up_backtrace: 293, ret: 10, base: 0x3de19130, 0x3de1a1d0, A1: 0x3de1a010, A0: 0xacb16da4
[   52.040013] [ 1] [ EMERG] [[audio] ] backtrace:
[   52.040577] [ 1] [ EMERG] [[audio] ] [10] [<0x2cb16da4>] up_block_task+0x74/0xa8
[   52.041592] [ 1] [ EMERG] [[audio] ] [10] [<0x2cb08de8>] nxsem_wait+0x68/0x98
[   52.042512] [ 1] [ EMERG] [[audio] ] [10] [<0x2cb2e48d>] _net_timedwait+0x75/0xb4
[   52.043492] [ 1] [ EMERG] [[audio] ] [10] [<0x2cb2e4db>] net_lockedwait+0xf/0x18
[   52.044462] [ 1] [ EMERG] [[audio] ] [10] [<0x2cb2ab8e>] rpmsg_socket_accept+0xc6/0xf8
[   52.045495] [ 1] [ EMERG] [[audio] ] [10] [<0x2cb2842c>] psock_accept+0x40/0x74
[   52.046460] [ 1] [ EMERG] [[audio] ] [10] [<0x2cb28498>] accept+0x38/0xa4
[   52.047355] [ 1] [ EMERG] [[audio] ] [10] [<0x2cb24141>] rexecd_main+0x101/0x140
[   52.048317] [ 1] [ EMERG] [[audio] ] [10] [<0x2cb10f4c>] nxtask_startup+0x20/0x24
[   52.049281] [ 1] [ EMERG] [[audio] ] [10] [<0x2cb0a754>] nxtask_start+0x68/0x7c
[   52.050242] [ 1] [ EMERG] [[audio] ] up_taskdump: rptun: PID=3 Stack Used=1024 of 4240
[   52.054672] [ 1] [ EMERG] [[audio] ] backtrace:
[   52.055238] [ 1] [ EMERG] [[audio] ] [ 3] [<0x2cb10f92>] sched_dumpstack+0x12/0x44
[   52.056225] [ 1] [ EMERG] [[audio] ] [ 3] [<0x2cb1767e>] up_taskdump+0x36/0x38
[   52.057163] [ 1] [ EMERG] [[audio] ] [ 3] [<0x2cb0854a>] nxsched_foreach+0x2e/0x44
[   52.058131] [ 1] [ EMERG] [[audio] ] [ 3] [<0x2cb175f0>] xtensa_dumpstate+0x200/0x204
[   52.059142] [ 1] [ EMERG] [[audio] ] [ 3] [<0x2cb16c86>] xtensa_assert+0x6/0x38
[   52.060088] [ 1] [ EMERG] [[audio] ] [ 3] [<0x2cb16d2d>] xtensa_user_panic+0x39/0x3c
[   52.061084] [ 1] [ EMERG] [[audio] ] [ 3] [<0x2cb176a0>] _start+0/0xc
[   52.061863] [ 1] [ EMERG] [[audio] ] [ 3] [<0x2cb1689f>] _xtensa_user_handler+0x4f/0x6c
[   52.062893] [ 1] [ EMERG] [[audio] ] [ 3] [<0x40023>] Unknown+0x40023/0x2cb03948
[   52.063842] [ 1] [ EMERG] [[audio] ] [ 3] [<0x1eadbeef>] Unknown+0x1eadbeef/0x2cb03948
[   52.064852] [ 1] [ EMERG] [[audio] ] [ 3] [<0x2cb16da4>] up_block_task+0x74/0xa8
[   52.065823] [ 1] [ EMERG] [[audio] ] up_taskdump: rptun: PID=4 Stack Used=1040 of 4240
[   52.066742] [ 1] [ ALERT] [[audio] ] up_backtrace: 293, ret: 5, base: 0x3de14c00, 0x3de15c90, A1: 0x3de15ba0, A0: 0xacb16da4
[   52.068111] [ 1] [ EMERG] [[audio] ] backtrace:
[   52.068678] [ 1] [ EMERG] [[audio] ] [ 4] [<0x2cb16da4>] up_block_task+0x74/0xa8
[   52.069738] [ 1] [ EMERG] [[audio] ] [ 4] [<0x2cb08de8>] nxsem_wait+0x68/0x98
[   52.070657] [ 1] [ EMERG] [[audio] ] [ 4] [<0x2cb08e23>] nxsem_wait_uninterruptible+0xb/0x14
[   52.071725] [ 1] [ EMERG] [[audio] ] [ 4] [<0x2cb0c441>] rptun_thread+0x4d/0x3cc
[   52.072681] [ 1] [ EMERG] [[audio] ] [ 4] [<0x2cb0a743>] nxtask_start+0x57/0x7c
[   52.073642] [ 1] [ EMERG] [[audio] ] up_taskdump: audio_flinger: PID=5 Stack Used=400 of 2992
[   52.074638] [ 1] [ ALERT] [[audio] ] up_backtrace: 293, ret: 9, base: 0x3de09560, 0x3de0a110, A1: 0x3de09f90, A0: 0xacb16da4
[   52.076005] [ 1] [ EMERG] [[audio] ] backtrace:
[   52.076571] [ 1] [ EMERG] [[audio] ] [ 5] [<0x2cb16da4>] up_block_task+0x74/0xa8
[   52.077552] [ 1] [ EMERG] [[audio] ] [ 5] [<0x2cb08de8>] nxsem_wait+0x68/0x98
[   52.078474] [ 1] [ EMERG] [[audio] ] [ 5] [<0x2cb08e23>] nxsem_wait_uninterruptible+0xb/0x14
[   52.079541] [ 1] [ EMERG] [[audio] ] [ 5] [<0x2cb07d1d>] pthread_sem_take+0x39/0x40
[   52.080519] [ 1] [ EMERG] [[audio] ] [ 5] [<0x2cb07adb>] pthread_cond_wait+0x47/0x7c
[   52.081509] [ 1] [ EMERG] [[audio] ] [ 5] [<0x2cb43a84>] osSignalWait+0x174/0x1c4
[   52.082497] [ 1] [ EMERG] [[audio] ] [ 5] [<0x2cb8258a>] af_thread+0x1e/0x228
[   52.083452] [ 1] [ EMERG] [[audio] ] [ 5] [<0x2cb4384a>] main_proxy+0x5a/0x5c
[   52.084398] [ 1] [ EMERG] [[audio] ] [ 5] [<0x2cb0a743>] nxtask_start+0x57/0x7c
[   52.085348] [ 1] [ EMERG] [[audio] ] up_taskdump: init: PID=6 Stack Used=2064 of 4272
[   52.086258] [ 1] [ ALERT] [[audio] ] up_backtrace: 293, ret: 8, base: 0x3de16b90, 0x3de17c40, A1: 0x3de17a70, A0: 0xacb1d827
[   52.087629] [ 1] [ EMERG] [[audio] ] backtrace:
[   52.088195] [ 1] [ EMERG] [[audio] ] [ 6] [<0x2cb1d827>] nsh_command+0x63/0x68
[   52.089140] [ 1] [ EMERG] [[audio] ] [ 6] [<0x2cb1d109>] nsh_parse_command+0x83d/0x958
[   52.090161] [ 1] [ EMERG] [[audio] ] [ 6] [<0x2cb1c8a8>] nsh_parse+0x84/0xa8
[   52.091081] [ 1] [ EMERG] [[audio] ] [ 6] [<0x2cb20387>] nsh_session+0xab/0x15c
[   52.092031] [ 1] [ EMERG] [[audio] ] [ 6] [<0x2cb210c9>] nsh_consolemain+0x31/0x44
[   52.093010] [ 1] [ EMERG] [[audio] ] [ 6] [<0x2cb217c7>] nsh_main+0x33/0x50
[   52.093920] [ 1] [ EMERG] [[audio] ] [ 6] [<0x2cb10f4c>] nxtask_startup+0x20/0x24
[   52.094883] [ 1] [ EMERG] [[audio] ] [ 6] [<0x2cb0a754>] nxtask_start+0x68/0x7c
[   52.095845] [ 1] [ EMERG] [[audio] ] up_taskdump: usrsock: PID=7 Stack Used=680 of 4256
[   52.096778] [ 1] [ ALERT] [[audio] ] up_backtrace: 293, ret: 7, base: 0x3de17ca0, 0x3de18d40, A1: 0x3de18ba0, A0: 0xacb16da4
[   52.098138] [ 1] [ EMERG] [[audio] ] backtrace:
[   52.098704] [ 1] [ EMERG] [[audio] ] [ 7] [<0x2cb16da4>] up_block_task+0x74/0xa8
[   52.099759] [ 1] [ EMERG] [[audio] ] [ 7] [<0x2cb08de8>] nxsem_wait+0x68/0x98
[   52.100680] [ 1] [ EMERG] [[audio] ] [ 7] [<0x2cb2fa53>] nx_poll+0x16f/0x240
[   52.101612] [ 1] [ EMERG] [[audio] ] [ 7] [<0x2cb2fb35>] poll+0x11/0x2c
[   52.102490] [ 1] [ EMERG] [[audio] ] [ 7] [<0x2cb24362>] usrsock_main+0xd2/0x188
[   52.103451] [ 1] [ EMERG] [[audio] ] [ 7] [<0x2cb10f4c>] nxtask_startup+0x20/0x24
[   52.104415] [ 1] [ EMERG] [[audio] ] [ 7] [<0x2cb0a754>] nxtask_start+0x68/0x7c
```
