### PR TITLE
Cleanup Context/Dirlinks targets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,5 +49,5 @@ uImage
 /external
 # $(TOPDIR)/Makefile.[unix|win]::$(CONTEXTDIRS_DEPS)
 .context
-# $(TOPDIR)/Makefile.[unix|win]::$(DIRLINKS_EXTERNAL_DIRS)
+# The .dirlinks file denotes that all symlinks have been created
 .dirlinks

--- a/boards/Makefile
+++ b/boards/Makefile
@@ -20,26 +20,6 @@
 
 include $(TOPDIR)/Make.defs
 
-# Determine if there is a Kconfig file for any custom board configuration
-
-ifeq ($(CONFIG_ARCH_BOARD_CUSTOM),y)
-  CUSTOM_DIR = $(patsubst "%",%,$(CONFIG_ARCH_BOARD_CUSTOM_DIR))
-  ifeq ($(CONFIG_ARCH_BOARD_CUSTOM_DIR_RELPATH),y)
-    CUSTOM_KPATH = $(TOPDIR)$(DELIM)$(CUSTOM_DIR)$(DELIM)Kconfig
-  else
-    CUSTOM_KPATH = $(CUSTOM_DIR)$(DELIM)Kconfig
-  endif
-  CUSTOM_KCONFIG = $(if $(wildcard $(CUSTOM_KPATH)),y,)
-endif
-
-ifeq ($(CUSTOM_KCONFIG),y)
-  BOARD_KCONFIG = $(CUSTOM_KPATH)
-else
-  BOARD_KCONFIG = $(TOPDIR)$(DELIM)boards$(DELIM)dummy$(DELIM)dummy_kconfig
-endif
-
-DUMMY_KCONFIG = $(TOPDIR)$(DELIM)boards$(DELIM)dummy$(DELIM)Kconfig
-
 # The board configuration should be installed in the arch/ directory
 
 BOARDDIR = $(TOPDIR)$(DELIM)arch$(DELIM)$(CONFIG_ARCH)$(DELIM)src$(DELIM)board
@@ -94,19 +74,12 @@ makedepfile: $(CSRCS:.c=.ddc) $(ASRCS:.S=.dds) $(CXXSRCS:.cxx=.ddx)
 
 depend: .depend
 
-$(DUMMY_KCONFIG): $(BOARD_KCONFIG)
-	$(call DELFILE, $(DUMMY_KCONFIG))
-	$(call COPYFILE, $(BOARD_KCONFIG), $(DUMMY_KCONFIG))
-
-dirlinks: $(DUMMY_KCONFIG)
-
-context: $(DUMMY_KCONFIG)
+context:
 ifeq ($(BOARD_INSTALLED),y)
 	$(Q) $(MAKE) -C $(BOARDDIR) context
 endif
 
 clean_context:
-	$(call DELFILE, $(DUMMY_KCONFIG))
 
 clean: clean_context
 	$(call DELFILE, $(BIN))

--- a/tools/Config.mk
+++ b/tools/Config.mk
@@ -143,6 +143,13 @@ endif
 else
   BOARD_DIR ?= $(TOPDIR)$(DELIM)boards$(DELIM)$(CONFIG_ARCH)$(DELIM)$(CONFIG_ARCH_CHIP)$(DELIM)$(CONFIG_ARCH_BOARD)
 endif
+CUSTOM_BOARD_KPATH = $(BOARD_DIR)$(DELIM)Kconfig
+CUSTOM_BOARD_KCONFIG = $(if $(wildcard $(CUSTOM_BOARD_KPATH)),y,)
+ifeq ($(CUSTOM_BOARD_KCONFIG),y)
+  BOARD_KCONFIG = $(CUSTOM_BOARD_KPATH)
+else
+  BOARD_KCONFIG = $(TOPDIR)$(DELIM)boards$(DELIM)dummy$(DELIM)dummy_kconfig
+endif
 
 BOARD_COMMON_DIR ?= $(wildcard $(BOARD_DIR)$(DELIM)..$(DELIM)common)
 BOARD_DRIVERS_DIR ?= $(wildcard $(BOARD_DIR)$(DELIM)..$(DELIM)drivers)

--- a/tools/Unix.mk
+++ b/tools/Unix.mk
@@ -328,6 +328,12 @@ arch/dummy/Kconfig:
 	@echo "CP: $@ to $(CHIP_KCONFIG)"
 	$(Q) cp -f $(CHIP_KCONFIG) $@
 
+# Copy $(BOARD_KCONFIG) to boards/dummy/Kconfig
+
+boards/dummy/Kconfig:
+	@echo "CP: $@ to $(BOARD_KCONFIG)"
+	$(Q) cp -f $(BOARD_KCONFIG) $@
+
 DIRLINKS_SYMLINK = \
   include/arch \
   include/arch/board \
@@ -335,6 +341,7 @@ DIRLINKS_SYMLINK = \
 
 DIRLINKS_FILE = \
   arch/dummy/Kconfig \
+  boards/dummy/Kconfig \
 
 ifneq ($(INCLUDE_ARCH_CHIP_SYMLINK_DIR),)
 DIRLINKS_SYMLINK += include/arch/chip
@@ -352,24 +359,7 @@ ifneq ($(ARCH_SRC_BOARD_BOARD_SYMLINK),)
 DIRLINKS_SYMLINK += $(ARCH_SRC)/board/board
 endif
 
-DIRLINKS_EXTERNAL_DIRS = boards
-
-ifneq ($(APPDIR),)
-DIRLINKS_EXTERNAL_DIRS += $(APPDIR)
-endif
-
-# Generate a pattern to build $(DIRLINKS_EXTERNAL_DIRS)
-
-DIRLINKS_EXTERNAL_DEP = $(patsubst %,%/.dirlinks,$(DIRLINKS_EXTERNAL_DIRS))
-DIRLINKS_FILE += $(DIRLINKS_EXTERNAL_DEP)
-
 .dirlinks: $(DIRLINKS_FILE) | $(DIRLINKS_SYMLINK)
-	touch $@
-
-# Pattern rule for $(DIRLINKS_EXTERNAL_DEP)
-
-%/.dirlinks:
-	$(Q) $(MAKE) -C $(patsubst %/.dirlinks,%,$@) dirlinks
 	$(Q) touch $@
 
 # clean_dirlinks
@@ -589,36 +579,43 @@ pass2dep: context tools/mkdeps$(HOSTEXEEXT) tools/cnvwindeps$(HOSTEXEEXT)
 
 config:
 	$(Q) $(MAKE) clean_context
+	$(Q) $(MAKE) context
 	$(Q) $(MAKE) apps_preconfig
 	$(Q) APPSDIR=${CONFIG_APPS_DIR} EXTERNALDIR=$(EXTERNALDIR) kconfig-conf Kconfig
 
 oldconfig:
 	$(Q) $(MAKE) clean_context
+	$(Q) $(MAKE) context
 	$(Q) $(MAKE) apps_preconfig
 	$(Q) APPSDIR=${CONFIG_APPS_DIR} EXTERNALDIR=$(EXTERNALDIR) kconfig-conf --oldconfig Kconfig
 
 olddefconfig:
 	$(Q) $(MAKE) clean_context
+	$(Q) $(MAKE) context
 	$(Q) $(MAKE) apps_preconfig
 	$(Q) APPSDIR=${CONFIG_APPS_DIR} EXTERNALDIR=$(EXTERNALDIR) kconfig-conf --olddefconfig Kconfig
 
 menuconfig:
 	$(Q) $(MAKE) clean_context
+	$(Q) $(MAKE) context
 	$(Q) $(MAKE) apps_preconfig
 	$(Q) APPSDIR=${CONFIG_APPS_DIR} EXTERNALDIR=$(EXTERNALDIR) kconfig-mconf Kconfig
 
-nconfig: apps_preconfig
+nconfig:
 	$(Q) $(MAKE) clean_context
+	$(Q) $(MAKE) context
 	$(Q) $(MAKE) apps_preconfig
 	$(Q) APPSDIR=${CONFIG_APPS_DIR} EXTERNALDIR=$(EXTERNALDIR) kconfig-nconf Kconfig
 
-qconfig: apps_preconfig
+qconfig:
 	$(Q) $(MAKE) clean_context
+	$(Q) $(MAKE) context
 	$(Q) $(MAKE) apps_preconfig
 	$(Q) APPSDIR=${CONFIG_APPS_DIR} EXTERNALDIR=$(EXTERNALDIR) kconfig-qconf Kconfig
 
-gconfig: apps_preconfig
+gconfig:
 	$(Q) $(MAKE) clean_context
+	$(Q) $(MAKE) context
 	$(Q) $(MAKE) apps_preconfig
 	$(Q) APPSDIR=${CONFIG_APPS_DIR} EXTERNALDIR=$(EXTERNALDIR) kconfig-gconf Kconfig
 
@@ -719,7 +716,7 @@ endif
 # apps_distclean: Perform the distclean operation only in the user application
 #                 directory.
 
-apps_preconfig: .dirlinks
+apps_preconfig:
 ifneq ($(APPDIR),)
 	$(Q) $(MAKE) -C $(APPDIR) preconfig
 endif


### PR DESCRIPTION
## Summary
Previously the context rule and dirlinks rule were doing the same thing.
* the `context` target called other `context` targets in subdirectories.
* the `context` targets had `.dirlinks` as a prerequisite, which created symlinks
* the `.dirlinks` target called other `.dirlinks` targets in subdirectories, which created symlinks

Changes:
* `.dirlinks` doesn't call other sub-`.dirlinks` targets. All `context` targets will take care of creating symlinks by having `.dirlinks` as prerequisites
* There was logic in `tools/Config.mk` which was duplicated in `boards/Makefile`. This PR removes the duplicated logic
* `apps_preconfig` was incorrectly depending on `.dirlinks`
* All `Configuration targets` now run the in the following order, ensuring deterministic behavior: `clean-context`, `context`, `apps_preconfig` then `kconfig...`

## Impact
This PR cleans up and isolates logic. It additionally makes the `Configuration targets` set more deterministic by running `clean-context` then `context`

## Testing
Verified build locally, CI will verify all the builds
