### PR TITLE
arch/risc-v: Refine riscv_testset.S

### DIFF
--- a/arch/risc-v/Kconfig
+++ b/arch/risc-v/Kconfig
@@ -146,6 +146,7 @@ config ARCH_RV_ISA_M
 config ARCH_RV_ISA_A
 	bool
 	default n
+	select ARCH_HAVE_TESTSET
 
 config ARCH_RV_ISA_C
 	bool
@@ -161,11 +162,6 @@ config ARCH_RV_ISA_D
 	default n
 	depends on ARCH_RV_ISA_F
 	select ARCH_HAVE_DPFPU
-
-config ARCH_RV32I
-	bool
-	default n
-	select ARCH_HAVE_SETJMP
 
 config ARCH_FAMILY
 	string

--- a/arch/risc-v/src/bl602/Make.defs
+++ b/arch/risc-v/src/bl602/Make.defs
@@ -25,6 +25,8 @@ HEAD_ASRC = bl602_vectors.S
 # Specify our general Assembly files
 CHIP_ASRCS = bl602_head.S riscv_syscall.S bl602_entry.S
 
+CMN_ASRCS += riscv_testset.S
+
 # Specify C code within the common directory to be included
 CMN_CSRCS  += riscv_initialize.c riscv_swint.c
 CMN_CSRCS  += riscv_createstack.c riscv_exit.c

--- a/arch/risc-v/src/c906/Make.defs
+++ b/arch/risc-v/src/c906/Make.defs
@@ -25,6 +25,8 @@ HEAD_ASRC = c906_vectors.S
 # Specify our general Assembly files
 CHIP_ASRCS = c906_head.S
 
+CMN_ASRCS += riscv_testset.S
+
 # Specify C code within the common directory to be included
 CMN_CSRCS  += riscv_initialize.c riscv_swint.c
 CMN_CSRCS  += riscv_createstack.c riscv_exit.c riscv_fault.c

--- a/arch/risc-v/src/common/riscv_testset.S
+++ b/arch/risc-v/src/common/riscv_testset.S
@@ -1,5 +1,5 @@
 /****************************************************************************
- * arch/risc-v/src/rv64gc/riscv_testset.S
+ * arch/risc-v/src/common/riscv_testset.S
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -25,11 +25,19 @@
 #include <nuttx/config.h>
 #include <arch/spinlock.h>
 
-  .file "arm_testset.S"
+  .file "riscv_testset.S"
 
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
+
+#ifdef CONFIG_ARCH_RV32
+#define LR_INST lr.w
+#define SC_INST sc.w
+#else
+#define LR_INST lr.d
+#define SC_INST sc.d
+#endif
 
 /****************************************************************************
  * Public Symbols
@@ -78,29 +86,29 @@
 
 up_testset:
 
-  li     a1, SP_LOCKED
+  li       a1, SP_LOCKED
 
   /* Test if the spinlock is locked or not */
 
 retry:
-  lr.d   a2, (a0)       /* Test if spinlock is locked or not */
-  beq    a2, a1, locked /* Already locked? Go to locked: */
+  LR_INST  a2, (a0)       /* Test if spinlock is locked or not */
+  beq      a2, a1, locked /* Already locked? Go to locked: */
 
   /* Not locked ... attempt to lock it */
 
-  sc.d   a2, a1, (a0)   /* Attempt to set the locked state (a1) to (a0) */
-  bnez   a2, retry      /* a2 will not be zero, if sc.b failed, try again */
+  SC_INST  a2, a1, (a0)   /* Attempt to set the locked state (a1) to (a0) */
+  bnez     a2, retry      /* a2 will not be zero, if sc.b failed, try again */
 
   /* Lock acquired -- return SP_UNLOCKED */
 
-  fence                 /* Required before accessing protected resource */
-  li     a0, SP_UNLOCKED
-  jr     ra
+  fence                   /* Required before accessing protected resource */
+  li        a0, SP_UNLOCKED
+  jr        ra
 
   /* Lock not acquired -- return SP_LOCKED */
 
 locked:
-  li     a0, SP_LOCKED
-  jr     ra
+  li        a0, SP_LOCKED
+  jr        ra
   .size	up_testset, . - up_testset
   .end

--- a/arch/risc-v/src/fe310/Make.defs
+++ b/arch/risc-v/src/fe310/Make.defs
@@ -25,6 +25,8 @@ HEAD_ASRC = fe310_vectors.S
 # Specify our general Assembly files
 CHIP_ASRCS = fe310_head.S riscv_syscall.S
 
+CMN_ASRCS += riscv_testset.S
+
 # Specify C code within the common directory to be included
 CMN_CSRCS  += riscv_initialize.c riscv_swint.c
 CMN_CSRCS  += riscv_allocateheap.c riscv_createstack.c riscv_exit.c

--- a/arch/risc-v/src/litex/Make.defs
+++ b/arch/risc-v/src/litex/Make.defs
@@ -25,6 +25,8 @@ HEAD_ASRC = litex_vectors.S
 # Specify our general Assembly files
 CHIP_ASRCS = litex_head.S riscv_syscall.S
 
+CMN_ASRCS += riscv_testset.S
+
 # Specify C code within the common directory to be included
 CMN_CSRCS  += riscv_initialize.c riscv_swint.c
 CMN_CSRCS  += riscv_allocateheap.c riscv_createstack.c riscv_exit.c

--- a/arch/risc-v/src/mpfs/Make.defs
+++ b/arch/risc-v/src/mpfs/Make.defs
@@ -25,6 +25,8 @@ HEAD_ASRC = mpfs_vectors.S
 # Specify our general Assembly files
 CHIP_ASRCS = mpfs_head.S
 
+CMN_ASRCS += riscv_testset.S
+
 # Specify C code within the common directory to be included
 CMN_CSRCS  += riscv_initialize.c riscv_swint.c
 CMN_CSRCS  += riscv_createstack.c riscv_exit.c riscv_fault.c

--- a/arch/risc-v/src/qemu-rv32/Make.defs
+++ b/arch/risc-v/src/qemu-rv32/Make.defs
@@ -25,6 +25,8 @@ HEAD_ASRC = qemu_rv32_head.S
 # Specify our general Assembly files
 CHIP_ASRCS = qemu_rv32_vectors.S riscv_syscall.S
 
+CMN_ASRCS += riscv_testset.S
+
 # Specify C code within the common directory to be included
 CMN_CSRCS  += riscv_initialize.c riscv_swint.c
 CMN_CSRCS  += riscv_allocateheap.c riscv_createstack.c riscv_exit.c
@@ -39,15 +41,15 @@ CMN_CSRCS += riscv_checkstack.c
 endif
 
 ifeq ($(CONFIG_ARCH_HAVE_VFORK),y)
-CMN_CSRCS  += riscv_vfork.c
+CMN_CSRCS += riscv_vfork.c
 endif
 
 ifeq ($(CONFIG_SCHED_THREAD_LOCAL),y)
-CMN_CSRCS  += riscv_tls.c
+CMN_CSRCS += riscv_tls.c
 endif
 
 ifeq ($(CONFIG_ARCH_FPU),y)
-CMN_ASRCS  += riscv_fpu.S
+CMN_ASRCS += riscv_fpu.S
 endif
 
 # Specify our C code within this directory to be included


### PR DESCRIPTION
## Summary
riscv_testset.S depends on riscv A (atomic) extension, in this patch:
* Move riscv_testset.S to common
* Enable testset support by ARCH_RV_ISA_A selected
* Add riscv_testset.S to all chips that supports A extension
## Impact
Refator only.
## Testing
CI and rv32-virt:ostest
