### PR TITLE
arch/arm: select ARM_THUMB by default for Cortex-M 

### DIFF
--- a/arch/arm/Kconfig
+++ b/arch/arm/Kconfig
@@ -571,6 +571,7 @@ config ARCH_ARMV6M
 config ARCH_CORTEXM0
 	bool
 	default n
+	select ARM_THUMB
 	select ARCH_ARMV6M
 	select ARCH_HAVE_IRQPRIO
 	select ARCH_HAVE_RESET
@@ -584,6 +585,7 @@ config ARCH_ARMV7M
 config ARCH_CORTEXM3
 	bool
 	default n
+	select ARM_THUMB
 	select ARCH_ARMV7M
 	select ARCH_HAVE_IRQPRIO
 	select ARCH_HAVE_IRQTRIGGER
@@ -600,6 +602,7 @@ config ARCH_CORTEXM3
 config ARCH_CORTEXM4
 	bool
 	default n
+	select ARM_THUMB
 	select ARCH_ARMV7M
 	select ARCH_HAVE_IRQPRIO
 	select ARCH_HAVE_IRQTRIGGER
@@ -616,6 +619,7 @@ config ARCH_CORTEXM4
 config ARCH_CORTEXM7
 	bool
 	default n
+	select ARM_THUMB
 	select ARCH_ARMV7M
 	select ARCH_HAVE_FPU
 	select ARCH_HAVE_IRQPRIO
@@ -714,6 +718,7 @@ config ARCH_ARMV8M
 config ARCH_CORTEXM23
 	bool
 	default n
+	select ARM_THUMB
 	select ARCH_ARMV8M
 	select ARCH_HAVE_IRQPRIO
 	select ARCH_HAVE_IRQTRIGGER
@@ -727,6 +732,7 @@ config ARCH_CORTEXM23
 config ARCH_CORTEXM33
 	bool
 	default n
+	select ARM_THUMB
 	select ARCH_ARMV8M
 	select ARCH_HAVE_IRQPRIO
 	select ARCH_HAVE_IRQTRIGGER
@@ -744,6 +750,7 @@ config ARCH_CORTEXM33
 config ARCH_CORTEXM35P
 	bool
 	default n
+	select ARM_THUMB
 	select ARCH_ARMV8M
 	select ARCH_HAVE_IRQPRIO
 	select ARCH_HAVE_IRQTRIGGER
@@ -761,6 +768,7 @@ config ARCH_CORTEXM35P
 config ARCH_CORTEXM55
 	bool
 	default n
+	select ARM_THUMB
 	select ARCH_ARMV8M
 	select ARCH_HAVE_IRQPRIO
 	select ARCH_HAVE_IRQTRIGGER
@@ -854,7 +862,6 @@ endchoice # TrustZone Configuration
 config ARM_THUMB
 	bool
 	default n
-	depends on ARCH_ARMV7A
 
 config ARM_HAVE_WFE_SEV
 	bool


### PR DESCRIPTION
## Summary

arch/arm: select ARM_THUMB by default for Cortex-M 

Signed-off-by: chao.an <anchao@xiaomi.com>

## Impact

N/A

## Testing

CI-Check