### PR TITLE
boards/nucleo-f446re: add procfs support

### DIFF
--- a/boards/arm/stm32/nucleo-f446re/src/nucleo-f446re.h
+++ b/boards/arm/stm32/nucleo-f446re/src/nucleo-f446re.h
@@ -36,6 +36,16 @@
 
 /* Configuration ************************************************************/
 
+/* procfs File System */
+
+#ifdef CONFIG_FS_PROCFS
+#  ifdef CONFIG_NSH_PROC_MOUNTPOINT
+#    define STM32_PROCFS_MOUNTPOINT CONFIG_NSH_PROC_MOUNTPOINT
+#  else
+#    define STM32_PROCFS_MOUNTPOINT "/proc"
+#  endif
+#endif
+
 #define HAVE_MMCSD 1
 #if !defined(CONFIG_STM32_SDIO) || !defined(CONFIG_MMCSD) || \
     !defined(CONFIG_MMCSD_SDIO)

--- a/boards/arm/stm32/nucleo-f446re/src/stm32_bringup.c
+++ b/boards/arm/stm32/nucleo-f446re/src/stm32_bringup.c
@@ -79,6 +79,17 @@ int stm32_bringup(void)
 {
   int ret = OK;
 
+#ifdef CONFIG_FS_PROCFS
+  /* Mount the procfs file system */
+
+  ret = nx_mount(NULL, STM32_PROCFS_MOUNTPOINT, "procfs", 0, NULL);
+  if (ret < 0)
+    {
+      syslog(LOG_ERR,
+             "ERROR: Failed to mount the PROC filesystem: %d\n",  ret);
+    }
+#endif /* CONFIG_FS_PROCFS */
+
 #ifdef CONFIG_INPUT_BUTTONS
   /* Register the BUTTON driver */
 


### PR DESCRIPTION
## Summary
boards/nucleo-f446re: add procfs support

## Impact

## Testing

