### PR TITLE
binfmt/coredump: remove the block fragmentation

### DIFF
--- a/binfmt/libelf/libelf_coredump.c
+++ b/binfmt/libelf/libelf_coredump.c
@@ -43,7 +43,6 @@
  ****************************************************************************/
 
 #define ELF_PAGESIZE    4096
-#define ELF_BLOCKSIZE   1024
 
 #define ARRAY_SIZE(x)   (sizeof(x) / sizeof((x)[0]))
 #define ROUNDUP(x, y)   ((x + (y - 1)) / (y)) * (y)
@@ -82,8 +81,7 @@ static int elf_emit(FAR struct elf_dumpinfo_s *cinfo,
 
   while (total > 0)
     {
-      ret = cinfo->stream->puts(cinfo->stream, ptr, total > ELF_BLOCKSIZE ?
-                                ELF_BLOCKSIZE : total);
+      ret = cinfo->stream->puts(cinfo->stream, ptr, total);
       if (ret < 0)
         {
           break;


### PR DESCRIPTION
## Summary

binfmt/coredump: remove the block fragmentation

Hide the segmentation details to backend implementation

Signed-off-by: chao.an <anchao@xiaomi.com>

## Impact

coredump performance

## Testing
coredump speed boost, storge backend is block device

before this PR:

```
[   22.031200] [10] [ EMERG] [ap] board_reset: coredumping ...
[   39.734910] [10] [ EMERG] [ap] board_reset: rebooting
```

after this PR:

```
[   25.007077] [10] [ EMERG] [ap] board_reset: coredumping ...
[   27.058387] [10] [ EMERG] [ap] board_reset: rebooting
```
