### PR TITLE
rpmsg_rtc: resolve deadlock when the receive SYNC cmd

### DIFF
--- a/arch/sim/src/sim/up_rtc.c
+++ b/arch/sim/src/sim/up_rtc.c
@@ -124,10 +124,14 @@ static bool sim_rtc_havesettime(FAR struct rtc_lowerhalf_s *lower)
 int up_rtc_initialize(void)
 {
   FAR struct rtc_lowerhalf_s *rtc = &g_sim_rtc;
+  bool sync = true;
 
 #ifdef CONFIG_RTC_RPMSG_SERVER
   rtc = rpmsg_rtc_server_initialize(rtc);
+#elif defined(CONFIG_RTC_RPMSG)
+  rtc = rpmsg_rtc_initialize();
+  sync = false;
 #endif
-  up_rtc_set_lowerhalf(rtc, true);
+  up_rtc_set_lowerhalf(rtc, sync);
   return rtc_initialize(0, rtc);
 }

--- a/boards/arm/samv7/samv71-xult/src/sam_bringup.c
+++ b/boards/arm/samv7/samv71-xult/src/sam_bringup.c
@@ -221,7 +221,7 @@ int sam_bringup(void)
         {
           /* Synchronize the system time to the RTC time */
 
-          clock_synchronize();
+          clock_synchronize(NULL);
         }
     }
 
@@ -248,7 +248,7 @@ int sam_bringup(void)
         {
           /* Synchronize the system time to the RTC time */
 
-          clock_synchronize();
+          clock_synchronize(NULL);
         }
     }
 #endif

--- a/boards/arm/stm32/stm3210e-eval/src/stm32_idle.c
+++ b/boards/arm/stm32/stm3210e-eval/src/stm32_idle.c
@@ -316,7 +316,7 @@ static void stm32_idlepm(void)
                  */
 
 #ifdef CONFIG_RTC
-                clock_synchronize();
+                clock_synchronize(NULL);
 #endif
               }
           }

--- a/boards/arm/stm32/stm32f4discovery/src/stm32_ds1307.c
+++ b/boards/arm/stm32/stm32f4discovery/src/stm32_ds1307.c
@@ -100,7 +100,7 @@ int stm32_ds1307_init(void)
 
       /* Synchronize the system time to the RTC time */
 
-      clock_synchronize();
+      clock_synchronize(NULL);
 
       /* Now we are initialized */
 

--- a/boards/sim/sim/sim/src/sim_bringup.c
+++ b/boards/sim/sim/sim/src/sim_bringup.c
@@ -44,9 +44,7 @@
 #include <nuttx/sensors/wtgahrs2.h>
 #include <nuttx/serial/uart_rpmsg.h>
 #include <nuttx/syslog/syslog_rpmsg.h>
-#include <nuttx/timers/arch_rtc.h>
 #include <nuttx/timers/oneshot.h>
-#include <nuttx/timers/rpmsg_rtc.h>
 #include <nuttx/video/fb.h>
 #include <nuttx/timers/oneshot.h>
 #include <nuttx/wireless/pktradio.h>
@@ -104,9 +102,6 @@ int sim_bringup(void)
 #endif
 #ifdef CONFIG_SIM_SPI
   FAR struct spi_dev_s *spidev;
-#endif
-#if defined(CONFIG_RTC_RPMSG) && !defined(CONFIG_RTC_RPMSG_SERVER)
-  FAR struct rtc_lowerhalf_s *rtc;
 #endif
   int ret = OK;
 
@@ -446,12 +441,6 @@ int sim_bringup(void)
 
 #ifdef CONFIG_SYSLOG_RPMSG_SERVER
   syslog_rpmsg_server_init();
-#endif
-
-#if defined(CONFIG_RTC_RPMSG) && !defined(CONFIG_RTC_RPMSG_SERVER)
-  rtc = rpmsg_rtc_initialize();
-  up_rtc_set_lowerhalf(rtc, true);
-  rtc_initialize(0, rtc);
 #endif
 
 #if defined(CONFIG_FS_RPMSGFS) && defined(CONFIG_SIM_RPTUN_MASTER)

--- a/drivers/timers/arch_rtc.c
+++ b/drivers/timers/arch_rtc.c
@@ -58,7 +58,7 @@ void up_rtc_set_lowerhalf(FAR struct rtc_lowerhalf_s *lower, bool sync)
 #ifdef CONFIG_RTC_EXTERNAL
   if (sync)
     {
-      clock_synchronize();
+      clock_synchronize(NULL);
     }
 #endif
 }

--- a/drivers/timers/rtc.c
+++ b/drivers/timers/rtc.c
@@ -401,7 +401,7 @@ static int rtc_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
                  * current system time to match.
                  */
 
-                clock_synchronize();
+                clock_synchronize(NULL);
               }
           }
       }

--- a/include/nuttx/arch.h
+++ b/include/nuttx/arch.h
@@ -2321,7 +2321,7 @@ size_t  up_check_intstack_remain(void);
  *
  ****************************************************************************/
 
-#if defined(CONFIG_RTC) && !defined(CONFIG_RTC_EXTERNAL)
+#if defined(CONFIG_RTC)
 int up_rtc_initialize(void);
 #endif
 

--- a/include/nuttx/clock.h
+++ b/include/nuttx/clock.h
@@ -322,7 +322,7 @@ void clock_timespec_subtract(FAR const struct timespec *ts1,
  *   timers and delays.  So use this interface with care.
  *
  * Input Parameters:
- *   None
+ *   tp: rtc time should be synced, set NULL to re-get time
  *
  * Returned Value:
  *   None
@@ -332,7 +332,7 @@ void clock_timespec_subtract(FAR const struct timespec *ts1,
  ****************************************************************************/
 
 #ifdef CONFIG_RTC
-void clock_synchronize(void);
+void clock_synchronize(FAR const struct timespec *tp);
 #endif
 
 /****************************************************************************

--- a/sched/clock/clock_initialize.c
+++ b/sched/clock/clock_initialize.c
@@ -155,14 +155,22 @@ int clock_basetime(FAR struct timespec *tp)
  ****************************************************************************/
 
 #ifdef CONFIG_RTC
-static void clock_inittime(void)
+static void clock_inittime(FAR const struct timespec *tp)
 {
   /* (Re-)initialize the time value to match the RTC */
 
 #ifndef CONFIG_CLOCK_TIMEKEEPING
   struct timespec ts;
 
-  clock_basetime(&g_basetime);
+  if (tp)
+    {
+      memcpy(&g_basetime, tp, sizeof(struct timespec));
+    }
+  else
+    {
+      clock_basetime(&g_basetime);
+    }
+
   clock_systime_timespec(&ts);
 
   /* Adjust base time to hide initial timer ticks. */
@@ -175,7 +183,7 @@ static void clock_inittime(void)
       g_basetime.tv_sec--;
     }
 #else
-  clock_inittimekeeping();
+  clock_inittimekeeping(tp);
 #endif
 }
 #endif
@@ -212,7 +220,7 @@ void clock_initialize(void)
 #if !defined(CONFIG_RTC_EXTERNAL)
   /* Initialize the time value to match the RTC */
 
-  clock_inittime();
+  clock_inittime(NULL);
 #endif
 #endif
 }
@@ -236,7 +244,7 @@ void clock_initialize(void)
  *   timers and delays.  So use this interface with care.
  *
  * Input Parameters:
- *   None
+ *   tp: rtc time should be synced, set NULL to re-get time
  *
  * Returned Value:
  *   None
@@ -246,14 +254,14 @@ void clock_initialize(void)
  ****************************************************************************/
 
 #ifdef CONFIG_RTC
-void clock_synchronize(void)
+void clock_synchronize(FAR const struct timespec *tp)
 {
   irqstate_t flags;
 
   /* Re-initialize the time value to match the RTC */
 
   flags = enter_critical_section();
-  clock_inittime();
+  clock_inittime(tp);
   leave_critical_section(flags);
 }
 #endif

--- a/sched/clock/clock_initialize.c
+++ b/sched/clock/clock_initialize.c
@@ -202,16 +202,18 @@ void clock_initialize(void)
   up_timer_initialize();
 #endif
 
-#if defined(CONFIG_RTC) && !defined(CONFIG_RTC_EXTERNAL)
+#if defined(CONFIG_RTC)
   /* Initialize the internal RTC hardware.  Initialization of external RTC
    * must be deferred until the system has booted.
    */
 
   up_rtc_initialize();
 
+#if !defined(CONFIG_RTC_EXTERNAL)
   /* Initialize the time value to match the RTC */
 
   clock_inittime();
+#endif
 #endif
 }
 

--- a/sched/clock/clock_timekeeping.c
+++ b/sched/clock/clock_timekeeping.c
@@ -129,7 +129,8 @@ int clock_timekeeping_set_wall_time(FAR struct timespec *ts)
       goto errout_in_critical_section;
     }
 
-  g_clock_wall_time    = *ts;
+  memcpy(&g_clock_wall_time, ts, sizeof(struct timespec));
+
   g_clock_adjust       = 0;
   g_clock_last_counter = counter;
 
@@ -275,10 +276,19 @@ errout_in_critical_section:
  * Name: clock_inittimekeeping
  ****************************************************************************/
 
-void clock_inittimekeeping(void)
+void clock_inittimekeeping(FAR const struct timespec *tp)
 {
   up_timer_getmask(&g_clock_mask);
-  clock_basetime(&g_clock_wall_time);
+
+  if (tp)
+    {
+      memcpy(&g_clock_wall_time, tp, sizeof(struct timespec));
+    }
+  else
+    {
+      clock_basetime(&g_clock_wall_time);
+    }
+
   up_timer_getcounter(&g_clock_last_counter);
 }
 

--- a/sched/clock/clock_timekeeping.h
+++ b/sched/clock/clock_timekeeping.h
@@ -41,6 +41,6 @@ int clock_timekeeping_set_wall_time(FAR struct timespec *ts);
 
 void clock_update_wall_time(void);
 
-void clock_inittimekeeping(void);
+void clock_inittimekeeping(FAR const struct timespec *tp);
 
 #endif /* __SCHED_CLOCK_CLOCK_TIMEKEEPING_H */


### PR DESCRIPTION
## Summary

rpmsg_rtc: merge the rpmsg_rtc_init to same place
rpmsg_rtc: resolve deadlock when the receive SYNC cmd.
add `tp` param to up_rtc_set_lowerhalf() & clock_synchronize()

Modify these for 2 reasons:
1. client CPU call `up_rtc_set_lowerhalf(rpmsg_rtc_initialize(0))`;
up_rtc_set_lowerhalf() -> clock_synchronize -> clock_inittime -> clock_basetime -> up_rtc_getdatetime ->  g_rtc_lower->ops->rdtime  ->  rpmsg
if the server CPU hasn't start, and rptun hasn't setup done, then the rpmsg will be failed.

So with https://github.com/apache/incubator-nuttx/pull/5230, set the `up_rtc_set_lowerhalf() `sync param to false.

2. rtc rpmsg SYNC packet
this is means: server set time, then sync the time to all the remote core.
If the client receive the SYNC packet, then should call `clock_synchronize()`.
And, `clock_synchronize()` in SYNC packet handler will caused deadlock.

Before this PR, `clock_synchronize()` will send IPC to server get time again.
After this PR, SYNC packet with time, and `clock_synchronize()` don't need do IPC again.

## Impact

## Testing

