### PR TITLE
ioexpander/rpmsg: Select IOEXPANDER_INT_ENABLE instead depend on it

### DIFF
--- a/drivers/ioexpander/Kconfig
+++ b/drivers/ioexpander/Kconfig
@@ -25,7 +25,7 @@ if IOEXPANDER_RPMSG
 config IOEXPANDER_RPMSG_INT_NCALLBACKS
 	int "number of ioexpander rpmsg interrupt callbacks"
 	default 32
-	depends on IOEXPANDER_INT_ENABLE
+	select IOEXPANDER_INT_ENABLE
 	---help---
 		This set the IO expander number in interrupt callbacks.
 

--- a/drivers/ioexpander/ioe_rpmsg.c
+++ b/drivers/ioexpander/ioe_rpmsg.c
@@ -27,7 +27,7 @@
 #include <errno.h>
 #include <stdio.h>
 
-#include <nuttx/ioexpander/ioexpander.h>
+#include <nuttx/ioexpander/ioe_rpmsg.h>
 #include <nuttx/kmalloc.h>
 #include <nuttx/nuttx.h>
 #include <nuttx/semaphore.h>


### PR DESCRIPTION
## Summary
follow other similiar drivers

## Impact
Minor

## Testing
Pass CI
