### PR TITLE
wireless/bluetooth/bt_hcicore.c: fix buffer allocation

### DIFF
--- a/wireless/bluetooth/bt_hcicore.c
+++ b/wireless/bluetooth/bt_hcicore.c
@@ -1622,7 +1622,7 @@ int bt_receive(FAR struct bt_driver_s *btdev, enum bt_buf_type_e type,
    * queue.
    */
 
-  buf = bt_buf_alloc(type, NULL, 0);
+  buf = bt_buf_alloc(type, NULL, BLUETOOTH_H4_HDRLEN);
   if (buf == NULL)
     {
       return -ENOMEM;


### PR DESCRIPTION
## Summary
wireless/bluetooth/bt_hcicore.c: allocated recv buffer must reserve BLUETOOTH_H4_HDRLEN for head

This was broken since 6c69b12000e.
The first byte in io_data buffer must be the BT H4 packet type.
Without this change an assertion in bt_netdev.c:535 is always raised and nimble host layer crash.

## Impact
nimble host layer works again with NuttX

## Testing
nrf52
