### PR TITLE
arm/xtensa/risc-v: save the running registers to xcp context

### DIFF
--- a/arch/xtensa/src/common/xtensa_dumpstate.c
+++ b/arch/xtensa/src/common/xtensa_dumpstate.c
@@ -43,12 +43,6 @@
 #ifdef CONFIG_DEBUG_ALERT
 
 /****************************************************************************
- * Private Data
- ****************************************************************************/
-
-static uint32_t s_last_regs[XCPTCONTEXT_REGS];
-
-/****************************************************************************
  * Private Functions
  ****************************************************************************/
 
@@ -238,20 +232,8 @@ static void xtensa_stackdump(uint32_t sp, uint32_t stack_top)
  * Name: xtensa_registerdump
  ****************************************************************************/
 
-static inline void xtensa_registerdump(void)
+static inline void xtensa_registerdump(uintptr_t *regs)
 {
-  uint32_t *regs = (uint32_t *)CURRENT_REGS; /* Don't need volatile here */
-
-  /* Are user registers available from interrupt processing? */
-
-  if (regs == NULL)
-    {
-      /* No.. capture user registers by hand */
-
-      xtensa_context_save(s_last_regs);
-      regs = s_last_regs;
-    }
-
   _alert("   PC: %08lx    PS: %08lx\n",
          (unsigned long)regs[REG_PC], (unsigned long)regs[REG_PS]);
   _alert("   A0: %08lx    A1: %08lx    A2: %08lx    A3: %08lx\n",
@@ -301,9 +283,21 @@ void xtensa_dumpstate(void)
   _alert("CPU%d:\n", up_cpu_index());
 #endif
 
+  /* Update the xcp context */
+
+  if (CURRENT_REGS)
+    {
+      memcpy(rtcb->xcp.regs,
+             (uintptr_t *)CURRENT_REGS, XCPTCONTEXT_REGS);
+    }
+  else
+    {
+      xtensa_context_save(rtcb->xcp.regs);
+    }
+
   /* Dump the registers (if available) */
 
-  xtensa_registerdump();
+  xtensa_registerdump(rtcb->xcp.regs);
 
   /* Dump the backtrace */
 


### PR DESCRIPTION
## Summary

arm/xtensa/risc-v: save the running registers to xcp context
risc-v/assert: add CURRENT_REGS check to avoid null pointer reference

## Impact

N/A

## Testing

trigger fault and check the xcp registers