### PR TITLE
sim/netdev: eliminated RX data stream congestion in case of high TX network traffic

### DIFF
--- a/arch/sim/src/sim/up_netdriver.c
+++ b/arch/sim/src/sim/up_netdriver.c
@@ -315,6 +315,12 @@ static int netdriver_txavail(FAR struct net_driver_s *dev)
       work_queue(LPWORK, &g_avail_work, netdriver_txavail_work, dev, 0);
     }
 
+  /* Check RX data availability and read the data from the network device now
+   * to prevent RX data stream congestion in case of high TX network traffic.
+   */
+
+  netdriver_loop();
+
   return OK;
 }
 


### PR DESCRIPTION
## Summary

Fixed an issue with RX data stream congestion in case of high TX network traffic.
In case of high TX network traffic, netdriver_loop() that reads data from netdev was invoked via up_idle() only after high TX network traffic had stopped. That resulted in massive delay and drop of TCP ACK packets and any other packets from netdev (tun/tap device).

As a result (together with https://github.com/apache/incubator-nuttx-apps/pull/952 enhancement), TCP throughput on Linux host achieves 234 Mbits/sec.

## Impact

arch/sim/netdev(tun/tap)

## Testing

Build NuttX:
```
$ ./tools/configure.sh -l sim:tcpblaster
$ make menuconfig (enable CONFIG_NETUTILS_NETCAT_SENDFILE, disable CONFIG_NET_TCP_WRITE_BUFFERS)
$ make
```
Enable TUN/TAP on Linux host:
```
$ sudo setcap cap_net_admin+ep ./nuttx
$ sudo ./tools/simhostroute.sh wlan0 on
```
Run iperf server on Linux host:
`$ iperf -s -p 5471 -i 1 -w 416K`

Run NuttX on Linux host:
```
$ ./nuttx
NuttShell (NSH) NuttX-10.2.0
nsh> ifconfig eth0 10.0.1.2
nsh> ifup eth0
ifup eth0...OK
nsh> dd if=/dev/zero of=/tmp/test.bin count=10000
nsh> netcat LINUX_HOST_IP_ADDRESS 5471 /tmp/test.bin
nsh> poweroff
```

iperf on Linux host:
```
$ iperf -s -p 5471 -i 1 -w 416K
------------------------------------------------------------
Server listening on TCP port 5471
TCP window size:  416 KByte
------------------------------------------------------------
[  4] local 192.168.1.68 port 5471 connected with 10.0.1.2 port 25367
[ ID] Interval       Transfer     Bandwidth
[  4]  0.0- 0.2 sec  4.88 MBytes   234 Mbits/sec
```

Disable TUN/TAP on Linux host:
`$ sudo ./tools/simhostroute.sh wlan0 off`