### PR TITLE
Improve dependencies for include/nuttx/version.h

### DIFF
--- a/tools/Makefile.unix
+++ b/tools/Makefile.unix
@@ -42,10 +42,12 @@ CONFIG_VERSION_BUILD ?= "0"
 VERSION_ARG = -v $(CONFIG_VERSION_STRING) -b $(CONFIG_VERSION_BUILD)
 else
 
-# Generate .version every time from GIT history
+# Generate .version.tmp every time from GIT history
+# Only update .version if the contents of version.tmp actually changes
+# Note: this is executed before any rule is run
 
-.PHONY: $(TOPDIR)/.version
-
+$(shell tools/version.sh .version.tmp)
+$(shell $(call TESTANDREPLACEFILE, .version.tmp, .version))
 endif
 
 # Process architecture specific directories
@@ -225,8 +227,7 @@ $(TOPDIR)/.version:
 
 include/nuttx/version.h: $(TOPDIR)/.version tools/mkversion$(HOSTEXEEXT)
 	$(Q) echo "Create version.h"
-	$(Q) tools/mkversion $(TOPDIR) > $@.tmp
-	$(Q) $(call TESTANDREPLACEFILE, $@.tmp, $@)
+	$(Q) tools/mkversion $(TOPDIR) > $@
 
 # Targets used to build include/nuttx/config.h.  Creation of config.h is
 # part of the overall NuttX configuration sequence. Notice that the


### PR DESCRIPTION
## Summary
`include/nuttx/version.h` is dependent on `.version`, which needs to run for every invocation of make, since git info can update at any time.
Currently the `.version` target is PHONY, thus making `include/nuttx/version.h` and `context` targets (and every target that depends on `context`) have to run every time.

## Impact
This PR modifies `.version` so it's a real rule. Additionally, `tools/version.sh` is run every invocation of make. This maintains the current behavior while preventing some targets from needlessly running every time

## Testing
Verified `.version` changed appropriately when git's commit changed.
Verified `include/nuttx/version.h` changed appropriately only when a new `.version` file was generated 