### PR TITLE
fs/procfs: Remove the unnecessary strcmp

### DIFF
--- a/arch/arm/src/lc823450/lc823450_procfs_dvfs.c
+++ b/arch/arm/src/lc823450/lc823450_procfs_dvfs.c
@@ -137,14 +137,6 @@ static int dvfs_open(FAR struct file *filep, FAR const char *relpath,
 
   finfo("Open '%s'\n", relpath);
 
-  /* "dvfs" is the only acceptable value for the relpath */
-
-  if (strcmp(relpath, "dvfs") != 0)
-    {
-      ferr("ERROR: relpath is '%s'\n", relpath);
-      return -ENOENT;
-    }
-
   /* Allocate a container to hold the task and attribute selection */
 
   priv = (FAR struct dvfs_file_s *)kmm_zalloc(sizeof(struct dvfs_file_s));
@@ -355,12 +347,6 @@ static int dvfs_dup(FAR const struct file *oldp, FAR struct file *newp)
 
 static int dvfs_stat(const char *relpath, struct stat *buf)
 {
-  if (strcmp(relpath, "dvfs") != 0)
-    {
-      ferr("ERROR: relpath is '%s'\n", relpath);
-      return -ENOENT;
-    }
-
   buf->st_mode    =
     S_IFREG |
     S_IROTH | S_IWOTH |

--- a/arch/arm/src/s32k1xx/s32k1xx_resetcause.c
+++ b/arch/arm/src/s32k1xx/s32k1xx_resetcause.c
@@ -146,14 +146,6 @@ static int resetcause_open(FAR struct file *filep, FAR const char *relpath,
       return -EACCES;
     }
 
-  /* "resetcause" is the only acceptable value for the relpath */
-
-  if (strcmp(relpath, "resetcause") != 0)
-    {
-      ferr("ERROR: relpath is '%s'\n", relpath);
-      return -ENOENT;
-    }
-
   /* Allocate a container to hold the file attributes */
 
   attr = kmm_zalloc(sizeof(struct resetcause_file_s));
@@ -278,14 +270,6 @@ static int resetcause_dup(FAR const struct file *oldp, FAR struct file *newp)
 
 static int resetcause_stat(FAR const char *relpath, FAR struct stat *buf)
 {
-  /* "resetcause" is the only acceptable value for the relpath */
-
-  if (strcmp(relpath, "resetcause") != 0)
-    {
-      ferr("ERROR: relpath is '%s'\n", relpath);
-      return -ENOENT;
-    }
-
   /* "resetcause" is the name for a read-only file */
 
   memset(buf, 0, sizeof(struct stat));

--- a/fs/procfs/fs_procfscpuload.c
+++ b/fs/procfs/fs_procfscpuload.c
@@ -138,14 +138,6 @@ static int cpuload_open(FAR struct file *filep, FAR const char *relpath,
       return -EACCES;
     }
 
-  /* "cpuload" is the only acceptable value for the relpath */
-
-  if (strcmp(relpath, "cpuload") != 0)
-    {
-      ferr("ERROR: relpath is '%s'\n", relpath);
-      return -ENOENT;
-    }
-
   /* Allocate a container to hold the file attributes */
 
   attr = kmm_zalloc(sizeof(struct cpuload_file_s));
@@ -310,14 +302,6 @@ static int cpuload_dup(FAR const struct file *oldp, FAR struct file *newp)
 
 static int cpuload_stat(const char *relpath, struct stat *buf)
 {
-  /* "cpuload" is the only acceptable value for the relpath */
-
-  if (strcmp(relpath, "cpuload") != 0)
-    {
-      ferr("ERROR: relpath is '%s'\n", relpath);
-      return -ENOENT;
-    }
-
   /* "cpuload" is the name for a read-only file */
 
   memset(buf, 0, sizeof(struct stat));

--- a/fs/procfs/fs_procfscritmon.c
+++ b/fs/procfs/fs_procfscritmon.c
@@ -137,14 +137,6 @@ static int critmon_open(FAR struct file *filep, FAR const char *relpath,
       return -EACCES;
     }
 
-  /* "critmon" is the only acceptable value for the relpath */
-
-  if (strcmp(relpath, "critmon") != 0)
-    {
-      ferr("ERROR: relpath is '%s'\n", relpath);
-      return -ENOENT;
-    }
-
   /* Allocate a container to hold the file attributes */
 
   attr = kmm_zalloc(sizeof(struct critmon_file_s));
@@ -359,14 +351,6 @@ static int critmon_dup(FAR const struct file *oldp, FAR struct file *newp)
 
 static int critmon_stat(const char *relpath, struct stat *buf)
 {
-  /* "critmon" is the only acceptable value for the relpath */
-
-  if (strcmp(relpath, "critmon") != 0)
-    {
-      ferr("ERROR: relpath is '%s'\n", relpath);
-      return -ENOENT;
-    }
-
   /* "critmon" is the name for a read-only file */
 
   memset(buf, 0, sizeof(struct stat));

--- a/fs/procfs/fs_procfsiobinfo.c
+++ b/fs/procfs/fs_procfsiobinfo.c
@@ -209,14 +209,6 @@ static int iobinfo_open(FAR struct file *filep, FAR const char *relpath,
       return -EACCES;
     }
 
-  /* "iobinfo" is the only acceptable value for the relpath */
-
-  if (strcmp(relpath, "iobinfo") != 0)
-    {
-      ferr("ERROR: relpath is '%s'\n", relpath);
-      return -ENOENT;
-    }
-
   /* Allocate a container to hold the file attributes */
 
   procfile = (FAR struct iobinfo_file_s *)
@@ -395,14 +387,6 @@ static int iobinfo_dup(FAR const struct file *oldp, FAR struct file *newp)
 
 static int iobinfo_stat(FAR const char *relpath, FAR struct stat *buf)
 {
-  /* "iobinfo" is the only acceptable value for the relpath */
-
-  if (strcmp(relpath, "iobinfo") != 0)
-    {
-      ferr("ERROR: relpath is '%s'\n", relpath);
-      return -ENOENT;
-    }
-
   /* "iobinfo" is the name for a read-only file */
 
   memset(buf, 0, sizeof(struct stat));

--- a/fs/procfs/fs_procfsmeminfo.c
+++ b/fs/procfs/fs_procfsmeminfo.c
@@ -218,14 +218,6 @@ static int meminfo_open(FAR struct file *filep, FAR const char *relpath,
       return -EACCES;
     }
 
-  /* "meminfo" is the only acceptable value for the relpath */
-
-  if (strcmp(relpath, "meminfo") != 0)
-    {
-      ferr("ERROR: relpath is '%s'\n", relpath);
-      return -ENOENT;
-    }
-
   /* Allocate a container to hold the file attributes */
 
   procfile = (FAR struct meminfo_file_s *)
@@ -439,14 +431,6 @@ static int meminfo_dup(FAR const struct file *oldp, FAR struct file *newp)
 
 static int meminfo_stat(FAR const char *relpath, FAR struct stat *buf)
 {
-  /* "meminfo" is the only acceptable value for the relpath */
-
-  if (strcmp(relpath, "meminfo") != 0)
-    {
-      ferr("ERROR: relpath is '%s'\n", relpath);
-      return -ENOENT;
-    }
-
   /* "meminfo" is the name for a read-only file */
 
   memset(buf, 0, sizeof(struct stat));

--- a/fs/procfs/fs_procfstcbinfo.c
+++ b/fs/procfs/fs_procfstcbinfo.c
@@ -136,14 +136,6 @@ static int tcbinfo_open(FAR struct file *filep, FAR const char *relpath,
       return -EACCES;
     }
 
-  /* "tcbinfo" is the only acceptable value for the relpath */
-
-  if (strcmp(relpath, "tcbinfo") != 0)
-    {
-      ferr("ERROR: relpath is '%s'\n", relpath);
-      return -ENOENT;
-    }
-
   /* Allocate a container to hold the file attributes */
 
   attr = (FAR struct tcbinfo_file_s *)
@@ -274,14 +266,6 @@ static int tcbinfo_dup(FAR const struct file *oldp, FAR struct file *newp)
 
 static int tcbinfo_stat(FAR const char *relpath, FAR struct stat *buf)
 {
-  /* "tcbinfo" is the only acceptable value for the relpath */
-
-  if (strcmp(relpath, "tcbinfo") != 0)
-    {
-      ferr("ERROR: relpath is '%s'\n", relpath);
-      return -ENOENT;
-    }
-
   /* "tcbinfo" is the name for a read-only file */
 
   memset(buf, 0, sizeof(struct stat));

--- a/fs/procfs/fs_procfsuptime.c
+++ b/fs/procfs/fs_procfsuptime.c
@@ -139,14 +139,6 @@ static int uptime_open(FAR struct file *filep, FAR const char *relpath,
       return -EACCES;
     }
 
-  /* "uptime" is the only acceptable value for the relpath */
-
-  if (strcmp(relpath, "uptime") != 0)
-    {
-      ferr("ERROR: relpath is '%s'\n", relpath);
-      return -ENOENT;
-    }
-
   /* Allocate a container to hold the file attributes */
 
   attr = kmm_zalloc(sizeof(struct uptime_file_s));
@@ -330,14 +322,6 @@ static int uptime_dup(FAR const struct file *oldp, FAR struct file *newp)
 
 static int uptime_stat(FAR const char *relpath, FAR struct stat *buf)
 {
-  /* "uptime" is the only acceptable value for the relpath */
-
-  if (strcmp(relpath, "uptime") != 0)
-    {
-      ferr("ERROR: relpath is '%s'\n", relpath);
-      return -ENOENT;
-    }
-
   /* "uptime" is the name for a read-only file */
 
   memset(buf, 0, sizeof(struct stat));

--- a/fs/procfs/fs_procfsversion.c
+++ b/fs/procfs/fs_procfsversion.c
@@ -139,14 +139,6 @@ static int version_open(FAR struct file *filep, FAR const char *relpath,
       return -EACCES;
     }
 
-  /* "version" is the only acceptable value for the relpath */
-
-  if (strcmp(relpath, "version") != 0)
-    {
-      ferr("ERROR: relpath is '%s'\n", relpath);
-      return -ENOENT;
-    }
-
   /* Allocate a container to hold the file attributes */
 
   attr = (FAR struct version_file_s *)
@@ -279,14 +271,6 @@ static int version_dup(FAR const struct file *oldp, FAR struct file *newp)
 
 static int version_stat(FAR const char *relpath, FAR struct stat *buf)
 {
-  /* "version" is the only acceptable value for the relpath */
-
-  if (strcmp(relpath, "version") != 0)
-    {
-      ferr("ERROR: relpath is '%s'\n", relpath);
-      return -ENOENT;
-    }
-
   /* "version" is the name for a read-only file */
 
   memset(buf, 0, sizeof(struct stat));

--- a/sched/irq/irq_procfs.c
+++ b/sched/irq/irq_procfs.c
@@ -284,14 +284,6 @@ static int irq_open(FAR struct file *filep, FAR const char *relpath,
       return -EACCES;
     }
 
-  /* "irqs" is the only acceptable value for the relpath */
-
-  if (strcmp(relpath, "irqs") != 0)
-    {
-      ferr("ERROR: relpath is '%s'\n", relpath);
-      return -ENOENT;
-    }
-
   /* Allocate a container to hold the file attributes */
 
   irqfile = (FAR struct irq_file_s *)kmm_zalloc(sizeof(struct irq_file_s));
@@ -422,14 +414,6 @@ static int irq_dup(FAR const struct file *oldp, FAR struct file *newp)
 
 static int irq_stat(const char *relpath, struct stat *buf)
 {
-  /* "irqs" is the only acceptable value for the relpath */
-
-  if (strcmp(relpath, "irqs") != 0)
-    {
-      ferr("ERROR: relpath is '%s'\n", relpath);
-      return -ENOENT;
-    }
-
   /* "irqs" is the name for a read-only file */
 
   memset(buf, 0, sizeof(struct stat));


### PR DESCRIPTION
## Summary
since the procfs already make the same check for us

## Impact

## Testing

