### PR TITLE
driver/rwbuffer: Fix the compiler warning

### DIFF
--- a/drivers/rwbuffer.c
+++ b/drivers/rwbuffer.c
@@ -839,11 +839,11 @@ int rwb_initialize(FAR struct rwbuffer_s *rwb)
       rwb->wrbuffer = kmm_malloc(allocsize);
       if (!rwb->wrbuffer)
         {
-          ferr("Write buffer kmm_malloc(%d) failed\n", allocsize);
+          ferr("Write buffer kmm_malloc(%" PRIu32 ") failed\n", allocsize);
           return -ENOMEM;
         }
 
-      finfo("Write buffer size: %d bytes\n", allocsize);
+      finfo("Write buffer size: %" PRIu32 " bytes\n", allocsize);
     }
 #endif /* CONFIG_DRVR_WRITEBUFFER */
 


### PR DESCRIPTION
## Summary
```
rwbuffer.c: In function 'rwb_initialize':
rwbuffer.c:842:16: warning: format '%d' expects argument of type 'int', but argument 3 has type 'uint32_t' {aka 'long unsigned int'} [-Wformat=]
  842 |           ferr("Write buffer kmm_malloc(%d) failed\n", allocsize);
      |                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  ~~~~~~~~~
      |                                                        |
      |                                                        uint32_t {aka long unsigned int}
rwbuffer.c:842:42: note: format string is defined here
  842 |           ferr("Write buffer kmm_malloc(%d) failed\n", allocsize);
      |                                         ~^
      |                                          |
      |                                          int
      |                                         %ld
In file included from rwbuffer.c:36:
rwbuffer.c:846:13: warning: format '%d' expects argument of type 'int', but argument 3 has type 'uint32_t' {aka 'long unsigned int'} [-Wformat=]
  846 |       finfo("Write buffer size: %d bytes\n", allocsize);
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  ~~~~~~~~~
      |                                              |
      |                                              uint32_t {aka long unsigned int}
rwbuffer.c:846:34: note: format string is defined here
  846 |       finfo("Write buffer size: %d bytes\n", allocsize);
      |                                 ~^
      |                                  |
      |                                  int
      |                                 %ld
```

## Impact
Minor

## Testing
Pass CI
