### PR TITLE
nuttx: remove space befone newline in logs

### DIFF
--- a/arch/arm/src/am335x/am335x_i2c.c
+++ b/arch/arm/src/am335x/am335x_i2c.c
@@ -1437,7 +1437,7 @@ static int am335x_i2c_transfer(FAR struct i2c_master_s *dev,
       priv->msgc  = count;
       priv->flags = msgs->flags;
 
-      i2cinfo("Flags %x, len %d \n", msgs->flags, msgs->length);
+      i2cinfo("Flags %x, len %d\n", msgs->flags, msgs->length);
 
       /* Reset I2C trace logic */
 

--- a/arch/arm/src/cxd56xx/cxd56_cpupause.c
+++ b/arch/arm/src/cxd56xx/cxd56_cpupause.c
@@ -270,7 +270,7 @@ int arm_pause_handler(int irq, void *c, FAR void *arg)
   int cpu = up_cpu_index();
   int ret = OK;
 
-  DPRINTF("cpu%d will be paused \n", cpu);
+  DPRINTF("cpu%d will be paused\n", cpu);
 
   /* Clear SW_INT for APP_DSP(cpu) */
 

--- a/arch/arm/src/cxd56xx/cxd56_textheap.c
+++ b/arch/arm/src/cxd56xx/cxd56_textheap.c
@@ -55,7 +55,7 @@ FAR void *up_textheap_memalign(size_t align, size_t size)
 #ifdef CONFIG_CXD56_USE_SYSBUS
   if (ret)
     {
-      binfo("** ret=%p \n", ret);
+      binfo("** ret=%p\n", ret);
 
       /* NOTE:
        * kmm_malloc() will return the address in SYSBUS.
@@ -64,7 +64,7 @@ FAR void *up_textheap_memalign(size_t align, size_t size)
 
       ret -= SYSBUS_ADDRESS_OFFSET;
 
-      binfo("** mapped to %p \n", ret);
+      binfo("** mapped to %p\n", ret);
     }
 #endif
 
@@ -80,7 +80,7 @@ void up_textheap_free(FAR void *p)
 #ifdef CONFIG_CXD56_USE_SYSBUS
   if (p)
     {
-      binfo("** p=%p \n", p);
+      binfo("** p=%p\n", p);
 
       /* NOTE:
        * The address p will be in I/D BUS.
@@ -89,7 +89,7 @@ void up_textheap_free(FAR void *p)
 
       p += SYSBUS_ADDRESS_OFFSET;
 
-      binfo("** mapped to %p \n", p);
+      binfo("** mapped to %p\n", p);
     }
 #endif
 

--- a/arch/arm/src/efm32/efm32_spi.c
+++ b/arch/arm/src/efm32/efm32_spi.c
@@ -1215,7 +1215,7 @@ static uint32_t spi_send(struct spi_dev_s *dev, uint32_t wd)
   spi_wait_status(config, _USART_STATUS_RXDATAV_MASK, USART_STATUS_RXDATAV);
   ret = spi_getreg(config, EFM32_USART_RXDATA_OFFSET);
 
-  spiinfo("Sent: %04x Return: %04x \n", wd, ret);
+  spiinfo("Sent: %04x Return: %04x\n", wd, ret);
   return ret;
 }
 

--- a/arch/arm/src/efm32/efm32_timer.c
+++ b/arch/arm/src/efm32/efm32_timer.c
@@ -104,7 +104,7 @@ void efm32_timer_dumpregs(uintptr_t base, FAR const char *msg)
           getreg32(base + EFM32_TIMER_STATUS_OFFSET),
           getreg32(base + EFM32_TIMER_IEN_OFFSET),
           getreg32(base + EFM32_TIMER_IF_OFFSET));
-  tmrinfo("DTFAULT: %04x DTFAULTC: %04x  DTLOCK: %04x \n",
+  tmrinfo("DTFAULT: %04x DTFAULTC: %04x  DTLOCK: %04x\n",
           getreg32(base + EFM32_TIMER_CTRL_OFFSET),
           getreg32(base + EFM32_TIMER_STATUS_OFFSET),
           getreg32(base + EFM32_TIMER_IEN_OFFSET));
@@ -214,7 +214,7 @@ int efm32_timer_set_freq(uintptr_t base, uint32_t clk_freq, uint32_t freq)
 
   reload = (clk_freq / prescaler / freq);
 
-  tmrinfo("Source: %4" PRIx32 "Hz Div: %4x Reload: %4x \n",
+  tmrinfo("Source: %4" PRIx32 "Hz Div: %4x Reload: %4x\n",
           clk_freq, prescaler, reload);
 
   putreg32(reload, base + EFM32_TIMER_TOP_OFFSET);

--- a/arch/arm/src/imxrt/imxrt_lpi2c.c
+++ b/arch/arm/src/imxrt/imxrt_lpi2c.c
@@ -1686,7 +1686,7 @@ static int imxrt_lpi2c_transfer(FAR struct i2c_master_s *dev,
   priv->msgc  = count;
   priv->flags = msgs->flags;
 
-  i2cinfo("Flags %x, len %d \n", msgs->flags, msgs->length);
+  i2cinfo("Flags %x, len %d\n", msgs->flags, msgs->length);
 
   /* Reset I2C trace logic */
 

--- a/arch/arm/src/kinetis/kinetis_usbdev.c
+++ b/arch/arm/src/kinetis/kinetis_usbdev.c
@@ -4412,7 +4412,7 @@ static void khci_hwinitialize(struct khci_usbdev_s *priv)
   khci_putreg((uint8_t)(((uint32_t)g_bdt >> 8) & USB_BDTPAGE1_MASK),
       KINETIS_USB0_BDTPAGE1);
 
-  uinfo("BDT Address %p \n", (const void *)&g_bdt);
+  uinfo("BDT Address %p\n", (const void *)&g_bdt);
   uinfo("BDTPAGE3 %hhx\n", khci_getreg(KINETIS_USB0_BDTPAGE3));
   uinfo("BDTPAGE2 %hhx\n", khci_getreg(KINETIS_USB0_BDTPAGE2));
   uinfo("BDTPAGE1 %hhx\n", khci_getreg(KINETIS_USB0_BDTPAGE1));

--- a/arch/arm/src/lc823450/lc823450_i2s.c
+++ b/arch/arm/src/lc823450/lc823450_i2s.c
@@ -433,14 +433,14 @@ static int lc823450_i2s_ioctl(struct i2s_dev_s *dev, int cmd,
 
             if (rate[0] != rate[1])
               {
-                audinfo("change output rate: %" PRId32 " -> %" PRId32 " \n",
+                audinfo("change output rate: %" PRId32 " -> %" PRId32 "\n",
                         rate[0], rate[1]);
                 lc823450_i2s_txsamplerate(dev, rate[1]);
               }
 
             if (ch[0] != ch[1])
               {
-                audinfo("change output ch: %d -> %d \n", ch[0], ch[1]);
+                audinfo("change output ch: %d -> %d\n", ch[0], ch[1]);
                 lc823450_i2s_setchannel('C', ch[1]);
               }
 
@@ -457,14 +457,14 @@ static int lc823450_i2s_ioctl(struct i2s_dev_s *dev, int cmd,
 
             if (rate[0] != rate[1])
               {
-                audinfo("change input rate: %" PRId32 " -> %" PRId32 " \n",
+                audinfo("change input rate: %" PRId32 " -> %" PRId32 "\n",
                         rate[0], rate[1]);
                 lc823450_i2s_rxsamplerate(dev, rate[1]);
               }
 
             if (ch[0] != ch[1])
               {
-                audinfo("change input ch: %d -> %d \n", ch[0], ch[1]);
+                audinfo("change input ch: %d -> %d\n", ch[0], ch[1]);
                 lc823450_i2s_setchannel('J', ch[1]);
               }
           }
@@ -699,7 +699,7 @@ static int lc823450_i2s_send(struct i2s_dev_s *dev, struct ap_buffer_s *apb,
 
   if (0 == decsel && (n & 0x3))
     {
-      auderr("** PCM data is not word-aligned (n=%" PRId32 ") ** \n", n);
+      auderr("** PCM data is not word-aligned (n=%" PRId32 ") **\n", n);
 
       /* Set size to align on a word boundary */
 
@@ -747,7 +747,7 @@ static int lc823450_i2s_send(struct i2s_dev_s *dev, struct ap_buffer_s *apb,
 #ifdef SHOW_BUFFERING
   if (0 == bufc_enabled)
     {
-      audinfo("buffering (remain=%d) \n", getreg32(BUF_DTCAP('C')));
+      audinfo("buffering (remain=%d)\n", getreg32(BUF_DTCAP('C')));
     }
 #endif
 
@@ -826,9 +826,9 @@ static void lc823450_dmic_enable(void)
            33 << 8 | 33,
            VOLSP0_CONT);
 
-  audinfo("ASRC_FSIO=%" PRId32 " \n",  getreg32(ASRC_FSO));
-  audinfo("DTCAP(I)=0x%" PRIx32 " \n", getreg32(BUF_DTCAP('I')));
-  audinfo("DTCAP(J)=0x%" PRIx32 " \n", getreg32(BUF_DTCAP('J')));
+  audinfo("ASRC_FSIO=%" PRId32 "\n",  getreg32(ASRC_FSO));
+  audinfo("DTCAP(I)=0x%" PRIx32 "\n", getreg32(BUF_DTCAP('I')));
+  audinfo("DTCAP(J)=0x%" PRIx32 "\n", getreg32(BUF_DTCAP('J')));
 
   /* Start ASRC */
 
@@ -990,9 +990,9 @@ static int lc823450_i2s_configure(void)
   putreg32(0x1, SSRC_MODE);
   while (getreg32(SSRC_STATUS) != 0x1);
 
-  audinfo("DTCAP(C)=0x%08x \n", BUF_DTCAP('C'));
-  audinfo("DTCAP(I)=0x%08x \n", BUF_DTCAP('I'));
-  audinfo("DTCAP(J)=0x%08x \n", BUF_DTCAP('J'));
+  audinfo("DTCAP(C)=0x%08x\n", BUF_DTCAP('C'));
+  audinfo("DTCAP(I)=0x%08x\n", BUF_DTCAP('I'));
+  audinfo("DTCAP(J)=0x%08x\n", BUF_DTCAP('J'));
 
   /* Setup default tx threshold */
 

--- a/arch/arm/src/lc823450/lc823450_mtd.c
+++ b/arch/arm/src/lc823450/lc823450_mtd.c
@@ -452,7 +452,7 @@ static int mtd_mediainitialize(FAR struct lc823450_mtd_dev_s *dev)
       /* Try to change to High Speed DDR mode */
 
       ret = lc823450_sdc_changespeedmode(dev->channel, 4);
-      finfo("ch=%" PRId32 " DDR mode ret=%d \n", dev->channel, ret);
+      finfo("ch=%" PRId32 " DDR mode ret=%d\n", dev->channel, ret);
     }
   else
     {
@@ -463,7 +463,7 @@ static int mtd_mediainitialize(FAR struct lc823450_mtd_dev_s *dev)
 
       if (0 == ret)
         {
-          lldbg("ch=%d DDR50 mode ret=%d \n", dev->channel, ret);
+          lldbg("ch=%d DDR50 mode ret=%d\n", dev->channel, ret);
           goto get_card_size;
         }
 #endif
@@ -475,7 +475,7 @@ static int mtd_mediainitialize(FAR struct lc823450_mtd_dev_s *dev)
       if (0 == ret)
         {
           ret = lc823450_sdc_setclock(dev->channel, 40000000, sysclk);
-          finfo("ch=%" PRId32 " HS mode ret=%d \n", dev->channel, ret);
+          finfo("ch=%" PRId32 " HS mode ret=%d\n", dev->channel, ret);
         }
     }
 
@@ -504,7 +504,7 @@ get_card_size:
       lc823450_sdc_cachectl(dev->channel, 1);
     }
 
-  finfo("ch=%" PRId32 " size=%" PRId64 " \n",
+  finfo("ch=%" PRId32 " size=%" PRId64 "\n",
         dev->channel, (uint64_t)blocksize * (uint64_t)nblocks);
 
 exit_with_error:

--- a/arch/arm/src/lc823450/lc823450_procfs_dvfs.c
+++ b/arch/arm/src/lc823450/lc823450_procfs_dvfs.c
@@ -206,7 +206,7 @@ static ssize_t dvfs_read(FAR struct file *filep, FAR char *buffer,
 
   linesize = snprintf(priv->line,
                       DVFS_LINELEN,
-                      "cur_freq %d \n", g_dvfs_cur_freq);
+                      "cur_freq %d\n", g_dvfs_cur_freq);
   copysize = procfs_memcpy(priv->line, linesize, buffer, remaining, &offset);
   totalsize += copysize;
   buffer    += copysize;
@@ -219,7 +219,7 @@ static ssize_t dvfs_read(FAR struct file *filep, FAR char *buffer,
 
   linesize = snprintf(priv->line,
                       DVFS_LINELEN,
-                      "enable %d \n", g_dvfs_enabled);
+                      "enable %d\n", g_dvfs_enabled);
   copysize = procfs_memcpy(priv->line, linesize, buffer, remaining, &offset);
   totalsize += copysize;
   buffer    += copysize;
@@ -227,7 +227,7 @@ static ssize_t dvfs_read(FAR struct file *filep, FAR char *buffer,
 
   linesize = snprintf(priv->line,
                       DVFS_LINELEN,
-                      "auto %d \n", g_dvfs_auto);
+                      "auto %d\n", g_dvfs_auto);
   copysize = procfs_memcpy(priv->line, linesize, buffer, remaining, &offset);
   totalsize += copysize;
   buffer    += copysize;
@@ -235,7 +235,7 @@ static ssize_t dvfs_read(FAR struct file *filep, FAR char *buffer,
 
   linesize = snprintf(priv->line,
                       DVFS_LINELEN,
-                      "fstat %" PRId32 " %" PRId32 " %" PRId32 " \n",
+                      "fstat %" PRId32 " %" PRId32 " %" PRId32 "\n",
                       g_dvfs_freq_stat[0],
                       g_dvfs_freq_stat[1],
                       g_dvfs_freq_stat[2]);
@@ -250,7 +250,7 @@ static ssize_t dvfs_read(FAR struct file *filep, FAR char *buffer,
     {
       linesize = snprintf(priv->line,
                           DVFS_LINELEN,
-                          "idle%d %lld \n",
+                          "idle%d %lld\n",
                           i, idletime[i]);
 
       copysize = procfs_memcpy(priv->line, linesize, buffer,

--- a/arch/arm/src/lc823450/lc823450_sdc.c
+++ b/arch/arm/src/lc823450/lc823450_sdc.c
@@ -201,7 +201,7 @@ int lc823450_sdc_clearcardinfo(uint32_t ch)
 {
   int ret;
 
-  mcinfo("++++ start \n");
+  mcinfo("++++ start\n");
 
   ret = _sdc_semtake(&_sdc_sem[ch]);
   if (ret < 0)
@@ -220,7 +220,7 @@ int lc823450_sdc_clearcardinfo(uint32_t ch)
 #endif
 
   _sdc_semgive(&_sdc_sem[ch]);
-  mcinfo("---- end ret=%d \n", ret);
+  mcinfo("---- end ret=%d\n", ret);
   return ret;
 }
 
@@ -276,14 +276,14 @@ int lc823450_sdc_initialize(uint32_t ch)
         DEBUGASSERT(false);
     }
 
-  mcinfo("++++ start \n");
+  mcinfo("++++ start\n");
 
   ret = _sdc_semtake(&_sdc_sem[ch]);
   if (ret >= 0)
     {
       ret = sddr_initialize(_cfg[ch]);
       _sdc_semgive(&_sdc_sem[ch]);
-      mcinfo("---- end ret=%d \n", ret);
+      mcinfo("---- end ret=%d\n", ret);
     }
 
   return ret;
@@ -297,14 +297,14 @@ int lc823450_sdc_finalize(uint32_t ch)
 {
   int ret;
 
-  mcinfo("++++ start ch=%ld \n", ch);
+  mcinfo("++++ start ch=%ld\n", ch);
 
   ret = _sdc_semtake(&_sdc_sem[ch]);
   if (ret >= 0)
     {
       ret = sddr_finalize(_cfg[ch]);
       _sdc_semgive(&_sdc_sem[ch]);
-      mcinfo("---- end ret=%d \n", ret);
+      mcinfo("---- end ret=%d\n", ret);
     }
 
   return ret;
@@ -318,7 +318,7 @@ int lc823450_sdc_identifycard(uint32_t ch)
 {
   int ret;
 
-  mcinfo("++++ start \n");
+  mcinfo("++++ start\n");
 
   ret = _sdc_semtake(&_sdc_sem[ch]);
   if (ret < 0)
@@ -337,7 +337,7 @@ int lc823450_sdc_identifycard(uint32_t ch)
 #endif
 
   _sdc_semgive(&_sdc_sem[ch]);
-  mcinfo("---- end ret=%d \n", ret);
+  mcinfo("---- end ret=%d\n", ret);
   return ret;
 }
 
@@ -357,7 +357,7 @@ int lc823450_sdc_setclock(uint32_t ch, uint32_t limitclk, uint32_t sysclk)
     {
       ret = sddr_setclock(limitclk, sysclk, _cfg[ch]);
       _sdc_semgive(&_sdc_sem[ch]);
-      mcinfo("---- end ret=%d \n", ret);
+      mcinfo("---- end ret=%d\n", ret);
     }
 
   return ret;
@@ -375,14 +375,14 @@ int lc823450_sdc_refmediatype(uint32_t ch)
 {
   int ret;
 
-  mcinfo("++++ start \n");
+  mcinfo("++++ start\n");
 
   ret = _sdc_semtake(&_sdc_sem[ch]);
   if (ret >= 0)
     {
       ret = sddr_refmediatype(_cfg[ch]);
       _sdc_semgive(&_sdc_sem[ch]);
-      mcinfo("---- end ret=%d \n", ret);
+      mcinfo("---- end ret=%d\n", ret);
     }
 
   return ret;
@@ -397,7 +397,7 @@ int lc823450_sdc_getcardsize(uint32_t ch,
 {
   int ret;
 
-  mcinfo("++++ start \n");
+  mcinfo("++++ start\n");
 
   ret = _sdc_semtake(&_sdc_sem[ch]);
   if (ret >= 0)
@@ -405,7 +405,7 @@ int lc823450_sdc_getcardsize(uint32_t ch,
       ret = sddr_getcardsize(psecnum, psecsize, _cfg[ch]);
 
       _sdc_semgive(&_sdc_sem[ch]);
-      mcinfo("---- end ret=%d \n", ret);
+      mcinfo("---- end ret=%d\n", ret);
     }
 
   return ret;
@@ -429,7 +429,7 @@ int lc823450_sdc_readsector(uint32_t ch,
     }
 
 #ifdef CONFIG_LC823450_SDC_LOG
-  mcinfo("++++ start ch=%d, addr=%ld, cnt=%d \n", ch, addr, cnt);
+  mcinfo("++++ start ch=%d, addr=%ld, cnt=%d\n", ch, addr, cnt);
 #endif
 
 #ifdef CONFIG_LC823450_SDC_CACHE
@@ -458,7 +458,7 @@ int lc823450_sdc_readsector(uint32_t ch,
           break;
         }
 
-      mcinfo("ret=%d ch=%" PRId32 " add=%ld cnt=%d i=%d \n",
+      mcinfo("ret=%d ch=%" PRId32 " add=%ld cnt=%d i=%d\n",
              ret, ch, addr, cnt, i);
     }
 
@@ -470,7 +470,7 @@ int lc823450_sdc_readsector(uint32_t ch,
           uint8_t *p = (pbuf + 0x1c2); /* partition id */
           if (0x7 == *p)
             {
-              mcinfo("exFAT (NTFS) detected \n");
+              mcinfo("exFAT (NTFS) detected\n");
               _sec_cache_enabled = 1;
             }
         }
@@ -493,7 +493,7 @@ errout_with_semaphore:
 #endif
   _sdc_semgive(&_sdc_sem[ch]);
 
-  mcinfo("----  end ret=%d \n", ret);
+  mcinfo("----  end ret=%d\n", ret);
   return ret;
 }
 
@@ -514,7 +514,7 @@ int lc823450_sdc_writesector(uint32_t ch,
     }
 
 #ifdef CONFIG_LC823450_SDC_LOG
-  mcinfo("++++ start ch=%d, addr=%ld, cnt=%d \n", ch, addr, cnt);
+  mcinfo("++++ start ch=%d, addr=%ld, cnt=%d\n", ch, addr, cnt);
 #endif
 
 #ifdef CONFIG_LC823450_SDC_CACHE
@@ -534,12 +534,12 @@ int lc823450_sdc_writesector(uint32_t ch,
 
   if (0 > ret)
     {
-      mcinfo("ret=%d ch=%" PRId32 " add=%ld cnt=%d \n", ret, ch, addr, cnt);
+      mcinfo("ret=%d ch=%" PRId32 " add=%ld cnt=%d\n", ret, ch, addr, cnt);
     }
 
   _sdc_semgive(&_sdc_sem[ch]);
 
-  mcinfo("----  end ret=%d \n", ret);
+  mcinfo("----  end ret=%d\n", ret);
   return ret;
 }
 
@@ -568,7 +568,7 @@ int lc823450_sdc_trimsector(uint32_t ch, unsigned long addr,
     }
 
 #ifdef CONFIG_LC823450_SDC_LOG
-  mcinfo("++++ start ch=%d, addr=%ld, cnt=%d \n", ch, addr, cnt);
+  mcinfo("++++ start ch=%d, addr=%ld, cnt=%d\n", ch, addr, cnt);
 #endif
 
   lc823450_sdc_access_led(ch, addr);
@@ -580,12 +580,12 @@ int lc823450_sdc_trimsector(uint32_t ch, unsigned long addr,
   ret = sddr_eraseseq(0x00000001, addr, cnt, _cfg[ch]);
   if (0 > ret)
     {
-      mcinfo("ret=%d ch=%" PRId32 " add=%ld cnt=%d \n", ret, ch, addr, cnt);
+      mcinfo("ret=%d ch=%" PRId32 " add=%ld cnt=%d\n", ret, ch, addr, cnt);
     }
 
   _sdc_semgive(&_sdc_sem[ch]);
 
-  mcinfo("----  end ret=%d \n", ret);
+  mcinfo("----  end ret=%d\n", ret);
   return ret;
 }
 
@@ -597,7 +597,7 @@ int lc823450_sdc_cachectl(uint32_t ch, int ctrl)
 {
   int ret;
 
-  mcinfo("++++ ch=%" PRId32 ", ctrl=%d \n", ch, ctrl);
+  mcinfo("++++ ch=%" PRId32 ", ctrl=%d\n", ch, ctrl);
 
   ret = _sdc_semtake(&_sdc_sem[ch]);
   if (ret >= 0)
@@ -605,7 +605,7 @@ int lc823450_sdc_cachectl(uint32_t ch, int ctrl)
       ret = sddr_cachectrl(ctrl, _cfg[ch]);
 
       _sdc_semgive(&_sdc_sem[ch]);
-      mcinfo("----  end ret=%d \n", ret);
+      mcinfo("----  end ret=%d\n", ret);
     }
 
   return ret;
@@ -619,7 +619,7 @@ int lc823450_sdc_changespeedmode(uint32_t ch, int mode)
 {
   int ret;
 
-  mcinfo("++++ ch=%" PRId32 ", mode=%d \n", ch, mode);
+  mcinfo("++++ ch=%" PRId32 ", mode=%d\n", ch, mode);
 
   ret = _sdc_semtake(&_sdc_sem[ch]);
   if (ret < 0)
@@ -648,7 +648,7 @@ int lc823450_sdc_changespeedmode(uint32_t ch, int mode)
     }
 
   _sdc_semgive(&_sdc_sem[ch]);
-  mcinfo("----  end ret=%d \n", ret);
+  mcinfo("----  end ret=%d\n", ret);
   return ret;
 }
 
@@ -661,7 +661,7 @@ int lc823450_sdc_getcid(uint32_t ch, char *cidstr, int length)
   uint8_t cid[16];
   int ret;
 
-  mcinfo("++++ ch=%" PRId32 " \n", ch);
+  mcinfo("++++ ch=%" PRId32 "\n", ch);
 
   ret = _sdc_semtake(&_sdc_sem[ch]);
   if (ret < 0)
@@ -685,7 +685,7 @@ int lc823450_sdc_getcid(uint32_t ch, char *cidstr, int length)
     }
 
   _sdc_semgive(&_sdc_sem[ch]);
-  mcinfo("----  end ret=%d \n", ret);
+  mcinfo("----  end ret=%d\n", ret);
   return ret;
 }
 

--- a/arch/arm/src/lc823450/lc823450_syscontrol.c
+++ b/arch/arm/src/lc823450/lc823450_syscontrol.c
@@ -67,16 +67,16 @@ uint32_t get_cpu_ver(void)
   switch (reg)
     {
       case MODEM_MAV_ES1:
-        sinfo("ES1 \n");
+        sinfo("ES1\n");
         break;
 
       case MODEM_MAV_ES2:
-        sinfo("ES2 \n");
+        sinfo("ES2\n");
         ret = 1;
         break;
 
       default:
-        sinfo("??? \n");
+        sinfo("???\n");
         break;
     }
 
@@ -119,7 +119,7 @@ void mod_stby_regs(uint32_t enabits, uint32_t disbits)
       modifyreg32(ISOCNT, 0, enabits);
     }
 
-  /* sinfo("ISOCNT=0x%x, LSISTBY=0x%x \n",
+  /* sinfo("ISOCNT=0x%x, LSISTBY=0x%x\n",
    * getreg32(ISOCNT), getreg32(LSISTBY));
    */
 }

--- a/arch/arm/src/lc823450/lc823450_timer.c
+++ b/arch/arm/src/lc823450/lc823450_timer.c
@@ -711,7 +711,7 @@ int up_rtc_gettime(FAR struct timespec *tp)
 
   spin_unlock_irqrestore(NULL, flags);
 
-  tmrinfo("elapsed = %lld \n", elapsed);
+  tmrinfo("elapsed = %lld\n", elapsed);
 
   /* Convert the elapsed time in seconds and nanoseconds. */
 

--- a/arch/arm/src/lpc43xx/lpc43_spifi.c
+++ b/arch/arm/src/lpc43xx/lpc43_spifi.c
@@ -849,7 +849,7 @@ static int lpc43_ioctl(FAR struct mtd_dev_s *dev, int cmd, unsigned long arg)
   FAR struct lpc43_dev_s *priv = (FAR struct lpc43_dev_s *)dev;
   int ret = -EINVAL; /* Assume good command with bad parameters */
 
-  finfo("cmd: %d \n", cmd);
+  finfo("cmd: %d\n", cmd);
 
   switch (cmd)
     {

--- a/arch/arm/src/nrf52/nrf52_irq.c
+++ b/arch/arm/src/nrf52/nrf52_irq.c
@@ -102,7 +102,7 @@ static void nrf52_dumpnvic(const char *msg, int irq)
   irqinfo("  INTCTRL:    %08x VECTAB: %08x\n",
           getreg32(NVIC_INTCTRL), getreg32(NVIC_VECTAB));
 #if 0
-  irqinfo("  SYSH ENABLE MEMFAULT: %08x BUSFAULT: %08x \n",
+  irqinfo("  SYSH ENABLE MEMFAULT: %08x BUSFAULT: %08x\n",
           getreg32(NVIC_SYSHCON_MEMFAULTENA),
           getreg32(NVIC_SYSHCON_BUSFAULTENA));
   irqinfo("  USGFAULT: %08x SYSTICK: %08x\n",

--- a/arch/arm/src/phy62xx/pplus_mtd_flash.c
+++ b/arch/arm/src/phy62xx/pplus_mtd_flash.c
@@ -262,7 +262,7 @@ static int pplus_fls_ioctl(FAR struct mtd_dev_s *dev,
   FAR struct pplus_fls_dev_s *priv = (FAR struct pplus_fls_dev_s *)dev;
   int ret = -EINVAL; /* Assume good command with bad parameters */
 
-  finfo("cmd: %d \n", cmd);
+  finfo("cmd: %d\n", cmd);
 
   switch (cmd)
     {

--- a/arch/arm/src/rp2040/rp2040_cpupause.c
+++ b/arch/arm/src/rp2040/rp2040_cpupause.c
@@ -257,7 +257,7 @@ int arm_pause_handler(int irq, void *c, FAR void *arg)
       return OK;
     }
 
-  DPRINTF("cpu%d will be paused \n", cpu);
+  DPRINTF("cpu%d will be paused\n", cpu);
 
   /* Check for false alarms.  Such false could occur as a consequence of
    * some deadlock breaking logic that might have already serviced the SG2

--- a/arch/arm/src/s32k1xx/s32k1xx_lpi2c.c
+++ b/arch/arm/src/s32k1xx/s32k1xx_lpi2c.c
@@ -1556,7 +1556,7 @@ static int s32k1xx_lpi2c_transfer(FAR struct i2c_master_s *dev,
   priv->msgc  = count;
   priv->flags = msgs->flags;
 
-  i2cinfo("Flags %x, len %d \n", msgs->flags, msgs->length);
+  i2cinfo("Flags %x, len %d\n", msgs->flags, msgs->length);
 
   /* Reset I2C trace logic */
 

--- a/arch/arm/src/sam34/sam_emac.c
+++ b/arch/arm/src/sam34/sam_emac.c
@@ -1861,7 +1861,7 @@ static int sam_ifup(struct net_driver_s *dev)
     }
 
   while (sam_linkup(priv) == 0);
-  ninfo("Link detected \n");
+  ninfo("Link detected\n");
 
   /* Enable normal MAC operation */
 

--- a/arch/arm/src/sama5/sam_emaca.c
+++ b/arch/arm/src/sama5/sam_emaca.c
@@ -1922,7 +1922,7 @@ static int sam_ifup(struct net_driver_s *dev)
     }
 
   while (sam_linkup(priv) == 0);
-  ninfo("Link detected \n");
+  ninfo("Link detected\n");
 
   /* Enable normal MAC operation */
 

--- a/arch/arm/src/sama5/sam_emacb.c
+++ b/arch/arm/src/sama5/sam_emacb.c
@@ -2267,7 +2267,7 @@ static int sam_ifup(struct net_driver_s *dev)
     }
 
   while (sam_linkup(priv) == 0);
-  ninfo("Link detected \n");
+  ninfo("Link detected\n");
 
   /* Enable normal MAC operation */
 

--- a/arch/arm/src/samd2l2/sam_spi.c
+++ b/arch/arm/src/samd2l2/sam_spi.c
@@ -1472,7 +1472,7 @@ struct spi_dev_s *sam_spibus_initialize(int port)
 
   /* Get the port state structure */
 
-  spiinfo("port: %d \n", port);
+  spiinfo("port: %d\n", port);
 
 #ifdef SAMD2L2_HAVE_SPI0
   if (port == 0)

--- a/arch/arm/src/samd5e5/sam_spi.c
+++ b/arch/arm/src/samd5e5/sam_spi.c
@@ -1555,7 +1555,7 @@ struct spi_dev_s *sam_spibus_initialize(int port)
 
   /* Get the port state structure */
 
-  spiinfo("port: %d \n", port);
+  spiinfo("port: %d\n", port);
 
 #ifdef SAMD5E5_HAVE_SPI0
   if (port == 0)

--- a/arch/arm/src/samv7/sam_emac.c
+++ b/arch/arm/src/samv7/sam_emac.c
@@ -2743,7 +2743,7 @@ static int sam_ifup(struct net_driver_s *dev)
     }
 
   while (sam_linkup(priv) == 0);
-  ninfo("Link detected \n");
+  ninfo("Link detected\n");
 
   /* Enable normal MAC operation */
 

--- a/arch/arm/src/stm32/stm32_i2c_alt.c
+++ b/arch/arm/src/stm32/stm32_i2c_alt.c
@@ -1866,7 +1866,7 @@ static int stm32_i2c_isr_process(struct stm32_i2c_priv_s *priv)
       status |= (stm32_i2c_getreg(priv, STM32_I2C_SR2_OFFSET) << 16);
 
       i2cerr("ERROR:  "
-             "No correct state detected(start bit, read or write) \n");
+             "No correct state detected(start bit, read or write)\n");
       i2cerr("   state %" PRIi32 "\n", status);
 
       /* Set condition to terminate ISR and wake waiting thread */

--- a/arch/arm/src/stm32/stm32_qencoder.c
+++ b/arch/arm/src/stm32/stm32_qencoder.c
@@ -1314,7 +1314,7 @@ static int stm32_setindex(FAR struct qe_lowerhalf_s *lower, uint32_t pos)
 
   if (priv->index_use == false)
     {
-      snerr("ERROR: QE TIM%d index not registered \n",
+      snerr("ERROR: QE TIM%d index not registered\n",
             priv->config->timid);
       ret = -EPERM;
       goto errout;
@@ -1464,7 +1464,7 @@ int stm32_qe_index_init(int tim, uint32_t gpio)
                            stm32_qe_index_irq, priv);
   if (ret < 0)
     {
-      snerr("ERROR: QE TIM%d failed register irq \n", tim);
+      snerr("ERROR: QE TIM%d failed register irq\n", tim);
       goto errout;
     }
 

--- a/arch/arm/src/stm32/stm32f40xxx_i2c.c
+++ b/arch/arm/src/stm32/stm32f40xxx_i2c.c
@@ -1969,7 +1969,7 @@ static int stm32_i2c_isr_process(struct stm32_i2c_priv_s *priv)
           priv->status |= I2C_SR1_BERR;
         }
 
-      i2cinfo(" No correct state detected(start bit, read or write) \n");
+      i2cinfo(" No correct state detected(start bit, read or write)\n");
       i2cinfo(" state %" PRIi32 "\n", status);
 
       /* Set condition to terminate ISR and wake waiting thread */
@@ -2077,7 +2077,7 @@ static void stm32_i2c_dmarxcallback(DMA_HANDLE handle,
   uint32_t regval;
 #endif
 
-  i2cinfo("DMA rx callback, status = %d \n", status);
+  i2cinfo("DMA rx callback, status = %d\n", status);
 
   FAR struct stm32_i2c_priv_s *priv = (FAR struct stm32_i2c_priv_s *)arg;
 
@@ -2134,7 +2134,7 @@ static void stm32_i2c_dmatxcallback(DMA_HANDLE handle,
   uint32_t regval;
 #endif
 
-  i2cinfo("DMA tx callback, status = %d \n", status);
+  i2cinfo("DMA tx callback, status = %d\n", status);
 
   FAR struct stm32_i2c_priv_s *priv = (FAR struct stm32_i2c_priv_s *)arg;
 

--- a/arch/misoc/src/lm32/lm32_dumpstate.c
+++ b/arch/misoc/src/lm32/lm32_dumpstate.c
@@ -74,7 +74,7 @@ static inline void lm32_registerdump(void)
 
   if (g_current_regs)
     {
-      _alert("EPC:%08x \n",
+      _alert("EPC:%08x\n",
              g_current_regs[REG_EPC]);
       _alert(" X0:%08x  A0:%08x  A1:%08x  A2:%08x "
              " A3:%08x  A4:%08x  A5:%08x  A6:%08x\n",

--- a/arch/misoc/src/minerva/minerva_dumpstate.c
+++ b/arch/misoc/src/minerva/minerva_dumpstate.c
@@ -74,7 +74,7 @@ static inline void mineva_registerdump(void)
 
   if (g_current_regs)
     {
-      _alert("EPC:%08x \n", g_current_regs[REG_CSR_MEPC]);
+      _alert("EPC:%08x\n", g_current_regs[REG_CSR_MEPC]);
       _alert(" X0:%08x  A0:%08x  A1:%08x  A2:%08x "
              " A3:%08x  A4:%08x  A5:%08x  A6:%08x\n",
              g_current_regs[REG_X0_NDX], g_current_regs[REG_X1_NDX],

--- a/arch/renesas/src/rx65n/rx65n_usbhost.c
+++ b/arch/renesas/src/rx65n/rx65n_usbhost.c
@@ -841,7 +841,7 @@ uint16_t hw_usb_hread_devadd (uint16_t devsel)
   if (devadr > USB_MAXDEVADDR)
     {
       uerr("ERROR: device address %d is more than max device \
-            address. \n", devadd);
+            address.\n", devadd);
       return -ENODEV;
     }
   else
@@ -2765,7 +2765,7 @@ void usb_hstd_buf_to_fifo (uint8_t *buffer, size_t buflen, uint16_t pipe,
 
       /* FIFO access error */
 
-      syslog (LOG_INFO, "### FIFO access error \n");
+      syslog (LOG_INFO, "### FIFO access error\n");
       usb_hstd_forced_termination(pipe, (uint16_t) USB_DATA_ERR);
       break;
 
@@ -6215,7 +6215,7 @@ static void rx65n_usbhost_bottomhalf (void *arg)
         {
           /* Yes.. connected. */
 
-          connected_times ++;
+          connected_times++;
           syslog (LOG_INFO, "NuttX: USB Device Connected. %d\n",
                   connected_times);
           priv->connected = true;
@@ -6730,7 +6730,7 @@ static int rx65n_usbhost_epalloc(struct usbhost_driver_s *drvr,
 
       /* Note down the pipe number for reference */
 
-      ed ->pipenum = pipe_num;
+      ed->pipenum = pipe_num;
 
       /* Get the direction of the endpoint.  For control endpoints, the
        * direction is in the TD.
@@ -7615,7 +7615,7 @@ static ssize_t rx65n_usbhost_transfer(struct usbhost_driver_s *drvr,
 
         case TD_CC_DEVNOTRESPONDING:
           xfrinfo->wdhwait = false;
-          transfer_retry_count ++;
+          transfer_retry_count++;
           nbytes = -EBUSY;
           break;
 

--- a/arch/risc-v/src/bl602/bl602_i2c.c
+++ b/arch/risc-v/src/bl602/bl602_i2c.c
@@ -754,7 +754,7 @@ static int bl602_i2c_transfer(struct i2c_master_s *dev,
         }
       else
         {
-          i2cerr("i2c transfer error, event = %d \n", priv->i2cstate);
+          i2cerr("i2c transfer error, event = %d\n", priv->i2cstate);
         }
 
       nxsem_post(&priv->sem_isr);
@@ -938,7 +938,7 @@ static int bl602_i2c_irq(int cpuint, void *context, void *arg)
     }
   else
     {
-      i2cerr("other interrupt \n");
+      i2cerr("other interrupt\n");
       priv->i2cstate = EV_I2C_UNKNOW_INT;
       bl602_i2c_callback(priv);
       return -1;

--- a/arch/risc-v/src/bl602/bl602_netdev.c
+++ b/arch/risc-v/src/bl602/bl602_netdev.c
@@ -529,7 +529,7 @@ static void bl602_net_reply(struct bl602_net_driver_s *priv)
         {
           /* NOTIC: The release path of tx buffer cannot acquire net lock */
 
-          nerr("can not replay due to no tx buffer! \n");
+          nerr("can not replay due to no tx buffer!\n");
           PANIC();
         }
     }
@@ -1786,7 +1786,7 @@ bl602_net_ioctl(struct net_driver_s *dev, int cmd, unsigned long arg)
               memcpy(priv->wlan->mac,
                      priv->net_dev.d_mac.ether.ether_addr_octet,
                      6);
-              wlinfo("now in station mode \n");
+              wlinfo("now in station mode\n");
               priv->current_mode = IW_MODE_INFRA;
               return OK;
             }

--- a/arch/risc-v/src/esp32c3/esp32c3_freerun.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_freerun.c
@@ -159,7 +159,7 @@ int esp32c3_freerun_initialize(struct esp32c3_freerun_s *freerun, int chan,
 
       pre = esp32c3_clk_apb_freq() * resolution / USEC_PER_SEC;
 
-      tmrinfo("pre=% "PRIu16 " clk=%d \n", pre, esp32c3_clk_apb_freq());
+      tmrinfo("pre=% "PRIu16 " clk=%d\n", pre, esp32c3_clk_apb_freq());
 
       /* Configure TIMER prescaler */
 

--- a/arch/risc-v/src/esp32c3/esp32c3_spiflash_mtd.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_spiflash_mtd.c
@@ -632,7 +632,7 @@ static int esp32c3_ioctl(struct mtd_dev_s *dev, int cmd,
                          unsigned long arg)
 {
   int ret = OK;
-  finfo("cmd: %d \n", cmd);
+  finfo("cmd: %d\n", cmd);
 
   switch (cmd)
     {

--- a/arch/risc-v/src/rv32im/riscv_assert.c
+++ b/arch/risc-v/src/rv32im/riscv_assert.c
@@ -95,7 +95,7 @@ static inline void riscv_registerdump(volatile uint32_t *regs)
 {
   /* Are user registers available from interrupt processing? */
 
-  _alert("EPC:%08x \n", regs[REG_EPC]);
+  _alert("EPC:%08x\n", regs[REG_EPC]);
   _alert("A0:%08x A1:%08x A2:%08x A3:%08x A4:%08x A5:%08x "
          "A6:%08x A7:%08x\n",
          regs[REG_A0], regs[REG_A1], regs[REG_A2], regs[REG_A3],

--- a/arch/risc-v/src/rv64gc/riscv_assert.c
+++ b/arch/risc-v/src/rv64gc/riscv_assert.c
@@ -98,35 +98,35 @@ static inline void riscv_registerdump(volatile uintptr_t *regs)
 {
   /* Are user registers available from interrupt processing? */
 
-  _alert("EPC:%016" PRIx64 " \n", regs[REG_EPC]);
+  _alert("EPC:%016" PRIx64 "\n", regs[REG_EPC]);
   _alert("A0:%016" PRIx64 " A1:%01" PRIx64 "6 A2:%016" PRIx64
-         " A3:%016" PRIx64 " \n",
+         " A3:%016" PRIx64 "\n",
          regs[REG_A0], regs[REG_A1], regs[REG_A2], regs[REG_A3]);
   _alert("A4:%016" PRIx64 " A5:%016" PRIx64 "A6:%016" PRIx64
-         " A7:%016" PRIx64 " \n",
+         " A7:%016" PRIx64 "\n",
          regs[REG_A4], regs[REG_A5], regs[REG_A6], regs[REG_A7]);
   _alert("T0:%016" PRIx64 " T1:%016" PRIx64 " T2:%016" PRIx64
-         " T3:%016" PRIx64 " \n",
+         " T3:%016" PRIx64 "\n",
          regs[REG_T0], regs[REG_T1], regs[REG_T2], regs[REG_T3]);
-  _alert("T4:%016" PRIx64 " T5:%016" PRIx64 " T6:%016" PRIx64 " \n",
+  _alert("T4:%016" PRIx64 " T5:%016" PRIx64 " T6:%016" PRIx64 "\n",
          regs[REG_T4], regs[REG_T5], regs[REG_T6]);
   _alert("S0:%016" PRIx64 " S1:%016" PRIx64 " S2:%016" PRIx64
-         " S3:%016" PRIx64 " \n",
+         " S3:%016" PRIx64 "\n",
          regs[REG_S0], regs[REG_S1], regs[REG_S2], regs[REG_S3]);
   _alert("S4:%016" PRIx64 " S5:%016" PRIx64 " S6:%016" PRIx64
-         " S7:%016" PRIx64 " \n",
+         " S7:%016" PRIx64 "\n",
          regs[REG_S4], regs[REG_S5], regs[REG_S6], regs[REG_S7]);
   _alert("S8:%016" PRIx64 " S9:%016" PRIx64 " S10:%016" PRIx64
-         " S11:%016" PRIx64 " \n",
+         " S11:%016" PRIx64 "\n",
          regs[REG_S8], regs[REG_S9], regs[REG_S10], regs[REG_S11]);
 #ifdef RISCV_SAVE_GP
   _alert("GP:%016" PRIx64 " SP:%016" PRIx64 " FP:%016" PRIx64
-         " TP:%016" PRIx64 " RA:%016" PRIx64 " \n",
+         " TP:%016" PRIx64 " RA:%016" PRIx64 "\n",
          regs[REG_GP], regs[REG_SP], regs[REG_FP], regs[REG_TP],
          regs[REG_RA]);
 #else
   _alert("SP:%016" PRIx64 " FP:%016" PRIx64 " TP:%016" PRIx64
-         " RA:%016" PRIx64 " \n",
+         " RA:%016" PRIx64 "\n",
          regs[REG_SP], regs[REG_FP], regs[REG_TP], regs[REG_RA]);
 #endif
 }

--- a/arch/risc-v/src/rv64gc/riscv_fault.c
+++ b/arch/risc-v/src/rv64gc/riscv_fault.c
@@ -61,7 +61,7 @@ void up_fault(int irq, uint64_t *regs)
   _alert("EPC:%016" PRIx64 "\n",
          CURRENT_REGS[REG_EPC]);
 
-  _alert("Fault IRQ=%d \n", irq);
+  _alert("Fault IRQ=%d\n", irq);
 
   /* Dump register info */
 
@@ -81,7 +81,7 @@ void up_fault(int irq, uint64_t *regs)
          CURRENT_REGS[REG_T2], CURRENT_REGS[REG_T3]);
 
   _alert("T4:%016" PRIx64 " T5:%016" PRIx64
-         " T6:%016" PRIx64 " \n",
+         " T6:%016" PRIx64 "\n",
          CURRENT_REGS[REG_T4], CURRENT_REGS[REG_T5],
          CURRENT_REGS[REG_T6]);
 

--- a/arch/xtensa/src/esp32/esp32_ble.c
+++ b/arch/xtensa/src/esp32/esp32_ble.c
@@ -178,7 +178,7 @@ static int esp32_ble_recv_cb(uint8_t *data, uint16_t len)
 
   if (!valid)
     {
-      wlerr("Invalid H4 header \n");
+      wlerr("Invalid H4 header\n");
       ret = ERROR;
     }
   else

--- a/arch/xtensa/src/esp32/esp32_ble_adapter.c
+++ b/arch/xtensa/src/esp32/esp32_ble_adapter.c
@@ -2179,7 +2179,7 @@ static void *queue_create_wrapper(uint32_t queue_len, uint32_t item_size)
 
   if (ret < 0)
     {
-      wlerr("Failed to create mqueue %d \n", ret);
+      wlerr("Failed to create mqueue %d\n", ret);
       kmm_free(mq_adpt);
       return NULL;
     }

--- a/arch/xtensa/src/esp32/esp32_spiflash.c
+++ b/arch/xtensa/src/esp32/esp32_spiflash.c
@@ -1908,7 +1908,7 @@ static int esp32_ioctl(struct mtd_dev_s *dev, int cmd,
   int ret = -EINVAL;
   struct esp32_spiflash_s *priv = MTD2PRIV(dev);
 
-  finfo("cmd: %d \n", cmd);
+  finfo("cmd: %d\n", cmd);
 
   switch (cmd)
     {

--- a/arch/xtensa/src/esp32s2/esp32s2_freerun.c
+++ b/arch/xtensa/src/esp32s2/esp32s2_freerun.c
@@ -159,7 +159,7 @@ int esp32s2_freerun_initialize(struct esp32s2_freerun_s *freerun,
 
       pre = esp_clk_apb_freq() * resolution / USEC_PER_SEC;
 
-      tmrinfo("pre= %" PRIu16 " clk=%d \n", pre, esp_clk_apb_freq());
+      tmrinfo("pre= %" PRIu16 " clk=%d\n", pre, esp_clk_apb_freq());
 
       /* Configure TIMER prescaler */
 

--- a/boards/arm/cxd56xx/common/src/cxd56_gs2200m.c
+++ b/boards/arm/cxd56xx/common/src/cxd56_gs2200m.c
@@ -113,7 +113,7 @@ static void gs2200m_irq_enable(void)
 {
   irqstate_t flags = enter_critical_section();
 
-  wlinfo("== ec:%" PRId32 " called=%" PRId32 " \n",
+  wlinfo("== ec:%" PRId32 " called=%" PRId32 "\n",
          _enable_count, _n_called++);
 
   if (0 == _enable_count)
@@ -134,7 +134,7 @@ static void gs2200m_irq_disable(void)
 {
   irqstate_t flags = enter_critical_section();
 
-  wlinfo("== ec:%" PRId32 " called=%" PRId32 " \n",
+  wlinfo("== ec:%" PRId32 " called=%" PRId32 "\n",
          _enable_count, _n_called++);
 
   _enable_count--;

--- a/boards/arm/cxd56xx/spresense/src/cxd56_bringup.c
+++ b/boards/arm/cxd56xx/spresense/src/cxd56_bringup.c
@@ -336,7 +336,7 @@ int cxd56_bringup(void)
   ret = board_pwm_setup();
   if (ret < 0)
     {
-      _err("ERROR: Failed to initialize pwm. \n");
+      _err("ERROR: Failed to initialize pwm.\n");
     }
 #endif
 
@@ -344,7 +344,7 @@ int cxd56_bringup(void)
   ret = cxd56_adcinitialize();
   if (ret < 0)
     {
-      _err("ERROR: Failed to initialize adc. \n");
+      _err("ERROR: Failed to initialize adc.\n");
     }
 #endif
 
@@ -352,7 +352,7 @@ int cxd56_bringup(void)
   ret = userled_lower_initialize("/dev/userleds");
   if (ret < 0)
     {
-      _err("ERROR: Failed to initialize led. \n");
+      _err("ERROR: Failed to initialize led.\n");
     }
 #endif
 
@@ -405,7 +405,7 @@ int cxd56_bringup(void)
   ret = board_sdcard_initialize();
   if (ret < 0)
     {
-      _err("ERROR: Failed to initialize sdhci. \n");
+      _err("ERROR: Failed to initialize sdhci.\n");
     }
 #endif
 
@@ -443,7 +443,7 @@ int cxd56_bringup(void)
   ret = board_gs2200m_initialize("/dev/gs2200m", 5);
   if (ret < 0)
     {
-      _err("ERROR: Failed to initialize GS2200M. \n");
+      _err("ERROR: Failed to initialize GS2200M.\n");
     }
 #endif
 
@@ -451,7 +451,7 @@ int cxd56_bringup(void)
   ret = cxd56_gnssinitialize("/dev/gps");
   if (ret < 0)
     {
-      _err("ERROR: Failed to initialize gnss. \n");
+      _err("ERROR: Failed to initialize gnss.\n");
     }
 #endif
 
@@ -459,7 +459,7 @@ int cxd56_bringup(void)
   ret = cxd56_geofenceinitialize("/dev/geofence");
   if (ret < 0)
     {
-      _err("ERROR: Failed to initialize geofence. \n");
+      _err("ERROR: Failed to initialize geofence.\n");
     }
 #endif
 

--- a/boards/arm/cxd56xx/spresense/src/cxd56_sdcard.c
+++ b/boards/arm/cxd56xx/spresense/src/cxd56_sdcard.c
@@ -82,7 +82,8 @@ static struct work_s g_sdcard_work;
 #endif
 
 static struct pm_cpu_freqlock_s g_hv_lock =
-  PM_CPUFREQLOCK_INIT(PM_CPUFREQLOCK_TAG('S','D',0), PM_CPUFREQLOCK_FLAG_HV);
+  PM_CPUFREQLOCK_INIT(PM_CPUFREQLOCK_TAG('S', 'D', 0),
+                      PM_CPUFREQLOCK_FLAG_HV);
 
 /****************************************************************************
  * Private Functions
@@ -348,7 +349,7 @@ int board_sdcard_initialize(void)
                              NULL);
   if (ret < 0)
     {
-      _err("ERROR: Failed to configure GPIO int. \n");
+      _err("ERROR: Failed to configure GPIO int.\n");
     }
 
   /* Enabling Interrupt */

--- a/boards/arm/imxrt/imxrt1064-evk/src/imxrt_flexspi_nor.c
+++ b/boards/arm/imxrt/imxrt1064-evk/src/imxrt_flexspi_nor.c
@@ -545,7 +545,7 @@ static int imxrt_flexspi_nor_ioctl(FAR struct mtd_dev_s *dev,
                   (FAR struct imxrt_flexspi_nor_dev_s *)dev;
   int ret = -EINVAL; /* Assume good command with bad parameters */
 
-  finfo("cmd: %d \n", cmd);
+  finfo("cmd: %d\n", cmd);
 
   switch (cmd)
     {

--- a/boards/arm/lc823450/lc823450-xgevk/src/lc823450_wm8776.c
+++ b/boards/arm/lc823450/lc823450-xgevk/src/lc823450_wm8776.c
@@ -75,7 +75,7 @@ int lc823450_wm8776initialize(int minor)
   char devname[12];
   int ret;
 
-  ainfo("Initializing WM8776 \n");
+  ainfo("Initializing WM8776\n");
 
   /* Initialize I2C */
 

--- a/boards/arm/stm32/nucleo-l152re/src/stm32_spisd.c
+++ b/boards/arm/stm32/nucleo-l152re/src/stm32_spisd.c
@@ -113,7 +113,7 @@ int stm32_spisd_initialize(int port, int minor)
   stm32_configgpio(GPIO_SPI1_CS);   /* Assign CS */
   stm32_gpiowrite(GPIO_SPI1_CS, 1); /* Ensure the CS is inactive */
 
-  mcinfo("INFO: Initializing mmcsd port %d minor %d \n",
+  mcinfo("INFO: Initializing mmcsd port %d minor %d\n",
          port, minor);
 
   spi = stm32_spibus_initialize(port);

--- a/boards/arm/stm32/stm32f4discovery/src/stm32_bringup.c
+++ b/boards/arm/stm32/stm32f4discovery/src/stm32_bringup.c
@@ -518,7 +518,7 @@ int stm32_bringup(void)
   ret = stm32_gs2200m_initialize("/dev/gs2200m", 3);
   if (ret < 0)
     {
-      serr("ERROR: Failed to initialize GS2200M: %d \n", ret);
+      serr("ERROR: Failed to initialize GS2200M: %d\n", ret);
     }
 #endif
 

--- a/boards/arm/stm32/stm32f4discovery/src/stm32_gs2200m.c
+++ b/boards/arm/stm32/stm32f4discovery/src/stm32_gs2200m.c
@@ -107,7 +107,7 @@ static void gs2200m_irq_enable(void)
   irqstate_t flags = spin_lock_irqsave(NULL);
   uint32_t dready = 0;
 
-  wlinfo("== ec:%" PRId32 " called=%" PRId32 " \n",
+  wlinfo("== ec:%" PRId32 " called=%" PRId32 "\n",
          _enable_count, _n_called++);
 
   if (0 == _enable_count)
@@ -130,7 +130,7 @@ static void gs2200m_irq_enable(void)
     {
       /* Call g_irq_handler directly */
 
-      wlinfo("== ** call irq handler ** \n");
+      wlinfo("== ** call irq handler **\n");
       g_irq_handler(0, NULL, g_irq_arg);
     }
 }
@@ -143,7 +143,7 @@ static void gs2200m_irq_disable(void)
 {
   irqstate_t flags = spin_lock_irqsave(NULL);
 
-  wlinfo("== ec:%" PRId32 " called=%" PRId32 " \n",
+  wlinfo("== ec:%" PRId32 " called=%" PRId32 "\n",
          _enable_count, _n_called++);
 
   _enable_count--;

--- a/boards/arm/stm32/stm32f4discovery/src/stm32_mmcsd.c
+++ b/boards/arm/stm32/stm32f4discovery/src/stm32_mmcsd.c
@@ -82,7 +82,7 @@ int stm32_mmcsd_initialize(int port, int minor)
   stm32_configgpio(GPIO_MMCSD_NSS);   /* Assign CS */
   stm32_gpiowrite(GPIO_MMCSD_NSS, 1); /* Ensure the CS is inactive */
 
-  mcinfo("INFO: Initializing mmcsd port %d minor %d \n",
+  mcinfo("INFO: Initializing mmcsd port %d minor %d\n",
          port, minor);
 
   spi = stm32_spibus_initialize(port);

--- a/boards/renesas/rx65n/rx65n-rsk2mb/src/rx65n_bringup.c
+++ b/boards/renesas/rx65n/rx65n-rsk2mb/src/rx65n_bringup.c
@@ -170,7 +170,7 @@ static int nsh_usbhostinitialize(void)
 #ifdef CONFIG_USBHOST_CDCACM
   /* Register the CDC/ACM serial class */
 
-  printf ("USB Host CDCACM \n");
+  printf ("USB Host CDCACM\n");
   ret = usbhost_kbdinit();
   if (ret != OK)
     {

--- a/boards/risc-v/fe310/hifive1-revb/src/fe310_buttons.c
+++ b/boards/risc-v/fe310/hifive1-revb/src/fe310_buttons.c
@@ -106,7 +106,7 @@ uint32_t board_buttons(void)
       b0 = b1;
     }
 
-  iinfo("b=%d n=%d \n", b0, n);
+  iinfo("b=%d n=%d\n", b0, n);
 
   /* Low value means that the button is pressed */
 

--- a/boards/xtensa/esp32/esp32-devkitc/src/esp32_bringup.c
+++ b/boards/xtensa/esp32/esp32-devkitc/src/esp32_bringup.c
@@ -244,7 +244,7 @@ int esp32_bringup(void)
   ret = esp32_ble_initialize();
   if (ret)
     {
-      syslog(LOG_ERR, "ERROR: Failed to initialize BLE: %d \n", ret);
+      syslog(LOG_ERR, "ERROR: Failed to initialize BLE: %d\n", ret);
     }
 #endif
 

--- a/boards/xtensa/esp32/esp32-devkitc/src/esp32_buttons.c
+++ b/boards/xtensa/esp32/esp32-devkitc/src/esp32_buttons.c
@@ -102,7 +102,7 @@ uint32_t board_buttons(void)
       b0 = b1;
     }
 
-  iinfo("b=%d n=%d \n", b0, n);
+  iinfo("b=%d n=%d\n", b0, n);
 
   /* Low value means that the button is pressed */
 

--- a/boards/xtensa/esp32/esp32-ethernet-kit/src/esp32_bringup.c
+++ b/boards/xtensa/esp32/esp32-ethernet-kit/src/esp32_bringup.c
@@ -172,7 +172,7 @@ int esp32_bringup(void)
   ret = esp32_ble_initialize();
   if (ret)
     {
-      syslog(LOG_ERR, "ERROR: Failed to initialize BLE: %d \n", ret);
+      syslog(LOG_ERR, "ERROR: Failed to initialize BLE: %d\n", ret);
     }
 #endif
 

--- a/boards/xtensa/esp32/esp32-ethernet-kit/src/esp32_buttons.c
+++ b/boards/xtensa/esp32/esp32-ethernet-kit/src/esp32_buttons.c
@@ -102,7 +102,7 @@ uint32_t board_buttons(void)
       b0 = b1;
     }
 
-  iinfo("b=%d n=%d \n", b0, n);
+  iinfo("b=%d n=%d\n", b0, n);
 
   /* Low value means that the button is pressed */
 

--- a/boards/xtensa/esp32/esp32-wrover-kit/src/esp32_bringup.c
+++ b/boards/xtensa/esp32/esp32-wrover-kit/src/esp32_bringup.c
@@ -206,7 +206,7 @@ int esp32_bringup(void)
   ret = esp32_ble_initialize();
   if (ret)
     {
-      syslog(LOG_ERR, "ERROR: Failed to initialize BLE: %d \n", ret);
+      syslog(LOG_ERR, "ERROR: Failed to initialize BLE: %d\n", ret);
     }
 #endif
 

--- a/boards/xtensa/esp32/esp32-wrover-kit/src/esp32_buttons.c
+++ b/boards/xtensa/esp32/esp32-wrover-kit/src/esp32_buttons.c
@@ -102,7 +102,7 @@ uint32_t board_buttons(void)
       b0 = b1;
     }
 
-  iinfo("b=%d n=%d \n", b0, n);
+  iinfo("b=%d n=%d\n", b0, n);
 
   /* Low value means that the button is pressed */
 

--- a/boards/xtensa/esp32/ttgo_lora_esp32/src/esp32_buttons.c
+++ b/boards/xtensa/esp32/ttgo_lora_esp32/src/esp32_buttons.c
@@ -102,7 +102,7 @@ uint32_t board_buttons(void)
       b0 = b1;
     }
 
-  iinfo("b=%d n=%d \n", b0, n);
+  iinfo("b=%d n=%d\n", b0, n);
 
   /* Low value means that the button is pressed */
 

--- a/drivers/audio/wm8776.c
+++ b/drivers/audio/wm8776.c
@@ -283,7 +283,7 @@ static void wm8776_setvolume(FAR struct wm8776_dev_s *priv, uint16_t volume,
 
   wm8776_writereg(priv, WM8776_MASTER_ATT, regval);
 
-  audinfo("volume=%d mute=%d tmp_vol=%d (regval=0x%x) \n",
+  audinfo("volume=%d mute=%d tmp_vol=%d (regval=0x%x)\n",
           volume, mute, tmp_vol, regval);
 
   /* Remember the volume level and mute settings */

--- a/drivers/mtd/at24xx.c
+++ b/drivers/mtd/at24xx.c
@@ -579,7 +579,7 @@ static int at24c_ioctl(FAR struct mtd_dev_s *dev, int cmd, unsigned long arg)
   FAR struct at24c_dev_s *priv = (FAR struct at24c_dev_s *)dev;
   int ret = -EINVAL; /* Assume good command with bad parameters */
 
-  finfo("cmd: %d \n", cmd);
+  finfo("cmd: %d\n", cmd);
 
   switch (cmd)
     {

--- a/drivers/mtd/at25.c
+++ b/drivers/mtd/at25.c
@@ -605,7 +605,7 @@ static int at25_ioctl(FAR struct mtd_dev_s *dev, int cmd, unsigned long arg)
   FAR struct at25_dev_s *priv = (FAR struct at25_dev_s *)dev;
   int ret = -EINVAL; /* Assume good command with bad parameters */
 
-  finfo("cmd: %d \n", cmd);
+  finfo("cmd: %d\n", cmd);
 
   switch (cmd)
     {

--- a/drivers/mtd/at45db.c
+++ b/drivers/mtd/at45db.c
@@ -773,7 +773,7 @@ static int at45db_ioctl(FAR struct mtd_dev_s *mtd,
   FAR struct at45db_dev_s *priv = (FAR struct at45db_dev_s *)mtd;
   int ret = -EINVAL; /* Assume good command with bad parameters */
 
-  finfo("cmd: %d \n", cmd);
+  finfo("cmd: %d\n", cmd);
 
   switch (cmd)
     {

--- a/drivers/mtd/gd25.c
+++ b/drivers/mtd/gd25.c
@@ -923,7 +923,7 @@ static int gd25_ioctl(FAR struct mtd_dev_s *dev, int cmd, unsigned long arg)
   FAR struct gd25_dev_s *priv = (FAR struct gd25_dev_s *)dev;
   int ret = -EINVAL;
 
-  finfo("cmd: %d \n", cmd);
+  finfo("cmd: %d\n", cmd);
 
   switch (cmd)
     {

--- a/drivers/mtd/gd5f.c
+++ b/drivers/mtd/gd5f.c
@@ -691,7 +691,7 @@ static ssize_t gd5f_write(FAR struct mtd_dev_s *dev,
   size_t bytesleft = nbytes;
   uint32_t position = offset;
 
-  finfo("Write: offset: %08lx nbytes: %d \n", (long)offset, (int)nbytes);
+  finfo("Write: offset: %08lx nbytes: %d\n", (long)offset, (int)nbytes);
   gd5f_lock(priv->dev);
 
   /* Wait all operations complete */
@@ -759,7 +759,7 @@ static int gd5f_ioctl(FAR struct mtd_dev_s *dev, int cmd, unsigned long arg)
   FAR struct gd5f_dev_s *priv = (FAR struct gd5f_dev_s *)dev;
   int ret = -EINVAL;
 
-  finfo("cmd: %d \n", cmd);
+  finfo("cmd: %d\n", cmd);
 
   switch (cmd)
     {

--- a/drivers/mtd/is25xp.c
+++ b/drivers/mtd/is25xp.c
@@ -901,7 +901,7 @@ static int is25xp_ioctl(FAR struct mtd_dev_s *dev,
   FAR struct is25xp_dev_s *priv = (FAR struct is25xp_dev_s *)dev;
   int ret = -EINVAL; /* Assume good command with bad parameters */
 
-  finfo("cmd: %d \n", cmd);
+  finfo("cmd: %d\n", cmd);
 
   switch (cmd)
     {

--- a/drivers/mtd/m25px.c
+++ b/drivers/mtd/m25px.c
@@ -1046,7 +1046,7 @@ static int m25p_ioctl(FAR struct mtd_dev_s *dev, int cmd, unsigned long arg)
   FAR struct m25p_dev_s *priv = (FAR struct m25p_dev_s *)dev;
   int ret = -EINVAL; /* Assume good command with bad parameters */
 
-  finfo("cmd: %d \n", cmd);
+  finfo("cmd: %d\n", cmd);
 
   switch (cmd)
     {

--- a/drivers/mtd/mtd_rwbuffer.c
+++ b/drivers/mtd/mtd_rwbuffer.c
@@ -265,7 +265,7 @@ static int mtd_ioctl(FAR struct mtd_dev_s *dev, int cmd, unsigned long arg)
   FAR struct mtd_rwbuffer_s *priv = (FAR struct mtd_rwbuffer_s *)dev;
   int ret = -EINVAL; /* Assume good command with bad parameters */
 
-  finfo("cmd: %d \n", cmd);
+  finfo("cmd: %d\n", cmd);
 
   switch (cmd)
     {

--- a/drivers/mtd/mx25lx.c
+++ b/drivers/mtd/mx25lx.c
@@ -1025,7 +1025,7 @@ static int mx25l_ioctl(FAR struct mtd_dev_s *dev, int cmd, unsigned long arg)
   FAR struct mx25l_dev_s *priv = (FAR struct mx25l_dev_s *)dev;
   int ret = -EINVAL; /* Assume good command with bad parameters */
 
-  mxlinfo("cmd: %d \n", cmd);
+  mxlinfo("cmd: %d\n", cmd);
 
   switch (cmd)
     {

--- a/drivers/mtd/mx25rxx.c
+++ b/drivers/mtd/mx25rxx.c
@@ -605,8 +605,8 @@ int mx25rxx_erase(FAR struct mtd_dev_s *dev,
           /* Erase each sector */
 
           mx25rxx_erase_sector(priv, startblock);
-          startblock ++;
-          blocksleft --;
+          startblock++;
+          blocksleft--;
         }
     }
 #endif
@@ -711,7 +711,7 @@ int mx25rxx_ioctl(FAR struct mtd_dev_s *dev, int cmd, unsigned long arg)
   FAR struct mx25rxx_dev_s *priv = (FAR struct mx25rxx_dev_s *)dev;
   int ret = -EINVAL; /* Assume good command with bad parameters */
 
-  finfo("cmd: %d \n", cmd);
+  finfo("cmd: %d\n", cmd);
 
   switch (cmd)
     {

--- a/drivers/mtd/mx35.c
+++ b/drivers/mtd/mx35.c
@@ -779,7 +779,7 @@ static int mx35_ioctl(FAR struct mtd_dev_s *dev, int cmd, unsigned long arg)
   FAR struct mx35_dev_s *priv = (FAR struct mx35_dev_s *)dev;
   int ret = -EINVAL; /* Assume good command with bad parameters */
 
-  mx35info("cmd: %d \n", cmd);
+  mx35info("cmd: %d\n", cmd);
 
   switch (cmd)
     {

--- a/drivers/mtd/n25qxxx.c
+++ b/drivers/mtd/n25qxxx.c
@@ -1360,7 +1360,7 @@ static int n25qxxx_ioctl(FAR struct mtd_dev_s *dev,
   FAR struct n25qxxx_dev_s *priv = (FAR struct n25qxxx_dev_s *)dev;
   int ret = -EINVAL; /* Assume good command with bad parameters */
 
-  finfo("cmd: %d \n", cmd);
+  finfo("cmd: %d\n", cmd);
 
   switch (cmd)
     {

--- a/drivers/mtd/ramtron.c
+++ b/drivers/mtd/ramtron.c
@@ -816,7 +816,7 @@ static int ramtron_ioctl(FAR struct mtd_dev_s *dev,
   FAR struct ramtron_dev_s *priv = (FAR struct ramtron_dev_s *)dev;
   int ret = -EINVAL; /* Assume good command with bad parameters */
 
-  finfo("cmd: %d \n", cmd);
+  finfo("cmd: %d\n", cmd);
 
   switch (cmd)
     {

--- a/drivers/mtd/s25fl1.c
+++ b/drivers/mtd/s25fl1.c
@@ -1408,7 +1408,7 @@ static int s25fl1_ioctl(FAR struct mtd_dev_s *dev,
   FAR struct s25fl1_dev_s *priv = (FAR struct s25fl1_dev_s *)dev;
   int ret = -EINVAL; /* Assume good command with bad parameters */
 
-  finfo("cmd: %d \n", cmd);
+  finfo("cmd: %d\n", cmd);
 
   switch (cmd)
     {

--- a/drivers/mtd/sector512.c
+++ b/drivers/mtd/sector512.c
@@ -511,7 +511,7 @@ static int s512_ioctl(FAR struct mtd_dev_s *dev, int cmd, unsigned long arg)
   FAR struct s512_dev_s *priv = (FAR struct s512_dev_s *)dev;
   int ret = -EINVAL; /* Assume good command with bad parameters */
 
-  finfo("cmd: %d \n", cmd);
+  finfo("cmd: %d\n", cmd);
 
   switch (cmd)
     {

--- a/drivers/mtd/sst25.c
+++ b/drivers/mtd/sst25.c
@@ -1157,7 +1157,7 @@ static int sst25_ioctl(FAR struct mtd_dev_s *dev, int cmd, unsigned long arg)
   FAR struct sst25_dev_s *priv = (FAR struct sst25_dev_s *)dev;
   int ret = -EINVAL; /* Assume good command with bad parameters */
 
-  finfo("cmd: %d \n", cmd);
+  finfo("cmd: %d\n", cmd);
 
   switch (cmd)
     {

--- a/drivers/mtd/sst25xx.c
+++ b/drivers/mtd/sst25xx.c
@@ -861,7 +861,7 @@ static int sst25xx_ioctl(FAR struct mtd_dev_s *dev, int cmd,
   FAR struct sst25xx_dev_s *priv = (FAR struct sst25xx_dev_s *)dev;
   int ret = -EINVAL; /* Assume good command with bad parameters */
 
-  finfo("cmd: %d \n", cmd);
+  finfo("cmd: %d\n", cmd);
 
   switch (cmd)
     {

--- a/drivers/mtd/sst26.c
+++ b/drivers/mtd/sst26.c
@@ -867,7 +867,7 @@ static int sst26_ioctl(FAR struct mtd_dev_s *dev, int cmd, unsigned long arg)
   FAR struct sst26_dev_s *priv = (FAR struct sst26_dev_s *)dev;
   int ret = -EINVAL; /* Assume good command with bad parameters */
 
-  sstinfo("cmd: %d \n", cmd);
+  sstinfo("cmd: %d\n", cmd);
 
   switch (cmd)
     {

--- a/drivers/mtd/w25.c
+++ b/drivers/mtd/w25.c
@@ -1284,7 +1284,7 @@ static int w25_ioctl(FAR struct mtd_dev_s *dev, int cmd, unsigned long arg)
   FAR struct w25_dev_s *priv = (FAR struct w25_dev_s *)dev;
   int ret = -EINVAL; /* Assume good command with bad parameters */
 
-  finfo("cmd: %d \n", cmd);
+  finfo("cmd: %d\n", cmd);
 
   switch (cmd)
     {

--- a/drivers/mtd/w25qxxxjv.c
+++ b/drivers/mtd/w25qxxxjv.c
@@ -1367,7 +1367,7 @@ static int w25qxxxjv_ioctl(FAR struct mtd_dev_s *dev,
   FAR struct w25qxxxjv_dev_s *priv = (FAR struct w25qxxxjv_dev_s *)dev;
   int ret = -EINVAL; /* Assume good command with bad parameters */
 
-  finfo("cmd: %d \n", cmd);
+  finfo("cmd: %d\n", cmd);
 
   switch (cmd)
     {

--- a/drivers/sensors/apds9960.c
+++ b/drivers/sensors/apds9960.c
@@ -680,7 +680,7 @@ static bool apds9960_processgesture(FAR struct apds9960_dev_s *priv)
 
       for (i = priv->gesture_data.total_gestures - 1; i >= 0; i--)
         {
-          sninfo("Finding last: \n");
+          sninfo("Finding last:\n");
           sninfo("U: %03d\n", priv->gesture_data.u_data[i]);
           sninfo("D: %03d\n", priv->gesture_data.d_data[i]);
           sninfo("L: %03d\n", priv->gesture_data.l_data[i]);
@@ -707,13 +707,13 @@ static bool apds9960_processgesture(FAR struct apds9960_dev_s *priv)
   ud_ratio_last  = ((u_last  - d_last)  * 100) / (u_last  + d_last);
   lr_ratio_last  = ((l_last  - r_last)  * 100) / (l_last  + r_last);
 
-  sninfo("Last Values: \n");
+  sninfo("Last Values:\n");
   sninfo("U: %03d\n", u_last);
   sninfo("D: %03d\n", d_last);
   sninfo("L: %03d\n", l_last);
   sninfo("R: %03d\n", r_last);
 
-  sninfo("Ratios: \n");
+  sninfo("Ratios:\n");
   sninfo("UD Fi: %03d\n", ud_ratio_first);
   sninfo("UD La: %03d\n", ud_ratio_last);
   sninfo("LR Fi: %03d\n", lr_ratio_first);
@@ -724,7 +724,7 @@ static bool apds9960_processgesture(FAR struct apds9960_dev_s *priv)
   ud_delta = ud_ratio_last - ud_ratio_first;
   lr_delta = lr_ratio_last - lr_ratio_first;
 
-  sninfo("Deltas: \n");
+  sninfo("Deltas:\n");
   sninfo("UD: %03d\n", ud_delta);
   sninfo("LR: %03d\n", lr_delta);
 
@@ -733,7 +733,7 @@ static bool apds9960_processgesture(FAR struct apds9960_dev_s *priv)
   priv->gesture_ud_delta += ud_delta;
   priv->gesture_lr_delta += lr_delta;
 
-  sninfo("Accumulations: \n");
+  sninfo("Accumulations:\n");
   sninfo("UD: %03d\n", priv->gesture_ud_delta);
   sninfo("LR: %03d\n", priv->gesture_lr_delta);
 

--- a/drivers/sensors/vl53l1x.c
+++ b/drivers/sensors/vl53l1x.c
@@ -843,7 +843,7 @@ static uint16_t vl53l1x_getreg16(FAR struct vl53l1x_dev_s *priv,
 
   /* Register to read */
 
-  sninfo("Reg %02x % \n", reg_addr_aux[0], reg_addr_aux[1]);
+  sninfo("Reg %02x %\n", reg_addr_aux[0], reg_addr_aux[1]);
   ret = i2c_write(priv->i2c, &config, (uint8_t *)&reg_addr_aux, 2);
   if (ret < 0)
     {

--- a/drivers/sensors/wtgahrs2.c
+++ b/drivers/sensors/wtgahrs2.c
@@ -333,7 +333,7 @@ static void wtgahrs2_gps_data(FAR struct wtgahrs2_dev_s *rtdata,
              rtdata->gps.timestamp, rtdata->gps.time_utc);
       sninfo("GPS longitude : %fdegree, latitude:%fdegree\n",
               rtdata->gps.longitude, rtdata->gps.latitude);
-      sninfo("GPS speed: %fm/s, altitude: %fm \n",
+      sninfo("GPS speed: %fm/s, altitude: %fm\n",
               rtdata->gps.ground_speed, rtdata->gps.altitude);
     }
 }

--- a/drivers/usbdev/rndis.c
+++ b/drivers/usbdev/rndis.c
@@ -1290,7 +1290,7 @@ static inline int rndis_recvpacket(FAR struct rndis_dev_s *priv,
             }
           else
             {
-              uerr("The packet exceeds request buffer (reqlen=%d) \n",
+              uerr("The packet exceeds request buffer (reqlen=%d)\n",
                    reqlen);
             }
         }

--- a/drivers/wireless/gs2200m.c
+++ b/drivers/wireless/gs2200m.c
@@ -423,7 +423,7 @@ static void _notif_q_push(FAR struct gs2200m_dev_s *dev, char cid)
       nxsem_post(dev->pfd->sem);
     }
 
-  wlinfo("+++ pushed %c count=%d \n", cid, dev->notif_q.count);
+  wlinfo("+++ pushed %c count=%d\n", cid, dev->notif_q.count);
 }
 
 /****************************************************************************
@@ -503,7 +503,7 @@ static void _check_pkt_q_cnt(FAR struct gs2200m_dev_s *dev, char cid)
 
   if (0 != cnt)
     {
-      wlinfo("--- _pkt_p_cnt[%c]=%d \n", cid, cnt);
+      wlinfo("--- _pkt_p_cnt[%c]=%d\n", cid, cnt);
     }
 }
 
@@ -522,7 +522,7 @@ static void _check_pkt_q_empty(FAR struct gs2200m_dev_s *dev, char cid)
 
       while (pkt_dat)
         {
-          wlerr("=== error: found (type=%d msg[0]=%s|) \n",
+          wlerr("=== error: found (type=%d msg[0]=%s|)\n",
                 pkt_dat->type, pkt_dat->msg[0]);
           pkt_dat = (FAR struct pkt_dat_s *)pkt_dat->dq.flink;
         }
@@ -543,14 +543,14 @@ static bool _control_pkt_q(FAR struct gs2200m_dev_s *dev)
 
   if (dev->int_enabled && over)
     {
-      wlinfo("--- disable irq \n");
+      wlinfo("--- disable irq\n");
       dev->int_enabled = false;
       dev->lower->disable();
     }
 
   if (!dev->int_enabled && !over)
     {
-      wlinfo("--- enable irq again \n");
+      wlinfo("--- enable irq again\n");
       dev->lower->enable();
       dev->int_enabled = true;
     }
@@ -628,7 +628,7 @@ static bool _copy_data_from_pkt(FAR struct gs2200m_dev_s *dev,
   pkt_dat = (FAR struct pkt_dat_s *)dq_peek(&dev->pkt_q[c]);
   ASSERT(pkt_dat);
 
-  wlinfo("+++ msg(req=%d:len=%d) pkt_data(t=%d:remain=%d) \n",
+  wlinfo("+++ msg(req=%d:len=%d) pkt_data(t=%d:remain=%d)\n",
          msg->reqlen, msg->len, pkt_dat->type, pkt_dat->remain);
 
   if (msg->len && TYPE_DISCONNECT == pkt_dat->type)
@@ -748,7 +748,7 @@ static ssize_t gs2200m_read(FAR struct file *filep, FAR char *buffer,
   ASSERT(0 < _notif_q_count(dev));
   char cid = _notif_q_pop(dev);
 
-  wlinfo("---- cid=%c (notif_q_cnt=%d) \n", cid, _notif_q_count(dev));
+  wlinfo("---- cid=%c (notif_q_cnt=%d)\n", cid, _notif_q_count(dev));
 
   /* Copy the cid to the buffer */
 
@@ -893,7 +893,7 @@ retry:
 
   if (RD_RESP_NOK == res[1])
     {
-      wlwarn("*** warning: RD_RESP_NOK received.. retrying. (n=%d) \n", n);
+      wlwarn("*** warning: RD_RESP_NOK received.. retrying. (n=%d)\n", n);
       nxsig_usleep(100 * 1000);
       n++;
       goto retry;
@@ -940,11 +940,11 @@ retry:
 
   if (dev->lower->dready(NULL))
     {
-      wlwarn("*** warning: gs2200m is busy.. retrying. (n=%d) \n", n);
+      wlwarn("*** warning: gs2200m is busy.. retrying. (n=%d)\n", n);
 
       if (!work_available(&dev->irq_work))
         {
-          wlwarn("*** warning: there is still pending work **** \n");
+          wlwarn("*** warning: there is still pending work ****\n");
         }
       else
         {
@@ -982,7 +982,7 @@ retry:
 
   if (WR_RESP_NOK == res[1] || 0x0 == res[1])
     {
-      wlwarn("*** warning: 0x%x received.. retrying. (n=%d) \n",
+      wlwarn("*** warning: 0x%x received.. retrying. (n=%d)\n",
              res[1], n);
       nxsig_usleep(10 * 1000);
 
@@ -1040,7 +1040,7 @@ enum spi_status_e gs2200m_hal_read(FAR struct gs2200m_dev_s *dev,
 
   if (HAL_TIMEOUT == i)
     {
-      wlerr("***** error: timeout! \n");
+      wlerr("***** error: timeout!\n");
       r = SPI_TIMEOUT;
       goto errout;
     }
@@ -1051,7 +1051,7 @@ enum spi_status_e gs2200m_hal_read(FAR struct gs2200m_dev_s *dev,
 
   *len = _read_data_len(dev);
 
-  wlinfo("+++++ (len=%d) \n", *len);
+  wlinfo("+++++ (len=%d)\n", *len);
 
   /* Check the length */
 
@@ -1085,7 +1085,7 @@ enum pkt_type_e _check_evt(FAR const char *buff)
         }
     }
 
-  wlinfo("+++++ %s +++++ \n", buff);
+  wlinfo("+++++ %s +++++\n", buff);
   return TYPE_UNMATCH;
 }
 
@@ -1145,7 +1145,7 @@ static void _parse_pkt_in_s1(FAR struct pkt_ctx_s *pkt_ctx,
       n = sscanf(msg, "DISCONNECT %c", &(pkt_dat->cid));
       ASSERT(1 == n);
 
-      wlinfo("+++++ msg=%s| cid=%c \n", msg, pkt_dat->cid);
+      wlinfo("+++++ msg=%s| cid=%c\n", msg, pkt_dat->cid);
     }
   else if (pkt_ctx->type == TYPE_CONNECT)
     {
@@ -1156,20 +1156,20 @@ static void _parse_pkt_in_s1(FAR struct pkt_ctx_s *pkt_ctx,
       n = sscanf(msg, "CONNECT %c", &(pkt_dat->cid));
       DEBUGASSERT(1 == n);
 
-      wlinfo("+++++ msg=%s| \n", msg);
+      wlinfo("+++++ msg=%s|\n", msg);
     }
 
   if (pkt_dat)
     {
       /* If specified, store the msg pointer to pkt_dat */
 
-      wlinfo("+++++ %d:(msize=%d, msg=%s|) \n", pkt_dat->n, msize, msg);
+      wlinfo("+++++ %d:(msize=%d, msg=%s|)\n", pkt_dat->n, msize, msg);
       ASSERT(pkt_dat->n < NRESPMSG);
       pkt_dat->msg[pkt_dat->n++] = msg;
     }
   else
     {
-      wlinfo("+++++ (msize=%d, msg=%s|) \n", msize, msg);
+      wlinfo("+++++ (msize=%d, msg=%s|)\n", msize, msg);
       kmm_free(msg);
     }
 
@@ -1194,7 +1194,7 @@ static void _parse_pkt_in_s2(FAR struct pkt_ctx_s *pkt_ctx,
 
   if ('Z' == c)
     {
-      wlinfo("** <ESC>Z \n");
+      wlinfo("** <ESC>Z\n");
 
       /* NOTE: See 7.5.3.2 Bulk Data Handling */
 
@@ -1202,7 +1202,7 @@ static void _parse_pkt_in_s2(FAR struct pkt_ctx_s *pkt_ctx,
     }
   else if ('y' == c)
     {
-      wlinfo("** <ESC>y \n");
+      wlinfo("** <ESC>y\n");
 
       /* NOTE: See 7.5.3.2 Bulk Data Handling */
 
@@ -1210,7 +1210,7 @@ static void _parse_pkt_in_s2(FAR struct pkt_ctx_s *pkt_ctx,
     }
   else if ('F' == c)
     {
-      wlwarn("** <ESC>F \n");
+      wlwarn("** <ESC>F\n");
 
       /* NOTE: See Table 6 Data Handling Responses at Completion */
 
@@ -1219,7 +1219,7 @@ static void _parse_pkt_in_s2(FAR struct pkt_ctx_s *pkt_ctx,
     }
   else
     {
-      wlerr("** <ESC>%c not supported \n", c);
+      wlerr("** <ESC>%c not supported\n", c);
       ASSERT(false);
     }
 }
@@ -1251,7 +1251,7 @@ static void _parse_pkt_in_s3(FAR struct pkt_ctx_s *pkt_ctx,
       pkt_ctx->dlen = _to_uint16((char *)pkt_ctx->ptr);
       pkt_ctx->ptr += 3;
 
-      wlinfo("dlen=%d \n", pkt_ctx->dlen);
+      wlinfo("dlen=%d\n", pkt_ctx->dlen);
 
       /* Allocate memory for the packet */
 
@@ -1303,7 +1303,7 @@ static void _parse_pkt_in_s4(FAR struct pkt_ctx_s *pkt_ctx,
       n = sscanf((char *)pkt_ctx->ptr, "%s %s\t", addr, port);
       ASSERT(2 == n);
 
-      wlinfo("from (%s:%s) \n", addr, port);
+      wlinfo("from (%s:%s)\n", addr, port);
 
       inet_aton(addr, &pkt_dat->addr.sin_addr);
       pkt_dat->addr.sin_port = htons((uint16_t)atoi(port));
@@ -1318,7 +1318,7 @@ static void _parse_pkt_in_s4(FAR struct pkt_ctx_s *pkt_ctx,
       pkt_ctx->dlen = _to_uint16((char *)pkt_ctx->ptr);
       pkt_ctx->ptr += 3;
 
-      wlinfo("dlen=%d \n", pkt_ctx->dlen);
+      wlinfo("dlen=%d\n", pkt_ctx->dlen);
 
       /* Allocate memory for the packet */
 
@@ -1461,7 +1461,7 @@ static enum pkt_type_e gs2200m_recv_pkt(FAR struct gs2200m_dev_s *dev,
       goto errout;
     }
 
-  wlinfo("+++ len=%d pkt_dat=%p \n", len, pkt_dat);
+  wlinfo("+++ len=%d pkt_dat=%p\n", len, pkt_dat);
 
   /* Parse the received packet */
 
@@ -1530,7 +1530,7 @@ retry_recv:
 
   if ((TYPE_BULK_DATA_TCP == r || TYPE_BULK_DATA_UDP == r) && pkt_dat)
     {
-      wlwarn("*** Found bulk data \n");
+      wlwarn("*** Found bulk data\n");
 
       /* Bulk data found in the response,
        * duplicate the packet and notify
@@ -1559,7 +1559,7 @@ retry_recv:
           memset(pkt_dat, 0, sizeof(pkt_dat));
         }
 
-      wlwarn("*** retry cmd=%s (n=%d) \n", cmd, n);
+      wlwarn("*** retry cmd=%s (n=%d)\n", cmd, n);
       goto retry;
     }
 
@@ -1567,7 +1567,7 @@ errout:
 
   if (bulk)
     {
-      wlwarn("*** Normal response r=%d \n", r);
+      wlwarn("*** Normal response r=%d\n", r);
     }
 
   /* Enable gs2200m irq again */
@@ -1925,7 +1925,7 @@ gs2200m_create_clnt(FAR struct gs2200m_dev_s *dev,
 
   if (r != TYPE_OK || pkt_dat.n == 0)
     {
-      wlerr("+++ error: r=%d pkt_dat.msg[0]=%s \n",
+      wlerr("+++ error: r=%d pkt_dat.msg[0]=%s\n",
             r, pkt_dat.msg[0]);
       goto errout;
     }
@@ -1934,7 +1934,7 @@ gs2200m_create_clnt(FAR struct gs2200m_dev_s *dev,
     {
       n = sscanf(p, "CONNECT %c", cid);
       ASSERT(1 == n);
-      wlinfo("+++ OK: p=%s| (n=%d) \n", p, n);
+      wlinfo("+++ OK: p=%s| (n=%d)\n", p, n);
     }
 
 errout:
@@ -1982,7 +1982,7 @@ static enum pkt_type_e gs2200m_start_server(FAR struct gs2200m_dev_s *dev,
     {
       n = sscanf(p, "CONNECT %c", cid);
       ASSERT(1 == n);
-      wlinfo("+++ OK: p=%s| (n=%d) \n", p, n);
+      wlinfo("+++ OK: p=%s| (n=%d)\n", p, n);
     }
 
 errout:
@@ -2015,7 +2015,7 @@ static enum pkt_type_e gs2200m_send_bulk(FAR struct gs2200m_dev_s *dev,
 
   _to_ascii_char(msg->len, digits);
 
-  wlinfo("** cid=%c len=%d digits=%s \n", msg->cid, msg->len, digits);
+  wlinfo("** cid=%c len=%d digits=%s\n", msg->cid, msg->len, digits);
 
   if (msg->is_tcp)
     {
@@ -2027,7 +2027,7 @@ static enum pkt_type_e gs2200m_send_bulk(FAR struct gs2200m_dev_s *dev,
     }
   else
     {
-      wlinfo("** addr=%s port=%d \n", inet_ntoa(msg->addr.sin_addr),
+      wlinfo("** addr=%s port=%d\n", inet_ntoa(msg->addr.sin_addr),
              ntohs(msg->addr.sin_port));
 
       /* NOTE: See 7.5.3.2 Bulk Data Handling for UDP
@@ -2184,7 +2184,7 @@ static enum pkt_type_e gs2200m_get_cstatus(FAR struct gs2200m_dev_s *dev,
 
   if (r != TYPE_OK || pkt_dat.n <= 2)
     {
-      wlerr("+++ error: r=%d pkt_dat.msg[0]=%s \n",
+      wlerr("+++ error: r=%d pkt_dat.msg[0]=%s\n",
             r, pkt_dat.msg[0]);
 
       goto errout;
@@ -2207,7 +2207,7 @@ static enum pkt_type_e gs2200m_get_cstatus(FAR struct gs2200m_dev_s *dev,
                  &a[0], &a[1], &a[2], &a[3]);
       ASSERT(9 == n);
 
-      wlinfo("[%d]: %c %s %s %d %d %d.%d.%d.%d \n",
+      wlinfo("[%d]: %c %s %s %d %d %d.%d.%d.%d\n",
              i, c, type, mode, p[0], p[1],
              a[0], a[1], a[2], a[3]);
 
@@ -2257,7 +2257,7 @@ static int gs2200m_ioctl_bind(FAR struct gs2200m_dev_s *dev,
   char cid = 'z';
   int ret = OK;
 
-  wlinfo("+++ start: (cid=%c, port=%s) \n", msg->cid, msg->port);
+  wlinfo("+++ start: (cid=%c, port=%s)\n", msg->cid, msg->port);
 
   port = (uint16_t)strtol(msg->port, NULL, 10);
 
@@ -2297,7 +2297,7 @@ errout:
   msg->type = type;
   msg->cid  = cid;
 
-  wlinfo("+++ end: type=%d (cid=%c) \n", type, cid);
+  wlinfo("+++ end: type=%d (cid=%c)\n", type, cid);
 
   return ret;
 }
@@ -2313,7 +2313,7 @@ static int gs2200m_ioctl_connect(FAR struct gs2200m_dev_s *dev,
   char cid = 'z';
   int ret = OK;
 
-  wlinfo("++ start: addr=%s port=%s \n", msg->addr, msg->port);
+  wlinfo("++ start: addr=%s port=%s\n", msg->addr, msg->port);
 
   /* Create TCP or UDP connection */
 
@@ -2344,12 +2344,12 @@ static int gs2200m_ioctl_connect(FAR struct gs2200m_dev_s *dev,
         break;
 
       default:
-        wlerr("+++ error: type=%d \n", type);
+        wlerr("+++ error: type=%d\n", type);
         ASSERT(false);
         ret = -EINVAL;
     }
 
-  wlinfo("++ end: cid=%c (type=%d,ret=%d) \n", cid, type, ret);
+  wlinfo("++ end: cid=%c (type=%d,ret=%d)\n", cid, type, ret);
 
   return ret;
 }
@@ -2365,7 +2365,7 @@ static int gs2200m_ioctl_send(FAR struct gs2200m_dev_s *dev,
   enum pkt_type_e type;
   int ret = OK;
 
-  wlinfo("+++ start: (cid=%c) \n", msg->cid);
+  wlinfo("+++ start: (cid=%c)\n", msg->cid);
 
 #ifdef USE_LED
   gs2200m_set_gpio(dev, LED_GPIO, 1);
@@ -2381,13 +2381,13 @@ static int gs2200m_ioctl_send(FAR struct gs2200m_dev_s *dev,
       ret = gs2200m_ioctl_bind(dev, &bmsg);
       ASSERT(0 == ret);
 
-      wlinfo("+++ cid is assigned for udp (cid=%c) \n", bmsg.cid);
+      wlinfo("+++ cid is assigned for udp (cid=%c)\n", bmsg.cid);
       msg->cid = bmsg.cid;
     }
 
   if (!_cid_is_set(&dev->valid_cid_bits, msg->cid))
     {
-      wlinfo("+++ already closed \n");
+      wlinfo("+++ already closed\n");
       type = TYPE_DISCONNECT;
       ret = -ENOTCONN;
       goto errout;
@@ -2408,7 +2408,7 @@ errout:
   gs2200m_set_gpio(dev, LED_GPIO, 0);
 #endif
 
-  wlinfo("+++ end: cid=%c len=%d type=%d \n",
+  wlinfo("+++ end: cid=%c len=%d type=%d\n",
          msg->cid, msg->len, type);
 
   return ret;
@@ -2425,7 +2425,7 @@ static int gs2200m_ioctl_recv(FAR struct gs2200m_dev_s *dev,
   int      ret  = OK;
   uint8_t  c    = _cid_to_uint8(msg->cid);
 
-  wlinfo("+++ start: cid=%c \n", msg->cid);
+  wlinfo("+++ start: cid=%c\n", msg->cid);
 
 #ifdef USE_LED
   gs2200m_set_gpio(dev, LED_GPIO, 1);
@@ -2435,7 +2435,7 @@ static int gs2200m_ioctl_recv(FAR struct gs2200m_dev_s *dev,
     {
       /* REVISIT */
 
-      wlwarn("**** no packet for cid=%c \n", msg->cid);
+      wlwarn("**** no packet for cid=%c\n", msg->cid);
       ret = -EAGAIN;
       goto errout;
     }
@@ -2454,7 +2454,7 @@ static int gs2200m_ioctl_recv(FAR struct gs2200m_dev_s *dev,
       cont = _copy_data_from_pkt(dev, msg);
     }
 
-  wlinfo("+++ pkt_q_cnt[%c]=%d \n", msg->cid, dev->pkt_q_cnt[c]);
+  wlinfo("+++ pkt_q_cnt[%c]=%d\n", msg->cid, dev->pkt_q_cnt[c]);
 
   if (dev->pkt_q_cnt[c])
     {
@@ -2471,7 +2471,7 @@ errout:
   gs2200m_set_gpio(dev, LED_GPIO, 0);
 #endif
 
-  wlinfo("+++ end: cid=%c len=%d type=%d ret=%d \n",
+  wlinfo("+++ end: cid=%c len=%d type=%d ret=%d\n",
          msg->cid, msg->len, msg->type, ret);
 
   return ret;
@@ -2487,11 +2487,11 @@ static int gs2200m_ioctl_close(FAR struct gs2200m_dev_s *dev,
   enum pkt_type_e type = TYPE_OK;
   int ret = OK;
 
-  wlinfo("++ start: (cid=%c) \n", msg->cid);
+  wlinfo("++ start: (cid=%c)\n", msg->cid);
 
   if (!_cid_is_set(&dev->valid_cid_bits, msg->cid))
     {
-      wlinfo("+++ already closed \n");
+      wlinfo("+++ already closed\n");
       goto errout;
     }
 
@@ -2516,7 +2516,7 @@ errout:
 
   _control_pkt_q(dev);
 
-  wlinfo("++ end: cid=%c type=%d \n", msg->cid, type);
+  wlinfo("++ end: cid=%c type=%d\n", msg->cid, type);
 
   return ret;
 }
@@ -2536,7 +2536,7 @@ static int gs2200m_ioctl_accept(FAR struct gs2200m_dev_s *dev,
   char c_cid;
   int n;
 
-  wlinfo("+++ start: cid=%c \n", msg->cid);
+  wlinfo("+++ start: cid=%c\n", msg->cid);
 
   c = _cid_to_uint8(msg->cid);
   pkt_dat = (FAR struct pkt_dat_s *)dq_peek(&dev->pkt_q[c]);
@@ -2545,7 +2545,7 @@ static int gs2200m_ioctl_accept(FAR struct gs2200m_dev_s *dev,
   n = sscanf(pkt_dat->msg[0], "CONNECT %c %c", &s_cid, &c_cid);
   ASSERT(2 == n);
 
-  wlinfo("+++ s_cid=%c c_cid=%c \n", s_cid, c_cid);
+  wlinfo("+++ s_cid=%c c_cid=%c\n", s_cid, c_cid);
 
   /* Remove the accept packet (actually CONNECT) from the queue */
 
@@ -2576,7 +2576,7 @@ static int gs2200m_ioctl_accept(FAR struct gs2200m_dev_s *dev,
 
   msg->addr = nmsg.addr;
 
-  wlinfo("+++ end: type=%d (msg->cid=%c) \n", msg->type, msg->cid);
+  wlinfo("+++ end: type=%d (msg->cid=%c)\n", msg->type, msg->cid);
 
   return OK;
 }
@@ -2634,7 +2634,7 @@ static int gs2200m_ioctl_assoc_sta(FAR struct gs2200m_dev_s *dev,
 
   if (TYPE_OK != gs2200m_calc_key(dev, msg->ssid, msg->key))
     {
-      wlerr("*** error: invalid wpa2 key (key:%s) \n", msg->key);
+      wlerr("*** error: invalid wpa2 key (key:%s)\n", msg->key);
       return -1;
     }
 
@@ -2642,7 +2642,7 @@ static int gs2200m_ioctl_assoc_sta(FAR struct gs2200m_dev_s *dev,
 
   if (TYPE_OK != gs2200m_join_network(dev, msg->ssid, 0))
     {
-      wlerr("*** error: failed to join (ssid:%s) \n", msg->ssid);
+      wlerr("*** error: failed to join (ssid:%s)\n", msg->ssid);
       return -1;
     }
 
@@ -2699,7 +2699,7 @@ static int gs2200m_ioctl_assoc_ap(FAR struct gs2200m_dev_s *dev,
 
   if (TYPE_OK != gs2200m_set_wepkey(dev, msg->key))
     {
-      wlerr("*** error: invalid wepkey: %s \n", msg->key);
+      wlerr("*** error: invalid wepkey: %s\n", msg->key);
       return -1;
     }
 #else
@@ -2712,7 +2712,7 @@ static int gs2200m_ioctl_assoc_ap(FAR struct gs2200m_dev_s *dev,
 
   if (TYPE_OK != gs2200m_set_wpa2pf(dev, msg->key))
     {
-      wlerr("*** error: invalid passphrase: %s \n", msg->key);
+      wlerr("*** error: invalid passphrase: %s\n", msg->key);
       return -1;
     }
 #endif
@@ -2726,7 +2726,7 @@ static int gs2200m_ioctl_assoc_ap(FAR struct gs2200m_dev_s *dev,
 
   if (TYPE_OK != gs2200m_join_network(dev, msg->ssid, msg->ch))
     {
-      wlerr("*** error: failed to join (ssid:%s, ch:%d) \n",
+      wlerr("*** error: failed to join (ssid:%s, ch:%d)\n",
             msg->ssid, msg->ch);
       return -1;
     }
@@ -2757,7 +2757,7 @@ static int gs2200m_ioctl_iwreq(FAR struct gs2200m_dev_s *dev,
 
   if (r != TYPE_OK || pkt_dat.n <= 7)
     {
-      wlerr("+++ error: r=%d pkt_dat.msg[0]=%s \n",
+      wlerr("+++ error: r=%d pkt_dat.msg[0]=%s\n",
             r, pkt_dat.msg[0]);
 
       goto errout;
@@ -2769,7 +2769,7 @@ static int gs2200m_ioctl_iwreq(FAR struct gs2200m_dev_s *dev,
     {
       if (strstr(pkt_dat.msg[2], "BSSID=") == NULL)
         {
-          wlerr("+++ error: pkt_dat.msg[2]=%s \n", pkt_dat.msg[2]);
+          wlerr("+++ error: pkt_dat.msg[2]=%s\n", pkt_dat.msg[2]);
           goto errout;
         }
 
@@ -2788,7 +2788,7 @@ static int gs2200m_ioctl_iwreq(FAR struct gs2200m_dev_s *dev,
     {
       if (strstr(pkt_dat.msg[2], "CHANNEL=") == NULL)
         {
-          wlerr("+++ error: pkt_dat.msg[2]=%s \n", pkt_dat.msg[2]);
+          wlerr("+++ error: pkt_dat.msg[2]=%s\n", pkt_dat.msg[2]);
           goto errout;
         }
 
@@ -2801,7 +2801,7 @@ static int gs2200m_ioctl_iwreq(FAR struct gs2200m_dev_s *dev,
     {
       if (strstr(pkt_dat.msg[3], "RSSI=") == NULL)
         {
-          wlerr("+++ error: pkt_dat.msg[3]=%s \n", pkt_dat.msg[3]);
+          wlerr("+++ error: pkt_dat.msg[3]=%s\n", pkt_dat.msg[3]);
           goto errout;
         }
 
@@ -2834,7 +2834,7 @@ static int gs2200m_ioctl_ifreq(FAR struct gs2200m_dev_s *dev,
   bool getreq = false;
   int ret = OK;
 
-  wlinfo("+++ start: cmd=%" PRIx32 " \n", msg->cmd);
+  wlinfo("+++ start: cmd=%" PRIx32 "\n", msg->cmd);
 
   inaddr = (FAR struct sockaddr_in *)&msg->ifr.ifr_addr;
 
@@ -2895,7 +2895,7 @@ static int gs2200m_ioctl_ifreq(FAR struct gs2200m_dev_s *dev,
       gs2200m_set_addresses(dev, addr[0], addr[1], addr[2]);
     }
 
-  wlinfo("+++ end: \n");
+  wlinfo("+++ end:\n");
   return ret;
 }
 
@@ -3124,7 +3124,7 @@ static int gs2200m_poll(FAR struct file *filep, FAR struct pollfd *fds,
         {
           dev->pfd->revents |= POLLIN;
           nxsem_post(dev->pfd->sem);
-          wlinfo("==== _notif_q_count=%d \n", n);
+          wlinfo("==== _notif_q_count=%d\n", n);
         }
     }
   else
@@ -3173,7 +3173,7 @@ static void gs2200m_irq_worker(FAR void *arg)
 repeat:
 
   n = dev->lower->dready(&ec);
-  wlinfo("== start (dready=%d, ec=%d) \n", n, ec);
+  wlinfo("== start (dready=%d, ec=%d)\n", n, ec);
 
   /* Allocate a new pkt_dat and initialize it */
 
@@ -3215,7 +3215,7 @@ repeat:
     {
       /* An error event? */
 
-      wlerr("=== ignore (type=%d msg[0]=%s|) \n",
+      wlerr("=== ignore (type=%d msg[0]=%s|)\n",
             pkt_dat->type, pkt_dat->msg[0]);
 
       ignored = true;
@@ -3226,7 +3226,7 @@ repeat:
 
   if (!_cid_is_set(&dev->valid_cid_bits, pkt_dat->cid))
     {
-      wlinfo("=== already closed (type=%d msg[0]=%s|) \n",
+      wlinfo("=== already closed (type=%d msg[0]=%s|)\n",
              pkt_dat->type, pkt_dat->msg[0]);
 
       ignored = true;
@@ -3240,13 +3240,13 @@ repeat:
   dq_addlast((FAR dq_entry_t *)pkt_dat, &dev->pkt_q[c]);
   dev->pkt_q_cnt[c]++;
 
-  wlinfo("=== added to qkt_q[%d] t=%d \n", c, t);
+  wlinfo("=== added to qkt_q[%d] t=%d\n", c, t);
 
   /* When a DISCONNECT packet received, disable the cid */
 
   if (TYPE_DISCONNECT == t)
     {
-      wlinfo("=== received DISCONNECT for cid=%c \n", pkt_dat->cid);
+      wlinfo("=== received DISCONNECT for cid=%c\n", pkt_dat->cid);
       _enable_cid(&dev->valid_cid_bits, pkt_dat->cid, false);
     }
 
@@ -3268,7 +3268,7 @@ repeat:
       n = sscanf(pkt_dat->msg[0], "CONNECT %c %c", &s_cid, &c_cid);
       ASSERT(2 == n);
 
-      wlinfo("==== CONNECT requested (%c:%c) pfd=%p \n",
+      wlinfo("==== CONNECT requested (%c:%c) pfd=%p\n",
              s_cid, c_cid, dev->pfd);
 
       /* Check pkt_q for the new client is empty */
@@ -3299,7 +3299,7 @@ errout:
 
   n = dev->lower->dready(&ec);
 
-  wlinfo("== end: cid=%c (dready=%d, ec=%d) type=%d \n",
+  wlinfo("== end: cid=%c (dready=%d, ec=%d) type=%d\n",
          pkt_dat->cid, n, ec, t);
 
   if (1 == n && !over)
@@ -3325,11 +3325,11 @@ static int gs2200m_irq(int irq, FAR void *context, FAR void *arg)
   DEBUGASSERT(arg != NULL);
   dev = (FAR struct gs2200m_dev_s *)arg;
 
-  wlinfo(">>>> \n");
+  wlinfo(">>>>\n");
 
   if (!work_available(&dev->irq_work))
     {
-      wlwarn("*** warning: there is still pending work **** \n");
+      wlwarn("*** warning: there is still pending work ****\n");
       return 0;
     }
 
@@ -3353,7 +3353,7 @@ static int gs2200m_start(FAR struct gs2200m_dev_s *dev)
 
   /* Check boot msg */
 
-  wlinfo("*** wait for boot msg \n");
+  wlinfo("*** wait for boot msg\n");
 
   while (dev->lower->dready(NULL))
     {

--- a/drivers/wireless/ieee80211/bcm43xxx/bcmf_driver.c
+++ b/drivers/wireless/ieee80211/bcm43xxx/bcmf_driver.c
@@ -262,7 +262,7 @@ int bcmf_driver_download_clm(FAR struct bcmf_dev_s *priv)
                   O_RDONLY | O_BINARY);
   if (ret < 0)
     {
-      wlerr("ERROR: Failed to open the FILE MTD file \n", ret);
+      wlerr("ERROR: Failed to open the FILE MTD file\n", ret);
       return ret;
     }
 

--- a/drivers/wireless/ieee802154/at86rf23x/at86rf23x.c
+++ b/drivers/wireless/ieee802154/at86rf23x/at86rf23x.c
@@ -614,7 +614,7 @@ static int at86rf23x_set_trxstate(FAR struct at86rf23x_dev_s *dev,
       break;
 
     default:
-      wlerr("ERRPR: %s \n", EINVAL_STR);
+      wlerr("ERRPR: %s\n", EINVAL_STR);
       init_status = 0;  /* Placed this here to keep compiler if no debug */
       return -EINVAL;
     }

--- a/drivers/wireless/lpwan/sx127x/sx127x.c
+++ b/drivers/wireless/lpwan/sx127x/sx127x.c
@@ -905,7 +905,7 @@ static ssize_t sx127x_write(FAR struct file *filep, FAR const char *buffer,
       return ret;
     }
 
-  wlinfo("buflen=%d \n", buflen);
+  wlinfo("buflen=%d\n", buflen);
 
   /* Change mode to STANDBY */
 
@@ -4113,7 +4113,7 @@ static int sx127x_calibration(FAR struct sx127x_dev_s *dev, uint32_t freq)
   ret = sx127x_modulation_set(dev, SX127X_MODULATION_FSK);
   if (ret < 0)
     {
-      wlerr("ERROR: can't change modulation to FSK \n");
+      wlerr("ERROR: can't change modulation to FSK\n");
       goto errout;
     }
 
@@ -4220,7 +4220,7 @@ static int sx127x_init(FAR struct sx127x_dev_s *dev)
   ret = sx127x_calibration(dev, SX127X_FREQ_CALIBRATION);
   if (ret < 0)
     {
-      wlerr("ERROR: calibration failed \n");
+      wlerr("ERROR: calibration failed\n");
     }
 
   /* Set default modulation */

--- a/fs/nfs/nfs_util.c
+++ b/fs/nfs/nfs_util.c
@@ -136,7 +136,7 @@ int nfs_request(FAR struct nfsmount *nmp, int procnum,
 
       /* Reconnect */
 
-      finfo("Reconnect due to timeout \n");
+      finfo("Reconnect due to timeout\n");
 
       error = rpcclnt_connect(nmp->nm_rpcclnt);
 

--- a/fs/romfs/fs_romfs.c
+++ b/fs/romfs/fs_romfs.c
@@ -601,7 +601,7 @@ static int romfs_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
       return OK;
     }
 
-  ferr("ERROR: Invalid cmd: %d \n", cmd);
+  ferr("ERROR: Invalid cmd: %d\n", cmd);
   return -ENOTTY;
 }
 

--- a/libs/libc/machine/risc-v/common/arch_elf.c
+++ b/libs/libc/machine/risc-v/common/arch_elf.c
@@ -172,7 +172,7 @@ static void _calc_imm(long offset, long *imm_hi, long *imm_lo)
 
   lo = offset - (hi * 4096);
 
-  binfo("offset=%ld: hi=%ld lo=%ld \n",
+  binfo("offset=%ld: hi=%ld lo=%ld\n",
         offset, hi, lo);
 
   ASSERT(-2048 <= lo && lo <= 2047);
@@ -290,7 +290,7 @@ int up_relocateadd(FAR const Elf_Rela *rel, FAR const Elf_Sym *sym,
     {
       /* NOTE: RELAX has no symbol, so just return */
 
-      binfo("%s at %08" PRIxPTR " [%08" PRIx32 "] \n",
+      binfo("%s at %08" PRIxPTR " [%08" PRIx32 "]\n",
             _get_rname(relotype),
             addr, _get_val((uint16_t *)addr));
 
@@ -394,7 +394,7 @@ int up_relocateadd(FAR const Elf_Rela *rel, FAR const Elf_Sym *sym,
           ASSERT(offset && val);
 
           binfo("offset for Bx=%ld (0x%lx) (val=0x%08" PRIx32 ") "
-                "already set! \n",
+                "already set!\n",
                 offset, offset, val);
         }
         break;
@@ -493,7 +493,7 @@ int up_relocateadd(FAR const Elf_Rela *rel, FAR const Elf_Sym *sym,
 
           ASSERT(offset && val);
 
-          binfo("offset for C.J=%ld (0x%lx) (val=0x%04x) already set! \n",
+          binfo("offset for C.J=%ld (0x%lx) (val=0x%04x) already set!\n",
                 offset, offset, val);
         }
         break;

--- a/libs/libc/netdb/lib_dnsquery.c
+++ b/libs/libc/netdb/lib_dnsquery.c
@@ -471,7 +471,7 @@ static int dns_recv_response(int sd, FAR union dns_addr_u *addr, int naddr,
 
       ans = (FAR struct dns_answer_s *)nameptr;
 
-      ninfo("Answer: type=%04x, class=%04x, ttl=%06x, length=%04x \n",
+      ninfo("Answer: type=%04x, class=%04x, ttl=%06x, length=%04x\n",
             ntohs(ans->type), ntohs(ans->class),
             (ntohs(ans->ttl[0]) << 16) | ntohs(ans->ttl[1]),
             ntohs(ans->len));

--- a/net/mld/mld_send.c
+++ b/net/mld/mld_send.c
@@ -154,7 +154,7 @@ void mld_send(FAR struct net_driver_s *dev, FAR struct mld_group_s *group,
 
       default:
         {
-          mlderr("Bad msgtype: %02x \n", msgtype);
+          mlderr("Bad msgtype: %02x\n", msgtype);
           DEBUGPANIC();
         }
 

--- a/tools/nuttx-gdbinit
+++ b/tools/nuttx-gdbinit
@@ -84,14 +84,14 @@ define _examine_target
     python if (type(gdb.lookup_global_symbol("up_check_tcbstack")) is gdb.Symbol) : \
     gdb.execute("set $_target_has_stack_coloration = 1")
 
-    printf "target examined \n"
+    printf "target examined\n"
     python print("_target_arch.name=" + _target_arch.name())
 
     # NOTE: i386:x86-64 (qemu) does not work
-    #printf "$_target_arch : %s \n", $_target_arch
+    #printf "$_target_arch : %s\n", $_target_arch
 
-    printf "$_target_has_fpu : %d \n", $_target_has_fpu
-    printf "$_target_has_smp : %d \n", $_target_has_smp
+    printf "$_target_has_fpu : %d\n", $_target_has_fpu
+    printf "$_target_has_smp : %d\n", $_target_has_smp
     set $_target_examined = 1
   end
 end
@@ -155,7 +155,7 @@ define _save_current_tcb
       set $tcb = (struct tcb_s *)g_assignedtasks[$cpu]->head
       _save_tcb $tcb
     end
-    printf "saved current_tcb (pid=%d) \n", $tcb->pid
+    printf "saved current_tcb (pid=%d)\n", $tcb->pid
     set $_current_tcb = $tcb
   end
 end
@@ -455,7 +455,7 @@ define info_nxthreads
 end
 
 define nxcontinue
-  printf "nxcontinue \n"
+  printf "nxcontinue\n"
   # TODO: SMP
   set $tcb = g_readytorun->head
   _switch_tcb $tcb

--- a/tools/nxstyle.c
+++ b/tools/nxstyle.c
@@ -1913,7 +1913,7 @@ int main(int argc, char **argv, char **envp)
                        */
 
                       ncomment = 0;
-                       ERROR("Closing without opening comment", lineno, n);
+                      ERROR("Closing without opening comment", lineno, n);
                     }
 
                   n++;
@@ -1926,7 +1926,8 @@ int main(int argc, char **argv, char **envp)
                 {
                   /* Check for URI schemes, e.g. "http://" or "https://" */
 
-                  if (n == 0 || strncmp(&line[n - 1], "://", 3) != 0)
+                  if ((ncomment == 0) &&
+                      (n == 0 || strncmp(&line[n - 1], "://", 3) != 0))
                     {
                       ERROR("C++ style comment", lineno, n);
                       n++;

--- a/wireless/bluetooth/bt_att.c
+++ b/wireless/bluetooth/bt_att.c
@@ -1199,7 +1199,7 @@ static uint8_t att_read_mult_req(FAR struct bt_conn_s *conn,
     {
       handle = bt_buf_get_le16(buf);
 
-      wlinfo("handle 0x%04x \n", handle);
+      wlinfo("handle 0x%04x\n", handle);
 
       bt_gatt_foreach_attr(handle, handle, read_cb, &data);
 


### PR DESCRIPTION
## Summary
Many log messages contain spaces right before the newline. Those spaces does not give useful visual experience and can be removed to save some memory

## Impact
No functional changes

## Testing
Pass CI