### PR TITLE
sched/backtrace: Dump the complete stack regardless the depth

### DIFF
--- a/arch/arm/src/common/arm_backtrace_thumb.c
+++ b/arch/arm/src/common/arm_backtrace_thumb.c
@@ -316,10 +316,10 @@ static FAR void *backtrace_push_internal(FAR void **psp,
 #ifdef CONFIG_MM_KASAN
 __attribute__((no_sanitize_address))
 #endif
-static int backtrace_push(FAR void *limit, FAR void **sp,
-                          FAR void *pc, FAR void **buffer, int size)
+static int backtrace_push(FAR void *limit, FAR void **sp, FAR void *pc,
+                          FAR void **buffer, int size, FAR int *skip)
 {
-  int i = 0;
+  int i = 1;
 
   if (!in_code_region(pc))
     {
@@ -328,7 +328,10 @@ static int backtrace_push(FAR void *limit, FAR void **sp,
 
   pc = (uintptr_t)pc & 0xfffffffe;
 
-  buffer[i++] = pc;
+  if (*skip-- <= 0)
+    {
+      *buffer++ = pc;
+    }
 
   for (; i < size; i++)
     {
@@ -337,10 +340,20 @@ static int backtrace_push(FAR void *limit, FAR void **sp,
           break;
         }
 
-      buffer[i] = backtrace_push_internal(sp, &pc);
-      if (!buffer[i])
+      pc = backtrace_push_internal(sp, &pc);
+      if (!pc)
         {
           break;
+        }
+
+      if (*skip-- <= 0)
+        {
+          *buffer++ = pc;
+        }
+
+      if (ip)
+        {
+          ip = NULL;
         }
     }
 
@@ -359,7 +372,7 @@ static int backtrace_push(FAR void *limit, FAR void **sp,
 __attribute__((no_sanitize_address))
 #endif
 static int backtrace_branch(FAR void *limit, FAR void *sp,
-                            FAR void **buffer, int size)
+                            FAR void **buffer, int size, FAR int *skip)
 {
   uint16_t ins16;
   uint32_t addr;
@@ -377,7 +390,11 @@ static int backtrace_branch(FAR void *limit, FAR void *sp,
       ins16 = *(FAR uint16_t *)addr;
       if (INSTR_IS(ins16, T_BLX))
         {
-          buffer[i++] = addr;
+          i++;
+          if (*skip-- <= 0)
+            {
+              *buffer++ = addr;
+            }
         }
 
       /* BL Instruction
@@ -393,7 +410,11 @@ static int backtrace_branch(FAR void *limit, FAR void *sp,
           ins16 = *(FAR uint16_t *)addr;
           if (INSTR_IS(ins16, T_BL))
             {
-              buffer[i++] = addr;
+              i++;
+              if (*skip-- <= 0)
+                {
+                  *buffer++ = addr;
+                }
             }
         }
     }
@@ -468,7 +489,8 @@ void up_backtrace_init_code_regions(FAR void **regions)
 #ifdef CONFIG_MM_KASAN
 __attribute__((no_sanitize_address))
 #endif
-int up_backtrace(FAR struct tcb_s *tcb, FAR void **buffer, int size)
+int up_backtrace(FAR struct tcb_s *tcb,
+                 FAR void **buffer, int size, FAR int skip)
 {
   FAR struct tcb_s *rtcb = running_task();
   irqstate_t flags;
@@ -504,7 +526,7 @@ int up_backtrace(FAR struct tcb_s *tcb, FAR void **buffer, int size)
           ret = backtrace_push(rtcb->stack_base_ptr +
                                rtcb->adj_stack_size,
                                &sp, (FAR void *)up_backtrace + 10,
-                               buffer, size);
+                               buffer, size, &skip);
 #endif
           if (ret < size)
             {
@@ -512,7 +534,7 @@ int up_backtrace(FAR struct tcb_s *tcb, FAR void **buffer, int size)
               ret += backtrace_push(rtcb->stack_base_ptr +
                                     rtcb->adj_stack_size, &sp,
                                     (FAR void *)CURRENT_REGS[REG_PC],
-                                    &buffer[ret], size - ret);
+                                    &buffer[ret], size - ret, &skip);
             }
         }
       else
@@ -520,14 +542,14 @@ int up_backtrace(FAR struct tcb_s *tcb, FAR void **buffer, int size)
           ret = backtrace_push(rtcb->stack_base_ptr +
                                rtcb->adj_stack_size, &sp,
                                (FAR void *)up_backtrace + 10,
-                               buffer, size);
+                               buffer, size, &skip);
         }
 
       if (ret < size)
         {
           ret += backtrace_branch(rtcb->stack_base_ptr +
                                   rtcb->adj_stack_size, sp,
-                                  &buffer[ret], size - ret);
+                                  &buffer[ret], size - ret, &skip);
         }
     }
   else
@@ -544,13 +566,13 @@ int up_backtrace(FAR struct tcb_s *tcb, FAR void **buffer, int size)
           ret += backtrace_push(tcb->stack_base_ptr +
                                 tcb->adj_stack_size, &sp,
                                 (FAR void *)tcb->xcp.regs[REG_LR],
-                                &buffer[ret], size - ret);
+                                &buffer[ret], size - ret, &skip);
 
           if (ret < size)
             {
               ret += backtrace_branch(tcb->stack_base_ptr +
                                       tcb->adj_stack_size, sp,
-                                      &buffer[ret], size - ret);
+                                      &buffer[ret], size - ret, &skip);
             }
         }
 

--- a/arch/xtensa/src/common/xtensa_backtrace.c
+++ b/arch/xtensa/src/common/xtensa_backtrace.c
@@ -106,8 +106,8 @@ static void get_window_regs(struct xtensa_windowregs_s *frame)
 
 #ifndef __XTENSA_CALL0_ABI__
 static int backtrace_window(uintptr_t *base, uintptr_t *limit,
-                     struct xtensa_windowregs_s *frame,
-                     void **buffer, int size)
+                            struct xtensa_windowregs_s *frame,
+                            void **buffer, int size, int *skip)
 {
   uint32_t windowstart;
   uint32_t ra;
@@ -136,7 +136,11 @@ static int backtrace_window(uintptr_t *base, uintptr_t *limit,
               continue;
             }
 
-          buffer[i++] = MAKE_PC_FROM_RA(ra);
+          i++;
+          if (*skip-- <= 0)
+            {
+              *buffer++ = MAKE_PC_FROM_RA(ra);
+            }
         }
     }
 
@@ -153,14 +157,18 @@ static int backtrace_window(uintptr_t *base, uintptr_t *limit,
  ****************************************************************************/
 
 static int backtrace_stack(uintptr_t *base, uintptr_t *limit,
-                     uintptr_t *sp, uintptr_t *ra,
-                     void **buffer, int size)
+                           uintptr_t *sp, uintptr_t *ra,
+                           void **buffer, int size, int *skip)
 {
   int i = 0;
 
   if (ra)
     {
-      buffer[i++] = MAKE_PC_FROM_RA((uintptr_t)ra);
+      i++;
+      if (*skip-- <= 0)
+        {
+          *buffer++ = MAKE_PC_FROM_RA((uintptr_t)ra);
+        }
     }
 
   for (; i < size; sp = (uintptr_t *)*(sp - 3), i++)
@@ -176,7 +184,10 @@ static int backtrace_stack(uintptr_t *base, uintptr_t *limit,
           break;
         }
 
-      buffer[i] = MAKE_PC_FROM_RA((uintptr_t)ra);
+      if (*skip-- <= 0)
+        {
+          *buffer++ = MAKE_PC_FROM_RA((uintptr_t)ra);
+        }
     }
 
   return i;
@@ -204,13 +215,14 @@ static int backtrace_stack(uintptr_t *base, uintptr_t *limit,
  *   tcb    - Address of the task's TCB
  *   buffer - Return address from the corresponding stack frame
  *   size   - Maximum number of addresses that can be stored in buffer
+ *   skip   - number of addresses to be skipped
  *
  * Returned Value:
  *   up_backtrace() returns the number of addresses returned in buffer
  *
  ****************************************************************************/
 
-int up_backtrace(struct tcb_s *tcb, void **buffer, int size)
+int up_backtrace(struct tcb_s *tcb, void **buffer, int size, int skip)
 {
   struct tcb_s *rtcb = running_task();
   irqstate_t flags;
@@ -235,20 +247,21 @@ int up_backtrace(struct tcb_s *tcb, void **buffer, int size)
           xtensa_window_spill();
 
           ret = backtrace_stack((void *)istackbase,
-                          (void *)(istackbase +
-                                   CONFIG_ARCH_INTERRUPTSTACK),
-                          (void *)up_getsp(), NULL, buffer, size);
+                                (void *)(istackbase +
+                                         CONFIG_ARCH_INTERRUPTSTACK),
+                                (void *)up_getsp(), NULL,
+                                buffer, size, &skip);
 #else
           ret = backtrace_stack(rtcb->stack_base_ptr,
-                          rtcb->stack_base_ptr + rtcb->adj_stack_size,
-                          (void *)up_getsp(), NULL, buffer, size);
+                                rtcb->stack_base_ptr + rtcb->adj_stack_size,
+                                (void *)up_getsp(), NULL,
+                                buffer, size, &skip);
 #endif
           ret += backtrace_stack(rtcb->stack_base_ptr,
-                          rtcb->stack_base_ptr +
-                          rtcb->adj_stack_size,
-                          (void *)CURRENT_REGS[REG_A1],
-                          (void *)CURRENT_REGS[REG_A0],
-                          &buffer[ret], size - ret);
+                                 rtcb->stack_base_ptr + rtcb->adj_stack_size,
+                                 (void *)CURRENT_REGS[REG_A1],
+                                 (void *)CURRENT_REGS[REG_A0],
+                                 &buffer[ret], size - ret, &skip);
         }
       else
         {
@@ -268,12 +281,13 @@ int up_backtrace(struct tcb_s *tcb, void **buffer, int size)
           get_window_regs(&frame);
 
           ret = backtrace_window(rtcb->stack_base_ptr,
-                          rtcb->stack_base_ptr + rtcb->adj_stack_size,
-                          &frame, buffer, size);
+                                 rtcb->stack_base_ptr + rtcb->adj_stack_size,
+                                 &frame, buffer, size, &skip);
 #endif
           ret += backtrace_stack(rtcb->stack_base_ptr,
-                          rtcb->stack_base_ptr + rtcb->adj_stack_size,
-                          (void *)up_getsp(), NULL, buffer, size - ret);
+                                 rtcb->stack_base_ptr + rtcb->adj_stack_size,
+                                 (void *)up_getsp(), NULL,
+                                 buffer, size - ret, &skip);
         }
     }
   else
@@ -283,10 +297,10 @@ int up_backtrace(struct tcb_s *tcb, void **buffer, int size)
       flags = enter_critical_section();
 
       ret = backtrace_stack(tcb->stack_base_ptr,
-                      tcb->stack_base_ptr + tcb->adj_stack_size,
-                      (void *)tcb->xcp.regs[REG_A1],
-                      (void *)tcb->xcp.regs[REG_A0],
-                      buffer, size);
+                            tcb->stack_base_ptr + tcb->adj_stack_size,
+                            (void *)tcb->xcp.regs[REG_A1],
+                            (void *)tcb->xcp.regs[REG_A0],
+                            buffer, size, &skip);
 
       leave_critical_section(flags);
     }

--- a/include/execinfo.h
+++ b/include/execinfo.h
@@ -38,8 +38,8 @@
  * ARRAY and return the exact number of values stored.
  */
 
-#define backtrace(buffer, size) sched_backtrace(gettid(), buffer, size)
-#define dump_stack()            sched_dumpstack(gettid())
+# define backtrace(buffer, size) sched_backtrace(gettid(), buffer, size, 0)
+# define dump_stack()            sched_dumpstack(gettid())
 
 #else
 # define backtrace(buffer, size) 0

--- a/include/nuttx/arch.h
+++ b/include/nuttx/arch.h
@@ -513,13 +513,15 @@ void up_assert(FAR const char *filename, int linenum);
  *   tcb    - Address of the task's TCB, NULL means dump the running task
  *   buffer - Return address from the corresponding stack frame
  *   size   - Maximum number of addresses that can be stored in buffer
+ *   skip   - number of addresses to be skipped
  *
  * Returned Value:
  *   up_backtrace() returns the number of addresses returned in buffer
  *
  ****************************************************************************/
 
-int up_backtrace(FAR struct tcb_s *tcb, FAR void **buffer, int size);
+int up_backtrace(FAR struct tcb_s *tcb,
+                 FAR void **buffer, int size, int skip);
 #endif /* CONFIG_ARCH_HAVE_BACKTRACE */
 
 /****************************************************************************

--- a/include/sched.h
+++ b/include/sched.h
@@ -264,7 +264,7 @@ bool   sched_idletask(void);
 
 /* Task Backtrace */
 
-int    sched_backtrace(pid_t tid, FAR void **buffer, int size);
+int    sched_backtrace(pid_t tid, FAR void **buffer, int size, int skip);
 void   sched_dumpstack(pid_t tid);
 
 #undef EXTERN

--- a/include/sys/syscall_lookup.h
+++ b/include/sys/syscall_lookup.h
@@ -45,7 +45,7 @@ SYSCALL_LOOKUP(sched_yield,                0)
 SYSCALL_LOOKUP(nxsched_get_stackinfo,      2)
 
 #ifdef CONFIG_SCHED_BACKTRACE
-  SYSCALL_LOOKUP(sched_backtrace,          3)
+  SYSCALL_LOOKUP(sched_backtrace,          4)
 #endif
 
 #ifdef CONFIG_SMP

--- a/libs/libc/sched/sched_backtrace.c
+++ b/libs/libc/sched/sched_backtrace.c
@@ -64,7 +64,7 @@ backtrace_helper(FAR struct _Unwind_Context *ctx, FAR void *a)
    * Skip it.
    */
 
-  if (arg->cnt != -1)
+  if (arg->cnt >= 0)
     {
       arg->array[arg->cnt] = (FAR void *)_Unwind_GetIP(ctx);
       if (arg->cnt > 0)
@@ -88,7 +88,7 @@ backtrace_helper(FAR struct _Unwind_Context *ctx, FAR void *a)
       arg->cfa = cfa;
     }
 
-  if (++arg->cnt == arg->size)
+  if (++arg->cnt >= arg->size)
     {
       return _URC_END_OF_STACK;
     }
@@ -108,7 +108,7 @@ backtrace_helper(FAR struct _Unwind_Context *ctx, FAR void *a)
  *
  ****************************************************************************/
 
-int sched_backtrace(pid_t tid, FAR void **buffer, int size)
+int sched_backtrace(pid_t tid, FAR void **buffer, int size, int skip)
 {
   struct trace_arg arg;
 
@@ -120,7 +120,7 @@ int sched_backtrace(pid_t tid, FAR void **buffer, int size)
   arg.array = buffer;
   arg.cfa = 0;
   arg.size = size;
-  arg.cnt = -1;
+  arg.cnt = -skip - 1;
 
   if (size <= 0)
     {
@@ -138,7 +138,7 @@ int sched_backtrace(pid_t tid, FAR void **buffer, int size)
       --arg.cnt;
     }
 
-  return arg.cnt != -1 ? arg.cnt : 0;
+  return arg.cnt > 0 ? arg.cnt : 0;
 }
 
 #endif /* !CONFIG_ARCH_HAVE_BACKTRACE */

--- a/libs/libc/sched/sched_dumpstack.c
+++ b/libs/libc/sched/sched_dumpstack.c
@@ -31,12 +31,14 @@
 #include <syslog.h>
 #include <execinfo.h>
 
-#define DUMP_FORMAT "%*p"
-#define DUMP_WIDTH  (int)(2 * sizeof(FAR void *) + 3)
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
 
 #define DUMP_DEPTH  16
 #define DUMP_NITEM  8
-#define DUMP_LINESIZE (DUMP_NITEM * DUMP_WIDTH)
+#define DUMP_WIDTH  (int)(2 * sizeof(FAR void *) + 2)
+#define DUMP_LINESZ (DUMP_NITEM * (DUMP_WIDTH + 1))
 
 /****************************************************************************
  * Public Functions
@@ -54,7 +56,8 @@ void sched_dumpstack(pid_t tid)
 {
   FAR void *address[DUMP_DEPTH];
 #ifndef CONFIG_ALLSYMS
-  char line[DUMP_LINESIZE + 1];
+  const char *format = " %0*p";
+  char line[DUMP_LINESZ + 1];
   int ret = 0;
 #endif
   int size;
@@ -70,10 +73,10 @@ void sched_dumpstack(pid_t tid)
   for (i = 0; i < size; i++)
     {
       ret += snprintf(line + ret, sizeof(line) - ret,
-                      DUMP_FORMAT, DUMP_WIDTH, address[i]);
-      if (i == size - 1 || ret % DUMP_LINESIZE == 0)
+                      format, DUMP_WIDTH, address[i]);
+      if (i == size - 1 || ret % DUMP_LINESZ == 0)
         {
-          syslog(LOG_EMERG, "backtrace|%2d: %s\n", tid, line);
+          syslog(LOG_EMERG, "backtrace|%2d:%s\n", tid, line);
           ret = 0;
         }
     }

--- a/libs/libc/sched/sched_dumpstack.c
+++ b/libs/libc/sched/sched_dumpstack.c
@@ -23,6 +23,7 @@
  ****************************************************************************/
 
 #include <nuttx/config.h>
+#include <nuttx/allsyms.h>
 
 #include <sys/types.h>
 
@@ -52,8 +53,10 @@
 void sched_dumpstack(pid_t tid)
 {
   FAR void *address[DUMP_DEPTH];
+#ifndef CONFIG_ALLSYMS
   char line[DUMP_LINESIZE + 1];
   int ret = 0;
+#endif
   int size;
   int i;
 
@@ -63,6 +66,7 @@ void sched_dumpstack(pid_t tid)
       return;
     }
 
+#ifndef CONFIG_ALLSYMS
   for (i = 0; i < size; i++)
     {
       ret += snprintf(line + ret, sizeof(line) - ret,
@@ -73,4 +77,12 @@ void sched_dumpstack(pid_t tid)
           ret = 0;
         }
     }
+#else
+  syslog(LOG_EMERG, "backtrace:\n");
+  for (i = 0; i < size; i++)
+    {
+      syslog(LOG_EMERG, "[%2d] [<%p>] %pS\n",
+                         tid, address[i], address[i]);
+    }
+#endif
 }

--- a/sched/sched/sched_backtrace.c
+++ b/sched/sched/sched_backtrace.c
@@ -40,7 +40,7 @@
  *
  ****************************************************************************/
 
-int sched_backtrace(pid_t tid, FAR void **buffer, int size)
+int sched_backtrace(pid_t tid, FAR void **buffer, int size, int skip)
 {
   FAR struct tcb_s *rtcb = NULL;
 
@@ -53,5 +53,5 @@ int sched_backtrace(pid_t tid, FAR void **buffer, int size)
         }
     }
 
-  return up_backtrace(rtcb, buffer, size);
+  return up_backtrace(rtcb, buffer, size, skip);
 }

--- a/syscall/syscall.csv
+++ b/syscall/syscall.csv
@@ -132,7 +132,7 @@
 "sched_setscheduler","sched.h","","int","pid_t","int","const struct sched_param *"
 "sched_unlock","sched.h","","int"
 "sched_yield","sched.h","","int"
-"sched_backtrace","sched.h","defined(CONFIG_SCHED_BACKTRACE)","int","pid_t","FAR void **","int"
+"sched_backtrace","sched.h","defined(CONFIG_SCHED_BACKTRACE)","int","pid_t","FAR void **","int","int"
 "seekdir","dirent.h","","void","FAR DIR *","off_t"
 "select","sys/select.h","","int","int","FAR fd_set *","FAR fd_set *","FAR fd_set *","FAR struct timeval *"
 "sem_clockwait","semaphore.h","","int","FAR sem_t *","clockid_t","FAR const struct timespec *"


### PR DESCRIPTION
## Summary

- libs/dumpstack: add support for print symbol name
- libc: Prefix the address with 0 to the specified width in sched_dumpstack
- sched/backtrace: Dump the complete stack regardless the depth

## Impact
New functionality

## Testing
Pass CI
