### PR TITLE
libc/math: fix fmod family operation

### DIFF
--- a/libs/libc/math/lib_fmod.c
+++ b/libs/libc/math/lib_fmod.c
@@ -43,10 +43,8 @@ double fmod(double x, double div)
 {
   double n0;
 
-  x /= div;
-  x = modf(x, &n0);
-  x *= div;
+  modf(x / div, &n0);
 
-  return x;
+  return x - n0 * div;
 }
 #endif

--- a/libs/libc/math/lib_fmodf.c
+++ b/libs/libc/math/lib_fmodf.c
@@ -39,9 +39,7 @@ float fmodf(float x, float div)
 {
   float n0;
 
-  x /= div;
-  x = modff(x, &n0);
-  x *= div;
+  modff(x / div, &n0);
 
-  return x;
+  return x - n0 * div;
 }

--- a/libs/libc/math/lib_fmodl.c
+++ b/libs/libc/math/lib_fmodl.c
@@ -43,10 +43,8 @@ long double fmodl(long double x, long double div)
 {
   long double n0;
 
-  x /= div;
-  x = modfl(x, &n0);
-  x *= div;
+  modfl(x / div, &n0);
 
-  return x;
+  return x - n0 * div;
 }
 #endif

--- a/libs/libc/math/lib_modf.c
+++ b/libs/libc/math/lib_modf.c
@@ -46,12 +46,12 @@ double modf(double x, double *iptr)
     }
   else if (fabs(x) < 1.0)
     {
-      *iptr = (x * 0.0);
+      *iptr = 0.0;
       return x;
     }
   else
     {
-      *iptr = (double)(int64_t) x;
+      *iptr = (double)(int64_t)x;
       return (x - *iptr);
     }
 }

--- a/libs/libc/math/lib_modff.c
+++ b/libs/libc/math/lib_modff.c
@@ -44,7 +44,7 @@ float modff(float x, float *iptr)
     }
   else if (fabsf(x) < 1.0F)
     {
-      *iptr = (x * 0.0F);
+      *iptr = 0.0F;
       return x;
     }
   else

--- a/libs/libc/math/lib_modfl.c
+++ b/libs/libc/math/lib_modfl.c
@@ -49,12 +49,12 @@ long double modfl(long double x, long double *iptr)
     }
   else if (fabsl(x) < 1.0)
     {
-      *iptr = (x * 0.0);
+      *iptr = 0.0;
       return x;
     }
   else
     {
-      *iptr = (long double)(int64_t) x;
+      *iptr = (long double)(int64_t)x;
       return (x - *iptr);
     }
 }


### PR DESCRIPTION
## Summary
`fmod()` returns incorrect value. This is due to calculations are based on dividing and multiplying back fractional part, so calculation brings computation error. Rework `fmod()` functions family 

## Impact
NuttX native math library users

## Testing
Tested with online C compiler.