### PR TITLE
fs/partition/fs_gpt.c: Fix compilation errors when CONFIG_FS_LARGEFIL…

### DIFF
--- a/fs/partition/fs_gpt.c
+++ b/fs/partition/fs_gpt.c
@@ -41,6 +41,15 @@
 #define GPT_LBA_TO_BLOCK(lba, blk)      ((le64toh(lba) * 512 + (blk) -1) / (blk))
 #define GPT_MIN(x, y)                   (((x) < (y)) ? (x) : (y))
 
+/* Helper macro for printing lba addresses according to the  sys/types.h */
+#if defined(CONFIG_FS_LARGEFILE) && defined(CONFIG_HAVE_LONG_LONG)
+#define PRIxLBA PRIx64
+#define PRIdLBA PRId64
+#else
+#define PRIxLBA PRIx32
+#define PRIdLBA PRId32
+#endif
+
 /****************************************************************************
  * Private Types
  ****************************************************************************/
@@ -261,7 +270,7 @@ static int gpt_header_is_valid(FAR struct partition_state_s *state,
   if (le64toh(gpt->signature) != GPT_HEADER_SIGNATURE)
     {
       ferr("GUID Partition Table Header signature is wrong:"
-            "0x%" PRIx64 " != 0x%" PRIx64 "\n",
+            "0x%" PRIx64 " != 0x%llx\n",
             le64toh(gpt->signature), GPT_HEADER_SIGNATURE);
       return -EINVAL;
     }
@@ -287,7 +296,7 @@ static int gpt_header_is_valid(FAR struct partition_state_s *state,
 
   if (le64toh(gpt->my_lba) != lba)
     {
-      ferr("GPT: my_lba incorrect: %" PRIx64 " != %" PRIx64 "\n",
+      ferr("GPT: my_lba incorrect: %" PRIx64 " != %" PRIxLBA "\n",
            le64toh(gpt->my_lba), lba);
       return -EINVAL;
     }
@@ -297,14 +306,14 @@ static int gpt_header_is_valid(FAR struct partition_state_s *state,
   lastlba = gpt_last_lba(state);
   if (le64toh(gpt->first_usable_lba) > lastlba)
     {
-      ferr("GPT: first_usable_lba incorrect: %" PRId64 " > %" PRId64 "\n",
+      ferr("GPT: first_usable_lba incorrect: %" PRId64 " > %" PRIdLBA "\n",
            le64toh(gpt->first_usable_lba), lastlba);
       return -EINVAL;
     }
 
   if (le64toh(gpt->last_usable_lba) > lastlba)
     {
-      ferr("GPT: last_usable_lba incorrect: %" PRId64 " > %" PRId64 "\n",
+      ferr("GPT: last_usable_lba incorrect: %" PRId64 " > %" PRIdLBA "\n",
            le64toh(gpt->last_usable_lba), lastlba);
       return -EINVAL;
     }


### PR DESCRIPTION
…E is not defined

This fixes some number formatting errors for 64-bit targets
- GPT_HEADER_SIGNATURE is defined as "unsigned long long", so just print it as it is (without PRI macro)
- The size of blkcnt_t depends on CONFIG_FS_LARGEFILE and CONFIG_HAVE_LONG_LONG

Signed-off-by: Jukka Laitinen <jukkax@ssrc.tii.ae>
