### PR TITLE
fs/procfs: fix readdir loss last character

### DIFF
--- a/fs/procfs/fs_procfs.c
+++ b/fs/procfs/fs_procfs.c
@@ -800,7 +800,7 @@ static int procfs_readdir(struct inode *mountpt, struct fs_dirent_s *dir)
 
               level0->lastlen = strcspn(name, "/");
               level0->lastread = name;
-              strlcpy(dir->fd_dir.d_name, name, level0->lastlen);
+              strlcpy(dir->fd_dir.d_name, name, level0->lastlen + 1);
 
               /* If the entry is a directory type OR if the reported name is
                * only a sub-string of the entry (meaning that it contains


### PR DESCRIPTION

## Summary

fs/procfs: fix readdir loss last character

nsh> ls
/proc:
 0/
 1/
 2/
 3/
 4/
 5/
 meminf
 iobinf
 f/
 ne/
 sel/
 uptim
 versio

Signed-off-by: Jiuzhu Dong <dongjiuzhu1@xiaomi.com>

## Impact
N/A
## Testing
local test
