### PR TITLE
S32K1XX: implement uniqueid

### DIFF
--- a/arch/arm/src/s32k1xx/Make.defs
+++ b/arch/arm/src/s32k1xx/Make.defs
@@ -38,7 +38,7 @@ endif
 
 CHIP_CSRCS  = s32k1xx_start.c s32k1xx_lowputc.c s32k1xx_clockconfig.c
 CHIP_CSRCS += s32k1xx_periphclocks.c s32k1xx_pin.c s32k1xx_pingpio.c
-CHIP_CSRCS += s32k1xx_idle.c
+CHIP_CSRCS += s32k1xx_idle.c s32k1xx_uid.c
 
 ifeq ($(CONFIG_BOOT_RUNFROMFLASH),y)
 CHIP_CSRCS += s32k1xx_flashcfg.c

--- a/arch/arm/src/s32k1xx/s32k1xx_uid.c
+++ b/arch/arm/src/s32k1xx/s32k1xx_uid.c
@@ -1,0 +1,79 @@
+/****************************************************************************
+ * arch/arm/src/s32k1xx/s32k1xx_uid.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <stddef.h>
+#include <stdint.h>
+#include <assert.h>
+
+#include "arm_arch.h"
+
+#include "hardware/s32k1xx_sim.h"
+#include "s32k1xx_uid.h"
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: s32k1xx_get_uniqueid
+ ****************************************************************************/
+
+void s32k1xx_get_uniqueid(uint8_t *uniqueid)
+{
+  uint32_t regval;
+
+  DEBUGASSERT(uniqueid != NULL);
+
+  /* Retrieve all 16 bytes (128 bits) of the unique identifier and store the
+   * individual bytes in order from lowest byte first to highest byte last.
+   */
+
+  regval = getreg32(S32K1XX_SIM_UIDL);
+
+  uniqueid[0]  = (uint8_t)((regval & 0x000000ff) >>  0);
+  uniqueid[1]  = (uint8_t)((regval & 0x0000ff00) >>  8);
+  uniqueid[2]  = (uint8_t)((regval & 0x00ff0000) >> 16);
+  uniqueid[3]  = (uint8_t)((regval & 0xff000000) >> 24);
+
+  regval = getreg32(S32K1XX_SIM_UIDML);
+
+  uniqueid[4]  = (uint8_t)((regval & 0x000000ff) >>  0);
+  uniqueid[5]  = (uint8_t)((regval & 0x0000ff00) >>  8);
+  uniqueid[6]  = (uint8_t)((regval & 0x00ff0000) >> 16);
+  uniqueid[7]  = (uint8_t)((regval & 0xff000000) >> 24);
+
+  regval = getreg32(S32K1XX_SIM_UIDMH);
+
+  uniqueid[8]  = (uint8_t)((regval & 0x000000ff) >>  0);
+  uniqueid[9]  = (uint8_t)((regval & 0x0000ff00) >>  8);
+  uniqueid[10] = (uint8_t)((regval & 0x00ff0000) >> 16);
+  uniqueid[11] = (uint8_t)((regval & 0xff000000) >> 24);
+
+  regval = getreg32(S32K1XX_SIM_UIDH);
+
+  uniqueid[12] = (uint8_t)((regval & 0x000000ff) >>  0);
+  uniqueid[13] = (uint8_t)((regval & 0x0000ff00) >>  8);
+  uniqueid[14] = (uint8_t)((regval & 0x00ff0000) >> 16);
+  uniqueid[15] = (uint8_t)((regval & 0xff000000) >> 24);
+}

--- a/arch/arm/src/s32k1xx/s32k1xx_uid.h
+++ b/arch/arm/src/s32k1xx/s32k1xx_uid.h
@@ -1,0 +1,42 @@
+/****************************************************************************
+ * arch/arm/src/s32k1xx/s32k1xx_uid.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __ARCH_ARM_SRC_S32K1XX_S32K1XX_UID_H
+#define __ARCH_ARM_SRC_S32K1XX_S32K1XX_UID_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <stdint.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define S32K1XX_UID_SIZE 16
+
+/****************************************************************************
+ * Public Functions Prototypes
+ ****************************************************************************/
+
+void s32k1xx_get_uniqueid(uint8_t *uniqueid);
+
+#endif /* __ARCH_ARM_SRC_S32K1XX_S32K1XX_UID_H */

--- a/boards/arm/s32k1xx/s32k144evb/src/Makefile
+++ b/boards/arm/s32k1xx/s32k144evb/src/Makefile
@@ -37,6 +37,10 @@ ifeq ($(CONFIG_BOARDCTL),y)
 CSRCS += s32k1xx_appinit.c
 endif
 
+ifeq ($(CONFIG_BOARDCTL_UNIQUEID),y)
+CSRCS += s32k1xx_uid.c
+endif
+
 ifeq ($(CONFIG_S32K1XX_LPI2C),y)
 CSRCS += s32k1xx_i2c.c
 endif

--- a/boards/arm/s32k1xx/s32k144evb/src/s32k1xx_uid.c
+++ b/boards/arm/s32k1xx/s32k144evb/src/s32k1xx_uid.c
@@ -1,0 +1,57 @@
+/****************************************************************************
+ * boards/arm/s32k1xx/s32k144evb/src/s32k1xx_uid.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <nuttx/board.h>
+#include <nuttx/compiler.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <errno.h>
+
+#include "s32k1xx_uid.h"
+
+#ifdef CONFIG_BOARDCTL_UNIQUEID
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: board_uniqueid
+ ****************************************************************************/
+
+int board_uniqueid(FAR uint8_t *uniqueid)
+{
+  if (uniqueid == NULL)
+    {
+      return -EINVAL;
+    }
+
+  s32k1xx_get_uniqueid(uniqueid);
+
+  return OK;
+}
+
+#endif /* CONFIG_BOARDCTL_UNIQUEID */


### PR DESCRIPTION
## Summary
Adds s32k1xx_get_uniqueid which can be used to read the MCU unique ID. Also provides a board_uniqueid implementation for S32K144EVB, which allows the MCU/board unique ID to be retrieved through the boardctl interface (after enabling CONFIG_BOARDCTL_UNIQUEID).

## Impact

## Testing
Tested on S32K144EVB.

