### PR TITLE
libc/symtab: optimize the find speed by bisection

### DIFF
--- a/libs/libc/symtab/symtab_findbyvalue.c
+++ b/libs/libc/symtab/symtab_findbyvalue.c
@@ -54,9 +54,55 @@ FAR const struct symtab_s *
 symtab_findbyvalue(FAR const struct symtab_s *symtab,
                    FAR void *value, int nsyms)
 {
+#ifndef CONFIG_SYMTAB_ORDEREDBYVALUE
   FAR const struct symtab_s *retval = NULL;
+#else
+  int high = nsyms - 1;
+  int mid  = high >> 1;
+  int low  = 0;
+#endif
 
   DEBUGASSERT(symtab != NULL);
+
+#ifdef CONFIG_SYMTAB_ORDEREDBYVALUE
+
+  while (high >= low)
+    {
+      mid = (low + high) >> 1;
+
+      if (symtab[mid].sym_value == value)
+        {
+          break;
+        }
+      else if (symtab[mid].sym_value > value)
+        {
+          if (symtab[mid - 1].sym_value <= value)
+            {
+              mid -= 1;
+              break;
+            }
+          else
+            {
+              high = mid - 1;
+            }
+        }
+      else if (symtab[mid].sym_value < value)
+        {
+          if (symtab[mid + 1].sym_value >= value)
+            {
+              break;
+            }
+          else
+            {
+              low = mid + 1;
+            }
+        }
+    }
+
+  return &symtab[mid];
+
+#else /* CONFIG_SYMTAB_ORDEREDBYVALUE */
+
   for (; nsyms > 0; symtab++, nsyms--)
     {
       /* Look for symbols of lesser or equal value (probably address) to
@@ -89,4 +135,5 @@ symtab_findbyvalue(FAR const struct symtab_s *symtab,
     }
 
   return retval;
+#endif /* CONFIG_SYMTAB_ORDEREDBYVALUE */
 }

--- a/libs/libc/unistd/Kconfig
+++ b/libs/libc/unistd/Kconfig
@@ -103,6 +103,12 @@ config SYMTAB_ORDEREDBYNAME
 		Otherwise, the symbol table is assumed to be un-ordered and only
 		slow, linear searches are supported.
 
+config SYMTAB_ORDEREDBYVALUE
+	bool "Symbol Tables Ordered by Value"
+	default n
+	---help---
+		Select if the symbol table is ordered by symbol value.
+
 config SYMTAB_DECORATED
 	bool "Symbols are decorated with leading underscores"
 	default n


### PR DESCRIPTION
## Summary

libc/symtab: optimize the find speed by bisection

Signed-off-by: chao.an <anchao@xiaomi.com>

## Impact

symtab_findbyvalue

## Testing

sort the symbol table by value and search the table entry