### PR TITLE
net: unify FAR keyword usage for all net buffer memory mapped buffers

### DIFF
--- a/arch/arm/src/c5471/c5471_ethernet.c
+++ b/arch/arm/src/c5471/c5471_ethernet.c
@@ -281,7 +281,7 @@
 
 /* This is a helper pointer for accessing the contents of Ethernet header */
 
-#define BUF ((struct eth_hdr_s *)priv->c_dev.d_buf)
+#define BUF ((FAR struct eth_hdr_s *)priv->c_dev.d_buf)
 
 /****************************************************************************
  * Private Types

--- a/arch/arm/src/imx6/imx_enet.c
+++ b/arch/arm/src/imx6/imx_enet.c
@@ -260,7 +260,7 @@
  * the contents of the Ethernet header
  */
 
-#define BUF ((struct eth_hdr_s *)priv->dev.d_buf)
+#define BUF ((FAR struct eth_hdr_s *)priv->dev.d_buf)
 
 #define IMX_BUF_SIZE  ENET_ALIGN_UP(CONFIG_NET_ETH_PKTSIZE)
 

--- a/arch/arm/src/imxrt/imxrt_enet.c
+++ b/arch/arm/src/imxrt/imxrt_enet.c
@@ -244,7 +244,7 @@
  * the contents of the Ethernet header
  */
 
-#define BUF ((struct eth_hdr_s *)priv->dev.d_buf)
+#define BUF ((FAR struct eth_hdr_s *)priv->dev.d_buf)
 
 #define IMXRT_BUF_SIZE  ENET_ALIGN_UP(CONFIG_NET_ETH_PKTSIZE + \
                                       CONFIG_NET_GUARDSIZE)

--- a/arch/arm/src/kinetis/kinetis_enet.c
+++ b/arch/arm/src/kinetis/kinetis_enet.c
@@ -194,7 +194,7 @@
  * header
  */
 
-#define BUF ((struct eth_hdr_s *)priv->dev.d_buf)
+#define BUF ((FAR struct eth_hdr_s *)priv->dev.d_buf)
 
 #define KINETIS_BUF_SIZE  ((CONFIG_NET_ETH_PKTSIZE & 0xfffffff0) + 0x10)
 

--- a/arch/arm/src/lpc17xx_40xx/lpc17_40_ethernet.c
+++ b/arch/arm/src/lpc17xx_40xx/lpc17_40_ethernet.c
@@ -165,7 +165,7 @@
 
 /* This is a helper pointer for accessing the contents of Ethernet header */
 
-#define BUF ((struct eth_hdr_s *)priv->lp_dev.d_buf)
+#define BUF ((FAR struct eth_hdr_s *)priv->lp_dev.d_buf)
 
 /* This is the number of ethernet GPIO pins that must be configured */
 

--- a/arch/arm/src/lpc43xx/lpc43_ethernet.c
+++ b/arch/arm/src/lpc43xx/lpc43_ethernet.c
@@ -498,7 +498,7 @@
  * header
  */
 
-#define BUF ((struct eth_hdr_s *)priv->dev.d_buf)
+#define BUF ((FAR struct eth_hdr_s *)priv->dev.d_buf)
 
 /****************************************************************************
  * Private Types

--- a/arch/arm/src/lpc54xx/lpc54_ethernet.c
+++ b/arch/arm/src/lpc54xx/lpc54_ethernet.c
@@ -257,8 +257,8 @@
  * header.
  */
 
-#define ETHBUF       ((struct eth_hdr_s *)priv->eth_dev.d_buf)
-#define ETH8021QWBUF ((struct eth_8021qhdr_s *)priv->eth_dev.d_buf)
+#define ETHBUF       ((FAR struct eth_hdr_s *)priv->eth_dev.d_buf)
+#define ETH8021QWBUF ((FAR struct eth_8021qhdr_s *)priv->eth_dev.d_buf)
 
 /****************************************************************************
  * Private Types

--- a/arch/arm/src/rtl8720c/amebaz_netdev.c
+++ b/arch/arm/src/rtl8720c/amebaz_netdev.c
@@ -156,7 +156,7 @@ void amebaz_netdev_notify_receive(FAR struct amebaz_dev_s *priv,
   NETDEV_RXPACKETS(&priv->dev);
   net_lock();
   oldbuf = priv->dev.d_buf;
-  hdr = (struct eth_hdr_s *)skb->data;
+  hdr = (FAR struct eth_hdr_s *)skb->data;
   priv->dev.d_buf = (void *)skb->data;
   priv->dev.d_len = len;
 #ifdef CONFIG_NET_PKT

--- a/arch/arm/src/s32k1xx/s32k1xx_enet.c
+++ b/arch/arm/src/s32k1xx/s32k1xx_enet.c
@@ -239,7 +239,7 @@
 
 /* This is a helper pointer for accessing the contents of Ethernet header */
 
-#define BUF ((struct eth_hdr_s *)priv->dev.d_buf)
+#define BUF ((FAR struct eth_hdr_s *)priv->dev.d_buf)
 
 #define S32K1XX_BUF_SIZE  ENET_ALIGN_UP(CONFIG_NET_ETH_PKTSIZE)
 

--- a/arch/arm/src/sam34/sam_emac.c
+++ b/arch/arm/src/sam34/sam_emac.c
@@ -236,7 +236,7 @@
  * header
  */
 
-#define BUF ((struct eth_hdr_s *)priv->dev.d_buf)
+#define BUF ((FAR struct eth_hdr_s *)priv->dev.d_buf)
 
 /****************************************************************************
  * Private Types

--- a/arch/arm/src/sama5/sam_emaca.c
+++ b/arch/arm/src/sama5/sam_emaca.c
@@ -267,7 +267,7 @@
  * header
  */
 
-#define BUF ((struct eth_hdr_s *)priv->dev.d_buf)
+#define BUF ((FAR struct eth_hdr_s *)priv->dev.d_buf)
 
 /****************************************************************************
  * Private Types

--- a/arch/arm/src/sama5/sam_emacb.c
+++ b/arch/arm/src/sama5/sam_emacb.c
@@ -314,7 +314,7 @@
  * header
  */
 
-#define BUF ((struct eth_hdr_s *)priv->dev.d_buf)
+#define BUF ((FAR struct eth_hdr_s *)priv->dev.d_buf)
 
 /****************************************************************************
  * Private Types

--- a/arch/arm/src/sama5/sam_gmac.c
+++ b/arch/arm/src/sama5/sam_gmac.c
@@ -193,7 +193,7 @@
  * header
  */
 
-#define BUF ((struct eth_hdr_s *)priv->dev.d_buf)
+#define BUF ((FAR struct eth_hdr_s *)priv->dev.d_buf)
 
 /****************************************************************************
  * Private Types

--- a/arch/arm/src/samd5e5/sam_gmac.c
+++ b/arch/arm/src/samd5e5/sam_gmac.c
@@ -190,7 +190,7 @@
  * header
  */
 
-#define BUF ((struct eth_hdr_s *)priv->dev.d_buf)
+#define BUF ((FAR struct eth_hdr_s *)priv->dev.d_buf)
 
 /****************************************************************************
  * Private Types

--- a/arch/arm/src/samv7/sam_emac.c
+++ b/arch/arm/src/samv7/sam_emac.c
@@ -410,7 +410,7 @@
  * header
  */
 
-#define BUF ((struct eth_hdr_s *)priv->dev.d_buf)
+#define BUF ((FAR struct eth_hdr_s *)priv->dev.d_buf)
 
 /****************************************************************************
  * Private Types

--- a/arch/arm/src/stm32/stm32_eth.c
+++ b/arch/arm/src/stm32/stm32_eth.c
@@ -607,7 +607,7 @@
  * header
  */
 
-#define BUF ((struct eth_hdr_s *)priv->dev.d_buf)
+#define BUF ((FAR struct eth_hdr_s *)priv->dev.d_buf)
 
 /****************************************************************************
  * Private Types
@@ -3690,7 +3690,7 @@ static int stm32_ethreset(FAR struct stm32_ethmac_s *priv)
   while (((stm32_getreg(STM32_ETH_DMABMR) & ETH_DMABMR_SR) != 0) &&
          retries > 0)
     {
-      retries --;
+      retries--;
       up_mdelay(10);
     }
 

--- a/arch/arm/src/stm32f7/stm32_ethernet.c
+++ b/arch/arm/src/stm32f7/stm32_ethernet.c
@@ -594,7 +594,7 @@
  * header
  */
 
-#define BUF ((struct eth_hdr_s *)priv->dev.d_buf)
+#define BUF ((FAR struct eth_hdr_s *)priv->dev.d_buf)
 
 /****************************************************************************
  * Private Types

--- a/arch/arm/src/stm32h7/stm32_ethernet.c
+++ b/arch/arm/src/stm32h7/stm32_ethernet.c
@@ -599,7 +599,7 @@
  * header
  */
 
-#define BUF ((struct eth_hdr_s *)priv->dev.d_buf)
+#define BUF ((FAR struct eth_hdr_s *)priv->dev.d_buf)
 
 /****************************************************************************
  * Private Types

--- a/arch/arm/src/tiva/lm/lm3s_ethernet.c
+++ b/arch/arm/src/tiva/lm/lm3s_ethernet.c
@@ -167,7 +167,7 @@
 
 /* This is a helper pointer for accessing the contents of Ethernet header */
 
-#define ETHBUF ((struct eth_hdr_s *)priv->ld_dev.d_buf)
+#define ETHBUF ((FAR struct eth_hdr_s *)priv->ld_dev.d_buf)
 
 #define TIVA_MAX_MDCCLK 2500000
 

--- a/arch/arm/src/tiva/tm4c/tm4c_ethernet.c
+++ b/arch/arm/src/tiva/tm4c/tm4c_ethernet.c
@@ -615,7 +615,7 @@
  * header
  */
 
-#define BUF ((struct eth_hdr_s *)priv->dev.d_buf)
+#define BUF ((FAR struct eth_hdr_s *)priv->dev.d_buf)
 
 /****************************************************************************
  * Private Types

--- a/arch/hc/src/m9s12/m9s12_ethernet.c
+++ b/arch/hc/src/m9s12/m9s12_ethernet.c
@@ -69,7 +69,7 @@
 
 /* This is a helper pointer for accessing the contents of Ethernet header */
 
-#define BUF ((struct eth_hdr_s *)priv->d_dev.d_buf)
+#define BUF ((FAR struct eth_hdr_s *)priv->d_dev.d_buf)
 
 /****************************************************************************
  * Private Types

--- a/arch/mips/src/pic32mx/pic32mx_ethernet.c
+++ b/arch/mips/src/pic32mx/pic32mx_ethernet.c
@@ -215,7 +215,7 @@
  * header
  */
 
-#define BUF ((struct eth_hdr_s *)priv->pd_dev.d_buf)
+#define BUF ((FAR struct eth_hdr_s *)priv->pd_dev.d_buf)
 
 /* PHYs *********************************************************************/
 

--- a/arch/mips/src/pic32mz/pic32mz_ethernet.c
+++ b/arch/mips/src/pic32mz/pic32mz_ethernet.c
@@ -254,7 +254,7 @@
  * header
  */
 
-#define BUF ((struct eth_hdr_s *)priv->pd_dev.d_buf)
+#define BUF ((FAR struct eth_hdr_s *)priv->pd_dev.d_buf)
 
 /* PHYs *********************************************************************/
 

--- a/arch/misoc/src/common/misoc_net.c
+++ b/arch/misoc/src/common/misoc_net.c
@@ -88,7 +88,7 @@
 
 /* This is a helper pointer for accessing the contents of Ethernet header */
 
-#define BUF ((struct eth_hdr_s *)priv->misoc_net_dev.d_buf)
+#define BUF ((FAR struct eth_hdr_s *)priv->misoc_net_dev.d_buf)
 
 /****************************************************************************
  * Private Types

--- a/arch/renesas/src/rx65n/rx65n_eth.c
+++ b/arch/renesas/src/rx65n/rx65n_eth.c
@@ -198,7 +198,7 @@
  * header
  */
 
-#define BUF ((struct eth_hdr_s *)priv->dev.d_buf)
+#define BUF ((FAR struct eth_hdr_s *)priv->dev.d_buf)
 
 /* PHY return definitions */
 
@@ -3646,7 +3646,7 @@ static int rx65n_ethreset(FAR struct rx65n_ethmac_s *priv)
   while (((rx65n_getreg(RX65N_ETHD_EDMR) & ETHD_EDMR_SWR) != 0) &&
          retries > 0)
     {
-      retries --;
+      retries--;
       up_mdelay(10);
     }
 
@@ -3703,7 +3703,7 @@ static int rx65n_macconfig(FAR struct rx65n_ethmac_s *priv)
   while (((rx65n_getreg(RX65N_ETHD_EDMR) & ETHD_EDMR_SWR) != 0) &&
          retries > 0)
     {
-      retries --;
+      retries--;
       up_mdelay(10);
     }
 

--- a/arch/xtensa/src/esp32/esp32_wlan.c
+++ b/arch/xtensa/src/esp32/esp32_wlan.c
@@ -1077,7 +1077,7 @@ static void wlan_txtimeout_expiry(wdparm_t arg)
 static void wlan_poll_work(void *arg)
 {
   int32_t delay_tick = WLAN_WDDELAY;
-  FAR struct wlan_priv_s *priv = (FAR struct wlan_priv_s *)arg;
+  struct wlan_priv_s *priv = (struct wlan_priv_s *)arg;
   struct net_driver_s *dev = &priv->dev;
   struct wlan_pktbuf *pktbuf;
 

--- a/arch/z80/src/ez80/ez80_emac.c
+++ b/arch/z80/src/ez80/ez80_emac.c
@@ -255,7 +255,7 @@ extern uintptr_t _RAM_ADDR_U_INIT_PARAM;
 
 /* This is a helper pointer for accessing the contents of Ethernet header */
 
-#define ETHBUF ((struct eth_hdr_s *)priv->dev.d_buf)
+#define ETHBUF ((FAR struct eth_hdr_s *)priv->dev.d_buf)
 
 /****************************************************************************
  * Private Types

--- a/drivers/net/dm90x0.c
+++ b/drivers/net/dm90x0.c
@@ -281,7 +281,7 @@
 
 /* This is a helper pointer for accessing the contents of Ethernet header */
 
-#define BUF ((struct eth_hdr_s *)priv->dm_dev.d_buf)
+#define BUF ((FAR struct eth_hdr_s *)priv->dm_dev.d_buf)
 
 /****************************************************************************
  * Private Types

--- a/drivers/net/enc28j60.c
+++ b/drivers/net/enc28j60.c
@@ -181,7 +181,7 @@
 
 /* This is a helper pointer for accessing the contents of Ethernet header */
 
-#define BUF ((struct eth_hdr_s *)priv->dev.d_buf)
+#define BUF ((FAR struct eth_hdr_s *)priv->dev.d_buf)
 
 /* Debug ********************************************************************/
 

--- a/drivers/net/encx24j600.c
+++ b/drivers/net/encx24j600.c
@@ -164,7 +164,7 @@
 
 /* This is a helper pointer for accessing the contents of Ethernet header */
 
-#define BUF ((struct eth_hdr_s *)priv->dev.d_buf)
+#define BUF ((FAR struct eth_hdr_s *)priv->dev.d_buf)
 
 /* Debug ********************************************************************/
 

--- a/drivers/net/ftmac100.c
+++ b/drivers/net/ftmac100.c
@@ -95,7 +95,7 @@
  * header.
  */
 
-#define BUF ((struct eth_hdr_s *)priv->ft_dev.d_buf)
+#define BUF ((FAR struct eth_hdr_s *)priv->ft_dev.d_buf)
 
 /* RX/TX buffer alignment */
 

--- a/drivers/net/rpmsgdrv.c
+++ b/drivers/net/rpmsgdrv.c
@@ -457,8 +457,8 @@ static int net_rpmsg_drv_sockioctl_handler(FAR struct rpmsg_endpoint *ept,
 static bool net_rpmsg_drv_is_ipv4(FAR struct net_driver_s *dev)
 {
   FAR struct ipv4_hdr_s *ip =
-    (struct ipv4_hdr_s *)(dev->d_buf + dev->d_llhdrlen);
-  FAR struct eth_hdr_s *eth = (struct eth_hdr_s *)dev->d_buf;
+    (FAR struct ipv4_hdr_s *)(dev->d_buf + dev->d_llhdrlen);
+  FAR struct eth_hdr_s *eth = (FAR struct eth_hdr_s *)dev->d_buf;
 
   if (dev->d_lltype == NET_LL_ETHERNET || dev->d_lltype == NET_LL_IEEE80211)
     {
@@ -475,8 +475,8 @@ static bool net_rpmsg_drv_is_ipv4(FAR struct net_driver_s *dev)
 static bool net_rpmsg_drv_is_ipv6(FAR struct net_driver_s *dev)
 {
   FAR struct ipv6_hdr_s *ip =
-    (struct ipv6_hdr_s *)(dev->d_buf + dev->d_llhdrlen);
-  FAR struct eth_hdr_s *eth = (struct eth_hdr_s *)dev->d_buf;
+    (FAR struct ipv6_hdr_s *)(dev->d_buf + dev->d_llhdrlen);
+  FAR struct eth_hdr_s *eth = (FAR struct eth_hdr_s *)dev->d_buf;
 
   if (dev->d_lltype == NET_LL_ETHERNET || dev->d_lltype == NET_LL_IEEE80211)
     {
@@ -492,7 +492,7 @@ static bool net_rpmsg_drv_is_ipv6(FAR struct net_driver_s *dev)
 #ifdef CONFIG_NET_ARP
 static bool net_rpmsg_drv_is_arp(FAR struct net_driver_s *dev)
 {
-  FAR struct eth_hdr_s *eth = (struct eth_hdr_s *)dev->d_buf;
+  FAR struct eth_hdr_s *eth = (FAR struct eth_hdr_s *)dev->d_buf;
 
   if (dev->d_lltype == NET_LL_ETHERNET || dev->d_lltype == NET_LL_IEEE80211)
     {

--- a/drivers/net/skeleton.c
+++ b/drivers/net/skeleton.c
@@ -88,7 +88,7 @@
 
 /* This is a helper pointer for accessing the contents of Ethernet header */
 
-#define BUF ((struct eth_hdr_s *)priv->sk_dev.d_buf)
+#define BUF ((FAR struct eth_hdr_s *)priv->sk_dev.d_buf)
 
 /****************************************************************************
  * Private Types

--- a/drivers/usbdev/cdcecm.c
+++ b/drivers/usbdev/cdcecm.c
@@ -98,7 +98,7 @@
 
 /* This is a helper pointer for accessing the contents of Ethernet header */
 
-#define BUF ((struct eth_hdr_s *)self->dev.d_buf)
+#define BUF ((FAR struct eth_hdr_s *)self->dev.d_buf)
 
 /****************************************************************************
  * Private Types

--- a/drivers/usbhost/usbhost_cdcmbim.c
+++ b/drivers/usbhost/usbhost_cdcmbim.c
@@ -2271,7 +2271,7 @@ static void cdcmbim_receive(struct usbhost_cdcmbim_s *priv,
   priv->netdev.d_buf = buf;
   priv->netdev.d_len = len;
 
-  switch (((struct ipv4_hdr_s *)buf)->vhl & IP_VERSION_MASK)
+  switch (((FAR struct ipv4_hdr_s *)buf)->vhl & IP_VERSION_MASK)
     {
 #ifdef CONFIG_NET_IPv4
     case IPv4_VERSION:

--- a/drivers/wireless/ieee80211/bcm43xxx/bcmf_netdev.c
+++ b/drivers/wireless/ieee80211/bcm43xxx/bcmf_netdev.c
@@ -95,7 +95,7 @@
 
 /* This is a helper pointer for accessing the contents of Ethernet header */
 
-#define BUF ((struct eth_hdr_s *)priv->bc_dev.d_buf)
+#define BUF ((FAR struct eth_hdr_s *)priv->bc_dev.d_buf)
 
 /****************************************************************************
  * Private Function Prototypes

--- a/include/nuttx/net/netdev.h
+++ b/include/nuttx/net/netdev.h
@@ -451,7 +451,7 @@ typedef CODE int (*devif_poll_callback_t)(FAR struct net_driver_s *dev);
  * Ethernet, you will need to call the network ARP code before calling
  * this function:
  *
- *     #define BUF ((struct eth_hdr_s *)&dev->d_buf[0])
+ *     #define BUF ((FAR struct eth_hdr_s *)&dev->d_buf[0])
  *     dev->d_len = ethernet_devicedrver_poll();
  *     if (dev->d_len > 0)
  *       {

--- a/net/arp/arp_arpin.c
+++ b/net/arp/arp_arpin.c
@@ -59,8 +59,8 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-#define ETHBUF  ((struct eth_hdr_s *)&dev->d_buf[0])
-#define ARPBUF  ((struct arp_hdr_s *)&dev->d_buf[ETH_HDRLEN])
+#define ETHBUF ((FAR struct eth_hdr_s *)&dev->d_buf[0])
+#define ARPBUF ((FAR struct arp_hdr_s *)&dev->d_buf[ETH_HDRLEN])
 
 /****************************************************************************
  * Public Functions

--- a/net/arp/arp_format.c
+++ b/net/arp/arp_format.c
@@ -59,8 +59,8 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-#define ETHBUF  ((struct eth_hdr_s *)&dev->d_buf[0])
-#define ARPBUF  ((struct arp_hdr_s *)&dev->d_buf[ETH_HDRLEN])
+#define ETHBUF ((FAR struct eth_hdr_s *)&dev->d_buf[0])
+#define ARPBUF ((FAR struct arp_hdr_s *)&dev->d_buf[ETH_HDRLEN])
 
 /****************************************************************************
  * Public Functions

--- a/net/arp/arp_ipin.c
+++ b/net/arp/arp_ipin.c
@@ -56,8 +56,8 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-#define ETHBUF ((struct eth_hdr_s *)&dev->d_buf[0])
-#define IPBUF  ((struct arp_iphdr_s *)&dev->d_buf[ETH_HDRLEN])
+#define ETHBUF ((FAR struct eth_hdr_s *)&dev->d_buf[0])
+#define IPBUF  ((FAR struct arp_iphdr_s *)&dev->d_buf[ETH_HDRLEN])
 
 /****************************************************************************
  * Public Functions

--- a/net/arp/arp_out.c
+++ b/net/arp/arp_out.c
@@ -59,9 +59,9 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-#define ETHBUF  ((struct eth_hdr_s *)&dev->d_buf[0])
-#define ARPBUF  ((struct arp_hdr_s *)&dev->d_buf[ETH_HDRLEN])
-#define IPBUF   ((struct arp_iphdr_s *)&dev->d_buf[ETH_HDRLEN])
+#define ETHBUF ((FAR struct eth_hdr_s *)&dev->d_buf[0])
+#define ARPBUF ((FAR struct arp_hdr_s *)&dev->d_buf[ETH_HDRLEN])
+#define IPBUF  ((FAR struct arp_iphdr_s *)&dev->d_buf[ETH_HDRLEN])
 
 /****************************************************************************
  * Private Data

--- a/net/devif/ipv4_input.c
+++ b/net/devif/ipv4_input.c
@@ -110,7 +110,7 @@
 
 /* Macros */
 
-#define BUF                  ((FAR struct ipv4_hdr_s *)&dev->d_buf[NET_LL_HDRLEN(dev)])
+#define BUF ((FAR struct ipv4_hdr_s *)&dev->d_buf[NET_LL_HDRLEN(dev)])
 
 /****************************************************************************
  * Private Data

--- a/net/icmp/icmp_recvmsg.c
+++ b/net/icmp/icmp_recvmsg.c
@@ -43,8 +43,8 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-#define IPv4BUF  ((struct ipv4_hdr_s *)&dev->d_buf[NET_LL_HDRLEN(dev)])
-#define ICMPBUF  ((struct icmp_hdr_s *)&dev->d_buf[NET_LL_HDRLEN(dev) + IPv4_HDRLEN])
+#define IPv4BUF  ((FAR struct ipv4_hdr_s *)&dev->d_buf[NET_LL_HDRLEN(dev)])
+#define ICMPBUF  ((FAR struct icmp_hdr_s *)&dev->d_buf[NET_LL_HDRLEN(dev) + IPv4_HDRLEN])
 #define ICMPSIZE ((dev)->d_len - IPv4_HDRLEN)
 
 /****************************************************************************

--- a/net/icmp/icmp_reply.c
+++ b/net/icmp/icmp_reply.c
@@ -51,7 +51,7 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-#define IPv4BUF ((struct ipv4_hdr_s *)&dev->d_buf[NET_LL_HDRLEN(dev)])
+#define IPv4BUF ((FAR struct ipv4_hdr_s *)&dev->d_buf[NET_LL_HDRLEN(dev)])
 
 /* RFC 1812:
  * 4.3.2.3, Original Message Header
@@ -93,7 +93,7 @@ void icmp_reply(FAR struct net_driver_s *dev, int type, int code)
 {
   int ipicmplen = IPv4_HDRLEN + sizeof(struct icmp_hdr_s);
   FAR struct ipv4_hdr_s *ipv4 = IPv4BUF;
-  FAR struct icmp_hdr_s *icmp = (FAR void *)(ipv4 + 1);
+  FAR struct icmp_hdr_s *icmp = (FAR struct icmp_hdr_s *)(ipv4 + 1);
   uint16_t datalen;
 #ifdef CONFIG_NET_BROADCAST
   const in_addr_t bcast = INADDR_BROADCAST;

--- a/net/icmp/icmp_sendmsg.c
+++ b/net/icmp/icmp_sendmsg.c
@@ -60,9 +60,9 @@
  ****************************************************************************/
 
 #define IPv4BUF \
-  ((struct ipv4_hdr_s *)&dev->d_buf[NET_LL_HDRLEN(dev)])
+  ((FAR struct ipv4_hdr_s *)&dev->d_buf[NET_LL_HDRLEN(dev)])
 #define ICMPBUF \
-  ((struct icmp_hdr_s *)&dev->d_buf[NET_LL_HDRLEN(dev) + IPv4_HDRLEN])
+  ((FAR struct icmp_hdr_s *)&dev->d_buf[NET_LL_HDRLEN(dev) + IPv4_HDRLEN])
 
 /****************************************************************************
  * Private Types

--- a/net/icmpv6/icmpv6_advertise.c
+++ b/net/icmpv6/icmpv6_advertise.c
@@ -45,10 +45,10 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-#define IPv6BUF  ((struct ipv6_hdr_s *)&dev->d_buf[NET_LL_HDRLEN(dev)])
+#define IPv6BUF  ((FAR struct ipv6_hdr_s *)&dev->d_buf[NET_LL_HDRLEN(dev)])
 
 #define ICMPv6ADVERTISE \
-  ((struct icmpv6_neighbor_advertise_s *)&dev->d_buf[NET_LL_HDRLEN(dev) + IPv6_HDRLEN])
+  ((FAR struct icmpv6_neighbor_advertise_s *)&dev->d_buf[NET_LL_HDRLEN(dev) + IPv6_HDRLEN])
 
 /****************************************************************************
  * Public Functions

--- a/net/icmpv6/icmpv6_input.c
+++ b/net/icmpv6/icmpv6_input.c
@@ -52,9 +52,9 @@
 #define ICMPv6REPLY      ((FAR struct icmpv6_echo_reply_s *)icmpv6)
 #define ICMPv6SIZE       ((dev)->d_len - iplen)
 
-#define ICMPv6SOLICIT    ((struct icmpv6_neighbor_solicit_s *)icmpv6)
-#define ICMPv6ADVERTISE  ((struct icmpv6_neighbor_advertise_s *)icmpv6)
-#define ICMPv6RADVERTISE ((struct icmpv6_router_advertise_s *)icmpv6)
+#define ICMPv6SOLICIT    ((FAR struct icmpv6_neighbor_solicit_s *)icmpv6)
+#define ICMPv6ADVERTISE  ((FAR struct icmpv6_neighbor_advertise_s *)icmpv6)
+#define ICMPv6RADVERTISE ((FAR struct icmpv6_router_advertise_s *)icmpv6)
 
 #define MLDQUERY         ((FAR struct mld_mcast_listen_query_s *)icmpv6)
 #define MLDREPORT_V1     ((FAR struct mld_mcast_listen_report_v1_s *)icmpv6)

--- a/net/icmpv6/icmpv6_radvertise.c
+++ b/net/icmpv6/icmpv6_radvertise.c
@@ -45,10 +45,10 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-#define IPv6BUF  ((struct ipv6_hdr_s *)&dev->d_buf[NET_LL_HDRLEN(dev)])
+#define IPv6BUF  ((FAR struct ipv6_hdr_s *)&dev->d_buf[NET_LL_HDRLEN(dev)])
 
 #define ICMPv6ADVERTISE \
-  ((struct icmpv6_router_advertise_s *)&dev->d_buf[NET_LL_HDRLEN(dev) + IPv6_HDRLEN])
+  ((FAR struct icmpv6_router_advertise_s *)&dev->d_buf[NET_LL_HDRLEN(dev) + IPv6_HDRLEN])
 
 /****************************************************************************
  * Private Data

--- a/net/icmpv6/icmpv6_recvmsg.c
+++ b/net/icmpv6/icmpv6_recvmsg.c
@@ -44,9 +44,9 @@
  ****************************************************************************/
 
 #define IPv6_BUF \
-  ((struct ipv6_hdr_s *)&dev->d_buf[NET_LL_HDRLEN(dev)])
+  ((FAR struct ipv6_hdr_s *)&dev->d_buf[NET_LL_HDRLEN(dev)])
 #define ICMPv6_BUF \
-  ((struct icmpv6_echo_reply_s *)&dev->d_buf[NET_LL_HDRLEN(dev) + IPv6_HDRLEN])
+  ((FAR struct icmpv6_echo_reply_s *)&dev->d_buf[NET_LL_HDRLEN(dev) + IPv6_HDRLEN])
 #define ICMPv6_SIZE \
   ((dev)->d_len - IPv6_HDRLEN)
 

--- a/net/icmpv6/icmpv6_reply.c
+++ b/net/icmpv6/icmpv6_reply.c
@@ -51,7 +51,7 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-#define IPv6BUF ((struct ipv6_hdr_s *)&dev->d_buf[NET_LL_HDRLEN(dev)])
+#define IPv6BUF ((FAR struct ipv6_hdr_s *)&dev->d_buf[NET_LL_HDRLEN(dev)])
 
 /* The latest drafts declared increase in minimal mtu up to 1280. */
 
@@ -88,7 +88,7 @@ void icmpv6_reply(FAR struct net_driver_s *dev, int type, int code, int data)
 {
   int ipicmplen = IPv6_HDRLEN + sizeof(struct icmpv6_hdr_s);
   FAR struct ipv6_hdr_s *ipv6 = IPv6BUF;
-  FAR struct icmpv6_hdr_s *icmpv6 = (FAR void *)(ipv6 + 1);
+  FAR struct icmpv6_hdr_s *icmpv6 = (FAR struct icmpv6_hdr_s *)(ipv6 + 1);
   uint16_t datalen;
 
   if (net_ipv6addr_cmp(ipv6->destipaddr, g_ipv6_unspecaddr)

--- a/net/icmpv6/icmpv6_rsolicit.c
+++ b/net/icmpv6/icmpv6_rsolicit.c
@@ -43,9 +43,9 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-#define IPv6BUF  ((struct ipv6_hdr_s *)&dev->d_buf[NET_LL_HDRLEN(dev)])
+#define IPv6BUF  ((FAR struct ipv6_hdr_s *)&dev->d_buf[NET_LL_HDRLEN(dev)])
 #define ICMPv6RSOLICIT \
-  ((struct icmpv6_router_solicit_s *)&dev->d_buf[NET_LL_HDRLEN(dev) + IPv6_HDRLEN])
+  ((FAR struct icmpv6_router_solicit_s *)&dev->d_buf[NET_LL_HDRLEN(dev) + IPv6_HDRLEN])
 
 /****************************************************************************
  * Public Functions

--- a/net/icmpv6/icmpv6_sendmsg.c
+++ b/net/icmpv6/icmpv6_sendmsg.c
@@ -59,9 +59,9 @@
  ****************************************************************************/
 
 #define IPv6BUF \
-  ((struct ipv6_hdr_s *)&dev->d_buf[NET_LL_HDRLEN(dev)])
+  ((FAR struct ipv6_hdr_s *)&dev->d_buf[NET_LL_HDRLEN(dev)])
 #define ICMPv6BUF \
-  ((struct icmpv6_echo_request_s *)&dev->d_buf[NET_LL_HDRLEN(dev) + IPv6_HDRLEN])
+  ((FAR struct icmpv6_echo_request_s *)&dev->d_buf[NET_LL_HDRLEN(dev) + IPv6_HDRLEN])
 
 /****************************************************************************
  * Private Types

--- a/net/icmpv6/icmpv6_solicit.c
+++ b/net/icmpv6/icmpv6_solicit.c
@@ -43,9 +43,9 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-#define IPv6BUF  ((struct ipv6_hdr_s *)&dev->d_buf[NET_LL_HDRLEN(dev)])
+#define IPv6BUF  ((FAR struct ipv6_hdr_s *)&dev->d_buf[NET_LL_HDRLEN(dev)])
 #define ICMPv6SOLICIT \
-  ((struct icmpv6_neighbor_solicit_s *)&dev->d_buf[NET_LL_HDRLEN(dev) + IPv6_HDRLEN])
+  ((FAR struct icmpv6_neighbor_solicit_s *)&dev->d_buf[NET_LL_HDRLEN(dev) + IPv6_HDRLEN])
 
 /****************************************************************************
  * Private Data

--- a/net/sixlowpan/sixlowpan_tcpsend.c
+++ b/net/sixlowpan/sixlowpan_tcpsend.c
@@ -52,7 +52,7 @@
 
 /* Buffer access helpers */
 
-#define TCPBUF(dev)   ((FAR struct tcp_hdr_s *)(&(dev)->d_buf[IPv6_HDRLEN]))
+#define TCPBUF(dev) ((FAR struct tcp_hdr_s *)(&(dev)->d_buf[IPv6_HDRLEN]))
 
 /****************************************************************************
  * Pre-processor Definitions

--- a/net/tcp/tcp_conn.c
+++ b/net/tcp/tcp_conn.c
@@ -72,8 +72,8 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-#define IPv4BUF ((struct ipv4_hdr_s *)&dev->d_buf[NET_LL_HDRLEN(dev)])
-#define IPv6BUF ((struct ipv6_hdr_s *)&dev->d_buf[NET_LL_HDRLEN(dev)])
+#define IPv4BUF ((FAR struct ipv4_hdr_s *)&dev->d_buf[NET_LL_HDRLEN(dev)])
+#define IPv6BUF ((FAR struct ipv6_hdr_s *)&dev->d_buf[NET_LL_HDRLEN(dev)])
 
 /****************************************************************************
  * Private Data

--- a/net/tcp/tcp_recvfrom.c
+++ b/net/tcp/tcp_recvfrom.c
@@ -46,11 +46,11 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-#define IPv4BUF    ((struct ipv4_hdr_s *)&dev->d_buf[NET_LL_HDRLEN(dev)])
-#define IPv6BUF    ((struct ipv6_hdr_s *)&dev->d_buf[NET_LL_HDRLEN(dev)])
+#define IPv4BUF    ((FAR struct ipv4_hdr_s *)&dev->d_buf[NET_LL_HDRLEN(dev)])
+#define IPv6BUF    ((FAR struct ipv6_hdr_s *)&dev->d_buf[NET_LL_HDRLEN(dev)])
 
-#define TCPIPv4BUF ((struct tcp_hdr_s *)&dev->d_buf[NET_LL_HDRLEN(dev) + IPv4_HDRLEN])
-#define TCPIPv6BUF ((struct tcp_hdr_s *)&dev->d_buf[NET_LL_HDRLEN(dev) + IPv6_HDRLEN])
+#define TCPIPv4BUF ((FAR struct tcp_hdr_s *)&dev->d_buf[NET_LL_HDRLEN(dev) + IPv4_HDRLEN])
+#define TCPIPv6BUF ((FAR struct tcp_hdr_s *)&dev->d_buf[NET_LL_HDRLEN(dev) + IPv6_HDRLEN])
 
 /****************************************************************************
  * Private Types

--- a/net/tcp/tcp_send.c
+++ b/net/tcp/tcp_send.c
@@ -66,11 +66,11 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-#define IPv4BUF    ((struct ipv4_hdr_s *)&dev->d_buf[NET_LL_HDRLEN(dev)])
-#define IPv6BUF    ((struct ipv6_hdr_s *)&dev->d_buf[NET_LL_HDRLEN(dev)])
+#define IPv4BUF    ((FAR struct ipv4_hdr_s *)&dev->d_buf[NET_LL_HDRLEN(dev)])
+#define IPv6BUF    ((FAR struct ipv6_hdr_s *)&dev->d_buf[NET_LL_HDRLEN(dev)])
 
-#define TCPIPv4BUF ((struct tcp_hdr_s *)&dev->d_buf[NET_LL_HDRLEN(dev) + IPv4_HDRLEN])
-#define TCPIPv6BUF ((struct tcp_hdr_s *)&dev->d_buf[NET_LL_HDRLEN(dev) + IPv6_HDRLEN])
+#define TCPIPv4BUF ((FAR struct tcp_hdr_s *)&dev->d_buf[NET_LL_HDRLEN(dev) + IPv4_HDRLEN])
+#define TCPIPv6BUF ((FAR struct tcp_hdr_s *)&dev->d_buf[NET_LL_HDRLEN(dev) + IPv6_HDRLEN])
 
 /****************************************************************************
  * Private Functions
@@ -649,7 +649,7 @@ uint16_t tcp_rx_mss(FAR struct net_driver_s *dev)
 void tcp_synack(FAR struct net_driver_s *dev, FAR struct tcp_conn_s *conn,
                 uint8_t ack)
 {
-  struct tcp_hdr_s *tcp;
+  FAR struct tcp_hdr_s *tcp;
   uint16_t tcp_mss;
   int16_t optlen = 0;
 

--- a/net/tcp/tcp_send_buffered.c
+++ b/net/tcp/tcp_send_buffered.c
@@ -77,8 +77,8 @@
 #  define NEED_IPDOMAIN_SUPPORT 1
 #endif
 
-#define TCPIPv4BUF ((struct tcp_hdr_s *)&dev->d_buf[NET_LL_HDRLEN(dev) + IPv4_HDRLEN])
-#define TCPIPv6BUF ((struct tcp_hdr_s *)&dev->d_buf[NET_LL_HDRLEN(dev) + IPv6_HDRLEN])
+#define TCPIPv4BUF ((FAR struct tcp_hdr_s *)&dev->d_buf[NET_LL_HDRLEN(dev) + IPv4_HDRLEN])
+#define TCPIPv6BUF ((FAR struct tcp_hdr_s *)&dev->d_buf[NET_LL_HDRLEN(dev) + IPv6_HDRLEN])
 
 /* Debug */
 

--- a/net/tcp/tcp_send_unbuffered.c
+++ b/net/tcp/tcp_send_unbuffered.c
@@ -67,8 +67,8 @@
 #  define NEED_IPDOMAIN_SUPPORT 1
 #endif
 
-#define TCPIPv4BUF ((struct tcp_hdr_s *)&dev->d_buf[NET_LL_HDRLEN(dev) + IPv4_HDRLEN])
-#define TCPIPv6BUF ((struct tcp_hdr_s *)&dev->d_buf[NET_LL_HDRLEN(dev) + IPv6_HDRLEN])
+#define TCPIPv4BUF ((FAR struct tcp_hdr_s *)&dev->d_buf[NET_LL_HDRLEN(dev) + IPv4_HDRLEN])
+#define TCPIPv6BUF ((FAR struct tcp_hdr_s *)&dev->d_buf[NET_LL_HDRLEN(dev) + IPv6_HDRLEN])
 
 /****************************************************************************
  * Private Types

--- a/net/tcp/tcp_sendfile.c
+++ b/net/tcp/tcp_sendfile.c
@@ -62,8 +62,8 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-#define TCPIPv4BUF ((struct tcp_hdr_s *)&dev->d_buf[NET_LL_HDRLEN(dev) + IPv4_HDRLEN])
-#define TCPIPv6BUF ((struct tcp_hdr_s *)&dev->d_buf[NET_LL_HDRLEN(dev) + IPv6_HDRLEN])
+#define TCPIPv4BUF ((FAR struct tcp_hdr_s *)&dev->d_buf[NET_LL_HDRLEN(dev) + IPv4_HDRLEN])
+#define TCPIPv6BUF ((FAR struct tcp_hdr_s *)&dev->d_buf[NET_LL_HDRLEN(dev) + IPv6_HDRLEN])
 
 /****************************************************************************
  * Private Types

--- a/net/udp/udp_conn.c
+++ b/net/udp/udp_conn.c
@@ -72,8 +72,8 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-#define IPv4BUF ((struct ipv4_hdr_s *)&dev->d_buf[NET_LL_HDRLEN(dev)])
-#define IPv6BUF ((struct ipv6_hdr_s *)&dev->d_buf[NET_LL_HDRLEN(dev)])
+#define IPv4BUF ((FAR struct ipv4_hdr_s *)&dev->d_buf[NET_LL_HDRLEN(dev)])
+#define IPv6BUF ((FAR struct ipv6_hdr_s *)&dev->d_buf[NET_LL_HDRLEN(dev)])
 
 /****************************************************************************
  * Private Data

--- a/net/udp/udp_recvfrom.c
+++ b/net/udp/udp_recvfrom.c
@@ -46,11 +46,11 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-#define IPv4BUF    ((struct ipv4_hdr_s *)&dev->d_buf[NET_LL_HDRLEN(dev)])
-#define IPv6BUF    ((struct ipv6_hdr_s *)&dev->d_buf[NET_LL_HDRLEN(dev)])
+#define IPv4BUF    ((FAR struct ipv4_hdr_s *)&dev->d_buf[NET_LL_HDRLEN(dev)])
+#define IPv6BUF    ((FAR struct ipv6_hdr_s *)&dev->d_buf[NET_LL_HDRLEN(dev)])
 
-#define UDPIPv4BUF ((struct udp_hdr_s *)&dev->d_buf[NET_LL_HDRLEN(dev) + IPv4_HDRLEN])
-#define UDPIPv6BUF ((struct udp_hdr_s *)&dev->d_buf[NET_LL_HDRLEN(dev) + IPv6_HDRLEN])
+#define UDPIPv4BUF ((FAR struct udp_hdr_s *)&dev->d_buf[NET_LL_HDRLEN(dev) + IPv4_HDRLEN])
+#define UDPIPv6BUF ((FAR struct udp_hdr_s *)&dev->d_buf[NET_LL_HDRLEN(dev) + IPv6_HDRLEN])
 
 /****************************************************************************
  * Private Types

--- a/net/udp/udp_send.c
+++ b/net/udp/udp_send.c
@@ -66,14 +66,14 @@
  ****************************************************************************/
 
 #define IPv4BUF \
-  ((struct ipv4_hdr_s *)&dev->d_buf[NET_LL_HDRLEN(dev)])
+  ((FAR struct ipv4_hdr_s *)&dev->d_buf[NET_LL_HDRLEN(dev)])
 #define IPv6BUF \
-  ((struct ipv6_hdr_s *)&dev->d_buf[NET_LL_HDRLEN(dev)])
+  ((FAR struct ipv6_hdr_s *)&dev->d_buf[NET_LL_HDRLEN(dev)])
 
 #define UDPIPv4BUF \
-  ((struct udp_hdr_s *)&dev->d_buf[NET_LL_HDRLEN(dev) + IPv4_HDRLEN])
+  ((FAR struct udp_hdr_s *)&dev->d_buf[NET_LL_HDRLEN(dev) + IPv4_HDRLEN])
 #define UDPIPv6BUF \
-  ((struct udp_hdr_s *)&dev->d_buf[NET_LL_HDRLEN(dev) + IPv6_HDRLEN])
+  ((FAR struct udp_hdr_s *)&dev->d_buf[NET_LL_HDRLEN(dev) + IPv6_HDRLEN])
 
 /****************************************************************************
  * Public Functions

--- a/net/udp/udp_sendto_buffered.c
+++ b/net/udp/udp_sendto_buffered.c
@@ -74,8 +74,8 @@
 #  define NEED_IPDOMAIN_SUPPORT 1
 #endif
 
-#define UDPIPv4BUF ((struct udp_hdr_s *)&dev->d_buf[NET_LL_HDRLEN(dev) + IPv4_HDRLEN])
-#define UDPIPv6BUF ((struct udp_hdr_s *)&dev->d_buf[NET_LL_HDRLEN(dev) + IPv6_HDRLEN])
+#define UDPIPv4BUF ((FAR struct udp_hdr_s *)&dev->d_buf[NET_LL_HDRLEN(dev) + IPv4_HDRLEN])
+#define UDPIPv6BUF ((FAR struct udp_hdr_s *)&dev->d_buf[NET_LL_HDRLEN(dev) + IPv6_HDRLEN])
 
 /* Debug */
 

--- a/net/utils/net_ipchksum.c
+++ b/net/utils/net_ipchksum.c
@@ -37,8 +37,8 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-#define IPv4BUF  ((struct ipv4_hdr_s *)&dev->d_buf[NET_LL_HDRLEN(dev)])
-#define IPv6BUF  ((struct ipv6_hdr_s *)&dev->d_buf[NET_LL_HDRLEN(dev)])
+#define IPv4BUF ((FAR struct ipv4_hdr_s *)&dev->d_buf[NET_LL_HDRLEN(dev)])
+#define IPv6BUF ((FAR struct ipv6_hdr_s *)&dev->d_buf[NET_LL_HDRLEN(dev)])
 
 /****************************************************************************
  * Public Functions

--- a/sched/init/nx_start.c
+++ b/sched/init/nx_start.c
@@ -808,7 +808,7 @@ void nx_start(void)
             {
 #if CONFIG_TASK_NAME_SIZE > 0
               _alert("Stack check failed, pid %d, name %s\n",
-                      tcb->pid, tcb->name);
+                     tcb->pid, tcb->name);
 #else
               _alert("Stack check failed, pid %d\n", tcb->pid);
 #endif


### PR DESCRIPTION
## Summary
In some cases the `FAR` keyword is missing when working with network buffers and using memory mapped types. Restore consistency

## Impact
No functional changes

## Testing
Pass CI
