### PR TITLE
SocketCAN: minor fixes

### DIFF
--- a/include/nuttx/can.h
+++ b/include/nuttx/can.h
@@ -18,12 +18,14 @@
  *
  ****************************************************************************/
 
-#ifndef __INCLUDE_NUTTX_CAN_CAN_H
-#define __INCLUDE_NUTTX_CAN_CAN_H
+#ifndef __INCLUDE_NUTTX_CAN_H
+#define __INCLUDE_NUTTX_CAN_H
 
 /****************************************************************************
  * Included Files
  ****************************************************************************/
+
+#include <nuttx/config.h>
 
 #ifdef CONFIG_CAN_TXREADY
 #  include <nuttx/wqueue.h>
@@ -307,4 +309,4 @@ extern "C"
 #endif
 
 #endif /* CONFIG_CAN */
-#endif /* __INCLUDE_NUTTX_CAN_CAN_H */
+#endif /* __INCLUDE_NUTTX_CAN_H */

--- a/net/can/can_recvmsg.c
+++ b/net/can/can_recvmsg.c
@@ -410,7 +410,10 @@ static uint16_t can_recvfrom_eventhandler(FAR struct net_driver_s *dev,
                                           FAR void *pvpriv, uint16_t flags)
 {
   struct can_recvfrom_s *pstate = (struct can_recvfrom_s *)pvpriv;
+#if defined(CONFIG_NET_CANPROTO_OPTIONS) || defined(CONFIG_NET_CAN_CANFD) || \
+  defined(CONFIG_NET_TIMESTAMP)
   struct can_conn_s *conn = (struct can_conn_s *)pstate->pr_sock->s_conn;
+#endif
 
   /* 'priv' might be null in some race conditions (?) */
 

--- a/net/devif/devif_cansend.c
+++ b/net/devif/devif_cansend.c
@@ -83,7 +83,7 @@
 void devif_can_send(FAR struct net_driver_s *dev, FAR const void *buf,
                     unsigned int len)
 {
-  DEBUGASSERT(dev && len > 0 && len < NETDEV_PKTSIZE(dev));
+  DEBUGASSERT(dev && len > 0 && len <= NETDEV_PKTSIZE(dev));
 
   /* Copy the data into the device packet buffer */
 


### PR DESCRIPTION
## Summary

- net/can/can_recvmsg.c: fix warning
- include/nuttx/can.h: include nuttx/config.h
- net/devif/devif_cansend.c: fix assertion for max data len

## Impact

## Testing
SocketCAN on stm32
