### PR TITLE
arch/risc-v: Rename bl602_entry.S to bl602_head.S

### DIFF
--- a/arch/risc-v/src/bl602/Make.defs
+++ b/arch/risc-v/src/bl602/Make.defs
@@ -20,7 +20,7 @@
 
 # Specify our HEAD assembly file.  This will be linked as
 # the first object file, so it will appear at address 0
-HEAD_ASRC = bl602_entry.S
+HEAD_ASRC = bl602_head.S
 
 # Specify our general Assembly files
 CMN_ASRCS += riscv_vectors.S riscv_testset.S riscv_exception_common.S

--- a/arch/risc-v/src/bl602/bl602_head.S
+++ b/arch/risc-v/src/bl602/bl602_head.S
@@ -1,5 +1,5 @@
 /****************************************************************************
- * arch/risc-v/src/bl602/bl602_entry.S
+ * arch/risc-v/src/bl602/bl602_head.S
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with


### PR DESCRIPTION
## Summary
Rename bl602_entry.S to bl602_head.S as other chip does.
## Impact
Rename only.
## Testing
CI
