### PR TITLE
net/icmp: post the semaphore if multiple references

### DIFF
--- a/net/icmp/icmp_conn.c
+++ b/net/icmp/icmp_conn.c
@@ -165,8 +165,9 @@ void icmp_free(FAR struct icmp_conn_s *conn)
       /* Free the connection */
 
       dq_addlast(&conn->node, &g_free_icmp_connections);
-      nxsem_post(&g_free_sem);
     }
+
+  nxsem_post(&g_free_sem);
 }
 
 /****************************************************************************


### PR DESCRIPTION
## Summary

net/icmp: post the semaphore if multiple references

## Impact

icmp may have potential deadlock issue

## Testing

icmp ping test