### PR TITLE
Add backtrace to risc-v common sources

### DIFF
--- a/arch/risc-v/src/bl602/Make.defs
+++ b/arch/risc-v/src/bl602/Make.defs
@@ -34,6 +34,10 @@ CMN_CSRCS  += riscv_releasepending.c riscv_reprioritizertr.c riscv_copyfullstate
 CMN_CSRCS  += riscv_releasestack.c riscv_stackframe.c riscv_schedulesigaction.c
 CMN_CSRCS  += riscv_sigdeliver.c riscv_udelay.c riscv_unblocktask.c riscv_usestack.c
 
+ifeq ($(CONFIG_SCHED_BACKTRACE),y)
+CMN_CSRCS += riscv_backtrace.c
+endif
+
 ifeq ($(CONFIG_STACK_COLORATION),y)
 CMN_CSRCS += riscv_checkstack.c
 endif

--- a/arch/risc-v/src/c906/Make.defs
+++ b/arch/risc-v/src/c906/Make.defs
@@ -35,6 +35,10 @@ CMN_CSRCS  += riscv_releasestack.c riscv_stackframe.c riscv_schedulesigaction.c
 CMN_CSRCS  += riscv_sigdeliver.c riscv_unblocktask.c riscv_usestack.c
 CMN_CSRCS  += riscv_mdelay.c riscv_copyfullstate.c
 
+ifeq ($(CONFIG_SCHED_BACKTRACE),y)
+CMN_CSRCS += riscv_backtrace.c
+endif
+
 ifeq ($(CONFIG_STACK_COLORATION),y)
 CMN_CSRCS += riscv_checkstack.c
 endif

--- a/arch/risc-v/src/esp32c3/Make.defs
+++ b/arch/risc-v/src/esp32c3/Make.defs
@@ -37,6 +37,10 @@ CMN_CSRCS  += riscv_releasepending.c riscv_reprioritizertr.c riscv_copyfullstate
 CMN_CSRCS  += riscv_releasestack.c riscv_stackframe.c riscv_schedulesigaction.c
 CMN_CSRCS  += riscv_sigdeliver.c riscv_udelay.c riscv_unblocktask.c riscv_usestack.c
 
+ifeq ($(CONFIG_SCHED_BACKTRACE),y)
+CMN_CSRCS += riscv_backtrace.c
+endif
+
 ifeq ($(CONFIG_STACK_COLORATION),y)
 CMN_CSRCS += riscv_checkstack.c
 endif

--- a/arch/risc-v/src/fe310/Make.defs
+++ b/arch/risc-v/src/fe310/Make.defs
@@ -34,6 +34,10 @@ CMN_CSRCS  += riscv_releasepending.c riscv_reprioritizertr.c riscv_copyfullstate
 CMN_CSRCS  += riscv_releasestack.c riscv_stackframe.c riscv_schedulesigaction.c
 CMN_CSRCS  += riscv_sigdeliver.c riscv_udelay.c riscv_unblocktask.c riscv_usestack.c
 
+ifeq ($(CONFIG_SCHED_BACKTRACE),y)
+CMN_CSRCS += riscv_backtrace.c
+endif
+
 ifeq ($(CONFIG_STACK_COLORATION),y)
 CMN_CSRCS += riscv_checkstack.c
 endif

--- a/arch/risc-v/src/k210/Make.defs
+++ b/arch/risc-v/src/k210/Make.defs
@@ -37,6 +37,10 @@ CMN_CSRCS  += riscv_releasestack.c riscv_stackframe.c riscv_schedulesigaction.c
 CMN_CSRCS  += riscv_sigdeliver.c riscv_unblocktask.c riscv_usestack.c
 CMN_CSRCS  += riscv_mdelay.c riscv_copyfullstate.c
 
+ifeq ($(CONFIG_SCHED_BACKTRACE),y)
+CMN_CSRCS += riscv_backtrace.c
+endif
+
 ifeq ($(CONFIG_STACK_COLORATION),y)
 CMN_CSRCS += riscv_checkstack.c
 endif

--- a/arch/risc-v/src/litex/Make.defs
+++ b/arch/risc-v/src/litex/Make.defs
@@ -34,6 +34,10 @@ CMN_CSRCS  += riscv_releasepending.c riscv_reprioritizertr.c riscv_copyfullstate
 CMN_CSRCS  += riscv_releasestack.c riscv_stackframe.c riscv_schedulesigaction.c
 CMN_CSRCS  += riscv_sigdeliver.c riscv_udelay.c riscv_unblocktask.c riscv_usestack.c
 
+ifeq ($(CONFIG_SCHED_BACKTRACE),y)
+CMN_CSRCS += riscv_backtrace.c
+endif
+
 ifeq ($(CONFIG_STACK_COLORATION),y)
 CMN_CSRCS += riscv_checkstack.c
 endif

--- a/arch/risc-v/src/mpfs/Make.defs
+++ b/arch/risc-v/src/mpfs/Make.defs
@@ -35,6 +35,10 @@ CMN_CSRCS  += riscv_releasestack.c riscv_stackframe.c riscv_schedulesigaction.c
 CMN_CSRCS  += riscv_sigdeliver.c riscv_unblocktask.c riscv_usestack.c
 CMN_CSRCS  += riscv_mdelay.c riscv_udelay.c riscv_copyfullstate.c
 
+ifeq ($(CONFIG_SCHED_BACKTRACE),y)
+CMN_CSRCS += riscv_backtrace.c
+endif
+
 ifeq ($(CONFIG_STACK_COLORATION),y)
 CMN_CSRCS += riscv_checkstack.c
 endif

--- a/arch/risc-v/src/qemu-rv32/Make.defs
+++ b/arch/risc-v/src/qemu-rv32/Make.defs
@@ -34,6 +34,10 @@ CMN_CSRCS  += riscv_releasepending.c riscv_reprioritizertr.c riscv_copyfullstate
 CMN_CSRCS  += riscv_releasestack.c riscv_stackframe.c riscv_schedulesigaction.c
 CMN_CSRCS  += riscv_sigdeliver.c riscv_unblocktask.c riscv_usestack.c
 
+ifeq ($(CONFIG_SCHED_BACKTRACE),y)
+CMN_CSRCS += riscv_backtrace.c
+endif
+
 ifeq ($(CONFIG_STACK_COLORATION),y)
 CMN_CSRCS += riscv_checkstack.c
 endif

--- a/arch/risc-v/src/rv32m1/Make.defs
+++ b/arch/risc-v/src/rv32m1/Make.defs
@@ -34,6 +34,10 @@ CMN_CSRCS  += riscv_releasepending.c riscv_reprioritizertr.c riscv_copyfullstate
 CMN_CSRCS  += riscv_releasestack.c riscv_stackframe.c riscv_schedulesigaction.c
 CMN_CSRCS  += riscv_sigdeliver.c riscv_unblocktask.c riscv_usestack.c
 
+ifeq ($(CONFIG_SCHED_BACKTRACE),y)
+CMN_CSRCS += riscv_backtrace.c
+endif
+
 ifeq ($(CONFIG_STACK_COLORATION),y)
 CMN_CSRCS += riscv_checkstack.c
 endif


### PR DESCRIPTION
## Summary
Improvements from https://github.com/apache/incubator-nuttx/pull/5057 require the code to be linked in (https://github.com/apache/incubator-nuttx/pull/5099#issuecomment-1002609532).

## Impact
risc-v can enable `SCHED_BACKTRACE` and build successfully.

## Testing
Minimal. I've only tested this on a bl602 chipset. I just copy and paste the 3 lines to everywhere else that had `SCHED_COLORATION` (all `risc-v` except `opensbi`).