### PR TITLE
net/tcp/udp: allocate tcp/udp connect dynamically 

### DIFF
--- a/net/Kconfig
+++ b/net/Kconfig
@@ -312,6 +312,16 @@ source "net/ipforward/Kconfig"
 
 endmenu # Internet Protocol Selection
 
+config NET_ALLOC_CONNS
+	bool "Allocate connect instance dynamically"
+	default n
+	---help---
+		Enable to allocate connection instances dynamically.
+		Use this feature if the number of connections can not be determined at
+		compile time. When enabled the stack will be compiled without the static
+		pre-allocate connection list and all connection instances will be dynamically
+		allocated from heap at run time.
+
 source "net/socket/Kconfig"
 source "net/inet/Kconfig"
 source "net/pkt/Kconfig"

--- a/net/tcp/tcp_conn.c
+++ b/net/tcp/tcp_conn.c
@@ -55,6 +55,7 @@
 #include <arch/irq.h>
 
 #include <nuttx/clock.h>
+#include <nuttx/kmalloc.h>
 #include <nuttx/net/netconfig.h>
 #include <nuttx/net/net.h>
 #include <nuttx/net/netdev.h>
@@ -80,7 +81,9 @@
 
 /* The array containing all TCP connections. */
 
+#ifndef CONFIG_NET_ALLOC_CONNS
 static struct tcp_conn_s g_tcp_connections[CONFIG_NET_TCP_CONNS];
+#endif
 
 /* A list of all free TCP connections */
 
@@ -110,15 +113,12 @@ static FAR struct tcp_conn_s *
   tcp_listener(uint8_t domain, FAR const union ip_addr_u *ipaddr,
                uint16_t portno)
 {
-  FAR struct tcp_conn_s *conn;
-  int i;
+  FAR struct tcp_conn_s *conn = NULL;
 
   /* Check if this port number is in use by any active UIP TCP connection */
 
-  for (i = 0; i < CONFIG_NET_TCP_CONNS; i++)
+  while ((conn = tcp_nextconn(conn)) != NULL)
     {
-      conn = &g_tcp_connections[i];
-
       /* Check if this connection is open and the local port assignment
        * matches the requested port number.
        */
@@ -524,6 +524,46 @@ static inline int tcp_ipv6_bind(FAR struct tcp_conn_s *conn,
 #endif /* CONFIG_NET_IPv6 */
 
 /****************************************************************************
+ * Name: tcp_alloc_conn
+ *
+ * Description:
+ *   Find or allocate a free TCP/IP connection structure for use.
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_NET_ALLOC_CONNS
+FAR struct tcp_conn_s *tcp_alloc_conn(void)
+{
+  FAR struct tcp_conn_s *conn;
+  int i;
+
+  /* Return the entry from the head of the free list */
+
+  if (dq_peek(&g_free_tcp_connections) == NULL)
+    {
+      conn = kmm_zalloc(sizeof(struct tcp_conn_s) *
+                        CONFIG_NET_TCP_CONNS);
+      if (conn == NULL)
+        {
+          return conn;
+        }
+
+      /* Now initialize each connection structure */
+
+      for (i = 0; i < CONFIG_NET_TCP_CONNS; i++)
+        {
+          /* Mark the connection closed and move it to the free list */
+
+          conn[i].tcpstateflags = TCP_CLOSED;
+          dq_addlast(&conn[i].node, &g_free_tcp_connections);
+        }
+    }
+
+  return (FAR struct tcp_conn_s *)dq_remfirst(&g_free_tcp_connections);
+}
+#endif
+
+/****************************************************************************
  * Public Functions
  ****************************************************************************/
 
@@ -538,7 +578,9 @@ static inline int tcp_ipv6_bind(FAR struct tcp_conn_s *conn,
 
 void tcp_initialize(void)
 {
+#ifndef CONFIG_NET_ALLOC_CONNS
   int i;
+#endif
 
   /* Initialize the queues */
 
@@ -547,6 +589,7 @@ void tcp_initialize(void)
 
   /* Now initialize each connection structure */
 
+#ifndef CONFIG_NET_ALLOC_CONNS
   for (i = 0; i < CONFIG_NET_TCP_CONNS; i++)
     {
       /* Mark the connection closed and move it to the free list */
@@ -554,6 +597,7 @@ void tcp_initialize(void)
       g_tcp_connections[i].tcpstateflags = TCP_CLOSED;
       dq_addlast(&g_tcp_connections[i].node, &g_free_tcp_connections);
     }
+#endif
 }
 
 /****************************************************************************
@@ -653,6 +697,15 @@ FAR struct tcp_conn_s *tcp_alloc(uint8_t domain)
           conn = (FAR struct tcp_conn_s *)
             dq_remfirst(&g_free_tcp_connections);
         }
+    }
+#endif
+
+  /* Allocate the connect entry from heap */
+
+#ifdef CONFIG_NET_ALLOC_CONNS
+  if (conn == NULL)
+    {
+      conn = tcp_alloc_conn();
     }
 #endif
 

--- a/net/udp/udp_conn.c
+++ b/net/udp/udp_conn.c
@@ -80,7 +80,9 @@
 
 /* The array containing all UDP connections. */
 
+#ifndef CONFIG_NET_ALLOC_CONNS
 struct udp_conn_s g_udp_connections[CONFIG_NET_UDP_CONNS];
+#endif
 
 /* A list of all free UDP connections */
 
@@ -125,15 +127,12 @@ static FAR struct udp_conn_s *udp_find_conn(uint8_t domain,
                                             FAR union ip_binding_u *ipaddr,
                                             uint16_t portno)
 {
-  FAR struct udp_conn_s *conn;
-  int i;
+  FAR struct udp_conn_s *conn = NULL;
 
   /* Now search each connection structure. */
 
-  for (i = 0; i < CONFIG_NET_UDP_CONNS; i++)
+  while ((conn = udp_nextconn(conn)) != NULL)
     {
-      conn = &g_udp_connections[i];
-
       /* If the port local port number assigned to the connections matches
        * AND the IP address of the connection matches, then return a
        * reference to the connection structure.  INADDR_ANY is a special
@@ -454,6 +453,46 @@ static inline FAR struct udp_conn_s *
 #endif /* CONFIG_NET_IPv6 */
 
 /****************************************************************************
+ * Name: udp_alloc_conn
+ *
+ * Description:
+ *   Allocate a uninitialized UDP connection structure.
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_NET_ALLOC_CONNS
+FAR struct udp_conn_s *udp_alloc_conn(void)
+{
+  FAR struct udp_conn_s *conn;
+  int i;
+
+  /* Return the entry from the head of the free list */
+
+  if (dq_peek(&g_free_udp_connections) == NULL)
+    {
+      conn = kmm_zalloc(sizeof(struct udp_conn_s) *
+                        CONFIG_NET_UDP_CONNS);
+      if (conn == NULL)
+        {
+          return conn;
+        }
+
+      /* Now initialize each connection structure */
+
+      for (i = 0; i < CONFIG_NET_UDP_CONNS; i++)
+        {
+          /* Mark the connection closed and move it to the free list */
+
+          conn[i].lport = 0;
+          dq_addlast(&conn[i].node, &g_free_udp_connections);
+        }
+    }
+
+  return (FAR struct udp_conn_s *)dq_remfirst(&g_free_udp_connections);
+}
+#endif
+
+/****************************************************************************
  * Public Functions
  ****************************************************************************/
 
@@ -538,7 +577,9 @@ uint16_t udp_select_port(uint8_t domain, FAR union ip_binding_u *u)
 
 void udp_initialize(void)
 {
+#ifndef CONFIG_NET_ALLOC_CONNS
   int i;
+#endif
 
   /* Initialize the queues */
 
@@ -546,6 +587,7 @@ void udp_initialize(void)
   dq_init(&g_active_udp_connections);
   nxsem_init(&g_free_sem, 0, 1);
 
+#ifndef CONFIG_NET_ALLOC_CONNS
   for (i = 0; i < CONFIG_NET_UDP_CONNS; i++)
     {
       /* Mark the connection closed and move it to the free list */
@@ -553,6 +595,7 @@ void udp_initialize(void)
       g_udp_connections[i].lport = 0;
       dq_addlast(&g_udp_connections[i].node, &g_free_udp_connections);
     }
+#endif
 }
 
 /****************************************************************************
@@ -571,7 +614,11 @@ FAR struct udp_conn_s *udp_alloc(uint8_t domain)
   /* The free list is protected by a semaphore (that behaves like a mutex). */
 
   _udp_semtake(&g_free_sem);
+#ifndef CONFIG_NET_ALLOC_CONNS
   conn = (FAR struct udp_conn_s *)dq_remfirst(&g_free_udp_connections);
+#else
+  conn = udp_alloc_conn();
+#endif
   if (conn)
     {
       /* Make sure that the connection is marked as uninitialized */


### PR DESCRIPTION
## Summary

net/udp: rename NET_UDP_CONNS to NET_UDP_CONNS_PER_ALLOC
net/tcp: rename NET_TCP_CONNS to NET_TCP_CONNS_PER_ALLOC
net/udp: allocate udp connect dynamically
net/tcp: allocate tcp connect dynamically

## Impact

tcp/udp connect instance allocate

## Testing

tcp/udp client/server test