### PR TITLE
add 5-Clause Nordic License barrier for Nordic SoftDevice Controller

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -40,6 +40,17 @@ config ALLOW_GPL_COMPONENTS
 		NOTE: Please check that the license for each enabled
 		component matches your project license.
 
+config ALLOW_BSDNORDIC_COMPONENTS
+	bool "Use components that have 5-Clause Nordic licenses"
+	depends on ARCH_CHIP_NRF52
+	default n
+	---help---
+		When this option is enabled the project will allow the use
+		of components that have 5-Clause Nordic licenses.
+
+		NOTE: Please check that the license for each enabled
+		component matches your project license.
+
 endmenu # License Setup
 
 menu "Build Setup"

--- a/LICENSE
+++ b/LICENSE
@@ -2459,3 +2459,44 @@ drivers/wireless/spirit/
  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+arch/arm/src/nrf52/sdk-nrfxlib
+===============================
+ Nordic SoftDevice Controller is based on the 3-Clause BSD License:
+
+   Copyright (c) 2018, Nordic Semiconductor ASA
+
+   All rights reserved.
+
+   Redistribution and use in source and binary forms, with or without modification,
+   are permitted provided that the following conditions are met:
+
+   1. Redistributions of source code must retain the above copyright notice, this
+      list of conditions and the following disclaimer.
+
+   2. Redistributions in binary form, except as embedded into a Nordic
+      Semiconductor ASA integrated circuit in a product or a software update for
+      such product, must reproduce the above copyright notice, this list of
+      conditions and the following disclaimer in the documentation and/or other
+      materials provided with the distribution.
+
+   3. Neither the name of Nordic Semiconductor ASA nor the names of its
+      contributors may be used to endorse or promote products derived from this
+      software without specific prior written permission.
+
+   4. This software, with or without modification, must only be used with a
+      Nordic Semiconductor ASA integrated circuit.
+
+   5. Any software provided in binary form under this license must not be reverse
+      engineered, decompiled, modified and/or disassembled.
+
+   THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS
+   OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+   OF MERCHANTABILITY, NONINFRINGEMENT, AND FITNESS FOR A PARTICULAR PURPOSE ARE
+   DISCLAIMED. IN NO EVENT SHALL NORDIC SEMICONDUCTOR ASA OR CONTRIBUTORS BE
+   LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+   CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+   GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+   HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+   OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/arch/arm/src/nrf52/Kconfig
+++ b/arch/arm/src/nrf52/Kconfig
@@ -661,6 +661,7 @@ endmenu
 
 menuconfig NRF52_SOFTDEVICE_CONTROLLER
 	bool "SoftDevice Controller"
+	depends on ALLOW_BSDNORDIC_COMPONENTS
 	select CONFIG_ARMV7M_USEBASEPRI
 	select CONFIG_ARCH_RAMVECTORS
 	select NRF52_USE_LFCLK


### PR DESCRIPTION
## Summary
add 5-Clause Nordic License barrier for Nordic SoftDevice Controller

## Impact

## Testing
CI
