### PR TITLE
nrf52832-dk/nrf52840-dk: add procfs and sdc support

### DIFF
--- a/boards/arm/nrf52/nrf52832-dk/src/nrf52832-dk.h
+++ b/boards/arm/nrf52/nrf52832-dk/src/nrf52832-dk.h
@@ -34,6 +34,18 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
+/* Configuration ************************************************************/
+
+/* procfs File System */
+
+#ifdef CONFIG_FS_PROCFS
+#  ifdef CONFIG_NSH_PROC_MOUNTPOINT
+#    define NRF52_PROCFS_MOUNTPOINT CONFIG_NSH_PROC_MOUNTPOINT
+#  else
+#    define NRF52_PROCFS_MOUNTPOINT "/proc"
+#  endif
+#endif
+
 /* LED definitions **********************************************************/
 
 /* Definitions to configure LED GPIO as outputs */

--- a/boards/arm/nrf52/nrf52832-dk/src/nrf52_bringup.c
+++ b/boards/arm/nrf52/nrf52832-dk/src/nrf52_bringup.c
@@ -27,6 +27,8 @@
 #include <sys/types.h>
 #include <syslog.h>
 
+#include <nuttx/fs/fs.h>
+
 #ifdef CONFIG_NRF52_WDT
 #  include "nrf52_wdt_lowerhalf.h"
 #endif
@@ -34,6 +36,8 @@
 #ifdef CONFIG_USERLED
 #  include <nuttx/leds/userled.h>
 #endif
+
+#include "nrf52832-dk.h"
 
 /****************************************************************************
  * Public Functions
@@ -56,6 +60,17 @@
 int nrf52_bringup(void)
 {
   int ret;
+
+#ifdef CONFIG_FS_PROCFS
+  /* Mount the procfs file system */
+
+  ret = nx_mount(NULL, NRF52_PROCFS_MOUNTPOINT, "procfs", 0, NULL);
+  if (ret < 0)
+    {
+      syslog(LOG_ERR,
+             "ERROR: Failed to mount the PROC filesystem: %d\n",  ret);
+    }
+#endif /* CONFIG_FS_PROCFS */
 
 #ifdef CONFIG_NRF52_WDT
   /* Start Watchdog timer */

--- a/boards/arm/nrf52/nrf52832-dk/src/nrf52_bringup.c
+++ b/boards/arm/nrf52/nrf52832-dk/src/nrf52_bringup.c
@@ -37,6 +37,10 @@
 #  include <nuttx/leds/userled.h>
 #endif
 
+#ifdef CONFIG_NRF52_SOFTDEVICE_CONTROLLER
+#  include "nrf52_sdc.h"
+#endif
+
 #include "nrf52832-dk.h"
 
 /****************************************************************************
@@ -89,6 +93,15 @@ int nrf52_bringup(void)
   if (ret < 0)
     {
       syslog(LOG_ERR, "ERROR: userled_lower_initialize() failed: %d\n", ret);
+    }
+#endif
+
+#ifdef CONFIG_NRF52_SOFTDEVICE_CONTROLLER
+  ret = nrf52_sdc_initialize();
+
+  if (ret < 0)
+    {
+      syslog(LOG_ERR, "ERROR: nrf52_sdc_initialize() failed: %d\n", ret);
     }
 #endif
 

--- a/boards/arm/nrf52/nrf52840-dk/src/nrf52840-dk.h
+++ b/boards/arm/nrf52/nrf52840-dk/src/nrf52840-dk.h
@@ -34,6 +34,18 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
+/* Configuration ************************************************************/
+
+/* procfs File System */
+
+#ifdef CONFIG_FS_PROCFS
+#  ifdef CONFIG_NSH_PROC_MOUNTPOINT
+#    define NRF52_PROCFS_MOUNTPOINT CONFIG_NSH_PROC_MOUNTPOINT
+#  else
+#    define NRF52_PROCFS_MOUNTPOINT "/proc"
+#  endif
+#endif
+
 /* LED definitions **********************************************************/
 
 /* Definitions to configure LED GPIO as outputs */

--- a/boards/arm/nrf52/nrf52840-dk/src/nrf52_bringup.c
+++ b/boards/arm/nrf52/nrf52840-dk/src/nrf52_bringup.c
@@ -27,6 +27,8 @@
 #include <sys/types.h>
 #include <syslog.h>
 
+#include <nuttx/fs/fs.h>
+
 #ifdef CONFIG_USERLED
 #  include <nuttx/leds/userled.h>
 #endif
@@ -112,6 +114,17 @@ static void nrf52_i2ctool(void)
 int nrf52_bringup(void)
 {
   int ret;
+
+#ifdef CONFIG_FS_PROCFS
+  /* Mount the procfs file system */
+
+  ret = nx_mount(NULL, NRF52_PROCFS_MOUNTPOINT, "procfs", 0, NULL);
+  if (ret < 0)
+    {
+      syslog(LOG_ERR,
+             "ERROR: Failed to mount the PROC filesystem: %d\n",  ret);
+    }
+#endif /* CONFIG_FS_PROCFS */
 
 #ifdef CONFIG_USERLED
   /* Register the LED driver */

--- a/boards/arm/nrf52/nrf52840-dk/src/nrf52_bringup.c
+++ b/boards/arm/nrf52/nrf52840-dk/src/nrf52_bringup.c
@@ -33,6 +33,10 @@
 #  include <nuttx/leds/userled.h>
 #endif
 
+#ifdef CONFIG_NRF52_SOFTDEVICE_CONTROLLER
+#  include "nrf52_sdc.h"
+#endif
+
 #include "nrf52840-dk.h"
 
 /****************************************************************************
@@ -211,6 +215,15 @@ int nrf52_bringup(void)
       syslog(LOG_ERR,
              "ERROR: Failed to initialize ADC driver: %d\n",
              ret);
+    }
+#endif
+
+#ifdef CONFIG_NRF52_SOFTDEVICE_CONTROLLER
+  ret = nrf52_sdc_initialize();
+
+  if (ret < 0)
+    {
+      syslog(LOG_ERR, "ERROR: nrf52_sdc_initialize() failed: %d\n", ret);
     }
 #endif
 


### PR DESCRIPTION
## Summary

- boards/arm/nrf52/nrf52840-dk: add procfs support
- boards/arm/nrf52/nrf52832-dk: add procfs support
- boards/arm/nrf52/nrf52840-dk: add sdc support
- boards/arm/nrf52/nrf52832-dk: add sdc support

## Impact

## Testing
nrf52832-dk and nrf52840-dk
