### PR TITLE
Update IFF_RUNNING flag by netdev_carrier_on and netdev_carrier_off

### DIFF
--- a/arch/sim/src/sim/up_netdriver.c
+++ b/arch/sim/src/sim/up_netdriver.c
@@ -283,11 +283,13 @@ static int netdriver_ifup(FAR struct net_driver_s *dev)
 {
   netdev_ifup(dev->d_ipaddr);
   work_queue(LPWORK, &g_timer_work, netdriver_timer_work, dev, CLK_TCK);
+  netdev_carrier_on(dev);
   return OK;
 }
 
 static int netdriver_ifdown(FAR struct net_driver_s *dev)
 {
+  netdev_carrier_off(dev);
   work_cancel(LPWORK, &g_timer_work);
   netdev_ifdown();
   return OK;

--- a/drivers/net/loopback.c
+++ b/drivers/net/loopback.c
@@ -306,6 +306,7 @@ static int lo_ifup(FAR struct net_driver_s *dev)
            lo_poll_expiry, (wdparm_t)priv);
 
   priv->lo_bifup = true;
+  netdev_carrier_on(dev);
   return OK;
 }
 
@@ -328,6 +329,8 @@ static int lo_ifup(FAR struct net_driver_s *dev)
 static int lo_ifdown(FAR struct net_driver_s *dev)
 {
   FAR struct lo_driver_s *priv = (FAR struct lo_driver_s *)dev->d_private;
+
+  netdev_carrier_off(dev);
 
   /* Cancel the TX poll timer and TX timeout timers */
 

--- a/drivers/net/slip.c
+++ b/drivers/net/slip.c
@@ -818,6 +818,7 @@ static int slip_ifup(FAR struct net_driver_s *dev)
   /* Mark the interface up */
 
   priv->bifup = true;
+  netdev_carrier_on(dev);
   return OK;
 }
 
@@ -841,6 +842,8 @@ static int slip_ifdown(FAR struct net_driver_s *dev)
 {
   FAR struct slip_driver_s *priv =
     (FAR struct slip_driver_s *)dev->d_private;
+
+  netdev_carrier_off(dev);
 
   /* Mark the device "down" */
 

--- a/drivers/net/tun.c
+++ b/drivers/net/tun.c
@@ -883,6 +883,7 @@ static int tun_ifup(FAR struct net_driver_s *dev)
   wd_start(&priv->txpoll, TUN_WDDELAY, tun_poll_expiry, (wdparm_t)priv);
 
   priv->bifup = true;
+  netdev_carrier_on(dev);
   return OK;
 }
 
@@ -906,6 +907,8 @@ static int tun_ifdown(FAR struct net_driver_s *dev)
 {
   FAR struct tun_device_s *priv = (FAR struct tun_device_s *)dev->d_private;
   irqstate_t flags;
+
+  netdev_carrier_off(dev);
 
   flags = enter_critical_section();
 


### PR DESCRIPTION
## Summary

- sim/netdev: Update IFF_RUNNING flag by netdev_carrier_on and netdev_carrier_off
- net/loopback: Update IFF_RUNNING flag by netdev_carrier_on and netdev_carrier_off
- net/tun: Update IFF_RUNNING flag by netdev_carrier_on and netdev_carrier_off
- net/slip: Update IFF_RUNNING flag by netdev_carrier_on and netdev_carrier_off

## Impact

running flag reflect the carrier state correctly for the pseudo netdev.

## Testing

Pass CI