### PR TITLE
ethernet: apply compiler packing to all ethernet packet based types that are memory mapped

### DIFF
--- a/include/net/ethernet.h
+++ b/include/net/ethernet.h
@@ -25,6 +25,8 @@
  * Included Files
  ****************************************************************************/
 
+#include <nuttx/compiler.h>
+
 #include <stdint.h>
 
 /****************************************************************************
@@ -37,17 +39,17 @@
  * Public Type Definitions
  ****************************************************************************/
 
-struct ether_addr
+begin_packed_struct struct ether_addr
 {
   uint8_t ether_addr_octet[6];            /* 48-bit Ethernet address */
-};
+} end_packed_struct;
 
-struct ether_header
+begin_packed_struct struct ether_header
 {
   uint8_t  ether_dhost[ETHER_ADDR_LEN];   /* Destination Ethernet address */
   uint8_t  ether_shost[ETHER_ADDR_LEN];   /* Source Ethernet address */
   uint16_t ether_type;                    /* Ethernet packet type */
-};
+} end_packed_struct;
 
 /****************************************************************************
  * Public Function Prototypes

--- a/include/nuttx/net/dns.h
+++ b/include/nuttx/net/dns.h
@@ -44,7 +44,7 @@
  * Included Files
  ****************************************************************************/
 
-#include <nuttx/config.h>
+#include <nuttx/compiler.h>
 
 #include <sys/socket.h>
 #include <netinet/in.h>
@@ -138,7 +138,7 @@
 
 /* The DNS message header */
 
-struct dns_header_s
+begin_packed_struct struct dns_header_s
 {
   uint16_t id;
   uint8_t  flags1;
@@ -147,15 +147,15 @@ struct dns_header_s
   uint16_t numanswers;
   uint16_t numauthrr;
   uint16_t numextrarr;
-};
+} end_packed_struct;
 
 /* The DNS question message structure */
 
-struct dns_question_s
+begin_packed_struct struct dns_question_s
 {
   uint16_t type;
   uint16_t class;
-};
+} end_packed_struct;
 
 /* The DNS answer message structure */
 

--- a/include/nuttx/net/ethernet.h
+++ b/include/nuttx/net/ethernet.h
@@ -45,8 +45,10 @@
  * Included Files
  ****************************************************************************/
 
-#include <nuttx/config.h>
+#include <nuttx/compiler.h>
+
 #include <stdint.h>
+
 #include <net/ethernet.h>
 
 /****************************************************************************
@@ -87,12 +89,12 @@
  * some compilers refuse to pack 6 byte structures.
  */
 
-struct eth_hdr_s
+begin_packed_struct struct eth_hdr_s
 {
   uint8_t  dest[6]; /* Ethernet destination address (6 bytes) */
   uint8_t  src[6];  /* Ethernet source address (6 bytes) */
   uint16_t type;    /* Type code (2 bytes) */
-};
+} end_packed_struct;
 
 /* IEEE 802.1Q adds a 32-bit field between the source MAC address and the
  * type fields of the original Ethernet header.  Two bytes are used for the
@@ -101,14 +103,14 @@ struct eth_hdr_s
  * VID.
  */
 
-struct eth_8021qhdr_s
+begin_packed_struct struct eth_8021qhdr_s
 {
   uint8_t  dest[6]; /* Ethernet destination address (6 bytes) */
   uint8_t  src[6];  /* Ethernet source address (6 bytes) */
   uint16_t tpid;    /* TCI: Tag protocol identifier (2 bytes) */
   uint16_t tci;     /* TCI: Tag control information: PCP, DEI, VID (2 bytes) */
   uint16_t type;    /* Type code (2 bytes) */
-};
+} end_packed_struct;
 
 /****************************************************************************
  * Public Data

--- a/include/nuttx/net/icmp.h
+++ b/include/nuttx/net/icmp.h
@@ -45,7 +45,7 @@
  * Included Files
  ****************************************************************************/
 
-#include <nuttx/config.h>
+#include <nuttx/compiler.h>
 
 #include <stdint.h>
 
@@ -118,7 +118,7 @@
  * Public Type Definitions
  ****************************************************************************/
 
-struct icmp_hdr_s
+begin_packed_struct struct icmp_hdr_s
 {
   /* ICMP header */
 
@@ -143,7 +143,7 @@ struct icmp_hdr_s
 
       uint16_t data[2];
     };
-};
+} end_packed_struct;
 
 /* The structure holding the ICMP statistics that are gathered if
  * CONFIG_NET_STATISTICS is defined.

--- a/include/nuttx/net/icmpv6.h
+++ b/include/nuttx/net/icmpv6.h
@@ -46,7 +46,7 @@
  * Included Files
  ****************************************************************************/
 
-#include <nuttx/config.h>
+#include <nuttx/compiler.h>
 
 #include <stdint.h>
 
@@ -147,7 +147,7 @@
 
 /* The ICMPv6 header */
 
-struct icmpv6_hdr_s
+begin_packed_struct struct icmpv6_hdr_s
 {
   uint8_t  type;             /* Defines the format of the ICMP message */
   uint8_t  code;             /* Further qualifies the ICMP messages */
@@ -158,11 +158,11 @@ struct icmpv6_hdr_s
    */
 
   uint16_t data[2];
-};
+} end_packed_struct;
 
 /* The ICMPv6 and IPv6 headers */
 
-struct icmpv6_iphdr_s
+begin_packed_struct struct icmpv6_iphdr_s
 {
   /* IPv6 Ip header */
 
@@ -184,11 +184,11 @@ struct icmpv6_iphdr_s
   /* Data following the ICMP header contains the data specific to the
    * message type indicated by the Type and Code fields.
    */
-};
+} end_packed_struct;
 
 /* This the message format for the ICMPv6 Neighbor Solicitation message */
 
-struct icmpv6_neighbor_solicit_s
+begin_packed_struct struct icmpv6_neighbor_solicit_s
 {
   uint8_t  type;             /* Message Type: ICMPv6_NEIGHBOR_SOLICIT */
   uint8_t  code;             /* Further qualifies the ICMP messages */
@@ -199,14 +199,14 @@ struct icmpv6_neighbor_solicit_s
   uint8_t  opttype;          /* Option Type: ICMPv6_OPT_SRCLLADDR */
   uint8_t  optlen;           /* Option length: 1 octet */
   uint8_t  srclladdr[6];     /* Options: Source link layer address */
-};
+} end_packed_struct;
 
 #define SIZEOF_ICMPV6_NEIGHBOR_SOLICIT_S(n) \
   (sizeof(struct icmpv6_neighbor_solicit_s) + ICMPv6_OPT_SIZE(n) - 8)
 
 /* This the message format for the ICMPv6 Neighbor Advertisement message */
 
-struct icmpv6_neighbor_advertise_s
+begin_packed_struct struct icmpv6_neighbor_advertise_s
 {
   uint8_t  type;             /* Message Type: ICMPv6_NEIGHBOR_ADVERTISE */
   uint8_t  code;             /* Further qualifies the ICMP messages */
@@ -218,14 +218,14 @@ struct icmpv6_neighbor_advertise_s
   uint8_t  optlen;           /* Option length in octets */
   uint8_t  tgtlladdr[6];     /* Options: Target link layer address */
                              /* Actual size determined by optlen */
-};
+} end_packed_struct;
 
 #define SIZEOF_ICMPV6_NEIGHBOR_ADVERTISE_S(n) \
   (sizeof(struct icmpv6_neighbor_advertise_s) + ICMPv6_OPT_SIZE(n) - 8)
 
 /* This the message format for the ICMPv6 Router Solicitation message */
 
-struct icmpv6_router_solicit_s
+begin_packed_struct struct icmpv6_router_solicit_s
 {
   uint8_t  type;             /* Message Type: ICMPV6_ROUTER_SOLICIT */
   uint8_t  code;             /* Further qualifies the ICMP messages */
@@ -235,7 +235,7 @@ struct icmpv6_router_solicit_s
   uint8_t  opttype;          /* Option Type: ICMPv6_OPT_SRCLLADDR */
   uint8_t  optlen;           /* Option length in octets */
   uint8_t  srclladdr[6];     /* Options: Source link layer address */
-};
+} end_packed_struct;
 
 #define SIZEOF_ICMPV6_ROUTER_SOLICIT_S(n) \
   (sizeof(struct icmpv6_router_solicit_s) + ICMPv6_OPT_SIZE(n) - 8)
@@ -245,7 +245,7 @@ struct icmpv6_router_solicit_s
  *                      ICMPv6_OPT_PREFIX
  */
 
-struct icmpv6_router_advertise_s
+begin_packed_struct struct icmpv6_router_advertise_s
 {
   uint8_t  type;             /* Message Type: ICMPV6_ROUTER_ADVERTISE */
   uint8_t  code;             /* Further qualifies the ICMP messages */
@@ -256,14 +256,14 @@ struct icmpv6_router_advertise_s
   uint32_t reachable;        /* Reachable time */
   uint32_t retrans;          /* Retransmission timer */
                              /* Options begin here */
-};
+} end_packed_struct;
 
 #define ICMPv6_RADV_MINLEN    (16)
 #define ICMPv6_RADV_OPTLEN(n) ((n) - ICMPv6_RADV_MINLEN)
 
 /* This the message format for the ICMPv6 Echo Request message */
 
-struct icmpv6_echo_request_s
+begin_packed_struct struct icmpv6_echo_request_s
 {
   uint8_t  type;             /* Message Type: ICMPv6_ECHO_REQUEST */
   uint8_t  code;             /* Further qualifies the ICMP messages */
@@ -271,14 +271,14 @@ struct icmpv6_echo_request_s
   uint16_t id;               /* Identifier */
   uint16_t seqno;            /* Sequence Number */
   uint8_t  data[1];          /* Data follows */
-};
+} end_packed_struct;
 
 #define SIZEOF_ICMPV6_ECHO_REQUEST_S(n) \
   (sizeof(struct icmpv6_echo_request_s) - 1 + (n))
 
 /* This the message format for the ICMPv6 Echo Reply message */
 
-struct icmpv6_echo_reply_s
+begin_packed_struct struct icmpv6_echo_reply_s
 {
   uint8_t  type;             /* Message Type: ICMPv6_ECHO_REQUEST */
   uint8_t  code;             /* Further qualifies the ICMP messages */
@@ -286,39 +286,39 @@ struct icmpv6_echo_reply_s
   uint16_t id;               /* Identifier */
   uint16_t seqno;            /* Sequence Number */
   uint8_t  data[1];          /* Data follows */
-};
+} end_packed_struct;
 
 #define SIZEOF_ICMPV6_ECHO_REPLY_S(n) \
   (sizeof(struct icmpv6_echo_reply_s) - 1 + (n))
 
 /* Option types */
 
-struct icmpv6_generic_s
+begin_packed_struct struct icmpv6_generic_s
 {
   uint8_t  opttype;          /* Octet 1: Option Type */
   uint8_t  optlen;           /* "   " ": Option length (in octets) */
   uint16_t pad;              /* "   " ": The rest depends on the option */
-};
+} end_packed_struct;
 
-struct icmpv6_srclladdr_s
+begin_packed_struct struct icmpv6_srclladdr_s
 {
   uint8_t  opttype;          /* Octet 1: Option Type: ICMPv6_OPT_SRCLLADDR */
   uint8_t  optlen;           /* "   " ": Option length: 1 octet */
   uint8_t  srclladdr[6];     /* "   " ": Options: Source link layer address */
-};
+} end_packed_struct;
 
 #define SIZEOF_ICMPV6_SRCLLADDR_S(n) ICMPv6_OPT_SIZE(n)
 
-struct icmpv6_tgrlladdr_s
+begin_packed_struct struct icmpv6_tgrlladdr_s
 {
   uint8_t  opttype;          /* Octet 1: Option Type: ICMPv6_OPT_TGTLLADDR */
   uint8_t  optlen;           /* "   " ": Option length in octets */
   uint8_t  tgtlladdr[6];     /* "   " ": Options: Target link layer address */
-};
+} end_packed_struct;
 
 #define SIZEOF_ICMPV6_TGRLLADDR_S(n) ICMPv6_OPT_SIZE(n)
 
-struct icmpv6_prefixinfo_s
+begin_packed_struct struct icmpv6_prefixinfo_s
 {
   uint8_t  opttype;          /* Octet 1: Option Type: ICMPv6_OPT_PREFIX */
   uint8_t  optlen;           /* "   " ": Option length: 4 octets */
@@ -328,23 +328,23 @@ struct icmpv6_prefixinfo_s
   uint32_t plifetime;        /* Octet 2: Preferred lifetime */
   uint16_t reserved[2];      /* "   " ": Reserved */
   uint16_t prefix[8];        /* Octets 3-4: Prefix */
-};
+} end_packed_struct;
 
-struct icmpv6_redirect_s
+begin_packed_struct struct icmpv6_redirect_s
 {
   uint8_t  opttype;          /* Octet 1: Option Type: ICMPv6_OPT_REDIRECT */
   uint8_t  optlen;           /* "   " ": Option length: 1 octet */
   uint16_t reserved[3];      /* "   " ": Reserved */
   uint8_t  header[1];        /* Octets 2-: Beginning of the IP header */
-};
+} end_packed_struct;
 
-struct icmpv6_mtu_s
+begin_packed_struct struct icmpv6_mtu_s
 {
   uint8_t  opttype;          /* Octet 1: Option Type: ICMPv6_OPT_MTU */
   uint8_t  optlen;           /* "   " ": Option length: 1 octet */
   uint16_t reserved;         /* "   " ": Reserved */
   uint32_t mtu;              /* "   " ": MTU */
-};
+} end_packed_struct;
 
 /* The structure holding the ICMP statistics that are gathered if
  * CONFIG_NET_STATISTICS is defined.

--- a/include/nuttx/net/igmp.h
+++ b/include/nuttx/net/igmp.h
@@ -48,7 +48,7 @@
  * Included Files
  ****************************************************************************/
 
-#include <nuttx/config.h>
+#include <nuttx/compiler.h>
 
 #include <stdint.h>
 #include <stdbool.h>
@@ -85,7 +85,7 @@
 
 /* Convenience [re-]definition of the IPv4 header with the router alert */
 
-struct igmp_iphdr_s
+begin_packed_struct struct igmp_iphdr_s
 {
   /* IPv4 IP header */
 
@@ -103,7 +103,7 @@ struct igmp_iphdr_s
   /* Router Alert IP header option */
 
   uint16_t ra[2];            /* RFC 2113 */
-};
+} end_packed_struct;
 
 /* IGMPv2 packet structure as defined by RFC 2236.
  *
@@ -113,7 +113,7 @@ struct igmp_iphdr_s
  * (0x11); in other messages it is set to 0 and ignored by the receiver.
  */
 
-struct igmp_hdr_s
+begin_packed_struct struct igmp_hdr_s
 {
   /* IGMPv2 header:
    *
@@ -130,7 +130,7 @@ struct igmp_hdr_s
   uint8_t  maxresp;          /* 8-bit Max response time */
   uint16_t chksum;           /* 16-bit Checksum */
   uint16_t grpaddr[2];       /* 32-bit Group address */
-};
+} end_packed_struct;
 
 #ifdef CONFIG_NET_STATISTICS
 struct igmp_stats_s

--- a/include/nuttx/net/ip.h
+++ b/include/nuttx/net/ip.h
@@ -48,7 +48,7 @@
  * Included Files
  ****************************************************************************/
 
-#include <nuttx/config.h>
+#include <nuttx/compiler.h>
 
 #include <stdint.h>
 #include <stdbool.h>
@@ -151,7 +151,7 @@ union ip_binding_u
 #ifdef CONFIG_NET_IPv4
 /* The IPv4 header */
 
-struct ipv4_hdr_s
+begin_packed_struct struct ipv4_hdr_s
 {
   uint8_t  vhl;              /*  8-bit Version (4) and header length (5 or 6) */
   uint8_t  tos;              /*  8-bit Type of service (e.g., 6=TCP) */
@@ -163,13 +163,13 @@ struct ipv4_hdr_s
   uint16_t ipchksum;         /* 16-bit Header checksum */
   uint16_t srcipaddr[2];     /* 32-bit Source IP address */
   uint16_t destipaddr[2];    /* 32-bit Destination IP address */
-};
+} end_packed_struct;
 #endif /* CONFIG_NET_IPv4 */
 
 #ifdef CONFIG_NET_IPv6
 /* The IPv6 header */
 
-struct ipv6_hdr_s
+begin_packed_struct struct ipv6_hdr_s
 {
   uint8_t  vtc;              /* Bits 0-3: version, bits 4-7: traffic class (MS) */
   uint8_t  tcf;              /* Bits 0-3: traffic class (LS), 4-bits: flow label (MS) */
@@ -179,7 +179,7 @@ struct ipv6_hdr_s
   uint8_t  ttl;              /*  8-bit Hop limit (like IPv4 TTL field) */
   net_ipv6addr_t srcipaddr;  /* 128-bit Source address */
   net_ipv6addr_t destipaddr; /* 128-bit Destination address */
-};
+} end_packed_struct;
 #endif /* CONFIG_NET_IPv6 */
 
 #ifdef CONFIG_NET_STATISTICS

--- a/include/nuttx/net/mld.h
+++ b/include/nuttx/net/mld.h
@@ -26,7 +26,8 @@
  * Included Files
  ****************************************************************************/
 
-#include <nuttx/config.h>
+#include <nuttx/compiler.h>
+
 #include <stdint.h>
 #include <queue.h>
 
@@ -249,7 +250,7 @@
  * All queries have the following format:
  */
 
-struct mld_mcast_listen_query_s
+begin_packed_struct struct mld_mcast_listen_query_s
 {
   /* The initial fields are common for MLDv1 and MLDv2 (24-bytes) */
 
@@ -267,7 +268,7 @@ struct mld_mcast_listen_query_s
   uint16_t nsources;         /* Number of sources that follow */
   net_ipv6addr_t srcaddr[1]; /* Array of source IPv6 address (actual size is
                               * nsources) */
-};
+} end_packed_struct;
 
 /* The actual size of the query structure depends on the number of sources */
 
@@ -282,7 +283,7 @@ struct mld_mcast_listen_query_s
  * Version 1 Multicast Listener Report (RFC 2710)
  */
 
-struct mld_mcast_listen_report_v1_s
+begin_packed_struct struct mld_mcast_listen_report_v1_s
 {
   uint8_t  type;             /* Message Type: ICMPV6_MCAST_LISTEN_REPORT_V1 */
   uint8_t  reserved1;        /* Reserved, must be zero on transmission */
@@ -290,13 +291,13 @@ struct mld_mcast_listen_report_v1_s
   uint16_t reserved2;        /* Reserved, must be zero on transmission */
   uint16_t reserved3;        /* Reserved, must be zero on transmission */
   net_ipv6addr_t mcastaddr;  /* Multicast address */
-};
+} end_packed_struct;
 
 /* Version 2 Multicast Listener Report (RFC 3810). */
 
 /* This is the form of the address record used in the listener report */
 
-struct mld_mcast_addrec_v2_s
+begin_packed_struct struct mld_mcast_addrec_v2_s
 {
   uint8_t rectype;           /* Record type.  See definitions above. */
   uint8_t auxdatlen;         /* Auxiliary data length */
@@ -306,7 +307,7 @@ struct mld_mcast_addrec_v2_s
                               * nsources) */
 
   /* Auxiliary data may follow the list of address records. */
-};
+} end_packed_struct;
 
 /* The actual size of the query structure depends on the number of sources
  * as well as the size of any auxiliary data.
@@ -317,7 +318,7 @@ struct mld_mcast_addrec_v2_s
    sizeof(net_ipv6addr_t) * ((nsources) - 1) + \
    (auxdatlen))
 
-struct mld_mcast_listen_report_v2_s
+begin_packed_struct struct mld_mcast_listen_report_v2_s
 {
   uint8_t  type;             /* Message Type: ICMPV6_MCAST_LISTEN_REPORT_V2 */
   uint8_t  reserved1;        /* Reserved, must be zero on transmission */
@@ -328,7 +329,7 @@ struct mld_mcast_listen_report_v2_s
   /* List of multicast address records (actual size is naddrec) */
 
   struct mld_mcast_addrec_v2_s addrec[1];
-};
+} end_packed_struct;
 
 /* The actual size of the listener report depends on the sum of the
  * size of each variable length address record (addreclen).
@@ -341,7 +342,7 @@ struct mld_mcast_listen_report_v2_s
 
 /* Multicast Listener Done (RFC 2710) */
 
-struct mld_mcast_listen_done_s
+begin_packed_struct struct mld_mcast_listen_done_s
 {
   uint8_t  type;             /* Message Type: ICMPV6_MCAST_LISTEN_DONE */
   uint8_t  reserved1;        /* Reserved, must be zero on transmission */
@@ -349,7 +350,7 @@ struct mld_mcast_listen_done_s
   uint16_t reserved2;        /* Reserved, must be zero on transmission */
   uint16_t reserved3;        /* Reserved, must be zero on transmission */
   net_ipv6addr_t mcastaddr;  /* Multicast address */
-};
+} end_packed_struct;
 
 /* This structure represents the overall MLD state for a single network.
  * This structure in included within the net_driver_s structure.

--- a/include/nuttx/net/netconfig.h
+++ b/include/nuttx/net/netconfig.h
@@ -52,8 +52,10 @@
  * Included Files
  ****************************************************************************/
 
-#include <stdint.h>
 #include <nuttx/config.h>
+
+#include <stdint.h>
+
 #include <nuttx/net/ethernet.h>
 
 /****************************************************************************

--- a/include/nuttx/net/tcp.h
+++ b/include/nuttx/net/tcp.h
@@ -50,7 +50,8 @@
  * Included Files
  ****************************************************************************/
 
-#include <nuttx/config.h>
+#include <nuttx/compiler.h>
+
 #ifdef CONFIG_NET_TCP
 
 #include <stdint.h>
@@ -163,7 +164,7 @@
 
 /* TCP header */
 
-struct tcp_hdr_s
+begin_packed_struct struct tcp_hdr_s
 {
   uint16_t srcport;
   uint16_t destport;
@@ -175,7 +176,7 @@ struct tcp_hdr_s
   uint16_t tcpchksum;
   uint8_t  urgp[2];
   uint8_t  optdata[0];
-};
+} end_packed_struct;
 
 /* The structure holding the TCP/IP statistics that are gathered if
  * CONFIG_NET_STATISTICS is defined.

--- a/include/nuttx/net/udp.h
+++ b/include/nuttx/net/udp.h
@@ -49,7 +49,7 @@
  * Included Files
  ****************************************************************************/
 
-#include <nuttx/config.h>
+#include <nuttx/compiler.h>
 
 #include <stdint.h>
 
@@ -78,13 +78,13 @@
 
 /* The UDP header */
 
-struct udp_hdr_s
+begin_packed_struct struct udp_hdr_s
 {
   uint16_t srcport;
   uint16_t destport;
   uint16_t udplen;
   uint16_t udpchksum;
-};
+} end_packed_struct;
 
 /* The structure holding the UDP statistics that are gathered if
  * CONFIG_NET_STATISTICS is defined.

--- a/net/arp/arp.h
+++ b/net/arp/arp.h
@@ -35,7 +35,7 @@
  * Included Files
  ****************************************************************************/
 
-#include <nuttx/config.h>
+#include <nuttx/compiler.h>
 
 #include <stdint.h>
 #include <queue.h>
@@ -86,7 +86,7 @@
 
 /* ARP header -- Size 28 bytes */
 
-struct arp_hdr_s
+begin_packed_struct struct arp_hdr_s
 {
   uint16_t ah_hwtype;        /* 16-bit Hardware type (Ethernet=0x001) */
   uint16_t ah_protocol;      /* 16-bit Protocol type (IP=0x0800) */
@@ -97,11 +97,11 @@ struct arp_hdr_s
   uint16_t ah_sipaddr[2];    /* 32-bit Sender IP address */
   uint8_t  ah_dhwaddr[6];    /* 48-bit Target hardware address */
   uint16_t ah_dipaddr[2];    /* 32-bit Target IP address */
-};
+} end_packed_struct;
 
 /* IP header -- Size 20 or 24 bytes */
 
-struct arp_iphdr_s
+begin_packed_struct struct arp_iphdr_s
 {
   uint8_t  eh_vhl;           /*  8-bit Version (4) and header length (5 or 6) */
   uint8_t  eh_tos;           /*  8-bit Type of service (e.g., 6=TCP) */
@@ -114,7 +114,7 @@ struct arp_iphdr_s
   uint16_t eh_srcipaddr[2];  /* 32-bit Source IP address */
   uint16_t eh_destipaddr[2]; /* 32-bit Destination IP address */
   uint16_t eh_ipoption[2];   /* (optional) */
-};
+} end_packed_struct;
 
 #ifdef CONFIG_NET_ARP_SEND
 /* This structure holds the state of the send operation until it can be

--- a/net/sixlowpan/sixlowpan_internal.h
+++ b/net/sixlowpan/sixlowpan_internal.h
@@ -59,7 +59,7 @@
  * Included Files
  ****************************************************************************/
 
-#include <nuttx/config.h>
+#include <nuttx/compiler.h>
 
 #include <sys/types.h>
 #include <stdbool.h>
@@ -145,31 +145,31 @@
 #ifdef CONFIG_NET_TCP
 /* IPv6 + TCP header.  Cast compatible based on IPv6 protocol field. */
 
-struct ipv6tcp_hdr_s
+begin_packed_struct struct ipv6tcp_hdr_s
 {
   struct ipv6_hdr_s     ipv6;
   struct tcp_hdr_s      tcp;
-};
+} end_packed_struct;
 #endif
 
 #ifdef CONFIG_NET_UDP
 /* IPv6 + UDP header */
 
-struct ipv6udp_hdr_s
+begin_packed_struct struct ipv6udp_hdr_s
 {
   struct ipv6_hdr_s     ipv6;
   struct udp_hdr_s      udp;
-};
+} end_packed_struct;
 #endif
 
 #ifdef CONFIG_NET_ICMPv6
 /* IPv6 + ICMPv6 header */
 
-struct ipv6icmp_hdr_s
+begin_packed_struct struct ipv6icmp_hdr_s
 {
   struct ipv6_hdr_s     ipv6;
   struct icmpv6_iphdr_s icmp;
-};
+} end_packed_struct;
 #endif
 
 #ifdef CONFIG_WIRELESS_IEEE802154


### PR DESCRIPTION
## Summary
The network stack does not have any information about memory that stores the Ethernet (TCP/IP) packet, so in order to generate proper code that takes care all the alignment issues we need to use "packed" types.
Equip all Ethernet packet based types with `begin_packed_struct` / `end_packed_struct`

## Impact
Ethernet based networking sub-system

## Testing
Pass CI
