### PR TITLE
drivers/ioexpander: fix the kconfig warning 

### DIFF
--- a/drivers/ioexpander/Kconfig
+++ b/drivers/ioexpander/Kconfig
@@ -17,6 +17,7 @@ if IOEXPANDER
 config IOEXPANDER_RPMSG
 	bool "IO expander rpmsg server and client"
 	default n
+	select IOEXPANDER_INT_ENABLE
 	---help---
 		This settings enable ioexpander rpmsg server and client.
 
@@ -25,7 +26,6 @@ if IOEXPANDER_RPMSG
 config IOEXPANDER_RPMSG_INT_NCALLBACKS
 	int "number of ioexpander rpmsg interrupt callbacks"
 	default 32
-	select IOEXPANDER_INT_ENABLE
 	---help---
 		This set the IO expander number in interrupt callbacks.
 


### PR DESCRIPTION
## Summary

drivers/ioexpander: fix the kconfig warning 

drivers/ioexpander/Kconfig:28:

warning:
config symbol 'IOEXPANDER_RPMSG_INT_NCALLBACKS' uses select, but is not boolean or tristate

Signed-off-by: chao.an <anchao@xiaomi.com>

## Impact

N/A

## Testing

CI-check