### PR TITLE
Simplify the RTC rpmsg driver implementation

### DIFF
--- a/arch/sim/src/sim/up_rtc.c
+++ b/arch/sim/src/sim/up_rtc.c
@@ -128,6 +128,6 @@ int up_rtc_initialize(void)
 #ifdef CONFIG_RTC_RPMSG_SERVER
   rtc = rpmsg_rtc_server_initialize(rtc);
 #endif
-  up_rtc_set_lowerhalf(rtc);
+  up_rtc_set_lowerhalf(rtc, true);
   return rtc_initialize(0, rtc);
 }

--- a/arch/sim/src/sim/up_rtc.c
+++ b/arch/sim/src/sim/up_rtc.c
@@ -123,10 +123,11 @@ static bool sim_rtc_havesettime(FAR struct rtc_lowerhalf_s *lower)
 
 int up_rtc_initialize(void)
 {
+  FAR struct rtc_lowerhalf_s *rtc = &g_sim_rtc;
+
 #ifdef CONFIG_RTC_RPMSG_SERVER
-  up_rtc_set_lowerhalf(rpmsg_rtc_server_initialize(&g_sim_rtc));
-#else
-  up_rtc_set_lowerhalf(&g_sim_rtc);
+  rtc = rpmsg_rtc_server_initialize(rtc);
 #endif
-  return rtc_initialize(0, &g_sim_rtc);
+  up_rtc_set_lowerhalf(rtc);
+  return rtc_initialize(0, rtc);
 }

--- a/boards/sim/sim/sim/src/sim_bringup.c
+++ b/boards/sim/sim/sim/src/sim_bringup.c
@@ -450,7 +450,7 @@ int sim_bringup(void)
 
 #if defined(CONFIG_RTC_RPMSG) && !defined(CONFIG_RTC_RPMSG_SERVER)
   rtc = rpmsg_rtc_initialize();
-  up_rtc_set_lowerhalf(rtc);
+  up_rtc_set_lowerhalf(rtc, true);
   rtc_initialize(0, rtc);
 #endif
 

--- a/boards/sim/sim/sim/src/sim_bringup.c
+++ b/boards/sim/sim/sim/src/sim_bringup.c
@@ -105,7 +105,9 @@ int sim_bringup(void)
 #ifdef CONFIG_SIM_SPI
   FAR struct spi_dev_s *spidev;
 #endif
-
+#if defined(CONFIG_RTC_RPMSG) && !defined(CONFIG_RTC_RPMSG_SERVER)
+  FAR struct rtc_lowerhalf_s *rtc;
+#endif
   int ret = OK;
 
 #ifdef CONFIG_FS_BINFS
@@ -446,14 +448,14 @@ int sim_bringup(void)
   syslog_rpmsg_server_init();
 #endif
 
-#ifndef CONFIG_RTC_RPMSG_SERVER
-  up_rtc_set_lowerhalf(rpmsg_rtc_initialize(0));
+#if defined(CONFIG_RTC_RPMSG) && !defined(CONFIG_RTC_RPMSG_SERVER)
+  rtc = rpmsg_rtc_initialize();
+  up_rtc_set_lowerhalf(rtc);
+  rtc_initialize(0, rtc);
 #endif
 
-#ifdef CONFIG_FS_RPMSGFS
-#ifdef CONFIG_SIM_RPTUN_MASTER
+#if defined(CONFIG_FS_RPMSGFS) && defined(CONFIG_SIM_RPTUN_MASTER)
   rpmsgfs_server_init();
-#endif
 #endif
 #endif
 

--- a/drivers/timers/arch_rtc.c
+++ b/drivers/timers/arch_rtc.c
@@ -50,13 +50,16 @@ volatile bool g_rtc_enabled = false;
  * Public Functions
  ****************************************************************************/
 
-void up_rtc_set_lowerhalf(FAR struct rtc_lowerhalf_s *lower)
+void up_rtc_set_lowerhalf(FAR struct rtc_lowerhalf_s *lower, bool sync)
 {
   g_rtc_lower   = lower;
   g_rtc_enabled = true;
 
 #ifdef CONFIG_RTC_EXTERNAL
-  clock_synchronize();
+  if (sync)
+    {
+      clock_synchronize();
+    }
 #endif
 }
 

--- a/drivers/timers/rpmsg_rtc.c
+++ b/drivers/timers/rpmsg_rtc.c
@@ -689,9 +689,6 @@ static void rpmsg_rtc_server_ns_bind(FAR struct rpmsg_device *rdev,
  *
  *   Take remote core RTC as external RTC hardware through rpmsg.
  *
- * Input Parameters:
- *   minor  - device minor number
- *
  * Returned Value:
  *   Return the lower half RTC driver instance on success;
  *   A NULL pointer on failure.
@@ -699,21 +696,19 @@ static void rpmsg_rtc_server_ns_bind(FAR struct rpmsg_device *rdev,
  ****************************************************************************/
 
 #ifndef CONFIG_RTC_RPMSG_SERVER
-FAR struct rtc_lowerhalf_s *rpmsg_rtc_initialize(int minor)
+FAR struct rtc_lowerhalf_s *rpmsg_rtc_initialize(void)
 {
   FAR struct rpmsg_rtc_lowerhalf_s *lower;
 
   lower = kmm_zalloc(sizeof(*lower));
-  if (lower)
+  if (lower != NULL)
     {
-      lower->ops     = &g_rpmsg_rtc_ops;
+      lower->ops = &g_rpmsg_rtc_ops;
 
       rpmsg_register_callback(lower,
                               rpmsg_rtc_device_created,
                               rpmsg_rtc_device_destroy,
                               NULL);
-
-      rtc_initialize(minor, (FAR struct rtc_lowerhalf_s *)lower);
     }
 
   return (FAR struct rtc_lowerhalf_s *)lower;

--- a/include/nuttx/timers/arch_rtc.h
+++ b/include/nuttx/timers/arch_rtc.h
@@ -42,11 +42,11 @@ extern "C"
 
 #ifdef CONFIG_RTC_ARCH
 
-void up_rtc_set_lowerhalf(FAR struct rtc_lowerhalf_s *lower);
+void up_rtc_set_lowerhalf(FAR struct rtc_lowerhalf_s *lower, bool sync);
 
 #else
 
-#  define up_rtc_set_lowerhalf(lower)
+#  define up_rtc_set_lowerhalf(lower, sync)
 
 #endif /* CONFIG_RTC_ARCH */
 

--- a/include/nuttx/timers/rpmsg_rtc.h
+++ b/include/nuttx/timers/rpmsg_rtc.h
@@ -42,7 +42,7 @@ extern "C"
 
 #ifdef CONFIG_RTC_RPMSG
 #ifndef CONFIG_RTC_RPMSG_SERVER
-FAR struct rtc_lowerhalf_s *rpmsg_rtc_initialize(int minor);
+FAR struct rtc_lowerhalf_s *rpmsg_rtc_initialize(void);
 #else
 FAR struct rtc_lowerhalf_s *rpmsg_rtc_server_initialize(
                                          FAR struct rtc_lowerhalf_s *lower);


### PR DESCRIPTION
## Summary

- rtc/rpmsg: Replace session to client 
- rtc/rpmsg: Call up_rtc_set_lowerhalf inside rpmsg_rtc_[server_]initialize

## Impact
Refactor only

## Testing
Pass CI
