### PR TITLE
make/allsyms: skip the unnecessary link operation

### DIFF
--- a/arch/arm/src/Makefile
+++ b/arch/arm/src/Makefile
@@ -168,7 +168,7 @@ ifneq ($(CONFIG_ALLSYMS),y)
 		$(LDSTARTGROUP) $(LDLIBS) $(EXTRA_LIBS) $(LDENDGROUP)
 else
 	$(Q) # Link and generate default table
-	$(Q) $(call LINK_ALLSYMS, $^)
+	$(Q) $(if $(wildcard $(shell echo $(NUTTX))),,$(call LINK_ALLSYMS,$^))
 	$(Q) # Extract all symbols
 	$(Q) $(call LINK_ALLSYMS, $^)
 	$(Q) # Extract again since the table offset may changed

--- a/arch/risc-v/src/Makefile
+++ b/arch/risc-v/src/Makefile
@@ -170,7 +170,7 @@ ifneq ($(CONFIG_ALLSYMS),y)
 		$(LDSTARTGROUP) $(LDLIBS) $(EXTRA_LIBS) $(LDENDGROUP)
 else
 	$(Q) # Link and generate default table
-	$(Q) $(call LINK_ALLSYMS, $^)
+	$(Q) $(if $(wildcard $(shell echo $(NUTTX))),,$(call LINK_ALLSYMS,$^))
 	$(Q) # Extract all symbols
 	$(Q) $(call LINK_ALLSYMS, $^)
 	$(Q) # Extract again since the table offset may changed

--- a/arch/xtensa/src/Makefile
+++ b/arch/xtensa/src/Makefile
@@ -122,7 +122,7 @@ ifneq ($(CONFIG_ALLSYMS),y)
 		$(LDSTARTGROUP) $(LDLIBS) $(EXTRA_LIBS) $(LDENDGROUP)
 else
 	$(Q) # Link and generate default table
-	$(Q) $(call LINK_ALLSYMS, $^)
+	$(Q) $(if $(wildcard $(shell echo $(NUTTX))),,$(call LINK_ALLSYMS,$^))
 	$(Q) # Extract all symbols
 	$(Q) $(call LINK_ALLSYMS, $^)
 	$(Q) # Extract again since the table offset may changed


### PR DESCRIPTION
## Summary

make/allsyms: skip the unnecessary link operation

For incremental compilation, skip the stage 1 dummy link
operation if nuttx elf has been generated

## Impact

Compile speed if CONFIG_ALLSYMS enabled

## Testing

```
$ time make -j12
real	0m31.078s
user	0m37.415s
sys	0m11.793s
```

after patch:
```
$ time make -j12
real	0m25.536s
user	0m30.583s
sys	0m9.510s
```
