### PR TITLE
sensor: reset interval,latency and circbuf when sensor is closed 

### DIFF
--- a/drivers/sensors/sensor.c
+++ b/drivers/sensors/sensor.c
@@ -370,6 +370,13 @@ static int sensor_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
           if (ret >= 0)
             {
               upper->enabled = !!arg;
+              if (!upper->enabled)
+                {
+                  upper->interval = 0;
+                  upper->latency = 0;
+                  ret = circbuf_resize(&upper->buffer, lower->buffer_number *
+                                                       upper->esize);
+                }
             }
         }
         break;

--- a/mm/circbuf/circbuf.c
+++ b/mm/circbuf/circbuf.c
@@ -109,6 +109,10 @@ int circbuf_resize(FAR struct circbuf_s *circ, size_t bytes)
 
   DEBUGASSERT(circ);
   DEBUGASSERT(!circ->external);
+  if (bytes == circ->size)
+    {
+      return 0;
+    }
 
   if (bytes)
     {


### PR DESCRIPTION
## Summary
sensor: reset interval,latency and circbuf when sensor is closed., then setting  same interval  successfully when sensor activated again.

## Impact
N/A
## Testing
daily test
