### PR TITLE
libc: Add backtrace_symbols[_fd] functions

### DIFF
--- a/libs/libc/misc/Make.defs
+++ b/libs/libc/misc/Make.defs
@@ -36,7 +36,7 @@ endif
 
 CSRCS += lib_dumpbuffer.c lib_dumpvbuffer.c lib_fnmatch.c lib_debug.c
 CSRCS += lib_crc64.c lib_crc32.c lib_crc16.c lib_crc8.c lib_crc8ccitt.c
-CSRCS += lib_crc8table.c lib_glob.c
+CSRCS += lib_crc8table.c lib_glob.c lib_execinfo.c
 
 # Keyboard driver encoder/decoder
 


### PR DESCRIPTION
## Summary
specified here:
https://linux.die.net/man/3/backtrace_symbols

## Impact
New API

## Testing
Pass CI
