### PR TITLE
file_operations: get back C89 compatible initializer

### DIFF
--- a/arch/arm/src/cxd56xx/cxd56_adc.c
+++ b/arch/arm/src/cxd56xx/cxd56_adc.c
@@ -202,11 +202,12 @@ static const struct file_operations g_adcops =
   cxd56_adc_open,            /* open */
   cxd56_adc_close,           /* close */
   cxd56_adc_read,            /* read */
-  0,                         /* write */
-  0,                         /* seek */
+  NULL,                      /* write */
+  NULL,                      /* seek */
   cxd56_adc_ioctl,           /* ioctl */
-#ifndef CONFIG_DISABLE_POLL
-  0,                         /* poll */
+  NULL                       /* poll */
+#ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
+  , NULL                     /* unlink */
 #endif
 };
 

--- a/arch/arm/src/cxd56xx/cxd56_charger.c
+++ b/arch/arm/src/cxd56xx/cxd56_charger.c
@@ -96,11 +96,9 @@ static const struct file_operations g_chargerops =
   charger_close,  /* close */
   charger_read,   /* read */
   charger_write,  /* write */
-  0,              /* seek */
-  charger_ioctl   /* ioctl */
-#ifndef CONFIG_DISABLE_POLL
-  , NULL          /* poll */
-#endif
+  NULL,           /* seek */
+  charger_ioctl,  /* ioctl */
+  NULL            /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , NULL          /* unlink */
 #endif

--- a/arch/arm/src/cxd56xx/cxd56_gauge.c
+++ b/arch/arm/src/cxd56xx/cxd56_gauge.c
@@ -81,11 +81,9 @@ static const struct file_operations g_gaugeops =
   gauge_close,  /* close */
   gauge_read,   /* read */
   gauge_write,  /* write */
-  0,            /* seek */
-  gauge_ioctl   /* ioctl */
-#ifndef CONFIG_DISABLE_POLL
-  , NULL        /* poll */
-#endif
+  NULL,         /* seek */
+  gauge_ioctl,  /* ioctl */
+  NULL          /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , NULL        /* unlink */
 #endif

--- a/arch/arm/src/cxd56xx/cxd56_geofence.c
+++ b/arch/arm/src/cxd56xx/cxd56_geofence.c
@@ -76,11 +76,9 @@ static ssize_t cxd56_geofence_read(FAR struct file *filep,
 static int cxd56_geofence_ioctl(FAR struct file *filep,
                                 int cmd,
                                 unsigned long arg);
-#ifndef CONFIG_DISABLE_POLL
 static int cxd56_geofence_poll(FAR struct file *filep,
                                FAR struct pollfd *fds,
                                bool setup);
-#endif
 
 /* ioctl command functions */
 
@@ -106,11 +104,12 @@ static const struct file_operations g_geofencefops =
   cxd56_geofence_open,  /* open */
   cxd56_geofence_close, /* close */
   cxd56_geofence_read,  /* read */
-  0,                    /* write */
-  0,                    /* seek */
+  NULL,                 /* write */
+  NULL,                 /* seek */
   cxd56_geofence_ioctl, /* ioctl */
-#ifndef CONFIG_DISABLE_POLL
-  cxd56_geofence_poll,  /* poll */
+  cxd56_geofence_poll   /* poll */
+#ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
+  , NULL                /* unlink */
 #endif
 };
 
@@ -607,7 +606,6 @@ static int cxd56_geofence_ioctl(FAR struct file *filep, int cmd,
  *
  ****************************************************************************/
 
-#ifndef CONFIG_DISABLE_POLL
 static int cxd56_geofence_poll(FAR struct file *filep,
                                FAR struct pollfd *fds,
                                bool setup)
@@ -674,7 +672,6 @@ errout:
   nxsem_post(&priv->devsem);
   return ret;
 }
-#endif
 
 /****************************************************************************
  * Name: cxd56_geofence_register

--- a/arch/arm/src/cxd56xx/cxd56_gnss.c
+++ b/arch/arm/src/cxd56xx/cxd56_gnss.c
@@ -293,10 +293,8 @@ static ssize_t cxd56_gnss_write(FAR struct file *filep,
                                 FAR const char *buffer, size_t buflen);
 static int cxd56_gnss_ioctl(FAR struct file *filep, int cmd,
                             unsigned long arg);
-#ifndef CONFIG_DISABLE_POLL
 static int cxd56_gnss_poll(FAR struct file *filep, FAR struct pollfd *fds,
                            bool setup);
-#endif
 static int8_t cxd56_gnss_select_notifytype(off_t fpos, uint32_t *offset);
 
 static int cxd56_gnss_cpufifo_api(FAR struct file *filep,
@@ -315,10 +313,11 @@ static const struct file_operations g_gnssfops =
   cxd56_gnss_close, /* close */
   cxd56_gnss_read,  /* read */
   cxd56_gnss_write, /* write */
-  0,                /* seek */
+  NULL,             /* seek */
   cxd56_gnss_ioctl, /* ioctl */
-#ifndef CONFIG_DISABLE_POLL
-  cxd56_gnss_poll,  /* poll */
+  cxd56_gnss_poll   /* poll */
+#ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
+  , NULL            /* unlink */
 #endif
 };
 
@@ -2899,7 +2898,6 @@ static int cxd56_gnss_ioctl(FAR struct file *filep, int cmd,
  *
  ****************************************************************************/
 
-#ifndef CONFIG_DISABLE_POLL
 static int cxd56_gnss_poll(FAR struct file *filep, FAR struct pollfd *fds,
                            bool setup)
 {
@@ -2965,7 +2963,6 @@ errout:
   nxsem_post(&priv->devsem);
   return ret;
 }
-#endif
 
 /****************************************************************************
  * Name: cxd56_gnss_register

--- a/arch/x86_64/src/intel64/intel64_rng.c
+++ b/arch/x86_64/src/intel64/intel64_rng.c
@@ -66,17 +66,15 @@ static struct rng_dev_s g_rngdev;
 
 static const struct file_operations g_rngops =
 {
-  0,               /* open */
-  0,               /* close */
+  NULL,            /* open */
+  NULL,            /* close */
   x86_rngread,     /* read */
-  0,               /* write */
-  0,               /* seek */
-  0                /* ioctl */
-#ifndef CONFIG_DISABLE_POLL
-  , 0              /* poll */
-#endif
+  NULL,            /* write */
+  NULL,            /* seek */
+  NULL,            /* ioctl */
+  NULL             /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
-  , 0              /* unlink */
+  , NULL           /* unlink */
 #endif
 };
 

--- a/audio/audio.c
+++ b/audio/audio.c
@@ -122,6 +122,9 @@ static const struct file_operations g_audioops =
   NULL,        /* seek */
   audio_ioctl, /* ioctl */
   NULL         /* poll */
+#ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
+  , NULL       /* unlink */
+#endif
 };
 
 /****************************************************************************

--- a/boards/arm/cxd56xx/drivers/sensors/ak09912_scu.c
+++ b/boards/arm/cxd56xx/drivers/sensors/ak09912_scu.c
@@ -171,12 +171,12 @@ static const struct file_operations g_ak09912fops =
   ak09912_close,                 /* close */
   ak09912_read,                  /* read */
   ak09912_write,                 /* write */
-  0,                             /* seek */
+  NULL,                          /* seek */
   ak09912_ioctl,                 /* ioctl */
-#ifndef CONFIG_DISABLE_POLL
-  0,                             /* poll */
+  NULL                           /* poll */
+#ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
+  , NULL                         /* unlink */
 #endif
-  0                              /* unlink */
 };
 
 /* Take XYZ data, temperature and Status 2 register.

--- a/boards/arm/cxd56xx/drivers/sensors/apds9930_scu.c
+++ b/boards/arm/cxd56xx/drivers/sensors/apds9930_scu.c
@@ -181,12 +181,12 @@ static const struct file_operations g_apds9930alsfops =
   apds9930_close_als,          /* close */
   apds9930_read_als,           /* read */
   apds9930_write,              /* write */
-  0,                           /* seek */
+  NULL,                        /* seek */
   apds9930_ioctl_als,          /* ioctl */
-#ifndef CONFIG_DISABLE_POLL
-  0,                           /* poll */
+  NULL                         /* poll */
+#ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
+  , NULL                       /* unlink */
 #endif
-  0                            /* unlink */
 };
 
 /* Proximity sensor */
@@ -197,12 +197,12 @@ static const struct file_operations g_apds9930psfops =
   apds9930_close_ps,           /* close */
   apds9930_read_ps,            /* read */
   apds9930_write,              /* write */
-  0,                           /* seek */
+  NULL,                        /* seek */
   apds9930_ioctl_ps,           /* ioctl */
-#ifndef CONFIG_DISABLE_POLL
-  0,                           /* poll */
+  NULL                         /* poll */
+#ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
+  , NULL                       /* unlink */
 #endif
-  0                            /* unlink */
 };
 
 /* SCU instructions for pick ambient light sensing data. */

--- a/boards/arm/cxd56xx/drivers/sensors/bh1721fvc_scu.c
+++ b/boards/arm/cxd56xx/drivers/sensors/bh1721fvc_scu.c
@@ -103,12 +103,12 @@ static const struct file_operations g_bh1721fvcfops =
   bh1721fvc_close,             /* close */
   bh1721fvc_read,              /* read */
   bh1721fvc_write,             /* write */
-  0,                           /* seek */
+  NULL,                        /* seek */
   bh1721fvc_ioctl,             /* ioctl */
-#ifndef CONFIG_DISABLE_POLL
-  0,                           /* poll */
+  NULL                         /* poll */
+#ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
+  , NULL                       /* unlink */
 #endif
-  0                            /* unlink */
 };
 
 /* Take ambient light data. */

--- a/boards/arm/cxd56xx/drivers/sensors/bh1745nuc_scu.c
+++ b/boards/arm/cxd56xx/drivers/sensors/bh1745nuc_scu.c
@@ -126,12 +126,12 @@ static const struct file_operations g_bh1745nucfops =
   bh1745nuc_close,             /* close */
   bh1745nuc_read,              /* read */
   bh1745nuc_write,             /* write */
-  0,                           /* seek */
+  NULL,                        /* seek */
   bh1745nuc_ioctl,             /* ioctl */
-#ifndef CONFIG_DISABLE_POLL
-  0,                           /* poll */
+  NULL                         /* poll */
+#ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
+  , NULL                       /* unlink */
 #endif
-  0                            /* unlink */
 };
 
 /* Take color data. */

--- a/boards/arm/cxd56xx/drivers/sensors/bm1383glv_scu.c
+++ b/boards/arm/cxd56xx/drivers/sensors/bm1383glv_scu.c
@@ -125,12 +125,12 @@ static const struct file_operations g_bm1383glvfops =
   bm1383glv_close,             /* close */
   bm1383glv_read,              /* read */
   bm1383glv_write,             /* write */
-  0,                           /* seek */
+  NULL,                        /* seek */
   bm1383glv_ioctl,             /* ioctl */
-#ifndef CONFIG_DISABLE_POLL
-  0,                           /* poll */
+  NULL                         /* poll */
+#ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
+  , NULL                       /* unlink */
 #endif
-  0                            /* unlink */
 };
 
 /* Device is not BM1383AGLV but BM1383GLV */

--- a/boards/arm/cxd56xx/drivers/sensors/bm1422gmv_scu.c
+++ b/boards/arm/cxd56xx/drivers/sensors/bm1422gmv_scu.c
@@ -139,12 +139,12 @@ static const struct file_operations g_bm1422gmvfops =
   bm1422gmv_close,             /* close */
   bm1422gmv_read,              /* read */
   bm1422gmv_write,             /* write */
-  0,                           /* seek */
+  NULL,                        /* seek */
   bm1422gmv_ioctl,             /* ioctl */
-#ifndef CONFIG_DISABLE_POLL
-  0,                           /* poll */
+  NULL                         /* poll */
+#ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
+  , NULL                       /* unlink */
 #endif
-  0                            /* unlink */
 };
 
 /* Take XYZ data. */

--- a/boards/arm/cxd56xx/drivers/sensors/kx022_scu.c
+++ b/boards/arm/cxd56xx/drivers/sensors/kx022_scu.c
@@ -130,12 +130,12 @@ static const struct file_operations g_kx022fops =
   kx022_close,                 /* close */
   kx022_read,                  /* read */
   kx022_write,                 /* write */
-  0,                           /* seek */
+  NULL,                        /* seek */
   kx022_ioctl,                 /* ioctl */
-#ifndef CONFIG_DISABLE_POLL
-  0,                           /* poll */
+  NULL                         /* poll */
+#ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
+  , NULL                       /* unlink */
 #endif
-  0                            /* unlink */
 };
 
 /* Take XYZ data. */

--- a/boards/arm/cxd56xx/drivers/sensors/lt1pa01_scu.c
+++ b/boards/arm/cxd56xx/drivers/sensors/lt1pa01_scu.c
@@ -176,12 +176,12 @@ static const struct file_operations g_lt1pa01alsfops =
   lt1pa01_close_als,           /* close */
   lt1pa01_read_als,            /* read */
   lt1pa01_write,               /* write */
-  0,                           /* seek */
+  NULL,                        /* seek */
   lt1pa01_ioctl_als,           /* ioctl */
-#ifndef CONFIG_DISABLE_POLL
-  0,                           /* poll */
+  NULL                         /* poll */
+#ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
+  , NULL                       /* unlink */
 #endif
-  0                            /* unlink */
 };
 
 /* Proximity sensor */
@@ -192,12 +192,12 @@ static const struct file_operations g_lt1pa01proxfops =
   lt1pa01_close_prox,          /* close */
   lt1pa01_read_prox,           /* read */
   lt1pa01_write,               /* write */
-  0,                           /* seek */
+  NULL,                        /* seek */
   lt1pa01_ioctl_prox,          /* ioctl */
-#ifndef CONFIG_DISABLE_POLL
-  0,                           /* poll */
+  NULL                         /* poll */
+#ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
+  , NULL                       /* unlink */
 #endif
-  0                            /* unlink */
 };
 
 /* SCU instructions for pick ambient light sensing data. */

--- a/boards/arm/cxd56xx/drivers/sensors/rpr0521rs_scu.c
+++ b/boards/arm/cxd56xx/drivers/sensors/rpr0521rs_scu.c
@@ -164,12 +164,12 @@ static const struct file_operations g_rpr0521rsalsfops =
   rpr0521rs_close_als,         /* close */
   rpr0521rs_read_als,          /* read */
   rpr0521rs_write,             /* write */
-  0,                           /* seek */
+  NULL,                        /* seek */
   rpr0521rs_ioctl_als,         /* ioctl */
-#ifndef CONFIG_DISABLE_POLL
-  0,                           /* poll */
+  NULL                         /* poll */
+#ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
+  , NULL                       /* unlink */
 #endif
-  0                            /* unlink */
 };
 
 /* Proximity sensor */
@@ -180,12 +180,12 @@ static const struct file_operations g_rpr0521rspsfops =
   rpr0521rs_close_ps,          /* close */
   rpr0521rs_read_ps,           /* read */
   rpr0521rs_write,             /* write */
-  0,                           /* seek */
+  NULL,                        /* seek */
   rpr0521rs_ioctl_ps,          /* ioctl */
-#ifndef CONFIG_DISABLE_POLL
-  0,                           /* poll */
+  NULL                         /* poll */
+#ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
+  , NULL                       /* unlink */
 #endif
-  0                            /* unlink */
 };
 
 /* SCU instructions for pick ambient light sensing data. */

--- a/drivers/analog/adc.c
+++ b/drivers/analog/adc.c
@@ -91,8 +91,8 @@ static const struct file_operations g_adc_fops =
   adc_open,     /* open */
   adc_close,    /* close */
   adc_read,     /* read */
-  0,            /* write */
-  0,            /* seek */
+  NULL,         /* write */
+  NULL,         /* seek */
   adc_ioctl,    /* ioctl */
   adc_poll      /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS

--- a/drivers/analog/ads1242.c
+++ b/drivers/analog/ads1242.c
@@ -101,13 +101,16 @@ static int     ads1242_ioctl(FAR struct file *filep, int cmd,
 
 static const struct file_operations g_ads1242_fops =
 {
-  ads1242_open,
-  ads1242_close,
-  ads1242_read,
-  ads1242_write,
-  NULL,
-  ads1242_ioctl,
-  NULL
+  ads1242_open,   /* open */
+  ads1242_close,  /* close */
+  ads1242_read,   /* read */
+  ads1242_write,  /* write */
+  NULL,           /* seek */
+  ads1242_ioctl,  /* ioctl */
+  NULL            /* poll */
+#ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
+  , NULL          /* unlink */
+#endif
 };
 
 /****************************************************************************

--- a/drivers/analog/dac.c
+++ b/drivers/analog/dac.c
@@ -86,13 +86,16 @@ static int     dac_ioctl(FAR struct file *filep, int cmd, unsigned long arg);
 
 static const struct file_operations dac_fops =
 {
-  dac_open,
-  dac_close,
-  dac_read,
-  dac_write,
-  NULL,
-  dac_ioctl,
-  NULL
+  dac_open,       /* open */
+  dac_close,      /* close */
+  dac_read,       /* read */
+  dac_write,      /* write */
+  NULL,           /* seek */
+  dac_ioctl,      /* ioctl */
+  NULL            /* poll */
+#ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
+  , NULL          /* unlink */
+#endif
 };
 
 /****************************************************************************

--- a/drivers/contactless/mfrc522.c
+++ b/drivers/contactless/mfrc522.c
@@ -108,15 +108,15 @@ static inline int mfrc522_attachirq(FAR struct mfrc522_dev_s *dev,
 
 static const struct file_operations g_mfrc522fops =
 {
-  mfrc522_open,
-  mfrc522_close,
-  mfrc522_read,
-  mfrc522_write,
-  NULL,
-  mfrc522_ioctl,
-  NULL
+  mfrc522_open,   /* open */
+  mfrc522_close,  /* close */
+  mfrc522_read,   /* read */
+  mfrc522_write,  /* write */
+  NULL,           /* seek */
+  mfrc522_ioctl,  /* ioctl */
+  NULL            /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
-  , NULL
+  , NULL          /* unlink */
 #endif
 };
 

--- a/drivers/contactless/pn532.c
+++ b/drivers/contactless/pn532.c
@@ -104,15 +104,15 @@ static inline int pn532_attachirq(FAR struct pn532_dev_s *dev, xcpt_t isr);
 
 static const struct file_operations g_pn532fops =
 {
-  _open,
-  _close,
-  _read,
-  _write,
-  NULL,
-  _ioctl,
-  NULL
+  _open,          /* open */
+  _close,         /* close */
+  _read,          /* read */
+  _write,         /* write */
+  NULL,           /* seek */
+  _ioctl,         /* ioctl */
+  NULL            /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
-  , NULL
+  , NULL          /* unlink */
 #endif
 };
 

--- a/drivers/eeprom/i2c_xx24xx.c
+++ b/drivers/eeprom/i2c_xx24xx.c
@@ -239,6 +239,9 @@ static const struct file_operations ee24xx_fops =
   ee24xx_seek,  /* seek */
   ee24xx_ioctl, /* ioctl */
   NULL          /* poll */
+#ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
+  , NULL        /* unlink */
+#endif
 };
 
 #ifdef CONFIG_AT24CS_UUID
@@ -251,6 +254,9 @@ static const struct file_operations at24cs_uuid_fops =
   NULL,             /* seek */
   NULL,             /* ioctl */
   NULL              /* poll */
+#ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
+  , NULL            /* unlink */
+#endif
 };
 #endif
 

--- a/drivers/eeprom/spi_xx25xx.c
+++ b/drivers/eeprom/spi_xx25xx.c
@@ -276,6 +276,9 @@ static const struct file_operations ee25xx_fops =
   ee25xx_seek,  /* seek */
   ee25xx_ioctl, /* ioctl */
   NULL          /* poll */
+#ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
+  , NULL        /* unlink */
+#endif
 };
 
 /****************************************************************************

--- a/drivers/efuse/efuse.c
+++ b/drivers/efuse/efuse.c
@@ -88,6 +88,9 @@ static const struct file_operations g_efuseops =
   NULL,        /* seek */
   efuse_ioctl, /* ioctl */
   NULL         /* poll */
+#ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
+  , NULL       /* unlink */
+#endif
 };
 
 /****************************************************************************

--- a/drivers/i2s/i2schar.c
+++ b/drivers/i2s/i2schar.c
@@ -111,7 +111,10 @@ static const struct file_operations i2schar_fops =
   i2schar_write,        /* write */
   NULL,                 /* seek  */
   i2schar_ioctl,        /* ioctl */
-  NULL,                 /* poll  */
+  NULL                  /* poll  */
+#ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
+  , NULL                /* unlink */
+#endif
 };
 
 /****************************************************************************

--- a/drivers/input/ads7843e.c
+++ b/drivers/input/ads7843e.c
@@ -119,10 +119,13 @@ static const struct file_operations ads7843e_fops =
   ads7843e_open,    /* open */
   ads7843e_close,   /* close */
   ads7843e_read,    /* read */
-  0,                /* write */
-  0,                /* seek */
+  NULL,             /* write */
+  NULL,             /* seek */
   ads7843e_ioctl,   /* ioctl */
   ads7843e_poll     /* poll */
+#ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
+  , NULL            /* unlink */
+#endif
 };
 
 /* If only a single ADS7843E device is supported, then the driver state

--- a/drivers/input/ajoystick.c
+++ b/drivers/input/ajoystick.c
@@ -142,10 +142,13 @@ static const struct file_operations ajoy_fops =
   ajoy_open,  /* open */
   ajoy_close, /* close */
   ajoy_read,  /* read */
-  0,          /* write */
-  0,          /* seek */
+  NULL,       /* write */
+  NULL,       /* seek */
   ajoy_ioctl, /* ioctl */
   ajoy_poll   /* poll */
+#ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
+  , NULL      /* unlink */
+#endif
 };
 
 /****************************************************************************

--- a/drivers/input/button_upper.c
+++ b/drivers/input/button_upper.c
@@ -142,6 +142,9 @@ static const struct file_operations btn_fops =
   NULL,      /* seek */
   btn_ioctl, /* ioctl */
   btn_poll   /* poll */
+#ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
+  , NULL     /* unlink */
+#endif
 };
 
 /****************************************************************************

--- a/drivers/input/cypress_mbr3108.c
+++ b/drivers/input/cypress_mbr3108.c
@@ -225,6 +225,9 @@ static const struct file_operations g_mbr3108_fileops =
   NULL,           /* seek */
   NULL,           /* ioctl */
   mbr3108_poll    /* poll */
+#ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
+  , NULL          /* unlink */
+#endif
 };
 
 /****************************************************************************

--- a/drivers/input/djoystick.c
+++ b/drivers/input/djoystick.c
@@ -142,10 +142,13 @@ static const struct file_operations djoy_fops =
   djoy_open,  /* open */
   djoy_close, /* close */
   djoy_read,  /* read */
-  0,          /* write */
-  0,          /* seek */
+  NULL,       /* write */
+  NULL,       /* seek */
   djoy_ioctl, /* ioctl */
   djoy_poll   /* poll */
+#ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
+  , NULL      /* unlink */
+#endif
 };
 
 /****************************************************************************

--- a/drivers/input/max11802.c
+++ b/drivers/input/max11802.c
@@ -112,12 +112,12 @@ static const struct file_operations max11802_fops =
   max11802_open,    /* open */
   max11802_close,   /* close */
   max11802_read,    /* read */
-  0,                /* write */
-  0,                /* seek */
+  NULL,             /* write */
+  NULL,             /* seek */
   max11802_ioctl,   /* ioctl */
   max11802_poll     /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
-  , 0               /* unlink */
+  , NULL            /* unlink */
 #endif
 };
 

--- a/drivers/input/mxt.c
+++ b/drivers/input/mxt.c
@@ -276,10 +276,13 @@ static const struct file_operations mxt_fops =
   mxt_open,    /* open */
   mxt_close,   /* close */
   mxt_read,    /* read */
-  0,           /* write */
-  0,           /* seek */
+  NULL,        /* write */
+  NULL,        /* seek */
   mxt_ioctl,   /* ioctl */
   mxt_poll     /* poll */
+#ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
+  , NULL       /* unlink */
+#endif
 };
 
 /****************************************************************************

--- a/drivers/input/spq10kbd.c
+++ b/drivers/input/spq10kbd.c
@@ -248,13 +248,16 @@ static int  spq10kbd_poll(FAR struct file *filep, FAR struct pollfd *fds,
 
 static const struct file_operations g_hidkbd_fops =
 {
-  spq10kbd_open,             /* open      */
-  spq10kbd_close,            /* close     */
-  spq10kbd_read,             /* read      */
-  spq10kbd_write,            /* write     */
-  NULL,                      /* seek      */
-  NULL,                      /* ioctl     */
-  spq10kbd_poll              /* poll      */
+  spq10kbd_open,             /* open */
+  spq10kbd_close,            /* close */
+  spq10kbd_read,             /* read */
+  spq10kbd_write,            /* write */
+  NULL,                      /* seek */
+  NULL,                      /* ioctl */
+  spq10kbd_poll              /* poll */
+#ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
+  , NULL                     /* unlink */
+#endif
 };
 
 /****************************************************************************

--- a/drivers/input/stmpe811_tsc.c
+++ b/drivers/input/stmpe811_tsc.c
@@ -125,6 +125,9 @@ static const struct file_operations g_stmpe811fops =
   NULL,             /* seek */
   stmpe811_ioctl,   /* ioctl */
   stmpe811_poll     /* poll */
+#ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
+  , NULL            /* unlink */
+#endif
 };
 
 /****************************************************************************

--- a/drivers/input/touchscreen_upper.c
+++ b/drivers/input/touchscreen_upper.c
@@ -87,13 +87,16 @@ static int     touch_poll(FAR struct file *filep, FAR struct pollfd *fds,
 
 static const struct file_operations g_touch_fops =
 {
-  touch_open,
-  touch_close,
-  touch_read,
-  NULL,
-  NULL,
-  touch_ioctl,
-  touch_poll
+  touch_open,     /* open */
+  touch_close,    /* close */
+  touch_read,     /* read */
+  NULL,           /* write */
+  NULL,           /* seek */
+  touch_ioctl,    /* ioctl */
+  touch_poll      /* poll */
+#ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
+  , NULL          /* unlink */
+#endif
 };
 
 /****************************************************************************

--- a/drivers/input/tsc2007.c
+++ b/drivers/input/tsc2007.c
@@ -205,10 +205,13 @@ static const struct file_operations tsc2007_fops =
   tsc2007_open,    /* open */
   tsc2007_close,   /* close */
   tsc2007_read,    /* read */
-  0,               /* write */
-  0,               /* seek */
+  NULL,            /* write */
+  NULL,            /* seek */
   tsc2007_ioctl,   /* ioctl */
   tsc2007_poll     /* poll */
+#ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
+  , NULL           /* unlink */
+#endif
 };
 
 /* If only a single TSC2007 device is supported, then the driver state

--- a/drivers/lcd/ht16k33_14seg.c
+++ b/drivers/lcd/ht16k33_14seg.c
@@ -160,9 +160,9 @@ static const struct file_operations g_ht16k33fops =
   ht16k33_write,  /* write */
   ht16k33_seek,   /* seek */
   ht16k33_ioctl,  /* ioctl */
-  NULL,           /* poll */
+  NULL            /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
-  NULL            /* unlink */
+  , NULL          /* unlink */
 #endif
 };
 

--- a/drivers/lcd/pcf8574_lcd_backpack.c
+++ b/drivers/lcd/pcf8574_lcd_backpack.c
@@ -123,9 +123,9 @@ static const struct file_operations g_pcf8574_lcd_fops =
   pcf8574_lcd_write,            /* write */
   pcf8574_lcd_seek,             /* seek */
   pcf8574_lcd_ioctl,            /* ioctl */
-  pcf8574lcd_poll,              /* poll */
+  pcf8574lcd_poll               /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
-  pcf8574_lcd_unlink            /* unlink */
+  , pcf8574_lcd_unlink          /* unlink */
 #endif
 };
 

--- a/drivers/lcd/st7032.c
+++ b/drivers/lcd/st7032.c
@@ -116,9 +116,9 @@ static const struct file_operations g_st7032fops =
   st7032_write,  /* write */
   st7032_seek,   /* seek */
   st7032_ioctl,  /* ioctl */
-  NULL,          /* poll */
+  NULL           /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
-  NULL           /* unlink */
+  , NULL         /* unlink */
 #endif
 };
 

--- a/drivers/leds/max7219.c
+++ b/drivers/leds/max7219.c
@@ -89,9 +89,9 @@ static const struct file_operations g_max7219fops =
   max7219_write,  /* write */
   NULL,           /* seek */
   NULL,           /* ioctl */
-  NULL,           /* poll */
+  NULL            /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
-  NULL            /* unlink */
+  , NULL          /* unlink */
 #endif
 };
 

--- a/drivers/leds/ncp5623c.c
+++ b/drivers/leds/ncp5623c.c
@@ -86,9 +86,12 @@ static const struct file_operations g_ncp5623c_fileops =
   ncp5623c_close,              /* close */
   ncp5623c_read,               /* read */
   ncp5623c_write,              /* write */
-  0,                           /* seek */
+  NULL,                        /* seek */
   ncp5623c_ioctl,              /* ioctl */
-  0                            /* poll */
+  NULL                         /* poll */
+#ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
+  , NULL                      /* unlink */
+#endif
 };
 
 /****************************************************************************

--- a/drivers/leds/pca9635pw.c
+++ b/drivers/leds/pca9635pw.c
@@ -68,11 +68,14 @@ static const struct file_operations g_pca9635pw_fileops =
 {
   pca9635pw_open,               /* open */
   pca9635pw_close,              /* close */
-  0,                            /* read */
-  0,                            /* write */
-  0,                            /* seek */
+  NULL,                         /* read */
+  NULL,                         /* write */
+  NULL,                         /* seek */
   pca9635pw_ioctl,              /* ioctl */
-  0                             /* poll */
+  NULL                          /* poll */
+#ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
+  , NULL                        /* unlink */
+#endif
 };
 
 /****************************************************************************

--- a/drivers/leds/ws2812.c
+++ b/drivers/leds/ws2812.c
@@ -131,9 +131,9 @@ static const struct file_operations g_ws2812fops =
   ws2812_write,   /* write */
   ws2812_seek,    /* seek */
   NULL,           /* ioctl */
-  NULL,           /* poll */
+  NULL            /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
-  NULL            /* unlink */
+  , NULL          /* unlink */
 #endif
 };
 

--- a/drivers/loop/loop.c
+++ b/drivers/loop/loop.c
@@ -58,6 +58,9 @@ static const struct file_operations g_loop_fops =
   NULL,          /* seek */
   loop_ioctl,    /* ioctl */
   NULL           /* poll */
+#ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
+  , NULL         /* unlink */
+#endif
 };
 
 /****************************************************************************

--- a/drivers/lwl_console.c
+++ b/drivers/lwl_console.c
@@ -139,8 +139,7 @@ static const struct file_operations g_consoleops =
   lwlconsole_ioctl,           /* ioctl */
   NULL                        /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
-    ,
-  NULL                        /* unlink */
+  , NULL                      /* unlink */
 #endif
 };
 

--- a/drivers/math/cordic.c
+++ b/drivers/math/cordic.c
@@ -82,6 +82,9 @@ static const struct file_operations g_cordicops =
   NULL,         /* seek */
   cordic_ioctl, /* ioctl */
   NULL          /* poll */
+#ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
+  , NULL        /* unlink */
+#endif
 };
 
 /****************************************************************************

--- a/drivers/modem/altair/altmdm.c
+++ b/drivers/modem/altair/altmdm.c
@@ -62,8 +62,12 @@ static const struct file_operations g_altmdmfops =
   altmdm_close,                 /* close */
   altmdm_read,                  /* read */
   altmdm_write,                 /* write */
-  0,                            /* seek */
+  NULL,                         /* seek */
   altmdm_ioctl,                 /* ioctl */
+  NULL                          /* poll */
+#ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
+  , NULL                        /* unlink */
+#endif
 };
 
 /****************************************************************************

--- a/drivers/modem/u-blox.c
+++ b/drivers/modem/u-blox.c
@@ -108,13 +108,16 @@ static int     ubxmdm_poll (FAR struct file * filep,
 
 static const struct file_operations ubxmdm_fops =
 {
-  0,            /* open */
-  0,            /* close */
+  NULL,         /* open */
+  NULL,         /* close */
   ubxmdm_read,  /* read */
   ubxmdm_write, /* write */
-  0,            /* seek */
+  NULL,         /* seek */
   ubxmdm_ioctl, /* ioctl */
   ubxmdm_poll   /* poll */
+#ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
+  , NULL        /* unlink */
+#endif
 };
 
 /****************************************************************************

--- a/drivers/mtd/mtd_config.c
+++ b/drivers/mtd/mtd_config.c
@@ -119,10 +119,13 @@ static const struct file_operations mtdconfig_fops =
   mtdconfig_open,  /* open */
   mtdconfig_close, /* close */
   mtdconfig_read,  /* read */
-  0,               /* write */
-  0,               /* seek */
+  NULL,            /* write */
+  NULL,            /* seek */
   mtdconfig_ioctl, /* ioctl */
   mtdconfig_poll   /* poll */
+#ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
+  , NULL            /* unlink */
+#endif
 };
 
 /****************************************************************************

--- a/drivers/net/tun.c
+++ b/drivers/net/tun.c
@@ -237,9 +237,9 @@ static const struct file_operations g_tun_file_ops =
   tun_write,    /* write */
   NULL,         /* seek */
   tun_ioctl,    /* ioctl */
-  tun_poll,     /* poll */
+  tun_poll      /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
-  NULL,         /* unlink */
+  , NULL        /* unlink */
 #endif
 };
 

--- a/drivers/note/notectl_driver.c
+++ b/drivers/note/notectl_driver.c
@@ -54,7 +54,7 @@ static const struct file_operations notectl_fops =
   notectl_ioctl, /* ioctl */
   NULL           /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
-  , 0            /* unlink */
+  , NULL         /* unlink */
 #endif
 };
 

--- a/drivers/note/noteram_driver.c
+++ b/drivers/note/noteram_driver.c
@@ -88,7 +88,7 @@ static const struct file_operations g_noteram_fops =
   noteram_ioctl, /* ioctl */
   NULL           /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
-  , 0            /* unlink */
+  , NULL         /* unlink */
 #endif
 };
 

--- a/drivers/pipes/fifo.c
+++ b/drivers/pipes/fifo.c
@@ -41,15 +41,15 @@
 
 static const struct file_operations fifo_fops =
 {
-  pipecommon_open,  /* open */
-  pipecommon_close, /* close */
-  pipecommon_read,  /* read */
-  pipecommon_write, /* write */
-  0,                /* seek */
-  pipecommon_ioctl, /* ioctl */
-  pipecommon_poll,  /* poll */
+  pipecommon_open,     /* open */
+  pipecommon_close,    /* close */
+  pipecommon_read,     /* read */
+  pipecommon_write,    /* write */
+  NULL,                /* seek */
+  pipecommon_ioctl,    /* ioctl */
+  pipecommon_poll      /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
-  pipecommon_unlink /* unlink */
+  , pipecommon_unlink  /* unlink */
 #endif
 };
 

--- a/drivers/pipes/pipe.c
+++ b/drivers/pipes/pipe.c
@@ -61,15 +61,15 @@ static int pipe_close(FAR struct file *filep);
 
 static const struct file_operations pipe_fops =
 {
-  pipecommon_open,   /* open */
-  pipe_close,        /* close */
-  pipecommon_read,   /* read */
-  pipecommon_write,  /* write */
-  0,                 /* seek */
-  pipecommon_ioctl,  /* ioctl */
-  pipecommon_poll,   /* poll */
+  pipecommon_open,     /* open */
+  pipe_close,          /* close */
+  pipecommon_read,     /* read */
+  pipecommon_write,    /* write */
+  NULL,                /* seek */
+  pipecommon_ioctl,    /* ioctl */
+  pipecommon_poll      /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
-  pipecommon_unlink  /* unlink */
+  , pipecommon_unlink  /* unlink */
 #endif
 };
 

--- a/drivers/power/battery_charger.c
+++ b/drivers/power/battery_charger.c
@@ -85,13 +85,16 @@ static int     bat_charger_poll(FAR struct file *filep,
 
 static const struct file_operations g_batteryops =
 {
-  bat_charger_open,
-  bat_charger_close,
-  bat_charger_read,
-  bat_charger_write,
-  NULL,
-  bat_charger_ioctl,
-  bat_charger_poll,
+  bat_charger_open,    /* open */
+  bat_charger_close,   /* close */
+  bat_charger_read,    /* read */
+  bat_charger_write,   /* write */
+  NULL,                /* seek */
+  bat_charger_ioctl,   /* ioctl */
+  bat_charger_poll     /* poll */
+#ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
+  , NULL               /* unlink */
+#endif
 };
 
 /****************************************************************************

--- a/drivers/power/battery_gauge.c
+++ b/drivers/power/battery_gauge.c
@@ -87,13 +87,16 @@ static int     bat_gauge_poll(FAR struct file *filep,
 
 static const struct file_operations g_batteryops =
 {
-  bat_gauge_open,
-  bat_gauge_close,
-  bat_gauge_read,
-  bat_gauge_write,
-  NULL,
-  bat_gauge_ioctl,
-  bat_gauge_poll
+  bat_gauge_open,   /* open */
+  bat_gauge_close,  /* close */
+  bat_gauge_read,   /* read */
+  bat_gauge_write,  /* write */
+  NULL,             /* seek */
+  bat_gauge_ioctl,  /* ioctl */
+  bat_gauge_poll    /* poll */
+#ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
+  , NULL            /* unlink */
+#endif
 };
 
 /****************************************************************************

--- a/drivers/power/battery_monitor.c
+++ b/drivers/power/battery_monitor.c
@@ -86,13 +86,16 @@ static int     bat_monitor_poll(FAR struct file *filep,
 
 static const struct file_operations g_batteryops =
 {
-  bat_monitor_open,
-  bat_monitor_close,
-  bat_monitor_read,
-  bat_monitor_write,
-  NULL,
-  bat_monitor_ioctl,
-  bat_monitor_poll
+  bat_monitor_open,    /* open */
+  bat_monitor_close,   /* close */
+  bat_monitor_read,    /* read */
+  bat_monitor_write,   /* write */
+  NULL,                /* seek */
+  bat_monitor_ioctl,   /* ioctl */
+  bat_monitor_poll     /* poll */
+#ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
+  , NULL               /* unlink */
+#endif
 };
 
 /****************************************************************************

--- a/drivers/rc/lirc_dev.c
+++ b/drivers/rc/lirc_dev.c
@@ -97,13 +97,16 @@ static ssize_t lirc_read(FAR struct file *filep, FAR char *buffer,
 
 static const struct file_operations g_lirc_fops =
 {
-  lirc_open,   /* open  */
+  lirc_open,   /* open */
   lirc_close,  /* close */
-  lirc_read,   /* read  */
+  lirc_read,   /* read */
   lirc_write,  /* write */
-  NULL,        /* seek  */
+  NULL,        /* seek */
   lirc_ioctl,  /* ioctl */
-  lirc_poll,   /* poll  */
+  lirc_poll    /* poll */
+#ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
+  , NULL       /* unlink */
+#endif
 };
 
 /****************************************************************************

--- a/drivers/rf/dat-31r5-sp.c
+++ b/drivers/rf/dat-31r5-sp.c
@@ -79,13 +79,16 @@ static int dat31r5sp_ioctl(FAR struct file *filep, int cmd,
 
 static const struct file_operations g_dat31r5sp_fops =
 {
-  dat31r5sp_open,
-  dat31r5sp_close,
-  dat31r5sp_read,
-  dat31r5sp_write,
-  NULL,
-  dat31r5sp_ioctl,
-  NULL
+  dat31r5sp_open,   /* open */
+  dat31r5sp_close,  /* close */
+  dat31r5sp_read,   /* read */
+  dat31r5sp_write,  /* write */
+  NULL,             /* seek */
+  dat31r5sp_ioctl,  /* ioctl */
+  NULL              /* poll */
+#ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
+  , NULL            /* unlink */
+#endif
 };
 
 /****************************************************************************

--- a/drivers/rptun/rptun.c
+++ b/drivers/rptun/rptun.c
@@ -153,7 +153,16 @@ static struct remoteproc_ops g_rptun_ops =
 
 static const struct file_operations g_rptun_devops =
 {
-  .ioctl = rptun_dev_ioctl,
+  NULL,             /* open */
+  NULL,             /* close */
+  NULL,             /* read */
+  NULL,             /* write */
+  NULL,             /* seek */
+  rptun_dev_ioctl,  /* ioctl */
+  NULL              /* poll */
+#ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
+  , NULL            /* unlink */
+#endif
 };
 
 #ifdef CONFIG_RPTUN_LOADER

--- a/drivers/sensors/adt7320.c
+++ b/drivers/sensors/adt7320.c
@@ -101,13 +101,16 @@ static int adt7320_ioctl(FAR struct file *filep, int cmd, unsigned long arg);
 
 static const struct file_operations g_adt7320fops =
 {
-  adt7320_open,
-  adt7320_close,
-  adt7320_read,
-  adt7320_write,
-  NULL,
-  adt7320_ioctl,
-  NULL
+  adt7320_open,    /* open */
+  adt7320_close,   /* close */
+  adt7320_read,    /* read */
+  adt7320_write,   /* write */
+  NULL,            /* seek */
+  adt7320_ioctl,   /* ioctl */
+  NULL             /* poll */
+#ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
+  , NULL           /* unlink */
+#endif
 };
 
 /****************************************************************************

--- a/drivers/sensors/adxl345_base.c
+++ b/drivers/sensors/adxl345_base.c
@@ -65,9 +65,13 @@ static const struct file_operations g_adxl345fops =
   adxl345_open,    /* open */
   adxl345_close,   /* close */
   adxl345_read,    /* read */
-  0,               /* write */
-  0,               /* seek */
-  0,               /* ioctl */
+  NULL,            /* write */
+  NULL,            /* seek */
+  NULL,            /* ioctl */
+  NULL             /* poll */
+#ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
+  , NULL           /* unlink */
+#endif
 };
 
 /****************************************************************************

--- a/drivers/sensors/adxl372.c
+++ b/drivers/sensors/adxl372.c
@@ -119,15 +119,15 @@ static void     adxl372_dvr_exchange(FAR void *instance,
 
 static const struct file_operations g_adxl372_fops =
 {
-  adxl372_open,
-  adxl372_close,
-  adxl372_read,
-  adxl372_write,
-  adxl372_seek,
-  adxl372_ioctl,
-  NULL
+  adxl372_open,    /* open */
+  adxl372_close,   /* close */
+  adxl372_read,    /* read */
+  adxl372_write,   /* write */
+  adxl372_seek,    /* seek */
+  adxl372_ioctl,   /* ioctl */
+  NULL             /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
-  , NULL
+  , NULL           /* unlink */
 #endif
 };
 

--- a/drivers/sensors/ak09912.c
+++ b/drivers/sensors/ak09912.c
@@ -178,12 +178,12 @@ static const struct file_operations g_ak09912fops =
   ak09912_close,                 /* close */
   ak09912_read,                  /* read */
   ak09912_write,                 /* write */
-  0,                             /* seek */
+  NULL,                          /* seek */
   ak09912_ioctl,                 /* ioctl */
-#ifndef CONFIG_DISABLE_POLL
-  0,                             /* poll */
+  NULL                           /* poll */
+#ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
+  , NULL                         /* unlink */
 #endif
-  0                              /* unlink */
 };
 
 /****************************************************************************

--- a/drivers/sensors/bmg160.c
+++ b/drivers/sensors/bmg160.c
@@ -95,15 +95,15 @@ static int bmg160_ioctl(FAR struct file *filep, int cmd, unsigned long arg);
 
 static const struct file_operations g_bmg160_fops =
 {
-  bmg160_open,
-  bmg160_close,
-  bmg160_read,
-  bmg160_write,
-  NULL,
-  bmg160_ioctl,
-  NULL
+  bmg160_open,     /* open */
+  bmg160_close,    /* close */
+  bmg160_read,     /* read */
+  bmg160_write,    /* write */
+  NULL,            /* seek */
+  bmg160_ioctl,    /* ioctl */
+  NULL             /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
-  , NULL
+  , NULL           /* unlink */
 #endif
 };
 

--- a/drivers/sensors/bmi160.c
+++ b/drivers/sensors/bmi160.c
@@ -258,12 +258,16 @@ static int bmi160_checkid(FAR struct bmi160_dev_s *priv);
 
 static const struct file_operations g_bmi160fops =
 {
-  bmi160_open,    /* open */
-  bmi160_close,   /* close */
-  bmi160_read,    /* read */
-  0,              /* write */
-  0,              /* seek */
-  bmi160_ioctl,   /* ioctl */
+  bmi160_open,     /* open */
+  bmi160_close,    /* close */
+  bmi160_read,     /* read */
+  NULL,            /* write */
+  NULL,            /* seek */
+  bmi160_ioctl,    /* ioctl */
+  NULL             /* poll */
+#ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
+  , NULL           /* unlink */
+#endif
 };
 
 /****************************************************************************

--- a/drivers/sensors/fxos8700cq.c
+++ b/drivers/sensors/fxos8700cq.c
@@ -107,12 +107,16 @@ static int fxos8700cq_checkid(FAR struct fxos8700cq_dev_s *priv);
 
 static const struct file_operations g_fxos8700cqfops =
 {
-  fxos8700cq_open,
-  fxos8700cq_close,
-  fxos8700cq_read,
-  0, /* write */
-  0, /* seek */
-  0, /* ioctl */
+  fxos8700cq_open,    /* open */
+  fxos8700cq_close,   /* close */
+  fxos8700cq_read,    /* read */
+  NULL,               /* write */
+  NULL,               /* seek */
+  NULL,               /* ioctl */
+  NULL                /* poll */
+#ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
+  , NULL              /* unlink */
+#endif
 };
 
 /****************************************************************************

--- a/drivers/sensors/hall3ph.c
+++ b/drivers/sensors/hall3ph.c
@@ -78,9 +78,12 @@ static const struct file_operations g_hall3ops =
   hall3_close, /* close */
   hall3_read,  /* read */
   hall3_write, /* write */
-  NULL  ,      /* seek */
+  NULL,        /* seek */
   hall3_ioctl, /* ioctl */
   NULL         /* poll */
+#ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
+  , NULL       /* unlink */
+#endif
 };
 
 /****************************************************************************

--- a/drivers/sensors/ina219.c
+++ b/drivers/sensors/ina219.c
@@ -113,15 +113,15 @@ static int     ina219_ioctl(FAR struct file *filep, int cmd,
 
 static const struct file_operations g_ina219fops =
 {
-  ina219_open,
-  ina219_close,
-  ina219_read,
-  ina219_write,
-  NULL,
-  ina219_ioctl,
-  NULL
+  ina219_open,     /* open */
+  ina219_close,    /* close */
+  ina219_read,     /* read */
+  ina219_write,    /* write */
+  NULL,            /* seek */
+  ina219_ioctl,    /* ioctl */
+  NULL             /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
-  , NULL
+  , NULL           /* unlink */
 #endif
 };
 

--- a/drivers/sensors/ina226.c
+++ b/drivers/sensors/ina226.c
@@ -95,15 +95,15 @@ static int     ina226_ioctl(FAR struct file *filep, int cmd,
 
 static const struct file_operations g_ina226fops =
 {
-  ina226_open,
-  ina226_close,
-  ina226_read,
-  ina226_write,
-  NULL,
-  ina226_ioctl,
-  NULL
+  ina226_open,     /* open */
+  ina226_close,    /* close */
+  ina226_read,     /* read */
+  ina226_write,    /* write */
+  NULL,            /* seek */
+  ina226_ioctl,    /* ioctl */
+  NULL             /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
-  , NULL
+  , NULL           /* unlink */
 #endif
 };
 

--- a/drivers/sensors/ina3221.c
+++ b/drivers/sensors/ina3221.c
@@ -118,15 +118,15 @@ static int     ina3221_ioctl(FAR struct file *filep, int cmd,
 
 static const struct file_operations g_ina3221fops =
 {
-  ina3221_open,
-  ina3221_close,
-  ina3221_read,
-  ina3221_write,
-  NULL,
-  ina3221_ioctl,
-  NULL
+  ina3221_open,    /* open */
+  ina3221_close,   /* close */
+  ina3221_read,    /* read */
+  ina3221_write,   /* write */
+  NULL,            /* seek */
+  ina3221_ioctl,   /* ioctl */
+  NULL             /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
-  , NULL
+  , NULL           /* unlink */
 #endif
 };
 

--- a/drivers/sensors/isl29023.c
+++ b/drivers/sensors/isl29023.c
@@ -130,6 +130,9 @@ static const struct file_operations g_isl29023fops =
   NULL,            /* seek */
   isl29023_ioctl,  /* ioctl */
   NULL             /* poll */
+#ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
+  , NULL           /* unlink */
+#endif
 };
 
 /****************************************************************************

--- a/drivers/sensors/kxtj9.c
+++ b/drivers/sensors/kxtj9.c
@@ -161,15 +161,15 @@ static int     kxtj9_ioctl(FAR struct file *filep, int cmd,
 
 static const struct file_operations g_fops =
 {
-  kxtj9_open,
-  kxtj9_close,
-  kxtj9_read,
-  kxtj9_write,
-  NULL,
-  kxtj9_ioctl,
-  NULL,
+  kxtj9_open,      /* open */
+  kxtj9_close,     /* close */
+  kxtj9_read,      /* read */
+  kxtj9_write,     /* write */
+  NULL,            /* seek */
+  kxtj9_ioctl,     /* ioctl */
+  NULL             /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
-  NULL,
+  , NULL           /* unlink */
 #endif
 };
 

--- a/drivers/sensors/lis3dh.c
+++ b/drivers/sensors/lis3dh.c
@@ -120,15 +120,15 @@ static int lis3dh_ioctl(FAR struct file *filep, int cmd, unsigned long arg);
 
 static const struct file_operations g_lis3dh_fops =
 {
-  lis3dh_open,
-  lis3dh_close,
-  lis3dh_read,
-  lis3dh_write,
-  NULL,
-  lis3dh_ioctl,
-  NULL
+  lis3dh_open,     /* open */
+  lis3dh_close,    /* close */
+  lis3dh_read,     /* read */
+  lis3dh_write,    /* write */
+  NULL,            /* seek */
+  lis3dh_ioctl,    /* ioctl */
+  NULL             /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
-  , NULL
+  , NULL           /* unlink */
 #endif
 };
 

--- a/drivers/sensors/lis3dsh.c
+++ b/drivers/sensors/lis3dsh.c
@@ -100,15 +100,15 @@ static int lis3dsh_ioctl(FAR struct file *filep, int cmd, unsigned long arg);
 
 static const struct file_operations g_lis3dsh_fops =
 {
-  lis3dsh_open,
-  lis3dsh_close,
-  lis3dsh_read,
-  lis3dsh_write,
-  NULL,
-  lis3dsh_ioctl,
-  NULL
+  lis3dsh_open,    /* open */
+  lis3dsh_close,   /* close */
+  lis3dsh_read,    /* read */
+  lis3dsh_write,   /* write */
+  NULL,            /* seek */
+  lis3dsh_ioctl,   /* ioctl */
+  NULL             /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
-  , NULL
+  , NULL           /* unlink */
 #endif
 };
 

--- a/drivers/sensors/lis3mdl.c
+++ b/drivers/sensors/lis3mdl.c
@@ -101,15 +101,15 @@ static int lis3mdl_ioctl(FAR struct file *filep,
 
 static const struct file_operations g_lis3mdl_fops =
 {
-  lis3mdl_open,
-  lis3mdl_close,
-  lis3mdl_read,
-  lis3mdl_write,
-  NULL,
-  lis3mdl_ioctl,
-  NULL
+  lis3mdl_open,    /* open */
+  lis3mdl_close,   /* close */
+  lis3mdl_read,    /* read */
+  lis3mdl_write,   /* write */
+  NULL,            /* seek */
+  lis3mdl_ioctl,   /* ioctl */
+  NULL             /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
-  , NULL
+  , NULL           /* unlink */
 #endif
 };
 

--- a/drivers/sensors/lm75.c
+++ b/drivers/sensors/lm75.c
@@ -98,13 +98,16 @@ static int     lm75_ioctl(FAR struct file *filep, int cmd,
 
 static const struct file_operations g_lm75fops =
 {
-  lm75_open,
-  lm75_close,
-  lm75_read,
-  lm75_write,
-  NULL,
-  lm75_ioctl,
-  NULL
+  lm75_open,       /* open */
+  lm75_close,      /* close */
+  lm75_read,       /* read */
+  lm75_write,      /* write */
+  NULL,            /* seek */
+  lm75_ioctl,      /* ioctl */
+  NULL             /* poll */
+#ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
+  , NULL           /* unlink */
+#endif
 };
 
 /****************************************************************************

--- a/drivers/sensors/lm92.c
+++ b/drivers/sensors/lm92.c
@@ -97,13 +97,16 @@ static int     lm92_ioctl(FAR struct file *filep,
 
 static const struct file_operations g_lm92fops =
 {
-  lm92_open,
-  lm92_close,
-  lm92_read,
-  lm92_write,
-  NULL,
-  lm92_ioctl,
-  NULL
+  lm92_open,       /* open */
+  lm92_close,      /* close */
+  lm92_read,       /* read */
+  lm92_write,      /* write */
+  NULL,            /* seek */
+  lm92_ioctl,      /* ioctl */
+  NULL             /* poll */
+#ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
+  , NULL           /* unlink */
+#endif
 };
 
 /****************************************************************************

--- a/drivers/sensors/lsm303agr.c
+++ b/drivers/sensors/lsm303agr.c
@@ -126,15 +126,15 @@ static double g_magnetofactor = 0;
 
 static const struct file_operations g_fops =
 {
-  lsm303agr_open,
-  lsm303agr_close,
-  lsm303agr_read,
-  lsm303agr_write,
-  NULL,
-  lsm303agr_ioctl,
-  NULL
+  lsm303agr_open,     /* open */
+  lsm303agr_close,    /* close */
+  lsm303agr_read,     /* read */
+  lsm303agr_write,    /* write */
+  NULL,               /* seek */
+  lsm303agr_ioctl,    /* ioctl */
+  NULL                /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
-  , NULL
+  , NULL              /* unlink */
 #endif
 };
 

--- a/drivers/sensors/lsm330_spi.c
+++ b/drivers/sensors/lsm330_spi.c
@@ -144,29 +144,29 @@ static void     lsm330_dvr_exchange(FAR void *instance_handle,
 
 static const struct file_operations g_lsm330a_fops =
 {
-  lsm330acl_open,
-  lsm330acl_close,
-  lsm330acl_read,
-  lsm330acl_write,
-  lsm330acl_seek,
-  lsm330_ioctl,
-  NULL
+  lsm330acl_open,      /* open */
+  lsm330acl_close,     /* close */
+  lsm330acl_read,      /* read */
+  lsm330acl_write,     /* write */
+  lsm330acl_seek,      /* seek */
+  lsm330_ioctl,        /* ioctl */
+  NULL                 /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
-  , NULL
+  , NULL               /* unlink */
 #endif
 };
 
 static const struct file_operations g_lsm330g_fops =
 {
-  lsm330gyro_open,
-  lsm330gyro_close,
-  lsm330gyro_read,
-  lsm330gyro_write,
-  lsm330gyro_seek,
-  lsm330_ioctl,
-  NULL
+  lsm330gyro_open,     /* open */
+  lsm330gyro_close,    /* close */
+  lsm330gyro_read,     /* read */
+  lsm330gyro_write,    /* write */
+  lsm330gyro_seek,     /* seek */
+  lsm330_ioctl,        /* ioctl */
+  NULL                 /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
-  , NULL
+  , NULL               /* unlink */
 #endif
 };
 

--- a/drivers/sensors/lsm6dsl.c
+++ b/drivers/sensors/lsm6dsl.c
@@ -134,16 +134,16 @@ static double g_gyrofactor = 0;
 
 static const struct file_operations g_fops =
 {
-  lsm6dsl_open,
-  lsm6dsl_close,
-  lsm6dsl_read,
-  lsm6dsl_write,
-  NULL,
-  lsm6dsl_ioctl,
-  NULL
+  lsm6dsl_open,    /* open */
+  lsm6dsl_close,   /* close */
+  lsm6dsl_read,    /* read */
+  lsm6dsl_write,   /* write */
+  NULL,            /* seek */
+  lsm6dsl_ioctl,   /* ioctl */
+  NULL             /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
-  , NULL
-#  endif
+  , NULL           /* unlink */
+#endif
 };
 
 static const struct lsm6dsl_ops_s g_lsm6dsl_sensor_ops =

--- a/drivers/sensors/lsm9ds1.c
+++ b/drivers/sensors/lsm9ds1.c
@@ -584,15 +584,15 @@ static int lsm9ds1_register(FAR const char *devpath,
 
 static const struct file_operations g_fops =
 {
-  lsm9ds1_open,
-  lsm9ds1_close,
-  lsm9ds1_read,
-  lsm9ds1_write,
-  NULL,
-  lsm9ds1_ioctl,
-  NULL,
+  lsm9ds1_open,    /* open */
+  lsm9ds1_close,   /* close */
+  lsm9ds1_read,    /* read */
+  lsm9ds1_write,   /* write */
+  NULL,            /* seek */
+  lsm9ds1_ioctl,   /* ioctl */
+  NULL             /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
-  NULL,
+  , NULL           /* unlink */
 #endif
 };
 

--- a/drivers/sensors/ltc4151.c
+++ b/drivers/sensors/ltc4151.c
@@ -105,15 +105,15 @@ static int     ltc4151_ioctl(FAR struct file *filep, int cmd,
 
 static const struct file_operations g_ltc4151fops =
 {
-  ltc4151_open,
-  ltc4151_close,
-  ltc4151_read,
-  ltc4151_write,
-  NULL,
-  ltc4151_ioctl,
-  NULL
+  ltc4151_open,    /* open */
+  ltc4151_close,   /* close */
+  ltc4151_read,    /* read */
+  ltc4151_write,   /* write */
+  NULL,            /* seek */
+  ltc4151_ioctl,   /* ioctl */
+  NULL             /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
-  , NULL
+  , NULL           /* unlink */
 #endif
 };
 

--- a/drivers/sensors/max31855.c
+++ b/drivers/sensors/max31855.c
@@ -90,13 +90,16 @@ static ssize_t max31855_write(FAR struct file *filep, FAR const char *buffer,
 
 static const struct file_operations g_max31855fops =
 {
-  max31855_open,
-  max31855_close,
-  max31855_read,
-  max31855_write,
-  NULL,
-  NULL,
-  NULL
+  max31855_open,   /* open */
+  max31855_close,  /* close */
+  max31855_read,   /* read */
+  max31855_write,  /* write */
+  NULL,            /* seek */
+  NULL,            /* ioctl */
+  NULL             /* poll */
+#ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
+  , NULL           /* unlink */
+#endif
 };
 
 /****************************************************************************

--- a/drivers/sensors/max6675.c
+++ b/drivers/sensors/max6675.c
@@ -85,13 +85,16 @@ static ssize_t max6675_write(FAR struct file *filep, FAR const char *buffer,
 
 static const struct file_operations g_max6675fops =
 {
-  max6675_open,
-  max6675_close,
-  max6675_read,
-  max6675_write,
-  NULL,
-  NULL,
-  NULL
+  max6675_open,    /* open */
+  max6675_close,   /* close */
+  max6675_read,    /* read */
+  max6675_write,   /* write */
+  NULL,            /* seek */
+  NULL,            /* ioctl */
+  NULL             /* poll */
+#ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
+  , NULL           /* unlink */
+#endif
 };
 
 /****************************************************************************

--- a/drivers/sensors/mb7040.c
+++ b/drivers/sensors/mb7040.c
@@ -83,15 +83,15 @@ static int     mb7040_ioctl(FAR struct file *filep, int cmd,
 
 static const struct file_operations g_fops =
 {
-  mb7040_open,
-  mb7040_close,
-  mb7040_read,
-  mb7040_write,
-  NULL,
-  mb7040_ioctl,
-  NULL
+  mb7040_open,     /* open */
+  mb7040_close,    /* close */
+  mb7040_read,     /* read */
+  mb7040_write,    /* write */
+  NULL,            /* seek */
+  mb7040_ioctl,    /* ioctl */
+  NULL             /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
-  , NULL
+  , NULL           /* unlink */
 #endif
 };
 

--- a/drivers/sensors/mcp9844.c
+++ b/drivers/sensors/mcp9844.c
@@ -82,13 +82,16 @@ static int     mcp9844_ioctl(FAR struct file *filep, int cmd,
 
 static const struct file_operations g_mcp9844_fops =
 {
-  mcp9844_open,
-  mcp9844_close,
-  mcp9844_read,
-  mcp9844_write,
-  NULL,
-  mcp9844_ioctl,
-  NULL
+  mcp9844_open,    /* open */
+  mcp9844_close,   /* close */
+  mcp9844_read,    /* read */
+  mcp9844_write,   /* write */
+  NULL,            /* seek */
+  mcp9844_ioctl,   /* ioctl */
+  NULL             /* poll */
+#ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
+  , NULL           /* unlink */
+#endif
 };
 
 /****************************************************************************

--- a/drivers/sensors/mlx90393.c
+++ b/drivers/sensors/mlx90393.c
@@ -101,15 +101,15 @@ static int mlx90393_ioctl(FAR struct file *filep,
 
 static const struct file_operations g_mlx90393_fops =
 {
-  mlx90393_open,
-  mlx90393_close,
-  mlx90393_read,
-  mlx90393_write,
-  NULL,
-  mlx90393_ioctl,
-  NULL
+  mlx90393_open,   /* open */
+  mlx90393_close,  /* close */
+  mlx90393_read,   /* read */
+  mlx90393_write,  /* write */
+  NULL,            /* seek */
+  mlx90393_ioctl,  /* ioctl */
+  NULL             /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
-  , NULL
+  , NULL           /* unlink */
 #endif
 };
 

--- a/drivers/sensors/mpl115a.c
+++ b/drivers/sensors/mpl115a.c
@@ -91,9 +91,9 @@ static const struct file_operations g_mpl115afops =
   mpl115a_write,  /* write */
   NULL,           /* seek */
   NULL,           /* ioctl */
-  NULL,           /* poll */
+  NULL            /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
-  NULL            /* unlink */
+  , NULL          /* unlink */
 #endif
 };
 

--- a/drivers/sensors/mpu60x0.c
+++ b/drivers/sensors/mpu60x0.c
@@ -263,15 +263,15 @@ static int mpu_ioctl(FAR struct file *filep, int cmd, unsigned long arg);
 
 static const struct file_operations g_mpu_fops =
 {
-  mpu_open,
-  mpu_close,
-  mpu_read,
-  mpu_write,
-  mpu_seek,
-  mpu_ioctl,
-  NULL
+  mpu_open,        /* open */
+  mpu_close,       /* close */
+  mpu_read,        /* read */
+  mpu_write,       /* write */
+  mpu_seek,        /* seek */
+  mpu_ioctl,       /* ioctl */
+  NULL             /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
-  , NULL
+  , NULL           /* unlink */
 #endif
 };
 

--- a/drivers/sensors/ms58xx.c
+++ b/drivers/sensors/ms58xx.c
@@ -160,15 +160,15 @@ static int     ms58xx_ioctl(FAR struct file *filep, int cmd,
 
 static const struct file_operations g_fops =
 {
-  ms58xx_open,
-  ms58xx_close,
-  ms58xx_read,
-  ms58xx_write,
-  NULL,
-  ms58xx_ioctl,
-  NULL
+  ms58xx_open,     /* open */
+  ms58xx_close,    /* close */
+  ms58xx_read,     /* read */
+  ms58xx_write,    /* write */
+  NULL,            /* seek */
+  ms58xx_ioctl,    /* ioctl */
+  NULL             /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
-  , NULL
+  , NULL           /* unlink */
 #endif
 };
 

--- a/drivers/sensors/msa301.c
+++ b/drivers/sensors/msa301.c
@@ -110,17 +110,16 @@ static int msa301_register(FAR const char *               devpath,
 
 static const struct file_operations g_fops =
 {
-  msa301_open,
-  msa301_close,
-  msa301_read,
-  msa301_write,
-  NULL,
-  msa301_ioctl,
-  NULL
-#  ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
-  ,
-  NULL
-#  endif
+  msa301_open,     /* open */
+  msa301_close,    /* close */
+  msa301_read,     /* read */
+  msa301_write,    /* write */
+  NULL,            /* seek */
+  msa301_ioctl,    /* ioctl */
+  NULL             /* poll */
+#ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
+  , NULL           /* unlink */
+#endif
 };
 
 static const struct msa301_ops_s g_msa301_sensor_ops =

--- a/drivers/sensors/qencoder.c
+++ b/drivers/sensors/qencoder.c
@@ -89,6 +89,9 @@ static const struct file_operations g_qeops =
   NULL,     /* seek */
   qe_ioctl, /* ioctl */
   NULL      /* poll */
+#ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
+  , NULL    /* unlink */
+#endif
 };
 
 /****************************************************************************

--- a/drivers/sensors/sensor.c
+++ b/drivers/sensors/sensor.c
@@ -141,6 +141,9 @@ static const struct file_operations g_sensor_fops =
   NULL,           /* seek  */
   sensor_ioctl,   /* ioctl */
   sensor_poll     /* poll  */
+#ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
+  , NULL          /* unlink */
+#endif
 };
 
 /****************************************************************************

--- a/drivers/sensors/sht3x.c
+++ b/drivers/sensors/sht3x.c
@@ -168,12 +168,10 @@ static const struct file_operations g_sht3xfops =
   sht3x_read,     /* read */
   sht3x_write,    /* write */
   NULL,           /* seek */
-  sht3x_ioctl     /* ioctl */
-#ifndef CONFIG_DISABLE_POLL
-  , NULL          /* poll */
-#endif
+  sht3x_ioctl,    /* ioctl */
+  NULL            /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
-  , sht3x_unlink /* unlink */
+  , sht3x_unlink  /* unlink */
 #endif
 };
 

--- a/drivers/sensors/vl53l1x.c
+++ b/drivers/sensors/vl53l1x.c
@@ -250,11 +250,9 @@ static const struct file_operations g_vl53l1xfops =
   vl53l1x_write,                /* write */
   NULL,                         /* seek */
   vl53l1x_ioctl,                /* ioctl */
-#ifndef CONFIG_DISABLE_POLL
-  NULL,                         /* poll */
-#endif
+  NULL                          /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
-  NULL,                         /* unlink */
+  , NULL                        /* unlink */
 #endif
 };
 

--- a/drivers/sensors/zerocross.c
+++ b/drivers/sensors/zerocross.c
@@ -115,7 +115,7 @@ static const struct file_operations g_zcops =
   zc_ioctl,  /* ioctl */
   NULL       /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
-  , 0        /* unlink */
+  , NULL     /* unlink */
 #endif
 };
 

--- a/drivers/serial/serial.c
+++ b/drivers/serial/serial.c
@@ -127,7 +127,7 @@ static const struct file_operations g_serialops =
   uart_close, /* close */
   uart_read,  /* read */
   uart_write, /* write */
-  0,          /* seek */
+  NULL,       /* seek */
   uart_ioctl, /* ioctl */
   uart_poll   /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS

--- a/drivers/serial/uart_bth4.c
+++ b/drivers/serial/uart_bth4.c
@@ -83,12 +83,16 @@ static int     uart_bth4_poll (FAR struct file *filep,
 
 static const struct file_operations g_uart_bth4_ops =
 {
-  .open  = uart_bth4_open,
-  .close = uart_bth4_close,
-  .read  = uart_bth4_read,
-  .write = uart_bth4_write,
-  .ioctl = uart_bth4_ioctl,
-  .poll  = uart_bth4_poll
+  uart_bth4_open,   /* open */
+  uart_bth4_close,  /* cose */
+  uart_bth4_read,   /* read */
+  uart_bth4_write,  /* write */
+  NULL,             /* seek */
+  uart_bth4_ioctl,  /* ioctl */
+  uart_bth4_poll    /* poll */
+#ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
+  , NULL            /* unlink */
+#endif
 };
 
 /****************************************************************************

--- a/drivers/syslog/syslog_console.c
+++ b/drivers/syslog/syslog_console.c
@@ -58,6 +58,9 @@ static const struct file_operations g_consoleops =
   NULL,                 /* seek */
   syslog_console_ioctl, /* ioctl */
   NULL                  /* poll */
+#ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
+  , NULL                /* unlink */
+#endif
 };
 
 /****************************************************************************

--- a/drivers/timers/pwm.c
+++ b/drivers/timers/pwm.c
@@ -101,6 +101,9 @@ static const struct file_operations g_pwmops =
   NULL,      /* seek */
   pwm_ioctl, /* ioctl */
   NULL       /* poll */
+#ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
+  , NULL     /* unlink */
+#endif
 };
 
 /****************************************************************************

--- a/drivers/timers/rtc.c
+++ b/drivers/timers/rtc.c
@@ -129,9 +129,9 @@ static const struct file_operations rtc_fops =
   rtc_write,     /* write */
   NULL,          /* seek */
   rtc_ioctl,     /* ioctl */
-  NULL,          /* poll */
+  NULL           /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
-  rtc_unlink     /* unlink */
+  , rtc_unlink   /* unlink */
 #endif
 };
 

--- a/drivers/timers/watchdog.c
+++ b/drivers/timers/watchdog.c
@@ -118,6 +118,9 @@ static const struct file_operations g_wdogops =
   NULL,       /* seek */
   wdog_ioctl, /* ioctl */
   NULL        /* poll */
+#ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
+  , NULL      /* unlink */
+#endif
 };
 
 /****************************************************************************

--- a/drivers/usbdev/adb.c
+++ b/drivers/usbdev/adb.c
@@ -236,12 +236,12 @@ static void adb_char_on_connect(FAR struct usbdev_adb_s *priv, int connect);
 
 static const struct usbdevclass_driverops_s g_adb_driverops =
 {
-  usbclass_bind,       /* bind       */
-  usbclass_unbind,     /* unbind     */
-  usbclass_setup,      /* setup      */
+  usbclass_bind,       /* bind */
+  usbclass_unbind,     /* unbind */
+  usbclass_setup,      /* setup */
   usbclass_disconnect, /* disconnect */
-  usbclass_suspend,    /* suspend    */
-  usbclass_resume      /* resume     */
+  usbclass_suspend,    /* suspend */
+  usbclass_resume      /* resume */
 };
 
 /* Char device **************************************************************/
@@ -252,9 +252,12 @@ static const struct file_operations g_adb_fops =
   adb_char_close, /* close */
   adb_char_read,  /* read */
   adb_char_write, /* write */
-  0,              /* seek */
+  NULL,           /* seek */
   adb_char_ioctl, /* ioctl */
   adb_char_poll   /* poll */
+#ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
+  , NULL          /* unlink */
+#endif
 };
 
 /* USB descriptor ***********************************************************/

--- a/drivers/usbhost/usbhost_cdcmbim.c
+++ b/drivers/usbhost/usbhost_cdcmbim.c
@@ -331,21 +331,21 @@ static void cdcmbim_txpoll_work(void *arg);
 
 static const struct usbhost_id_s g_id =
 {
-  USB_CLASS_CDC,      /* base     */
+  USB_CLASS_CDC,      /* base */
   CDC_SUBCLASS_MBIM,  /* subclass */
-  0,                  /* proto    */
-  0,                  /* vid      */
-  0                   /* pid      */
+  0,                  /* proto */
+  0,                  /* vid */
+  0                   /* pid */
 };
 
 /* This is the USB host storage class's registry entry */
 
 static struct usbhost_registry_s g_cdcmbim =
 {
-  NULL,                   /* flink    */
-  usbhost_create,         /* create   */
-  1,                      /* nids     */
-  &g_id                   /* id[]     */
+  NULL,                   /* flink */
+  usbhost_create,         /* create */
+  1,                      /* nids */
+  &g_id                   /* id[] */
 };
 
 /* File operations for control channel */

--- a/drivers/usbhost/usbhost_hidkbd.c
+++ b/drivers/usbhost/usbhost_hidkbd.c
@@ -329,32 +329,35 @@ static int  usbhost_poll(FAR struct file *filep, FAR struct pollfd *fds,
 
 static const struct usbhost_id_s g_hidkbd_id =
 {
-  USB_CLASS_HID,            /* base     */
+  USB_CLASS_HID,            /* base */
   USBHID_SUBCLASS_BOOTIF,   /* subclass */
-  USBHID_PROTOCOL_KEYBOARD, /* proto    */
-  0,                        /* vid      */
-  0                         /* pid      */
+  USBHID_PROTOCOL_KEYBOARD, /* proto */
+  0,                        /* vid */
+  0                         /* pid */
 };
 
 /* This is the USB host storage class's registry entry */
 
 static struct usbhost_registry_s g_hidkbd =
 {
-  NULL,                     /* flink     */
-  usbhost_create,           /* create    */
-  1,                        /* nids      */
-  &g_hidkbd_id              /* id[]      */
+  NULL,                     /* flink */
+  usbhost_create,           /* create */
+  1,                        /* nids */
+  &g_hidkbd_id              /* id[] */
 };
 
 static const struct file_operations g_hidkbd_fops =
 {
-  usbhost_open,             /* open      */
-  usbhost_close,            /* close     */
-  usbhost_read,             /* read      */
-  usbhost_write,            /* write     */
-  NULL,                     /* seek      */
-  NULL,                     /* ioctl     */
-  usbhost_poll              /* poll      */
+  usbhost_open,             /* open */
+  usbhost_close,            /* close */
+  usbhost_read,             /* read */
+  usbhost_write,            /* write */
+  NULL,                     /* seek */
+  NULL,                     /* ioctl */
+  usbhost_poll              /* poll */
+#ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
+  , NULL                    /* unlink */
+#endif
 };
 
 /* This is a bitmap that is used to allocate device names /dev/kbda-z. */

--- a/drivers/usbhost/usbhost_hidmouse.c
+++ b/drivers/usbhost/usbhost_hidmouse.c
@@ -380,32 +380,35 @@ static int usbhost_poll(FAR struct file *filep, FAR struct pollfd *fds,
 
 static const struct usbhost_id_s g_hidmouse_id =
 {
-  USB_CLASS_HID,           /* base     */
+  USB_CLASS_HID,           /* base */
   USBHID_SUBCLASS_BOOTIF,  /* subclass */
-  USBHID_PROTOCOL_MOUSE,   /* proto    */
-  0,                       /* vid      */
-  0                        /* pid      */
+  USBHID_PROTOCOL_MOUSE,   /* proto */
+  0,                       /* vid */
+  0                        /* pid */
 };
 
 /* This is the USB host storage class's registry entry */
 
 static struct usbhost_registry_s g_hidmouse =
 {
-  NULL,                    /* flink     */
-  usbhost_create,          /* create    */
-  1,                       /* nids      */
-  &g_hidmouse_id           /* id[]      */
+  NULL,                    /* flink */
+  usbhost_create,          /* create */
+  1,                       /* nids */
+  &g_hidmouse_id           /* id[] */
 };
 
 static const struct file_operations g_hidmouse_fops =
 {
-  usbhost_open,            /* open      */
-  usbhost_close,           /* close     */
-  usbhost_read,            /* read      */
-  usbhost_write,           /* write     */
-  NULL,                    /* seek      */
-  NULL,                    /* ioctl     */
-  usbhost_poll             /* poll      */
+  usbhost_open,            /* open */
+  usbhost_close,           /* close */
+  usbhost_read,            /* read */
+  usbhost_write,           /* write */
+  NULL,                    /* seek */
+  NULL,                    /* ioctl */
+  usbhost_poll             /* poll */
+#ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
+  , NULL                   /* unlink */
+#endif
 };
 
 /* This is a bitmap that is used to allocate device names /dev/mouse0-31. */

--- a/drivers/usbhost/usbhost_xboxcontroller.c
+++ b/drivers/usbhost/usbhost_xboxcontroller.c
@@ -307,6 +307,9 @@ static const struct file_operations g_xboxcontroller_fops =
   NULL,                     /* seek */
   usbhost_ioctl,            /* ioctl */
   usbhost_poll              /* poll */
+#ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
+  , NULL                    /* unlink */
+#endif
 };
 
 /* This is a bitmap that is used to allocate device names /dev/xboxa-z. */

--- a/drivers/video/max7456.c
+++ b/drivers/video/max7456.c
@@ -336,15 +336,16 @@ static ssize_t mx7_debug_write(FAR struct file *filep,
 
 static const struct file_operations g_mx7_fops =
 {
-  .poll   = NULL,
+  mx7_open,      /* open */
+  mx7_close,     /* close */
+  mx7_read,      /* read */
+  mx7_write,     /* write */
+  NULL,          /* seek */
+  mx7_ioctl,     /* ioctl */
+  NULL           /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
-  .unlink = NULL,
+  , NULL         /* unlink */
 #endif
-  .open   = mx7_open,
-  .close  = mx7_close,
-  .read   = mx7_read,
-  .write  = mx7_write,
-  .ioctl  = mx7_ioctl
 };
 
 #if defined(DEBUG)
@@ -353,14 +354,16 @@ static const struct file_operations g_mx7_fops =
 
 static const struct file_operations g_mx7_debug_fops =
 {
-  .poll   = NULL,
+  mx7_debug_open,      /* open */
+  mx7_debug_close,     /* close */
+  mx7_debug_read,      /* read */
+  mx7_debug_write,     /* write */
+  NULL,                /* seek */
+  NULL,                /* ioctl */
+  NULL                 /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
-  .unlink = NULL,
+  , NULL               /* unlink */
 #endif
-  .open   = mx7_debug_open,
-  .close  = mx7_debug_close,
-  .read   = mx7_debug_read,
-  .write  = mx7_debug_write,
 };
 #endif
 

--- a/drivers/video/video.c
+++ b/drivers/video/video.c
@@ -265,14 +265,14 @@ static const struct file_operations g_video_fops =
 {
   video_open,               /* open */
   video_close,              /* close */
-  0,                        /* read */
-  0,                        /* write */
-  0,                        /* seek */
+  NULL,                     /* read */
+  NULL,                     /* write */
+  NULL,                     /* seek */
   video_ioctl,              /* ioctl */
-#ifndef CONFIG_DISABLE_POLL
-  0,                        /* poll */
+  NULL                      /* poll */
+#ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
+  , NULL                    /* unlink */
 #endif
-  0                         /* unlink */
 };
 
 static bool is_initialized = false;

--- a/drivers/wireless/cc1101.c
+++ b/drivers/wireless/cc1101.c
@@ -306,8 +306,7 @@ static const struct file_operations g_cc1101ops =
   NULL,              /* ioctl */
   cc1101_file_poll   /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
-  ,
-  NULL               /* unlink */
+  , NULL             /* unlink */
 #endif
 };
 

--- a/drivers/wireless/gs2200m.c
+++ b/drivers/wireless/gs2200m.c
@@ -233,8 +233,10 @@ static const struct file_operations g_gs2200m_fops =
   gs2200m_write, /* write */
   NULL,          /* seek */
   gs2200m_ioctl, /* ioctl */
-  gs2200m_poll,  /* poll */
-  NULL           /* unlink */
+  gs2200m_poll   /* poll */
+#ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
+  , NULL         /* unlink */
+#endif
 };
 
 static struct evt_code_s _evt_table[] =

--- a/fs/mqueue/mq_open.c
+++ b/fs/mqueue/mq_open.c
@@ -60,9 +60,9 @@ static const struct file_operations g_nxmq_fileops =
   NULL,             /* write */
   NULL,             /* seek */
   NULL,             /* ioctl */
-  nxmq_file_poll,   /* poll */
+  nxmq_file_poll    /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
-  NULL,             /* unlink */
+  , NULL            /* unlink */
 #endif
 };
 

--- a/fs/socket/socket.c
+++ b/fs/socket/socket.c
@@ -64,9 +64,9 @@ static const struct file_operations g_sock_fileops =
   sock_file_write,  /* write */
   NULL,             /* seek */
   sock_file_ioctl,  /* ioctl */
-  sock_file_poll,   /* poll */
+  sock_file_poll    /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
-  NULL,               /* unlink */
+  , NULL            /* unlink */
 #endif
 };
 

--- a/fs/vfs/fs_epoll.c
+++ b/fs/vfs/fs_epoll.c
@@ -67,8 +67,16 @@ static int epoll_do_poll(FAR struct file *filep,
 
 static const struct file_operations g_epoll_ops =
 {
-  .close = epoll_do_close,
-  .poll  = epoll_do_poll
+  NULL,             /* open */
+  epoll_do_close,   /* close */
+  NULL,             /* read */
+  NULL,             /* write */
+  NULL,             /* seek */
+  NULL,             /* ioctl */
+  epoll_do_poll     /* poll */
+#ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
+  , NULL            /* unlink */
+#endif
 };
 
 /****************************************************************************

--- a/fs/vfs/fs_eventfd.c
+++ b/fs/vfs/fs_eventfd.c
@@ -120,9 +120,14 @@ static const struct file_operations g_eventfd_fops =
   eventfd_do_read,  /* read */
   eventfd_do_write, /* write */
   NULL,             /* seek */
-  NULL              /* ioctl */
+  NULL,             /* ioctl */
 #ifdef CONFIG_EVENT_FD_POLL
-  , eventfd_do_poll /* poll */
+  eventfd_do_poll   /* poll */
+#else
+  NULL              /* poll */
+#endif
+#ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
+  , NULL            /* unlink */
 #endif
 };
 

--- a/fs/vfs/fs_timerfd.c
+++ b/fs/vfs/fs_timerfd.c
@@ -132,9 +132,14 @@ static const struct file_operations g_timerfd_fops =
   timerfd_read,  /* read */
   NULL,          /* write */
   NULL,          /* seek */
-  NULL           /* ioctl */
+  NULL,          /* ioctl */
 #ifdef CONFIG_TIMER_FD_POLL
-  , timerfd_poll /* poll */
+  timerfd_poll   /* poll */
+#else
+  NULL           /* poll */
+#endif
+#ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
+  , NULL         /* unlink */
 #endif
 };
 

--- a/graphics/nxterm/nxterm_driver.c
+++ b/graphics/nxterm/nxterm_driver.c
@@ -60,16 +60,15 @@ static int     nxterm_unlink(FAR struct inode *inode);
 
 const struct file_operations g_nxterm_drvrops =
 {
-  nxterm_open,  /* open */
-  nxterm_close, /* close */
-  nxterm_read,  /* read */
-  nxterm_write, /* write */
-  NULL,         /* seek */
-  nxterm_ioctl, /* ioctl */
-  nxterm_poll   /* poll */
+  nxterm_open,    /* open */
+  nxterm_close,   /* close */
+  nxterm_read,    /* read */
+  nxterm_write,   /* write */
+  NULL,           /* seek */
+  nxterm_ioctl,   /* ioctl */
+  nxterm_poll     /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
-  ,
-  nxterm_unlink /* unlink */
+  , nxterm_unlink /* unlink */
 #endif
 };
 
@@ -77,16 +76,15 @@ const struct file_operations g_nxterm_drvrops =
 
 const struct file_operations g_nxterm_drvrops =
 {
-  nxterm_open,  /* open */
-  nxterm_close, /* close */
-  NULL,         /* read */
-  nxterm_write, /* write */
-  NULL,         /* seek */
-  nxterm_ioctl, /* ioctl */
-  NULL          /* poll */
+  nxterm_open,    /* open */
+  nxterm_close,   /* close */
+  NULL,           /* read */
+  nxterm_write,   /* write */
+  NULL,           /* seek */
+  nxterm_ioctl,   /* ioctl */
+  NULL            /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
-  ,
-  nxterm_unlink /* unlink */
+  , nxterm_unlink /* unlink */
 #endif
 };
 

--- a/sched/Kconfig
+++ b/sched/Kconfig
@@ -675,7 +675,7 @@ config PTHREAD_CLEANUP_STACKSIZE
 		The maximum number of cleanup actions that may be pushed by
 		pthread_clean_push().  This setting will increase the size of EVERY
 		pthread task control block by about n * CONFIG_PTHREAD_CLEANUP_STACKSIZE
-		where n is the size of a pointer, 2* sizeof(uintptr_t), this would be
+		where n is the size of a pointer, 2 * sizeof(uintptr_t), this would be
 		8 for a CPU with 32-bit addressing and 4 for a CPU with 16-bit
 		addressing.
 


### PR DESCRIPTION
## Summary
C99 designated initializers are used all over the common code. This is the first stage of clean-up and getting back to C89

## Impact
No functional changes. Refactoring only

## Testing
Pass CI