### PR TITLE
tools/mpfs: prepare OpenSBI image

### DIFF
--- a/boards/risc-v/mpfs/icicle/scripts/Make.defs
+++ b/boards/risc-v/mpfs/icicle/scripts/Make.defs
@@ -20,6 +20,7 @@
 
 include $(TOPDIR)/.config
 include $(TOPDIR)/tools/Config.mk
+include $(TOPDIR)/tools/mpfs/Config.mk
 include $(TOPDIR)/arch/risc-v/src/common/Toolchain.defs
 
 ifeq ($(CONFIG_MPFS_BOOTLOADER),y)

--- a/tools/mpfs/Config.mk
+++ b/tools/mpfs/Config.mk
@@ -1,0 +1,37 @@
+############################################################################
+# tools/mpfs/Config.mk
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+# These are the macros that will be used in the NuttX make system to compile
+# and assembly source files and to insert the resulting object files into an
+# archive.  These replace the default definitions at tools/Config.mk
+
+# POSTBUILD -- Perform post build operations
+
+ifeq ($(CONFIG_MPFS_OPENSBI),y)
+define POSTBUILD
+	$(Q) echo "SBI: Creating nuttx.sbi file"
+	$(Q) $(OBJCOPY) -O binary -j .text.sbi -j .ddrstorage $(BIN) nuttx.sbi
+	$(Q) ([ $$? -eq 0 ] && echo "Done.")
+	$(Q) echo nuttx.sbi >> nuttx.manifest
+	$(Q) echo "SBI: Removing unnecessary sections from nuttx binary"
+	$(Q) $(OBJCOPY) -O binary -R .text.sbi -R .l2_scratchpad -R .ddrstorage $(BIN) nuttx.bin
+	$(Q) ([ $$? -eq 0 ] && echo "Done.")
+endef
+endif


### PR DESCRIPTION
Polarfire Icicle board has only (128K - 256) bytes for the bootloader
in the non-volatile eNVM. This space is barely enough for running NuttX.
If OpenSBI is selected, it will be placed in DDR. This all means the
nuttx.bin file grows into gigabyte size, filling the unused space (ddr -
envm) with zeroes.

The memory layout is as follows:

MEMORY
{
    ddr  (rx)          : ORIGIN = 0x80000000, LENGTH = 4M
    envm (rx)          : ORIGIN = 0x20220100, LENGTH = 128K - 256
    l2lim  (rwx)       : ORIGIN = 0x08000000, LENGTH = 1024k
    l2zerodevice (rwx) : ORIGIN = 0x0A000000, LENGTH = 512k
}

OpenSBI library is used as a separate binary, which is stored into
eMMC or SD-card. It is then loaded into its precise location in DDR.

Thus, we separate OpenSBI from NuttX and end up with two images
by utilizing the objcopy options:

  --only-section=sectionpattern (-j in short)
  --remove-section=sectionpattern (-R in short)

This is only valid when CONFIG_MPFS_OPENSBI is set.

Signed-off-by: Eero Nurkkala <eero.nurkkala@offcode.fi>

## Summary

This step is currently required for MPFS.

## Impact

## Testing

Polarfire Icicle board.