### PR TITLE
arch/sim: Rename up_vfork[32|64].S to up_vfork_x[32|64].S

### DIFF
--- a/arch/sim/src/Makefile
+++ b/arch/sim/src/Makefile
@@ -41,12 +41,12 @@ REQUIREDOBJS = $(LINKOBJS)
 
 ifeq ($(CONFIG_HOST_X86_64),y)
 ifeq ($(CONFIG_SIM_M32),y)
-  ASRCS += up_vfork32.S
+  ASRCS += up_vfork_x32.S
 else
-  ASRCS += up_vfork64.S
+  ASRCS += up_vfork_x64.S
 endif
 else ifeq ($(CONFIG_HOST_X86),y)
-  ASRCS += up_vfork32.S
+  ASRCS += up_vfork_x32.S
 else ifeq ($(CONFIG_HOST_ARM),y)
   ASRCS += up_vfork_arm.S
 endif

--- a/arch/sim/src/sim/up_vfork_x32.S
+++ b/arch/sim/src/sim/up_vfork_x32.S
@@ -1,5 +1,5 @@
 /************************************************************************************
- * arch/sim/src/sim/up_vfork64.S
+ * arch/sim/src/sim/up_vfork_x32.S
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -96,19 +96,15 @@
 #endif
 
 SYMBOL(vfork):
-	sub	$XCPTCONTEXT_SIZE, %rsp
-#ifdef CONFIG_SIM_X8664_MICROSOFT
-	mov	%rsp, %rcx
-#else /* if defined(CONFIG_SIM_X8664_SYSTEMV) */
-	mov	%rsp, %rdi
-#endif
+	sub	$XCPTCONTEXT_SIZE, %esp
+	push	%esp
 	call	SYMBOL(setjmp)
 
 	sub	$1, %eax
 	jz	child
 	call	SYMBOL(up_vfork)
 child:
-	add	$XCPTCONTEXT_SIZE, %rsp
+	add	$XCPTCONTEXT_SIZE+4, %esp
 	ret
 #ifdef __ELF__
 	.size	SYMBOL(vfork), . - SYMBOL(vfork)

--- a/arch/sim/src/sim/up_vfork_x64.S
+++ b/arch/sim/src/sim/up_vfork_x64.S
@@ -1,5 +1,5 @@
 /************************************************************************************
- * arch/sim/src/sim/up_vfork32.S
+ * arch/sim/src/sim/up_vfork_x64.S
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -96,15 +96,19 @@
 #endif
 
 SYMBOL(vfork):
-	sub	$XCPTCONTEXT_SIZE, %esp
-	push	%esp
+	sub	$XCPTCONTEXT_SIZE, %rsp
+#ifdef CONFIG_SIM_X8664_MICROSOFT
+	mov	%rsp, %rcx
+#else /* if defined(CONFIG_SIM_X8664_SYSTEMV) */
+	mov	%rsp, %rdi
+#endif
 	call	SYMBOL(setjmp)
 
 	sub	$1, %eax
 	jz	child
 	call	SYMBOL(up_vfork)
 child:
-	add	$XCPTCONTEXT_SIZE+4, %esp
+	add	$XCPTCONTEXT_SIZE, %rsp
 	ret
 #ifdef __ELF__
 	.size	SYMBOL(vfork), . - SYMBOL(vfork)


### PR DESCRIPTION
## Summary
to align with up_vfork_arm.S naming style

## Impact
No, rename only

## Testing
Pass CI
