### PR TITLE
net/tcp(unbuffered): tx_unacked overflow occurred if NET_TCP_WINDOW_SCALE option was enabled.

### DIFF
--- a/net/tcp/tcp.h
+++ b/net/tcp/tcp.h
@@ -215,7 +215,8 @@ struct tcp_conn_s
   int32_t  snd_bufs;      /* Maximum amount of bytes queued in send */
   sem_t    snd_sem;       /* Semaphore signals send completion */
 #endif
-#ifdef CONFIG_NET_TCP_WRITE_BUFFERS
+#if defined(CONFIG_NET_TCP_WRITE_BUFFERS) || \
+    defined(CONFIG_NET_TCP_WINDOW_SCALE)
   uint32_t tx_unacked;    /* Number bytes sent but not yet ACKed */
 #else
   uint16_t tx_unacked;    /* Number bytes sent but not yet ACKed */


### PR DESCRIPTION
## Summary

Fixed an issue with conn->tx_unacked overflow that occurred if NET_TCP_WINDOW_SCALE option was enabled.
If the remote TCP receiver advertised TCP window size greater than 64 KB and TCP ACK packets returned to the NuttX TCP sender with a significant delay, conn->tx_unacked overflowed and further TCP send stalled forever (until TCP re-connection).

## Impact

TCP

## Testing