### PR TITLE
Fix unaligned memory access when creating ICMP Port Unreachable messages

### DIFF
--- a/include/nuttx/net/icmp.h
+++ b/include/nuttx/net/icmp.h
@@ -141,7 +141,7 @@ struct icmp_hdr_s
           uint16_t seqno;   /* "  " "" "   " "      " "  " "     " */
         };
 
-      uint32_t data;
+      uint16_t data[2];
     };
 };
 

--- a/include/nuttx/net/icmpv6.h
+++ b/include/nuttx/net/icmpv6.h
@@ -157,7 +157,7 @@ struct icmpv6_hdr_s
    * message type indicated by the Type and Code fields.
    */
 
-  uint32_t data;
+  uint16_t data[2];
 };
 
 /* The ICMPv6 and IPv6 headers */

--- a/net/icmp/icmp_reply.c
+++ b/net/icmp/icmp_reply.c
@@ -153,7 +153,8 @@ void icmp_reply(FAR struct net_driver_s *dev, int type, int code)
 
   icmp->type        = type;
   icmp->icode       = code;
-  icmp->data        = 0;
+  icmp->data[0]     = 0;
+  icmp->data[1]     = 0;
 
   /* Calculate the ICMP checksum. */
 

--- a/net/icmpv6/icmpv6_reply.c
+++ b/net/icmpv6/icmpv6_reply.c
@@ -133,9 +133,10 @@ void icmpv6_reply(FAR struct net_driver_s *dev, int type, int code, int data)
 
   /* Initialize the ICMPv6 header */
 
-  icmpv6->type   = type;
-  icmpv6->code   = code;
-  icmpv6->data   = htonl(data);
+  icmpv6->type    = type;
+  icmpv6->code    = code;
+  icmpv6->data[0] = data >> 16;
+  icmpv6->data[1] = data & 0xffff;
 
   /* Calculate the ICMPv6 checksum over the ICMPv6 header and payload. */
 


### PR DESCRIPTION
## Summary
commit 3b69d09c80b4d21681475c43d9f165838bbf1a5c corrected the unreachable handling for net/udp/icmp but introduced an unaligned store. This splits the `uint32_t` data field into a two element `uint16_t` data field to avoid the unaligned store.

## Impact
Prevents a fatal assertion when receiving a UDP packet on a port without a active UDP socket.

Also removes the `data` argument from the `icmpv6_reply` function as it's only used in 1 place where a constant of `0` is passed, and it simplifies the logic in `icmpv6_reply` to remove the argument (otherwise the return value of `htonl(0)` would need to be split over the two data elements).

## Testing
Tested with the bl602evb risc-v board, flashed onto a magichome LED controller (with a BL602 chipset).