### PR TITLE
boards/arm/samv7: improve progmem common interface

### DIFF
--- a/boards/arm/sama5/sama5d4-ek/src/sam_at25.c
+++ b/boards/arm/sama5/sama5d4-ek/src/sam_at25.c
@@ -117,8 +117,8 @@ int sam_at25_automount(int minor)
 #if defined(CONFIG_BCH)
       /* Use the minor number to create device paths */
 
-      snprintf(blockdev, 18, "/dev/mtdblock%d", minor);
-      snprintf(chardev, 12, "/dev/mtd%d", minor);
+      snprintf(blockdev, sizeof(blockdev), "/dev/mtdblock%d", minor);
+      snprintf(chardev, sizeof(chardev), "/dev/mtd%d", minor);
 
       /* Now create a character device on the block device */
 

--- a/boards/arm/samv7/common/include/board_progmem.h
+++ b/boards/arm/samv7/common/include/board_progmem.h
@@ -1,5 +1,5 @@
 /****************************************************************************
- * boards/arm/samv7/common/include/sam_progmem_common.h
+ * boards/arm/samv7/common/include/board_progmem.h
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -18,8 +18,8 @@
  *
  ****************************************************************************/
 
-#ifndef __BOARDS_ARM_SAMV7_COMMON_INCLUDE_SAM_PROGMEM_COMMON_H
-#define __BOARDS_ARM_SAMV7_COMMON_INCLUDE_SAM_PROGMEM_COMMON_H
+#ifndef __BOARDS_ARM_SAMV7_COMMON_INCLUDE_BOARD_PROGMEM_H
+#define __BOARDS_ARM_SAMV7_COMMON_INCLUDE_BOARD_PROGMEM_H
 
 /****************************************************************************
  * Public Types
@@ -45,13 +45,21 @@ extern "C"
  ****************************************************************************/
 
 /****************************************************************************
- * Name: sam_progmem_init
+ * Name: board_progmem_init
  *
  * Description:
  *   Initialize the FLASH and register MTD devices.
+ *
+ * Input Parameters:
+ *   minor - The starting minor number for progmem MTD partitions.
+ *
+ * Returned Value:
+ *   Zero is returned on success.  Otherwise, a negated errno value is
+ *   returned to indicate the nature of the failure.
+ *
  ****************************************************************************/
 
-int sam_progmem_common_initialize(void);
+int board_progmem_init(int minor);
 
 #undef EXTERN
 #if defined(__cplusplus)
@@ -59,4 +67,4 @@ int sam_progmem_common_initialize(void);
 #endif
 
 #endif /* __ASSEMBLY__ */
-#endif /* __BOARDS_ARM_SAMV7_COMMON_INCLUDE_SAM_PROGMEM_COMMON_H */
+#endif /* __BOARDS_ARM_SAMV7_COMMON_INCLUDE_BOARD_PROGMEM_H */

--- a/boards/arm/samv7/common/src/Make.defs
+++ b/boards/arm/samv7/common/src/Make.defs
@@ -23,9 +23,9 @@ CSRCS += sam_boot_image.c
 endif
 
 ifeq ($(CONFIG_BOARDCTL),y)
-CSRCS += sam_progmem_common.c
+CSRCS += sam_progmem.c
 else ifeq ($(CONFIG_BOARD_LATE_INITIALIZE),y)
-CSRCS += sam_progmem_common.c
+CSRCS += sam_progmem.c
 endif
 
 DEPPATH += --dep-path src

--- a/boards/arm/samv7/same70-qmtech/src/sam_bringup.c
+++ b/boards/arm/samv7/same70-qmtech/src/sam_bringup.c
@@ -36,11 +36,12 @@
 #include <nuttx/drivers/ramdisk.h>
 #include <nuttx/fs/fs.h>
 #include <nuttx/fs/nxffs.h>
-#include <nuttx/i2c/i2c_master.h>
 
-#include "sam_twihs.h"
-#include "sam_progmem_common.h"
 #include "same70-qmtech.h"
+
+#ifdef HAVE_PROGMEM_CHARDEV
+#  include "board_progmem.h"
+#endif
 
 #ifdef HAVE_ROMFS
 #  include <arch/board/boot_romfsimg.h>
@@ -152,7 +153,7 @@ int sam_bringup(void)
 #ifdef HAVE_PROGMEM_CHARDEV
   /* Initialize the SAME70 FLASH programming memory library */
 
-  ret = sam_progmem_common_initialize();
+  ret = board_progmem_init(PROGMEM_MTD_MINOR);
   if (ret < 0)
     {
       syslog(LOG_ERR, "ERROR: Failed to initialize progmem: %d\n", ret);

--- a/boards/arm/samv7/same70-qmtech/src/same70-qmtech.h
+++ b/boards/arm/samv7/same70-qmtech/src/same70-qmtech.h
@@ -269,17 +269,6 @@ int sam_hsmci_initialize(int slot, int minor);
 #endif
 
 /****************************************************************************
- * Name: sam_progmem_init
- *
- * Description:
- *   Initialize the FLASH and register the MTD device.
- ****************************************************************************/
-
-#ifdef HAVE_PROGMEM_CHARDEV
-int sam_progmem_init(void);
-#endif
-
-/****************************************************************************
  * Name: sam_can_setup
  *
  * Description:

--- a/boards/arm/samv7/same70-xplained/src/sam_bringup.c
+++ b/boards/arm/samv7/same70-xplained/src/sam_bringup.c
@@ -43,8 +43,11 @@
 #include <nuttx/i2c/i2c_master.h>
 
 #include "sam_twihs.h"
-#include "sam_progmem_common.h"
 #include "same70-xplained.h"
+
+#ifdef HAVE_PROGMEM_CHARDEV
+#  include "board_progmem.h"
+#endif
 
 #ifdef HAVE_ROMFS
 #  include <arch/board/boot_romfsimg.h>
@@ -241,7 +244,7 @@ int sam_bringup(void)
 #ifdef HAVE_PROGMEM_CHARDEV
   /* Initialize the SAME70 FLASH programming memory library */
 
-  ret = sam_progmem_common_initialize();
+  ret = board_progmem_init(PROGMEM_MTD_MINOR);
   if (ret < 0)
     {
       syslog(LOG_ERR, "ERROR: Failed to initialize progmem: %d\n", ret);

--- a/boards/arm/samv7/same70-xplained/src/same70-xplained.h
+++ b/boards/arm/samv7/same70-xplained/src/same70-xplained.h
@@ -501,17 +501,6 @@ int sam_hsmci_initialize(int slot, int minor);
 #endif
 
 /****************************************************************************
- * Name: sam_progmem_init
- *
- * Description:
- *   Initialize the FLASH and register the MTD device.
- ****************************************************************************/
-
-#ifdef HAVE_PROGMEM_CHARDEV
-int sam_progmem_init(void);
-#endif
-
-/****************************************************************************
  * Name:  sam_usbinitialize
  *
  * Description:

--- a/boards/arm/samv7/samv71-xult/src/sam_bringup.c
+++ b/boards/arm/samv7/samv71-xult/src/sam_bringup.c
@@ -61,8 +61,7 @@
 #endif
 
 #ifdef HAVE_PROGMEM_CHARDEV
-#  include "sam_progmem.h"
-#  include "sam_progmem_common.h"
+#  include "board_progmem.h"
 #endif
 
 #if defined(HAVE_RTC_DSXXXX) || defined(HAVE_RTC_PCF85263)
@@ -421,8 +420,9 @@ int sam_bringup(void)
 #if defined(CONFIG_BCH)
       /* Use the minor number to create device paths */
 
-      snprintf(blockdev, 18, "/dev/mtdblock%d", S25FL1_MTD_MINOR);
-      snprintf(chardev, 12, "/dev/mtd%d", S25FL1_MTD_MINOR);
+      snprintf(blockdev, sizeof(blockdev), "/dev/mtdblock%d",
+               S25FL1_MTD_MINOR);
+      snprintf(chardev, sizeof(chardev), "/dev/mtd%d", S25FL1_MTD_MINOR);
 
       /* Now create a character device on the block device */
 
@@ -441,7 +441,7 @@ int sam_bringup(void)
 #ifdef HAVE_PROGMEM_CHARDEV
   /* Initialize the SAMV71 FLASH programming memory library */
 
-  ret = sam_progmem_common_initialize();
+  ret = board_progmem_init(PROGMEM_MTD_MINOR);
   if (ret < 0)
     {
       syslog(LOG_ERR, "ERROR: Failed to initialize progmem: %d\n", ret);

--- a/boards/arm/stm32l4/stm32l476vg-disco/src/stm32_appinit.c
+++ b/boards/arm/stm32l4/stm32l476vg-disco/src/stm32_appinit.c
@@ -253,8 +253,9 @@ int board_app_initialize(uintptr_t arg)
 #if defined(CONFIG_BCH)
       /* Use the minor number to create device paths */
 
-      snprintf(blockdev, 18, "/dev/mtdblock%d", N25QXXX_MTD_MINOR);
-      snprintf(chardev, 12, "/dev/mtd%d", N25QXXX_MTD_MINOR);
+      snprintf(blockdev, sizeof(blockdev), "/dev/mtdblock%d",
+               N25QXXX_MTD_MINOR);
+      snprintf(chardev, sizeof(chardev), "/dev/mtd%d", N25QXXX_MTD_MINOR);
 
       /* Now create a character device on the block device */
 

--- a/boards/risc-v/esp32c3/esp32c3-devkit/src/esp32c3_spiflash.c
+++ b/boards/risc-v/esp32c3/esp32c3-devkit/src/esp32c3_spiflash.c
@@ -140,7 +140,7 @@ static int init_ota_partitions(void)
         }
 
 #ifdef CONFIG_BCH
-      snprintf(blockdev, 18, "/dev/mtdblock%d", i);
+      snprintf(blockdev, sizeof(blockdev), "/dev/mtdblock%d", i);
 
       ret = bchdev_register(blockdev, part->devpath, false);
       if (ret < 0)

--- a/boards/xtensa/esp32/common/src/esp32_board_spiflash.c
+++ b/boards/xtensa/esp32/common/src/esp32_board_spiflash.c
@@ -123,7 +123,7 @@ static int init_ota_partitions(void)
         }
 
 #ifdef CONFIG_BCH
-      snprintf(blockdev, 18, "/dev/mtdblock%d", i);
+      snprintf(blockdev, sizeof(blockdev), "/dev/mtdblock%d", i);
 
       ret = bchdev_register(blockdev, part->devpath, false);
       if (ret < 0)


### PR DESCRIPTION
## Summary
During reorganizing of SAMV7 code to common the samv71-xult MTD compatibility was broken. The S25FL1 and PROGMEM now utilize the same minor number for MTD driver. Also not all headers were cleaned-up. Also there is some code duplication that can be eliminated.

Fix above and reorganize code a bit.

## Impact
SAMV7 based devices

## Testing
Pass CI