### PR TITLE
tools: Fix parallel build issue due to missing dependency

### DIFF
--- a/tools/Unix.mk
+++ b/tools/Unix.mk
@@ -317,7 +317,7 @@ INCLUDE_ARCH_CHIP_SYMLINK_DIR=$(TOPDIR)/$(ARCH_INC)/$(CONFIG_ARCH_CHIP)
 endif
 
 ifneq ($(INCLUDE_ARCH_CHIP_SYMLINK_DIR),)
-include/arch/chip:
+include/arch/chip: | include/arch
 	@echo "LN: $@ to $(INCLUDE_ARCH_CHIP_SYMLINK_DIR)"
 	$(DIRLINK) $(INCLUDE_ARCH_CHIP_SYMLINK_DIR) $@
 endif

--- a/tools/Win.mk
+++ b/tools/Win.mk
@@ -302,7 +302,7 @@ INCLUDE_ARCH_CHIP_SYMLINK_DIR=$(TOPDIR)\$(ARCH_INC)\$(CONFIG_ARCH_CHIP)
 endif
 
 ifneq ($(INCLUDE_ARCH_CHIP_SYMLINK_DIR),)
-include\arch\chip:
+include\arch\chip: | include\arch
 	@echo "LN: $@ to $(INCLUDE_ARCH_CHIP_SYMLINK_DIR)"
 	$(DIRLINK) $(INCLUDE_ARCH_CHIP_SYMLINK_DIR) $@
 endif


### PR DESCRIPTION
## Summary
This PR intends to fix an issue with parallel build due to missing dependency on the `include/arch/chip:` Make rule.

```bash
$ ./tools/configure.sh  esp32-wrover-kit:bmp180 -s -j 1>/dev/null
ln: failed to create symbolic link 'include/arch/chip': No such file or directory
make[1]: *** [tools/Makefile.unix:321: include/arch/chip] Error 1
make[1]: *** Waiting for unfinished jobs....
make: *** [tools/Makefile.unix:601: olddefconfig] Error 2
```

## Impact
Fix for an issue, should not have any impact.

## Testing
CI build pass.
