### PR TITLE
net/tcp/tcp_send*: reliably obtain the TCP connection pointer in TCP event handlers

### DIFF
--- a/net/devif/devif.h
+++ b/net/devif/devif.h
@@ -390,7 +390,7 @@ void devif_dev_callback_free(FAR struct net_driver_s *dev,
  *   dev - The network device state structure associated with the network
  *     device that initiated the callback event.
  *   pvconn - Holds a reference to the TCP connection structure or the UDP
- *     port structure.  May be NULL if the even is not related to a TCP
+ *     port structure. It can be NULL if the event is not related to a TCP
  *     connection or UDP port.
  *   flags - The bit set of events to be notified.
  *   list - The list to traverse in performing the notifications
@@ -416,7 +416,7 @@ uint16_t devif_conn_event(FAR struct net_driver_s *dev, FAR void *pvconn,
  *   dev - The network device state structure associated with the network
  *     device that initiated the callback event.
  *   pvconn - Holds a reference to the TCP connection structure or the UDP
- *     port structure.  May be NULL if the even is not related to a TCP
+ *     port structure. It can be NULL if the event is not related to a TCP
  *     connection or UDP port.
  *   flags - The bit set of events to be notified.
  *

--- a/net/devif/devif_callback.c
+++ b/net/devif/devif_callback.c
@@ -466,7 +466,7 @@ void devif_dev_callback_free(FAR struct net_driver_s *dev,
  *   dev - The network device state structure associated with the network
  *     device that initiated the callback event.
  *   pvconn - Holds a reference to the TCP connection structure or the UDP
- *     port structure.  May be NULL if the even is not related to a TCP
+ *     port structure. It can be NULL if the event is not related to a TCP
  *     connection or UDP port.
  *   flags - The bit set of events to be notified.
  *   list - The list to traverse in performing the notifications
@@ -529,7 +529,7 @@ uint16_t devif_conn_event(FAR struct net_driver_s *dev, void *pvconn,
  *   dev - The network device state structure associated with the network
  *     device that initiated the callback event.
  *   pvconn - Holds a reference to the TCP connection structure or the UDP
- *     port structure.  May be NULL if the even is not related to a TCP
+ *     port structure. It can be NULL if the event is not related to a TCP
  *     connection or UDP port.
  *   flags - The bit set of events to be notified.
  *

--- a/net/tcp/tcp_send_unbuffered.c
+++ b/net/tcp/tcp_send_unbuffered.c
@@ -170,8 +170,29 @@ static uint16_t tcpsend_eventhandler(FAR struct net_driver_s *dev,
                                      FAR void *pvconn,
                                      FAR void *pvpriv, uint16_t flags)
 {
-  FAR struct tcp_conn_s *conn = (FAR struct tcp_conn_s *)pvconn;
+  /* FAR struct tcp_conn_s *conn = (FAR struct tcp_conn_s *)pvconn;
+   *
+   * Do not use pvconn argument to get the TCP connection pointer (the above
+   * commented line) because pvconn is normally NULL for some events like
+   * NETDEV_DOWN. Instead, the TCP connection pointer can be reliably
+   * obtained from the corresponding TCP socket.
+   */
+
   FAR struct send_s *pstate = (FAR struct send_s *)pvpriv;
+  FAR struct socket *psock;
+  FAR struct tcp_conn_s *conn;
+
+  DEBUGASSERT(pstate != NULL);
+
+  psock = pstate->snd_sock;
+  DEBUGASSERT(psock != NULL);
+
+  /* Get the TCP connection pointer reliably from
+   * the corresponding TCP socket.
+   */
+
+  conn = psock->s_conn;
+  DEBUGASSERT(conn != NULL);
 
   /* The TCP socket is connected and, hence, should be bound to a device.
    * Make sure that the polling device is the one that we are bound to.
@@ -315,8 +336,6 @@ static uint16_t tcpsend_eventhandler(FAR struct net_driver_s *dev,
 
   else if ((flags & TCP_DISCONN_EVENTS) != 0)
     {
-      FAR struct socket *psock = pstate->snd_sock;
-
       ninfo("Lost connection\n");
 
       /* We could get here recursively through the callback actions of
@@ -324,7 +343,6 @@ static uint16_t tcpsend_eventhandler(FAR struct net_driver_s *dev,
        * already been disconnected.
        */
 
-      DEBUGASSERT(psock != NULL);
       if (_SS_ISCONNECTED(psock->s_flags))
         {
           /* Report not connected */
@@ -402,6 +420,8 @@ static uint16_t tcpsend_eventhandler(FAR struct net_driver_s *dev,
 end_wait:
 
   /* Do not allow any further callbacks */
+
+  DEBUGASSERT(pstate->snd_cb != NULL);
 
   pstate->snd_cb->flags   = 0;
   pstate->snd_cb->priv    = NULL;
@@ -509,7 +529,6 @@ ssize_t psock_tcp_send(FAR struct socket *psock,
   /* Make sure that we have the IP address mapping */
 
   conn = (FAR struct tcp_conn_s *)psock->s_conn;
-  DEBUGASSERT(conn);
 
 #if defined(CONFIG_NET_ARP_SEND) || defined(CONFIG_NET_ICMPv6_NEIGHBOR)
 #ifdef CONFIG_NET_ARP_SEND


### PR DESCRIPTION
## Summary

Do not use pvconn argument to get the TCP connection pointer because pvconn is normally NULL for some events like NETDEV_DOWN. Instead, the TCP connection pointer can be reliably obtained from the corresponding TCP socket.

This PR is related to PR #2257.

## Impact

TCP

## Testing

Build NuttX:
```
$ ./tools/configure.sh -l sim:tcpblaster
$ make menuconfig
(enable CONFIG_DEBUG_WARN,
enable CONFIG_DEBUG_ASSERTIONS,
enable / disable CONFIG_NETUTILS_NETCAT_SENDFILE,
enable / disable CONFIG_NET_TCP_WRITE_BUFFERS)
$ make
```
Enable TUN/TAP on Linux host:
```
$ sudo setcap cap_net_admin+ep ./nuttx
$ sudo ./tools/simhostroute.sh wlan0 on
```
Run netcat server on Linux host:
`$ netcat -l -p 31337`

Run NuttX on Linux host:
```
$ ./nuttx
NuttShell (NSH) NuttX-10.2.0
nsh> ifconfig eth0 10.0.1.2
nsh> ifup eth0
ifup eth0...OK
nsh> dd if=/dev/zero of=/tmp/test.bin count=1000
nsh> netcat LINUX_HOST_IP_ADDRESS 31337 /tmp/test.bin &
nsh> ifdown eth0
sendfile_eventhandler: WARNING: Lost connection
ifdown eth0...OK
nsh> sendfile error: Error 128
sendfile error
nsh>
nsh> poweroff
```

Disable TUN/TAP on Linux host:
`$ sudo ./tools/simhostroute.sh wlan0 off`