### PR TITLE
Ensure that sethostname null terminates the hostname correctly

### DIFF
--- a/include/unistd.h
+++ b/include/unistd.h
@@ -386,8 +386,8 @@ FAR int   *getopterrp(void);  /* Print error message */
 FAR int   *getoptindp(void);  /* Index into argv */
 FAR int   *getoptoptp(void);  /* Unrecognized option character */
 
-int     gethostname(FAR char *name, size_t size);
-int     sethostname(FAR const char *name, size_t size);
+int     gethostname(FAR char *name, size_t namelen);
+int     sethostname(FAR const char *name, size_t namelen);
 
 /* Get configurable system variables */
 

--- a/libs/libc/unistd/lib_sethostname.c
+++ b/libs/libc/unistd/lib_sethostname.c
@@ -105,7 +105,7 @@ extern char g_hostname[HOST_NAME_MAX + 1];
  *
  ****************************************************************************/
 
-int sethostname(FAR const char *name, size_t size)
+int sethostname(FAR const char *name, size_t namelen)
 {
   irqstate_t flags;
 
@@ -116,8 +116,7 @@ int sethostname(FAR const char *name, size_t size)
    */
 
   flags = enter_critical_section();
-  strncpy(g_hostname, name, MIN(HOST_NAME_MAX, size));
-  g_hostname[HOST_NAME_MAX] = '\0';
+  strlcpy(g_hostname, name, sizeof(g_hostname));
   leave_critical_section(flags);
 
   return 0;


### PR DESCRIPTION
## Summary
commit e1c306f2dd3b8f4f304a77a908e965c05fb3eab2 added sethostname. The null terminator should be added after the new hostname (and only at the very end if the new hostname is the maximum length).

## Impact
Without this if the hostname is set to `hello-world` and then it's set to `short`, the resulting hostname is incorrectly `short-world`.

Also renamed the `size` argument (for `sethostname` code and for `gethostname` and `sethostname` in the header file) to `namelen` to match the `gethostname` code and the blockcomment input parameter names.

## Testing
Manually tested with medium and then short hostnames. Also tested with hostnames 31, 32, and 33 characters in length to check that they were truncated correctly.