### PR TITLE
signal: signal handler may cause task's state error

### DIFF
--- a/arch/arm/src/arm/arm_sigdeliver.c
+++ b/arch/arm/src/arm/arm_sigdeliver.c
@@ -57,13 +57,6 @@ void arm_sigdeliver(void)
   struct tcb_s  *rtcb = this_task();
   uint32_t regs[XCPTCONTEXT_REGS];
 
-  /* Save the errno.  This must be preserved throughout the signal handling
-   * so that the user code final gets the correct errno value (probably
-   * EINTR).
-   */
-
-  int saved_errno = get_errno();
-
   board_autoled_on(LED_SIGNAL);
 
   sinfo("rtcb=%p sigdeliver=%p sigpendactionq.head=%p\n",
@@ -93,7 +86,6 @@ void arm_sigdeliver(void)
 
   sinfo("Resuming\n");
   up_irq_save();
-  set_errno(saved_errno);
 
   /* Modify the saved return state with the actual saved values in the
    * TCB.  This depends on the fact that nested signal handling is

--- a/arch/arm/src/armv6-m/arm_sigdeliver.c
+++ b/arch/arm/src/armv6-m/arm_sigdeliver.c
@@ -62,13 +62,6 @@ void arm_sigdeliver(void)
   struct tcb_s  *rtcb = this_task();
   uint32_t regs[XCPTCONTEXT_REGS + 4];
 
-  /* Save the errno.  This must be preserved throughout the signal handling
-   * so that the user code final gets the correct errno value (probably
-   * EINTR).
-   */
-
-  int saved_errno = get_errno();
-
 #ifdef CONFIG_SMP
   /* In the SMP case, we must terminate the critical section while the signal
    * handler executes, but we also need to restore the irqcount when the
@@ -145,10 +138,6 @@ void arm_sigdeliver(void)
 #ifndef CONFIG_SUPPRESS_INTERRUPTS
   up_irq_save();
 #endif
-
-  /* Restore the saved errno value */
-
-  set_errno(saved_errno);
 
   /* Modify the saved return state with the actual saved values in the
    * TCB.  This depends on the fact that nested signal handling is

--- a/arch/arm/src/armv7-a/arm_sigdeliver.c
+++ b/arch/arm/src/armv7-a/arm_sigdeliver.c
@@ -57,13 +57,6 @@ void arm_sigdeliver(void)
   struct tcb_s  *rtcb = this_task();
   uint32_t regs[XCPTCONTEXT_REGS];
 
-  /* Save the errno.  This must be preserved throughout the signal handling
-   * so that the user code final gets the correct errno value (probably
-   * EINTR).
-   */
-
-  int saved_errno = get_errno();
-
 #ifdef CONFIG_SMP
   /* In the SMP case, we must terminate the critical section while the signal
    * handler executes, but we also need to restore the irqcount when the
@@ -140,10 +133,6 @@ void arm_sigdeliver(void)
 #ifndef CONFIG_SUPPRESS_INTERRUPTS
   up_irq_save();
 #endif
-
-  /* Restore the saved errno value */
-
-  set_errno(saved_errno);
 
   /* Modify the saved return state with the actual saved values in the
    * TCB.  This depends on the fact that nested signal handling is

--- a/arch/arm/src/armv7-m/arm_sigdeliver.c
+++ b/arch/arm/src/armv7-m/arm_sigdeliver.c
@@ -57,13 +57,6 @@ void arm_sigdeliver(void)
   struct tcb_s  *rtcb = this_task();
   uint32_t regs[XCPTCONTEXT_REGS];
 
-  /* Save the errno.  This must be preserved throughout the signal handling
-   * so that the user code final gets the correct errno value (probably
-   * EINTR).
-   */
-
-  int saved_errno = get_errno();
-
 #ifdef CONFIG_SMP
   /* In the SMP case, we must terminate the critical section while the signal
    * handler executes, but we also need to restore the irqcount when the
@@ -144,10 +137,6 @@ void arm_sigdeliver(void)
 #ifndef CONFIG_SUPPRESS_INTERRUPTS
   up_irq_save();
 #endif
-
-  /* Restore the saved errno value */
-
-  set_errno(saved_errno);
 
   /* Modify the saved return state with the actual saved values in the
    * TCB.  This depends on the fact that nested signal handling is

--- a/arch/arm/src/armv7-r/arm_sigdeliver.c
+++ b/arch/arm/src/armv7-r/arm_sigdeliver.c
@@ -57,13 +57,6 @@ void arm_sigdeliver(void)
   struct tcb_s  *rtcb = this_task();
   uint32_t regs[XCPTCONTEXT_REGS];
 
-  /* Save the errno.  This must be preserved throughout the signal handling
-   * so that the user code final gets the correct errno value (probably
-   * EINTR).
-   */
-
-  int saved_errno = get_errno();
-
   board_autoled_on(LED_SIGNAL);
 
   sinfo("rtcb=%p sigdeliver=%p sigpendactionq.head=%p\n",
@@ -93,7 +86,6 @@ void arm_sigdeliver(void)
 
   sinfo("Resuming\n");
   up_irq_save();
-  set_errno(saved_errno);
 
   /* Modify the saved return state with the actual saved values in the
    * TCB.  This depends on the fact that nested signal handling is

--- a/arch/arm/src/armv8-m/arm_sigdeliver.c
+++ b/arch/arm/src/armv8-m/arm_sigdeliver.c
@@ -57,13 +57,6 @@ void arm_sigdeliver(void)
   struct tcb_s  *rtcb = this_task();
   uint32_t regs[XCPTCONTEXT_REGS];
 
-  /* Save the errno.  This must be preserved throughout the signal handling
-   * so that the user code final gets the correct errno value (probably
-   * EINTR).
-   */
-
-  int saved_errno = get_errno();
-
 #ifdef CONFIG_SMP
   /* In the SMP case, we must terminate the critical section while the signal
    * handler executes, but we also need to restore the irqcount when the
@@ -144,10 +137,6 @@ void arm_sigdeliver(void)
 #ifndef CONFIG_SUPPRESS_INTERRUPTS
   up_irq_save();
 #endif
-
-  /* Restore the saved errno value */
-
-  set_errno(saved_errno);
 
   /* Modify the saved return state with the actual saved values in the
    * TCB.  This depends on the fact that nested signal handling is

--- a/arch/avr/src/avr/up_sigdeliver.c
+++ b/arch/avr/src/avr/up_sigdeliver.c
@@ -57,13 +57,6 @@ void up_sigdeliver(void)
   struct tcb_s *rtcb = this_task();
   uint8_t regs[XCPTCONTEXT_REGS];
 
-  /* Save the errno.  This must be preserved throughout the signal handling
-   * so that the user code final gets the correct errno value (probably
-   * EINTR).
-   */
-
-  int saved_errno = get_errno();
-
   board_autoled_on(LED_SIGNAL);
 
   sinfo("rtcb=%p sigdeliver=%p sigpendactionq.head=%p\n",
@@ -93,7 +86,6 @@ void up_sigdeliver(void)
 
   sinfo("Resuming\n");
   up_irq_save();
-  set_errno(saved_errno);
 
   /* Modify the saved return state with the actual saved values in the
    * TCB.  This depends on the fact that nested signal handling is

--- a/arch/avr/src/avr32/up_sigdeliver.c
+++ b/arch/avr/src/avr32/up_sigdeliver.c
@@ -61,13 +61,6 @@ void up_sigdeliver(void)
   uint32_t regs[XCPTCONTEXT_REGS];
 #endif
 
-  /* Save the errno.  This must be preserved throughout the signal handling
-   * so that the user code final gets the correct errno value (probably
-   * EINTR).
-   */
-
-  int saved_errno = get_errno();
-
   board_autoled_on(LED_SIGNAL);
 
   sinfo("rtcb=%p sigdeliver=%p sigpendactionq.head=%p\n",
@@ -97,7 +90,6 @@ void up_sigdeliver(void)
 
   sinfo("Resuming\n");
   up_irq_save();
-  set_errno(saved_errno);
 
   /* Modify the saved return state with the actual saved values in the
    * TCB.  This depends on the fact that nested signal handling is

--- a/arch/mips/src/mips32/mips_sigdeliver.c
+++ b/arch/mips/src/mips32/mips_sigdeliver.c
@@ -59,13 +59,6 @@ void up_sigdeliver(void)
   struct tcb_s *rtcb = this_task();
   uint32_t regs[XCPTCONTEXT_REGS];
 
-  /* Save the errno.  This must be preserved throughout the signal handling
-   * so that the user code final gets the correct errno value (probably
-   * EINTR).
-   */
-
-  int saved_errno = get_errno();
-
   board_autoled_on(LED_SIGNAL);
 
   sinfo("rtcb=%p sigdeliver=%p sigpendactionq.head=%p\n",
@@ -97,7 +90,6 @@ void up_sigdeliver(void)
         regs[REG_EPC], regs[REG_STATUS]);
 
   up_irq_save();
-  set_errno(saved_errno);
 
   /* Modify the saved return state with the actual saved values in the
    * TCB.  This depends on the fact that nested signal handling is

--- a/arch/misoc/src/lm32/lm32_sigdeliver.c
+++ b/arch/misoc/src/lm32/lm32_sigdeliver.c
@@ -57,13 +57,6 @@ void lm32_sigdeliver(void)
   struct tcb_s *rtcb = this_task();
   uint32_t regs[XCPTCONTEXT_REGS];
 
-  /* Save the errno.  This must be preserved throughout the signal handling
-   * so that the user code final gets the correct errno value (probably
-   * EINTR).
-   */
-
-  int saved_errno = get_errno();
-
   board_autoled_on(LED_SIGNAL);
 
   sinfo("rtcb=%p sigdeliver=%p sigpendactionq.head=%p\n",
@@ -95,7 +88,6 @@ void lm32_sigdeliver(void)
         regs[REG_EPC], regs[REG_INT_CTX]);
 
   up_irq_save();
-  set_errno(saved_errno);
 
   /* Modify the saved return state with the actual saved values in the
    * TCB.  This depends on the fact that nested signal handling is

--- a/arch/misoc/src/minerva/minerva_sigdeliver.c
+++ b/arch/misoc/src/minerva/minerva_sigdeliver.c
@@ -59,13 +59,6 @@ void minerva_sigdeliver(void)
   uint32_t regs[XCPTCONTEXT_REGS];
   sig_deliver_t sigdeliver;
 
-  /* Save the errno.  This must be preserved throughout the signal handling
-   * so that the user code final gets the correct errno value (probably
-   * EINTR).
-   */
-
-  int saved_errno = get_errno();
-
   board_autoled_on(LED_SIGNAL);
 
   sinfo("rtcb=%p sigdeliver=%p sigpendactionq.head=%p\n",
@@ -107,7 +100,6 @@ void minerva_sigdeliver(void)
         regs[REG_CSR_MSTATUS]);
 
   up_irq_save();
-  set_errno(saved_errno);
 
   /* Then restore the correct state for this thread of execution. */
 

--- a/arch/renesas/src/m16c/m16c_sigdeliver.c
+++ b/arch/renesas/src/m16c/m16c_sigdeliver.c
@@ -56,13 +56,6 @@ void up_sigdeliver(void)
   struct tcb_s *rtcb = this_task();
   uint8_t regs[XCPTCONTEXT_SIZE];
 
-  /* Save the errno.  This must be preserved throughout the signal handling
-   * so that the user code final gets the correct errno value (probably
-   * EINTR).
-   */
-
-  int saved_errno = get_errno();
-
   board_autoled_on(LED_SIGNAL);
 
   sinfo("rtcb=%p sigdeliver=%p sigpendactionq.head=%p\n",
@@ -92,7 +85,6 @@ void up_sigdeliver(void)
 
   sinfo("Resuming\n");
   up_irq_save();
-  set_errno(saved_errno);
 
   /* Modify the saved return state with the actual saved values in the
    * TCB.  This depends on the fact that nested signal handling is

--- a/arch/renesas/src/rx65n/rx65n_sigdeliver.c
+++ b/arch/renesas/src/rx65n/rx65n_sigdeliver.c
@@ -57,13 +57,6 @@ void up_sigdeliver(void)
   uint32_t regs[XCPTCONTEXT_REGS];
   sig_deliver_t sigdeliver;
 
-  /* Save the errno.  This must be preserved throughout the signal handling
-   * so that the user code final gets the correct errno value (probably
-   * EINTR).
-   */
-
-  int saved_errno = get_errno();
-
   board_autoled_on(LED_SIGNAL);
 
   sinfo("rtcb=%p sigdeliver=%p sigpendactionq.head=%p\n",
@@ -104,7 +97,6 @@ void up_sigdeliver(void)
 
   sinfo("Resuming\n");
   up_irq_save();
-  set_errno(saved_errno);
 
   /* Then restore the correct state for this thread of
    * execution.

--- a/arch/renesas/src/sh1/sh1_sigdeliver.c
+++ b/arch/renesas/src/sh1/sh1_sigdeliver.c
@@ -56,13 +56,6 @@ void up_sigdeliver(void)
   struct tcb_s  *rtcb = this_task();
   uint32_t regs[XCPTCONTEXT_REGS];
 
-  /* Save the errno.  This must be preserved throughout the signal handling
-   * so that the user code final gets the correct errno value (probably
-   * EINTR).
-   */
-
-  int saved_errno = get_errno();
-
   board_autoled_on(LED_SIGNAL);
 
   sinfo("rtcb=%p sigdeliver=%p sigpendactionq.head=%p\n",
@@ -92,7 +85,6 @@ void up_sigdeliver(void)
 
   sinfo("Resuming\n");
   up_irq_save();
-  set_errno(saved_errno);
 
   /* Modify the saved return state with the actual saved values in the
    * TCB.  This depends on the fact that nested signal handling is

--- a/arch/risc-v/src/rv32im/riscv_sigdeliver.c
+++ b/arch/risc-v/src/rv32im/riscv_sigdeliver.c
@@ -59,13 +59,6 @@ void riscv_sigdeliver(void)
   struct tcb_s *rtcb = this_task();
   uint32_t regs[XCPTCONTEXT_REGS];
 
-  /* Save the errno.  This must be preserved throughout the signal handling
-   * so that the user code final gets the correct errno value (probably
-   * EINTR).
-   */
-
-  int saved_errno = get_errno();
-
   board_autoled_on(LED_SIGNAL);
 
   sinfo("rtcb=%p sigdeliver=%p sigpendactionq.head=%p\n",
@@ -97,7 +90,6 @@ void riscv_sigdeliver(void)
         regs[REG_EPC], regs[REG_INT_CTX]);
 
   up_irq_save();
-  set_errno(saved_errno);
 
   /* Modify the saved return state with the actual saved values in the
    * TCB.  This depends on the fact that nested signal handling is

--- a/arch/risc-v/src/rv64gc/riscv_sigdeliver.c
+++ b/arch/risc-v/src/rv64gc/riscv_sigdeliver.c
@@ -59,13 +59,6 @@ void riscv_sigdeliver(void)
   struct tcb_s *rtcb = this_task();
   uint64_t regs[XCPTCONTEXT_REGS];
 
-  /* Save the errno.  This must be preserved throughout the signal handling
-   * so that the user code final gets the correct errno value (probably
-   * EINTR).
-   */
-
-  int saved_errno = get_errno();
-
 #ifdef CONFIG_SMP
   /* In the SMP case, we must terminate the critical section while the signal
    * handler executes, but we also need to restore the irqcount when the
@@ -140,10 +133,6 @@ void riscv_sigdeliver(void)
 #ifndef CONFIG_SUPPRESS_INTERRUPTS
   up_irq_save();
 #endif
-
-  /* Restore the saved errno value */
-
-  set_errno(saved_errno);
 
   /* Modify the saved return state with the actual saved values in the
    * TCB.  This depends on the fact that nested signal handling is

--- a/arch/sim/src/sim/up_sigdeliver.c
+++ b/arch/sim/src/sim/up_sigdeliver.c
@@ -66,13 +66,6 @@ void sim_sigdeliver(void)
   irqstate_t flags = enter_critical_section();
 #endif
 
-  /* Save the errno.  This must be preserved throughout the signal handling
-   * so that the user code final gets the correct errno value (probably
-   * EINTR).
-   */
-
-  int saved_errno = get_errno();
-
 #ifdef CONFIG_SMP
   /* In the SMP case, we must terminate the critical section while the signal
    * handler executes, but we also need to restore the irqcount when the
@@ -133,10 +126,6 @@ void sim_sigdeliver(void)
       enter_critical_section();
     }
 #endif
-
-  /* Restore the saved errno value */
-
-  set_errno(saved_errno);
 
   /* Allows next handler to be scheduled */
 

--- a/arch/x86/src/i486/up_sigdeliver.c
+++ b/arch/x86/src/i486/up_sigdeliver.c
@@ -57,13 +57,6 @@ void up_sigdeliver(void)
   struct tcb_s *rtcb = this_task();
   uint32_t regs[XCPTCONTEXT_REGS];
 
-  /* Save the errno.  This must be preserved throughout the signal handling
-   * so that the user code final gets the correct errno value (probably
-   * EINTR).
-   */
-
-  int saved_errno = get_errno();
-
   board_autoled_on(LED_SIGNAL);
 
   sinfo("rtcb=%p sigdeliver=%p sigpendactionq.head=%p\n",
@@ -93,7 +86,6 @@ void up_sigdeliver(void)
 
   sinfo("Resuming\n");
   up_irq_save();
-  set_errno(saved_errno);
 
   /* Modify the saved return state with the actual saved values in the
    * TCB.  This depends on the fact that nested signal handling is

--- a/arch/x86_64/src/intel64/up_sigdeliver.c
+++ b/arch/x86_64/src/intel64/up_sigdeliver.c
@@ -63,13 +63,6 @@ void up_sigdeliver(void)
 
   regs = (uint64_t *)(((uint64_t)(regs_area) + 15) & (~(uint64_t)15));
 
-  /* Save the errno.  This must be preserved throughout the signal handling
-   * so that the user code final gets the correct errno value (probably
-   * EINTR).
-   */
-
-  int saved_errno = get_errno();
-
   /* Save the real return state on the stack ASAP before any chance we went
    * sleeping and break the register profile.  We entered this function with
    * interrupt disabled, therefore we don't have to worried being preempted
@@ -109,7 +102,6 @@ void up_sigdeliver(void)
 
   sinfo("Resuming\n");
   (void)up_irq_save();
-  set_errno(saved_errno);
 
   /* Modify the saved return state with the actual saved values in the
    * TCB.  This depends on the fact that nested signal handling is

--- a/arch/xtensa/src/common/xtensa_sigdeliver.c
+++ b/arch/xtensa/src/common/xtensa_sigdeliver.c
@@ -56,13 +56,6 @@ void xtensa_sig_deliver(void)
   struct tcb_s *rtcb = this_task();
   uint32_t regs[XCPTCONTEXT_REGS];
 
-  /* Save the errno.  This must be preserved throughout the signal handling
-   * so that the user code final gets the correct errno value (probably
-   * EINTR).
-   */
-
-  int saved_errno = get_errno();
-
 #ifdef CONFIG_SMP
   /* In the SMP case, we must terminate the critical section while the signal
    * handler executes, but we also need to restore the irqcount when the
@@ -137,10 +130,6 @@ void xtensa_sig_deliver(void)
 #ifndef CONFIG_SUPPRESS_INTERRUPTS
   up_irq_save();
 #endif
-
-  /* Restore the saved errno value */
-
-  set_errno(saved_errno);
 
   /* Modify the saved return state with the actual saved values in the
    * TCB.  This depends on the fact that nested signal handling is

--- a/arch/z16/src/common/z16_sigdeliver.c
+++ b/arch/z16/src/common/z16_sigdeliver.c
@@ -57,13 +57,6 @@ void z16_sigdeliver(void)
   chipreg_t regs[XCPTCONTEXT_REGS];
   FAR uint32_t *regs32 = (FAR uint32_t *)regs;
 
-  /* Save the errno.  This must be preserved throughout the signal handling
-   * so that the user code final gets the correct errno value (probably
-   * EINTR).
-   */
-
-  int saved_errno = get_errno();
-
   board_autoled_on(LED_SIGNAL);
 
   sinfo("rtcb=%p sigdeliver=%p sigpendactionq.head=%p\n",
@@ -93,7 +86,6 @@ void z16_sigdeliver(void)
 
   sinfo("Resuming\n");
   up_irq_save();
-  set_errno(saved_errno);
 
   /* Modify the saved return state with the actual saved values in the
    * TCB.  This depends on the fact that nested signal handling is

--- a/arch/z80/src/ez80/ez80_sigdeliver.c
+++ b/arch/z80/src/ez80/ez80_sigdeliver.c
@@ -58,13 +58,6 @@ void z80_sigdeliver(void)
   FAR struct tcb_s *rtcb = this_task();
   chipreg_t regs[XCPTCONTEXT_REGS];
 
-  /* Save the errno.  This must be preserved throughout the signal handling
-   * so that the user code final gets the correct errno value (probably
-   * EINTR).
-   */
-
-  int saved_errno = get_errno();
-
   board_autoled_on(LED_SIGNAL);
 
   sinfo("rtcb=%p sigdeliver=%p sigpendactionq.head=%p\n",
@@ -94,7 +87,6 @@ void z80_sigdeliver(void)
 
   sinfo("Resuming\n");
   up_irq_save();
-  set_errno(saved_errno);
 
   /* Modify the saved return state with the actual saved values in the
    * TCB.  This depends on the fact that nested signal handling is

--- a/arch/z80/src/z180/z180_sigdeliver.c
+++ b/arch/z80/src/z180/z180_sigdeliver.c
@@ -55,13 +55,6 @@ void z80_sigdeliver(void)
   FAR struct tcb_s  *rtcb = this_task();
   chipreg_t regs[XCPTCONTEXT_REGS];
 
-  /* Save the errno.  This must be preserved throughout the signal handling
-   * so that the user code final gets the correct errno value (probably
-   * EINTR).
-   */
-
-  int saved_errno = get_errno();
-
   board_autoled_on(LED_SIGNAL);
 
   sinfo("rtcb=%p sigdeliver=%p sigpendactionq.head=%p\n",
@@ -91,7 +84,6 @@ void z80_sigdeliver(void)
 
   sinfo("Resuming\n");
   up_irq_save();
-  set_errno(saved_errno);
 
   /* Modify the saved return state with the actual saved values in the
    * TCB.  This depends on the fact that nested signal handling is

--- a/arch/z80/src/z8/z8_sigdeliver.c
+++ b/arch/z80/src/z8/z8_sigdeliver.c
@@ -74,13 +74,6 @@ void z80_sigdeliver(void)
   FAR struct tcb_s *rtcb = this_task();
   chipreg_t regs[XCPTCONTEXT_REGS];
 
-  /* Save the errno.  This must be preserved throughout the signal handling
-   * so that the user code final gets the correct errno value (probably
-   * EINTR).
-   */
-
-  int saved_errno = get_errno();
-
   board_autoled_on(LED_SIGNAL);
 
   sinfo("rtcb=%p sigdeliver=%p sigpendactionq.head=%p\n",
@@ -110,7 +103,6 @@ void z80_sigdeliver(void)
 
   sinfo("Resuming\n");
   up_irq_save();
-  set_errno(saved_errno);
 
   /* Modify the saved return state with the actual saved values in the
    * TCB.  This depends on the fact that nested signal handling is

--- a/arch/z80/src/z80/z80_sigdeliver.c
+++ b/arch/z80/src/z80/z80_sigdeliver.c
@@ -55,13 +55,6 @@ void z80_sigdeliver(void)
   FAR struct tcb_s *rtcb = this_task();
   chipreg_t regs[XCPTCONTEXT_REGS];
 
-  /* Save the errno.  This must be preserved throughout the signal handling
-   * so that the user code final gets the correct errno value (probably
-   * EINTR).
-   */
-
-  int saved_errno = get_errno();
-
   board_autoled_on(LED_SIGNAL);
 
   sinfo("rtcb=%p sigdeliver=%p sigpendactionq.head=%p\n",
@@ -91,7 +84,6 @@ void z80_sigdeliver(void)
 
   sinfo("Resuming\n");
   up_irq_save();
-  set_errno(saved_errno);
 
   /* Modify the saved return state with the actual saved values in the
    * TCB.  This depends on the fact that nested signal handling is

--- a/sched/signal/sig_deliver.c
+++ b/sched/signal/sig_deliver.c
@@ -51,6 +51,14 @@
 
 void nxsig_deliver(FAR struct tcb_s *stcb)
 {
+  /* Save the errno.  This must be preserved throughout the signal handling
+   * so that the user code final gets the correct errno value (probably
+   * EINTR).
+   */
+
+  int saved_errno = get_errno();
+  int16_t saved_errcode = stcb->errcode;
+
   FAR sigq_t *sigq;
   sigset_t    savesigprocmask;
   sigset_t    newsigprocmask;
@@ -194,4 +202,9 @@ void nxsig_deliver(FAR struct tcb_s *stcb)
 
       nxsig_release_pendingsigaction(sigq);
     }
+
+  /* Restore the saved errno value */
+
+  set_errno(saved_errno);
+  stcb->errcode = saved_errcode;
 }


### PR DESCRIPTION
For example, task is blocked by nxsem_wait(sem1), use nxsem_wait(sem2)
in signal handler, and take sem2 successfully, after exit from signal
handler to task, nxsem_wait(sem1) returns OK, but the correct result
should be -EINTR.

Signed-off-by: Zeng Zhaoxiu <zhaoxiu.zeng@gmail.com>

## Summary

## Impact

## Testing

