### PR TITLE
boards/esp32: Enable canaries stack protection to ESP32 chips

### DIFF
--- a/boards/xtensa/esp32/esp32-devkitc/scripts/Make.defs
+++ b/boards/xtensa/esp32/esp32-devkitc/scripts/Make.defs
@@ -65,6 +65,10 @@ ifeq ($(CONFIG_DEBUG_SYMBOLS),y)
   ARCHOPTIMIZATION = -g
 endif
 
+ifeq ($(CONFIG_STACK_CANARIES),y)
+  ARCHOPTIMIZATION += -fstack-protector-all
+endif
+
 ifneq ($(CONFIG_DEBUG_NOOPT),y)
   ARCHOPTIMIZATION += $(MAXOPTIMIZATION) -fno-strict-aliasing -fno-strength-reduce -fomit-frame-pointer
 endif

--- a/boards/xtensa/esp32/esp32-ethernet-kit/scripts/Make.defs
+++ b/boards/xtensa/esp32/esp32-ethernet-kit/scripts/Make.defs
@@ -65,6 +65,10 @@ ifeq ($(CONFIG_DEBUG_SYMBOLS),y)
   ARCHOPTIMIZATION = -g
 endif
 
+ifeq ($(CONFIG_STACK_CANARIES),y)
+  ARCHOPTIMIZATION += -fstack-protector-all
+endif
+
 ifneq ($(CONFIG_DEBUG_NOOPT),y)
   ARCHOPTIMIZATION += $(MAXOPTIMIZATION) -fno-strict-aliasing -fno-strength-reduce -fomit-frame-pointer
 endif

--- a/boards/xtensa/esp32/esp32-wrover-kit/scripts/Make.defs
+++ b/boards/xtensa/esp32/esp32-wrover-kit/scripts/Make.defs
@@ -65,6 +65,10 @@ ifeq ($(CONFIG_DEBUG_SYMBOLS),y)
   ARCHOPTIMIZATION = -g
 endif
 
+ifeq ($(CONFIG_STACK_CANARIES),y)
+  ARCHOPTIMIZATION += -fstack-protector-all
+endif
+
 ifneq ($(CONFIG_DEBUG_NOOPT),y)
   ARCHOPTIMIZATION += $(MAXOPTIMIZATION) -fno-strict-aliasing -fno-strength-reduce -fomit-frame-pointer
 endif

--- a/boards/xtensa/esp32/ttgo_lora_esp32/scripts/Make.defs
+++ b/boards/xtensa/esp32/ttgo_lora_esp32/scripts/Make.defs
@@ -65,6 +65,10 @@ ifeq ($(CONFIG_DEBUG_SYMBOLS),y)
   ARCHOPTIMIZATION = -g
 endif
 
+ifeq ($(CONFIG_STACK_CANARIES),y)
+  ARCHOPTIMIZATION += -fstack-protector-all
+endif
+
 ifneq ($(CONFIG_DEBUG_NOOPT),y)
   ARCHOPTIMIZATION += $(MAXOPTIMIZATION) -fno-strict-aliasing -fno-strength-reduce -fomit-frame-pointer
 endif


### PR DESCRIPTION
## Summary
Enable canaries stack protection to ESP32 chips
## Impact
Users will be able to use stack protection on ESP32
## Testing
N/A
