### PR TITLE
net/devif: allocate devif callback dynamically

### DIFF
--- a/net/udp/udp_conn.c
+++ b/net/udp/udp_conn.c
@@ -55,6 +55,7 @@
 #include <arch/irq.h>
 
 #include <nuttx/clock.h>
+#include <nuttx/kmalloc.h>
 #include <nuttx/semaphore.h>
 #include <nuttx/net/netconfig.h>
 #include <nuttx/net/net.h>


### PR DESCRIPTION
## Summary

net/devif_callback: add support for CONFIG_NET_ALLOC_CONNS

## Impact

netdev interface callback allocate

## Testing

iperf client/server test