### PR TITLE
arm/riscv/xtensa: enhance the task dump 

### DIFF
--- a/arch/arm/src/armv7-r/arm_assert.c
+++ b/arch/arm/src/armv7-r/arm_assert.c
@@ -126,57 +126,165 @@ static inline void arm_registerdump(FAR volatile uint32_t *regs)
 #endif
 
 /****************************************************************************
- * Name: up_taskdump
+ * Name: arm_dump_task
  ****************************************************************************/
 
-#if defined(CONFIG_STACK_COLORATION) || defined(CONFIG_SCHED_BACKTRACE)
-static void up_taskdump(FAR struct tcb_s *tcb, FAR void *arg)
+static void arm_dump_task(FAR struct tcb_s *tcb, FAR void *arg)
 {
+#ifdef CONFIG_STACK_COLORATION
+  uint32_t stack_filled = 0;
+  uint32_t stack_used;
+#endif
+#ifdef CONFIG_SCHED_CPULOAD
+  struct cpuload_s cpuload;
+  uint32_t fracpart;
+  uint32_t intpart;
+  uint32_t tmp;
+
+  clock_cpuload(tcb->pid, &cpuload);
+
+  if (cpuload.total > 0)
+    {
+      tmp      = (1000 * cpuload.active) / cpuload.total;
+      intpart  = tmp / 10;
+      fracpart = tmp - 10 * intpart;
+    }
+  else
+    {
+      intpart  = 0;
+      fracpart = 0;
+    }
+#endif
+
+#ifdef CONFIG_STACK_COLORATION
+  stack_used = up_check_tcbstack(tcb);
+  if (tcb->adj_stack_size > 0 && stack_used > 0)
+    {
+      /* Use fixed-point math with one decimal place */
+
+      stack_filled = 10 * 100 * stack_used / tcb->adj_stack_size;
+    }
+#endif
+
   /* Dump interesting properties of this task */
 
-  _alert(
-#if CONFIG_TASK_NAME_SIZE > 0
-         "%s: "
-#endif
-         "PID=%d "
+  _alert("  %4d   %4d"
 #ifdef CONFIG_STACK_COLORATION
-         "Stack Used=%lu of %lu\n",
-#else
-         "Stack=%lu\n",
+         "   %7lu"
+#endif
+         "   %7lu"
+#ifdef CONFIG_STACK_COLORATION
+         "   %3" PRId32 ".%1" PRId32 "%%%c"
+#endif
+#ifdef CONFIG_SCHED_CPULOAD
+         "   %3" PRId32 ".%01" PRId32 "%%"
 #endif
 #if CONFIG_TASK_NAME_SIZE > 0
-        tcb->name,
+         "   %s"
 #endif
-        tcb->pid,
+         "\n",
+         tcb->pid, tcb->sched_priority,
 #ifdef CONFIG_STACK_COLORATION
-        (unsigned long)up_check_tcbstack(tcb),
+         (unsigned long)up_check_tcbstack(tcb),
 #endif
-        (unsigned long)tcb->adj_stack_size);
-
-  /* Show back trace */
-
-#ifdef CONFIG_SCHED_BACKTRACE
-  sched_dumpstack(tcb->pid);
+         (unsigned long)tcb->adj_stack_size
+#ifdef CONFIG_STACK_COLORATION
+         , stack_filled / 10, stack_filled % 10,
+         (stack_filled >= 10 * 80 ? '!' : ' ')
 #endif
-
-  /* Dump the registers */
-
-  arm_registerdump(tcb->xcp.regs);
+#ifdef CONFIG_SCHED_CPULOAD
+         , intpart, fracpart
+#endif
+#if CONFIG_TASK_NAME_SIZE > 0
+         , tcb->name
+#endif
+        );
 }
 
 /****************************************************************************
- * Name: up_showtasks
+ * Name: arm_dump_backtrace
  ****************************************************************************/
 
-static inline void up_showtasks(void)
+#ifdef CONFIG_SCHED_BACKTRACE
+static void arm_dump_backtrace(FAR struct tcb_s *tcb, FAR void *arg)
 {
+  /* Show back trace */
+
+  sched_dumpstack(tcb->pid);
+}
+#endif
+
+/****************************************************************************
+ * Name: arm_showtasks
+ ****************************************************************************/
+
+static inline void arm_showtasks(void)
+{
+#if CONFIG_ARCH_INTERRUPTSTACK > 7
+#  ifdef CONFIG_STACK_COLORATION
+  uint32_t stack_used = up_check_intstack();
+  uint32_t stack_filled = 0;
+
+  if ((CONFIG_ARCH_INTERRUPTSTACK & ~7) > 0 && stack_used > 0)
+    {
+      /* Use fixed-point math with one decimal place */
+
+      stack_filled = 10 * 100 *
+                     stack_used / (CONFIG_ARCH_INTERRUPTSTACK & ~7);
+    }
+#  endif
+#endif
+
   /* Dump interesting properties of each task in the crash environment */
 
-  nxsched_foreach(up_taskdump, NULL);
-}
-#else
-#  define up_showtasks()
+  _alert("   PID    PRI"
+#ifdef CONFIG_STACK_COLORATION
+         "      USED"
 #endif
+         "     STACK"
+#ifdef CONFIG_STACK_COLORATION
+         "   FILLED "
+#endif
+#ifdef CONFIG_SCHED_CPULOAD
+         "      CPU"
+#endif
+#if CONFIG_TASK_NAME_SIZE > 0
+         "   COMMAND"
+#endif
+         "\n");
+
+#if CONFIG_ARCH_INTERRUPTSTACK > 7
+  _alert("  ----   ----"
+#  ifdef CONFIG_STACK_COLORATION
+         "   %7lu"
+#  endif
+         "   %7lu"
+#  ifdef CONFIG_STACK_COLORATION
+         "   %3" PRId32 ".%1" PRId32 "%%%c"
+#  endif
+#  ifdef CONFIG_SCHED_CPULOAD
+         "     ----"
+#  endif
+#  if CONFIG_TASK_NAME_SIZE > 0
+         "   irq"
+#  endif
+         "\n"
+#  ifdef CONFIG_STACK_COLORATION
+         , (unsigned long)stack_used
+#  endif
+         , (unsigned long)(CONFIG_ARCH_INTERRUPTSTACK & ~7)
+#  ifdef CONFIG_STACK_COLORATION
+         , stack_filled / 10, stack_filled % 10,
+         (stack_filled >= 10 * 80 ? '!' : ' ')
+#  endif
+        );
+#endif
+
+  nxsched_foreach(arm_dump_task, NULL);
+#ifdef CONFIG_SCHED_BACKTRACE
+  nxsched_foreach(arm_dump_backtrace, NULL);
+#endif
+}
 
 /****************************************************************************
  * Name: assert_tracecallback
@@ -249,9 +357,6 @@ static void up_dumpstate(void)
   _alert("Interrupt stack:\n");
   _alert("  base: %08x\n", istackbase);
   _alert("  size: %08x\n", istacksize);
-#ifdef CONFIG_STACK_COLORATION
-  _alert("  used: %08x\n", up_check_intstack());
-#endif
 #endif
 
   /* Show user stack info */
@@ -259,9 +364,6 @@ static void up_dumpstate(void)
   _alert("User stack:\n");
   _alert("  base: %08x\n", ustackbase);
   _alert("  size: %08x\n", ustacksize);
-#ifdef CONFIG_STACK_COLORATION
-  _alert("  used: %08x\n", up_check_tcbstack(rtcb));
-#endif
 
 #ifdef CONFIG_ARCH_KERNEL_STACK
   /* Does this thread have a kernel stack allocated? */
@@ -337,7 +439,7 @@ static void up_dumpstate(void)
 
   /* Dump the state of all tasks (if available) */
 
-  up_showtasks();
+  arm_showtasks();
 
 #ifdef CONFIG_ARCH_USBDUMP
   /* Dump USB trace data */

--- a/arch/risc-v/src/rv32im/riscv_assert.c
+++ b/arch/risc-v/src/rv32im/riscv_assert.c
@@ -123,43 +123,93 @@ static inline void riscv_registerdump(volatile uint32_t *regs)
 #endif
 
 /****************************************************************************
- * Name: riscv_taskdump
+ * Name: riscv_dump_task
  ****************************************************************************/
 
-#if defined(CONFIG_STACK_COLORATION) || defined(CONFIG_SCHED_BACKTRACE)
-static void riscv_taskdump(struct tcb_s *tcb, void *arg)
+static void riscv_dump_task(struct tcb_s *tcb, void *arg)
 {
+#ifdef CONFIG_STACK_COLORATION
+  uint32_t stack_filled = 0;
+  uint32_t stack_used;
+#endif
+#ifdef CONFIG_SCHED_CPULOAD
+  struct cpuload_s cpuload;
+  uint32_t fracpart;
+  uint32_t intpart;
+  uint32_t tmp;
+
+  clock_cpuload(tcb->pid, &cpuload);
+
+  if (cpuload.total > 0)
+    {
+      tmp      = (1000 * cpuload.active) / cpuload.total;
+      intpart  = tmp / 10;
+      fracpart = tmp - 10 * intpart;
+    }
+  else
+    {
+      intpart  = 0;
+      fracpart = 0;
+    }
+#endif
+
+#ifdef CONFIG_STACK_COLORATION
+  stack_used = up_check_tcbstack(tcb);
+  if (tcb->adj_stack_size > 0 && stack_used > 0)
+    {
+      /* Use fixed-point math with one decimal place */
+
+      stack_filled = 10 * 100 * stack_used / tcb->adj_stack_size;
+    }
+#endif
+
   /* Dump interesting properties of this task */
 
-  _alert(
-#if CONFIG_TASK_NAME_SIZE > 0
-         "%s: "
-#endif
-         "PID=%d "
+  _alert("  %4d   %4d"
 #ifdef CONFIG_STACK_COLORATION
-         "Stack Used=%lu of %lu\n",
-#else
-         "Stack=%lu\n",
+         "   %7lu"
+#endif
+         "   %7lu"
+#ifdef CONFIG_STACK_COLORATION
+         "   %3" PRId32 ".%1" PRId32 "%%%c"
+#endif
+#ifdef CONFIG_SCHED_CPULOAD
+         "   %3" PRId32 ".%01" PRId32 "%%"
 #endif
 #if CONFIG_TASK_NAME_SIZE > 0
-        tcb->name,
+         "   %s"
 #endif
-        tcb->pid,
+         "\n",
+         tcb->pid, tcb->sched_priority,
 #ifdef CONFIG_STACK_COLORATION
-        (unsigned long)up_check_tcbstack(tcb),
+         (unsigned long)up_check_tcbstack(tcb),
 #endif
-        (unsigned long)tcb->adj_stack_size);
+         (unsigned long)tcb->adj_stack_size
+#ifdef CONFIG_STACK_COLORATION
+         , stack_filled / 10, stack_filled % 10,
+         (stack_filled >= 10 * 80 ? '!' : ' ')
+#endif
+#ifdef CONFIG_SCHED_CPULOAD
+         , intpart, fracpart
+#endif
+#if CONFIG_TASK_NAME_SIZE > 0
+         , tcb->name
+#endif
+        );
+}
 
-  /* Show back trace */
+/****************************************************************************
+ * Name: riscv_dump_backtrace
+ ****************************************************************************/
 
 #ifdef CONFIG_SCHED_BACKTRACE
+static void riscv_dump_backtrace(struct tcb_s *tcb, void *arg)
+{
+  /* Show back trace */
+
   sched_dumpstack(tcb->pid);
-#endif
-
-  /* Dump the registers */
-
-  riscv_registerdump(tcb->xcp.regs);
 }
+#endif
 
 /****************************************************************************
  * Name: riscv_showtasks
@@ -167,13 +217,71 @@ static void riscv_taskdump(struct tcb_s *tcb, void *arg)
 
 static inline void riscv_showtasks(void)
 {
+#if CONFIG_ARCH_INTERRUPTSTACK > 15
+#  ifdef CONFIG_STACK_COLORATION
+  uint32_t stack_used = up_check_intstack();
+  uint32_t stack_filled = 0;
+
+  if ((CONFIG_ARCH_INTERRUPTSTACK & ~15) > 0 && stack_used > 0)
+    {
+      /* Use fixed-point math with one decimal place */
+
+      stack_filled = 10 * 100 *
+                     stack_used / (CONFIG_ARCH_INTERRUPTSTACK & ~15);
+    }
+#  endif
+#endif
+
   /* Dump interesting properties of each task in the crash environment */
 
-  nxsched_foreach(riscv_taskdump, NULL);
-}
-#else
-#  define riscv_showtasks()
+  _alert("   PID    PRI"
+#ifdef CONFIG_STACK_COLORATION
+         "      USED"
 #endif
+         "     STACK"
+#ifdef CONFIG_STACK_COLORATION
+         "   FILLED "
+#endif
+#ifdef CONFIG_SCHED_CPULOAD
+         "      CPU"
+#endif
+#if CONFIG_TASK_NAME_SIZE > 0
+         "   COMMAND"
+#endif
+         "\n");
+
+#if CONFIG_ARCH_INTERRUPTSTACK > 15
+  _alert("  ----   ----"
+#  ifdef CONFIG_STACK_COLORATION
+         "   %7lu"
+#  endif
+         "   %7lu"
+#  ifdef CONFIG_STACK_COLORATION
+         "   %3" PRId32 ".%1" PRId32 "%%%c"
+#  endif
+#  ifdef CONFIG_SCHED_CPULOAD
+         "     ----"
+#  endif
+#  if CONFIG_TASK_NAME_SIZE > 0
+         "   irq"
+#  endif
+         "\n"
+#  ifdef CONFIG_STACK_COLORATION
+         , (unsigned long)stack_used
+#  endif
+         , (unsigned long)(CONFIG_ARCH_INTERRUPTSTACK & ~15)
+#  ifdef CONFIG_STACK_COLORATION
+         , stack_filled / 10, stack_filled % 10,
+         (stack_filled >= 10 * 80 ? '!' : ' ')
+#  endif
+        );
+#endif
+
+  nxsched_foreach(riscv_dump_task, NULL);
+#ifdef CONFIG_SCHED_BACKTRACE
+  nxsched_foreach(riscv_dump_backtrace, NULL);
+#endif
+}
 
 /****************************************************************************
  * Name: riscv_dumpstate

--- a/arch/xtensa/src/common/xtensa_dumpstate.c
+++ b/arch/xtensa/src/common/xtensa_dumpstate.c
@@ -53,47 +53,165 @@ static uint32_t s_last_regs[XCPTCONTEXT_REGS];
  ****************************************************************************/
 
 /****************************************************************************
- * Name: up_taskdump
+ * Name: xtensa_dump_task
  ****************************************************************************/
 
-#ifdef CONFIG_STACK_COLORATION
-static void up_taskdump(struct tcb_s *tcb, void *arg)
+static void xtensa_dump_task(struct tcb_s *tcb, void *arg)
 {
+#ifdef CONFIG_STACK_COLORATION
+  uint32_t stack_filled = 0;
+  uint32_t stack_used;
+#endif
+#ifdef CONFIG_SCHED_CPULOAD
+  struct cpuload_s cpuload;
+  uint32_t fracpart;
+  uint32_t intpart;
+  uint32_t tmp;
+
+  clock_cpuload(tcb->pid, &cpuload);
+
+  if (cpuload.total > 0)
+    {
+      tmp      = (1000 * cpuload.active) / cpuload.total;
+      intpart  = tmp / 10;
+      fracpart = tmp - 10 * intpart;
+    }
+  else
+    {
+      intpart  = 0;
+      fracpart = 0;
+    }
+#endif
+
+#ifdef CONFIG_STACK_COLORATION
+  stack_used = up_check_tcbstack(tcb);
+  if (tcb->adj_stack_size > 0 && stack_used > 0)
+    {
+      /* Use fixed-point math with one decimal place */
+
+      stack_filled = 10 * 100 * stack_used / tcb->adj_stack_size;
+    }
+#endif
+
   /* Dump interesting properties of this task */
 
+  _alert("  %4d   %4d"
+#ifdef CONFIG_STACK_COLORATION
+         "   %7lu"
+#endif
+         "   %7lu"
+#ifdef CONFIG_STACK_COLORATION
+         "   %3" PRId32 ".%1" PRId32 "%%%c"
+#endif
+#ifdef CONFIG_SCHED_CPULOAD
+         "   %3" PRId32 ".%01" PRId32 "%%"
+#endif
 #if CONFIG_TASK_NAME_SIZE > 0
-  _alert("%s: PID=%d Stack Used=%lu of %lu\n",
-         tcb->name, tcb->pid, (unsigned long)up_check_tcbstack(tcb),
-         (unsigned long)tcb->adj_stack_size);
-#else
-  _alert("PID: %d Stack Used=%lu of %lu\n",
-         tcb->pid, (unsigned long)up_check_tcbstack(tcb),
-         (unsigned long)tcb->adj_stack_size);
+         "   %s"
 #endif
+         "\n",
+         tcb->pid, tcb->sched_priority,
+#ifdef CONFIG_STACK_COLORATION
+         (unsigned long)up_check_tcbstack(tcb),
+#endif
+         (unsigned long)tcb->adj_stack_size
+#ifdef CONFIG_STACK_COLORATION
+         , stack_filled / 10, stack_filled % 10,
+         (stack_filled >= 10 * 80 ? '!' : ' ')
+#endif
+#ifdef CONFIG_SCHED_CPULOAD
+         , intpart, fracpart
+#endif
+#if CONFIG_TASK_NAME_SIZE > 0
+         , tcb->name
+#endif
+        );
+}
 
-  /* Dump the backtrace */
+/****************************************************************************
+ * Name: xtensa_dump_backtrace
+ ****************************************************************************/
 
-#if defined(CONFIG_XTENSA_DUMPBT_ON_ASSERT) && \
-    defined(CONFIG_SCHED_BACKTRACE)
+#ifdef CONFIG_SCHED_BACKTRACE
+static void xtensa_dump_backtrace(struct tcb_s *tcb, void *arg)
+{
+  /* Show back trace */
+
   sched_dumpstack(tcb->pid);
-#endif
 }
 #endif
 
 /****************************************************************************
- * Name: up_showtasks
+ * Name: xtensa_showtasks
  ****************************************************************************/
 
-#ifdef CONFIG_STACK_COLORATION
-static inline void up_showtasks(void)
+static inline void xtensa_showtasks(void)
 {
+#if CONFIG_ARCH_INTERRUPTSTACK > 15
+#  ifdef CONFIG_STACK_COLORATION
+  uint32_t stack_used = up_check_intstack();
+  uint32_t stack_filled = 0;
+
+  if ((CONFIG_ARCH_INTERRUPTSTACK & ~15) > 0 && stack_used > 0)
+    {
+      /* Use fixed-point math with one decimal place */
+
+      stack_filled = 10 * 100 *
+                     stack_used / (CONFIG_ARCH_INTERRUPTSTACK & ~15);
+    }
+#  endif
+#endif
+
   /* Dump interesting properties of each task in the crash environment */
 
-  nxsched_foreach(up_taskdump, NULL);
-}
-#else
-#  define up_showtasks()
+  _alert("   PID    PRI"
+#ifdef CONFIG_STACK_COLORATION
+         "      USED"
 #endif
+         "     STACK"
+#ifdef CONFIG_STACK_COLORATION
+         "   FILLED "
+#endif
+#ifdef CONFIG_SCHED_CPULOAD
+         "      CPU"
+#endif
+#if CONFIG_TASK_NAME_SIZE > 0
+         "   COMMAND"
+#endif
+         "\n");
+
+#if CONFIG_ARCH_INTERRUPTSTACK > 15
+  _alert("  ----   ----"
+#  ifdef CONFIG_STACK_COLORATION
+         "   %7lu"
+#  endif
+         "   %7lu"
+#  ifdef CONFIG_STACK_COLORATION
+         "   %3" PRId32 ".%1" PRId32 "%%%c"
+#  endif
+#  ifdef CONFIG_SCHED_CPULOAD
+         "     ----"
+#  endif
+#  if CONFIG_TASK_NAME_SIZE > 0
+         "   irq"
+#  endif
+         "\n"
+#  ifdef CONFIG_STACK_COLORATION
+         , (unsigned long)stack_used
+#  endif
+         , (unsigned long)(CONFIG_ARCH_INTERRUPTSTACK & ~15)
+#  ifdef CONFIG_STACK_COLORATION
+         , stack_filled / 10, stack_filled % 10,
+         (stack_filled >= 10 * 80 ? '!' : ' ')
+#  endif
+        );
+#endif
+
+  nxsched_foreach(xtensa_dump_task, NULL);
+#ifdef CONFIG_SCHED_BACKTRACE
+  nxsched_foreach(xtensa_dump_backtrace, NULL);
+#endif
+}
 
 /****************************************************************************
  * Name: xtensa_stackdump
@@ -279,7 +397,7 @@ void xtensa_dumpstate(void)
 
   /* Dump the state of all tasks (if available) */
 
-  up_showtasks();
+  xtensa_showtasks();
 }
 
 #endif /* CONFIG_DEBUG_ALERT */


### PR DESCRIPTION
## Summary

arm/riscv/xtensa: enhance the task dump

add irq stack information
add cpu loading

## Impact

N/A, assert dump

## Testing

before:

```
Idle Task: PID=0 PRI=0 Stack Used=512 of 3048
hpwork: PID=1 PRI=224 Stack Used=304 of 2016
lpwork: PID=2 PRI=100 Stack Used=304 of 2016
rptun: PID=4 PRI=224 Stack Used=856 of 2008
```

after:

```
[ EMERG] [ap] arm_showtasks:    PID    PRI      USED     STACK   FILLED       CPU   COMMAND
[ EMERG] [ap] arm_showtasks:   ----   ----       928      2048    45.3%      ----   irq
[ EMERG] [ap] arm_dump_task:      0      0       512      3048    16.7%     99.4%   Idle Task
[ EMERG] [ap] arm_dump_task:      1    224       304      2016    15.0%      0.0%   hpwork
[ EMERG] [ap] arm_dump_task:      2    100       304      2016    15.0%      0.0%   lpwork
[ EMERG] [ap] arm_dump_task:      4    224       856      2008    42.6%      0.0%   rptun

```