### PR TITLE
socket: extend socket_storage for rpmsg_socket addrinfo

### DIFF
--- a/include/sys/socket.h
+++ b/include/sys/socket.h
@@ -284,23 +284,13 @@
  * aligned at an appropriate boundary so that pointers to it can be cast
  * as pointers to protocol-specific address structures and used to access
  * the fields of those structures without alignment problems.
- *
- * REVISIT: sizeof(struct sockaddr_storge) should be 128 bytes.
  */
 
-#ifdef CONFIG_NET_IPv6
 struct sockaddr_storage
 {
   sa_family_t ss_family;       /* Address family */
-  char        ss_data[26];     /* 26-bytes of address data */
+  char        ss_data[126];    /* 126-bytes of address data */
 };
-#else
-struct sockaddr_storage
-{
-  sa_family_t ss_family;       /* Address family */
-  char        ss_data[14];     /* 14-bytes of address data */
-};
-#endif
 
 /* The sockaddr structure is used to define a socket address which is used
  * in the bind(), connect(), getpeername(), getsockname(), recvfrom(), and


### PR DESCRIPTION


## Summary
Extend socket_storage to fix compile warning about rexecd.

rexecd.c: In function 'rexecd_main':
rexecd.c:191:9: warning: array subscript 18 is outside array bounds of 'struct sockaddr_storage[1]' [-Warray-bounds]
  191 |         snprintf(((FAR struct sockaddr_rpmsg *)&addr)->rp_name,
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  192 |                  RPMSG_SOCKET_NAME_SIZE, "%d", REXECD_PORT);
      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
rexecd.c:142:27: note: while referencing 'addr'
  142 |   struct sockaddr_storage addr;

Signed-off-by: Jiuzhu Dong <dongjiuzhu1@xiaomi.com>
## Impact
fix compile warning
## Testing
daily test
