### PR TITLE
Rename `tools/Makefile.*` to have the `.mk` extension

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,8 +40,8 @@ DUMMY  := ${shell $(MAKE) -C tools -f Makefile.host incdir \
 # Include the correct Makefile for the selected architecture.
 
 ifeq ($(CONFIG_WINDOWS_NATIVE),y)
-include tools/Makefile.win
+include tools/Win.mk
 else
-include tools/Makefile.unix
+include tools/Unix.mk
 endif
 endif

--- a/README.md
+++ b/README.md
@@ -1325,7 +1325,7 @@ damage your configuration (see
   environment:
 
   1. You can run the configuration tool using Cygwin.  However, the
-     Cygwin `Makefile.win` will complain so to do this will, you have
+     Cygwin `Win.mk` will complain so to do this will, you have
      to manually edit the `.config` file:
 
      a. Delete the line: `CONFIG_WINDOWS_NATIVE=y`

--- a/boards/arm/stm32/stm32f4discovery/README.txt
+++ b/boards/arm/stm32/stm32f4discovery/README.txt
@@ -2415,7 +2415,7 @@ Configuration Sub-directories
        usable as of this writing.  The windows native build logic is currently
        separate and must be started by:
 
-        make -f Makefile.win
+        make -f Win.mk
 
       This build:
 

--- a/boards/mips/pic32mx/pic32mx-starterkit/README.txt
+++ b/boards/mips/pic32mx/pic32mx-starterkit/README.txt
@@ -522,7 +522,7 @@ On Board Debug Support
   that provides debugger connectivity over USB. The PIC32MX440F512H is hard-wired
   to the PIC32 device to provide two types of protocol translation:
 
-    - I/O pins of PIC32MX440F512H to the ICSP™ pins of the PIC32
+    - I/O pins of PIC32MX440F512H to the ICSPâ„¢ pins of the PIC32
     - I/O pins of PIC32MX440F512H to the JTAG pins of the PIC32
 
   The PIC32 Ethernet Starter Kit currently uses the JTAG pins of the PIC32 device for
@@ -1038,7 +1038,7 @@ Where <subdir> is one of the following:
        as NSH built-in built in functions.
 
        To use USB device, connect the starter kit to the host using a cable
-       with a Type-B micro-plug to the starter kit’s micro-A/B port J5, located
+       with a Type-B micro-plug to the starter kit's micro-A/B port J5, located
        on the bottom side of the starter kit. The other end of the cable
        must have a Type-A plug. Connect it to a USB host. Jumper JP2 should be
        removed.

--- a/boards/mips/pic32mz/pic32mz-starterkit/README.txt
+++ b/boards/mips/pic32mz/pic32mz-starterkit/README.txt
@@ -78,9 +78,9 @@ On Board Debug Support
   The starter kit includes a PIC24FJ256GB106 USB microcontroller that
   provides debugger connectivity over USB. The PIC24FJ256GB106 is hard-wired
   to the PIC32 device to provide protocol translation through the I/O pins
-  of the PIC24FJ256GB106 to the ICSP™ pins of the PIC32 device.
+  of the PIC24FJ256GB106 to the ICSPâ„¢ pins of the PIC32 device.
 
-  If MPLAB® REAL ICE™ or MPLAB ICD 3 is used with the starter kit,
+  If MPLABÂ® REAL ICEâ„¢ or MPLAB ICD 3 is used with the starter kit,
   disconnect the onboard debugger from the PIC32 device by removing the
   jumper JP2. When the on-board debugger is required, replace the jumper
   JP2. When the jumper JP2 is installed, pin 1 must be connected to pin 3

--- a/boards/renesas/rx65n/rx65n-grrose/README.txt
+++ b/boards/renesas/rx65n/rx65n-grrose/README.txt
@@ -316,7 +316,7 @@ DTC has been tested using RSPI driver.
 
 USB Host Configurations
 --------------------------
-The following configurations need to be enabled for USB Host Mode driver to 
+The following configurations need to be enabled for USB Host Mode driver to
 support USB HID Keyboard class and MSC Class.
 
 CONFIG_USBHOST=y
@@ -326,10 +326,10 @@ CONFIG_EXAMPLES_HIDKBD=y
 
 USB Host Driver Testing
 ------------------------
-The Following Class Drivers were tested as mentioned below : 
+The Following Class Drivers were tested as mentioned below :
 
 - USB HID Keyboard Class
-On the NuttX Console "hidkbd" application was executed 
+On the NuttX Console "hidkbd" application was executed
 
 nsh> hidkbd
 The characters typed from the keyboard were executed correctly.
@@ -338,11 +338,11 @@ The characters typed from the keyboard were executed correctly.
 
 The MSC device is enumerated as sda in /dev directory.
 
-The block device is mounted using the command as mentioned below : 
+The block device is mounted using the command as mentioned below :
 
 mount -t vfat /dev/sda /mnt
 
-The MSC device is mounted in /dev directory 
+The MSC device is mounted in /dev directory
 
 The copy command is executed to test the Read/Write functionality
 
@@ -350,7 +350,7 @@ cp /mnt/<file.txt> /mnt/file_copy.txt
 
 USB Host Hub Configurations
 --------------------------
-The following configurations need to be enabled for USB Host Mode driver to 
+The following configurations need to be enabled for USB Host Mode driver to
 support USB HID Keyboard class and MSC Class.
 
 CONFIG_RX65N_USBHOST=y
@@ -363,10 +363,10 @@ CONFIG_EXAMPLES_HIDKBD=y
 
 USB Host Hub Driver Testing
 ------------------------
-The Following Class Drivers were tested as mentioned below : 
+The Following Class Drivers were tested as mentioned below :
 
 - USB HID Keyboard Class
-On the NuttX Console "hidkbd" application was executed 
+On the NuttX Console "hidkbd" application was executed
 
 nsh> hidkbd
 The characters typed from the keyboard were executed correctly.
@@ -374,11 +374,11 @@ The characters typed from the keyboard were executed correctly.
 - USB MSC Class
 The MSC device is enumerated as sda in /dev directory.
 
-The block device is mounted using the command as mentioned below : 
+The block device is mounted using the command as mentioned below :
 
 mount -t vfat /dev/sda /mnt
 
-The MSC device is mounted in /dev directory 
+The MSC device is mounted in /dev directory
 
 The copy command is executed to test the Read/Write functionality
 
@@ -408,7 +408,7 @@ Alternatively, NuttX binary can be flashed using Renesas flash programmer tool w
 Below are the steps mentioned to flash NuttX binary using Renesas flash programmer tool(RFP).
 
 1.In order to flash using Renesas flash programmer tool, nuttx.mot file should be generated.
-2. Add the following lines in tools/Makefile.unix file :
+2. Add the following lines in tools/Unix.mk file :
 ifeq ($(CONFIG_MOTOROLA_SREC),y)
 	@echo "CP: nuttx.mot"
 	$(Q) $(OBJCOPY) $(OBJCOPYARGS) $(BIN) -O srec -I elf32-rx-be-ns nuttx.mot

--- a/boards/renesas/rx65n/rx65n-rsk2mb/README.txt
+++ b/boards/renesas/rx65n/rx65n-rsk2mb/README.txt
@@ -290,7 +290,7 @@ DTC has been tested using RSPI driver.
 
 USB Host Configurations
 --------------------------
-The following configurations need to be enabled for USB Host Mode driver to 
+The following configurations need to be enabled for USB Host Mode driver to
 support USB HID Keyboard class and MSC Class.
 
 CONFIG_USBHOST=y
@@ -300,10 +300,10 @@ CONFIG_EXAMPLES_HIDKBD=y
 
 USB Host Driver Testing
 ------------------------
-The Following Class Drivers were tested as mentioned below : 
+The Following Class Drivers were tested as mentioned below :
 
 - USB HID Keyboard Class
-On the NuttX Console "hidkbd" application was executed 
+On the NuttX Console "hidkbd" application was executed
 
 nsh> hidkbd
 The characters typed from the keyboard were executed correctly.
@@ -312,11 +312,11 @@ The characters typed from the keyboard were executed correctly.
 
 The MSC device is enumerated as sda in /dev directory.
 
-The block device is mounted using the command as mentioned below : 
+The block device is mounted using the command as mentioned below :
 
 mount -t vfat /dev/sda /mnt
 
-The MSC device is mounted in /dev directory 
+The MSC device is mounted in /dev directory
 
 The copy command is executed to test the Read/Write functionality
 
@@ -324,7 +324,7 @@ cp /mnt/<file.txt> /mnt/file_copy.txt
 
 USB Host Hub Configurations
 --------------------------
-The following configurations need to be enabled for USB Host Mode driver to 
+The following configurations need to be enabled for USB Host Mode driver to
 support USB HID Keyboard class and MSC Class.
 
 CONFIG_RX65N_USBHOST=y
@@ -337,10 +337,10 @@ CONFIG_EXAMPLES_HIDKBD=y
 
 USB Host Hub Driver Testing
 ------------------------
-The Following Class Drivers were tested as mentioned below : 
+The Following Class Drivers were tested as mentioned below :
 
 - USB HID Keyboard Class
-On the NuttX Console "hidkbd" application was executed 
+On the NuttX Console "hidkbd" application was executed
 
 nsh> hidkbd
 The characters typed from the keyboard were executed correctly.
@@ -348,11 +348,11 @@ The characters typed from the keyboard were executed correctly.
 - USB MSC Class
 The MSC device is enumerated as sda in /dev directory.
 
-The block device is mounted using the command as mentioned below : 
+The block device is mounted using the command as mentioned below :
 
 mount -t vfat /dev/sda /mnt
 
-The MSC device is mounted in /dev directory 
+The MSC device is mounted in /dev directory
 
 The copy command is executed to test the Read/Write functionality
 
@@ -381,7 +381,7 @@ Alternatively, NuttX binary can be flashed using Renesas flash programmer tool w
 Below are the steps mentioned to flash NuttX binary using Renesas flash programmer tool(RFP).
 
 1.In order to flash using Renesas flash programmer tool, nuttx.mot file should be generated.
-2. Add the following lines in tools/Makefile.unix file :
+2. Add the following lines in tools/Unix.mk file :
 ifeq ($(CONFIG_MOTOROLA_SREC),y)
 	@echo "CP: nuttx.mot"
 	$(Q) $(OBJCOPY) $(OBJCOPYARGS) $(BIN) -O srec -I elf32-rx-be-ns nuttx.mot

--- a/tools/Export.mk
+++ b/tools/Export.mk
@@ -1,5 +1,5 @@
 ############################################################################
-# tools/Makefile.export
+# tools/Export.mk
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with

--- a/tools/README.txt
+++ b/tools/README.txt
@@ -175,11 +175,11 @@ lowhex.c
 Makefile.[unix|win]
 -----------------
 
-  Makefile.unix is the Makefile used when building NuttX in Unix-like
-  systems.  It is selected from the top-level Makefile.
+  Unix.mk is the Makefile used when building NuttX in Unix-like systems.
+  It is selected from the top-level Makefile.
 
-  Makefile.win is the Makefile used when building natively under
-  Windows.  It is selected from the top-level Makefile.
+  Win.mk is the Makefile used when building natively under Windows.
+  It is selected from the top-level Makefile.
 
 mkconfig.c, cfgdefine.c, and cfgdefine.h
 ----------------------------------------
@@ -191,10 +191,10 @@ mkconfig.c, cfgdefine.c, and cfgdefine.h
   in the top level NuttX directory (See boards/README.txt or
   Documentation/NuttXPortingGuide.html).  The first time you make NuttX,
   the top-level makefile will build the mkconfig executable from mkconfig.c
-  (using Makefile.host).  The top-level Makefile will then execute the
-  mkconfig program to convert the .config file in the top level directory
-  into include/nuttx/config.h.  config.h is a another version of the
-  NuttX configuration that can be included by C files.
+  (using Makefile.host).  The top-level Makefile will then execute the mkconfig
+  program to convert the .config file in the top level directory into
+  include/nuttx/config.h.  config.h is a another version of the NuttX
+  configuration that can be included by C files.
 
 mkconfigvars.sh
 ---------------
@@ -218,14 +218,14 @@ mkconfigvars.sh
     -h
        show this help message and exit
 
-mkexport.sh and Makefile.export
+mkexport.sh and Export.mk
 -------------------------------
 
   These implement part of the top-level Makefile's 'export' target.  That
   target will bundle up all of the NuttX libraries, header files, and the
   startup object into an export-able, binary NuttX distribution.  The
-  Makefile.export is used only by the mkexport.sh script to parse out
-  options from the top-level Make.defs file.
+  Export.mk is used only by the mkexport.sh script to parse out options
+  from the top-level Make.defs file.
 
   USAGE: tools/mkexport.sh [-d] [-z] [-u] -t <top-dir> [-x <lib-ext>] -l "lib1 [lib2 [lib3 ...]]"
 
@@ -253,8 +253,8 @@ mkversion.c, cfgdefine.c, and cfgdefine.h
   When you build NuttX there should be a version file called .version in
   the top level NuttX directory (See Documentation/NuttXPortingGuide.html).
   The first time you make NuttX, the top-level makefile will build the
-  mkversion executable from mkversion.c (using Makefile.host).  The top-
-  level Makefile will then execute the mkversion program to convert the
+  mkversion executable from mkversion.c (using Makefile.host).  The top-level
+  Makefile will then execute the mkversion program to convert the
   .version file in the top level directory into include/nuttx/version.h.
   version.h provides version information that can be included by C files.
 

--- a/tools/Unix.mk
+++ b/tools/Unix.mk
@@ -1,5 +1,5 @@
 ############################################################################
-# tools/Makefile.win
+# tools/Unix.mk
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
@@ -18,42 +18,60 @@
 #
 ############################################################################
 
-export SHELL=cmd
+export TOPDIR := ${shell echo $(CURDIR) | sed -e 's/ /\\ /g'}
+include $(TOPDIR)/Make.defs
 
-export TOPDIR := ${shell echo %CD%}
-include $(TOPDIR)\Make.defs
--include $(TOPDIR)\.version
+# GIT directory present
 
-# In case .version file does not exist
+GIT_DIR = $(if $(wildcard $(TOPDIR)$(DELIM).git),y,)
+
+ifeq ($(GIT_DIR),y)
+GIT_PRESENT = `git rev-parse --git-dir 2> /dev/null`
+endif
+
+# In case we cannot get version information from GIT
+
+ifeq ($(GIT_PRESENT),)
+-include $(TOPDIR)/.version
+
+# In case the version file does not exist
 
 CONFIG_VERSION_STRING ?= "0.0.0"
-CONFIG_VERSION_MAJOR ?= 0
-CONFIG_VERSION_MINOR ?= 0
-CONFIG_VERSION_PATCH ?= 0
 CONFIG_VERSION_BUILD ?= "0"
 
-# Process architecture and board-specific directories
+VERSION_ARG = -v $(CONFIG_VERSION_STRING) -b $(CONFIG_VERSION_BUILD)
+else
 
-ARCH_DIR = arch\$(CONFIG_ARCH)
-ARCH_SRC = $(ARCH_DIR)\src
-ARCH_INC = $(ARCH_DIR)\include
+# Generate .version.tmp every time from GIT history
+# Only update .version if the contents of version.tmp actually changes
+# Note: this is executed before any rule is run
+
+$(shell tools/version.sh .version.tmp)
+$(shell $(call TESTANDREPLACEFILE, .version.tmp, .version))
+endif
+
+# Process architecture specific directories
+
+ARCH_DIR = arch/$(CONFIG_ARCH)
+ARCH_SRC = $(ARCH_DIR)/src
+ARCH_INC = $(ARCH_DIR)/include
 
 # CONFIG_APPS_DIR can be over-ridden from the command line or in the .config file.
-# The default value of CONFIG_APPS_DIR is ..\apps.  Ultimately, the application
+# The default value of CONFIG_APPS_DIR is ../apps.  Ultimately, the application
 # will be built if APPDIR is defined.  APPDIR will be defined if a directory containing
 # a Makefile is found at the path provided by CONFIG_APPS_DIR
 
 ifeq ($(CONFIG_APPS_DIR),)
-CONFIG_APPS_DIR = ..\apps
+CONFIG_APPS_DIR = ../apps
 endif
-APPDIR := $(realpath ${shell if exist "$(CONFIG_APPS_DIR)\Makefile" echo $(CONFIG_APPS_DIR)})
+APPDIR := $(realpath ${shell if [ -r $(CONFIG_APPS_DIR)/Makefile ]; then echo "$(CONFIG_APPS_DIR)"; fi})
 
 # External code support
 # If external/ contains a Kconfig, we define the EXTERNALDIR variable to 'external'
 # so that main Kconfig can find it. Otherwise, we redirect it to a dummy Kconfig
 # This is due to kconfig inability to do conditional inclusion.
 
-EXTERNALDIR := $(shell if [ -r $(TOPDIR)\external\Kconfig ]; then echo 'external'; else echo 'dummy'; fi)
+EXTERNALDIR := $(shell if [ -r $(TOPDIR)/external/Kconfig ]; then echo 'external'; else echo 'dummy'; fi)
 
 # CONTEXTDIRS include directories that have special, one-time pre-build
 #   requirements.  Normally this includes things like auto-generation of
@@ -71,7 +89,7 @@ EXTERNALDIR := $(shell if [ -r $(TOPDIR)\external\Kconfig ]; then echo 'external
 #   then this holds only the directories containing user files. If
 #   CONFIG_BUILD_KERNEL is selected, then applications are not build at all.
 
-include tools\Directories.mk
+include tools/Directories.mk
 
 #
 # Extra objects used in the final link.
@@ -94,22 +112,22 @@ endif
 #   'make export' is
 
 ifeq ($(CONFIG_BUILD_PROTECTED),y)
-include tools\ProtectedLibs.mk
+include tools/ProtectedLibs.mk
 else ifeq ($(CONFIG_BUILD_KERNEL),y)
-include tools\KernelLibs.mk
+include tools/KernelLibs.mk
 else
-include tools\FlatLibs.mk
+include tools/FlatLibs.mk
 endif
 
 # LINKLIBS derives from NUTTXLIBS and is simply the same list with the
 #   subdirectory removed
 
-LINKLIBS = $(patsubst staging\\%,%,$(NUTTXLIBS))
+LINKLIBS = $(patsubst staging/%,%,$(NUTTXLIBS))
 
 # Export tool definitions
 
-MKEXPORT = tools\mkexport.bat
-MKEXPORT_ARGS = -t "$(TOPDIR)"
+MKEXPORT= tools/mkexport.sh
+MKEXPORT_ARGS = -t "$(TOPDIR)" -b "$(BOARD_DIR)"
 
 ifneq ($(CONFIG_BUILD_FLAT),y)
 MKEXPORT_ARGS += -u
@@ -131,20 +149,20 @@ endif
 BIN = nuttx$(EXEEXT)
 
 all: $(BIN)
-.PHONY: context clean_context config oldconfig menuconfig nconfig export subdir_clean clean subdir_distclean distclean apps_clean apps_distclean
+.PHONY: context clean_context config oldconfig menuconfig nconfig qconfig gconfig export subdir_clean clean subdir_distclean distclean apps_clean apps_distclean
 .PHONY: pass1 pass1dep
 .PHONY: pass2 pass2dep
 
-# Target used to copy include\nuttx\math.h.  If CONFIG_ARCH_MATH_H is
+# Target used to copy include/nuttx/lib/math.h.  If CONFIG_ARCH_MATH_H is
 # defined, then there is an architecture specific math.h header file
-# that will be included indirectly from include\math.h.  But first, we
-# have to copy math.h from include\nuttx\. to include\.  Logic within
-# include\nuttx\math.h will hand the redirection to the architecture-
+# that will be included indirectly from include/math.h.  But first, we
+# have to copy math.h from include/nuttx/. to include/.  Logic within
+# include/nuttx/lib/math.h will hand the redirection to the architecture-
 # specific math.h header file.
 #
-# If the CONFIG_LIBM is defined, the Rhombus libm will be built at libc\math.
+# If the CONFIG_LIBM is defined, the Rhombus libm will be built at libc/math.
 # Definitions and prototypes for the Rhombus libm are also contained in
-# include\nuttx\math.h and so the file must also be copied in that case.
+# include/nuttx/lib/math.h and so the file must also be copied in that case.
 #
 # If neither CONFIG_ARCH_MATH_H nor CONFIG_LIBM is defined, then no math.h
 # header file will be provided.  You would want that behavior if (1) you
@@ -158,10 +176,8 @@ NEED_MATH_H = y
 endif
 
 ifeq ($(NEED_MATH_H),y)
-include\math.h: include\nuttx\math.h
-	$(Q) cp -f include\nuttx\math.h include\math.h
-else
-include\math.h:
+include/math.h: include/nuttx/lib/math.h
+	$(Q) cp -f include/nuttx/lib/math.h include/math.h
 endif
 
 # The float.h header file defines the properties of your floating point
@@ -171,67 +187,66 @@ endif
 # the settings in this float.h are actually correct for your platform!
 
 ifeq ($(CONFIG_ARCH_FLOAT_H),y)
-include\float.h: include\nuttx\float.h
-	$(Q) cp -f include\nuttx\float.h include\float.h
-else
-include\float.h:
+include/float.h: include/nuttx/lib/float.h
+	$(Q) cp -f include/nuttx/lib/float.h include/float.h
 endif
 
-# Target used to copy include\nuttx\stdarg.h.  If CONFIG_ARCH_STDARG_H is
+# Target used to copy include/nuttx/lib/stdarg.h.  If CONFIG_ARCH_STDARG_H is
 # defined, then there is an architecture specific stdarg.h header file
-# that will be included indirectly from include\stdarg.h.  But first, we
-# have to copy stdarg.h from include\nuttx\. to include\.
+# that will be included indirectly from include/lib/stdarg.h.  But first, we
+# have to copy stdarg.h from include/nuttx/. to include/.
 
 ifeq ($(CONFIG_ARCH_STDARG_H),y)
-include\stdarg.h: include\nuttx\stdarg.h
-	$(Q) cp -f include\nuttx\stdarg.h include\stdarg.h
-else
-include\stdarg.h:
+include/stdarg.h: include/nuttx/lib/stdarg.h
+	$(Q) cp -f include/nuttx/lib/stdarg.h include/stdarg.h
 endif
 
-# Target used to copy include\nuttx\setjmp.h.  If CONFIG_ARCH_SETJMP_H is
+# Target used to copy include/nuttx/lib/setjmp.h.  If CONFIG_ARCH_SETJMP_H is
 # defined, then there is an architecture specific setjmp.h header file
-# that will be included indirectly from include\setjmp.h.  But first, we
-# have to copy setjmp.h from include\nuttx\. to include\.
+# that will be included indirectly from include/lib/setjmp.h.  But first, we
+# have to copy setjmp.h from include/nuttx/. to include/.
 
 ifeq ($(CONFIG_ARCH_SETJMP_H),y)
-include\setjmp.h: include\nuttx\setjmp.h
-	$(Q) cp -f include\nuttx\setjmp.h include\setjmp.h
-else
-include\setjmp.h:
+include/setjmp.h: include/nuttx/lib/setjmp.h
+	$(Q) cp -f include/nuttx/lib/setjmp.h include/setjmp.h
 endif
 
-# Targets used to build include\nuttx\version.h.  Creation of version.h is
+# Targets used to build include/nuttx/version.h.  Creation of version.h is
 # part of the overall NuttX configuration sequence. Notice that the
-# tools\mkversion tool is built and used to create include\nuttx\version.h
+# tools/mkversion tool is built and used to create include/nuttx/version.h
 
-tools\mkversion$(HOSTEXEEXT):
+tools/mkversion$(HOSTEXEEXT):
 	$(Q) $(MAKE) -C tools -f Makefile.host mkversion$(HOSTEXEEXT)
 
-$(TOPDIR)\.version:
-	$(Q) echo CONFIG_VERSION_STRING="0" > .version
-	$(Q) echo CONFIG_VERSION_MAJOR=0 >> .version
-	$(Q) echo CONFIG_VERSION_MINOR=0 >> .version
-	$(Q) echo CONFIG_VERSION_PATCH=0 >> .version
-	$(Q) echo CONFIG_VERSION_BUILD="0" >> .version
+# [Re-]create .version if it doesn't already exist.
 
-include\nuttx\version.h: $(TOPDIR)\.version tools\mkversion$(HOSTEXEEXT)
-	$(Q) tools\mkversion$(HOSTEXEEXT) $(TOPDIR) > include\nuttx\version.h
+$(TOPDIR)/.version:
+	$(Q) echo "Create .version"
+	$(Q) tools/version.sh $(VERSION_ARG) .version
+	$(Q) chmod 755 .version
 
-# Targets used to build include\nuttx\config.h.  Creation of config.h is
+include/nuttx/version.h: $(TOPDIR)/.version tools/mkversion$(HOSTEXEEXT)
+	$(Q) echo "Create version.h"
+	$(Q) tools/mkversion $(TOPDIR) > $@
+
+# Targets used to build include/nuttx/config.h.  Creation of config.h is
 # part of the overall NuttX configuration sequence. Notice that the
-# tools\mkconfig tool is built and used to create include\nuttx\config.h
+# tools/mkconfig tool is built and used to create include/nuttx/config.h
 
-tools\mkconfig$(HOSTEXEEXT):
+tools/mkconfig$(HOSTEXEEXT):
 	$(Q) $(MAKE) -C tools -f Makefile.host mkconfig$(HOSTEXEEXT)
 
-include\nuttx\config.h: $(TOPDIR)\.config tools\mkconfig$(HOSTEXEEXT)
-	$(Q) tools\mkconfig$(HOSTEXEEXT) $(TOPDIR) > include\nuttx\config.h
+include/nuttx/config.h: $(TOPDIR)/.config tools/mkconfig$(HOSTEXEEXT)
+	$(Q) tools/mkconfig $(TOPDIR) > $@.tmp
+	$(Q) $(call TESTANDREPLACEFILE, $@.tmp, $@)
 
 # Targets used to create dependencies
 
-tools\mkdeps$(HOSTEXEEXT):
+tools/mkdeps$(HOSTEXEEXT):
 	$(Q) $(MAKE) -C tools -f Makefile.host mkdeps$(HOSTEXEEXT)
+
+tools/cnvwindeps$(HOSTEXEEXT):
+	$(Q) $(MAKE) -C tools -f Makefile.host cnvwindeps$(HOSTEXEEXT)
 
 # .dirlinks, and helpers
 #
@@ -239,102 +254,102 @@ tools\mkdeps$(HOSTEXEEXT):
 # setting up symbolic links with 'generic' directory names to specific,
 # configured directories.
 
-# Link the arch\<arch-name>\include directory to include\arch
+# Link the arch/<arch-name>/include directory to include/arch
 
-include\arch:
-	@echo "LN: $@ to $(ARCH_DIR)\include"
-	$(Q) $(DIRLINK) $(TOPDIR)\$(ARCH_DIR)\include $@
+include/arch:
+	@echo "LN: $@ to $(ARCH_DIR)/include"
+	$(Q) $(DIRLINK) $(TOPDIR)/$(ARCH_DIR)/include $@
 
-# Link the boards\<arch>\<chip>\<board>\include directory to include\arch\board
+# Link the boards/<arch>/<chip>/<board>/include directory to include/arch/board
 
-include\arch\board: | include\arch
-	@echo "LN: $@ to $(BOARD_DIR)\include"
-	$(Q) $(DIRLINK) $(BOARD_DIR)\include $@
+include/arch/board: | include/arch
+	@echo "LN: $@ to $(BOARD_DIR)/include"
+	$(Q) $(DIRLINK) $(BOARD_DIR)/include $@
 
-# Link the boards\<arch>\<chip>\common dir to arch\<arch-name>\src\board
-# Link the boards\<arch>\<chip>\<board>\src dir to arch\<arch-name>\src\board\board
+# Link the boards/<arch>/<chip>/common dir to arch/<arch-name>/src/board
+# Link the boards/<arch>/<chip>/<board>/src dir to arch/<arch-name>/src/board/board
 
 ifneq ($(BOARD_COMMON_DIR),)
 ARCH_SRC_BOARD_SYMLINK=$(BOARD_COMMON_DIR)
-ARCH_SRC_BOARD_BOARD_SYMLINK=$(BOARD_DIR)\src
+ARCH_SRC_BOARD_BOARD_SYMLINK=$(BOARD_DIR)/src
 else
-ARCH_SRC_BOARD_SYMLINK=$(BOARD_DIR)\src
+ARCH_SRC_BOARD_SYMLINK=$(BOARD_DIR)/src
 endif
 
 ifneq ($(ARCH_SRC_BOARD_SYMLINK),)
-$(ARCH_SRC)\board:
+$(ARCH_SRC)/board:
 	@echo "LN: $@ to $(ARCH_SRC_BOARD_SYMLINK)"
 	$(Q) $(DIRLINK) $(ARCH_SRC_BOARD_SYMLINK) $@
 endif
 
 ifneq ($(ARCH_SRC_BOARD_BOARD_SYMLINK),)
-$(ARCH_SRC)\board\board: | $(ARCH_SRC)\board
+$(ARCH_SRC)/board/board: | $(ARCH_SRC)/board
 	@echo "LN: $@ to $(ARCH_SRC_BOARD_BOARD_SYMLINK)"
 	$(Q) $(DIRLINK) $(ARCH_SRC_BOARD_BOARD_SYMLINK) $@
 endif
 
-# Link the boards\<arch>\<chip>\drivers dir to drivers\platform
+# Link the boards/<arch>/<chip>/drivers dir to drivers/platform
 
-drivers\platform:
+drivers/platform:
 	@echo "LN: $@ to $(BOARD_DRIVERS_DIR)"
 	$(Q) $(DIRLINK) $(BOARD_DRIVERS_DIR) $@
 
-# Link arch\<arch-name>\src\<chip-name> to arch\<arch-name>\src\chip
+# Link arch/<arch-name>/src/<chip-name> to arch/<arch-name>/src/chip
 
 ifeq ($(CONFIG_ARCH_CHIP_CUSTOM),y)
 ARCH_SRC_CHIP_SYMLINK_DIR=$(CHIP_DIR)
 else ifneq ($(CONFIG_ARCH_CHIP),)
-ARCH_SRC_CHIP_SYMLINK_DIR=$(TOPDIR)\$(ARCH_SRC)\$(CONFIG_ARCH_CHIP)
+ARCH_SRC_CHIP_SYMLINK_DIR=$(TOPDIR)/$(ARCH_SRC)/$(CONFIG_ARCH_CHIP)
 endif
 
 ifneq ($(ARCH_SRC_CHIP_SYMLINK_DIR),)
-$(ARCH_SRC)\chip:
+$(ARCH_SRC)/chip:
 	@echo "LN: $@ to $(ARCH_SRC_CHIP_SYMLINK_DIR)"
 	$(Q) $(DIRLINK) $(ARCH_SRC_CHIP_SYMLINK_DIR) $@
 endif
 
-# Link arch\<arch-name>\include\<chip-name> to include\arch\chip
+# Link arch/<arch-name>/include/<chip-name> to include/arch/chip
 
 ifeq ($(CONFIG_ARCH_CHIP_CUSTOM),y)
-INCLUDE_ARCH_CHIP_SYMLINK_DIR=$(CHIP_DIR)\include
+INCLUDE_ARCH_CHIP_SYMLINK_DIR=$(CHIP_DIR)/include
 else ifneq ($(CONFIG_ARCH_CHIP),)
-INCLUDE_ARCH_CHIP_SYMLINK_DIR=$(TOPDIR)\$(ARCH_INC)\$(CONFIG_ARCH_CHIP)
+INCLUDE_ARCH_CHIP_SYMLINK_DIR=$(TOPDIR)/$(ARCH_INC)/$(CONFIG_ARCH_CHIP)
 endif
 
 ifneq ($(INCLUDE_ARCH_CHIP_SYMLINK_DIR),)
-include\arch\chip:
+include/arch/chip:
 	@echo "LN: $@ to $(INCLUDE_ARCH_CHIP_SYMLINK_DIR)"
 	$(DIRLINK) $(INCLUDE_ARCH_CHIP_SYMLINK_DIR) $@
 endif
 
-# Copy $(CHIP_KCONFIG) to arch\dummy\Kconfig
+# Copy $(CHIP_KCONFIG) to arch/dummy/Kconfig
 
-arch\dummy\Kconfig:
+arch/dummy/Kconfig:
 	@echo "CP: $@ to $(CHIP_KCONFIG)"
 	$(Q) cp -f $(CHIP_KCONFIG) $@
 
 DIRLINKS_SYMLINK = \
-  include\arch \
-  include\arch\board \
-  drivers\platform \
+  include/arch \
+  include/arch/board \
+  drivers/platform \
 
 DIRLINKS_FILE = \
-  arch\dummy\Kconfig \
+  arch/dummy/Kconfig \
 
 ifneq ($(INCLUDE_ARCH_CHIP_SYMLINK_DIR),)
-DIRLINKS_SYMLINK += include\arch\chip
+DIRLINKS_SYMLINK += include/arch/chip
 endif
 
 ifneq ($(ARCH_SRC_CHIP_SYMLINK_DIR),)
-DIRLINKS_SYMLINK += $(ARCH_SRC)\chip
+DIRLINKS_SYMLINK += $(ARCH_SRC)/chip
 endif
 
 ifneq ($(ARCH_SRC_BOARD_SYMLINK),)
-DIRLINKS_SYMLINK += $(ARCH_SRC)\board
+DIRLINKS_SYMLINK += $(ARCH_SRC)/board
 endif
 
 ifneq ($(ARCH_SRC_BOARD_BOARD_SYMLINK),)
-DIRLINKS_SYMLINK += $(ARCH_SRC)\board\board
+DIRLINKS_SYMLINK += $(ARCH_SRC)/board/board
 endif
 
 DIRLINKS_EXTERNAL_DIRS = boards
@@ -344,7 +359,8 @@ DIRLINKS_EXTERNAL_DIRS += $(APPDIR)
 endif
 
 # Generate a pattern to build $(DIRLINKS_EXTERNAL_DIRS)
-DIRLINKS_EXTERNAL_DEP = $(patsubst %,%\.dirlinks,$(DIRLINKS_EXTERNAL_DIRS))
+
+DIRLINKS_EXTERNAL_DEP = $(patsubst %,%/.dirlinks,$(DIRLINKS_EXTERNAL_DIRS))
 DIRLINKS_FILE += $(DIRLINKS_EXTERNAL_DEP)
 
 .dirlinks: $(DIRLINKS_FILE) | $(DIRLINKS_SYMLINK)
@@ -352,10 +368,9 @@ DIRLINKS_FILE += $(DIRLINKS_EXTERNAL_DEP)
 
 # Pattern rule for $(DIRLINKS_EXTERNAL_DEP)
 
-%\.dirlinks:
-	$(Q) $(MAKE) -C $(patsubst %\.dirlinks,%,$@) dirlinks
+%/.dirlinks:
+	$(Q) $(MAKE) -C $(patsubst %/.dirlinks,%,$@) dirlinks
 	$(Q) touch $@
-
 
 # clean_dirlinks
 #
@@ -367,20 +382,20 @@ DIRLINKS_FILE += $(DIRLINKS_EXTERNAL_DEP)
 clean_dirlinks:
 	$(Q) $(call DELFILE, $(DIRLINKS_FILE))
 	$(Q) $(call DELFILE, .dirlinks)
-	$(Q) $(DIRUNLINK) drivers\platform
+	$(Q) $(DIRUNLINK) drivers/platform
 ifneq ($(INCLUDE_ARCH_CHIP_SYMLINK_DIR),)
-	$(Q) $(DIRUNLINK) include\arch\chip
+	$(Q) $(DIRUNLINK) include/arch/chip
 endif
-	$(Q) $(DIRUNLINK) include\arch\board
-	$(Q) $(DIRUNLINK) include\arch
+	$(Q) $(DIRUNLINK) include/arch/board
+	$(Q) $(DIRUNLINK) include/arch
 ifneq ($(ARCH_SRC_BOARD_BOARD_SYMLINK),)
-	$(Q) $(DIRUNLINK) $(ARCH_SRC)\board\board
+	$(Q) $(DIRUNLINK) $(ARCH_SRC)/board/board
 endif
 ifneq ($(ARCH_SRC_BOARD_SYMLINK),)
-	$(Q) $(DIRUNLINK) $(ARCH_SRC)\board
+	$(Q) $(DIRUNLINK) $(ARCH_SRC)/board
 endif
 ifneq ($(ARCH_SRC_CHIP_SYMLINK_DIR),)
-	$(Q) $(DIRUNLINK) $(ARCH_SRC)\chip
+	$(Q) $(DIRUNLINK) $(ARCH_SRC)/chip
 endif
 
 
@@ -388,72 +403,71 @@ endif
 #
 # The context target is invoked on each target build to assure that NuttX is
 # properly configured.  The basic configuration steps include creation of the
-# the config.h and version.h header files in the include\nuttx directory and
+# the config.h and version.h header files in the include/nuttx directory and
 # the establishment of symbolic links to configured directories.
 
 # Generate a pattern to make Directories.mk context
 
-CONTEXTDIRS_DEPS = $(patsubst %,%\.context,$(CONTEXTDIRS))
+CONTEXTDIRS_DEPS = $(patsubst %,%/.context,$(CONTEXTDIRS))
 
-context: include\nuttx\config.h include\nuttx\version.h $(CONTEXTDIRS_DEPS) .dirlinks | staging
-
-ifeq ($(NEED_MATH_H),y)
-context: include\math.h
-endif
-
-ifeq ($(CONFIG_ARCH_FLOAT_H),y)
-context: include\float.h
-endif
-
-ifeq ($(CONFIG_ARCH_STDARG_H),y)
-context: include\stdarg.h
-endif
-
-ifeq ($(CONFIG_ARCH_SETJMP_H),y)
-context: include\setjmp.h
-endif
+context: include/nuttx/config.h include/nuttx/version.h .dirlinks $(CONTEXTDIRS_DEPS) | staging
 
 staging:
 	$(Q) mkdir -p $@
 
 # Pattern rule for $(CONTEXTDIRS_DEPS)
 
-%.context: include\nuttx\config.h .dirlinks
+%.context: include/nuttx/config.h .dirlinks
 	$(Q) $(MAKE) -C $(patsubst %.context,%,$@) TOPDIR="$(TOPDIR)" context
 	$(Q) touch $@
+
+ifeq ($(NEED_MATH_H),y)
+context: include/math.h
+endif
+
+ifeq ($(CONFIG_ARCH_FLOAT_H),y)
+context: include/float.h
+endif
+
+ifeq ($(CONFIG_ARCH_STDARG_H),y)
+context: include/stdarg.h
+endif
+
+ifeq ($(CONFIG_ARCH_SETJMP_H),y)
+context: include/setjmp.h
+endif
 
 # clean_context
 #
 # This is part of the distclean target.  It removes all of the header files
 # and symbolic links created by the context target.
 
-clean_context:
-	$(Q) for %%G in ($(CCLEANDIRS)) do ( if exist %%G\Makefile $(MAKE) -C %%G clean_context )
-	$(call DELFILE, include\nuttx\config.h)
-	$(call DELFILE, include\nuttx\version.h)
-	$(call DELFILE, include\float.h)
-	$(call DELFILE, include\math.h)
-	$(call DELFILE, include\stdarg.h)
-	$(call DELFILE, include\setjmp.h)
-	$(call DELFILE, arch\dummy\Kconfig)
+clean_context: clean_dirlinks
+	$(Q) for dir in $(CCLEANDIRS) ; do \
+		if [ -e $$dir/Makefile ]; then \
+			$(MAKE) -C $$dir clean_context ; \
+		fi \
+	done
+	$(call DELFILE, include/nuttx/config.h)
+	$(call DELFILE, include/nuttx/version.h)
+	$(call DELFILE, include/float.h)
+	$(call DELFILE, include/math.h)
+	$(call DELFILE, include/stdarg.h)
+	$(call DELFILE, include/setjmp.h)
+	$(call DELFILE, arch/dummy/Kconfig)
 	$(call DELFILE, $(CONTEXTDIRS_DEPS))
-	$(call DIRUNLINK, include\arch\board)
-	$(call DIRUNLINK, include\arch\chip)
-	$(call DIRUNLINK, include\arch)
-	$(call DIRUNLINK, $(ARCH_SRC)\board\board)
-	$(call DIRUNLINK, $(ARCH_SRC)\board)
-	$(call DIRUNLINK, $(ARCH_SRC)\chip)
-	$(call DIRUNLINK, $(TOPDIR)\drivers\platform)
 
 # Archive targets.  The target build sequence will first create a series of
 # libraries, one per configured source file directory.  The final NuttX
 # execution will then be built from those libraries.  The following targets
 # build those libraries.
 
+include tools/LibTargets.mk
+
 # pass1 and pass2
 #
 # If the 2 pass build option is selected, then this pass1 target is
-# configured to built before the pass2 target.  This pass1 target may, as an
+# configured to be built before the pass2 target.  This pass1 target may, as an
 # example, build an extra link object (CONFIG_PASS1_OBJECT) which may be an
 # incremental (relative) link object, but could be a static library (archive);
 # some modification to this Makefile would be required if CONFIG_PASS1_OBJECT
@@ -482,15 +496,18 @@ ifeq ($(CONFIG_BUILD_2PASS),y)
 		echo "ERROR: CONFIG_PASS1_BUILDIR does not exist"; \
 		exit 1; \
 	fi
-	$(Q) if [ ! -f "$(CONFIG_PASS1_BUILDIR)\Makefile" ]; then \
+	$(Q) if [ ! -f "$(CONFIG_PASS1_BUILDIR)/Makefile" ]; then \
 		echo "ERROR: No Makefile in CONFIG_PASS1_BUILDIR"; \
 		exit 1; \
 	fi
 	$(Q) $(MAKE) -C $(CONFIG_PASS1_BUILDIR) LINKLIBS="$(LINKLIBS)" USERLIBS="$(USERLIBS)" "$(CONFIG_PASS1_TARGET)"
 endif
 	$(Q) $(MAKE) -C $(ARCH_SRC) EXTRA_OBJS="$(EXTRA_OBJS)" LINKLIBS="$(LINKLIBS)" EXTRAFLAGS="$(KDEFINE) $(EXTRAFLAGS)" $(BIN)
+	$(Q) if [ -w /tftpboot ] ; then \
+		cp -f $(BIN) /tftpboot/$(BIN).${CONFIG_ARCH}; \
+	fi
 	$(Q) echo $(BIN) > nuttx.manifest
-	$(Q) printf '%s\n' *.map >> nuttx.manifest
+	$(Q) printf "%s\n" *.map >> nuttx.manifest
 ifeq ($(CONFIG_INTELHEX_BINARY),y)
 	@echo "CP: nuttx.hex"
 	$(Q) $(OBJCOPY) $(OBJCOPYARGS) -O ihex $(BIN) nuttx.hex
@@ -505,6 +522,15 @@ ifeq ($(CONFIG_RAW_BINARY),y)
 	@echo "CP: nuttx.bin"
 	$(Q) $(OBJCOPY) $(OBJCOPYARGS) -O binary $(BIN) nuttx.bin
 	$(Q) echo nuttx.bin >> nuttx.manifest
+endif
+ifeq ($(CONFIG_UBOOT_UIMAGE),y)
+	@echo "MKIMAGE: uImage"
+	$(Q) mkimage -A $(CONFIG_ARCH) -O linux -C none -T kernel -a $(CONFIG_UIMAGE_LOAD_ADDRESS) \
+		-e $(CONFIG_UIMAGE_ENTRY_POINT) -n $(BIN) -d nuttx.bin uImage
+	$(Q) if [ -w /tftpboot ] ; then \
+		cp -f uImage /tftpboot/uImage; \
+	fi
+	$(Q) echo "uImage" >> nuttx.manifest
 endif
 	$(call POSTBUILD, $(TOPDIR))
 
@@ -544,53 +570,67 @@ clean_bootloader:
 # pass1dep: Create pass1 build dependencies
 # pass2dep: Create pass2 build dependencies
 
-pass1dep: context tools\mkdeps$(HOSTEXEEXT)
-	$(Q) for %%G in ($(USERDEPDIRS)) do ( $(MAKE) -C %%G depend )
+pass1dep: context tools/mkdeps$(HOSTEXEEXT) tools/cnvwindeps$(HOSTEXEEXT)
+	$(Q) for dir in $(USERDEPDIRS) ; do \
+		$(MAKE) -C $$dir depend || exit; \
+	done
 
-pass2dep: context tools\mkdeps$(HOSTEXEEXT)
-	$(Q) for %%G in ($(KERNDEPDIRS)) do ( $(MAKE) -C %%G EXTRAFLAGS="$(KDEFINE) $(EXTRAFLAGS)" depend )
+pass2dep: context tools/mkdeps$(HOSTEXEEXT) tools/cnvwindeps$(HOSTEXEEXT)
+	$(Q) for dir in $(KERNDEPDIRS) ; do \
+		$(MAKE) -C $$dir EXTRAFLAGS="$(KDEFINE) $(EXTRAFLAGS)" depend || exit; \
+	done
 
 # Configuration targets
 #
 # These targets depend on the kconfig-frontends packages.  To use these, you
 # must first download and install the kconfig-frontends package from this
-# location: https://bitbucket.org/nuttx/tools/downloads/.  See
-# misc\tools\README.txt for additional information.
+# location: https://bitbucket.org/nuttx/tools/downloads/.  See README.txt
+# file in the NuttX tools GIT repository for additional information.
 
 config:
 	$(Q) $(MAKE) clean_context
 	$(Q) $(MAKE) apps_preconfig
-	$(Q) set APPSDIR=$(patsubst "%",%,${CONFIG_APPS_DIR})& set EXTERNALDIR=$(EXTERNALDIR)& kconfig-conf Kconfig
+	$(Q) APPSDIR=${CONFIG_APPS_DIR} EXTERNALDIR=$(EXTERNALDIR) kconfig-conf Kconfig
 
 oldconfig:
 	$(Q) $(MAKE) clean_context
 	$(Q) $(MAKE) apps_preconfig
-	$(Q) set APPSDIR=$(patsubst "%",%,${CONFIG_APPS_DIR})& set EXTERNALDIR=$(EXTERNALDIR)& kconfig-conf --oldconfig Kconfig
+	$(Q) APPSDIR=${CONFIG_APPS_DIR} EXTERNALDIR=$(EXTERNALDIR) kconfig-conf --oldconfig Kconfig
 
 olddefconfig:
 	$(Q) $(MAKE) clean_context
 	$(Q) $(MAKE) apps_preconfig
-	$(Q) set APPSDIR=$(patsubst "%",%,${CONFIG_APPS_DIR})& set EXTERNALDIR=$(EXTERNALDIR)& kconfig-conf --olddefconfig Kconfig
+	$(Q) APPSDIR=${CONFIG_APPS_DIR} EXTERNALDIR=$(EXTERNALDIR) kconfig-conf --olddefconfig Kconfig
 
 menuconfig:
 	$(Q) $(MAKE) clean_context
 	$(Q) $(MAKE) apps_preconfig
-	$(Q) set APPSDIR=$(patsubst "%",%,${CONFIG_APPS_DIR})& set EXTERNALDIR=$(EXTERNALDIR)& kconfig-mconf Kconfig
+	$(Q) APPSDIR=${CONFIG_APPS_DIR} EXTERNALDIR=$(EXTERNALDIR) kconfig-mconf Kconfig
 
-nconfig:
+nconfig: apps_preconfig
 	$(Q) $(MAKE) clean_context
 	$(Q) $(MAKE) apps_preconfig
-	$(Q) set APPSDIR=$(patsubst "%",%,${CONFIG_APPS_DIR})& set EXTERNALDIR=$(EXTERNALDIR)& kconfig-nconf Kconfig
+	$(Q) APPSDIR=${CONFIG_APPS_DIR} EXTERNALDIR=$(EXTERNALDIR) kconfig-nconf Kconfig
+
+qconfig: apps_preconfig
+	$(Q) $(MAKE) clean_context
+	$(Q) $(MAKE) apps_preconfig
+	$(Q) APPSDIR=${CONFIG_APPS_DIR} EXTERNALDIR=$(EXTERNALDIR) kconfig-qconf Kconfig
+
+gconfig: apps_preconfig
+	$(Q) $(MAKE) clean_context
+	$(Q) $(MAKE) apps_preconfig
+	$(Q) APPSDIR=${CONFIG_APPS_DIR} EXTERNALDIR=$(EXTERNALDIR) kconfig-gconf Kconfig
 
 savedefconfig: apps_preconfig
-	$(Q) set APPSDIR=$(patsubst "%",%,${CONFIG_APPS_DIR})& set EXTERNALDIR=$(EXTERNALDIR)& kconfig-conf --savedefconfig defconfig.tmp Kconfig
+	$(Q) APPSDIR=${CONFIG_APPS_DIR} EXTERNALDIR=$(EXTERNALDIR) kconfig-conf --savedefconfig defconfig.tmp Kconfig
 	$(Q) kconfig-tweak --file defconfig.tmp -u CONFIG_APPS_DIR
 	$(Q) grep "CONFIG_ARCH=" .config >> defconfig.tmp
-	-$(Q) grep "^CONFIG_ARCH_CHIP_" .config >> defconfig.tmp
-	-$(Q) grep "CONFIG_ARCH_CHIP=" .config >> defconfig.tmp
-	-$(Q) grep "CONFIG_ARCH_BOARD=" .config >> defconfig.tmp
-	-$(Q) grep "^CONFIG_ARCH_CUSTOM" .config >> defconfig.tmp
-	-$(Q) grep "^CONFIG_ARCH_BOARD_CUSTOM" .config >> defconfig.tmp
+	$(Q) grep "^CONFIG_ARCH_CHIP_" .config >> defconfig.tmp; true
+	$(Q) grep "CONFIG_ARCH_CHIP=" .config >> defconfig.tmp; true
+	$(Q) grep "CONFIG_ARCH_BOARD=" .config >> defconfig.tmp; true
+	$(Q) grep "^CONFIG_ARCH_CUSTOM" .config >> defconfig.tmp; true
+	$(Q) grep "^CONFIG_ARCH_BOARD_CUSTOM" .config >> defconfig.tmp; true
 	$(Q) export LC_ALL=C; cat defconfig.tmp | sort | uniq > sortedconfig.tmp
 	$(Q) echo "#" > warning.tmp
 	$(Q) echo "# This file is autogenerated: PLEASE DO NOT EDIT IT." >> warning.tmp
@@ -609,11 +649,11 @@ savedefconfig: apps_preconfig
 # The export target will package the NuttX libraries and header files into
 # an exportable package.  Caveats: (1) These needs some extension for the KERNEL
 # build; it needs to receive USERLIBS and create a libuser.a). (2) The logic
-# in tools\mkexport.sh only supports GCC and, for example, explicitly assumes
+# in tools/mkexport.sh only supports GCC and, for example, explicitly assumes
 # that the archiver is 'ar'
 
-export: ${NUTTXLIBS}
-	$(Q) $(MKEXPORT) $(MKEXPORT_ARGS) -l "$(EXPORTLIBS)"
+export: $(NUTTXLIBS)
+	$(Q) MAKE=${MAKE} $(MKEXPORT) $(MKEXPORT_ARGS) -l "$(EXPORTLIBS)"
 
 # General housekeeping targets:  dependencies, cleaning, etc.
 #
@@ -639,9 +679,9 @@ clean: subdir_clean
 	$(call DELFILE, nuttx.*)
 	$(call DELFILE, *.map)
 	$(call DELFILE, _SAVED_APPS_config)
-	$(call DELFILE, nuttx-export*)
+	$(call DELFILE, nuttx-export*.zip)
+	$(call DELDIR, nuttx-export*)
 	$(call DELFILE, nuttx_user*)
-	$(call DELFILE, .gdbinit)
 	$(call DELDIR, staging)
 	$(call DELFILE, uImage)
 	$(call CLEAN)
@@ -662,10 +702,11 @@ endif
 	$(call DELFILE, defconfig)
 	$(call DELFILE, .config)
 	$(call DELFILE, .config.old)
+	$(call DELFILE, .gdbinit)
 	$(Q) $(MAKE) -C tools -f Makefile.host clean
 
 # Application housekeeping targets.  The APPDIR variable refers to the user
-# application directory.  A sample apps\ directory is included with NuttX,
+# application directory.  A sample apps/ directory is included with NuttX,
 # however, this is not treated as part of NuttX and may be replaced with a
 # different application directory.  For the most part, the application
 # directory is treated like any other build directory in this script.  However,
@@ -680,15 +721,15 @@ endif
 
 apps_preconfig: .dirlinks
 ifneq ($(APPDIR),)
-	$(Q) $(MAKE) -C "$(APPDIR)" preconfig
+	$(Q) $(MAKE) -C $(APPDIR) preconfig
 endif
 
 apps_clean:
 ifneq ($(APPDIR),)
-	$(Q) $(MAKE) -C "$(APPDIR)" clean
+	$(Q) $(MAKE) -C $(APPDIR) clean
 endif
 
 apps_distclean:
 ifneq ($(APPDIR),)
-	$(Q) $(MAKE) -C "$(APPDIR)" distclean
+	$(Q) $(MAKE) -C $(APPDIR) distclean
 endif

--- a/tools/Win.mk
+++ b/tools/Win.mk
@@ -1,5 +1,5 @@
 ############################################################################
-# tools/Makefile.unix
+# tools/Win.mk
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
@@ -18,60 +18,42 @@
 #
 ############################################################################
 
-export TOPDIR := ${shell echo $(CURDIR) | sed -e 's/ /\\ /g'}
-include $(TOPDIR)/Make.defs
+export SHELL=cmd
 
-# GIT directory present
+export TOPDIR := ${shell echo %CD%}
+include $(TOPDIR)\Make.defs
+-include $(TOPDIR)\.version
 
-GIT_DIR = $(if $(wildcard $(TOPDIR)$(DELIM).git),y,)
-
-ifeq ($(GIT_DIR),y)
-GIT_PRESENT = `git rev-parse --git-dir 2> /dev/null`
-endif
-
-# In case we cannot get version information from GIT
-
-ifeq ($(GIT_PRESENT),)
--include $(TOPDIR)/.version
-
-# In case the version file does not exist
+# In case .version file does not exist
 
 CONFIG_VERSION_STRING ?= "0.0.0"
+CONFIG_VERSION_MAJOR ?= 0
+CONFIG_VERSION_MINOR ?= 0
+CONFIG_VERSION_PATCH ?= 0
 CONFIG_VERSION_BUILD ?= "0"
 
-VERSION_ARG = -v $(CONFIG_VERSION_STRING) -b $(CONFIG_VERSION_BUILD)
-else
+# Process architecture and board-specific directories
 
-# Generate .version.tmp every time from GIT history
-# Only update .version if the contents of version.tmp actually changes
-# Note: this is executed before any rule is run
-
-$(shell tools/version.sh .version.tmp)
-$(shell $(call TESTANDREPLACEFILE, .version.tmp, .version))
-endif
-
-# Process architecture specific directories
-
-ARCH_DIR = arch/$(CONFIG_ARCH)
-ARCH_SRC = $(ARCH_DIR)/src
-ARCH_INC = $(ARCH_DIR)/include
+ARCH_DIR = arch\$(CONFIG_ARCH)
+ARCH_SRC = $(ARCH_DIR)\src
+ARCH_INC = $(ARCH_DIR)\include
 
 # CONFIG_APPS_DIR can be over-ridden from the command line or in the .config file.
-# The default value of CONFIG_APPS_DIR is ../apps.  Ultimately, the application
+# The default value of CONFIG_APPS_DIR is ..\apps.  Ultimately, the application
 # will be built if APPDIR is defined.  APPDIR will be defined if a directory containing
 # a Makefile is found at the path provided by CONFIG_APPS_DIR
 
 ifeq ($(CONFIG_APPS_DIR),)
-CONFIG_APPS_DIR = ../apps
+CONFIG_APPS_DIR = ..\apps
 endif
-APPDIR := $(realpath ${shell if [ -r $(CONFIG_APPS_DIR)/Makefile ]; then echo "$(CONFIG_APPS_DIR)"; fi})
+APPDIR := $(realpath ${shell if exist "$(CONFIG_APPS_DIR)\Makefile" echo $(CONFIG_APPS_DIR)})
 
 # External code support
 # If external/ contains a Kconfig, we define the EXTERNALDIR variable to 'external'
 # so that main Kconfig can find it. Otherwise, we redirect it to a dummy Kconfig
 # This is due to kconfig inability to do conditional inclusion.
 
-EXTERNALDIR := $(shell if [ -r $(TOPDIR)/external/Kconfig ]; then echo 'external'; else echo 'dummy'; fi)
+EXTERNALDIR := $(shell if [ -r $(TOPDIR)\external\Kconfig ]; then echo 'external'; else echo 'dummy'; fi)
 
 # CONTEXTDIRS include directories that have special, one-time pre-build
 #   requirements.  Normally this includes things like auto-generation of
@@ -89,7 +71,7 @@ EXTERNALDIR := $(shell if [ -r $(TOPDIR)/external/Kconfig ]; then echo 'external
 #   then this holds only the directories containing user files. If
 #   CONFIG_BUILD_KERNEL is selected, then applications are not build at all.
 
-include tools/Directories.mk
+include tools\Directories.mk
 
 #
 # Extra objects used in the final link.
@@ -112,22 +94,22 @@ endif
 #   'make export' is
 
 ifeq ($(CONFIG_BUILD_PROTECTED),y)
-include tools/ProtectedLibs.mk
+include tools\ProtectedLibs.mk
 else ifeq ($(CONFIG_BUILD_KERNEL),y)
-include tools/KernelLibs.mk
+include tools\KernelLibs.mk
 else
-include tools/FlatLibs.mk
+include tools\FlatLibs.mk
 endif
 
 # LINKLIBS derives from NUTTXLIBS and is simply the same list with the
 #   subdirectory removed
 
-LINKLIBS = $(patsubst staging/%,%,$(NUTTXLIBS))
+LINKLIBS = $(patsubst staging\\%,%,$(NUTTXLIBS))
 
 # Export tool definitions
 
-MKEXPORT= tools/mkexport.sh
-MKEXPORT_ARGS = -t "$(TOPDIR)" -b "$(BOARD_DIR)"
+MKEXPORT = tools\mkexport.bat
+MKEXPORT_ARGS = -t "$(TOPDIR)"
 
 ifneq ($(CONFIG_BUILD_FLAT),y)
 MKEXPORT_ARGS += -u
@@ -149,20 +131,20 @@ endif
 BIN = nuttx$(EXEEXT)
 
 all: $(BIN)
-.PHONY: context clean_context config oldconfig menuconfig nconfig qconfig gconfig export subdir_clean clean subdir_distclean distclean apps_clean apps_distclean
+.PHONY: context clean_context config oldconfig menuconfig nconfig export subdir_clean clean subdir_distclean distclean apps_clean apps_distclean
 .PHONY: pass1 pass1dep
 .PHONY: pass2 pass2dep
 
-# Target used to copy include/nuttx/lib/math.h.  If CONFIG_ARCH_MATH_H is
+# Target used to copy include\nuttx\math.h.  If CONFIG_ARCH_MATH_H is
 # defined, then there is an architecture specific math.h header file
-# that will be included indirectly from include/math.h.  But first, we
-# have to copy math.h from include/nuttx/. to include/.  Logic within
-# include/nuttx/lib/math.h will hand the redirection to the architecture-
+# that will be included indirectly from include\math.h.  But first, we
+# have to copy math.h from include\nuttx\. to include\.  Logic within
+# include\nuttx\math.h will hand the redirection to the architecture-
 # specific math.h header file.
 #
-# If the CONFIG_LIBM is defined, the Rhombus libm will be built at libc/math.
+# If the CONFIG_LIBM is defined, the Rhombus libm will be built at libc\math.
 # Definitions and prototypes for the Rhombus libm are also contained in
-# include/nuttx/lib/math.h and so the file must also be copied in that case.
+# include\nuttx\math.h and so the file must also be copied in that case.
 #
 # If neither CONFIG_ARCH_MATH_H nor CONFIG_LIBM is defined, then no math.h
 # header file will be provided.  You would want that behavior if (1) you
@@ -176,8 +158,10 @@ NEED_MATH_H = y
 endif
 
 ifeq ($(NEED_MATH_H),y)
-include/math.h: include/nuttx/lib/math.h
-	$(Q) cp -f include/nuttx/lib/math.h include/math.h
+include\math.h: include\nuttx\math.h
+	$(Q) cp -f include\nuttx\math.h include\math.h
+else
+include\math.h:
 endif
 
 # The float.h header file defines the properties of your floating point
@@ -187,66 +171,67 @@ endif
 # the settings in this float.h are actually correct for your platform!
 
 ifeq ($(CONFIG_ARCH_FLOAT_H),y)
-include/float.h: include/nuttx/lib/float.h
-	$(Q) cp -f include/nuttx/lib/float.h include/float.h
+include\float.h: include\nuttx\float.h
+	$(Q) cp -f include\nuttx\float.h include\float.h
+else
+include\float.h:
 endif
 
-# Target used to copy include/nuttx/lib/stdarg.h.  If CONFIG_ARCH_STDARG_H is
+# Target used to copy include\nuttx\stdarg.h.  If CONFIG_ARCH_STDARG_H is
 # defined, then there is an architecture specific stdarg.h header file
-# that will be included indirectly from include/lib/stdarg.h.  But first, we
-# have to copy stdarg.h from include/nuttx/. to include/.
+# that will be included indirectly from include\stdarg.h.  But first, we
+# have to copy stdarg.h from include\nuttx\. to include\.
 
 ifeq ($(CONFIG_ARCH_STDARG_H),y)
-include/stdarg.h: include/nuttx/lib/stdarg.h
-	$(Q) cp -f include/nuttx/lib/stdarg.h include/stdarg.h
+include\stdarg.h: include\nuttx\stdarg.h
+	$(Q) cp -f include\nuttx\stdarg.h include\stdarg.h
+else
+include\stdarg.h:
 endif
 
-# Target used to copy include/nuttx/lib/setjmp.h.  If CONFIG_ARCH_SETJMP_H is
+# Target used to copy include\nuttx\setjmp.h.  If CONFIG_ARCH_SETJMP_H is
 # defined, then there is an architecture specific setjmp.h header file
-# that will be included indirectly from include/lib/setjmp.h.  But first, we
-# have to copy setjmp.h from include/nuttx/. to include/.
+# that will be included indirectly from include\setjmp.h.  But first, we
+# have to copy setjmp.h from include\nuttx\. to include\.
 
 ifeq ($(CONFIG_ARCH_SETJMP_H),y)
-include/setjmp.h: include/nuttx/lib/setjmp.h
-	$(Q) cp -f include/nuttx/lib/setjmp.h include/setjmp.h
+include\setjmp.h: include\nuttx\setjmp.h
+	$(Q) cp -f include\nuttx\setjmp.h include\setjmp.h
+else
+include\setjmp.h:
 endif
 
-# Targets used to build include/nuttx/version.h.  Creation of version.h is
+# Targets used to build include\nuttx\version.h.  Creation of version.h is
 # part of the overall NuttX configuration sequence. Notice that the
-# tools/mkversion tool is built and used to create include/nuttx/version.h
+# tools\mkversion tool is built and used to create include\nuttx\version.h
 
-tools/mkversion$(HOSTEXEEXT):
+tools\mkversion$(HOSTEXEEXT):
 	$(Q) $(MAKE) -C tools -f Makefile.host mkversion$(HOSTEXEEXT)
 
-# [Re-]create .version if it doesn't already exist.
+$(TOPDIR)\.version:
+	$(Q) echo CONFIG_VERSION_STRING="0" > .version
+	$(Q) echo CONFIG_VERSION_MAJOR=0 >> .version
+	$(Q) echo CONFIG_VERSION_MINOR=0 >> .version
+	$(Q) echo CONFIG_VERSION_PATCH=0 >> .version
+	$(Q) echo CONFIG_VERSION_BUILD="0" >> .version
 
-$(TOPDIR)/.version:
-	$(Q) echo "Create .version"
-	$(Q) tools/version.sh $(VERSION_ARG) .version
-	$(Q) chmod 755 .version
+include\nuttx\version.h: $(TOPDIR)\.version tools\mkversion$(HOSTEXEEXT)
+	$(Q) tools\mkversion$(HOSTEXEEXT) $(TOPDIR) > include\nuttx\version.h
 
-include/nuttx/version.h: $(TOPDIR)/.version tools/mkversion$(HOSTEXEEXT)
-	$(Q) echo "Create version.h"
-	$(Q) tools/mkversion $(TOPDIR) > $@
-
-# Targets used to build include/nuttx/config.h.  Creation of config.h is
+# Targets used to build include\nuttx\config.h.  Creation of config.h is
 # part of the overall NuttX configuration sequence. Notice that the
-# tools/mkconfig tool is built and used to create include/nuttx/config.h
+# tools\mkconfig tool is built and used to create include\nuttx\config.h
 
-tools/mkconfig$(HOSTEXEEXT):
+tools\mkconfig$(HOSTEXEEXT):
 	$(Q) $(MAKE) -C tools -f Makefile.host mkconfig$(HOSTEXEEXT)
 
-include/nuttx/config.h: $(TOPDIR)/.config tools/mkconfig$(HOSTEXEEXT)
-	$(Q) tools/mkconfig $(TOPDIR) > $@.tmp
-	$(Q) $(call TESTANDREPLACEFILE, $@.tmp, $@)
+include\nuttx\config.h: $(TOPDIR)\.config tools\mkconfig$(HOSTEXEEXT)
+	$(Q) tools\mkconfig$(HOSTEXEEXT) $(TOPDIR) > include\nuttx\config.h
 
 # Targets used to create dependencies
 
-tools/mkdeps$(HOSTEXEEXT):
+tools\mkdeps$(HOSTEXEEXT):
 	$(Q) $(MAKE) -C tools -f Makefile.host mkdeps$(HOSTEXEEXT)
-
-tools/cnvwindeps$(HOSTEXEEXT):
-	$(Q) $(MAKE) -C tools -f Makefile.host cnvwindeps$(HOSTEXEEXT)
 
 # .dirlinks, and helpers
 #
@@ -254,102 +239,102 @@ tools/cnvwindeps$(HOSTEXEEXT):
 # setting up symbolic links with 'generic' directory names to specific,
 # configured directories.
 
-# Link the arch/<arch-name>/include directory to include/arch
+# Link the arch\<arch-name>\include directory to include\arch
 
-include/arch:
-	@echo "LN: $@ to $(ARCH_DIR)/include"
-	$(Q) $(DIRLINK) $(TOPDIR)/$(ARCH_DIR)/include $@
+include\arch:
+	@echo "LN: $@ to $(ARCH_DIR)\include"
+	$(Q) $(DIRLINK) $(TOPDIR)\$(ARCH_DIR)\include $@
 
-# Link the boards/<arch>/<chip>/<board>/include directory to include/arch/board
+# Link the boards\<arch>\<chip>\<board>\include directory to include\arch\board
 
-include/arch/board: | include/arch
-	@echo "LN: $@ to $(BOARD_DIR)/include"
-	$(Q) $(DIRLINK) $(BOARD_DIR)/include $@
+include\arch\board: | include\arch
+	@echo "LN: $@ to $(BOARD_DIR)\include"
+	$(Q) $(DIRLINK) $(BOARD_DIR)\include $@
 
-# Link the boards/<arch>/<chip>/common dir to arch/<arch-name>/src/board
-# Link the boards/<arch>/<chip>/<board>/src dir to arch/<arch-name>/src/board/board
+# Link the boards\<arch>\<chip>\common dir to arch\<arch-name>\src\board
+# Link the boards\<arch>\<chip>\<board>\src dir to arch\<arch-name>\src\board\board
 
 ifneq ($(BOARD_COMMON_DIR),)
 ARCH_SRC_BOARD_SYMLINK=$(BOARD_COMMON_DIR)
-ARCH_SRC_BOARD_BOARD_SYMLINK=$(BOARD_DIR)/src
+ARCH_SRC_BOARD_BOARD_SYMLINK=$(BOARD_DIR)\src
 else
-ARCH_SRC_BOARD_SYMLINK=$(BOARD_DIR)/src
+ARCH_SRC_BOARD_SYMLINK=$(BOARD_DIR)\src
 endif
 
 ifneq ($(ARCH_SRC_BOARD_SYMLINK),)
-$(ARCH_SRC)/board:
+$(ARCH_SRC)\board:
 	@echo "LN: $@ to $(ARCH_SRC_BOARD_SYMLINK)"
 	$(Q) $(DIRLINK) $(ARCH_SRC_BOARD_SYMLINK) $@
 endif
 
 ifneq ($(ARCH_SRC_BOARD_BOARD_SYMLINK),)
-$(ARCH_SRC)/board/board: | $(ARCH_SRC)/board
+$(ARCH_SRC)\board\board: | $(ARCH_SRC)\board
 	@echo "LN: $@ to $(ARCH_SRC_BOARD_BOARD_SYMLINK)"
 	$(Q) $(DIRLINK) $(ARCH_SRC_BOARD_BOARD_SYMLINK) $@
 endif
 
-# Link the boards/<arch>/<chip>/drivers dir to drivers/platform
+# Link the boards\<arch>\<chip>\drivers dir to drivers\platform
 
-drivers/platform:
+drivers\platform:
 	@echo "LN: $@ to $(BOARD_DRIVERS_DIR)"
 	$(Q) $(DIRLINK) $(BOARD_DRIVERS_DIR) $@
 
-# Link arch/<arch-name>/src/<chip-name> to arch/<arch-name>/src/chip
+# Link arch\<arch-name>\src\<chip-name> to arch\<arch-name>\src\chip
 
 ifeq ($(CONFIG_ARCH_CHIP_CUSTOM),y)
 ARCH_SRC_CHIP_SYMLINK_DIR=$(CHIP_DIR)
 else ifneq ($(CONFIG_ARCH_CHIP),)
-ARCH_SRC_CHIP_SYMLINK_DIR=$(TOPDIR)/$(ARCH_SRC)/$(CONFIG_ARCH_CHIP)
+ARCH_SRC_CHIP_SYMLINK_DIR=$(TOPDIR)\$(ARCH_SRC)\$(CONFIG_ARCH_CHIP)
 endif
 
 ifneq ($(ARCH_SRC_CHIP_SYMLINK_DIR),)
-$(ARCH_SRC)/chip:
+$(ARCH_SRC)\chip:
 	@echo "LN: $@ to $(ARCH_SRC_CHIP_SYMLINK_DIR)"
 	$(Q) $(DIRLINK) $(ARCH_SRC_CHIP_SYMLINK_DIR) $@
 endif
 
-# Link arch/<arch-name>/include/<chip-name> to include/arch/chip
+# Link arch\<arch-name>\include\<chip-name> to include\arch\chip
 
 ifeq ($(CONFIG_ARCH_CHIP_CUSTOM),y)
-INCLUDE_ARCH_CHIP_SYMLINK_DIR=$(CHIP_DIR)/include
+INCLUDE_ARCH_CHIP_SYMLINK_DIR=$(CHIP_DIR)\include
 else ifneq ($(CONFIG_ARCH_CHIP),)
-INCLUDE_ARCH_CHIP_SYMLINK_DIR=$(TOPDIR)/$(ARCH_INC)/$(CONFIG_ARCH_CHIP)
+INCLUDE_ARCH_CHIP_SYMLINK_DIR=$(TOPDIR)\$(ARCH_INC)\$(CONFIG_ARCH_CHIP)
 endif
 
 ifneq ($(INCLUDE_ARCH_CHIP_SYMLINK_DIR),)
-include/arch/chip:
+include\arch\chip:
 	@echo "LN: $@ to $(INCLUDE_ARCH_CHIP_SYMLINK_DIR)"
 	$(DIRLINK) $(INCLUDE_ARCH_CHIP_SYMLINK_DIR) $@
 endif
 
-# Copy $(CHIP_KCONFIG) to arch/dummy/Kconfig
+# Copy $(CHIP_KCONFIG) to arch\dummy\Kconfig
 
-arch/dummy/Kconfig:
+arch\dummy\Kconfig:
 	@echo "CP: $@ to $(CHIP_KCONFIG)"
 	$(Q) cp -f $(CHIP_KCONFIG) $@
 
 DIRLINKS_SYMLINK = \
-  include/arch \
-  include/arch/board \
-  drivers/platform \
+  include\arch \
+  include\arch\board \
+  drivers\platform \
 
 DIRLINKS_FILE = \
-  arch/dummy/Kconfig \
+  arch\dummy\Kconfig \
 
 ifneq ($(INCLUDE_ARCH_CHIP_SYMLINK_DIR),)
-DIRLINKS_SYMLINK += include/arch/chip
+DIRLINKS_SYMLINK += include\arch\chip
 endif
 
 ifneq ($(ARCH_SRC_CHIP_SYMLINK_DIR),)
-DIRLINKS_SYMLINK += $(ARCH_SRC)/chip
+DIRLINKS_SYMLINK += $(ARCH_SRC)\chip
 endif
 
 ifneq ($(ARCH_SRC_BOARD_SYMLINK),)
-DIRLINKS_SYMLINK += $(ARCH_SRC)/board
+DIRLINKS_SYMLINK += $(ARCH_SRC)\board
 endif
 
 ifneq ($(ARCH_SRC_BOARD_BOARD_SYMLINK),)
-DIRLINKS_SYMLINK += $(ARCH_SRC)/board/board
+DIRLINKS_SYMLINK += $(ARCH_SRC)\board\board
 endif
 
 DIRLINKS_EXTERNAL_DIRS = boards
@@ -359,8 +344,7 @@ DIRLINKS_EXTERNAL_DIRS += $(APPDIR)
 endif
 
 # Generate a pattern to build $(DIRLINKS_EXTERNAL_DIRS)
-
-DIRLINKS_EXTERNAL_DEP = $(patsubst %,%/.dirlinks,$(DIRLINKS_EXTERNAL_DIRS))
+DIRLINKS_EXTERNAL_DEP = $(patsubst %,%\.dirlinks,$(DIRLINKS_EXTERNAL_DIRS))
 DIRLINKS_FILE += $(DIRLINKS_EXTERNAL_DEP)
 
 .dirlinks: $(DIRLINKS_FILE) | $(DIRLINKS_SYMLINK)
@@ -368,9 +352,10 @@ DIRLINKS_FILE += $(DIRLINKS_EXTERNAL_DEP)
 
 # Pattern rule for $(DIRLINKS_EXTERNAL_DEP)
 
-%/.dirlinks:
-	$(Q) $(MAKE) -C $(patsubst %/.dirlinks,%,$@) dirlinks
+%\.dirlinks:
+	$(Q) $(MAKE) -C $(patsubst %\.dirlinks,%,$@) dirlinks
 	$(Q) touch $@
+
 
 # clean_dirlinks
 #
@@ -382,20 +367,20 @@ DIRLINKS_FILE += $(DIRLINKS_EXTERNAL_DEP)
 clean_dirlinks:
 	$(Q) $(call DELFILE, $(DIRLINKS_FILE))
 	$(Q) $(call DELFILE, .dirlinks)
-	$(Q) $(DIRUNLINK) drivers/platform
+	$(Q) $(DIRUNLINK) drivers\platform
 ifneq ($(INCLUDE_ARCH_CHIP_SYMLINK_DIR),)
-	$(Q) $(DIRUNLINK) include/arch/chip
+	$(Q) $(DIRUNLINK) include\arch\chip
 endif
-	$(Q) $(DIRUNLINK) include/arch/board
-	$(Q) $(DIRUNLINK) include/arch
+	$(Q) $(DIRUNLINK) include\arch\board
+	$(Q) $(DIRUNLINK) include\arch
 ifneq ($(ARCH_SRC_BOARD_BOARD_SYMLINK),)
-	$(Q) $(DIRUNLINK) $(ARCH_SRC)/board/board
+	$(Q) $(DIRUNLINK) $(ARCH_SRC)\board\board
 endif
 ifneq ($(ARCH_SRC_BOARD_SYMLINK),)
-	$(Q) $(DIRUNLINK) $(ARCH_SRC)/board
+	$(Q) $(DIRUNLINK) $(ARCH_SRC)\board
 endif
 ifneq ($(ARCH_SRC_CHIP_SYMLINK_DIR),)
-	$(Q) $(DIRUNLINK) $(ARCH_SRC)/chip
+	$(Q) $(DIRUNLINK) $(ARCH_SRC)\chip
 endif
 
 
@@ -403,71 +388,72 @@ endif
 #
 # The context target is invoked on each target build to assure that NuttX is
 # properly configured.  The basic configuration steps include creation of the
-# the config.h and version.h header files in the include/nuttx directory and
+# the config.h and version.h header files in the include\nuttx directory and
 # the establishment of symbolic links to configured directories.
 
 # Generate a pattern to make Directories.mk context
 
-CONTEXTDIRS_DEPS = $(patsubst %,%/.context,$(CONTEXTDIRS))
+CONTEXTDIRS_DEPS = $(patsubst %,%\.context,$(CONTEXTDIRS))
 
-context: include/nuttx/config.h include/nuttx/version.h .dirlinks $(CONTEXTDIRS_DEPS) | staging
+context: include\nuttx\config.h include\nuttx\version.h $(CONTEXTDIRS_DEPS) .dirlinks | staging
+
+ifeq ($(NEED_MATH_H),y)
+context: include\math.h
+endif
+
+ifeq ($(CONFIG_ARCH_FLOAT_H),y)
+context: include\float.h
+endif
+
+ifeq ($(CONFIG_ARCH_STDARG_H),y)
+context: include\stdarg.h
+endif
+
+ifeq ($(CONFIG_ARCH_SETJMP_H),y)
+context: include\setjmp.h
+endif
 
 staging:
 	$(Q) mkdir -p $@
 
 # Pattern rule for $(CONTEXTDIRS_DEPS)
 
-%.context: include/nuttx/config.h .dirlinks
+%.context: include\nuttx\config.h .dirlinks
 	$(Q) $(MAKE) -C $(patsubst %.context,%,$@) TOPDIR="$(TOPDIR)" context
 	$(Q) touch $@
-
-ifeq ($(NEED_MATH_H),y)
-context: include/math.h
-endif
-
-ifeq ($(CONFIG_ARCH_FLOAT_H),y)
-context: include/float.h
-endif
-
-ifeq ($(CONFIG_ARCH_STDARG_H),y)
-context: include/stdarg.h
-endif
-
-ifeq ($(CONFIG_ARCH_SETJMP_H),y)
-context: include/setjmp.h
-endif
 
 # clean_context
 #
 # This is part of the distclean target.  It removes all of the header files
 # and symbolic links created by the context target.
 
-clean_context: clean_dirlinks
-	$(Q) for dir in $(CCLEANDIRS) ; do \
-		if [ -e $$dir/Makefile ]; then \
-			$(MAKE) -C $$dir clean_context ; \
-		fi \
-	done
-	$(call DELFILE, include/nuttx/config.h)
-	$(call DELFILE, include/nuttx/version.h)
-	$(call DELFILE, include/float.h)
-	$(call DELFILE, include/math.h)
-	$(call DELFILE, include/stdarg.h)
-	$(call DELFILE, include/setjmp.h)
-	$(call DELFILE, arch/dummy/Kconfig)
+clean_context:
+	$(Q) for %%G in ($(CCLEANDIRS)) do ( if exist %%G\Makefile $(MAKE) -C %%G clean_context )
+	$(call DELFILE, include\nuttx\config.h)
+	$(call DELFILE, include\nuttx\version.h)
+	$(call DELFILE, include\float.h)
+	$(call DELFILE, include\math.h)
+	$(call DELFILE, include\stdarg.h)
+	$(call DELFILE, include\setjmp.h)
+	$(call DELFILE, arch\dummy\Kconfig)
 	$(call DELFILE, $(CONTEXTDIRS_DEPS))
+	$(call DIRUNLINK, include\arch\board)
+	$(call DIRUNLINK, include\arch\chip)
+	$(call DIRUNLINK, include\arch)
+	$(call DIRUNLINK, $(ARCH_SRC)\board\board)
+	$(call DIRUNLINK, $(ARCH_SRC)\board)
+	$(call DIRUNLINK, $(ARCH_SRC)\chip)
+	$(call DIRUNLINK, $(TOPDIR)\drivers\platform)
 
 # Archive targets.  The target build sequence will first create a series of
 # libraries, one per configured source file directory.  The final NuttX
 # execution will then be built from those libraries.  The following targets
 # build those libraries.
 
-include tools/LibTargets.mk
-
 # pass1 and pass2
 #
 # If the 2 pass build option is selected, then this pass1 target is
-# configured to be built before the pass2 target.  This pass1 target may, as an
+# configured to built before the pass2 target.  This pass1 target may, as an
 # example, build an extra link object (CONFIG_PASS1_OBJECT) which may be an
 # incremental (relative) link object, but could be a static library (archive);
 # some modification to this Makefile would be required if CONFIG_PASS1_OBJECT
@@ -496,18 +482,15 @@ ifeq ($(CONFIG_BUILD_2PASS),y)
 		echo "ERROR: CONFIG_PASS1_BUILDIR does not exist"; \
 		exit 1; \
 	fi
-	$(Q) if [ ! -f "$(CONFIG_PASS1_BUILDIR)/Makefile" ]; then \
+	$(Q) if [ ! -f "$(CONFIG_PASS1_BUILDIR)\Makefile" ]; then \
 		echo "ERROR: No Makefile in CONFIG_PASS1_BUILDIR"; \
 		exit 1; \
 	fi
 	$(Q) $(MAKE) -C $(CONFIG_PASS1_BUILDIR) LINKLIBS="$(LINKLIBS)" USERLIBS="$(USERLIBS)" "$(CONFIG_PASS1_TARGET)"
 endif
 	$(Q) $(MAKE) -C $(ARCH_SRC) EXTRA_OBJS="$(EXTRA_OBJS)" LINKLIBS="$(LINKLIBS)" EXTRAFLAGS="$(KDEFINE) $(EXTRAFLAGS)" $(BIN)
-	$(Q) if [ -w /tftpboot ] ; then \
-		cp -f $(BIN) /tftpboot/$(BIN).${CONFIG_ARCH}; \
-	fi
 	$(Q) echo $(BIN) > nuttx.manifest
-	$(Q) printf "%s\n" *.map >> nuttx.manifest
+	$(Q) printf '%s\n' *.map >> nuttx.manifest
 ifeq ($(CONFIG_INTELHEX_BINARY),y)
 	@echo "CP: nuttx.hex"
 	$(Q) $(OBJCOPY) $(OBJCOPYARGS) -O ihex $(BIN) nuttx.hex
@@ -522,15 +505,6 @@ ifeq ($(CONFIG_RAW_BINARY),y)
 	@echo "CP: nuttx.bin"
 	$(Q) $(OBJCOPY) $(OBJCOPYARGS) -O binary $(BIN) nuttx.bin
 	$(Q) echo nuttx.bin >> nuttx.manifest
-endif
-ifeq ($(CONFIG_UBOOT_UIMAGE),y)
-	@echo "MKIMAGE: uImage"
-	$(Q) mkimage -A $(CONFIG_ARCH) -O linux -C none -T kernel -a $(CONFIG_UIMAGE_LOAD_ADDRESS) \
-		-e $(CONFIG_UIMAGE_ENTRY_POINT) -n $(BIN) -d nuttx.bin uImage
-	$(Q) if [ -w /tftpboot ] ; then \
-		cp -f uImage /tftpboot/uImage; \
-	fi
-	$(Q) echo "uImage" >> nuttx.manifest
 endif
 	$(call POSTBUILD, $(TOPDIR))
 
@@ -570,67 +544,53 @@ clean_bootloader:
 # pass1dep: Create pass1 build dependencies
 # pass2dep: Create pass2 build dependencies
 
-pass1dep: context tools/mkdeps$(HOSTEXEEXT) tools/cnvwindeps$(HOSTEXEEXT)
-	$(Q) for dir in $(USERDEPDIRS) ; do \
-		$(MAKE) -C $$dir depend || exit; \
-	done
+pass1dep: context tools\mkdeps$(HOSTEXEEXT)
+	$(Q) for %%G in ($(USERDEPDIRS)) do ( $(MAKE) -C %%G depend )
 
-pass2dep: context tools/mkdeps$(HOSTEXEEXT) tools/cnvwindeps$(HOSTEXEEXT)
-	$(Q) for dir in $(KERNDEPDIRS) ; do \
-		$(MAKE) -C $$dir EXTRAFLAGS="$(KDEFINE) $(EXTRAFLAGS)" depend || exit; \
-	done
+pass2dep: context tools\mkdeps$(HOSTEXEEXT)
+	$(Q) for %%G in ($(KERNDEPDIRS)) do ( $(MAKE) -C %%G EXTRAFLAGS="$(KDEFINE) $(EXTRAFLAGS)" depend )
 
 # Configuration targets
 #
 # These targets depend on the kconfig-frontends packages.  To use these, you
 # must first download and install the kconfig-frontends package from this
-# location: https://bitbucket.org/nuttx/tools/downloads/.  See README.txt
-# file in the NuttX tools GIT repository for additional information.
+# location: https://bitbucket.org/nuttx/tools/downloads/.  See
+# misc\tools\README.txt for additional information.
 
 config:
 	$(Q) $(MAKE) clean_context
 	$(Q) $(MAKE) apps_preconfig
-	$(Q) APPSDIR=${CONFIG_APPS_DIR} EXTERNALDIR=$(EXTERNALDIR) kconfig-conf Kconfig
+	$(Q) set APPSDIR=$(patsubst "%",%,${CONFIG_APPS_DIR})& set EXTERNALDIR=$(EXTERNALDIR)& kconfig-conf Kconfig
 
 oldconfig:
 	$(Q) $(MAKE) clean_context
 	$(Q) $(MAKE) apps_preconfig
-	$(Q) APPSDIR=${CONFIG_APPS_DIR} EXTERNALDIR=$(EXTERNALDIR) kconfig-conf --oldconfig Kconfig
+	$(Q) set APPSDIR=$(patsubst "%",%,${CONFIG_APPS_DIR})& set EXTERNALDIR=$(EXTERNALDIR)& kconfig-conf --oldconfig Kconfig
 
 olddefconfig:
 	$(Q) $(MAKE) clean_context
 	$(Q) $(MAKE) apps_preconfig
-	$(Q) APPSDIR=${CONFIG_APPS_DIR} EXTERNALDIR=$(EXTERNALDIR) kconfig-conf --olddefconfig Kconfig
+	$(Q) set APPSDIR=$(patsubst "%",%,${CONFIG_APPS_DIR})& set EXTERNALDIR=$(EXTERNALDIR)& kconfig-conf --olddefconfig Kconfig
 
 menuconfig:
 	$(Q) $(MAKE) clean_context
 	$(Q) $(MAKE) apps_preconfig
-	$(Q) APPSDIR=${CONFIG_APPS_DIR} EXTERNALDIR=$(EXTERNALDIR) kconfig-mconf Kconfig
+	$(Q) set APPSDIR=$(patsubst "%",%,${CONFIG_APPS_DIR})& set EXTERNALDIR=$(EXTERNALDIR)& kconfig-mconf Kconfig
 
-nconfig: apps_preconfig
+nconfig:
 	$(Q) $(MAKE) clean_context
 	$(Q) $(MAKE) apps_preconfig
-	$(Q) APPSDIR=${CONFIG_APPS_DIR} EXTERNALDIR=$(EXTERNALDIR) kconfig-nconf Kconfig
-
-qconfig: apps_preconfig
-	$(Q) $(MAKE) clean_context
-	$(Q) $(MAKE) apps_preconfig
-	$(Q) APPSDIR=${CONFIG_APPS_DIR} EXTERNALDIR=$(EXTERNALDIR) kconfig-qconf Kconfig
-
-gconfig: apps_preconfig
-	$(Q) $(MAKE) clean_context
-	$(Q) $(MAKE) apps_preconfig
-	$(Q) APPSDIR=${CONFIG_APPS_DIR} EXTERNALDIR=$(EXTERNALDIR) kconfig-gconf Kconfig
+	$(Q) set APPSDIR=$(patsubst "%",%,${CONFIG_APPS_DIR})& set EXTERNALDIR=$(EXTERNALDIR)& kconfig-nconf Kconfig
 
 savedefconfig: apps_preconfig
-	$(Q) APPSDIR=${CONFIG_APPS_DIR} EXTERNALDIR=$(EXTERNALDIR) kconfig-conf --savedefconfig defconfig.tmp Kconfig
+	$(Q) set APPSDIR=$(patsubst "%",%,${CONFIG_APPS_DIR})& set EXTERNALDIR=$(EXTERNALDIR)& kconfig-conf --savedefconfig defconfig.tmp Kconfig
 	$(Q) kconfig-tweak --file defconfig.tmp -u CONFIG_APPS_DIR
 	$(Q) grep "CONFIG_ARCH=" .config >> defconfig.tmp
-	$(Q) grep "^CONFIG_ARCH_CHIP_" .config >> defconfig.tmp; true
-	$(Q) grep "CONFIG_ARCH_CHIP=" .config >> defconfig.tmp; true
-	$(Q) grep "CONFIG_ARCH_BOARD=" .config >> defconfig.tmp; true
-	$(Q) grep "^CONFIG_ARCH_CUSTOM" .config >> defconfig.tmp; true
-	$(Q) grep "^CONFIG_ARCH_BOARD_CUSTOM" .config >> defconfig.tmp; true
+	-$(Q) grep "^CONFIG_ARCH_CHIP_" .config >> defconfig.tmp
+	-$(Q) grep "CONFIG_ARCH_CHIP=" .config >> defconfig.tmp
+	-$(Q) grep "CONFIG_ARCH_BOARD=" .config >> defconfig.tmp
+	-$(Q) grep "^CONFIG_ARCH_CUSTOM" .config >> defconfig.tmp
+	-$(Q) grep "^CONFIG_ARCH_BOARD_CUSTOM" .config >> defconfig.tmp
 	$(Q) export LC_ALL=C; cat defconfig.tmp | sort | uniq > sortedconfig.tmp
 	$(Q) echo "#" > warning.tmp
 	$(Q) echo "# This file is autogenerated: PLEASE DO NOT EDIT IT." >> warning.tmp
@@ -649,11 +609,11 @@ savedefconfig: apps_preconfig
 # The export target will package the NuttX libraries and header files into
 # an exportable package.  Caveats: (1) These needs some extension for the KERNEL
 # build; it needs to receive USERLIBS and create a libuser.a). (2) The logic
-# in tools/mkexport.sh only supports GCC and, for example, explicitly assumes
+# in tools\mkexport.sh only supports GCC and, for example, explicitly assumes
 # that the archiver is 'ar'
 
-export: $(NUTTXLIBS)
-	$(Q) MAKE=${MAKE} $(MKEXPORT) $(MKEXPORT_ARGS) -l "$(EXPORTLIBS)"
+export: ${NUTTXLIBS}
+	$(Q) $(MKEXPORT) $(MKEXPORT_ARGS) -l "$(EXPORTLIBS)"
 
 # General housekeeping targets:  dependencies, cleaning, etc.
 #
@@ -679,9 +639,9 @@ clean: subdir_clean
 	$(call DELFILE, nuttx.*)
 	$(call DELFILE, *.map)
 	$(call DELFILE, _SAVED_APPS_config)
-	$(call DELFILE, nuttx-export*.zip)
-	$(call DELDIR, nuttx-export*)
+	$(call DELFILE, nuttx-export*)
 	$(call DELFILE, nuttx_user*)
+	$(call DELFILE, .gdbinit)
 	$(call DELDIR, staging)
 	$(call DELFILE, uImage)
 	$(call CLEAN)
@@ -702,11 +662,10 @@ endif
 	$(call DELFILE, defconfig)
 	$(call DELFILE, .config)
 	$(call DELFILE, .config.old)
-	$(call DELFILE, .gdbinit)
 	$(Q) $(MAKE) -C tools -f Makefile.host clean
 
 # Application housekeeping targets.  The APPDIR variable refers to the user
-# application directory.  A sample apps/ directory is included with NuttX,
+# application directory.  A sample apps\ directory is included with NuttX,
 # however, this is not treated as part of NuttX and may be replaced with a
 # different application directory.  For the most part, the application
 # directory is treated like any other build directory in this script.  However,
@@ -721,15 +680,15 @@ endif
 
 apps_preconfig: .dirlinks
 ifneq ($(APPDIR),)
-	$(Q) $(MAKE) -C $(APPDIR) preconfig
+	$(Q) $(MAKE) -C "$(APPDIR)" preconfig
 endif
 
 apps_clean:
 ifneq ($(APPDIR),)
-	$(Q) $(MAKE) -C $(APPDIR) clean
+	$(Q) $(MAKE) -C "$(APPDIR)" clean
 endif
 
 apps_distclean:
 ifneq ($(APPDIR),)
-	$(Q) $(MAKE) -C $(APPDIR) distclean
+	$(Q) $(MAKE) -C "$(APPDIR)" distclean
 endif

--- a/tools/mkexport.sh
+++ b/tools/mkexport.sh
@@ -163,7 +163,7 @@ cp -a "${TOPDIR}/Make.defs" "${EXPORTDIR}/Make.defs" ||
 
 # Extract information from the Make.defs file.  A Makefile can do this best
 
-${MAKE} -C "${TOPDIR}/tools" -f Makefile.export TOPDIR="${TOPDIR}" EXPORTDIR="${EXPORTDIR}"
+${MAKE} -C "${TOPDIR}/tools" -f Export.mk TOPDIR="${TOPDIR}" EXPORTDIR="${EXPORTDIR}"
 source "${EXPORTDIR}/makeinfo.sh"
 rm -f "${EXPORTDIR}/makeinfo.sh"
 rm -f "${EXPORTDIR}/Make.defs"


### PR DESCRIPTION
## Summary
This PR renames `tools/Makefile.*` to have the `.mk` extension. This PR also updates `README.md` and other files that references the other files.
Note: Skipped Makefile.host for this PR since it caused failures in CI for the sim build

## Impact
By using a standard extension for Makefiles (https://www.file-extension.info/format/mk), editors will auto-format files.
This change will also improve developer ergonomics when searching for specific files

## Testing
Verified locally that build still works, CI will verify more!