### PR TITLE
fs/smartfs: Fix file size corruption when opening with truncate mode

### DIFF
--- a/fs/smartfs/smartfs_smart.c
+++ b/fs/smartfs/smartfs_smart.c
@@ -318,11 +318,10 @@ static int smartfs_open(FAR struct file *filep, const char *relpath,
 
   /* When using sector buffering, current sector with its header should
    * always be present in sf->buffer. Otherwise data corruption may arise
-   * when writing. However, this does not apply when overwriting without
-   * append mode.
+   * when writing.
    */
 
-  if ((sf->currsector != SMARTFS_ERASEDSTATE_16BIT) && (oflags & O_APPEND))
+  if (sf->currsector != SMARTFS_ERASEDSTATE_16BIT)
     {
       readwrite.logsector = sf->currsector;
       readwrite.offset    = 0;

--- a/fs/smartfs/smartfs_utils.c
+++ b/fs/smartfs/smartfs_utils.c
@@ -1765,8 +1765,8 @@ int smartfs_shrinkfile(FAR struct smartfs_mountpt_s *fs,
               remaining = 0;
             }
         }
-      else
 #endif
+
       /* Are we retaining the sector it its entirety? */
 
       if (remaining >= available)


### PR DESCRIPTION
## Summary
If a existing file is opened with truncate mode e.g. fopen(file, "w+"),
the file size will be incorrect after writing any data to the file.
Before writing to the first sector, the reading is performed again.
As a result, it makes an invalid file size. When a sector buffer is used,
it must also write to the first sector.

The previous commit is wrong, so it is reverted, and a new commit is added.

## Impact
SmartFS when CONFIG_SMARTFS_USE_SECTOR_BUFFER is enabled

## Testing
Use spresense:usbnsh defconfig which enables SmartFS and CONFIG_SMARTFS_USE_SECTOR_BUFFER.
Test that appending to an existing file that is less than one sector will not break the file.
