### PR TITLE
Change fs strncpy to strlcpy to avoid losing'\0'

### DIFF
--- a/fs/binfs/fs_binfs.c
+++ b/fs/binfs/fs_binfs.c
@@ -326,7 +326,7 @@ static int binfs_readdir(struct inode *mountpt, struct fs_dirent_s *dir)
 
       finfo("Entry %d: \"%s\"\n", index, name);
       dir->fd_dir.d_type = DTYPE_FILE;
-      strncpy(dir->fd_dir.d_name, name, NAME_MAX);
+      strlcpy(dir->fd_dir.d_name, name, sizeof(dir->fd_dir.d_name));
 
       /* The application list is terminated by an entry with a NULL name.
        * Therefore, there is at least one more entry in the list.

--- a/fs/cromfs/fs_cromfs.c
+++ b/fs/cromfs/fs_cromfs.c
@@ -1289,7 +1289,7 @@ static int cromfs_readdir(struct inode *mountpt, struct fs_dirent_s *dir)
 
   name = (FAR char *)cromfs_offset2addr(fs, node->cn_name);
   finfo("Entry %" PRIu32 ": %s\n", offset, name);
-  strncpy(dir->fd_dir.d_name, name, NAME_MAX);
+  strlcpy(dir->fd_dir.d_name, name, sizeof(dir->fd_dir.d_name));
 
   switch (node->cn_mode & S_IFMT)
     {

--- a/fs/dirent/fs_readdir.c
+++ b/fs/dirent/fs_readdir.c
@@ -60,8 +60,8 @@ static inline int readpseudodir(struct fs_dirent_s *idir)
 
   /* Copy the inode name into the dirent structure */
 
-  strncpy(idir->fd_dir.d_name, idir->u.pseudo.fd_next->i_name,
-          NAME_MAX);
+  strlcpy(idir->fd_dir.d_name, idir->u.pseudo.fd_next->i_name,
+          sizeof(idir->fd_dir.d_name));
 
   /* If the node has file operations, we will say that it is a file. */
 

--- a/fs/driver/fs_blockpartition.c
+++ b/fs/driver/fs_blockpartition.c
@@ -227,7 +227,8 @@ static int part_ioctl(FAR struct inode *inode, int cmd, unsigned long arg)
               info->sectorsize  = dev->sectorsize;
               info->startsector = dev->firstsector;
 
-              strncpy(info->parent, dev->parent->i_name, NAME_MAX);
+              strlcpy(info->parent, dev->parent->i_name,
+                      sizeof(info->parent));
 
               ret = OK;
           }

--- a/fs/hostfs/hostfs.c
+++ b/fs/hostfs/hostfs.c
@@ -195,7 +195,7 @@ static void hostfs_mkpath(FAR struct hostfs_mountpt_s  *fs,
 
   /* Copy base host path to output */
 
-  strncpy(path, fs->fs_root, pathlen);
+  strlcpy(path, fs->fs_root, pathlen);
 
   /* Be sure we aren't trying to use ".." to display outside of our
    * mounted path.
@@ -1051,7 +1051,7 @@ static int hostfs_bind(FAR struct inode *blkdriver, FAR const void *data,
     {
       if ((strncmp(ptr, "fs=", 3) == 0))
         {
-          strncpy(fs->fs_root, &ptr[3], sizeof(fs->fs_root));
+          strlcpy(fs->fs_root, &ptr[3], sizeof(fs->fs_root));
         }
 
       ptr = strtok_r(NULL, ",", &saveptr);
@@ -1344,10 +1344,10 @@ int hostfs_rename(FAR struct inode *mountpt, FAR const char *oldrelpath,
 
   /* Append to the host's root directory */
 
-  strncpy(oldpath, fs->fs_root, sizeof(oldpath));
-  strncat(oldpath, oldrelpath, sizeof(oldpath)-strlen(oldpath)-1);
-  strncpy(newpath, fs->fs_root, sizeof(newpath));
-  strncat(newpath, newrelpath, sizeof(newpath)-strlen(newpath)-1);
+  strlcpy(oldpath, fs->fs_root, sizeof(oldpath));
+  strlcat(oldpath, oldrelpath, sizeof(oldpath));
+  strlcpy(newpath, fs->fs_root, sizeof(newpath));
+  strlcat(newpath, newrelpath, sizeof(newpath));
 
   /* Call the host FS to do the mkdir */
 

--- a/fs/littlefs/lfs_vfs.c
+++ b/fs/littlefs/lfs_vfs.c
@@ -782,7 +782,7 @@ static int littlefs_readdir(FAR struct inode *mountpt,
           dir->fd_dir.d_type = DTYPE_DIRECTORY;
         }
 
-      strcpy(dir->fd_dir.d_name, info.name);
+      strlcpy(dir->fd_dir.d_name, info.name, sizeof(dir->fd_dir.d_name));
     }
   else if (ret == 0)
     {

--- a/fs/nxffs/nxffs_dirent.c
+++ b/fs/nxffs/nxffs_dirent.c
@@ -133,7 +133,7 @@ int nxffs_readdir(FAR struct inode *mountpt, FAR struct fs_dirent_s *dir)
 
       finfo("Offset %jd: \"%s\"\n", (intmax_t)entry.hoffset, entry.name);
       dir->fd_dir.d_type = DTYPE_FILE;
-      strncpy(dir->fd_dir.d_name, entry.name, NAME_MAX);
+      strlcpy(dir->fd_dir.d_name, entry.name, sizeof(dir->fd_dir.d_name));
 
       /* Discard this entry and set the next offset. */
 

--- a/fs/partition/fs_ptable.c
+++ b/fs/partition/fs_ptable.c
@@ -129,7 +129,7 @@ int parse_ptable_partition(FAR struct partition_state_s *state,
 
       /* Convert the entry to partition */
 
-      strncpy(part.name, entry->name, sizeof(part.name));
+      strlcpy(part.name, entry->name, sizeof(part.name));
       part.index      = entry - ptable->entries;
       part.firstblock = entry->offset / state->blocksize;
       part.nblocks    = entry->length / state->blocksize;

--- a/fs/procfs/fs_procfs.c
+++ b/fs/procfs/fs_procfs.c
@@ -590,7 +590,8 @@ static int procfs_opendir(FAR struct inode *mountpt, FAR const char *relpath,
     }
   else
     {
-      int x, ret;
+      int x;
+      int ret;
       int len = strlen(relpath);
 
       /* Search the static array of procfs_entries */
@@ -799,8 +800,7 @@ static int procfs_readdir(struct inode *mountpt, struct fs_dirent_s *dir)
 
               level0->lastlen = strcspn(name, "/");
               level0->lastread = name;
-              strncpy(dir->fd_dir.d_name, name, level0->lastlen);
-              dir->fd_dir.d_name[level0->lastlen] = '\0';
+              strlcpy(dir->fd_dir.d_name, name, level0->lastlen);
 
               /* If the entry is a directory type OR if the reported name is
                * only a sub-string of the entry (meaning that it contains

--- a/fs/procfs/fs_procfsproc.c
+++ b/fs/procfs/fs_procfsproc.c
@@ -1779,7 +1779,7 @@ static int proc_readdir(struct fs_dirent_s *dir)
       /* Save the filename and file type */
 
       dir->fd_dir.d_type = node->dtype;
-      strncpy(dir->fd_dir.d_name, node->name, NAME_MAX);
+      strlcpy(dir->fd_dir.d_name, node->name, sizeof(dir->fd_dir.d_name));
 
       /* Set up the next directory entry offset.  NOTE that we could use the
        * standard f_pos instead of our own private index.

--- a/fs/procfs/fs_skeleton.c
+++ b/fs/procfs/fs_skeleton.c
@@ -440,7 +440,7 @@ static int skel_readdir(FAR struct fs_dirent_s *dir)
       /* TODO:  Specify the type of entry */
 
       dir->fd_dir.d_type = DTYPE_FILE;
-      strncpy(dir->fd_dir.d_name, filename, NAME_MAX);
+      strlcpy(dir->fd_dir.d_name, filename, sizeof(dir->fd_dir.d_name));
 
       /* Set up the next directory entry offset.  NOTE that we could use the
        * standard f_pos instead of our own private index.

--- a/fs/rpmsgfs/rpmsgfs.c
+++ b/fs/rpmsgfs/rpmsgfs.c
@@ -210,7 +210,7 @@ static void rpmsgfs_mkpath(FAR struct rpmsgfs_mountpt_s  *fs,
 
   /* Copy base host path to output */
 
-  strncpy(path, fs->fs_root, pathlen);
+  strlcpy(path, fs->fs_root, pathlen);
 
   /* Be sure we aren't trying to use ".." to display outside of our
    * mounted path.
@@ -1069,7 +1069,7 @@ static int rpmsgfs_bind(FAR struct inode *blkdriver, FAR const void *data,
     {
       if ((strncmp(ptr, "fs=", 3) == 0))
         {
-          strncpy(fs->fs_root, &ptr[3], sizeof(fs->fs_root));
+          strlcpy(fs->fs_root, &ptr[3], sizeof(fs->fs_root));
         }
       else if ((strncmp(ptr, "cpu=", 4) == 0))
         {
@@ -1362,10 +1362,10 @@ int rpmsgfs_rename(FAR struct inode *mountpt, FAR const char *oldrelpath,
 
   /* Append to the host's root directory */
 
-  strncpy(oldpath, fs->fs_root, sizeof(oldpath));
-  strncat(oldpath, oldrelpath, sizeof(oldpath)-strlen(oldpath)-1);
-  strncpy(newpath, fs->fs_root, sizeof(newpath));
-  strncat(newpath, newrelpath, sizeof(newpath)-strlen(newpath)-1);
+  strlcpy(oldpath, fs->fs_root, sizeof(oldpath));
+  strlcat(oldpath, oldrelpath, sizeof(oldpath));
+  strlcpy(newpath, fs->fs_root, sizeof(newpath));
+  strlcat(newpath, newrelpath, sizeof(newpath));
 
   /* Call the host FS to do the mkdir */
 

--- a/fs/rpmsgfs/rpmsgfs_client.c
+++ b/fs/rpmsgfs/rpmsgfs_client.c
@@ -168,8 +168,7 @@ static int rpmsgfs_readdir_handler(FAR struct rpmsg_endpoint *ept,
   cookie->result = header->result;
   if (cookie->result >= 0)
     {
-      strncpy(entry->d_name, rsp->name, NAME_MAX);
-      entry->d_name[NAME_MAX] = '\0';
+      strlcpy(entry->d_name, rsp->name, sizeof(entry->d_name));
       entry->d_type = rsp->type;
     }
 
@@ -587,7 +586,7 @@ int rpmsgfs_client_bind(FAR void **handle, FAR const char *cpuname)
       return -ENOMEM;
     }
 
-  strncpy(priv->cpuname, cpuname, RPMSG_NAME_SIZE);
+  strlcpy(priv->cpuname, cpuname, sizeof(priv->cpuname));
   ret = rpmsg_register_callback(priv,
                                 rpmsgfs_device_created,
                                 rpmsgfs_device_destroy,

--- a/fs/smartfs/smartfs_procfs.c
+++ b/fs/smartfs/smartfs_procfs.c
@@ -604,7 +604,8 @@ static int smartfs_closedir(FAR struct fs_dirent_s *dir)
 static int smartfs_readdir(struct fs_dirent_s *dir)
 {
   FAR struct smartfs_level1_s *level1;
-  int ret, index;
+  int ret;
+  int index;
 
   DEBUGASSERT(dir && dir->u.procfs);
   level1 = dir->u.procfs;
@@ -640,8 +641,8 @@ static int smartfs_readdir(struct fs_dirent_s *dir)
             }
 
           dir->fd_dir.d_type = DTYPE_DIRECTORY;
-          strncpy(dir->fd_dir.d_name, level1->mount->fs_blkdriver->i_name,
-                  NAME_MAX);
+          strlcpy(dir->fd_dir.d_name, level1->mount->fs_blkdriver->i_name,
+                  sizeof(dir->fd_dir.d_name));
 
           /* Advance to next entry */
 
@@ -653,16 +654,16 @@ static int smartfs_readdir(struct fs_dirent_s *dir)
           /* Listing the contents of a specific mount */
 
           dir->fd_dir.d_type = g_direntry[level1->base.index].type;
-          strncpy(dir->fd_dir.d_name, g_direntry[level1->base.index++].name,
-                  NAME_MAX);
+          strlcpy(dir->fd_dir.d_name, g_direntry[level1->base.index++].name,
+                  sizeof(dir->fd_dir.d_name));
         }
       else if (level1->base.level == 3)
         {
           /* Listing the contents of a specific entry */
 
           dir->fd_dir.d_type = g_direntry[level1->base.index].type;
-          strncpy(dir->fd_dir.d_name, g_direntry[level1->direntry].name,
-                  NAME_MAX);
+          strlcpy(dir->fd_dir.d_name, g_direntry[level1->direntry].name,
+                  sizeof(dir->fd_dir.d_name));
           level1->base.index++;
         }
 
@@ -874,7 +875,8 @@ static size_t   smartfs_mem_read(FAR struct file *filep, FAR char *buffer,
   FAR struct smartfs_file_s *priv;
   int       ret;
   uint16_t  x;
-  size_t    len, total;
+  size_t    len;
+  size_t    total;
 
   priv = (FAR struct smartfs_file_s *) filep->f_priv;
 
@@ -938,9 +940,13 @@ static size_t   smartfs_erasemap_read(FAR struct file *filep,
 {
   struct mtd_smart_procfs_data_s procfs_data;
   FAR struct smartfs_file_s *priv;
-  int       ret, rows, cols;
-  size_t    x, y;
-  size_t    len, copylen;
+  int       ret;
+  int       rows;
+  int       cols;
+  size_t    x;
+  size_t    y;
+  size_t    len;
+  size_t    copylen;
 
   priv = (FAR struct smartfs_file_s *) filep->f_priv;
 

--- a/fs/smartfs/smartfs_smart.c
+++ b/fs/smartfs/smartfs_smart.c
@@ -1272,7 +1272,6 @@ static int smartfs_readdir(struct inode *mountpt, struct fs_dirent_s *dir)
   struct smartfs_mountpt_s *fs;
   int                   ret;
   uint16_t              entrysize;
-  uint16_t              namelen;
   struct                smartfs_chain_header_s *header;
   struct                smart_read_write_s readwrite;
   struct                smartfs_entry_header_s *entry;
@@ -1350,14 +1349,8 @@ static int smartfs_readdir(struct inode *mountpt, struct fs_dirent_s *dir)
 
           /* Copy the entry name to dirent */
 
-          namelen = fs->fs_llformat.namesize;
-          if (namelen > NAME_MAX)
-            {
-              namelen = NAME_MAX;
-            }
-
-          memset(dir->fd_dir.d_name, 0, namelen);
-          strncpy(dir->fd_dir.d_name, entry->name, namelen);
+          strlcpy(dir->fd_dir.d_name, entry->name,
+                  sizeof(dir->fd_dir.d_name));
 
           /* Now advance to the next entry */
 

--- a/fs/spiffs/src/spiffs_vfs.c
+++ b/fs/spiffs/src/spiffs_vfs.c
@@ -342,9 +342,9 @@ static int spiffs_readdir_callback(FAR struct spiffs_s *fs,
         }
 #endif
 
-      strncpy(entryp->d_name,
+      strlcpy(entryp->d_name,
               (FAR char *)objhdr.name + SPIFFS_LEADING_SLASH_SIZE,
-              NAME_MAX);
+              sizeof(entryp->d_name));
       entryp->d_type = objhdr.type;
       return OK;
     }

--- a/fs/tmpfs/fs_tmpfs.c
+++ b/fs/tmpfs/fs_tmpfs.c
@@ -2035,7 +2035,7 @@ static int tmpfs_readdir(FAR struct inode *mountpt,
 
       /* Copy the entry name */
 
-      strncpy(dir->fd_dir.d_name, tde->tde_name, NAME_MAX);
+      strlcpy(dir->fd_dir.d_name, tde->tde_name, sizeof(dir->fd_dir.d_name));
 
       /* Save the index for next time */
 

--- a/fs/unionfs/fs_unionfs.c
+++ b/fs/unionfs/fs_unionfs.c
@@ -1710,7 +1710,7 @@ static int unionfs_readdir(struct inode *mountpt, struct fs_dirent_s *dir)
        * directories.
        */
 
-      strncpy(dir->fd_dir.d_name, um->um_prefix, NAME_MAX);
+      strlcpy(dir->fd_dir.d_name, um->um_prefix, sizeof(dir->fd_dir.d_name));
 
       /* Describe this as a read only directory */
 
@@ -1784,7 +1784,8 @@ static int unionfs_readdir(struct inode *mountpt, struct fs_dirent_s *dir)
                    * be multiple directories.
                    */
 
-                  strncpy(dir->fd_dir.d_name, um->um_prefix, NAME_MAX);
+                  strlcpy(dir->fd_dir.d_name, um->um_prefix,
+                          sizeof(dir->fd_dir.d_name));
 
                   /* Describe this as a read only directory */
 

--- a/fs/vfs/fs_readlink.c
+++ b/fs/vfs/fs_readlink.c
@@ -106,8 +106,7 @@ ssize_t readlink(FAR const char *path, FAR char *buf, size_t bufsize)
 
   /* Copy the link target pathto the user-provided buffer. */
 
-  *buf = '\0';
-  strncpy(buf, node->u.i_link, bufsize);
+  strlcpy(buf, node->u.i_link, bufsize);
 
   /* Release our reference on the inode and return the length */
 

--- a/tools/nxstyle.c
+++ b/tools/nxstyle.c
@@ -251,6 +251,8 @@ static const char *g_white_list[] =
   /* Ref:
    * fs/nfs/rpc.h
    * fs/nfs/nfs_proto.h
+   * fs/nfs/nfs_mount.h
+   * fs/nfs/nfs_vfsops.c
    */
 
   "CREATE3args",
@@ -275,6 +277,10 @@ static const char *g_white_list[] =
   "SETATTR3args",
   "SETATTR3resok",
   "FS3args",
+  "SIZEOF_rpc_reply_read",
+  "SIZEOF_rpc_call_write",
+  "SIZEOF_rpc_reply_readdir",
+  "SIZEOF_nfsmount",
 
   /* Ref:
    * mm/kasan/kasan.c


### PR DESCRIPTION
## Summary
strncpy does not end with'\0', stack overflow may occur during use. Report here: https://github.com/apache/incubator-nuttx/pull/5107

## Impact
After strncpy is modified to strlcpy,'\0' will be automatically added at the end to avoid usage problems.

## Testing
This modification does not affect the function.
