### PR TITLE
xtensa: fix lack of float register save & resotre

### DIFF
--- a/arch/xtensa/include/xtensa/xtensa_coproc.h
+++ b/arch/xtensa/include/xtensa/xtensa_coproc.h
@@ -38,6 +38,7 @@
  * Included Files
  ****************************************************************************/
 
+#include <assert.h>
 #include <arch/chip/core-isa.h>
 
 /****************************************************************************
@@ -131,7 +132,7 @@
 
 #define XTENSA_CPENABLE   0  /* (2 bytes) coprocessors active for this thread */
 #define XTENSA_CPSTORED   2  /* (2 bytes) coprocessors saved for this thread */
-#define XTENSA_CPASA      4  /* (4 bytes) ptr to aligned save area */
+#define XTENSA_CPASA      8  /* (8 bytes) ptr to aligned save area */
 
 /****************************************************************************
  * Public Types
@@ -141,10 +142,13 @@
 
 struct xtensa_cpstate_s
 {
-  uint16_t cpenable;  /* (2 bytes) Co-processors active for this thread */
-  uint16_t cpstored;  /* (2 bytes) Co-processors saved for this thread */
-  uint32_t *cpasa;    /* (4 bytes) Pointer to aligned save area */
+  uint16_t cpenable;                                 /* (2 bytes) Co-processors active for this thread */
+  uint16_t cpstored;                                 /* (2 bytes) Co-processors saved for this thread */
+  uint8_t  cpasa[XTENSA_CP_SA_SIZE] aligned_data(8); /* cp save area */
 };
+
+static_assert(offsetof(struct xtensa_cpstate_s, cpasa) == XTENSA_CPASA,
+              "CP save area address alignment violation.");
 
 /****************************************************************************
  * Inline Functions

--- a/arch/xtensa/src/common/xtensa_coproc.S
+++ b/arch/xtensa/src/common/xtensa_coproc.S
@@ -121,7 +121,7 @@ _xtensa_coproc_savestate:
 
 	s16i	a2, a15, XTENSA_CPSTORED		/* Save mask of CPs being stored */
 	movi	a13, _xtensa_coproc_saoffsets	/* Array of CP save offsets */
-	l32i	a15, a15, XTENSA_CPASA			/* a15 = base of aligned save area */
+	addi	a15, a15, XTENSA_CPASA			/* a15 = base of aligned save area */
 
 #if XCHAL_CP0_SA_SIZE > 0
 	bbci.l	a2, 0, 2f						/* CP 0 not enabled */
@@ -320,7 +320,7 @@ _xtensa_coproc_restorestate:
 	s16i	a3, a15, XTENSA_CPSTORED		/* Clear saved CP mask */
 
 	movi	a13, _xtensa_coproc_saoffsets	/* Array of CP save offsets */
-	l32i	a15, a15, XTENSA_CPASA			/* a15 = base of aligned save area */
+	addi	a15, a15, XTENSA_CPASA			/* a15 = base of aligned save area */
 
 #if XCHAL_CP0_SA_SIZE
 	bbci.l	a2, 0, 2f						/* CP 0 not enabled */

--- a/arch/xtensa/src/common/xtensa_createstack.c
+++ b/arch/xtensa/src/common/xtensa_createstack.c
@@ -99,11 +99,6 @@
 
 int up_create_stack(struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
 {
-#if XCHAL_CP_NUM > 0
-  struct xcptcontext *xcp;
-  uintptr_t cpstart;
-#endif
-
 #ifdef CONFIG_TLS_ALIGNED
   /* The allocated stack size must not exceed the maximum possible for the
    * TLS feature.
@@ -127,16 +122,6 @@ int up_create_stack(struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
 
       up_release_stack(tcb, ttype);
     }
-
-#if XCHAL_CP_NUM > 0
-  /* Add the size of the co-processor save area to the stack allocation.
-   * REVISIT:  This may waste memory.  Increasing the caller's requested
-   * stack size should only be necessary if the requested size could not
-   * hold the co-processor save area.
-   */
-
-  stack_size += XTENSA_CP_SA_SIZE;
-#endif
 
   /* Do we need to allocate a new stack? */
 
@@ -204,31 +189,6 @@ int up_create_stack(struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
        */
 
       top_of_stack = (uintptr_t)tcb->stack_alloc_ptr + stack_size;
-
-#if XCHAL_CP_NUM > 0
-      /* Allocate the co-processor save area at the top of the (push down)
-       * stack.
-       *
-       * REVISIT:  This is not secure.  In secure built configurations it
-       * be more appropriate to use kmm_memalign() to allocate protected
-       * memory rather than using the stack.
-       */
-
-      cpstart      = (uintptr_t)_CP_ALIGNDOWN(XCHAL_CP0_SA_ALIGN,
-                                              top_of_stack -
-                                              XCHAL_CP1_SA_ALIGN);
-      top_of_stack = cpstart;
-
-      /* Initialize the coprocessor save area (see xtensa_coproc.h) */
-
-      xcp                   = &tcb->xcp;
-      xcp->cpstate.cpenable = 0;                   /* No coprocessors active
-                                                    * for this thread */
-      xcp->cpstate.cpstored = 0;                   /* No coprocessors saved
-                                                    * for this thread */
-      xcp->cpstate.cpasa    = (uint32_t *)cpstart; /* Start of aligned save
-                                                    * area */
-#endif
 
       /* The XTENSA stack must be aligned.  If necessary top_of_stack must be
        * rounded down to the next boundary to meet this alignment

--- a/include/assert.h
+++ b/include/assert.h
@@ -21,6 +21,8 @@
 #ifndef __INCLUDE_ASSERT_H
 #define __INCLUDE_ASSERT_H
 
+#ifndef __ASSEMBLY__
+
 /****************************************************************************
  * Included Files
  ****************************************************************************/
@@ -105,4 +107,5 @@ void _assert(FAR const char *filename, int linenum) noreturn_function;
 }
 #endif
 
+#endif /* __ASSEMBLY__ */
 #endif /* __INCLUDE_ASSERT_H */


### PR DESCRIPTION
## Summary

xtensa: fix lack of float register save & resotre

Reason:

1. `up_create_stack` calculate cpasa error
2. original code setting cpasa only at `up_create_stack`, but not at `up_use_stack`
3. after fix 1&2 it still not worked, because `xcp` will be memset to 0 in `up_initial_state`
4. If fix all the questions, the xtensa code `up_initial_state` `up_use_stack` `up_use_stack` would have a big difference will other platform

So, I move the `cpasa` out, from stack to xcp

## Impact

xtensa/hifi

## Testing

VELA
