### PR TITLE
xtensa: Fix core voltage level when SPI Flash runs at 80Mhz

### DIFF
--- a/arch/xtensa/src/esp32/hardware/esp32_soc.h
+++ b/arch/xtensa/src/esp32/hardware/esp32_soc.h
@@ -620,7 +620,7 @@ extern int rom_i2c_writereg(int block, int block_id, int reg_add,
                                     (REG_GET_FIELD(EFUSE_BLK0_RDATA5_REG, \
                                      EFUSE_RD_VOL_LEVEL_HP_INV)))
 
-#ifdef CONFIG_ESPTOOLPY_FLASHFREQ_80M
+#ifdef CONFIG_ESP32_FLASH_FREQ_80M
 #define DIG_DBIAS_80M_160M          RTC_CNTL_DBIAS_HP_VOLT
 #else
 #define DIG_DBIAS_80M_160M          RTC_CNTL_DBIAS_1V10

--- a/arch/xtensa/src/esp32s2/hardware/esp32s2_soc.h
+++ b/arch/xtensa/src/esp32s2/hardware/esp32s2_soc.h
@@ -521,24 +521,14 @@ extern void rom_i2c_writereg_mask(uint8_t block, uint8_t host_id,
 /* Core voltage needs to be increased in two cases:
  * 1. running at 240 MHz
  * 2. running with 80MHz Flash frequency
- * There is a record in efuse which indicates the
- * proper voltage for these two cases.
  */
 
-#define RTC_CNTL_DBIAS_HP_VOLT      (RTC_CNTL_DBIAS_1V25 - \
-                                    (REG_GET_FIELD(EFUSE_BLK0_RDATA5_REG, \
-                                     EFUSE_RD_VOL_LEVEL_HP_INV)))
-
-#ifdef CONFIG_ESPTOOLPY_FLASHFREQ_80M
-#define DIG_DBIAS_80M_160M          RTC_CNTL_DBIAS_HP_VOLT
+#ifdef CONFIG_ESP32S2_FLASH_FREQ_80M
+#define DIG_DBIAS_80M_160M          RTC_CNTL_DBIAS_1V25
 #else
 #define DIG_DBIAS_80M_160M          RTC_CNTL_DBIAS_1V10
 #endif
-#define DIG_DBIAS_240M              RTC_CNTL_DBIAS_HP_VOLT
-#define DIG_DBIAS_XTAL              RTC_CNTL_DBIAS_1V10
-#define DIG_DBIAS_2M                RTC_CNTL_DBIAS_1V00
-
-#define DIG_DBIAS_240M              RTC_CNTL_DBIAS_HP_VOLT
+#define DIG_DBIAS_240M              RTC_CNTL_DBIAS_1V25
 #define DIG_DBIAS_XTAL              RTC_CNTL_DBIAS_1V10
 #define DIG_DBIAS_2M                RTC_CNTL_DBIAS_1V00
 


### PR DESCRIPTION
## Summary
This PR intends to fix the core voltage level of both **ESP32** and **ESP32-S2** when their SPI Flash runs at 80 MHz.

## Impact
Only for **ESP32** and **ESP32-S2** when their SPI Flash is configured to run at 80 MHz.
No impact if using default SPI Flash frequency of 40MHz.

## Testing
`esp32-devkitc:nsh` and `esp32s2-saola-1:nsh`.
