### PR TITLE
Use userspace chosen channel numbers when starting bl602 pwm

### DIFF
--- a/arch/risc-v/src/bl602/bl602_pwm_lowerhalf.c
+++ b/arch/risc-v/src/bl602/bl602_pwm_lowerhalf.c
@@ -381,9 +381,9 @@ static int bl602_pwm_start(struct pwm_lowerhalf_s *dev,
           break;
         }
 
-      bl602_pwm_freq(priv, i, info->frequency);
-      bl602_pwm_duty(priv, i, info->channels[i].duty);
-      pwm_channel_enable(i);
+      bl602_pwm_freq(priv, chan, info->frequency);
+      bl602_pwm_duty(priv, chan, info->channels[i].duty);
+      pwm_channel_enable(chan);
     }
 #else
   bl602_pwm_freq(priv, 0, info->frequency);

--- a/drivers/timers/pwm.c
+++ b/drivers/timers/pwm.c
@@ -629,7 +629,7 @@ int pwm_register(FAR const char *path, FAR struct pwm_lowerhalf_s *dev)
  *   1. The upper half driver calls the start method, providing the lower
  *      half driver with the pulse train characteristics.  If a fixed
  *      number of pulses is required, the 'count' value will be nonzero.
- *   2. The lower half driver's start() methoc must verify that it can
+ *   2. The lower half driver's start() method must verify that it can
  *      support the request pulse train (frequency, duty, AND pulse count).
  *      If it cannot, it should return an error.  If the pulse count is
  *      non-zero, it should set up the hardware for that number of pulses


### PR DESCRIPTION
## Summary
commit 2889315c207fcf7bb0ccd46f9955ba1fe323ebed added support for pwm but didn't read the channel numbers provided by user-space. They should be, otherwise it's not possible to start a sub-set of channels that are not the first "n" channels.

## Impact
bl602 pwm channels can now be chosen by userspace, where-as previously they were "hardcoded" to [0,1,2,3,4].

This includes a fix for a typo in the description of `pwm_expired`. I'm happy to split it out into a separate PR if that's preferred.

## Testing
Tested with apps/examples/pwm on a magichome LED controller (with a bl602 chipset)