### PR TITLE
arch/risc-v: Replace __LP64__ with CONFIG_ARCH_RV64

### DIFF
--- a/arch/risc-v/include/inttypes.h
+++ b/arch/risc-v/include/inttypes.h
@@ -29,7 +29,7 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-#if defined(__LP64__)
+#if defined(CONFIG_ARCH_RV64)
 #define _PRI32PREFIX
 #define _PRI64PREFIX "l"
 #define _PRIPTRPREFIX "l"
@@ -40,7 +40,7 @@
 #define INT64_C(x)  x ## l
 #define UINT32_C(x) x ## u
 #define UINT64_C(x) x ## ul
-#else /* defined(__LP64__) */
+#else /* defined(CONFIG_ARCH_RV64) */
 #define _PRI32PREFIX "l"
 #define _PRI64PREFIX "ll"
 #define _PRIPTRPREFIX
@@ -51,7 +51,7 @@
 #define INT64_C(x)  x ## ll
 #define UINT32_C(x) x ## ul
 #define UINT64_C(x) x ## ull
-#endif /* defined(__LP64__) */
+#endif /* defined(CONFIG_ARCH_RV64) */
 
 #define PRId8       "d"
 #define PRId16      "d"

--- a/arch/risc-v/include/spinlock.h
+++ b/arch/risc-v/include/spinlock.h
@@ -78,11 +78,7 @@
  * RISC-V architecture supports fence instruction to ensure memory ordering
  */
 
-#ifdef __LP64__
-typedef uint64_t spinlock_t;
-#else
-typedef uint32_t spinlock_t;
-#endif
+typedef uintptr_t spinlock_t;
 
 /****************************************************************************
  * Public Function Prototypes

--- a/arch/risc-v/include/types.h
+++ b/arch/risc-v/include/types.h
@@ -54,19 +54,19 @@ typedef unsigned char      _uint8_t;
 typedef signed short       _int16_t;
 typedef unsigned short     _uint16_t;
 
-#ifdef __LP64__
+#ifdef CONFIG_ARCH_RV64
 typedef signed int         _int32_t;
 typedef unsigned int       _uint32_t;
 
 typedef signed long        _int64_t;
 typedef unsigned long      _uint64_t;
-#else /* __LP64__ */
+#else /* CONFIG_ARCH_RV64 */
 typedef signed long        _int32_t;
 typedef unsigned long      _uint32_t;
 
 typedef signed long long   _int64_t;
 typedef unsigned long long _uint64_t;
-#endif /* __LP64__ */
+#endif /* CONFIG_ARCH_RV64 */
 #define __INT64_DEFINED
 
 typedef _int64_t           _intmax_t;
@@ -78,7 +78,7 @@ typedef __WCHAR_TYPE__     _wchar_t;
 typedef int                _wchar_t;
 #endif
 
-#ifdef __LP64__
+#ifdef CONFIG_ARCH_RV64
 /* A size is 8 bytes */
 
 #if defined(__SIZE_TYPE__)


### PR DESCRIPTION
## Summary
It can provide better auto complete experience for modern code editor,
since they use clang/gcc based parser to analyze code but lacks some
target dependent info such as __LP64__ for riscv64.
## Impact
None
## Testing
CI
