### PR TITLE
net/tcp(unbuffered): removed excessive overwrites of conn->sndseq

### DIFF
--- a/net/tcp/tcp_input.c
+++ b/net/tcp/tcp_input.c
@@ -684,8 +684,9 @@ found:
     {
       uint32_t unackseq;
       uint32_t ackseq;
+#ifdef CONFIG_NET_TCP_WRITE_BUFFERS
       uint32_t sndseq;
-
+#endif
       /* The next sequence number is equal to the current sequence
        * number (sndseq) plus the size of the outstanding, unacknowledged
        * data (tx_unacked).
@@ -737,6 +738,7 @@ found:
             }
         }
 
+#ifdef CONFIG_NET_TCP_WRITE_BUFFERS
       /* Update sequence number to the unacknowledge sequence number.  If
        * there is still outstanding, unacknowledged data, then this will
        * be beyond ackseq.
@@ -751,6 +753,7 @@ found:
                 (uint32_t)conn->tx_unacked);
           tcp_setsequence(conn->sndseq, ackseq);
         }
+#endif
 
       /* Do RTT estimation, unless we have done retransmissions. */
 

--- a/net/tcp/tcp_send_unbuffered.c
+++ b/net/tcp/tcp_send_unbuffered.c
@@ -321,8 +321,6 @@ static uint16_t tcpsend_eventhandler(FAR struct net_driver_s *dev,
 
   if ((flags & TCP_NEWDATA) == 0 && pstate->snd_sent < pstate->snd_buflen)
     {
-      uint32_t seqno;
-
       /* Get the amount of data that we can send in the next packet */
 
       uint32_t sndlen = pstate->snd_buflen - pstate->snd_sent;
@@ -336,19 +334,6 @@ static uint16_t tcpsend_eventhandler(FAR struct net_driver_s *dev,
 
       if ((pstate->snd_sent - pstate->snd_acked + sndlen) < conn->snd_wnd)
         {
-          /* Set the sequence number for this packet.  NOTE:  The network
-           * updates sndseq on receipt of ACK *before* this function is
-           * called.  In that case sndseq will point to the next
-           * unacknowledged byte (which might have already been sent).  We
-           * will overwrite the value of sndseq here before the packet is
-           * sent.
-           */
-
-          seqno = pstate->snd_sent + pstate->snd_isn;
-          ninfo("SEND: sndseq %08" PRIx32 "->%08" PRIx32 "\n",
-                tcp_getsequence(conn->sndseq), seqno);
-          tcp_setsequence(conn->sndseq, seqno);
-
 #ifdef NEED_IPDOMAIN_SUPPORT
           /* If both IPv4 and IPv6 support are enabled, then we will need to
            * select which one to use when generating the outgoing packet.


### PR DESCRIPTION
## Summary

conn->sndseq was updated in multiple places that was unreasonable and complicated.

## Impact

TCP

## Testing