### PR TITLE
syslog/rpmsg: using up_putc to force flush syslog_rpmsg buffer

### DIFF
--- a/arch/sim/src/sim/up_uart.c
+++ b/arch/sim/src/sim/up_uart.c
@@ -573,10 +573,10 @@ void up_uartloop(void)
  * Name: up_putc
  ****************************************************************************/
 
-#ifdef USE_DEVCONSOLE
 int up_putc(int ch)
 {
+#ifdef USE_DEVCONSOLE
   tty_send(&g_console_dev, ch);
+#endif
   return 0;
 }
-#endif


### PR DESCRIPTION
## Summary
syslog/rpmsg: using up_putc to force flush syslog_rpmsg buffer.

For multi-core, it's very important, this will make sure the crash log can be output by up_putc rather than rpmsg ipc, because the crash of slave will cause ipc buffer output to  master of syslog rpmsg in time. 

## Impact

## Testing
daily test
