### PR TITLE
pwm: add option to break the loops when using multiple PWM channels

### DIFF
--- a/arch/risc-v/src/bl602/bl602_pwm_lowerhalf.c
+++ b/arch/risc-v/src/bl602/bl602_pwm_lowerhalf.c
@@ -372,6 +372,15 @@ static int bl602_pwm_start(struct pwm_lowerhalf_s *dev,
 #ifdef CONFIG_PWM_NCHANNELS
   for (i = 0; i < CONFIG_PWM_NCHANNELS; i++)
     {
+      int8_t chan = info->channels[i].channel;
+
+      /* Break the loop if all following channels are not configured */
+
+      if (chan == -1)
+        {
+          break;
+        }
+
       bl602_pwm_freq(priv, i, info->frequency);
       bl602_pwm_duty(priv, i, info->channels[i].duty);
       pwm_channel_enable(i);

--- a/arch/risc-v/src/mpfs/mpfs_corepwm.c
+++ b/arch/risc-v/src/mpfs/mpfs_corepwm.c
@@ -424,7 +424,7 @@ static int pwm_timer(struct mpfs_pwmtimer_s *priv,
   for (i = 0; i < CONFIG_PWM_NCHANNELS; i++)
     {
       ub32_t    duty;
-      uint8_t   channel;
+      int8_t   channel;
       uint32_t  neg_edge;
 
       channel   = info->channels[i].channel;
@@ -435,6 +435,13 @@ static int pwm_timer(struct mpfs_pwmtimer_s *priv,
 
       duty      = ub16toub32(info->channels[i].duty);
       neg_edge  = b32toi(duty * period + b32HALF);
+
+      /* Break the loop if all following channels are not configured */
+
+      if (channel == -1)
+        {
+          break;
+        }
 
       if (channel == 0)   /* A value of zero means to skip this channel */
         {
@@ -627,7 +634,12 @@ static int pwm_start(struct pwm_lowerhalf_s *dev,
         {
           /* Set output if channel configured */
 
-          uint8_t chan = info->channels[i].channel;
+          int8_t chan = info->channels[i].channel;
+
+          if (chan == -1)
+            {
+              break;
+            }
 
           if (chan != 0 && chan <= priv->nchannels)
             {


### PR DESCRIPTION
## Summary
commit 7354ab187ed701ae041b45a0a6603878ab9b165d (https://github.com/apache/incubator-nuttx/pull/4227) added an option to break the loops when using multiple PWM channels to arm pwm drivers. This adds the same support to the risc-v pwm drivers.

## Impact
risc-v pwm drivers now respect when channel -1 is passed and stop processing channels.

## Testing
Tested the bl602 change with magichome LED controller (which has a BL602 chipset), but the mpfs change is untested. Suggestions welcome.
