### PR TITLE
net/usrsock: increase the sendto() length limit to UINT32_MAX 

### DIFF
--- a/include/nuttx/net/usrsock.h
+++ b/include/nuttx/net/usrsock.h
@@ -154,8 +154,8 @@ begin_packed_struct struct usrsock_request_sendto_s
 
   int16_t usockid;
   int32_t flags;
+  uint32_t buflen;
   uint16_t addrlen;
-  uint16_t buflen;
 } end_packed_struct;
 
 begin_packed_struct struct usrsock_request_recvfrom_s
@@ -164,7 +164,7 @@ begin_packed_struct struct usrsock_request_recvfrom_s
 
   int16_t usockid;
   int32_t flags;
-  uint16_t max_buflen;
+  uint32_t max_buflen;
   uint16_t max_addrlen;
 } end_packed_struct;
 

--- a/net/usrsock/usrsock_recvmsg.c
+++ b/net/usrsock/usrsock_recvmsg.c
@@ -159,9 +159,9 @@ static int do_recvfrom_request(FAR struct usrsock_conn_s *conn,
       addrlen = UINT16_MAX;
     }
 
-  if (buflen > UINT16_MAX)
+  if (buflen > UINT32_MAX)
     {
-      buflen = UINT16_MAX;
+      buflen = UINT32_MAX;
     }
 
   /* Prepare request for daemon to read. */

--- a/net/usrsock/usrsock_sendmsg.c
+++ b/net/usrsock/usrsock_sendmsg.c
@@ -159,9 +159,9 @@ static int do_sendto_request(FAR struct usrsock_conn_s *conn,
       req.buflen += msg->msg_iov[i].iov_len;
     }
 
-  if (req.buflen > UINT16_MAX)
+  if (req.buflen > UINT32_MAX)
     {
-      req.buflen = UINT16_MAX;
+      req.buflen = UINT32_MAX;
     }
 
   bufs[0].iov_base = (FAR void *)&req;


### PR DESCRIPTION
## Summary

net/usrsock: increase the sendto() length limit to UINT32_MAX 

change request type to uint32_t to the impove the throughput

Signed-off-by: chao.an <anchao@xiaomi.com>

## Impact

prototype changes need to recompile usrsock client/server

## Testing

sim usrsock test with vnc server