### PR TITLE
risc-v/esp32c3: SPI flash MTD device uses all flash space

### DIFF
--- a/arch/risc-v/src/esp32c3/Kconfig
+++ b/arch/risc-v/src/esp32c3/Kconfig
@@ -929,25 +929,10 @@ config ESP32C3_MTD
 	       Initialize an MTD driver for the ESP32-C3 SPI Flash, which will
                add an entry at /dev for application access from userspace.
 
-config ESP32C3_STORAGE_MTD_BLKSIZE
+config ESP32C3_SPIFLASH_MTD_BLKSIZE
 	int "Storage MTD block size"
 	default 64
 	depends on ESP32C3_MTD
-
-config ESP32C3_STORAGE_MTD_OFFSET
-	hex "Storage MTD base address in SPI Flash"
-	default 0x180000 if !ESP32C3_HAVE_OTA_PARTITION
-	default 0x250000 if ESP32C3_HAVE_OTA_PARTITION
-	depends on ESP32C3_MTD
-	---help---
-		MTD base address in SPI Flash.
-
-config ESP32C3_STORAGE_MTD_SIZE
-	hex "Storage MTD size in SPI Flash"
-	default 0x100000
-	depends on ESP32C3_MTD
-	---help---
-		MTD size in SPI Flash.
 
 config ESP32C3_STORAGE_MTD_DEBUG
 	bool "Storage MTD Debug"

--- a/arch/risc-v/src/esp32c3/esp32c3_spiflash_mtd.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_spiflash_mtd.c
@@ -47,12 +47,9 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-#define MTD_BLK_SIZE                CONFIG_ESP32C3_STORAGE_MTD_BLKSIZE
+#define MTD_BLK_SIZE                CONFIG_ESP32C3_SPIFLASH_MTD_BLKSIZE
 #define MTD_ERASE_SIZE              4096
 #define MTD_ERASED_STATE            (0xff)
-
-#define MTD_PART_OFFSET             CONFIG_ESP32C3_STORAGE_MTD_OFFSET
-#define MTD_PART_SIZE               CONFIG_ESP32C3_STORAGE_MTD_SIZE
 
 #define MTD2PRIV(_dev)              ((struct esp32c3_mtd_dev_s *)_dev)
 #define MTD_SIZE(_priv)             ((*(_priv)->data)->chip.chip_size)
@@ -638,12 +635,13 @@ static int esp32c3_ioctl(struct mtd_dev_s *dev, int cmd,
     {
       case MTDIOC_GEOMETRY:
         {
+          struct esp32c3_mtd_dev_s *priv = (struct esp32c3_mtd_dev_s *)dev;
           struct mtd_geometry_s *geo = (struct mtd_geometry_s *)arg;
           if (geo)
             {
               geo->blocksize    = MTD_BLK_SIZE;
               geo->erasesize    = MTD_ERASE_SIZE;
-              geo->neraseblocks = MTD_PART_SIZE / MTD_ERASE_SIZE;
+              geo->neraseblocks = MTD_SIZE(priv) / MTD_ERASE_SIZE;
               ret               = OK;
 
               finfo("blocksize: %" PRId32 " erasesize: %" PRId32 \
@@ -655,10 +653,11 @@ static int esp32c3_ioctl(struct mtd_dev_s *dev, int cmd,
 
       case BIOC_PARTINFO:
         {
+          struct esp32c3_mtd_dev_s *priv = (struct esp32c3_mtd_dev_s *)dev;
           struct partition_info_s *info = (struct partition_info_s *)arg;
           if (info != NULL)
             {
-              info->numsectors  = MTD_PART_SIZE / MTD_BLK_SIZE;
+              info->numsectors  = MTD_SIZE(priv) / MTD_BLK_SIZE;
               info->sectorsize  = MTD_BLK_SIZE;
               info->startsector = 0;
               info->parent[0]   = '\0';

--- a/boards/risc-v/esp32c3/esp32c3-devkit/Kconfig
+++ b/boards/risc-v/esp32c3/esp32c3-devkit/Kconfig
@@ -50,10 +50,25 @@ config ESP32C3_MERGE_BINS
 		This is only useful when the path to binary files (e.g. bootloader)
 		is provided via the ESPTOOL_BINDIR variable.
 
+config ESP32C3_STORAGE_MTD_OFFSET
+	hex "Storage MTD base address in SPI Flash"
+	default 0x180000 if !ESP32C3_HAVE_OTA_PARTITION
+	default 0x250000 if ESP32C3_HAVE_OTA_PARTITION
+	depends on ESP32C3_MTD
+	---help---
+		MTD base address in SPI Flash.
+
+config ESP32C3_STORAGE_MTD_SIZE
+	hex "Storage MTD size in SPI Flash"
+	default 0x100000
+	depends on ESP32C3_MTD
+	---help---
+		MTD size in SPI Flash.
+
 choice ESP32C3_SPIFLASH_FS
 	prompt "Mount SPI Flash MTD on bring-up"
 	default ESP32C3_SPIFLASH_SMARTFS
-	depends on ESP32C3_SPIFLASH
+	depends on ESP32C3_MTD
 	optional
 	---help---
 		Mount the SPI Flash MTD with the selected File System format on board


### PR DESCRIPTION
## Summary

SPI flash MTD device uses all flash space.

## Impact

## Testing

