### PR TITLE
input/ads7843e: complement critical section operation

### DIFF
--- a/drivers/input/ads7843e.c
+++ b/drivers/input/ads7843e.c
@@ -1216,6 +1216,7 @@ int ads7843e_register(FAR struct spi_dev_s *spi,
    */
 
 #ifdef CONFIG_ADS7843E_MULTIPLE
+  flags = enter_critical_section();
   priv->flink    = g_ads7843elist;
   g_ads7843elist = priv;
   leave_critical_section(flags);


### PR DESCRIPTION

## Summary

input/ads7843e: complement critical section operation

Signed-off-by: chao.an <anchao@xiaomi.com>

## Impact

N/A

## Testing

CI-check