### PR TITLE
Add board support to SHT3X sensor

### DIFF
--- a/boards/xtensa/esp32/common/include/esp32_sht3x.h
+++ b/boards/xtensa/esp32/common/include/esp32_sht3x.h
@@ -1,0 +1,84 @@
+/****************************************************************************
+ * boards/xtensa/esp32/common/include/esp32_sht3x.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __BOARDS_XTENSA_ESP32_COMMON_INCLUDE_BOARD_SHT3X_H
+#define __BOARDS_XTENSA_ESP32_COMMON_INCLUDE_BOARD_SHT3X_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Type Definitions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Types
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+#ifdef __cplusplus
+#define EXTERN extern "C"
+extern "C"
+{
+#else
+#define EXTERN extern
+#endif
+
+/****************************************************************************
+ * Inline Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: board_sht3x_initialize
+ *
+ * Description:
+ *   Initialize and register the SHT3X Temperature/Humidity Sensor driver.
+ *
+ * Input Parameters:
+ *   devno - The device number, used to build the device path as /dev/tempN
+ *   busno - The I2C bus number
+ *
+ * Returned Value:
+ *   Zero (OK) on success; a negated errno value on failure.
+ *
+ ****************************************************************************/
+
+int board_sht3x_initialize(int devno, int busno);
+
+#undef EXTERN
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __BOARDS_XTENSA_ESP32_COMMON_INCLUDE_BOARD_SHT3X_H */

--- a/boards/xtensa/esp32/common/src/Make.defs
+++ b/boards/xtensa/esp32/common/src/Make.defs
@@ -50,6 +50,10 @@ ifeq ($(CONFIG_SENSORS_BMP180),y)
   CSRCS += esp32_bmp180.c
 endif
 
+ifeq ($(CONFIG_SENSORS_SHT3X),y)
+  CSRCS += esp32_sht3x.c
+endif
+
 ifeq ($(CONFIG_LCD_HT16K33),y)
   CSRCS += esp32_ht16k33.c
 endif

--- a/boards/xtensa/esp32/common/src/esp32_sht3x.c
+++ b/boards/xtensa/esp32/common/src/esp32_sht3x.c
@@ -1,0 +1,113 @@
+/****************************************************************************
+ * boards/xtensa/esp32/common/src/esp32_sht3x.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <stdio.h>
+#include <debug.h>
+
+#include <nuttx/arch.h>
+#include <nuttx/sensors/sht3x.h>
+#include <nuttx/i2c/i2c_master.h>
+
+#include "esp32_board_i2c.h"
+#include "esp32_i2c.h"
+#include "esp32_sht3x.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Types
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Function Prototypes
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+#define SHT3X_I2CADDR    0x44
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: board_sht3x_initialize
+ *
+ * Description:
+ *   Initialize and register the SHT3X Temperature/Humidity Sensor driver.
+ *
+ * Input Parameters:
+ *   devno - The device number, used to build the device path as /dev/tempN
+ *   busno - The I2C bus number
+ *
+ * Returned Value:
+ *   Zero (OK) on success; a negated errno value on failure.
+ *
+ ****************************************************************************/
+
+int board_sht3x_initialize(int devno, int busno)
+{
+  struct i2c_master_s *i2c;
+  char devpath[12];
+  int ret;
+
+  sninfo("Initializing SHT3X!\n");
+
+  /* Initialize SHT3X */
+
+  i2c = esp32_i2cbus_initialize(busno);
+
+  if (i2c)
+    {
+      /* Then try to register the sensor in I2C Bus */
+
+      snprintf(devpath, 12, "/dev/temp%d", devno);
+      ret = sht3x_register(devpath, i2c, SHT3X_I2CADDR);
+      if (ret < 0)
+        {
+          snerr("ERROR: Error registering SHT3X in I2C%d\n", busno);
+        }
+    }
+  else
+    {
+      ret = -ENODEV;
+    }
+
+  return ret;
+}
+

--- a/boards/xtensa/esp32/esp32-devkitc/src/esp32_bringup.c
+++ b/boards/xtensa/esp32/esp32-devkitc/src/esp32_bringup.c
@@ -85,6 +85,10 @@
 #  include "esp32_bmp180.h"
 #endif
 
+#ifdef CONFIG_SENSORS_SHT3X
+#  include "esp32_sht3x.h"
+#endif
+
 #ifdef CONFIG_LCD_HT16K33
 #  include "esp32_ht16k33.h"
 #endif
@@ -383,6 +387,17 @@ int esp32_bringup(void)
   if (ret < 0)
     {
       syslog(LOG_ERR, "Failed to initialize BMP180 driver: %d\n", ret);
+    }
+#endif
+
+#ifdef CONFIG_SENSORS_SHT3X
+  /* Try to register SHT3x device in I2C0 */
+
+  ret = board_sht3x_initialize(0, 0);
+
+  if (ret < 0)
+    {
+      syslog(LOG_ERR, "Failed to initialize SHT3X driver: %d\n", ret);
     }
 #endif
 


### PR DESCRIPTION
## Summary
Add board support to SHT3X sensor
## Impact
User will be able to test SHT3X sensor easily on ESP32
## Testing
ESP32-Devkitc

