### PR TITLE
Revert pipenv version freeze

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Generate Documentation
         run: |
           cd Documentation/
-          pip3 install pipenv==2021.5.29
+          pip3 install pipenv
           pipenv install
           pipenv run make html
       - uses: actions/upload-artifact@v2


### PR DESCRIPTION
## Summary
This PR intends to revert the changes from https://github.com/apache/incubator-nuttx/pull/4807, then required to fix a regression introduced by the 2021.11.05 version of pipenv.

Latest version (2021.11.23) addresses the issue, and it is already available on Pypi (https://pypi.org/project/pipenv/).

## Impact
No impact, CI only.

## Testing
CI documentation job pass.

