### PR TITLE
risc-v/opensbi: update to version 1.0

### DIFF
--- a/arch/risc-v/src/opensbi/Make.defs
+++ b/arch/risc-v/src/opensbi/Make.defs
@@ -32,10 +32,10 @@ OPENSBI_ASRCS += opensbi/opensbi-3rdparty/lib/sbi/sbi_expected_trap.S
 OPENSBI_ASRCS += opensbi/opensbi-3rdparty/lib/sbi/sbi_hfence.S
 
 OPENSBI_UNPACK  = opensbi-3rdparty
-OPENSBI_COMMIT  = 69d7e536138ae71a24028ca849d401a4d64d564b
+OPENSBI_COMMIT  = 48f91ee9c960f048c4a7d1da4447d31e04931e38
 OPENSBI_URL     = https://github.com/riscv-software-src/opensbi/tarball
 OPENSBI_TARBALL = opensbi.tar.gz
-OPENSBI_DIR     = riscv-software-src-opensbi-69d7e53
+OPENSBI_DIR     = riscv-software-src-opensbi-48f91ee
 
 $(OPENSBI_TARBALL):
 	$(Q) echo "Downloading: OpenSBI"


### PR DESCRIPTION
OpenSBI recently introduced version 1.0. Use the latest
version here as well.

Signed-off-by: Eero Nurkkala <eero.nurkkala@offcode.fi>

## Summary

OpenSBI commit d30bde3 fixed issues with memcpy / memcmp ending up in the library's context via weak aliasing. OpenSBI versioned with 1.0.

## Impact

No impact

## Testing

Polarfire Icicle kit