### PR TITLE
video/fb: Fix typo error in include/nuttx/video/fb.h

### DIFF
--- a/arch/sim/src/sim/up_framebuffer.c
+++ b/arch/sim/src/sim/up_framebuffer.c
@@ -41,7 +41,7 @@
 
 #undef FB_FMT
 #if CONFIG_SIM_FBBPP == 1
-#  define FB_FMT FB_FMT_RGB1
+#  define FB_FMT FB_FMT_Y1
 #elif CONFIG_SIM_FBBPP == 4
 #  define FB_FMT FB_FMT_RGB4
 #elif CONFIG_SIM_FBBPP == 8

--- a/arch/sim/src/sim/up_lcd.c
+++ b/arch/sim/src/sim/up_lcd.c
@@ -64,7 +64,7 @@
 
 #undef FB_FMT
 #if CONFIG_SIM_FBBPP == 1
-#  define FB_FMT FB_FMT_RGB1
+#  define FB_FMT FB_FMT_Y1
 #elif CONFIG_SIM_FBBPP == 4
 #  define FB_FMT FB_FMT_RGB4
 #elif CONFIG_SIM_FBBPP == 8

--- a/include/nuttx/video/fb.h
+++ b/include/nuttx/video/fb.h
@@ -50,20 +50,19 @@
 #define FB_FMT_GREY           FB_FMT_Y8 /* BPP=8 */
 #define FB_FMT_Y800           FB_FMT_Y8 /* BPP=8 */
 
-#define FB_ISMONO(f)          (((f) >= FB_FMT_Y4) && (f) <= FB_FMT_Y16)
+#define FB_ISMONO(f)          (((f) >= FB_FMT_Y1) && (f) <= FB_FMT_Y16)
 
 /* RGB video formats ********************************************************/
 
 /* Standard RGB */
 
-#define FB_FMT_RGB1           FB_FMT_Y1   /* BPP=1 */
 #define FB_FMT_RGB4           5           /* BPP=4 */
 #define FB_FMT_RGB8           6           /* BPP=8 RGB palette index */
 #define FB_FMT_RGB8_222       7           /* BPP=8  R=2, G=2, B=2 */
 #define FB_FMT_RGB8_332       8           /* BPP=8  R=3, G=3, B=2 */
 #define FB_FMT_RGB12_444      9           /* BPP=12 R=4, G=4, B=4 */
 #define FB_FMT_RGB16_555      10          /* BPP=16 R=5, G=5, B=5 (1 unused bit) */
-#define FB_FMT_RGB16_565      11          /* BPP=16 R=6, G=6, B=5 */
+#define FB_FMT_RGB16_565      11          /* BPP=16 R=5, G=6, B=5 */
 #define FB_FMT_RGB24          12          /* BPP=24 */
 #define FB_FMT_RGB32          13          /* BPP=32 */
 
@@ -94,7 +93,7 @@
 #define FB_FMT_RGBT16         22          /* BPP=16 */
 #define FB_FMT_RGBT32         23          /* BPP=32 */
 
-#define FB_ISRGB(f)           (((f) >= FB_FMT_RGB1) && (f) <= FB_FMT_RGBT32)
+#define FB_ISRGB(f)           (((f) >= FB_FMT_RGB4) && (f) <= FB_FMT_RGBT32)
 
 /* Packed YUV Formats *******************************************************/
 
@@ -167,7 +166,7 @@
 #define FB_FMT_CXY1           61          /* BPP=12 */
 #define FB_FMT_CXY2           62          /* BPP=16 */
 
-#define FB_ISYUVPLANAR(f)     (((f) >= FB_FMT_AYUV) && (f) <= FB_FMT_YUVP)
+#define FB_ISYUVPLANAR(f)     (((f) >= FB_FMT_YVU9) && (f) <= FB_FMT_CXY2)
 #define FB_ISYUV(f)           (FB_ISYUVPACKED(f) || FB_ISYUVPLANAR(f))
 
 /* Hardware cursor control **************************************************/


### PR DESCRIPTION
## Summary

## Impact
shouldn't since no body reference these macro in mainline

## Testing
Pass CI
