### PR TITLE
sim/usrsock: increase the sim usrsock buffer size

### DIFF
--- a/arch/sim/src/sim/up_usrsock_host.c
+++ b/arch/sim/src/sim/up_usrsock_host.c
@@ -444,7 +444,6 @@ int usrsock_host_accept(int sockfd, struct nuttx_sockaddr *addr,
 {
   socklen_t naddrlen = sizeof(socklen_t);
   struct sockaddr naddr;
-  socklen_t naddrlen;
   int ret;
 
   ret = accept(sockfd, &naddr, &naddrlen);


### PR DESCRIPTION




## Summary

sim/usrsock: increase the sim usrsock buffer size

1. Increase the sim usrsock buffer size:
arch/sim/src/sim/up_usrsock.c

2. Fix build break
arch/sim/src/sim/up_usrsock_host.c

Signed-off-by: chao.an <anchao@xiaomi.com>

## Impact

usrsock throughput test

## Testing

sim usrsock native socket with vnc server