### PR TITLE
libc/pthread:pthread_barrierinit sem use pri_none

### DIFF
--- a/libs/libc/pthread/pthread_barrierinit.c
+++ b/libs/libc/pthread/pthread_barrierinit.c
@@ -82,6 +82,7 @@ int pthread_barrier_init(FAR pthread_barrier_t *barrier,
   else
     {
       sem_init(&barrier->sem, 0, 0);
+      sem_setprotocol(&barrier->sem, SEM_PRIO_NONE);
       barrier->count = count;
     }
 


### PR DESCRIPTION
barrier is used protect resources. don't lock
Signed-off-by: anjiahao <anjiahao@xiaomi.com>

## Summary

## Impact

## Testing

