### PR TITLE
arch/risc-v: Correct epc adjustment with C ISA

### DIFF
--- a/arch/risc-v/src/bl602/bl602_irq_dispatch.c
+++ b/arch/risc-v/src/bl602/bl602_irq_dispatch.c
@@ -67,7 +67,7 @@ void *bl602_dispatch_irq(uint32_t vector, uint32_t *regs)
 
   if (BL602_IRQ_ECALLM == irq)
     {
-      *mepc += 4;
+      *mepc += 2;
     }
 
   /* Acknowledge the interrupt */

--- a/arch/risc-v/src/fe310/fe310_irq_dispatch.c
+++ b/arch/risc-v/src/fe310/fe310_irq_dispatch.c
@@ -72,7 +72,7 @@ void *fe310_dispatch_irq(uint32_t vector, uint32_t *regs)
 
   if (FE310_IRQ_ECALLM == irq)
     {
-      *mepc += 4;
+      *mepc += 2;
     }
 
   /* Acknowledge the interrupt */

--- a/arch/risc-v/src/rv32m1/rv32m1_irq_dispatch.c
+++ b/arch/risc-v/src/rv32m1/rv32m1_irq_dispatch.c
@@ -65,7 +65,7 @@ void *rv32m1_dispatch_irq(uint32_t vector, uint32_t *regs)
 
   if (RV32M1_IRQ_ECALL_M == irq)
     {
-      *mepc += 4;
+      *mepc += 2;
     }
 
   if (RV32M1_IRQ_INTMUX0 <= irq)


### PR DESCRIPTION
## Summary
All instructions use the normal 32bit formal, but on some platform with C (Compressed instruction) support it would be 16bit, for FE310, you can adjust the mepc with 2 instead of 4:
## Impact
RV32C only.
## Testing
fe310 with QEMU
