### PR TITLE
net/tcp(unbuffered): advance sndseq by +1 because SYN and FIN occupy one sequence number

### DIFF
--- a/net/tcp/tcp_input.c
+++ b/net/tcp/tcp_input.c
@@ -870,6 +870,11 @@ found:
 
         if ((tcp->flags & TCP_CTL) == TCP_SYN)
           {
+#if !defined(CONFIG_NET_TCP_WRITE_BUFFERS)
+            tcp_setsequence(conn->sndseq, conn->rexmit_seq);
+#else
+            /* REVISIT for the buffered mode */
+#endif
             tcp_synack(dev, conn, TCP_ACK | TCP_SYN);
             return;
           }

--- a/net/tcp/tcp_send.c
+++ b/net/tcp/tcp_send.c
@@ -382,6 +382,25 @@ static void tcp_sendcommon(FAR struct net_driver_s *dev,
   /* Finish the IP portion of the message and calculate checksums */
 
   tcp_sendcomplete(dev, tcp);
+
+#if !defined(CONFIG_NET_TCP_WRITE_BUFFERS)
+  if ((tcp->flags & (TCP_SYN | TCP_FIN)) != 0)
+    {
+      /* Remember sndseq that will be used in case of a possible
+       * SYN or FIN retransmission
+       */
+
+      conn->rexmit_seq = tcp_getsequence(conn->sndseq);
+
+      /* Advance sndseq by +1 because SYN and FIN occupy
+       * one sequence number (RFC 793)
+       */
+
+      net_incr32(conn->sndseq, 1);
+    }
+#else
+  /* REVISIT for the buffered mode */
+#endif
 }
 
 /****************************************************************************

--- a/net/tcp/tcp_timer.c
+++ b/net/tcp/tcp_timer.c
@@ -317,6 +317,11 @@ void tcp_timer(FAR struct net_driver_s *dev, FAR struct tcp_conn_s *conn,
                      * SYNACK.
                      */
 
+#if !defined(CONFIG_NET_TCP_WRITE_BUFFERS)
+                    tcp_setsequence(conn->sndseq, conn->rexmit_seq);
+#else
+                    /* REVISIT for the buffered mode */
+#endif
                     tcp_synack(dev, conn, TCP_ACK | TCP_SYN);
                     goto done;
 
@@ -324,6 +329,11 @@ void tcp_timer(FAR struct net_driver_s *dev, FAR struct tcp_conn_s *conn,
 
                     /* In the SYN_SENT state, we retransmit out SYN. */
 
+#if !defined(CONFIG_NET_TCP_WRITE_BUFFERS)
+                    tcp_setsequence(conn->sndseq, conn->rexmit_seq);
+#else
+                    /* REVISIT for the buffered mode */
+#endif
                     tcp_synack(dev, conn, TCP_SYN);
                     goto done;
 
@@ -344,6 +354,11 @@ void tcp_timer(FAR struct net_driver_s *dev, FAR struct tcp_conn_s *conn,
 
                     /* In all these states we should retransmit a FINACK. */
 
+#if !defined(CONFIG_NET_TCP_WRITE_BUFFERS)
+                    tcp_setsequence(conn->sndseq, conn->rexmit_seq);
+#else
+                    /* REVISIT for the buffered mode */
+#endif
                     tcp_send(dev, conn, TCP_FIN | TCP_ACK, hdrlen);
                     goto done;
                 }


### PR DESCRIPTION
## Summary

Advance sndseq by +1 because SYN and FIN occupy one sequence number (RFC 793).
This PR refers to my previous PR #5102.

## Impact

TCP

## Testing

Install and configure vsftpd on Linux host.
Build NuttX:
```
$ ./tools/configure.sh -l sim:tcpblaster
$ make menuconfig (disable CONFIG_NET_TCP_WRITE_BUFFERS)
$ make
```
Enable TUN/TAP on Linux host:
```
$ sudo setcap cap_net_admin+ep ./nuttx
$ sudo ./tools/simhostroute.sh wlan0 on
```
Run NuttX on Linux host:
```
$ ./nuttx
NuttShell (NSH) NuttX-10.2.0
nsh> ifconfig eth0 10.0.1.2
nsh> ifup eth0
ifup eth0...OK
```
Start Wireshark (or tcpdump) and capture appeared tap0 interface.

Run in NuttX:
```
nsh> dd if=/dev/zero of=/tmp/test.bin count=1000
nsh> ftpc -4 -n LINUX_HOST_IP_ADDRESS
NuttX FTP Client:
login anonymous
put /tmp/test.bin pub/test.bin
quit
```
Observe TCP dump.

Shutdown NuttX:
`nsh> poweroff`

Disable TUN/TAP on Linux host:
`$ sudo ./tools/simhostroute.sh wlan0 off`