### PR TITLE
net/usrsock: add support for CONFIG_NET_ALLOC_CONNS

### DIFF
--- a/net/usrsock/usrsock_conn.c
+++ b/net/usrsock/usrsock_conn.c
@@ -33,6 +33,7 @@
 
 #include <arch/irq.h>
 
+#include <nuttx/kmalloc.h>
 #include <nuttx/semaphore.h>
 #include <nuttx/net/netconfig.h>
 #include <nuttx/net/net.h>
@@ -45,7 +46,9 @@
 
 /* The array containing all usrsock connections. */
 
+#ifndef CONFIG_NET_ALLOC_CONNS
 static struct usrsock_conn_s g_usrsock_connections[CONFIG_NET_USRSOCK_CONNS];
+#endif
 
 /* A list of all free usrsock connections */
 
@@ -94,23 +97,36 @@ static void _usrsock_semgive(FAR sem_t *sem)
 FAR struct usrsock_conn_s *usrsock_alloc(void)
 {
   FAR struct usrsock_conn_s *conn;
+#ifdef CONFIG_NET_ALLOC_CONNS
+  int i;
+#endif
 
   /* The free list is protected by a semaphore (that behaves like a mutex). */
 
   _usrsock_semtake(&g_free_sem);
+#ifdef CONFIG_NET_ALLOC_CONNS
+  if (dq_peek(&g_free_usrsock_connections) == NULL)
+    {
+      conn = kmm_zalloc(sizeof(*conn) * CONFIG_NET_USRSOCK_CONNS);
+      if (conn != NULL)
+        {
+          for (i = 0; i < CONFIG_NET_USRSOCK_CONNS; i++)
+            {
+              dq_addlast(&conn[i].node, &g_free_usrsock_connections);
+            }
+        }
+    }
+#endif
+
   conn = (FAR struct usrsock_conn_s *)
-    dq_remfirst(&g_free_usrsock_connections);
+         dq_remfirst(&g_free_usrsock_connections);
   if (conn)
     {
       /* Make sure that the connection is marked as uninitialized */
 
-      memset(conn, 0, sizeof(*conn));
       nxsem_init(&conn->resp.sem, 0, 1);
-      conn->dev = NULL;
       conn->usockid = -1;
       conn->state = USRSOCK_CONN_STATE_UNINITIALIZED;
-      conn->list = NULL;
-      conn->connected = false;
 
       /* Enqueue the connection into the active list */
 
@@ -146,10 +162,6 @@ void usrsock_free(FAR struct usrsock_conn_s *conn)
 
   nxsem_destroy(&conn->resp.sem);
   memset(conn, 0, sizeof(*conn));
-  conn->dev = NULL;
-  conn->usockid = -1;
-  conn->state = USRSOCK_CONN_STATE_UNINITIALIZED;
-  conn->list = NULL;
 
   /* Free the connection */
 
@@ -232,10 +244,10 @@ int usrsock_setup_request_callback(FAR struct usrsock_conn_s *conn,
   nxsem_init(&pstate->recvsem, 0, 0);
   nxsem_set_protocol(&pstate->recvsem, SEM_PRIO_NONE);
 
-  pstate->conn   = conn;
-  pstate->result = -EAGAIN;
+  pstate->conn      = conn;
+  pstate->result    = -EAGAIN;
   pstate->completed = false;
-  pstate->unlock = false;
+  pstate->unlock    = false;
 
   /* Set up the callback in the connection */
 
@@ -330,7 +342,10 @@ void usrsock_setup_datain(FAR struct usrsock_conn_s *conn,
 
 void usrsock_initialize(void)
 {
+#ifndef CONFIG_NET_ALLOC_CONNS
+  FAR struct usrsock_conn_s *conn;
   int i;
+#endif
 
   /* Initialize the queues */
 
@@ -338,20 +353,18 @@ void usrsock_initialize(void)
   dq_init(&g_active_usrsock_connections);
   nxsem_init(&g_free_sem, 0, 1);
 
+#ifndef CONFIG_NET_ALLOC_CONNS
   for (i = 0; i < CONFIG_NET_USRSOCK_CONNS; i++)
     {
-      FAR struct usrsock_conn_s *conn = &g_usrsock_connections[i];
+      conn = &g_usrsock_connections[i];
 
       /* Mark the connection closed and move it to the free list */
 
-      memset(conn, 0, sizeof(*conn));
-      conn->dev     = NULL;
       conn->usockid = -1;
       conn->state   = USRSOCK_CONN_STATE_UNINITIALIZED;
-      conn->list    = NULL;
-      conn->flags   = 0;
       dq_addlast(&conn->node, &g_free_usrsock_connections);
     }
+#endif
 
   /* Register /dev/usrsock character device. */
 


### PR DESCRIPTION
## Summary

net/usrsock: add support for CONFIG_NET_ALLOC_CONNS

## Impact

N/A

Depends on:
https://github.com/apache/incubator-nuttx/pull/5154
https://github.com/apache/incubator-nuttx-apps/pull/956

## Testing

CI-check