### PR TITLE
Improve Makefile.[unix|win]::context's dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,5 @@ core
 Make*.dep
 uImage
 /external
+# $(TOPDIR)/Makefile.[unix|win]::$(CONTEXTDIRS_DEPS)
+.context

--- a/tools/Makefile.unix
+++ b/tools/Makefile.unix
@@ -175,8 +175,6 @@ endif
 ifeq ($(NEED_MATH_H),y)
 include/math.h: include/nuttx/lib/math.h .clean_context
 	$(Q) cp -f include/nuttx/lib/math.h include/math.h
-else
-include/math.h:
 endif
 
 # The float.h header file defines the properties of your floating point
@@ -188,8 +186,6 @@ endif
 ifeq ($(CONFIG_ARCH_FLOAT_H),y)
 include/float.h: include/nuttx/lib/float.h .clean_context
 	$(Q) cp -f include/nuttx/lib/float.h include/float.h
-else
-include/float.h:
 endif
 
 # Target used to copy include/nuttx/lib/stdarg.h.  If CONFIG_ARCH_STDARG_H is
@@ -200,8 +196,6 @@ endif
 ifeq ($(CONFIG_ARCH_STDARG_H),y)
 include/stdarg.h: include/nuttx/lib/stdarg.h .clean_context
 	$(Q) cp -f include/nuttx/lib/stdarg.h include/stdarg.h
-else
-include/stdarg.h:
 endif
 
 # Target used to copy include/nuttx/lib/setjmp.h.  If CONFIG_ARCH_SETJMP_H is
@@ -212,8 +206,6 @@ endif
 ifeq ($(CONFIG_ARCH_SETJMP_H),y)
 include/setjmp.h: include/nuttx/lib/setjmp.h .clean_context
 	$(Q) cp -f include/nuttx/lib/setjmp.h include/setjmp.h
-else
-include/setjmp.h:
 endif
 
 # Targets used to build include/nuttx/version.h.  Creation of version.h is
@@ -336,11 +328,36 @@ dirlinks: include/arch include/arch/board include/arch/chip $(ARCH_SRC)/board $(
 # the config.h and version.h header files in the include/nuttx directory and
 # the establishment of symbolic links to configured directories.
 
-context: include/nuttx/config.h include/nuttx/version.h include/math.h include/float.h include/stdarg.h include/setjmp.h dirlinks
-	$(Q) mkdir -p staging
-	$(Q) for dir in $(CONTEXTDIRS) ; do \
-		$(MAKE) -C $$dir context || exit; \
-	done
+# Generate a pattern to make Directories.mk context
+
+CONTEXTDIRS_DEPS = $(patsubst %,%/.context,$(CONTEXTDIRS))
+
+context: include/nuttx/config.h include/nuttx/version.h dirlinks $(CONTEXTDIRS_DEPS) | staging
+
+staging:
+	$(Q) mkdir -p $@
+
+# Pattern rule for $(CONTEXTDIRS_DEPS)
+
+%.context: include/nuttx/config.h dirlinks
+	$(Q) $(MAKE) -C $(patsubst %.context,%,$@) TOPDIR="$(TOPDIR)" context
+	$(Q) touch $@
+
+ifeq ($(NEED_MATH_H),y)
+context: include/math.h
+endif
+
+ifeq ($(CONFIG_ARCH_FLOAT_H),y)
+context: include/float.h
+endif
+
+ifeq ($(CONFIG_ARCH_STDARG_H),y)
+context: include/stdarg.h
+endif
+
+ifeq ($(CONFIG_ARCH_SETJMP_H),y)
+context: include/setjmp.h
+endif
 
 # clean_context
 #
@@ -360,6 +377,7 @@ clean_context:
 	$(call DELFILE, include/stdarg.h)
 	$(call DELFILE, include/setjmp.h)
 	$(call DELFILE, arch/dummy/Kconfig)
+	$(call DELFILE, $(CONTEXTDIRS_DEPS))
 	$(Q) $(DIRUNLINK) include/arch/board
 	$(Q) $(DIRUNLINK) include/arch/chip
 	$(Q) $(DIRUNLINK) include/arch

--- a/tools/Makefile.win
+++ b/tools/Makefile.win
@@ -315,9 +315,36 @@ dirlinks: include\arch include\arch\board include\arch\chip $(ARCH_SRC)\board $(
 # the config.h and version.h header files in the include\nuttx directory and
 # the establishment of symbolic links to configured directories.
 
-context: include\nuttx\config.h include\nuttx\version.h include\math.h include\float.h include\stdarg.h include\setjmp.h dirlinks
-	$(Q) mkdir -p staging
-	$(Q) for %%G in ($(CONTEXTDIRS)) do ( $(MAKE) -C %%G context )
+# Generate a pattern to make Directories.mk context
+
+CONTEXTDIRS_DEPS = $(patsubst %,%\.context,$(CONTEXTDIRS))
+
+context: include\nuttx\config.h include\nuttx\version.h $(CONTEXTDIRS_DEPS) dirlinks | staging
+
+ifeq ($(NEED_MATH_H),y)
+context: include\math.h
+endif
+
+ifeq ($(CONFIG_ARCH_FLOAT_H),y)
+context: include\float.h
+endif
+
+ifeq ($(CONFIG_ARCH_STDARG_H),y)
+context: include\stdarg.h
+endif
+
+ifeq ($(CONFIG_ARCH_SETJMP_H),y)
+context: include\setjmp.h
+endif
+
+staging:
+	$(Q) mkdir -p $@
+
+# Pattern rule for $(CONTEXTDIRS_DEPS)
+
+%.context: include\nuttx\config.h dirlinks
+	$(Q) $(MAKE) -C $(patsubst %.context,%,$@) TOPDIR="$(TOPDIR)" context
+	$(Q) touch $@
 
 # clean_context
 #
@@ -333,6 +360,7 @@ clean_context:
 	$(call DELFILE, include\stdarg.h)
 	$(call DELFILE, include\setjmp.h)
 	$(call DELFILE, arch\dummy\Kconfig)
+	$(call DELFILE, $(CONTEXTDIRS_DEPS))
 	$(call DIRUNLINK, include\arch\board)
 	$(call DIRUNLINK, include\arch\chip)
 	$(call DIRUNLINK, include\arch)


### PR DESCRIPTION
## Summary
This pull request improves the dependencies for Makefile.[unix|win]::context rule.
* `include/math.h`, `include/float.h`, `include/stdarg.h`, `include/setjmp.h` are only added to `context`'s dependency if the Kconfig value is set. This prevents `context` from trying to make `include/math.h` only to find out there's no command to create the file.
* Instead of executing $(CONTEXTDIRS) in a for loop in the `context` rule, $(CONTEXTDIRS) are added as a dependency to `context` and a rule is created to create the targets. Real files are used, to prevent needlessly rebuilding the same `context` over and over and over again.
* Instead of making the directory `staging`, add it as an order-only dependency for `context`. this ensures the directory is only created if it doesn't exist.

## Impact
Makes incremental builds faster. Makes make dependencies more correct by not including files that won't be created.

## Testing

Tested by running:
```
(cd tools && ./configure.sh -a ../incubator-nuttx-apps stm32f3discovery:nsh)
make context
```

First time running context:
```
➜  incubator-nuttx git:(improve-make-context) time make context
make[1]: Entering directory '/home/user/code/fitbit/incubator-nuttx/tools'
make[1]: Leaving directory '/home/user/code/fitbit/incubator-nuttx/tools'
make[1]: Entering directory '/home/user/code/fitbit/incubator-nuttx'
make[2]: Entering directory '/home/user/code/fitbit/incubator-nuttx/boards'
make[2]: Leaving directory '/home/user/code/fitbit/incubator-nuttx/boards'
make[2]: Entering directory '/home/user/code/fitbit/incubator-nuttx-apps'
make[3]: Entering directory '/home/user/code/fitbit/incubator-nuttx-apps/platform'
make[3]: Leaving directory '/home/user/code/fitbit/incubator-nuttx-apps/platform'
make[3]: Entering directory '/home/user/code/fitbit/incubator-nuttx-apps/builtin'
make[3]: Leaving directory '/home/user/code/fitbit/incubator-nuttx-apps/builtin'
make[2]: Leaving directory '/home/user/code/fitbit/incubator-nuttx-apps'
make[2]: Entering directory '/home/user/code/fitbit/incubator-nuttx/graphics'
make[3]: Entering directory '/home/user/code/fitbit/incubator-nuttx/graphics/nxglib'
make[3]: Leaving directory '/home/user/code/fitbit/incubator-nuttx/graphics/nxglib'
make[3]: Entering directory '/home/user/code/fitbit/incubator-nuttx/graphics/nxglib'
make[3]: Leaving directory '/home/user/code/fitbit/incubator-nuttx/graphics/nxglib'
make[3]: Entering directory '/home/user/code/fitbit/incubator-nuttx/graphics/nxglib'
make[3]: Leaving directory '/home/user/code/fitbit/incubator-nuttx/graphics/nxglib'
make[2]: Leaving directory '/home/user/code/fitbit/incubator-nuttx/graphics'
make[1]: Leaving directory '/home/user/code/fitbit/incubator-nuttx'
Create .version
make[1]: Entering directory '/home/user/code/fitbit/incubator-nuttx/tools'
make[1]: Leaving directory '/home/user/code/fitbit/incubator-nuttx/tools'
Create version.h
LN: include/arch to arch/arm/include
LN: include/arch/board to /home/user/code/fitbit/incubator-nuttx/boards/arm/stm32/stm32f3discovery/include
LN: include/arch/chip to arch/arm/include/stm32
LN: arch/arm/src/board to /home/user/code/fitbit/incubator-nuttx/boards/arm/stm32/stm32f3discovery/../common
LN: arch/arm/src/board/board to /home/user/code/fitbit/incubator-nuttx/boards/arm/stm32/stm32f3discovery/src
LN: arch/arm/src/chip to arch/arm/src/stm32
LN: /home/user/code/fitbit/incubator-nuttx/drivers/platform to /home/user/code/fitbit/incubator-nuttx/drivers/dummy
make[1]: Entering directory '/home/user/code/fitbit/incubator-nuttx/boards'
make[1]: Leaving directory '/home/user/code/fitbit/incubator-nuttx/boards'
make[1]: Entering directory '/home/user/code/fitbit/incubator-nuttx-apps'
make[2]: Entering directory '/home/user/code/fitbit/incubator-nuttx-apps/platform'
LN: platform/board to /home/user/code/fitbit/incubator-nuttx-apps/platform/dummy
make[2]: Leaving directory '/home/user/code/fitbit/incubator-nuttx-apps/platform'
make[1]: Leaving directory '/home/user/code/fitbit/incubator-nuttx-apps'
make context  0.95s user 0.45s system 109% cpu 1.281 total
```
second time running context:
```
➜  incubator-nuttx git:(improve-make-context) time make context
Create .version
Create version.h
LN: include/arch/board to /home/user/code/fitbit/incubator-nuttx/boards/arm/stm32/stm32f3discovery/include
make[1]: Entering directory '/home/user/code/fitbit/incubator-nuttx/boards'
make[1]: Nothing to be done for 'dirlinks'.
make[1]: Leaving directory '/home/user/code/fitbit/incubator-nuttx/boards'
make[1]: Entering directory '/home/user/code/fitbit/incubator-nuttx-apps'
make[2]: Entering directory '/home/user/code/fitbit/incubator-nuttx-apps/platform'
LN: platform/board to /home/user/code/fitbit/incubator-nuttx-apps/platform/dummy
make[2]: Leaving directory '/home/user/code/fitbit/incubator-nuttx-apps/platform'
make[1]: Leaving directory '/home/user/code/fitbit/incubator-nuttx-apps'
make context  0.30s user 0.20s system 121% cpu 0.414 total
```