### PR TITLE
semphore: release all semphores' holder that the task held when exit

### DIFF
--- a/include/nuttx/sched.h
+++ b/include/nuttx/sched.h
@@ -611,6 +611,7 @@ struct tcb_s
   uint8_t  pend_reprios[CONFIG_SEM_NNESTPRIO];
 #endif
   uint8_t  base_priority;                /* "Normal" priority of the thread */
+  FAR struct semholder_s *holdsem;       /* List of held semaphores         */
 #endif
 
 #ifdef CONFIG_SMP

--- a/include/nuttx/semaphore.h
+++ b/include/nuttx/semaphore.h
@@ -44,7 +44,7 @@
     {(c), (f), NULL}                    /* semcount, flags, hhead */
 # else
 #  define NXSEM_INITIALIZER(c, f) \
-    {(c), (f), {{NULL, 0}, {NULL, 0}}}  /* semcount, flags, holder[2] */
+    {(c), (f), {SEMHOLDER_INITIALIZER, SEMHOLDER_INITIALIZER}}  /* semcount, flags, holder[2] */
 # endif
 #else /* CONFIG_PRIORITY_INHERITANCE */
 #  define NXSEM_INITIALIZER(c, f) \

--- a/include/semaphore.h
+++ b/include/semaphore.h
@@ -58,19 +58,38 @@
 
 #ifdef CONFIG_PRIORITY_INHERITANCE
 struct tcb_s; /* Forward reference */
+struct sem_s;
+
 struct semholder_s
 {
 #if CONFIG_SEM_PREALLOCHOLDERS > 0
-  struct semholder_s *flink;     /* Implements singly linked list */
+  FAR struct semholder_s *flink;  /* List of semaphore's holder            */
 #endif
-  FAR struct tcb_s *htcb;        /* Holder TCB */
-  int16_t counts;                /* Number of counts owned by this holder */
+  FAR struct semholder_s *tlink;  /* List of task held semaphores          */
+  FAR struct sem_s *sem;          /* Ths corresponding semaphore           */
+  FAR struct tcb_s *htcb;         /* Ths corresponding TCB                 */
+  int16_t counts;                 /* Number of counts owned by this holder */
 };
 
 #if CONFIG_SEM_PREALLOCHOLDERS > 0
-#  define SEMHOLDER_INITIALIZER {NULL, NULL, 0}
+#  define SEMHOLDER_INITIALIZER   {NULL, NULL, NULL, NULL, 0}
+#  define INITIALIZE_SEMHOLDER(h) \
+    do { \
+      (h)->flink  = NULL; \
+      (h)->tlink  = NULL; \
+      (h)->sem    = NULL; \
+      (h)->htcb   = NULL; \
+      (h)->counts = 0; \
+    } while (0)
 #else
-#  define SEMHOLDER_INITIALIZER {NULL, 0}
+#  define SEMHOLDER_INITIALIZER   {NULL, NULL, NULL, 0}
+#  define INITIALIZE_SEMHOLDER(h) \
+    do { \
+      (h)->tlink  = NULL; \
+      (h)->sem    = NULL; \
+      (h)->htcb   = NULL; \
+      (h)->counts = 0; \
+    } while (0)
 #endif
 #endif /* CONFIG_PRIORITY_INHERITANCE */
 

--- a/libs/libc/semaphore/sem_init.c
+++ b/libs/libc/semaphore/sem_init.c
@@ -78,10 +78,8 @@ int nxsem_init(FAR sem_t *sem, int pshared, unsigned int value)
 #  if CONFIG_SEM_PREALLOCHOLDERS > 0
       sem->hhead            = NULL;
 #  else
-      sem->holder[0].htcb   = NULL;
-      sem->holder[0].counts = 0;
-      sem->holder[1].htcb   = NULL;
-      sem->holder[1].counts = 0;
+      INITIALIZE_SEMHOLDER(&sem->holder[0]);
+      INITIALIZE_SEMHOLDER(&sem->holder[1]);
 #  endif
 #endif
       return OK;

--- a/sched/semaphore/sem_recover.c
+++ b/sched/semaphore/sem_recover.c
@@ -108,5 +108,9 @@ void nxsem_recover(FAR struct tcb_s *tcb)
       tcb->waitsem = NULL;
     }
 
+  /* Release all semphore holders for the task */
+
+  nxsem_release_all(tcb);
+
   leave_critical_section(flags);
 }

--- a/sched/semaphore/semaphore.h
+++ b/sched/semaphore/semaphore.h
@@ -79,6 +79,7 @@ void nxsem_boost_priority(FAR sem_t *sem);
 void nxsem_release_holder(FAR sem_t *sem);
 void nxsem_restore_baseprio(FAR struct tcb_s *stcb, FAR sem_t *sem);
 void nxsem_canceled(FAR struct tcb_s *stcb, FAR sem_t *sem);
+void nxsem_release_all(FAR struct tcb_s *stcb);
 #else
 #  define nxsem_initialize_holders()
 #  define nxsem_destroyholder(sem)
@@ -88,6 +89,7 @@ void nxsem_canceled(FAR struct tcb_s *stcb, FAR sem_t *sem);
 #  define nxsem_release_holder(sem)
 #  define nxsem_restore_baseprio(stcb,sem)
 #  define nxsem_canceled(stcb,sem)
+#  define nxsem_release_all(stcb)
 #endif
 
 #undef EXTERN


### PR DESCRIPTION
Add a list in TCB to track all semphores the task held, so we
can release all holders when exit, so nxsched_verify_tcb
is unnecessary.

Signed-off-by: Zeng Zhaoxiu <walker.zeng@transtekcorp.com>

## Summary

## Impact

## Testing

