### PR TITLE
z80: Fix z80sim build system

### DIFF
--- a/arch/z80/src/Makefile.sdccl
+++ b/arch/z80/src/Makefile.sdccl
@@ -21,6 +21,9 @@
 # Tools
 # CFLAGS, CPPFLAGS, ASFLAGS, LDFLAGS are set in $(TOPDIR)/Make.defs
 
+ARCH_SRCDIR = $(TOPDIR)$(DELIM)arch$(DELIM)$(CONFIG_ARCH)$(DELIM)src
+
+CFLAGS += ${shell $(INCDIR) "$(CC)" $(ARCH_SRCDIR)$(DELIM)}
 CFLAGS += ${shell $(INCDIR) "$(CC)" $(ARCH_SRCDIR)$(DELIM)chip}
 CFLAGS += ${shell $(INCDIR) "$(CC)" $(ARCH_SRCDIR)$(DELIM)common}
 CFLAGS += ${shell $(INCDIR) "$(CC)" $(TOPDIR)$(DELIM)sched}

--- a/tools/incdir.c
+++ b/tools/incdir.c
@@ -348,6 +348,10 @@ int main(int argc, char **argv, char **envp)
       wintool = true;
 #endif
     }
+  else if (compiler == COMPILER_SDCC)
+    {
+      cmdarg = "-I";
+    }
   else
     {
       cmdarg = (pathtype == SYSTEM_PATH) ? "-isystem" : "-I";


### PR DESCRIPTION
## Summary
The current z80sim build was not working
## Impact
User could follow with compilation to fix remaining SDCC compilation errors
## Testing
You can follow these steps to test:
```
$ sudo apt install sdcc
$ ./tools/configure.sh z80sim:nsh
$ make
```
Now it is complaining about code that is not compatible with SDCC:
```
CC:  clock/clock_initialize.c
/home/user/nuttxspace/nuttx/include/signal.h:333: error 97: SDCC cannot pass structure '_value' as function argument
/home/user/nuttxspace/nuttx/include/signal.h:428: error 97: SDCC cannot pass structure '_value' as function argument
/home/user/nuttxspace/nuttx/include/signal.h:428: error 97: SDCC cannot pass structure '_value' as function argument
/home/user/nuttxspace/nuttx/include/nuttx/sched.h:405: syntax error: token -> '}' ; column 3
make[1]: *** [Makefile:57: clock_initialize.rel] Error 1
make[1]: Leaving directory '/home/user/nuttxspace/nuttx/sched'
make: *** [tools/LibTargets.mk:59: sched/libsched.lib] Error 2
```