### PR TITLE
risc-v: Make exception_common 8 byte align

### DIFF
--- a/arch/risc-v/src/common/riscv_exception_common.S
+++ b/arch/risc-v/src/common/riscv_exception_common.S
@@ -43,6 +43,7 @@
 
   .section .text
   .global exception_common
+  .align  8
 
 exception_common:
 


### PR DESCRIPTION
## Summary
Some SoC like bl602 require the exception entry 8 byte align, it should
be safe for other chips so we can apply it globally.
## Impact
bl602
## Testing
CI / bl602 / QEMU-RV[32|64]