### PR TITLE
Add test to CI to verify that the `context` rule doesn't need to be rebuilt between runs

### DIFF
--- a/tools/testbuild.sh
+++ b/tools/testbuild.sh
@@ -258,6 +258,10 @@ function build {
     fail=1
   fi
 
+  # Verify that the context rule does not need to be rebuilt
+
+  makefunc context --question
+
   # Ensure nuttx and apps directory in clean state
 
   if [ ${CHECKCLEAN} -ne 0 ]; then


### PR DESCRIPTION
## Summary
With recent improvements to Makefiles in these PRs:
* https://github.com/apache/incubator-nuttx/pull/5055
* https://github.com/apache/incubator-nuttx/pull/5069
* https://github.com/apache/incubator-nuttx/pull/5116
* https://github.com/apache/incubator-nuttx/pull/5163 (not merged yet)
* https://github.com/apache/incubator-nuttx/pull/5147 (not merged yet)

The context rule now only needs to be run once.

## Impact
We can verify that by running `make` (which will run `context` as part of the normal build).
Then we can verify that by running `make context --question` which will return `0` if the target is up to date

## Testing
Verified locally, once the final two PRs are merged CI should pass (and it should fail before that)
