### PR TITLE
libc/unistd: getopt: Use argc to end parsing

### DIFF
--- a/libs/libc/unistd/lib_getopt_common.c
+++ b/libs/libc/unistd/lib_getopt_common.c
@@ -393,7 +393,7 @@ int getopt_common(int argc, FAR char * const argv[],
 
           /* Check for the end of the argument list */
 
-          go->go_optptr = argv[go->go_optind];
+          go->go_optptr = go->go_optind < argc ? argv[go->go_optind] : NULL;
           if (!go->go_optptr)
             {
               /* There are no more arguments, we are finished */


### PR DESCRIPTION
It should end parsing with argc even the argv are remaining or it may access to invalid address.
