### PR TITLE
libc: Enable terminal api regardless of CONFIG_SERIAL_TERMIOS setting

### DIFF
--- a/arch/renesas/include/rx65n/iodefine.h
+++ b/arch/renesas/include/rx65n/iodefine.h
@@ -1022,6 +1022,8 @@
 #define FLASHCONST      (*(volatile struct st_flashconst      *)0xfe7f7d90)
 #define TEMPSCONST      (*(volatile struct st_tempsconst      *)0xfe7f7d7c)
 
+#undef B0 /* Avoid the conflicted macro in termios.h */
+
 /****************************************************************************
  * Public Types
  ****************************************************************************/

--- a/drivers/serial/Kconfig
+++ b/drivers/serial/Kconfig
@@ -191,7 +191,6 @@ config TTY_FORCE_PANIC_CHAR
 config TTY_SIGINT
 	bool "Support SIGINT"
 	default n
-	depends on SERIAL_TERMIOS
 	---help---
 		Whether support Ctrl-c/x event.  Enabled automatically for console
 		devices.  May be enabled for other serial devices using the ISIG bit
@@ -235,7 +234,6 @@ config TTY_SIGINT_CHAR
 config TTY_SIGTSTP
 	bool "Support SIGTSTP"
 	default n
-	depends on SERIAL_TERMIOS
 	---help---
 		Whether support Ctrl-z event.  Enabled automatically for console
 		devices.  May be enabled for other serial devices using the ISIG bit

--- a/drivers/serial/Make.defs
+++ b/drivers/serial/Make.defs
@@ -36,12 +36,6 @@ ifeq ($(CONFIG_RPMSG_UART),y)
   CSRCS += uart_rpmsg.c
 endif
 
-# termios support
-
-ifeq ($(CONFIG_SERIAL_TERMIOS),y)
-  CSRCS += tcdrain.c
-endif
-
 # Pseudo-terminal support
 
 ifeq ($(CONFIG_PSEUDOTERM),y)

--- a/drivers/serial/serial.c
+++ b/drivers/serial/serial.c
@@ -1603,13 +1603,13 @@ errout:
 
 int uart_register(FAR const char *path, FAR uart_dev_t *dev)
 {
-#ifdef CONFIG_SERIAL_TERMIOS
-#  if defined(CONFIG_TTY_SIGINT) || defined(CONFIG_TTY_SIGTSTP)
+#if defined(CONFIG_TTY_SIGINT) || defined(CONFIG_TTY_SIGTSTP)
   /* Initialize  of the task that will receive SIGINT signals. */
 
   dev->pid = (pid_t)-1;
-#  endif
+#endif
 
+#ifdef CONFIG_SERIAL_TERMIOS
   /* If this UART is a serial console */
 
   if (dev->isconsole)

--- a/drivers/serial/serial.c
+++ b/drivers/serial/serial.c
@@ -1354,7 +1354,6 @@ static int uart_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
             }
             break;
 
-#ifdef CONFIG_SERIAL_TERMIOS
           case TCFLSH:
             {
               /* Empty the tx/rx buffers */
@@ -1391,7 +1390,6 @@ static int uart_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
               ret = uart_tcdrain(dev, true, 10 * TICK_PER_SEC);
             }
             break;
-#endif
 
 #if defined(CONFIG_TTY_SIGINT) || defined(CONFIG_TTY_SIGTSTP)
           /* Make the controlling terminal of the calling process */

--- a/drivers/serial/serial.c
+++ b/drivers/serial/serial.c
@@ -41,6 +41,7 @@
 #include <nuttx/sched.h>
 #include <nuttx/signal.h>
 #include <nuttx/fs/fs.h>
+#include <nuttx/cancelpt.h>
 #include <nuttx/serial/serial.h>
 #include <nuttx/fs/ioctl.h>
 #include <nuttx/power/pm.h>
@@ -87,7 +88,8 @@ static int     uart_putxmitchar(FAR uart_dev_t *dev, int ch,
 static inline ssize_t uart_irqwrite(FAR uart_dev_t *dev,
                                     FAR const char *buffer,
                                     size_t buflen);
-static int     uart_tcdrain(FAR uart_dev_t *dev, clock_t timeout);
+static int     uart_tcdrain(FAR uart_dev_t *dev,
+                            bool cancelable, clock_t timeout);
 
 /* Character driver methods */
 
@@ -397,9 +399,24 @@ static inline ssize_t uart_irqwrite(FAR uart_dev_t *dev,
  *
  ****************************************************************************/
 
-static int uart_tcdrain(FAR uart_dev_t *dev, clock_t timeout)
+static int uart_tcdrain(FAR uart_dev_t *dev,
+                        bool cancelable, clock_t timeout)
 {
   int ret;
+
+  /* tcdrain is a cancellation point */
+
+  if (cancelable && enter_cancellation_point())
+    {
+#ifdef CONFIG_CANCELLATION_POINTS
+      /* If there is a pending cancellation, then do not perform
+       * the wait.  Exit now with ECANCELED.
+       */
+
+      leave_cancellation_point();
+      return -ECANCELED;
+#endif
+    }
 
   /* Get exclusive access to the to dev->tmit.  We cannot permit new data to
    * be written while we are trying to flush the old data.
@@ -501,6 +518,11 @@ static int uart_tcdrain(FAR uart_dev_t *dev, clock_t timeout)
         }
 
       uart_givesem(&dev->xmit.sem);
+    }
+
+  if (cancelable)
+    {
+      leave_cancellation_point();
     }
 
   return ret;
@@ -661,7 +683,7 @@ static int uart_close(FAR struct file *filep)
     {
       /* Now we wait for the transmit buffer(s) to clear */
 
-      uart_tcdrain(dev, 4 * TICK_PER_SEC);
+      uart_tcdrain(dev, false, 4 * TICK_PER_SEC);
     }
 
   /* Free the IRQ and disable the UART */
@@ -1366,7 +1388,7 @@ static int uart_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
 
           case TCDRN:
             {
-              ret = uart_tcdrain(dev, 10 * TICK_PER_SEC);
+              ret = uart_tcdrain(dev, true, 10 * TICK_PER_SEC);
             }
             break;
 #endif

--- a/include/cxx/cunistd
+++ b/include/cxx/cunistd
@@ -56,9 +56,7 @@ namespace std
 
   // Terminal I/O
 
-#ifdef CONFIG_SERIAL_TERMIOS
   using ::isatty;
-#endif
 
   // Memory management
 

--- a/include/nuttx/serial/serial.h
+++ b/include/nuttx/serial/serial.h
@@ -31,9 +31,7 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <errno.h>
-#ifdef CONFIG_SERIAL_TERMIOS
-#  include <termios.h>
-#endif
+#include <termios.h>
 
 #include <nuttx/fs/fs.h>
 #include <nuttx/semaphore.h>

--- a/include/nuttx/serial/serial.h
+++ b/include/nuttx/serial/serial.h
@@ -280,15 +280,16 @@ struct uart_dev_s
 #endif
   bool                 isconsole;    /* true: This is the serial console */
 
+#if defined(CONFIG_TTY_SIGINT) || defined(CONFIG_TTY_SIGTSTP)
+  pid_t                pid;          /* Thread PID to receive signals (-1 if none) */
+#endif
+
 #ifdef CONFIG_SERIAL_TERMIOS
   /* Terminal control flags */
 
   tcflag_t             tc_iflag;     /* Input modes */
   tcflag_t             tc_oflag;     /* Output modes */
   tcflag_t             tc_lflag;     /* Local modes */
-#if defined(CONFIG_TTY_SIGINT) || defined(CONFIG_TTY_SIGTSTP)
-  pid_t                pid;          /* Thread PID to receive signals (-1 if none) */
-#endif
 #endif
 
   /* Semaphores */

--- a/include/stdlib.h
+++ b/include/stdlib.h
@@ -62,9 +62,7 @@
  * function call.  However, get_environ_ptr() can be used in its place.
  */
 
-#ifndef CONFIG_DISABLE_ENVIRON
-#  define environ get_environ_ptr()
-#endif
+#define environ get_environ_ptr()
 
 #if defined(CONFIG_FS_LARGEFILE) && defined(CONFIG_HAVE_LONG_LONG)
 #  define mkstemp64            mkstemp

--- a/include/sys/syscall_lookup.h
+++ b/include/sys/syscall_lookup.h
@@ -223,9 +223,6 @@ SYSCALL_LOOKUP(pwrite,                     4)
   SYSCALL_LOOKUP(timerfd_settime,          4)
   SYSCALL_LOOKUP(timerfd_gettime,          2)
 #endif
-#ifdef CONFIG_SERIAL_TERMIOS
-  SYSCALL_LOOKUP(tcdrain,                  1)
-#endif
 
 /* Board support */
 

--- a/include/termios.h
+++ b/include/termios.h
@@ -217,7 +217,7 @@
 
 /* Baud rate selection */
 
-typedef unsigned int  speed_t;   /* Used for terminal baud rates */
+typedef unsigned long speed_t;   /* Used for terminal baud rates */
 
 /* Types used within the termios structure */
 

--- a/include/termios.h
+++ b/include/termios.h
@@ -29,8 +29,6 @@
 #include <sys/types.h>
 #include <stdint.h>
 
-#ifdef CONFIG_SERIAL_TERMIOS
-
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
@@ -319,5 +317,4 @@ int tcsetattr(int fd, int options, FAR const struct termios *termiosp);
 }
 #endif
 
-#endif /* CONFIG_SERIAL_TERMIOS */
 #endif /* __INCLUDE_TERMIOS_H */

--- a/include/unistd.h
+++ b/include/unistd.h
@@ -327,14 +327,12 @@ ssize_t pwrite(int fd, FAR const void *buf, size_t nbytes, off_t offset);
 int     ftruncate(int fd, off_t length);
 int     fchown(int fd, uid_t owner, gid_t group);
 
-#ifdef CONFIG_SERIAL_TERMIOS
 /* Check if a file descriptor corresponds to a terminal I/O file */
 
 int     isatty(int fd);
 
 FAR char *ttyname(int fd);
 int       ttyname_r(int fd, FAR char *buf, size_t buflen);
-#endif
 
 /* Memory management */
 

--- a/include/unistd.h
+++ b/include/unistd.h
@@ -302,9 +302,7 @@ extern "C"
 pid_t   vfork(void);
 pid_t   getpid(void);
 pid_t   gettid(void);
-#ifdef CONFIG_SCHED_HAVE_PARENT
 pid_t   getppid(void);
-#endif
 void    _exit(int status) noreturn_function;
 unsigned int sleep(unsigned int seconds);
 int     usleep(useconds_t usec);

--- a/libs/libc/termios/Make.defs
+++ b/libs/libc/termios/Make.defs
@@ -21,8 +21,6 @@
 # termios.h support requires file descriptors and that CONFIG_SERIAL_TERMIOS
 # is defined
 
-ifeq ($(CONFIG_SERIAL_TERMIOS),y)
-
 # Add the termios C files to the build
 
 CSRCS += lib_cfspeed.c lib_cfmakeraw.c lib_isatty.c lib_tcflush.c
@@ -33,5 +31,3 @@ CSRCS += lib_ttyname.c lib_ttynamer.c
 
 DEPPATH += --dep-path termios
 VPATH += termios
-
-endif

--- a/libs/libc/termios/Make.defs
+++ b/libs/libc/termios/Make.defs
@@ -26,7 +26,7 @@ ifeq ($(CONFIG_SERIAL_TERMIOS),y)
 # Add the termios C files to the build
 
 CSRCS += lib_cfspeed.c lib_cfmakeraw.c lib_isatty.c lib_tcflush.c
-CSRCS += lib_tcflow.c lib_tcgetattr.c lib_tcsetattr.c
+CSRCS += lib_tcdrain.c lib_tcflow.c lib_tcgetattr.c lib_tcsetattr.c
 CSRCS += lib_ttyname.c lib_ttynamer.c
 
 # Add the termios directory to the build

--- a/libs/libc/termios/lib_tcdrain.c
+++ b/libs/libc/termios/lib_tcdrain.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * drivers/serial/tcdrain.c
+ * libs/libc/termios/lib_tcdrain.c
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -29,7 +29,6 @@
 #include <termios.h>
 #include <errno.h>
 
-#include <nuttx/cancelpt.h>
 #include <nuttx/serial/tioctl.h>
 
 /****************************************************************************
@@ -54,33 +53,5 @@
 
 int tcdrain(int fd)
 {
-  int ret;
-
-  /* tcdrain is a cancellation point */
-
-  if (enter_cancellation_point())
-    {
-#ifdef CONFIG_CANCELLATION_POINTS
-      /* If there is a pending cancellation, then do not perform
-       * the wait.  Exit now with ECANCELED.
-       */
-
-      set_errno(ECANCELED);
-      leave_cancellation_point();
-      return ERROR;
-#endif
-    }
-
-  /* Perform the TCDRM IOCTL command.  It is safe to use the file descriptor
-   * in this context because we are executing on the calling application's
-   * thread.
-   *
-   * NOTE: ioctl() will set the errno variable and return ERROR if any error
-   * occurs.
-   */
-
-  ret = ioctl(fd, TCDRN, (unsigned long)0);
-
-  leave_cancellation_point();
-  return ret;
+  return ioctl(fd, TCDRN, (unsigned long)0);
 }

--- a/libs/libc/termios/lib_tcgetattr.c
+++ b/libs/libc/termios/lib_tcgetattr.c
@@ -60,5 +60,5 @@
 
 int tcgetattr(int fd, FAR struct termios *termiosp)
 {
-  return ioctl(fd, TCGETS, (unsigned long)termiosp);
+  return ioctl(fd, TCGETS, (unsigned long)(uintptr_t)termiosp);
 }

--- a/libs/libc/termios/lib_tcsetattr.c
+++ b/libs/libc/termios/lib_tcsetattr.c
@@ -93,5 +93,5 @@ int tcsetattr(int fd, int options, FAR const struct termios *termiosp)
       tcflush(fd, TCIFLUSH);
     }
 
-  return ioctl(fd, TCSETS, (unsigned long)termiosp);
+  return ioctl(fd, TCSETS, (unsigned long)(uintptr_t)termiosp);
 }

--- a/syscall/syscall.csv
+++ b/syscall/syscall.csv
@@ -177,7 +177,6 @@
 "task_setcanceltype","sched.h","defined(CONFIG_CANCELLATION_POINTS)","int","int","FAR int *"
 "task_spawn","nuttx/spawn.h","!defined(CONFIG_BUILD_KERNEL)","int","FAR const char *","main_t","FAR const posix_spawn_file_actions_t *","FAR const posix_spawnattr_t *","FAR char * const []|FAR char * const *","FAR char * const []|FAR char * const *"
 "task_testcancel","pthread.h","defined(CONFIG_CANCELLATION_POINTS)","void"
-"tcdrain","termios.h","defined(CONFIG_SERIAL_TERMIOS)","int","int"
 "telldir","dirent.h","","off_t","FAR DIR *"
 "timer_create","time.h","!defined(CONFIG_DISABLE_POSIX_TIMERS)","int","clockid_t","FAR struct sigevent *","FAR timer_t *"
 "timer_delete","time.h","!defined(CONFIG_DISABLE_POSIX_TIMERS)","int","timer_t"


### PR DESCRIPTION
## Summary

since many functions aren't related to termios directly：

- serial: Make SIGINT and SIGTSTP work even without CONFIG_SERIAL_TERMIOS
- serial: Move tcdrain implementation from drivers/serial to libc
- Fix termios/lib_cfspeed.c:78:5: error: large integer implicitly truncated to unsigned type
- libc: Enable terminal api regardless of CONFIG_SERIAL_TERMIOS setting

## Impact
More functions can be called when CONFIG_SERIAL_TERMIOS isn't selected.

## Testing
Pass CI
