### PR TITLE
eventfd: Remove the unused and private eventfd_get_minor

### DIFF
--- a/fs/vfs/fs_eventfd.c
+++ b/fs/vfs/fs_eventfd.c
@@ -41,7 +41,7 @@
  ****************************************************************************/
 
 #ifndef CONFIG_EVENT_FD_VFS_PATH
-#define CONFIG_EVENT_FD_VFS_PATH "/dev"
+#define CONFIG_EVENT_FD_VFS_PATH "/var/event"
 #endif
 
 #ifndef CONFIG_EVENT_FD_NPOLLWAITERS
@@ -226,9 +226,9 @@ static int eventfd_do_close(FAR struct file *filep)
   FAR struct inode *inode = filep->f_inode;
   FAR struct eventfd_priv_s *priv = inode->i_private;
 
-  /* devpath: EVENT_FD_VFS_PATH + /efd (4) + %d (3) + null char (1) */
+  /* devpath: EVENT_FD_VFS_PATH + /efd (4) + %d (10) + null char (1) */
 
-  char devpath[sizeof(CONFIG_EVENT_FD_VFS_PATH) + 4 + 3 + 1];
+  char devpath[sizeof(CONFIG_EVENT_FD_VFS_PATH) + 4 + 10 + 1];
 
   /* Get exclusive access to the device structures */
 

--- a/fs/vfs/fs_eventfd.c
+++ b/fs/vfs/fs_eventfd.c
@@ -66,10 +66,10 @@ struct eventfd_priv_s
   sem_t     exclsem;            /* Enforces device exclusive access */
   eventfd_waiter_sem_t *rdsems; /* List of blocking readers */
   eventfd_waiter_sem_t *wrsems; /* List of blocking writers */
-  eventfd_t counter;            /* eventfd counter */
-  size_t    minor;              /* eventfd minor number */
-  uint8_t   crefs;              /* References counts on eventfd (max: 255) */
-  uint8_t   mode_semaphore;     /* eventfd mode (semaphore or counter) */
+  eventfd_t    counter;         /* eventfd counter */
+  unsigned int minor;           /* eventfd minor number */
+  uint8_t      crefs;           /* References counts on eventfd (max: 255) */
+  uint8_t      mode_semaphore;  /* eventfd mode (semaphore or counter) */
 
   /* The following is a list if poll structures of threads waiting for
    * driver events.
@@ -103,8 +103,8 @@ static int eventfd_blocking_io(FAR struct eventfd_priv_s *dev,
                                eventfd_waiter_sem_t *sem,
                                FAR eventfd_waiter_sem_t **slist);
 
-static size_t eventfd_get_unique_minor(void);
-static void eventfd_release_minor(size_t minor);
+static unsigned int eventfd_get_unique_minor(void);
+static void eventfd_release_minor(unsigned int minor);
 
 static FAR struct eventfd_priv_s *eventfd_allocdev(void);
 static void eventfd_destroy(FAR struct eventfd_priv_s *dev);
@@ -175,14 +175,14 @@ static void eventfd_pollnotify(FAR struct eventfd_priv_s *dev,
 }
 #endif
 
-static size_t eventfd_get_unique_minor(void)
+static unsigned int eventfd_get_unique_minor(void)
 {
-  static size_t minor;
+  static unsigned int minor;
 
   return minor++;
 }
 
-static void eventfd_release_minor(size_t minor)
+static void eventfd_release_minor(unsigned int minor)
 {
 }
 
@@ -591,7 +591,7 @@ int eventfd(unsigned int count, int flags)
 
   /* Get device path */
 
-  sprintf(devpath, CONFIG_EVENT_FD_VFS_PATH "/efd%d", new_dev->minor);
+  sprintf(devpath, CONFIG_EVENT_FD_VFS_PATH "/efd%u", new_dev->minor);
 
   /* Register the driver */
 

--- a/fs/vfs/fs_eventfd.c
+++ b/fs/vfs/fs_eventfd.c
@@ -91,8 +91,6 @@ static ssize_t eventfd_do_read(FAR struct file *filep, FAR char *buffer,
                                size_t len);
 static ssize_t eventfd_do_write(FAR struct file *filep,
                                 FAR const char *buffer, size_t len);
-static int eventfd_do_ioctl(FAR struct file *filep, int cmd,
-                            unsigned long arg);
 #ifdef CONFIG_EVENT_FD_POLL
 static int eventfd_do_poll(FAR struct file *filep, FAR struct pollfd *fds,
                        bool setup);
@@ -121,8 +119,8 @@ static const struct file_operations g_eventfd_fops =
   eventfd_do_close, /* close */
   eventfd_do_read,  /* read */
   eventfd_do_write, /* write */
-  0,                /* seek */
-  eventfd_do_ioctl  /* ioctl */
+  NULL,             /* seek */
+  NULL              /* ioctl */
 #ifdef CONFIG_EVENT_FD_POLL
   , eventfd_do_poll /* poll */
 #endif
@@ -473,21 +471,6 @@ static ssize_t eventfd_do_write(FAR struct file *filep,
 
   nxsem_post(&dev->exclsem);
   return sizeof(eventfd_t);
-}
-
-static int eventfd_do_ioctl(FAR struct file *filep, int cmd,
-                            unsigned long arg)
-{
-  FAR struct inode *inode = filep->f_inode;
-  FAR struct eventfd_priv_s *priv = inode->i_private;
-
-  if (cmd == FIOC_MINOR)
-    {
-      *(FAR int *)((uintptr_t)arg) = priv->minor;
-      return OK;
-    }
-
-  return -ENOSYS;
 }
 
 #ifdef CONFIG_EVENT_FD_POLL

--- a/fs/vfs/fs_eventfd.c
+++ b/fs/vfs/fs_eventfd.c
@@ -69,7 +69,7 @@ struct eventfd_priv_s
   eventfd_t    counter;         /* eventfd counter */
   unsigned int minor;           /* eventfd minor number */
   uint8_t      crefs;           /* References counts on eventfd (max: 255) */
-  uint8_t      mode_semaphore;  /* eventfd mode (semaphore or counter) */
+  bool         mode_semaphore;  /* eventfd mode (semaphore or counter) */
 
   /* The following is a list if poll structures of threads waiting for
    * driver events.

--- a/include/nuttx/fs/ioctl.h
+++ b/include/nuttx/fs/ioctl.h
@@ -169,14 +169,10 @@
                                            *      int value.
                                            * OUT: Origin option.
                                            */
-#define FIOC_MINOR      _FIOC(0x000c)     /* IN:  None
-                                           * OUT: Integer that contains device
-                                           *      minor number
-                                           */
-#define FIOCLEX         _FIOC(0x000d)     /* IN:  None
+#define FIOCLEX         _FIOC(0x000c)     /* IN:  None
                                            * OUT: None
                                            */
-#define FIONCLEX        _FIOC(0x000e)     /* IN:  None
+#define FIONCLEX        _FIOC(0x000d)     /* IN:  None
                                            * OUT: None
                                            */
 

--- a/include/sys/eventfd.h
+++ b/include/sys/eventfd.h
@@ -36,10 +36,6 @@
 #define EFD_SEMAPHORE O_BINARY
 #define EFD_CLOEXEC   O_CLOEXEC
 
-/* Get device minor number */
-
-#define EFD_FIOC_MINOR FIOC_MINOR
-
 /****************************************************************************
  * Public Type Declarations
  ****************************************************************************/
@@ -64,8 +60,6 @@ int eventfd(unsigned int count, int flags);
 
 int eventfd_read(int fd, FAR eventfd_t *value);
 int eventfd_write(int fd, eventfd_t value);
-
-int eventfd_get_minor(int fd);
 
 #undef EXTERN
 #ifdef __cplusplus

--- a/include/sys/eventfd.h
+++ b/include/sys/eventfd.h
@@ -42,7 +42,11 @@
 
 /* Type for event counter */
 
+#ifdef __INT64_DEFINED
+typedef uint64_t eventfd_t;
+#else
 typedef uint32_t eventfd_t;
+#endif
 
 /****************************************************************************
  * Public Function Prototypes

--- a/libs/libc/eventfd/lib_eventfd.c
+++ b/libs/libc/eventfd/lib_eventfd.c
@@ -40,18 +40,3 @@ int eventfd_write(int fd, eventfd_t value)
   return write(fd, &value,
       sizeof (eventfd_t)) != sizeof (eventfd_t) ? -1 : 0;
 }
-
-int eventfd_get_minor(int fd)
-{
-  int ret;
-  int minor;
-
-  ret = ioctl(fd, EFD_FIOC_MINOR, &minor);
-
-  if (ret < 0)
-    {
-      return ret;
-    }
-
-  return minor;
-}


### PR DESCRIPTION
## Summary
since it isn't defined by Linux kernel too

## Impact
Remove eventfd_get_minor

## Testing
Pass CI
