### PR TITLE
boards: hifive1-revb: Enable some nsh commands in nsh/defconfig

### DIFF
--- a/boards/risc-v/fe310/hifive1-revb/configs/nsh/defconfig
+++ b/boards/risc-v/fe310/hifive1-revb/configs/nsh/defconfig
@@ -6,8 +6,18 @@
 # modifications.
 #
 # CONFIG_NSH_DISABLEBG is not set
+# CONFIG_NSH_DISABLE_CAT is not set
+# CONFIG_NSH_DISABLE_ECHO is not set
+# CONFIG_NSH_DISABLE_FREE is not set
+# CONFIG_NSH_DISABLE_HELP is not set
+# CONFIG_NSH_DISABLE_KILL is not set
 # CONFIG_NSH_DISABLE_LOSMART is not set
+# CONFIG_NSH_DISABLE_LS is not set
+# CONFIG_NSH_DISABLE_MOUNT is not set
+# CONFIG_NSH_DISABLE_PS is not set
+# CONFIG_NSH_DISABLE_SLEEP is not set
 # CONFIG_NSH_DISABLE_UNAME is not set
+# CONFIG_NSH_DISABLE_USLEEP is not set
 # CONFIG_STANDARD_SERIAL is not set
 CONFIG_ARCH="risc-v"
 CONFIG_ARCH_BOARD="hifive1-revb"


### PR DESCRIPTION
## Summary

- I noticed that most of nsh commands are disabled by default
  due to the recent changes for CONFIG_MM_SMALL=y in apps.
- This commit re-enables some nsh commands.

## Impact

- None

## Testing

- Tested with QEMU
