### PR TITLE
xtensa: Rename up_stack_color to xtensa_stack_color.

### DIFF
--- a/arch/xtensa/src/common/xtensa.h
+++ b/arch/xtensa/src/common/xtensa.h
@@ -344,7 +344,7 @@ void xtensa_pminitialize(void);
 /* Debug ********************************************************************/
 
 #ifdef CONFIG_STACK_COLORATION
-void up_stack_color(void *stackbase, size_t nbytes);
+void xtensa_stack_color(void *stackbase, size_t nbytes);
 #endif
 
 #endif /* __ASSEMBLY__ */

--- a/arch/xtensa/src/common/xtensa_createstack.c
+++ b/arch/xtensa/src/common/xtensa_createstack.c
@@ -251,7 +251,7 @@ int up_create_stack(struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
        * water marks.
        */
 
-      up_stack_color(tcb->stack_base_ptr, tcb->adj_stack_size);
+      xtensa_stack_color(tcb->stack_base_ptr, tcb->adj_stack_size);
 #endif
       tcb->flags |= TCB_FLAG_FREE_STACK;
 
@@ -263,7 +263,7 @@ int up_create_stack(struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
 }
 
 /****************************************************************************
- * Name: up_stack_color
+ * Name: xtensa_stack_color
  *
  * Description:
  *   Write a well know value into the stack
@@ -271,7 +271,7 @@ int up_create_stack(struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
  ****************************************************************************/
 
 #ifdef CONFIG_STACK_COLORATION
-void up_stack_color(void *stackbase, size_t nbytes)
+void xtensa_stack_color(void *stackbase, size_t nbytes)
 {
   uintptr_t start;
   uintptr_t end;

--- a/arch/xtensa/src/common/xtensa_initialstate.c
+++ b/arch/xtensa/src/common/xtensa_initialstate.c
@@ -72,7 +72,7 @@ void up_initial_state(struct tcb_s *tcb)
        * water marks.
        */
 
-      up_stack_color(tcb->stack_alloc_ptr, 0);
+      xtensa_stack_color(tcb->stack_alloc_ptr, 0);
 #endif /* CONFIG_STACK_COLORATION */
     }
 

--- a/arch/xtensa/src/common/xtensa_usestack.c
+++ b/arch/xtensa/src/common/xtensa_usestack.c
@@ -132,7 +132,7 @@ int up_use_stack(struct tcb_s *tcb, void *stack, size_t stack_size)
    * water marks.
    */
 
-  up_stack_color(tcb->stack_base_ptr, tcb->adj_stack_size);
+  xtensa_stack_color(tcb->stack_base_ptr, tcb->adj_stack_size);
 #endif
 
   return OK;


### PR DESCRIPTION
## Summary
The function is internal to the Xtensa arch and should have the arch as prefix.
## Impact
N/A
## Testing
Code still builds.
