### PR TITLE
arch/sim: Support vncserver as display device

### DIFF
--- a/arch/sim/Kconfig
+++ b/arch/sim/Kconfig
@@ -307,6 +307,12 @@ config SIM_FRAMEBUFFER
 	---help---
 		Emulate a framebuffer
 
+config SIM_VNCSERVER
+	bool "VNC server"
+	depends on VNCSERVER
+	---help---
+		Serve a VNC server
+
 endchoice
 
 if INPUT

--- a/arch/sim/src/Makefile
+++ b/arch/sim/src/Makefile
@@ -113,10 +113,8 @@ endif
 
 ifeq ($(CONFIG_SIM_LCDDRIVER),y)
   CSRCS += up_lcd.c
-else
-  ifeq ($(CONFIG_SIM_FRAMEBUFFER),y)
+else ifeq ($(CONFIG_SIM_FRAMEBUFFER),y)
     CSRCS += up_framebuffer.c
-  endif
 endif
 
 ifeq ($(CONFIG_SIM_X11FB),y)


### PR DESCRIPTION
## Summary
Make vnc server as display device on sim
## Impact
None
## Testing
Tested on my local configuration.