### PR TITLE
risc-v/opensbi: Make.defs: use a wildcard for file listing

### DIFF
--- a/arch/risc-v/src/opensbi/Make.defs
+++ b/arch/risc-v/src/opensbi/Make.defs
@@ -23,45 +23,13 @@ ifeq ($(CONFIG_OPENSBI),y)
 DEPPATH += --dep-path opensbi/opensbi-3rdparty
 VPATH += :opensbi/opensbi-3rdparty
 
-OPENSBI_CSRCS = opensbi/opensbi-3rdparty/lib/sbi/riscv_asm.c
-OPENSBI_CSRCS += opensbi/opensbi-3rdparty/lib/sbi/riscv_atomic.c
-OPENSBI_CSRCS += opensbi/opensbi-3rdparty/lib/sbi/riscv_locks.c
-OPENSBI_CSRCS += opensbi/opensbi-3rdparty/lib/sbi/sbi_bitmap.c
-OPENSBI_CSRCS += opensbi/opensbi-3rdparty/lib/sbi/sbi_bitops.c
-OPENSBI_CSRCS += opensbi/opensbi-3rdparty/lib/sbi/sbi_console.c
-OPENSBI_CSRCS += opensbi/opensbi-3rdparty/lib/sbi/sbi_domain.c
-OPENSBI_CSRCS += opensbi/opensbi-3rdparty/lib/sbi/sbi_ecall.c
-OPENSBI_CSRCS += opensbi/opensbi-3rdparty/lib/sbi/sbi_ecall_base.c
-OPENSBI_CSRCS += opensbi/opensbi-3rdparty/lib/sbi/sbi_ecall_hsm.c
-OPENSBI_CSRCS += opensbi/opensbi-3rdparty/lib/sbi/sbi_ecall_legacy.c
-OPENSBI_CSRCS += opensbi/opensbi-3rdparty/lib/sbi/sbi_ecall_pmu.c
-OPENSBI_CSRCS += opensbi/opensbi-3rdparty/lib/sbi/sbi_ecall_replace.c
-OPENSBI_CSRCS += opensbi/opensbi-3rdparty/lib/sbi/sbi_ecall_vendor.c
-OPENSBI_CSRCS += opensbi/opensbi-3rdparty/lib/sbi/sbi_emulate_csr.c
-OPENSBI_CSRCS += opensbi/opensbi-3rdparty/lib/sbi/sbi_fifo.c
-OPENSBI_CSRCS += opensbi/opensbi-3rdparty/lib/sbi/sbi_hart.c
-OPENSBI_CSRCS += opensbi/opensbi-3rdparty/lib/sbi/sbi_hsm.c
-OPENSBI_CSRCS += opensbi/opensbi-3rdparty/lib/sbi/sbi_illegal_insn.c
-OPENSBI_CSRCS += opensbi/opensbi-3rdparty/lib/sbi/sbi_init.c
-OPENSBI_CSRCS += opensbi/opensbi-3rdparty/lib/sbi/sbi_ipi.c
-OPENSBI_CSRCS += opensbi/opensbi-3rdparty/lib/sbi/sbi_math.c
-OPENSBI_CSRCS += opensbi/opensbi-3rdparty/lib/sbi/sbi_misaligned_ldst.c
-OPENSBI_CSRCS += opensbi/opensbi-3rdparty/lib/sbi/sbi_platform.c
-OPENSBI_CSRCS += opensbi/opensbi-3rdparty/lib/sbi/sbi_pmu.c
-OPENSBI_CSRCS += opensbi/opensbi-3rdparty/lib/sbi/sbi_scratch.c
-OPENSBI_CSRCS += opensbi/opensbi-3rdparty/lib/sbi/sbi_string.c
-OPENSBI_CSRCS += opensbi/opensbi-3rdparty/lib/sbi/sbi_system.c
-OPENSBI_CSRCS += opensbi/opensbi-3rdparty/lib/sbi/sbi_timer.c
-OPENSBI_CSRCS += opensbi/opensbi-3rdparty/lib/sbi/sbi_tlb.c
-OPENSBI_CSRCS += opensbi/opensbi-3rdparty/lib/sbi/sbi_trap.c
-OPENSBI_CSRCS += opensbi/opensbi-3rdparty/lib/sbi/sbi_unpriv.c
-
-OPENSBI_ASRCS += opensbi/opensbi-3rdparty/lib/sbi/sbi_expected_trap.S
-OPENSBI_ASRCS += opensbi/opensbi-3rdparty/lib/sbi/sbi_hfence.S
-
+OPENSBI_CSRCS = $(wildcard opensbi/opensbi-3rdparty/lib/sbi/*.c)
 OPENSBI_CSRCS += opensbi/opensbi-3rdparty/lib/utils/ipi/aclint_mswi.c
 OPENSBI_CSRCS += opensbi/opensbi-3rdparty/lib/utils/irqchip/plic.c
 OPENSBI_CSRCS += opensbi/opensbi-3rdparty/lib/utils/timer/aclint_mtimer.c
+
+OPENSBI_ASRCS += opensbi/opensbi-3rdparty/lib/sbi/sbi_expected_trap.S
+OPENSBI_ASRCS += opensbi/opensbi-3rdparty/lib/sbi/sbi_hfence.S
 
 OPENSBI_UNPACK  = opensbi-3rdparty
 OPENSBI_COMMIT  = 69d7e536138ae71a24028ca849d401a4d64d564b


### PR DESCRIPTION
The source directory contents of the OpenSBI directory lib/sbi may be
listed with a one-line wildcard. This makes the Make.defs file look
simpler. The rest of the files need to be picked one at a time.

Co-authored-by: Jukka Laitinen <jukkax@ssrc.tii.ae>
Signed-off-by: Eero Nurkkala <eero.nurkkala@offcode.fi>

## Summary

Simplify the OpenSBI Make.defs file

## Impact

No impact

## Testing

Polarfire Icicle board