### PR TITLE
arch/assert: flush the syslog before stack dump to avoid buffer overwrite

### DIFF
--- a/arch/arm/src/arm/arm_assert.c
+++ b/arch/arm/src/arm/arm_assert.c
@@ -77,6 +77,10 @@ static void up_stackdump(uint32_t sp, uint32_t stack_top)
 {
   uint32_t stack;
 
+  /* Flush any buffered SYSLOG data to avoid overwrite */
+
+  syslog_flush();
+
   for (stack = sp & ~0x1f; stack < (stack_top & ~0x1f); stack += 32)
     {
       uint32_t *ptr = (uint32_t *)stack;

--- a/arch/arm/src/armv6-m/arm_assert.c
+++ b/arch/arm/src/armv6-m/arm_assert.c
@@ -76,6 +76,10 @@ static void up_stackdump(uint32_t sp, uint32_t stack_top)
 {
   uint32_t stack;
 
+  /* Flush any buffered SYSLOG data to avoid overwrite */
+
+  syslog_flush();
+
   for (stack = sp & ~0x1f; stack < (stack_top & ~0x1f); stack += 32)
     {
       uint32_t *ptr = (uint32_t *)stack;

--- a/arch/arm/src/armv7-a/arm_assert.c
+++ b/arch/arm/src/armv7-a/arm_assert.c
@@ -79,6 +79,10 @@ static void up_stackdump(uint32_t sp, uint32_t stack_top)
 {
   uint32_t stack;
 
+  /* Flush any buffered SYSLOG data to avoid overwrite */
+
+  syslog_flush();
+
   for (stack = sp & ~0x1f; stack < (stack_top & ~0x1f); stack += 32)
     {
       uint32_t *ptr = (uint32_t *)stack;

--- a/arch/arm/src/armv7-m/arm_assert.c
+++ b/arch/arm/src/armv7-m/arm_assert.c
@@ -79,6 +79,10 @@ static void up_stackdump(uint32_t sp, uint32_t stack_top)
 {
   uint32_t stack;
 
+  /* Flush any buffered SYSLOG data to avoid overwrite */
+
+  syslog_flush();
+
   for (stack = sp & ~0x1f; stack < (stack_top & ~0x1f); stack += 32)
     {
       uint32_t *ptr = (uint32_t *)stack;

--- a/arch/arm/src/armv7-r/arm_assert.c
+++ b/arch/arm/src/armv7-r/arm_assert.c
@@ -76,6 +76,10 @@ static void up_stackdump(uint32_t sp, uint32_t stack_top)
 {
   uint32_t stack;
 
+  /* Flush any buffered SYSLOG data to avoid overwrite */
+
+  syslog_flush();
+
   for (stack = sp & ~0x1f; stack < (stack_top & ~0x1f); stack += 32)
     {
       uint32_t *ptr = (uint32_t *)stack;

--- a/arch/arm/src/armv8-m/arm_assert.c
+++ b/arch/arm/src/armv8-m/arm_assert.c
@@ -79,6 +79,10 @@ static void up_stackdump(uint32_t sp, uint32_t stack_top)
 {
   uint32_t stack;
 
+  /* Flush any buffered SYSLOG data to avoid overwrite */
+
+  syslog_flush();
+
   for (stack = sp & ~0x1f; stack < (stack_top & ~0x1f); stack += 32)
     {
       uint32_t *ptr = (uint32_t *)stack;

--- a/arch/avr/src/avr/up_dumpstate.c
+++ b/arch/avr/src/avr/up_dumpstate.c
@@ -31,6 +31,7 @@
 
 #include <nuttx/irq.h>
 #include <nuttx/arch.h>
+#include <nuttx/syslog/syslog.h>
 #include <arch/board/board.h>
 
 #include "up_arch.h"
@@ -51,7 +52,11 @@ static void up_stackdump(uint16_t sp, uint16_t stack_top)
 {
   uint16_t stack;
 
-  for (stack = sp & ~3; stack < (stack_top & ~0x1f); stack += 12)
+  /* Flush any buffered SYSLOG data to avoid overwrite */
+
+  syslog_flush();
+
+  for (stack = sp & ~0x3; stack < (stack_top & ~0x3); stack += 12)
     {
       uint8_t *ptr = (uint8_t *)stack;
       _alert("%04x: %02x %02x %02x %02x %02x %02x %02x %02x"

--- a/arch/avr/src/avr32/up_dumpstate.c
+++ b/arch/avr/src/avr32/up_dumpstate.c
@@ -31,6 +31,7 @@
 
 #include <nuttx/irq.h>
 #include <nuttx/arch.h>
+#include <nuttx/syslog/syslog.h>
 #include <arch/board/board.h>
 
 #include "up_arch.h"
@@ -50,6 +51,10 @@
 static void up_stackdump(uint32_t sp, uint32_t stack_top)
 {
   uint32_t stack;
+
+  /* Flush any buffered SYSLOG data to avoid overwrite */
+
+  syslog_flush();
 
   for (stack = sp & ~0x1f; stack < (stack_top & ~0x1f); stack += 32)
     {

--- a/arch/hc/src/m9s12/m9s12_assert.c
+++ b/arch/hc/src/m9s12/m9s12_assert.c
@@ -76,7 +76,11 @@ static void up_stackdump(uint16_t sp, uint16_t stack_top)
 {
   uint16_t stack;
 
-  for (stack = sp; stack < (stack_top & ~0x1f); stack += 16)
+  /* Flush any buffered SYSLOG data to avoid overwrite */
+
+  syslog_flush();
+
+  for (stack = sp & ~0x1f; stack < (stack_top & ~0x1f); stack += 16)
     {
       uint8_t *ptr = (uint8_t *)stack;
 

--- a/arch/mips/src/mips32/mips_dumpstate.c
+++ b/arch/mips/src/mips32/mips_dumpstate.c
@@ -32,6 +32,7 @@
 
 #include <nuttx/irq.h>
 #include <nuttx/arch.h>
+#include <nuttx/syslog/syslog.h>
 #include <arch/board/board.h>
 
 #include "mips_arch.h"
@@ -51,6 +52,10 @@
 static void up_stackdump(uint32_t sp, uint32_t stack_top)
 {
   uint32_t stack;
+
+  /* Flush any buffered SYSLOG data to avoid overwrite */
+
+  syslog_flush();
 
   for (stack = sp & ~0x1f; stack < (stack_top & ~0x1f); stack += 32)
     {

--- a/arch/misoc/src/lm32/lm32_dumpstate.c
+++ b/arch/misoc/src/lm32/lm32_dumpstate.c
@@ -31,6 +31,7 @@
 
 #include <nuttx/irq.h>
 #include <nuttx/arch.h>
+#include <nuttx/syslog/syslog.h>
 #include <arch/board/board.h>
 
 #include "sched/sched.h"
@@ -49,6 +50,10 @@
 static void up_stackdump(uint32_t sp, uint32_t stack_top)
 {
   uint32_t stack;
+
+  /* Flush any buffered SYSLOG data to avoid overwrite */
+
+  syslog_flush();
 
   for (stack = sp & ~0x1f; stack < (stack_top & ~0x1f); stack += 32)
     {

--- a/arch/misoc/src/minerva/minerva_dumpstate.c
+++ b/arch/misoc/src/minerva/minerva_dumpstate.c
@@ -31,6 +31,7 @@
 
 #include <nuttx/irq.h>
 #include <nuttx/arch.h>
+#include <nuttx/syslog/syslog.h>
 #include <arch/board/board.h>
 
 #include "sched/sched.h"
@@ -49,6 +50,10 @@
 static void up_stackdump(uint32_t sp, uint32_t stack_top)
 {
   uint32_t stack;
+
+  /* Flush any buffered SYSLOG data to avoid overwrite */
+
+  syslog_flush();
 
   for (stack = sp & ~0x1f; stack < (stack_top & ~0x1f); stack += 32)
     {

--- a/arch/or1k/src/common/up_assert.c
+++ b/arch/or1k/src/common/up_assert.c
@@ -32,6 +32,7 @@
 #include <nuttx/irq.h>
 #include <nuttx/arch.h>
 #include <nuttx/board.h>
+#include <nuttx/syslog/syslog.h>
 #include <nuttx/usb/usbdev_trace.h>
 
 #include <arch/board/board.h>
@@ -74,6 +75,10 @@ static uint32_t s_last_regs[XCPTCONTEXT_REGS];
 static void up_stackdump(uint32_t sp, uint32_t stack_top)
 {
   uint32_t stack;
+
+  /* Flush any buffered SYSLOG data to avoid overwrite */
+
+  syslog_flush();
 
   for (stack = sp & ~0x1f; stack < (stack_top & ~0x1f); stack += 32)
     {

--- a/arch/renesas/src/m16c/m16c_dumpstate.c
+++ b/arch/renesas/src/m16c/m16c_dumpstate.c
@@ -29,6 +29,7 @@
 
 #include <nuttx/irq.h>
 #include <nuttx/arch.h>
+#include <nuttx/syslog/syslog.h>
 
 #include "up_arch.h"
 #include "up_internal.h"
@@ -67,7 +68,11 @@ static void m16c_stackdump(uint16_t sp, uint16_t stack_top)
 {
   uint16_t stack;
 
-  for (stack = sp & ~7; stack < stack_top; stack += 8)
+  /* Flush any buffered SYSLOG data to avoid overwrite */
+
+  syslog_flush();
+
+  for (stack = sp & ~7; stack < (stack_top & ~7); stack += 8)
     {
       uint8_t *ptr = (uint8_t *)stack;
       _alert("%04x: %02x %02x %02x %02x %02x %02x %02x %02x\n",

--- a/arch/renesas/src/rx65n/rx65n_dumpstate.c
+++ b/arch/renesas/src/rx65n/rx65n_dumpstate.c
@@ -30,6 +30,7 @@
 
 #include <nuttx/irq.h>
 #include <nuttx/arch.h>
+#include <nuttx/syslog/syslog.h>
 
 #include "up_arch.h"
 #include "up_internal.h"
@@ -69,7 +70,11 @@ static void rx65n_stackdump(uint16_t sp, uint16_t stack_top)
 {
   uint16_t stack;
 
-  for (stack = sp & ~7; stack < stack_top; stack += 8) /* check */
+  /* Flush any buffered SYSLOG data to avoid overwrite */
+
+  syslog_flush();
+
+  for (stack = sp & ~7; stack < (stack_top & ~7); stack += 8) /* check */
 
     {
       uint8_t *ptr = (uint8_t *)&stack;

--- a/arch/renesas/src/sh1/sh1_dumpstate.c
+++ b/arch/renesas/src/sh1/sh1_dumpstate.c
@@ -29,6 +29,7 @@
 
 #include <nuttx/irq.h>
 #include <nuttx/arch.h>
+#include <nuttx/syslog/syslog.h>
 
 #include "up_arch.h"
 #include "up_internal.h"
@@ -54,7 +55,11 @@ static void sh1_stackdump(uint32_t sp, uint32_t stack_top)
 {
   uint32_t stack;
 
-  for (stack = sp & ~0x1f; stack < stack_top; stack += 32)
+  /* Flush any buffered SYSLOG data to avoid overwrite */
+
+  syslog_flush();
+
+  for (stack = sp & ~0x1f; stack < (stack_top & ~0x1f); stack += 32)
     {
       uint32_t *ptr = (uint32_t *)stack;
       _alert("%08x: %08x %08x %08x %08x %08x %08x %08x %08x\n",

--- a/arch/risc-v/src/rv32im/riscv_assert.c
+++ b/arch/risc-v/src/rv32im/riscv_assert.c
@@ -72,7 +72,11 @@ static void riscv_stackdump(uint32_t sp, uint32_t stack_top)
 {
   uint32_t stack;
 
-  for (stack = sp & ~0x1f; stack < stack_top; stack += 32)
+  /* Flush any buffered SYSLOG data to avoid overwrite */
+
+  syslog_flush();
+
+  for (stack = sp & ~0x1f; stack < (stack_top & ~0x1f); stack += 32)
     {
       uint32_t *ptr = (uint32_t *)stack;
       _alert("%08x: %08x %08x %08x %08x %08x %08x %08x %08x\n",

--- a/arch/risc-v/src/rv64gc/riscv_assert.c
+++ b/arch/risc-v/src/rv64gc/riscv_assert.c
@@ -75,6 +75,10 @@ static void up_stackdump(uint64_t sp, uintptr_t stack_top)
 {
   uintptr_t stack;
 
+  /* Flush any buffered SYSLOG data to avoid overwrite */
+
+  syslog_flush();
+
   for (stack = sp & ~0x1f; stack < (stack_top & ~0x1f); stack += 32)
     {
       uint32_t *ptr = (uint32_t *)stack;

--- a/arch/x86/src/common/up_assert.c
+++ b/arch/x86/src/common/up_assert.c
@@ -77,6 +77,10 @@ static void up_stackdump(uint32_t sp, uint32_t stack_top)
 {
   uint32_t stack;
 
+  /* Flush any buffered SYSLOG data to avoid overwrite */
+
+  syslog_flush();
+
   for (stack = sp & ~0x1f; stack < (stack_top & ~0x1f); stack += 32)
     {
       uint32_t *ptr = (uint32_t *)stack;

--- a/arch/x86_64/src/common/up_assert.c
+++ b/arch/x86_64/src/common/up_assert.c
@@ -69,6 +69,10 @@ static void up_stackdump(uint64_t sp, uint64_t stack_top)
 {
   uint64_t stack;
 
+  /* Flush any buffered SYSLOG data to avoid overwrite */
+
+  syslog_flush();
+
   for (stack = sp & ~0x1f; stack < (stack_top & ~0x1f); stack += 32)
     {
       uint32_t *ptr = (uint32_t *)stack;

--- a/arch/xtensa/src/common/xtensa_dumpstate.c
+++ b/arch/xtensa/src/common/xtensa_dumpstate.c
@@ -31,6 +31,7 @@
 
 #include <nuttx/irq.h>
 #include <nuttx/arch.h>
+#include <nuttx/syslog/syslog.h>
 
 #include <arch/xtensa/xtensa_corebits.h>
 #include <arch/board/board.h>
@@ -102,7 +103,11 @@ static void xtensa_stackdump(uint32_t sp, uint32_t stack_top)
 {
   uint32_t stack;
 
-  for (stack = sp & ~0x1f; stack < stack_top; stack += 32)
+  /* Flush any buffered SYSLOG data to avoid overwrite */
+
+  syslog_flush();
+
+  for (stack = sp & ~0x1f; stack < (stack_top & ~0x1f); stack += 32)
     {
       uint32_t *ptr = (uint32_t *)stack;
       _alert("%08x: %08x %08x %08x %08x %08x %08x %08x %08x\n",

--- a/arch/z16/src/common/z16_stackdump.c
+++ b/arch/z16/src/common/z16_stackdump.c
@@ -23,6 +23,7 @@
  ****************************************************************************/
 
 #include <nuttx/config.h>
+#include <nuttx/syslog/syslog.h>
 
 #include <debug.h>
 
@@ -68,8 +69,12 @@ static void z16_stackdump(void)
       stack = stack_base;
     }
 
+  /* Flush any buffered SYSLOG data to avoid overwrite */
+
+  syslog_flush();
+
   for (stack = stack & ~0x0f;
-       stack < stack_base + stack_size;
+       stack < ((stack_base + stack_size) & ~0x0f);
        stack += 8 * sizeof(chipreg_t))
     {
       chipreg_t *ptr = (chipreg_t *)stack;


### PR DESCRIPTION
## Summary

arch/assert: flush the syslog before stack dump

flush the syslog before stack dump to avoid buffer overwrite

## Impact

dump printf

## Testing

Trigger crash and check the dump info