### PR TITLE
arch/backtrace: correct the skip counter 

### DIFF
--- a/arch/arm/src/common/arm_backtrace_thumb.c
+++ b/arch/arm/src/common/arm_backtrace_thumb.c
@@ -328,12 +328,12 @@ static int backtrace_push(FAR void *limit, FAR void **sp, FAR void *pc,
 
   pc = (uintptr_t)pc & 0xfffffffe;
 
-  if (*skip-- <= 0)
+  if ((*skip)-- <= 0)
     {
-      *buffer++ = pc;
+      buffer[i++] = pc;
     }
 
-  for (; i < size; i++)
+  while (i < size)
     {
       if (*sp >= limit)
         {
@@ -346,9 +346,9 @@ static int backtrace_push(FAR void *limit, FAR void **sp, FAR void *pc,
           break;
         }
 
-      if (*skip-- <= 0)
+      if ((*skip)-- <= 0)
         {
-          *buffer++ = pc;
+          buffer[i++] = pc;
         }
     }
 
@@ -371,9 +371,9 @@ static int backtrace_branch(FAR void *limit, FAR void *sp,
 {
   uint16_t ins16;
   uint32_t addr;
-  int i = 0;
+  int i;
 
-  for (; i < size && sp < limit; sp += sizeof(uint32_t))
+  for (i = 0; i < size && sp < limit; sp += sizeof(uint32_t))
     {
       addr = *(FAR uint32_t *)sp;
       if (!in_code_region(addr))
@@ -385,10 +385,9 @@ static int backtrace_branch(FAR void *limit, FAR void *sp,
       ins16 = *(FAR uint16_t *)addr;
       if (INSTR_IS(ins16, T_BLX))
         {
-          i++;
-          if (*skip-- <= 0)
+          if ((*skip)-- <= 0)
             {
-              *buffer++ = addr;
+              buffer[i++] = addr;
             }
         }
 
@@ -405,10 +404,9 @@ static int backtrace_branch(FAR void *limit, FAR void *sp,
           ins16 = *(FAR uint16_t *)addr;
           if (INSTR_IS(ins16, T_BL))
             {
-              i++;
-              if (*skip-- <= 0)
+              if ((*skip)-- <= 0)
                 {
-                  *buffer++ = addr;
+                  buffer[i++] = addr;
                 }
             }
         }

--- a/arch/risc-v/src/common/riscv_backtrace.c
+++ b/arch/risc-v/src/common/riscv_backtrace.c
@@ -69,14 +69,13 @@ static int backtrace(uintptr_t *base, uintptr_t *limit,
 
   if (ra)
     {
-      i++;
-      if (*skip-- <= 0)
+      if ((*skip)-- <= 0)
         {
-          *buffer++ = ra;
+          buffer[i++] = ra;
         }
     }
 
-  for (; i < size; fp = (uintptr_t *)*(fp - 2), i++)
+  for (; i < size; fp = (uintptr_t *)*(fp - 2))
     {
       if (fp > limit || fp < base)
         {
@@ -89,9 +88,9 @@ static int backtrace(uintptr_t *base, uintptr_t *limit,
           break;
         }
 
-      if (*skip-- <= 0)
+      if ((*skip)-- <= 0)
         {
-          *buffer++ = ra;
+          buffer[i++] = ra;
         }
     }
 

--- a/arch/xtensa/src/common/xtensa_backtrace.c
+++ b/arch/xtensa/src/common/xtensa_backtrace.c
@@ -136,10 +136,9 @@ static int backtrace_window(uintptr_t *base, uintptr_t *limit,
               continue;
             }
 
-          i++;
-          if (*skip-- <= 0)
+          if ((*skip)-- <= 0)
             {
-              *buffer++ = MAKE_PC_FROM_RA(ra);
+              buffer[i++] = MAKE_PC_FROM_RA(ra);
             }
         }
     }
@@ -164,14 +163,13 @@ static int backtrace_stack(uintptr_t *base, uintptr_t *limit,
 
   if (ra)
     {
-      i++;
-      if (*skip-- <= 0)
+      if ((*skip)-- <= 0)
         {
-          *buffer++ = MAKE_PC_FROM_RA((uintptr_t)ra);
+          buffer[i++] = MAKE_PC_FROM_RA((uintptr_t)ra);
         }
     }
 
-  for (; i < size; sp = (uintptr_t *)*(sp - 3), i++)
+  for (; i < size; sp = (uintptr_t *)*(sp - 3))
     {
       if (sp > limit || sp < base)
         {
@@ -184,9 +182,9 @@ static int backtrace_stack(uintptr_t *base, uintptr_t *limit,
           break;
         }
 
-      if (*skip-- <= 0)
+      if ((*skip)-- <= 0)
         {
-          *buffer++ = MAKE_PC_FROM_RA((uintptr_t)ra);
+          buffer[i++] = MAKE_PC_FROM_RA((uintptr_t)ra);
         }
     }
 


### PR DESCRIPTION
## Summary

arch/backtrace: correct the skip counter 

Signed-off-by: chao.an <anchao@xiaomi.com>

## Impact

N/A

## Testing

dump stack test:
```
audio> dumpstack 0 10
[   14.464813] [15] [ EMERG] [audio] backtrace:
[   14.465125] [15] [ EMERG] [audio] [ 0] [<0x2cb19638>] xtensa_context_restore+0x2c/0x38
[   14.465313] [15] [ EMERG] [audio] [ 0] [<0x2cb1a539>] _start+0x9/0xc
[   14.465375] [15] [ EMERG] [audio] [ 0] [<0x3de00260>] _xtensa_reset_handler+0x5c/0x1fc
[   14.465563] [15] [ EMERG] [audio] backtrace:
[   14.465625] [15] [ EMERG] [audio] [ 1] [<0x2cb19bb8>] up_block_task+0x70/0xa0
[   14.465688] [15] [ EMERG] [audio] [ 1] [<0x2cb0b4c3>] nxsem_wait+0x67/0x98
[   14.465813] [15] [ EMERG] [audio] [ 1] [<0x2cb0b4ff>] nxsem_wait_uninterruptible+0xb/0x14
[   14.465938] [15] [ EMERG] [audio] [ 1] [<0x2cb0da7c>] work_thread+0x24/0x50
[   14.466063] [15] [ EMERG] [audio] [ 1] [<0x2cb0cd5a>] nxtask_start+0x5a/0x74
[   14.466125] [15] [ EMERG] [audio] backtrace:
[   14.466188] [15] [ EMERG] [audio] [ 3] [<0x2cb19bb8>] up_block_task+0x70/0xa0
[   14.466313] [15] [ EMERG] [audio] [ 3] [<0x2cb0b4c3>] nxsem_wait+0x67/0x98
[   14.466438] [15] [ EMERG] [audio] [ 3] [<0x2cb0b4ff>] nxsem_wait_uninterruptible+0xb/0x14
[   14.466500] [15] [ EMERG] [audio] [ 3] [<0x2cb0ecef>] rptun_thread+0x47/0x3c4
[   14.466625] [15] [ EMERG] [audio] [ 3] [<0x2cb0cd5a>] nxtask_start+0x5a/0x74
[   14.466750] [15] [ EMERG] [audio] backtrace:
[   14.466813] [15] [ EMERG] [audio] [ 4] [<0x2cb19bb8>] up_block_task+0x70/0xa0
[   14.466875] [15] [ EMERG] [audio] [ 4] [<0x2cb0b4c3>] nxsem_wait+0x67/0x98
[   14.467000] [15] [ EMERG] [audio] [ 4] [<0x2cb0b4ff>] nxsem_wait_uninterruptible+0xb/0x14
[   14.467063] [15] [ EMERG] [audio] [ 4] [<0x2cb0ecef>] rptun_thread+0x47/0x3c4
[   14.467188] [15] [ EMERG] [audio] [ 4] [<0x2cb0cd5a>] nxtask_start+0x5a/0x74
```
