### PR TITLE
syslog: Fix in file channel initialization.

### DIFF
--- a/drivers/syslog/syslog_consolechannel.c
+++ b/drivers/syslog/syslog_consolechannel.c
@@ -42,14 +42,6 @@
 #define OPEN_MODE  (S_IROTH | S_IRGRP | S_IRUSR | S_IWUSR)
 
 /****************************************************************************
- * Private Data
- ****************************************************************************/
-
-/* Handle to the SYSLOG channel */
-
-FAR static struct syslog_channel_s *g_syslog_console_channel;
-
-/****************************************************************************
  * Public Functions
  ****************************************************************************/
 
@@ -81,24 +73,26 @@ FAR static struct syslog_channel_s *g_syslog_console_channel;
 
 FAR struct syslog_channel_s *syslog_console_channel(void)
 {
+  FAR struct syslog_channel_s *console_channel;
+
   /* Initialize the character driver interface */
 
-  g_syslog_console_channel = syslog_dev_initialize("/dev/console",
-                                                   OPEN_FLAGS, OPEN_MODE);
-  if (g_syslog_console_channel == NULL)
+  console_channel = syslog_dev_initialize("/dev/console",
+                                          OPEN_FLAGS, OPEN_MODE);
+  if (console_channel == NULL)
     {
       return NULL;
     }
 
   /* Use the character driver as the SYSLOG channel */
 
-  if (syslog_channel(g_syslog_console_channel) != OK)
+  if (syslog_channel(console_channel) != OK)
     {
-      syslog_dev_uninitialize(g_syslog_console_channel);
-      g_syslog_console_channel = NULL;
+      syslog_dev_uninitialize(console_channel);
+      console_channel = NULL;
     }
 
-  return g_syslog_console_channel;
+  return console_channel;
 }
 
 #endif /* CONFIG_SYSLOG_CONSOLE */

--- a/drivers/syslog/syslog_devchannel.c
+++ b/drivers/syslog/syslog_devchannel.c
@@ -42,14 +42,6 @@
 #define OPEN_MODE  (S_IROTH | S_IRGRP | S_IRUSR | S_IWUSR)
 
 /****************************************************************************
- * Private Data
- ****************************************************************************/
-
-/* Handle to the SYSLOG channel */
-
-FAR static struct syslog_channel_s *g_syslog_dev_channel;
-
-/****************************************************************************
  * Public Functions
  ****************************************************************************/
 
@@ -78,24 +70,26 @@ FAR static struct syslog_channel_s *g_syslog_dev_channel;
 
 FAR struct syslog_channel_s *syslog_dev_channel(void)
 {
+  FAR struct syslog_channel_s *dev_channel;
+
   /* Initialize the character driver interface */
 
-  g_syslog_dev_channel = syslog_dev_initialize(CONFIG_SYSLOG_DEVPATH,
-                                               OPEN_FLAGS, OPEN_MODE);
-  if (g_syslog_dev_channel == NULL)
+  dev_channel = syslog_dev_initialize(CONFIG_SYSLOG_DEVPATH,
+                                      OPEN_FLAGS, OPEN_MODE);
+  if (dev_channel == NULL)
     {
       return NULL;
     }
 
   /* Use the character driver as the SYSLOG channel */
 
-  if (syslog_channel(g_syslog_dev_channel) != OK)
+  if (syslog_channel(dev_channel) != OK)
     {
-      syslog_dev_uninitialize(g_syslog_dev_channel);
-      g_syslog_dev_channel = NULL;
+      syslog_dev_uninitialize(dev_channel);
+      dev_channel = NULL;
     }
 
-  return g_syslog_dev_channel;
+  return dev_channel;
 }
 
 #endif /* CONFIG_SYSLOG_CHAR */


### PR DESCRIPTION
## Summary

When creating a new syslog file channel through `syslog_file_channel()`, any previous file channel was automatically destroyed and substituted by the new channel.

This creates a couple of issues:
* You couldn't have more than one file channels. I really don't see the reason for this limitation.
* If the channel was already destroyed by any other means (e.g. by a call to `syslog_channel_remove()`), `syslog_file_channel()` would try to re-destroy an already non-existent channel. This will lead to a system crash.

The later is very important, as with this limitation files cannot residue on removable storages (not efficiently at least).  
You cannot create and destroy the channel as the medium is inserted/removed.

This PR intends to fix this.  
Channels are only created with `syslog_file_channel()` and only destroyed with `syslog_channel_remove()`.


## Impact

Applications that were relying on `syslog_file_channel()` to clean-up any previous channels will now have to be changed to use 
`syslog_channel_remove()` before the creation of the new channel.

However this is not an expected use-case. There is no need to re-initialize a file channel ever.  

If indeed the file residues on an external medium, the application must not call `syslog_file_channel()` again, as syslog_device already contains logic to re-open files in case of failure (i.e. the medium was removed).


## Testing

Basic build test only, for an STM32F427 target.  
I will un-draft it when testing is complete, I hope later today.
