### PR TITLE
fs/romfs: remove the error single list and using reference 

### DIFF
--- a/fs/romfs/fs_romfs.c
+++ b/fs/romfs/fs_romfs.c
@@ -271,14 +271,7 @@ static int romfs_open(FAR struct file *filep, FAR const char *relpath,
 
   filep->f_priv = rf;
 
-  /* Then insert the new instance into the mountpoint structure.
-   * It needs to be there (1) to handle error conditions that effect
-   * all files, and (2) to inform the umount logic that we are busy
-   * (but a simple reference count could have done that).
-   */
-
-  rf->rf_next = rm->rm_head;
-  rm->rm_head = rf->rf_next;
+  rm->rm_refs++;
 
   romfs_semgive(rm);
   return OK;
@@ -298,7 +291,7 @@ static int romfs_close(FAR struct file *filep)
 {
   FAR struct romfs_mountpt_s *rm;
   FAR struct romfs_file_s    *rf;
-  int                         ret = OK;
+  int                         ret;
 
   finfo("Closing\n");
 
@@ -312,6 +305,15 @@ static int romfs_close(FAR struct file *filep)
   rm = filep->f_inode->i_private;
 
   DEBUGASSERT(rm != NULL);
+
+  ret = romfs_semtake(rm);
+  if (ret < 0)
+    {
+      return ret;
+    }
+
+  rm->rm_refs--;
+  romfs_semgive(rm);
 
   /* Do not check if the mount is healthy.  We must support closing of
    * the file even when there is healthy mount.
@@ -681,14 +683,7 @@ static int romfs_dup(FAR const struct file *oldp, FAR struct file *newp)
 
   newp->f_priv = newrf;
 
-  /* Then insert the new instance into the mountpoint structure.
-   * It needs to be there (1) to handle error conditions that effect
-   * all files, and (2) to inform the umount logic that we are busy
-   * (but a simple reference count could have done that).
-   */
-
-  newrf->rf_next = rm->rm_head;
-  rm->rm_head = newrf->rf_next;
+  rm->rm_refs++;
 
   romfs_semgive(rm);
   return OK;
@@ -1091,7 +1086,7 @@ static int romfs_unbind(FAR void *handle, FAR struct inode **blkdriver,
       return ret;
     }
 
-  if (rm->rm_head)
+  if (rm->rm_refs)
     {
       /* We cannot unmount now.. there are open files */
 

--- a/fs/romfs/fs_romfs.h
+++ b/fs/romfs/fs_romfs.h
@@ -126,18 +126,17 @@
 struct romfs_file_s;
 struct romfs_mountpt_s
 {
-  struct inode        *rm_blkdriver; /* The block driver inode that hosts the FAT32 fs */
-  struct romfs_file_s *rm_head;      /* A list to all files opened on this mountpoint */
-
-  bool     rm_mounted;              /* true: The file system is ready */
-  uint16_t rm_hwsectorsize;         /* HW: Sector size reported by block driver */
-  sem_t    rm_sem;                  /* Used to assume thread-safe access */
-  uint32_t rm_rootoffset;           /* Saved offset to the first root directory entry */
-  uint32_t rm_hwnsectors;           /* HW: The number of sectors reported by the hardware */
-  uint32_t rm_volsize;              /* Size of the ROMFS volume */
-  uint32_t rm_cachesector;          /* Current sector in the rm_buffer */
-  uint8_t *rm_xipbase;              /* Base address of directly accessible media */
-  uint8_t *rm_buffer;               /* Device sector buffer, allocated if rm_xipbase==0 */
+  struct inode *rm_blkdriver; /* The block driver inode that hosts the FAT32 fs */
+  bool     rm_mounted;        /* true: The file system is ready */
+  uint16_t rm_hwsectorsize;   /* HW: Sector size reported by block driver */
+  sem_t    rm_sem;            /* Used to assume thread-safe access */
+  uint32_t rm_refs;           /* The references for all files opened on this mountpoint */
+  uint32_t rm_rootoffset;     /* Saved offset to the first root directory entry */
+  uint32_t rm_hwnsectors;     /* HW: The number of sectors reported by the hardware */
+  uint32_t rm_volsize;        /* Size of the ROMFS volume */
+  uint32_t rm_cachesector;    /* Current sector in the rm_buffer */
+  uint8_t *rm_xipbase;        /* Base address of directly accessible media */
+  uint8_t *rm_buffer;         /* Device sector buffer, allocated if rm_xipbase==0 */
 };
 
 /* This structure represents on open file under the mountpoint.  An instance
@@ -147,7 +146,6 @@ struct romfs_mountpt_s
 
 struct romfs_file_s
 {
-  FAR struct romfs_file_s *rf_next; /* Retained in a singly linked list */
   uint32_t rf_startoffset;          /* Offset to the start of the file data */
   uint32_t rf_size;                 /* Size of the file in bytes */
   uint32_t rf_cachesector;          /* Current sector in the rf_buffer */

--- a/fs/romfs/fs_romfsutil.c
+++ b/fs/romfs/fs_romfsutil.c
@@ -169,7 +169,7 @@ int16_t romfs_devcacheread(struct romfs_mountpt_s *rm, uint32_t offset)
   int      ret;
 
   /* rm->rm_cachesector holds the current sector that is buffer in or
-   * referenced by rm->tm_buffer. If the requested sector is the same as this
+   * referenced by rm->rm_buffer. If the requested sector is the same as this
    * this then we do nothing.
    */
 


### PR DESCRIPTION
## Summary
fs/romfs: remove the error single list and using reference to manager file opened.
## Impact
N/A
## Testing
daily test
