### PR TITLE
fix: Correct issues with userled support on the Nucleo F4x1RE.

### DIFF
--- a/boards/arm/stm32/nucleo-f4x1re/src/stm32_bringup.c
+++ b/boards/arm/stm32/nucleo-f4x1re/src/stm32_bringup.c
@@ -37,12 +37,27 @@
 
 #include <arch/board/board.h>
 
+#ifdef CONFIG_USERLED
+#  include <nuttx/leds/userled.h>
+#endif
+
 #include "nucleo-f4x1re.h"
 
 #include <nuttx/board.h>
 
 #ifdef CONFIG_SENSORS_QENCODER
 #include "board_qencoder.h"
+#endif
+
+#undef HAVE_LEDS
+#if !defined(CONFIG_ARCH_LEDS) && defined(CONFIG_USERLED_LOWER)
+#  define HAVE_LEDS 1
+#endif
+
+#ifdef CONFIG_EXAMPLES_LEDS_DEVPATH
+#  define LED_DRIVER_PATH CONFIG_EXAMPLES_LEDS_DEVPATH
+#else
+#  define LED_DRIVER_PATH "/dev/userleds"
 #endif
 
 /****************************************************************************
@@ -66,6 +81,17 @@
 int stm32_bringup(void)
 {
   int ret = OK;
+
+#ifdef HAVE_LEDS
+  /* Register the LED driver */
+
+  ret = userled_lower_initialize(LED_DRIVER_PATH);
+  if (ret < 0)
+    {
+      syslog(LOG_ERR, "ERROR: userled_lower_initialize() failed: %d\n", ret);
+      return ret;
+    }
+#endif
 
   /* Configure SPI-based devices */
 

--- a/boards/arm/stm32/nucleo-f4x1re/src/stm32_userleds.c
+++ b/boards/arm/stm32/nucleo-f4x1re/src/stm32_userleds.c
@@ -164,7 +164,7 @@ uint32_t board_userled_initialize(void)
 
 void board_userled(int led, bool ledon)
 {
-  if (led == 1)
+  if (BOARD_LD2_BIT == (1 << led))
     {
       stm32_gpiowrite(GPIO_LD2, ledon);
     }
@@ -176,8 +176,28 @@ void board_userled(int led, bool ledon)
 
 void board_userled_all(uint32_t ledset)
 {
+  /* An output of '1' illuminates the LED */
+
   stm32_gpiowrite(GPIO_LD2, (ledset & BOARD_LD2_BIT) != 0);
 }
+
+#ifdef CONFIG_USERLED_LOWER_READSTATE
+/****************************************************************************
+ * Name: board_userled_getall
+ ****************************************************************************/
+
+void board_userled_getall(uint32_t *ledset)
+{
+  /* Clear the LED bits */
+
+  *ledset = 0;
+
+  /* Get LED state. An output of '1' illuminates the LED. */
+
+  *ledset |= ((stm32_gpioread(GPIO_LD2) & 1) << BOARD_LD2);
+}
+
+#endif /* CONFIG_USERLED_LOWER_READSTATE */
 
 /****************************************************************************
  * Name: stm32_led_pminitialize


### PR DESCRIPTION
## Summary
Correct issues with userled support on the Nucleo F4x1RE.  

Specifically:
   The proper headers are included when CONFIG_USERLED is defined.
   LED_DRIVER_PATH is set when CONFIG_USERLED_LOWER is defined and CONFIG_ARCH_LEDS is NOT defined.
   board_userled() is corrected for the nucleo-f4x1re.
   board_userled_getall() is implemented for the nucleo-f4x1re.
   userled_lower_initialize() is called when properly configured.
   some comments added.
   
## Impact
userled support on the Nucleo F4x1RE will work properly for the Nucleo F4x1RE.  No other impacts.

## Testing
tested and verified on the Nucleo F4x1RE.
