### PR TITLE
stm32f7:sdmmc invalidate before DMA to avoid eviction overwrite

### DIFF
--- a/arch/arm/src/stm32f7/stm32_sdmmc.c
+++ b/arch/arm/src/stm32f7/stm32_sdmmc.c
@@ -3115,6 +3115,8 @@ static int stm32_dmarecvsetup(FAR struct sdio_dev_s *dev,
     {
       priv->rxbuffer = buffer;
       priv->rxend    = buffer + buflen;
+      up_invalidate_dcache((uintptr_t)priv->rxbuffer,
+                           (uintptr_t)priv->rxend);
     }
 
   /* Start the DMA */


### PR DESCRIPTION
## Summary

  For FAT the same buffer is used for read and writes, there
  is a possibility a cache line is dirty. But the fs is
  not dirty and will not write the sector to disk which would clean the cache. This can
  be seen  https://github.com/PX4/NuttX/pull/175

  When the system is busy that cache line can be evicted after the
  RX DMA has completed and overwrite the data in memory. The solution
  is to invalidate before the DMA to prevent an evection causing an
  overwite, and after the DMA it to insure coherency.

## Impact

random FS errors that are disk state dependent. 

## Testing

px4 16 tasks  of `tests dataman`

