### PR TITLE
Fix preprocessing directives for uart flow control

### DIFF
--- a/arch/risc-v/src/bl602/bl602_serial.c
+++ b/arch/risc-v/src/bl602/bl602_serial.c
@@ -567,19 +567,19 @@ static int bl602_ioctl(struct file *filep, int cmd, unsigned long arg)
 
           if (priv->config.idx == 0)
             {
-#if CONFIG_UART0_IFLOWCONTROL
+#ifdef CONFIG_UART0_IFLOWCONTROL
               config.iflow_ctl = (termiosp->c_cflag & CRTS_IFLOW) != 0;
 #endif
-#if CONFIG_UART0_OFLOWCONTROL
+#ifdef CONFIG_UART0_OFLOWCONTROL
               config.oflow_ctl = (termiosp->c_cflag & CCTS_OFLOW) != 0;
 #endif
             }
           else
             {
-#if CONFIG_UART1_IFLOWCONTROL
+#ifdef CONFIG_UART1_IFLOWCONTROL
               config.iflow_ctl = (termiosp->c_cflag & CRTS_IFLOW) != 0;
 #endif
-#if CONFIG_UART1_OFLOWCONTROL
+#ifdef CONFIG_UART1_OFLOWCONTROL
               config.oflow_ctl = (termiosp->c_cflag & CCTS_OFLOW) != 0;
 #endif
             }


### PR DESCRIPTION
## Summary
commit 58bd8737297efcf5c6f4f8961c88e86a3d5113c7 had a mix of `#if defined(X)` and `#ifdef X`, but used `#if X` in its TCSETS ioctl logic which causes compile warnings.

## Impact
Removes some compiler warnings

## Testing
Recompiled with bl602 board, warnings went away