### PR TITLE
espressif: Fix build system issues related to Flash Encryption

### DIFF
--- a/tools/esp32c3/Config.mk
+++ b/tools/esp32c3/Config.mk
@@ -58,7 +58,7 @@ else
 	ESPTOOL_WRITEFLASH_OPTS := -fs $(FLASH_SIZE) -fm dio -ff $(FLASH_FREQ)
 endif
 
-ifeq ($(CONFIG_ESP32C3_SECURE_BOOT),y)
+ifneq ($(CONFIG_ESP32C3_SECURE_BOOT)$(CONFIG_ESP32C3_SECURE_FLASH_ENC_ENABLED),)
 	ESPTOOL_RESET_OPTS += --after no_reset
 endif
 
@@ -76,14 +76,19 @@ ifdef ESPTOOL_BINDIR
 		FLASH_PT        := $(PT_OFFSET) $(PARTITION_TABLE)
 		ESPTOOL_BINS    := $(FLASH_BL) $(FLASH_PT)
 	else ifeq ($(CONFIG_ESP32C3_APP_FORMAT_MCUBOOT),y)
-		BL_OFFSET       := 0x0
+		BL_OFFSET        := 0x0
+
 		ifeq ($(CONFIG_ESP32C3_SECURE_BOOT),y)
 			BOOTLOADER   := $(ESPTOOL_BINDIR)/mcuboot-esp32c3.signed.bin
-			FLASH_BL     := $(BL_OFFSET) $(BOOTLOADER)
-			ESPTOOL_BINS :=
 		else
 			BOOTLOADER   := $(ESPTOOL_BINDIR)/mcuboot-esp32c3.bin
-			FLASH_BL     := $(BL_OFFSET) $(BOOTLOADER)
+		endif
+
+		FLASH_BL         := $(BL_OFFSET) $(BOOTLOADER)
+
+		ifneq ($(CONFIG_ESP32C3_SECURE_BOOT)$(CONFIG_ESP32C3_SECURE_FLASH_ENC_ENABLED),)
+			ESPTOOL_BINS :=
+		else
 			ESPTOOL_BINS := $(FLASH_BL)
 		endif
 	endif
@@ -131,7 +136,7 @@ endef
 
 define HELP_FLASH_BOOTLOADER
 	$(Q) echo ""
-	$(Q) echo "$(YELLOW)Secure boot enabled, so bootloader not flashed automatically.$(RST)"
+	$(Q) echo "$(YELLOW)Security features enabled, so bootloader not flashed automatically.$(RST)"
 	$(Q) echo "Use the following command to flash the bootloader:"
 	$(Q) echo "    esptool.py $(ESPTOOL_OPTS) write_flash $(ESPTOOL_WRITEFLASH_OPTS) $(FLASH_BL)"
 	$(Q) echo ""
@@ -257,5 +262,5 @@ define FLASH
 	$(eval ESPTOOL_OPTS := -c esp32c3 -p $(ESPTOOL_PORT) -b $(ESPTOOL_BAUD) $(ESPTOOL_RESET_OPTS) $(if $(CONFIG_ESP32C3_ESPTOOLPY_NO_STUB),--no-stub))
 	esptool.py $(ESPTOOL_OPTS) write_flash $(ESPTOOL_WRITEFLASH_OPTS) $(ESPTOOL_BINS)
 
-	$(if $(CONFIG_ESP32C3_SECURE_BOOT),$(call HELP_FLASH_BOOTLOADER))
+	$(if $(CONFIG_ESP32C3_SECURE_BOOT)$(CONFIG_ESP32C3_SECURE_FLASH_ENC_ENABLED),$(call HELP_FLASH_BOOTLOADER))
 endef

--- a/tools/esp32c3/Config.mk
+++ b/tools/esp32c3/Config.mk
@@ -112,7 +112,18 @@ else ifeq ($(CONFIG_ESP32C3_APP_FORMAT_MCUBOOT),y)
 	else
 		APP_IMAGE  := nuttx.bin
 	endif
+
 	FLASH_APP      := $(APP_OFFSET) $(APP_IMAGE)
+
+	ifeq ($(CONFIG_ESP32C3_SECURE_FLASH_ENC_ENABLED),y)
+		IMGTOOL_ALIGN_ARGS := --align 32 --max-align 32
+	else
+		IMGTOOL_ALIGN_ARGS := --align 4
+	endif
+
+	IMGTOOL_SIGN_ARGS := --pad $(VERIFIED) $(IMGTOOL_ALIGN_ARGS) -v 0 -s auto \
+		-H $(CONFIG_ESP32C3_APP_MCUBOOT_HEADER_SIZE) --pad-header \
+		-S $(CONFIG_ESP32C3_OTA_SLOT_SIZE)
 endif
 
 ESPTOOL_BINS += $(FLASH_APP)
@@ -130,7 +141,7 @@ define HELP_SIGN_APP
 	$(Q) echo ""
 	$(Q) echo "$(YELLOW)Application not signed. Sign the application before flashing.$(RST)"
 	$(Q) echo "To sign the application, you can use this command:"
-	$(Q) echo "    imgtool sign -k $(ESPSEC_KEYDIR)/$(CONFIG_ESP32C3_SECURE_BOOT_APP_SIGNING_KEY) --public-key-format hash --pad $(VERIFIED) --align 4 -v 0 -s auto -H $(CONFIG_ESP32C3_APP_MCUBOOT_HEADER_SIZE) --pad-header -S $(CONFIG_ESP32C3_OTA_SLOT_SIZE) nuttx.hex nuttx.signed.bin"
+	$(Q) echo "    imgtool sign -k $(ESPSEC_KEYDIR)/$(CONFIG_ESP32C3_SECURE_BOOT_APP_SIGNING_KEY) --public-key-format hash $(IMGTOOL_SIGN_ARGS) nuttx.hex nuttx.signed.bin"
 	$(Q) echo ""
 endef
 
@@ -185,13 +196,8 @@ define SIGNBIN
 		echo ""; \
 		exit 1; \
 	fi
-	$(if $(CONFIG_ESP32C3_SECURE_BOOT_BUILD_SIGNED_BINARIES), \
-		$(eval IMGTOOL_KEY_ARGS := -k $(APP_SIGN_KEY) --public-key-format hash))
 
-	imgtool sign $(IMGTOOL_KEY_ARGS) --pad $(VERIFIED) --align 4 -v 0 -s auto \
-		-H $(CONFIG_ESP32C3_APP_MCUBOOT_HEADER_SIZE) --pad-header \
-		-S $(CONFIG_ESP32C3_OTA_SLOT_SIZE) \
-		nuttx.hex nuttx.signed.bin
+	imgtool sign -k $(APP_SIGN_KEY) --public-key-format hash $(IMGTOOL_SIGN_ARGS) nuttx.hex nuttx.signed.bin
 	$(Q) echo nuttx.signed.bin >> nuttx.manifest
 	$(Q) echo "Generated: nuttx.signed.bin (MCUboot compatible)"
 endef
@@ -230,10 +236,7 @@ define MKIMAGE
 		echo "Run make again to create the nuttx.bin image."; \
 		exit 1; \
 	fi
-	imgtool sign --pad $(VERIFIED) --align 4 -v 0 -s auto \
-		-H $(CONFIG_ESP32C3_APP_MCUBOOT_HEADER_SIZE) --pad-header \
-		-S $(CONFIG_ESP32C3_OTA_SLOT_SIZE) \
-		nuttx.hex nuttx.bin
+	imgtool sign $(IMGTOOL_SIGN_ARGS) nuttx.hex nuttx.bin
 	$(Q) echo "Generated: nuttx.bin (MCUboot compatible)"
 endef
 endif

--- a/tools/esp32s2/Config.mk
+++ b/tools/esp32s2/Config.mk
@@ -58,7 +58,7 @@ else
 	ESPTOOL_WRITEFLASH_OPTS := -fs $(FLASH_SIZE) -fm dio -ff $(FLASH_FREQ)
 endif
 
-ifeq ($(CONFIG_ESP32S2_SECURE_BOOT),y)
+ifneq ($(CONFIG_ESP32S2_SECURE_BOOT)$(CONFIG_ESP32S2_SECURE_FLASH_ENC_ENABLED),)
 	ESPTOOL_RESET_OPTS += --after no_reset
 endif
 
@@ -76,14 +76,19 @@ ifdef ESPTOOL_BINDIR
 		FLASH_PT        := $(PT_OFFSET) $(PARTITION_TABLE)
 		ESPTOOL_BINS    := $(FLASH_BL) $(FLASH_PT)
 	else ifeq ($(CONFIG_ESP32S2_APP_FORMAT_MCUBOOT),y)
-		BL_OFFSET       := 0x1000
+		BL_OFFSET        := 0x1000
+
 		ifeq ($(CONFIG_ESP32S2_SECURE_BOOT),y)
 			BOOTLOADER   := $(ESPTOOL_BINDIR)/mcuboot-esp32s2.signed.bin
-			FLASH_BL     := $(BL_OFFSET) $(BOOTLOADER)
-			ESPTOOL_BINS :=
 		else
 			BOOTLOADER   := $(ESPTOOL_BINDIR)/mcuboot-esp32s2.bin
-			FLASH_BL     := $(BL_OFFSET) $(BOOTLOADER)
+		endif
+
+		FLASH_BL         := $(BL_OFFSET) $(BOOTLOADER)
+
+		ifneq ($(CONFIG_ESP32S2_SECURE_BOOT)$(CONFIG_ESP32S2_SECURE_FLASH_ENC_ENABLED),)
+			ESPTOOL_BINS :=
+		else
 			ESPTOOL_BINS := $(FLASH_BL)
 		endif
 	endif
@@ -131,7 +136,7 @@ endef
 
 define HELP_FLASH_BOOTLOADER
 	$(Q) echo ""
-	$(Q) echo "$(YELLOW)Secure boot enabled, so bootloader not flashed automatically.$(RST)"
+	$(Q) echo "$(YELLOW)Security features enabled, so bootloader not flashed automatically.$(RST)"
 	$(Q) echo "Use the following command to flash the bootloader:"
 	$(Q) echo "    esptool.py $(ESPTOOL_OPTS) write_flash $(ESPTOOL_WRITEFLASH_OPTS) $(FLASH_BL)"
 	$(Q) echo ""
@@ -256,5 +261,5 @@ define FLASH
 	$(eval ESPTOOL_OPTS := -c esp32s2 -p $(ESPTOOL_PORT) -b $(ESPTOOL_BAUD) $(ESPTOOL_RESET_OPTS) $(if $(CONFIG_ESP32S2_ESPTOOLPY_NO_STUB),--no-stub))
 	esptool.py $(ESPTOOL_OPTS) write_flash $(ESPTOOL_WRITEFLASH_OPTS) $(ESPTOOL_BINS)
 
-	$(if $(CONFIG_ESP32S2_SECURE_BOOT),$(call HELP_FLASH_BOOTLOADER))
+	$(if $(CONFIG_ESP32S2_SECURE_BOOT)$(CONFIG_ESP32S2_SECURE_FLASH_ENC_ENABLED),$(call HELP_FLASH_BOOTLOADER))
 endef

--- a/tools/esp32s2/Config.mk
+++ b/tools/esp32s2/Config.mk
@@ -112,7 +112,18 @@ else ifeq ($(CONFIG_ESP32S2_APP_FORMAT_MCUBOOT),y)
 	else
 		APP_IMAGE  := nuttx.bin
 	endif
+
 	FLASH_APP      := $(APP_OFFSET) $(APP_IMAGE)
+
+	ifeq ($(CONFIG_ESP32S2_SECURE_FLASH_ENC_ENABLED),y)
+		IMGTOOL_ALIGN_ARGS := --align 32 --max-align 32
+	else
+		IMGTOOL_ALIGN_ARGS := --align 4
+	endif
+
+	IMGTOOL_SIGN_ARGS := --pad $(VERIFIED) $(IMGTOOL_ALIGN_ARGS) -v 0 -s auto \
+		-H $(CONFIG_ESP32S2_APP_MCUBOOT_HEADER_SIZE) --pad-header \
+		-S $(CONFIG_ESP32S2_OTA_SLOT_SIZE)
 endif
 
 ESPTOOL_BINS += $(FLASH_APP)
@@ -130,7 +141,7 @@ define HELP_SIGN_APP
 	$(Q) echo ""
 	$(Q) echo "$(YELLOW)Application not signed. Sign the application before flashing.$(RST)"
 	$(Q) echo "To sign the application, you can use this command:"
-	$(Q) echo "    imgtool sign -k $(ESPSEC_KEYDIR)/$(CONFIG_ESP32S2_SECURE_BOOT_APP_SIGNING_KEY) --public-key-format hash --pad $(VERIFIED) --align 4 -v 0 -s auto -H $(CONFIG_ESP32S2_APP_MCUBOOT_HEADER_SIZE) --pad-header -S $(CONFIG_ESP32S2_OTA_SLOT_SIZE) nuttx.hex nuttx.signed.bin"
+	$(Q) echo "    imgtool sign -k $(ESPSEC_KEYDIR)/$(CONFIG_ESP32S2_SECURE_BOOT_APP_SIGNING_KEY) --public-key-format hash $(IMGTOOL_SIGN_ARGS) nuttx.hex nuttx.signed.bin"
 	$(Q) echo ""
 endef
 
@@ -185,13 +196,8 @@ define SIGNBIN
 		echo ""; \
 		exit 1; \
 	fi
-	$(if $(CONFIG_ESP32S2_SECURE_BOOT_BUILD_SIGNED_BINARIES), \
-		$(eval IMGTOOL_KEY_ARGS := -k $(APP_SIGN_KEY) --public-key-format hash))
 
-	imgtool sign $(IMGTOOL_KEY_ARGS) --pad $(VERIFIED) --align 4 -v 0 -s auto \
-		-H $(CONFIG_ESP32S2_APP_MCUBOOT_HEADER_SIZE) --pad-header \
-		-S $(CONFIG_ESP32S2_OTA_SLOT_SIZE) \
-		nuttx.hex nuttx.signed.bin
+	imgtool sign $(IMGTOOL_KEY_ARGS) $(IMGTOOL_SIGN_ARGS) nuttx.hex nuttx.signed.bin
 	$(Q) echo nuttx.signed.bin >> nuttx.manifest
 	$(Q) echo "Generated: nuttx.signed.bin (MCUboot compatible)"
 endef
@@ -230,10 +236,7 @@ define MKIMAGE
 		echo "Run make again to create the nuttx.bin image."; \
 		exit 1; \
 	fi
-	imgtool sign --pad $(VERIFIED) --align 4 -v 0 -s auto \
-		-H $(CONFIG_ESP32S2_APP_MCUBOOT_HEADER_SIZE) --pad-header \
-		-S $(CONFIG_ESP32S2_OTA_SLOT_SIZE) \
-		nuttx.hex nuttx.bin
+	imgtool sign $(IMGTOOL_SIGN_ARGS) nuttx.hex nuttx.bin
 	$(Q) echo "Generated: nuttx.bin (MCUboot compatible)"
 endef
 endif


### PR DESCRIPTION
## Summary
This PR intends to fix two build system issues related to the recently added feature of **Flash Encryption** on Espressif chips.

Commit 23dec090 prevents the build system from resetting the chip on the make flash command when Flash Encryption is select for build.
It also requires the manual flashing of the bootloader image, as already done when **Secure Boot** is enabled.
This approach is necessary for bringing in the user's attention, since it involves the activation of some irreversible security features of the chip.

Commit c8f069db fixes the alignment of the trailer area of the application image (MCUboot format). Espressif chips (ESP32, ESP32-S2 and ESP32-C3) require a minimum write alignment of 32 bytes when Flash Encryption is enabled, so it is important to consider this restriction when creating the binary image in MCUboot-format with imgtool.

## Impact
Platforms containing Espressif chips with Flash Encryption feature enabled.
No impact otherwise.

## Testing
- `esp32-ethernet-kit`
- `esp32s2-saola-1`
- `esp32c3-devkit`
