### PR TITLE
drivers/mmcsd/sdio.c: Fix struct packing of sdio_resp_r5

### DIFF
--- a/drivers/mmcsd/sdio.c
+++ b/drivers/mmcsd/sdio.c
@@ -66,6 +66,7 @@ begin_packed_struct struct sdio_cmd53
 begin_packed_struct struct sdio_resp_r5
 {
   uint32_t data             : 8;
+  begin_packed_struct
   struct
   {
     uint32_t out_of_range     : 1;
@@ -75,7 +76,8 @@ begin_packed_struct struct sdio_resp_r5
     uint32_t io_current_state : 2;
     uint32_t illegal_command  : 1;
     uint32_t com_crc_error    : 1;
-  } flags;
+  }
+  end_packed_struct flags;
   uint32_t reserved_16      : 16;
 } end_packed_struct;
 


### PR DESCRIPTION
The struct memeber should be packed as well

Signed-off-by: Jukka Laitinen <jukkax@ssrc.tii.ae>

## Summary
Fix an error on a 64-bit RISC-V board, which aligns the structure in a way that it becomes larger than intended

## Impact

## Testing
Tested on Microchip Polarfire SOC FPGA "Icicle" board
