### PR TITLE
[SMP]sched: task list should be protected by global spinlock 

### DIFF
--- a/sched/sched/Make.defs
+++ b/sched/sched/Make.defs
@@ -85,6 +85,7 @@ CSRCS += sched_processtimer.c
 endif
 
 ifeq ($(CONFIG_SMP),y)
+CSRCS += sched_tasklistlock.c
 CSRCS += sched_thistask.c
 endif
 

--- a/sched/sched/sched.h
+++ b/sched/sched/sched.h
@@ -382,6 +382,9 @@ FAR struct tcb_s *this_task(void);
 int  nxsched_select_cpu(cpu_set_t affinity);
 int  nxsched_pause_cpu(FAR struct tcb_s *tcb);
 
+irqstate_t nxsched_lock_tasklist(void);
+void nxsched_unlock_tasklist(irqstate_t lock);
+
 #  define nxsched_islocked_global() spin_islocked(&g_cpu_schedlock)
 #  define nxsched_islocked_tcb(tcb) nxsched_islocked_global()
 

--- a/sched/sched/sched_addblocked.c
+++ b/sched/sched/sched_addblocked.c
@@ -62,6 +62,12 @@ void nxsched_add_blocked(FAR struct tcb_s *btcb, tstate_t task_state)
   DEBUGASSERT(task_state >= FIRST_BLOCKED_STATE &&
               task_state <= LAST_BLOCKED_STATE);
 
+#ifdef CONFIG_SMP
+  /* Lock the tasklists before accessing */
+
+  irqstate_t lock = nxsched_lock_tasklist();
+#endif
+
   /* Add the TCB to the blocked task list associated with this state. */
 
   tasklist = TLIST_BLOCKED(task_state);
@@ -80,6 +86,12 @@ void nxsched_add_blocked(FAR struct tcb_s *btcb, tstate_t task_state)
 
       dq_addlast((FAR dq_entry_t *)btcb, tasklist);
     }
+
+#ifdef CONFIG_SMP
+  /* Unlock the tasklists */
+
+  nxsched_unlock_tasklist(lock);
+#endif
 
   /* Make sure the TCB's state corresponds to the list */
 

--- a/sched/sched/sched_addreadytorun.c
+++ b/sched/sched/sched_addreadytorun.c
@@ -158,6 +158,10 @@ bool nxsched_add_readytorun(FAR struct tcb_s *btcb)
   int cpu;
   int me;
 
+  /* Lock the tasklists before accessing */
+
+  irqstate_t lock = nxsched_lock_tasklist();
+
   /* Check if the blocked TCB is locked to this CPU */
 
   if ((btcb->flags & TCB_FLAG_CPU_LOCKED) != 0)
@@ -256,7 +260,9 @@ bool nxsched_add_readytorun(FAR struct tcb_s *btcb)
 
       if (cpu != me)
         {
+          nxsched_unlock_tasklist(lock);
           DEBUGVERIFY(up_cpu_pause(cpu));
+          lock = nxsched_lock_tasklist();
         }
 
       /* Add the task to the list corresponding to the selected state
@@ -376,6 +382,9 @@ bool nxsched_add_readytorun(FAR struct tcb_s *btcb)
         }
     }
 
+  /* Unlock the tasklists */
+
+  nxsched_unlock_tasklist(lock);
   return doswitch;
 }
 

--- a/sched/sched/sched_mergepending.c
+++ b/sched/sched/sched_mergepending.c
@@ -184,6 +184,10 @@ bool nxsched_merge_pending(void)
   int cpu;
   int me;
 
+  /* Lock the tasklist before accessing */
+
+  irqstate_t lock = nxsched_lock_tasklist();
+
   /* Remove and process every TCB in the g_pendingtasks list.
    *
    * Do nothing if (1) pre-emption is still disabled (by any CPU), or (2) if
@@ -200,7 +204,7 @@ bool nxsched_merge_pending(void)
         {
           /* The pending task list is empty */
 
-          goto errout;
+          goto errout_with_lock;
         }
 
       cpu  = nxsched_select_cpu(ALL_CPUS); /* REVISIT:  Maybe ptcb->affinity */
@@ -224,7 +228,9 @@ bool nxsched_merge_pending(void)
 
           /* Add the pending task to the correct ready-to-run list. */
 
+          nxsched_unlock_tasklist(lock);
           ret |= nxsched_add_readytorun(tcb);
+          lock = nxsched_lock_tasklist();
 
           /* This operation could cause the scheduler to become locked.
            * Check if that happened.
@@ -245,7 +251,7 @@ bool nxsched_merge_pending(void)
                * pending task list.
                */
 
-              goto errout;
+              goto errout_with_lock;
             }
 
           /* Set up for the next time through the loop */
@@ -256,7 +262,7 @@ bool nxsched_merge_pending(void)
             {
               /* The pending task list is empty */
 
-              goto errout;
+              goto errout_with_lock;
             }
 
           cpu  = nxsched_select_cpu(ALL_CPUS); /* REVISIT:  Maybe ptcb->affinity */
@@ -272,8 +278,11 @@ bool nxsched_merge_pending(void)
                                 TSTATE_TASK_READYTORUN);
     }
 
-errout:
+errout_with_lock:
 
+  /* Unlock the tasklist */
+
+  nxsched_unlock_tasklist(lock);
   return ret;
 }
 #endif /* CONFIG_SMP */

--- a/sched/sched/sched_mergeprioritized.c
+++ b/sched/sched/sched_mergeprioritized.c
@@ -68,6 +68,12 @@ void nxsched_merge_prioritized(FAR dq_queue_t *list1, FAR dq_queue_t *list2,
   FAR struct tcb_s *tcb2;
   FAR struct tcb_s *tmp;
 
+#ifdef CONFIG_SMP
+  /* Lock the tasklists before accessing */
+
+  irqstate_t lock = nxsched_lock_tasklist();
+#endif
+
   DEBUGASSERT(list1 != NULL && list2 != NULL);
 
   /* Get a private copy of list1, clearing list1.  We do this early so that
@@ -84,7 +90,7 @@ void nxsched_merge_prioritized(FAR dq_queue_t *list1, FAR dq_queue_t *list2,
     {
       /* Special case.. list1 is empty.  There is nothing to be done. */
 
-      goto out;
+      goto ret_with_lock;
     }
 
   /* Now the TCBs are no longer accessible and we can change the state on
@@ -107,7 +113,7 @@ void nxsched_merge_prioritized(FAR dq_queue_t *list1, FAR dq_queue_t *list2,
       /* Special case.. list2 is empty.  Move list1 to list2. */
 
       dq_move(&clone, list2);
-      goto out;
+      goto ret_with_lock;
     }
 
   /* Now loop until all entries from list1 have been merged into list2. tcb1
@@ -157,7 +163,12 @@ void nxsched_merge_prioritized(FAR dq_queue_t *list1, FAR dq_queue_t *list2,
     }
   while (tcb1 != NULL);
 
-out:
+ret_with_lock:
 
+#ifdef CONFIG_SMP
+  /* Unlock the tasklists */
+
+  nxsched_unlock_tasklist(lock);
+#endif
   return;
 }

--- a/sched/sched/sched_tasklistlock.c
+++ b/sched/sched/sched_tasklistlock.c
@@ -1,0 +1,118 @@
+/****************************************************************************
+ * sched/sched/sched_tasklistlock.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+#include <nuttx/spinlock.h>
+
+#include <sys/types.h>
+#include <arch/irq.h>
+
+#include "sched/sched.h"
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+/* Splinlock to protect the tasklists */
+
+static volatile spinlock_t g_tasklist_lock = SP_UNLOCKED;
+
+/* Handles nested calls */
+
+static volatile uint8_t g_tasklist_lock_count[CONFIG_SMP_NCPUS];
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: nxsched_lock_tasklist()
+ *
+ * Description:
+ *   Disable local interrupts and take the global spinlock (g_tasklist_lock)
+ *   if the call counter (g_tasklist_lock_count[cpu]) equals to 0. Then the
+ *   counter on the CPU is incremented to allow nested call.
+ *
+ *   NOTE: This API is used to protect tasklists in the scheduler. So do not
+ *   use this API for other purposes.
+ *
+ * Returned Value:
+ *   An opaque, architecture-specific value that represents the state of
+ *   the interrupts prior to the call to nxsched_lock_tasklist();
+ ****************************************************************************/
+
+irqstate_t nxsched_lock_tasklist(void)
+{
+  int me;
+  irqstate_t ret;
+
+  ret = up_irq_save();
+  me  = this_cpu();
+
+  if (0 == g_tasklist_lock_count[me])
+    {
+      spin_lock(&g_tasklist_lock);
+    }
+
+  g_tasklist_lock_count[me]++;
+  DEBUGASSERT(0 != g_tasklist_lock_count[me]);
+  return ret;
+}
+
+/****************************************************************************
+ * Name: nxsched_unlock_tasklist()
+ *
+ * Description:
+ *   Decrement the call counter (g_tasklist_lock_count[cpu]) and if it
+ *   decrements to zero then release the spinlock (g_tasklist_lock) and
+ *   restore the interrupt state as it was prior to the previous call to
+ *   nxsched_lock_tasklist().
+ *
+ *   NOTE: This API is used to protect tasklists in the scheduler. So do not
+ *   use this API for other purposes.
+ *
+ * Input Parameters:
+ *   lock - The architecture-specific value that represents the state of
+ *          the interrupts prior to the call to nxsched_lock_tasklist().
+ *
+ * Returned Value:
+ *   None
+ ****************************************************************************/
+
+void nxsched_unlock_tasklist(irqstate_t lock)
+{
+  int me;
+
+  me = this_cpu();
+
+  DEBUGASSERT(0 < g_tasklist_lock_count[me]);
+  g_tasklist_lock_count[me]--;
+
+  if (0 == g_tasklist_lock_count[me])
+    {
+      spin_unlock(&g_tasklist_lock);
+    }
+
+  up_irq_restore(lock);
+}


### PR DESCRIPTION

## Summary


sched: task list should be protected by global spinlock 

Revert "sched: sched: Remove sched_tasklistlock.c for SMP"

armv7-a dataabort:
```
-----------------------------------------------------------------
| up_assert: Assertion failed CPU0 at file:armv7-a/arm_dataabort.c line: 160 task: event_dispatch
| up_dumpstate: Call Trace:
| backtrace|17:  0x3c0221d8 0x3c03c2d4 0x3c028f6c 0x3c018634 0x3c017d04 0x3c04b5c4 0x3c053504 0x3c017530
| up_registerdump: R0: 3c5829f8 3c2bcd08 00000000 3c5e2730 3c2bcd08 3c5e2730 00000000 3c2bc700
| up_registerdump: R8: 3c2bcd5a 3c2bc2f4 00000000 3c582a14 00000000 3c5829f8 3c01c17c 3c0221d8
| up_registerdump: CPSR: 200000d3
| up_dumpstate: Current sp: 3c582848
| up_dumpstate: Interrupt stack:
| up_dumpstate:   base: 3c2bb0e8
| up_dumpstate:   size: 00001000
| up_dumpstate:   used: 00000208
| up_dumpstate: User stack:
| up_dumpstate:   base: 3c582bd8
| up_dumpstate:   size: 00002804
| up_dumpstate:   used: 00001180
| up_dumpstate: ERROR: Stack pointer is not within the interrupt stack
| up_dumpstate: User sp: 3c5829f8
| up_dumpstate: User Stack
| up_dumpstate: CPU0:
| up_showtasks:    PID    PRI      USED     STACK   FILLED       CPU   COMMAND
| up_showtasks:   ----   ----       520      4096    12.6%      ----   irq
| up_dump_task:      0      0       736      4076    18.0%      0.0%   CPU0 IDLE
| up_dump_task:      1      0       344      4076     8.4%      0.0%   CPU1 IDLE
| up_dump_task:      3    253       936      4068    23.0%      0.0%   hpwork
| up_dump_task:      4    253       936      4068    23.0%      0.0%   hpwork
| up_dump_task:      5    110       504      4068    12.3%      0.0%   lpwork
| up_dump_task:      6    110       504      4068    12.3%      0.0%   lpwork
| ...
| up_dump_task:     17    225      4480     10244    43.7%      0.0%   event_dispatch
-----------------------------------------------------------------
```

Task list corruption:
```
-----------------------------------------------------------------
| nuttx$ arm-none-eabi-addr2line -e nuttx 0x3c0221d8 0x3c03c2d4 0x3c028f6c 0x3c018634 0x3c017d04 0x3c04b5c4 0x3c053504 0x3c017530
| nuttx/libs/libc/queue/dq_cat.c:72
| nuttx/sched/sched/sched_mergepending.c:270
| nuttx/arch/arm/src/armv7-a/arm_releasepending.c:58
| nuttx/sched/sched/sched_unlock.c:141
| nuttx/sched/pthread/pthread_condwait.c:129
| external/pns/src/event_dispatch.c:1113
| external/pns/src/common_worker.c:26 (discriminator 3)
| nuttx/sched/pthread/pthread_create.c:191
-----------------------------------------------------------------
```

This reverts commit 1dad55d4bef2cd078ee51b949abc86f6b58f2e7d.

Signed-off-by: chao.an <anchao@xiaomi.com>


## Impact

Task list en/dequeue on SMP

## Testing

Products online test which already on the market