### PR TITLE
crypto: apply BSD barrier only to SW AES library

### DIFF
--- a/crypto/Kconfig
+++ b/crypto/Kconfig
@@ -13,7 +13,6 @@ if CRYPTO
 
 config CRYPTO_AES
 	bool "AES cypher support"
-	depends on ALLOW_BSD_COMPONENTS
 	default n
 
 config CRYPTO_ALGTEST
@@ -42,6 +41,7 @@ config CRYPTO_CRYPTODEV
 
 config CRYPTO_SW_AES
 	bool "Software AES library"
+	depends on ALLOW_BSD_COMPONENTS
 	default n
 	---help---
 		Enable the software AES library as described in


### PR DESCRIPTION
## Summary
All files that have code guarded by CONFIG_CRYPTO_AES or that implement aes_cypher() API for HW crypto have Apache license already. File aes.c for CONFIG_CRYPTO_SW_AES is only one that has BSD license header.

## Impact
Licensing only

## Testing
N/A
