### PR TITLE
Add usbdev serial use boardid

### DIFF
--- a/boards/Kconfig
+++ b/boards/Kconfig
@@ -3563,3 +3563,7 @@ config BOARDCTL_IOCTL
 		Architecture specific logic must provide board_ioctl() interface.
 
 endif # BOARDCTL
+
+config BOARD_USBDEV_SERIALSTR
+	bool
+	default n

--- a/boards/arm/cxd56xx/common/src/Make.defs
+++ b/boards/arm/cxd56xx/common/src/Make.defs
@@ -164,6 +164,10 @@ ifeq ($(CONFIG_CXD56_SPISD),y)
   CSRCS += cxd56_spisd.c
 endif
 
+ifeq ($(CONFIG_BOARD_USBDEV_SERIALSTR),y)
+  CSRCS += cxd56_usbdevserialstr.c
+endif
+
 DEPPATH += --dep-path src
 VPATH += :src
 CFLAGS += $(shell $(INCDIR) "$(CC)" $(TOPDIR)$(DELIM)arch$(DELIM)$(CONFIG_ARCH)$(DELIM)src$(DELIM)board$(DELIM)src)

--- a/boards/arm/cxd56xx/common/src/cxd56_usbdevserialstr.c
+++ b/boards/arm/cxd56xx/common/src/cxd56_usbdevserialstr.c
@@ -1,0 +1,52 @@
+/****************************************************************************
+ * boards/arm/cxd56xx/common/src/cxd56_usbdevserialstr.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <stdio.h>
+
+#include "cxd56_uid.h"
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+#ifdef CONFIG_BOARD_USBDEV_SERIALSTR
+
+static char g_serialstr[CONFIG_BOARDCTL_UNIQUEID_SIZE * 2 + 1];
+
+FAR const char *board_usbdev_serialstr(void)
+{
+  uint8_t uid[CONFIG_BOARDCTL_UNIQUEID_SIZE];
+
+  cxd56_get_uniqueid(uid);
+
+  snprintf(g_serialstr, sizeof(g_serialstr),
+           "%02X%02X%02X%02X%02X",
+           uid[0], uid[1], uid[2], uid[3], uid[4]);
+
+  return g_serialstr;
+}
+
+#endif

--- a/drivers/usbdev/Kconfig
+++ b/drivers/usbdev/Kconfig
@@ -227,9 +227,17 @@ config COMPOSITE_PRODUCTSTR
 	---help---
 		The product ID code/string
 
+config COMPOSITE_BOARD_SERIALSTR
+	bool "Enable board unique ID to composite serial string"
+	default n
+	select BOARD_USBDEV_SERIALSTR
+	---help---
+		Use board unique serial number to iSerialNumber in the device descriptor.
+
 config COMPOSITE_SERIALSTR
 	string "Composite serial string"
 	default "001"
+	depends on !COMPOSITE_BOARD_SERIALSTR
 	---help---
 		Device serial number string
 
@@ -351,6 +359,13 @@ config PL2303_PRODUCTID
 config PL2303_VENDORSTR
 	string "Vendor string"
 	default "NuttX"
+
+config PL2303_BOARD_SERIALSTR
+	bool "Enable board unique ID to PL2303 serial string"
+	default n
+	select BOARD_USBDEV_SERIALSTR
+	---help---
+		Use board unique serial number to iSerialNumber in the device descriptor.
 
 config PL2303_PRODUCTSTR
 	string "Product string"
@@ -565,6 +580,13 @@ config CDCACM_PRODUCTSTR
 	string "Product string"
 	default "CDC/ACM Serial"
 
+config CDCACM_BOARD_SERIALSTR
+	bool "Enable board unique ID to CDC/ACM serial string"
+	default n
+	select BOARD_USBDEV_SERIALSTR
+	---help---
+		Use board unique serial number to iSerialNumber in the device descriptor.
+
 endif # !CDCACM_COMPOSITE
 endif # CDCACM
 
@@ -675,9 +697,17 @@ config USBADB_PRODUCTSTR
 	string "Product string"
 	default "Debug Bridge"
 
+config USBADB_BOARD_SERIALSTR
+	bool "Enable board unique ID to USBADB serial string"
+	default n
+        select BOARD_USBDEV_SERIALSTR
+	---help---
+		Use board unique serial number to iSerialNumber in the device descriptor.
+
 config USBADB_SERIALSTR
 	string "Serial string"
 	default "1234"
+	depends on !USBADB_BOARD_SERIALSTR
 
 endif # !USBADB_COMPOSITE
 
@@ -824,6 +854,13 @@ config USBMSC_PRODUCTSTR
 	string "Mass storage product string"
 	default "Mass Storage"
 
+config USBMSC_BOARD_SERIALSTR
+	bool "Enable board unique ID to mass storage serial string"
+	default n
+        select BOARD_USBDEV_SERIALSTR
+	---help---
+		Use board unique serial number to iSerialNumber in the device descriptor.
+
 endif # !USBMSC_COMPOSITE
 
 config USBMSC_VERSIONNO
@@ -921,9 +958,17 @@ config RNDIS_PRODUCTSTR
 	string "RNDIS product string"
 	default "RNDIS gadget"
 
+config RNDIS_BOARD_SERIALSTR
+	bool "Enable board unique ID to RNDIS serial string"
+	default n
+	select BOARD_USBDEV_SERIALSTR
+	---help---
+		Use board unique serial number to iSerialNumber in the device descriptor.
+
 config RNDIS_SERIALSTR
 	string "RNDIS serial string"
 	default "1234"
+	depends on !RNDIS_BOARD_SERIALSTR
 
 config RNDIS_VERSIONNO
 	hex "RNDIS Version Number"
@@ -1136,6 +1181,13 @@ config CDCECM_VENDORSTR
 config CDCECM_PRODUCTSTR
 	string "Product string"
 	default "CDC/ECM Ethernet"
+
+config CDCECM_BOARD_SERIALSTR
+	bool "Enable board unique ID to CDC/ECM serial string"
+	default n
+	select BOARD_USBDEV_SERIALSTR
+	---help---
+		Use board unique serial number to iSerialNumber in the device descriptor.
 
 endif # !CDCECM_COMPOSITE
 endif # CDCECM

--- a/drivers/usbdev/adb.c
+++ b/drivers/usbdev/adb.c
@@ -40,6 +40,10 @@
 #include <fcntl.h>
 #include <poll.h>
 
+#ifdef CONFIG_USBADB_BOARD_SERIALSTR
+#include <nuttx/board.h>
+#endif
+
 #ifdef CONFIG_USBADB_COMPOSITE
 #  include <nuttx/usb/composite.h>
 #  include "composite.h"
@@ -890,7 +894,11 @@ static int usbclass_mkstrdesc(uint8_t id, FAR struct usb_strdesc_s *strdesc)
       break;
 
     case USBADB_SERIALSTRID:
+#ifdef CONFIG_USBADB_BOARD_SERIALSTR
+      str = board_usbdev_serialstr();
+#else
       str = CONFIG_USBADB_SERIALSTR;
+#endif
       break;
 
     case USBADB_CONFIGSTRID:

--- a/drivers/usbdev/cdcacm_desc.c
+++ b/drivers/usbdev/cdcacm_desc.c
@@ -36,6 +36,10 @@
 #include <nuttx/usb/cdcacm.h>
 #include <nuttx/usb/usbdev_trace.h>
 
+#ifdef CONFIG_CDCACM_BOARD_SERIALSTR
+#include <nuttx/board.h>
+#endif
+
 #include "cdcacm.h"
 
 /****************************************************************************
@@ -144,7 +148,11 @@ int cdcacm_mkstrdesc(uint8_t id, struct usb_strdesc_s *strdesc)
       break;
 
     case CDCACM_SERIALSTRID:
+#ifdef CONFIG_CDCACM_BOARD_SERIALSTR
+      str = board_usbdev_serialstr();
+#else
       str = CONFIG_CDCACM_SERIALSTR;
+#endif
       break;
 
     case CDCACM_CONFIGSTRID:

--- a/drivers/usbdev/cdcecm.c
+++ b/drivers/usbdev/cdcecm.c
@@ -56,6 +56,10 @@
 #  include <nuttx/net/pkt.h>
 #endif
 
+#ifdef CONFIG_CDCECM_BOARD_SERIALSTR
+#include <nuttx/board.h>
+#endif
+
 #include "cdcecm.h"
 
 #ifdef CONFIG_NET_CDCECM
@@ -1389,7 +1393,11 @@ static int cdcecm_mkstrdesc(uint8_t id, FAR struct usb_strdesc_s *strdesc)
       break;
 
     case CDCECM_SERIALSTRID:
+#ifdef CONFIG_CDCECM_BOARD_SERIALSTR
+      str = board_usbdev_serialstr();
+#else
       str = "0";
+#endif
       break;
 
     case CDCECM_CONFIGSTRID:

--- a/drivers/usbdev/composite.c
+++ b/drivers/usbdev/composite.c
@@ -118,7 +118,9 @@ static const struct usbdevclass_driverops_s g_driverops =
 
 const char g_compvendorstr[]  = CONFIG_COMPOSITE_VENDORSTR;
 const char g_compproductstr[] = CONFIG_COMPOSITE_PRODUCTSTR;
+#ifndef CONFIG_COMPOSITE_BOARD_SERIALSTR
 const char g_compserialstr[]  = CONFIG_COMPOSITE_SERIALSTR;
+#endif
 
 /****************************************************************************
  * Private Functions

--- a/drivers/usbdev/composite_desc.c
+++ b/drivers/usbdev/composite_desc.c
@@ -32,6 +32,10 @@
 #include <assert.h>
 #include <debug.h>
 
+#ifdef CONFIG_COMPOSITE_BOARD_SERIALSTR
+#include <nuttx/board.h>
+#endif
+
 #include <nuttx/usb/usbdev_trace.h>
 
 #include "composite.h"
@@ -143,7 +147,11 @@ int composite_mkstrdesc(uint8_t id, struct usb_strdesc_s *strdesc)
       break;
 
     case COMPOSITE_SERIALSTRID:
+#ifdef CONFIG_COMPOSITE_BOARD_SERIALSTR
+      str = board_usbdev_serialstr();
+#else
       str = g_compserialstr;
+#endif
       break;
 
     case COMPOSITE_CONFIGSTRID:

--- a/drivers/usbdev/pl2303.c
+++ b/drivers/usbdev/pl2303.c
@@ -46,6 +46,10 @@
 #include <nuttx/usb/usbdev.h>
 #include <nuttx/usb/usbdev_trace.h>
 
+#ifdef CONFIG_PL2303_BOARD_SERIALSTR
+#include <nuttx/board.h>
+#endif
+
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
@@ -853,7 +857,11 @@ static int usbclass_mkstrdesc(uint8_t id, struct usb_strdesc_s *strdesc)
       break;
 
     case PL2303_SERIALSTRID:
+#ifdef CONFIG_PL2303_BOARD_SERIALSTR
+      str = board_usbdev_serialstr();
+#else
       str = CONFIG_PL2303_SERIALSTR;
+#endif
       break;
 
     case PL2303_CONFIGSTRID:

--- a/drivers/usbdev/rndis.c
+++ b/drivers/usbdev/rndis.c
@@ -49,6 +49,10 @@
 #include <nuttx/wdog.h>
 #include <nuttx/wqueue.h>
 
+#ifdef CONFIG_RNDIS_BOARD_SERIALSTR
+#include <nuttx/board.h>
+#endif
+
 #include "rndis_std.h"
 
 /****************************************************************************
@@ -1921,7 +1925,11 @@ static int usbclass_mkstrdesc(uint8_t id, FAR struct usb_strdesc_s *strdesc)
         break;
 
       case RNDIS_SERIALSTRID:
+#ifdef CONFIG_RNDIS_BOARD_SERIALSTR
+        str = board_usbdev_serialstr();
+#else
         str = CONFIG_RNDIS_SERIALSTR;
+#endif
         break;
 #endif
 

--- a/drivers/usbdev/usbmsc.h
+++ b/drivers/usbdev/usbmsc.h
@@ -466,7 +466,9 @@ extern "C"
 #ifndef CONFIG_USBMSC_COMPOSITE
 EXTERN const char g_mscvendorstr[];
 EXTERN const char g_mscproductstr[];
+#ifndef CONFIG_USBMSC_BOARD_SERIALSTR
 EXTERN const char g_mscserialstr[];
+#endif
 
 /* If we are using a composite device, then vendor/product/serial number
  * strings are provided by the composite device logic.
@@ -475,11 +477,15 @@ EXTERN const char g_mscserialstr[];
 #else
 EXTERN const char g_compvendorstr[];
 EXTERN const char g_compproductstr[];
+#ifndef CONFIG_COMPOSITE_BOARD_SERIALSTR
 EXTERN const char g_compserialstr[];
+#endif
 
 #define g_mscvendorstr  g_compvendorstr
 #define g_mscproductstr g_compproductstr
+#ifndef CONFIG_USBMSC_BOARD_SERIALSTR
 #define g_mscserialstr  g_compserialstr
+#endif
 #endif
 
 /* Used to hand-off the state structure when the SCSI worker thread is

--- a/drivers/usbdev/usbmsc_desc.c
+++ b/drivers/usbdev/usbmsc_desc.c
@@ -33,6 +33,10 @@
 #include <nuttx/usb/usb.h>
 #include <nuttx/usb/usbdev_trace.h>
 
+#ifdef CONFIG_USBMSC_BOARD_SERIALSTR
+#include <nuttx/board.h>
+#endif
+
 #include "usbmsc.h"
 
 /****************************************************************************
@@ -103,7 +107,9 @@ static const struct usb_qualdesc_s g_qualdesc =
 #ifndef CONFIG_USBMSC_COMPOSITE
 const char g_mscvendorstr[]  = CONFIG_USBMSC_VENDORSTR;
 const char g_mscproductstr[] = CONFIG_USBMSC_PRODUCTSTR;
+#ifndef CONFIG_USBMSC_BOARD_SERIALSTR
 const char g_mscserialstr[]  = CONFIG_USBMSC_SERIALSTR;
+#endif
 #endif
 
 /****************************************************************************
@@ -152,7 +158,11 @@ int usbmsc_mkstrdesc(uint8_t id, struct usb_strdesc_s *strdesc)
       break;
 
     case USBMSC_SERIALSTRID:
+#ifdef CONFIG_USBMSC_BOARD_SERIALSTR
+      str = board_usbdev_serialstr();
+#else
       str = g_mscserialstr;
+#endif
       break;
 #endif
 

--- a/drivers/usbdev/usbmsc_scsi.c
+++ b/drivers/usbdev/usbmsc_scsi.c
@@ -173,6 +173,8 @@ static int    usbmsc_cmdstatusstate(FAR struct usbmsc_dev_s *priv);
  * Private Data
  ****************************************************************************/
 
+static const char *g_productrevision = "0101";
+
 /****************************************************************************
  * Private Functions
  ****************************************************************************/
@@ -703,13 +705,13 @@ static inline int usbmsc_cmdinquiry(FAR struct usbmsc_dev_s *priv,
 
           memcpy(response->productid, g_mscproductstr, len);
 
-          len = strlen(g_mscserialstr);
+          len = strlen(g_productrevision);
           if (len > 4)
             {
               len = 4;
             }
 
-          memcpy(response->revision, g_mscserialstr, len);
+          memcpy(response->revision, g_productrevision, len);
         }
     }
 

--- a/include/nuttx/board.h
+++ b/include/nuttx/board.h
@@ -430,6 +430,23 @@ FAR void *board_composite_connect(int port, int configid);
 #endif
 
 /****************************************************************************
+ * Name:  board_usbdev_serialstr
+ *
+ * Description:
+ *   Use board unique serial number string to iSerialNumber field in the
+ *   device descriptor. This is for determining the board when multiple
+ *   boards on the same host.
+ *
+ * Returned Value:
+ *   The board unique serial number string.
+ *
+ ****************************************************************************/
+
+#if defined(CONFIG_BOARD_USBDEV_SERIALSTR)
+FAR const char *board_usbdev_serialstr(void);
+#endif
+
+/****************************************************************************
  * Name: board_graphics_setup
  *
  * Description:


### PR DESCRIPTION
## Summary

Add use board unique ID as a USB device serial number support.

## Impact

USB devices (MSC, Composite, PL2303, CDCACM, CDCECM, RNDIS, ADB)

## Testing

Runs on Sony Spresense board with USBMSC configuration, and confirmed that board unique ID is set at iSerial field from connected PC.