### PR TITLE
drivers/sensors/as5048b: fix lower half init issue

### DIFF
--- a/arch/arm/src/imxrt/imxrt_enc.c
+++ b/arch/arm/src/imxrt/imxrt_enc.c
@@ -292,7 +292,7 @@ struct imxrt_enc_lowerhalf_s
 static inline uint16_t imxrt_enc_getreg16
                         (FAR struct imxrt_enc_lowerhalf_s *priv, int offset);
 static inline void imxrt_enc_putreg16(FAR struct imxrt_enc_lowerhalf_s *priv,
-              int offset,  uint16_t value);
+                                      int offset,  uint16_t value);
 static inline void imxrt_enc_modifyreg16
                     (FAR struct imxrt_enc_lowerhalf_s *priv, int offset,
                     uint16_t clearbits, uint16_t setbits);
@@ -300,22 +300,21 @@ static inline void imxrt_enc_modifyreg16
 static void imxrt_enc_clock_enable (uint32_t base);
 static void imxrt_enc_clock_disable (uint32_t base);
 
-static inline int  imxrt_enc_sem_wait(
-    FAR struct imxrt_enc_lowerhalf_s *priv);
-static inline void imxrt_enc_sem_post(
-    FAR struct imxrt_enc_lowerhalf_s *priv);
+static inline int imxrt_enc_sem_wait(FAR struct imxrt_enc_lowerhalf_s *priv);
+static inline void imxrt_enc_sem_post
+                    (FAR struct imxrt_enc_lowerhalf_s *priv);
 
 static int imxrt_enc_reconfig(FAR struct imxrt_enc_lowerhalf_s *priv,
-              uint16_t args);
+                              uint16_t args);
 static void imxrt_enc_set_initial_val(FAR struct imxrt_enc_lowerhalf_s *priv,
-              uint32_t value);
+                                      uint32_t value);
 static void imxrt_enc_modulo_enable(FAR struct imxrt_enc_lowerhalf_s *priv,
-              uint32_t modulus);
+                                    uint32_t modulus);
 static void imxrt_enc_modulo_disable(FAR struct imxrt_enc_lowerhalf_s *priv);
 
 #ifdef CONFIG_DEBUG_SENSORS
 static int imxrt_enc_test_gen(FAR struct imxrt_enc_lowerhalf_s *priv,
-              uint16_t value);
+                              uint16_t value);
 #endif
 
 /* Lower-half Quadrature Encoder Driver Methods */
@@ -326,7 +325,7 @@ static int imxrt_position(FAR struct qe_lowerhalf_s *lower,
                           FAR int32_t *pos);
 static int imxrt_reset(FAR struct qe_lowerhalf_s *lower);
 static int imxrt_ioctl(FAR struct qe_lowerhalf_s *lower, int cmd,
-              unsigned long arg);
+                       unsigned long arg);
 
 /****************************************************************************
  * Private Data
@@ -341,6 +340,7 @@ static const struct qe_ops_s g_qecallbacks =
   .position  = imxrt_position,
   .setposmax = NULL,            /* not supported yet */
   .reset     = imxrt_reset,
+  .setindex  = NULL,            /* not supported yet */
   .ioctl     = imxrt_ioctl,
 };
 
@@ -513,7 +513,7 @@ static inline void imxrt_enc_modifyreg16
  *
  ****************************************************************************/
 
-void imxrt_enc_clock_enable (uint32_t base)
+void imxrt_enc_clock_enable(uint32_t base)
 {
   if (base == IMXRT_ENC1_BASE)
     {
@@ -545,7 +545,7 @@ void imxrt_enc_clock_enable (uint32_t base)
  *
  ****************************************************************************/
 
-void imxrt_enc_clock_disable (uint32_t base)
+void imxrt_enc_clock_disable(uint32_t base)
 {
   if (base == IMXRT_ENC1_BASE)
     {
@@ -612,7 +612,7 @@ static inline void imxrt_enc_sem_post(struct imxrt_enc_lowerhalf_s *priv)
  ****************************************************************************/
 
 static int imxrt_enc_reconfig(FAR struct imxrt_enc_lowerhalf_s *priv,
-                                uint16_t args)
+                              uint16_t args)
 {
   uint16_t clear = 0;
   uint16_t set = 0;
@@ -773,7 +773,7 @@ static void imxrt_enc_modulo_disable(FAR struct imxrt_enc_lowerhalf_s *priv)
  ****************************************************************************/
 
 static int imxrt_enc_test_gen(FAR struct imxrt_enc_lowerhalf_s *priv,
-                                uint16_t value)
+                              uint16_t value)
 {
   if (value >> 9)
     {
@@ -1024,7 +1024,7 @@ static int imxrt_reset(FAR struct qe_lowerhalf_s *lower)
  ****************************************************************************/
 
 static int imxrt_ioctl(FAR struct qe_lowerhalf_s *lower, int cmd,
-              unsigned long arg)
+                       unsigned long arg)
 {
   struct imxrt_enc_lowerhalf_s *priv = (struct imxrt_enc_lowerhalf_s *)lower;
   switch (cmd)

--- a/arch/arm/src/sam34/sam4cm_tc.c
+++ b/arch/arm/src/sam34/sam4cm_tc.c
@@ -476,7 +476,7 @@ static bool sam_checkreg(struct sam_chan_s *chan, bool wr, uint32_t regaddr,
  * Name: sam_chan_getreg
  *
  * Description:
- *  Read an SPI register
+ *  Read an TC register
  *
  ****************************************************************************/
 
@@ -500,7 +500,7 @@ static inline uint32_t sam_chan_getreg(struct sam_chan_s *chan,
  * Name: sam_chan_putreg
  *
  * Description:
- *  Write a value to an SPI register
+ *  Write a value to an TC register
  *
  ****************************************************************************/
 

--- a/arch/arm/src/sama5/sam_tc.c
+++ b/arch/arm/src/sama5/sam_tc.c
@@ -587,7 +587,7 @@ static bool sam_checkreg(struct sam_tc_s *tc, bool wr, uint32_t regaddr,
  * Name: sam_tc_getreg
  *
  * Description:
- *  Read an SPI register
+ *  Read an TC register
  *
  ****************************************************************************/
 
@@ -612,7 +612,7 @@ static inline uint32_t sam_tc_getreg(struct sam_chan_s *chan,
  * Name: sam_tc_putreg
  *
  * Description:
- *  Write a value to an SPI register
+ *  Write a value to an TC register
  *
  ****************************************************************************/
 
@@ -636,7 +636,7 @@ static inline void sam_tc_putreg(struct sam_chan_s *chan, uint32_t regval,
  * Name: sam_chan_getreg
  *
  * Description:
- *  Read an SPI register
+ *  Read an TC channel register
  *
  ****************************************************************************/
 
@@ -660,7 +660,7 @@ static inline uint32_t sam_chan_getreg(struct sam_chan_s *chan,
  * Name: sam_chan_putreg
  *
  * Description:
- *  Write a value to an SPI register
+ *  Write a value to an TC channel register
  *
  ****************************************************************************/
 

--- a/arch/arm/src/samv7/sam_tc.c
+++ b/arch/arm/src/samv7/sam_tc.c
@@ -737,7 +737,7 @@ static bool sam_checkreg(struct sam_tc_s *tc, bool wr, uint32_t regaddr,
  * Name: sam_tc_getreg
  *
  * Description:
- *  Read an SPI register
+ *  Read an TC register
  *
  ****************************************************************************/
 
@@ -762,7 +762,7 @@ static inline uint32_t sam_tc_getreg(struct sam_chan_s *chan,
  * Name: sam_tc_putreg
  *
  * Description:
- *  Write a value to an SPI register
+ *  Write a value to an TC register
  *
  ****************************************************************************/
 
@@ -786,7 +786,7 @@ static inline void sam_tc_putreg(struct sam_chan_s *chan, uint32_t regval,
  * Name: sam_chan_getreg
  *
  * Description:
- *  Read an SPI register
+ *  Read an TC channel register
  *
  ****************************************************************************/
 
@@ -810,7 +810,7 @@ static inline uint32_t sam_chan_getreg(struct sam_chan_s *chan,
  * Name: sam_chan_putreg
  *
  * Description:
- *  Write a value to an SPI register
+ *  Write a value to an TC channel register
  *
  ****************************************************************************/
 

--- a/arch/arm/src/stm32f7/stm32_qencoder.c
+++ b/arch/arm/src/stm32f7/stm32_qencoder.c
@@ -224,15 +224,15 @@ struct stm32_lowerhalf_s
 static uint16_t stm32_getreg16(FAR struct stm32_lowerhalf_s *priv,
                                int offset);
 static void stm32_putreg16(FAR struct stm32_lowerhalf_s *priv, int offset,
-              uint16_t value);
+                           uint16_t value);
 static uint32_t stm32_getreg32(FAR struct stm32_lowerhalf_s *priv,
                                int offset);
 static void stm32_putreg32(FAR struct stm32_lowerhalf_s *priv, int offset,
-              uint32_t value);
+                           uint32_t value);
 
 #if defined(CONFIG_DEBUG_SENSORS) && defined(CONFIG_DEBUG_INFO)
 static void stm32_dumpregs(FAR struct stm32_lowerhalf_s *priv,
-              FAR const char *msg);
+                           FAR const char *msg);
 #else
 #  define stm32_dumpregs(priv,msg)
 #endif
@@ -253,7 +253,7 @@ static int stm32_position(FAR struct qe_lowerhalf_s *lower,
                           FAR int32_t *pos);
 static int stm32_reset(FAR struct qe_lowerhalf_s *lower);
 static int stm32_ioctl(FAR struct qe_lowerhalf_s *lower, int cmd,
-              unsigned long arg);
+                       unsigned long arg);
 
 /****************************************************************************
  * Private Data
@@ -268,6 +268,7 @@ static const struct qe_ops_s g_qecallbacks =
   .position  = stm32_position,
   .setposmax = NULL,            /* not supported yet */
   .reset     = stm32_reset,
+  .setindex  = NULL,            /* not supported yet */
   .ioctl     = stm32_ioctl,
 };
 

--- a/arch/arm/src/stm32h7/stm32_qencoder.c
+++ b/arch/arm/src/stm32h7/stm32_qencoder.c
@@ -224,15 +224,15 @@ struct stm32_lowerhalf_s
 static uint16_t stm32_getreg16(FAR struct stm32_lowerhalf_s *priv,
                                int offset);
 static void stm32_putreg16(FAR struct stm32_lowerhalf_s *priv, int offset,
-              uint16_t value);
+                           uint16_t value);
 static uint32_t stm32_getreg32(FAR struct stm32_lowerhalf_s *priv,
                                int offset);
 static void stm32_putreg32(FAR struct stm32_lowerhalf_s *priv, int offset,
-              uint32_t value);
+                           uint32_t value);
 
 #if defined(CONFIG_DEBUG_SENSORS) && defined(CONFIG_DEBUG_INFO)
 static void stm32_dumpregs(FAR struct stm32_lowerhalf_s *priv,
-              FAR const char *msg);
+                           FAR const char *msg);
 #else
 #  define stm32_dumpregs(priv,msg)
 #endif
@@ -253,7 +253,7 @@ static int stm32_position(FAR struct qe_lowerhalf_s *lower,
                           FAR int32_t *pos);
 static int stm32_reset(FAR struct qe_lowerhalf_s *lower);
 static int stm32_ioctl(FAR struct qe_lowerhalf_s *lower, int cmd,
-              unsigned long arg);
+                       unsigned long arg);
 
 /****************************************************************************
  * Private Data
@@ -268,6 +268,7 @@ static const struct qe_ops_s g_qecallbacks =
   .position  = stm32_position,
   .setposmax = NULL,            /* not supported yet */
   .reset     = stm32_reset,
+  .setindex  = NULL,            /* not supported yet */
   .ioctl     = stm32_ioctl,
 };
 

--- a/arch/arm/src/stm32l4/stm32l4_qencoder.c
+++ b/arch/arm/src/stm32l4/stm32l4_qencoder.c
@@ -247,8 +247,8 @@ static int stm32l4_shutdown(FAR struct qe_lowerhalf_s *lower);
 static int stm32l4_position(FAR struct qe_lowerhalf_s *lower,
                             FAR int32_t *pos);
 static int stm32l4_reset(FAR struct qe_lowerhalf_s *lower);
-static int stm32l4_ioctl(FAR struct qe_lowerhalf_s *lower,
-                         int cmd, unsigned long arg);
+static int stm32l4_ioctl(FAR struct qe_lowerhalf_s *lower, int cmd,
+                         unsigned long arg);
 
 /****************************************************************************
  * Private Data
@@ -263,6 +263,7 @@ static const struct qe_ops_s g_qecallbacks =
   .position  = stm32l4_position,
   .setposmax = NULL,            /* not supported yet */
   .reset     = stm32l4_reset,
+  .setindex  = NULL,            /* not supported yet */
   .ioctl     = stm32l4_ioctl,
 };
 

--- a/arch/arm/src/tiva/common/tiva_qencoder.c
+++ b/arch/arm/src/tiva/common/tiva_qencoder.c
@@ -112,6 +112,7 @@ static const struct qe_ops_s g_qe_ops =
   .position  = tiva_qe_position,
   .setposmax = NULL,            /* not supported yet */
   .reset     = tiva_qe_reset,
+  .setindex  = NULL,            /* not supported yet */
   .ioctl     = tiva_qe_ioctl,
 };
 

--- a/drivers/sensors/as5048b.c
+++ b/drivers/sensors/as5048b.c
@@ -91,11 +91,13 @@ static int as5048b_ioctl(FAR struct qe_lowerhalf_s *lower, int cmd,
 
 static const struct qe_ops_s g_qeops =
 {
-  as5048b_setup,
-  as5048b_shutdown,
-  as5048b_position,
-  as5048b_reset,
-  as5048b_ioctl
+  .setup     = as5048b_setup,
+  .shutdown  = as5048b_shutdown,
+  .position  = as5048b_position,
+  .setposmax = NULL,            /* not supported yet */
+  .reset     = as5048b_reset,
+  .setindex  = NULL,            /* not supported yet */
+  .ioctl     = as5048b_ioctl
 };
 
 /****************************************************************************


### PR DESCRIPTION
## Summary
AS5048B quadrature encoder lower half struct is initialized in a wrong way, so improper handlers are assigned.

## Impact
AS5048B users

## Testing
Pass CI
