### PR TITLE
add touchscreen uinput driver

### DIFF
--- a/boards/sim/sim/sim/src/sim_bringup.c
+++ b/boards/sim/sim/sim/src/sim_bringup.c
@@ -36,6 +36,7 @@
 #include <nuttx/fs/nxffs.h>
 #include <nuttx/fs/rpmsgfs.h>
 #include <nuttx/i2c/i2c_master.h>
+#include <nuttx/input/uinput.h>
 #include <nuttx/spi/spi_transfer.h>
 #include <nuttx/rc/lirc_dev.h>
 #include <nuttx/rc/dummy.h>
@@ -320,6 +321,16 @@ int sim_bringup(void)
   if (ret < 0)
     {
       syslog(LOG_ERR, "ERROR: sim_tsc_initialize failed: %d\n", ret);
+    }
+#endif
+
+#ifdef CONFIG_INPUT_UINPUT
+  /* Initialize the touchscreen uinput */
+
+  ret = uinput_touch_initialize("utouch", 1, 4);
+  if (ret < 0)
+    {
+      syslog(LOG_ERR, "ERROR: uinput_touch_initialize failed: %d\n", ret);
     }
 #endif
 

--- a/drivers/input/Kconfig
+++ b/drivers/input/Kconfig
@@ -45,6 +45,13 @@ config INPUT_TOUCHSCREEN_NPOLLWAITERS
 
 endif # INPUT_TOUCHSCREEN
 
+config INPUT_UINPUT
+	bool "Enable uinput"
+	select INPUT_TOUCHSCREEN
+	default n
+	---help---
+		Enable support virtual input device driver
+
 config INPUT_MAX11802
 	bool "MAX11802 touchscreen controller"
 	default n

--- a/drivers/input/Make.defs
+++ b/drivers/input/Make.defs
@@ -32,6 +32,10 @@ ifeq ($(CONFIG_INPUT_TSC2007),y)
   CSRCS += tsc2007.c
 endif
 
+ifeq ($(CONFIG_INPUT_UINPUT),y)
+  CSRCS += uinput.c
+endif
+
 ifeq ($(CONFIG_INPUT_FT5X06),y)
   CSRCS += ft5x06.c
 endif

--- a/drivers/input/button_upper.c
+++ b/drivers/input/button_upper.c
@@ -129,6 +129,11 @@ static int     btn_ioctl(FAR struct file *filep, int cmd,
 static int     btn_poll(FAR struct file *filep, FAR struct pollfd *fds,
                         bool setup);
 
+#ifdef CONFIG_INPUT_UINPUT
+static ssize_t btn_write(FAR struct file *filep, FAR const char *buffer,
+                         size_t buflen);
+#endif
+
 /****************************************************************************
  * Private Data
  ****************************************************************************/
@@ -138,7 +143,11 @@ static const struct file_operations btn_fops =
   btn_open,  /* open */
   btn_close, /* close */
   btn_read,  /* read */
+#ifdef CONFIG_INPUT_UINPUT
+  btn_write, /* write */
+#else
   NULL,      /* write */
+#endif
   NULL,      /* seek */
   btn_ioctl, /* ioctl */
   btn_poll   /* poll */
@@ -508,7 +517,7 @@ static ssize_t btn_read(FAR struct file *filep, FAR char *buffer,
 
   if (len < sizeof(btn_buttonset_t))
     {
-      ierr("ERROR: buffer too small: %lu\n", (unsigned long)len);
+      ierr("ERROR: buffer too small: %zu\n", len);
       return -EINVAL;
     }
 
@@ -530,6 +539,64 @@ static ssize_t btn_read(FAR struct file *filep, FAR char *buffer,
   btn_givesem(&priv->bu_exclsem);
   return (ssize_t)sizeof(btn_buttonset_t);
 }
+
+/****************************************************************************
+ * Name: btn_write
+ ****************************************************************************/
+
+#ifdef CONFIG_INPUT_UINPUT
+
+static ssize_t btn_write(FAR struct file *filep, FAR const char *buffer,
+                         size_t buflen)
+{
+  FAR struct inode *inode;
+  FAR struct btn_upperhalf_s *priv;
+  FAR const struct btn_lowerhalf_s *lower;
+  int ret;
+
+  DEBUGASSERT(filep && filep->f_inode);
+  inode = filep->f_inode;
+  DEBUGASSERT(inode->i_private);
+  priv  = (FAR struct btn_upperhalf_s *)inode->i_private;
+
+  /* Make sure that the buffer is sufficiently large to hold at least one
+   * complete sample.
+   *
+   * REVISIT:  Should also check buffer alignment.
+   */
+
+  if (buflen < sizeof(btn_buttonset_t))
+    {
+      ierr("ERROR: buffer too small: %zu\n", buflen);
+      return -EINVAL;
+    }
+
+  /* Get exclusive access to the driver structure */
+
+  ret = btn_takesem(&priv->bu_exclsem);
+  if (ret < 0)
+    {
+      ierr("ERROR: btn_takesem failed: %d\n", ret);
+      return ret;
+    }
+
+  /* Write the current state of the buttons */
+
+  lower = priv->bu_lower;
+  DEBUGASSERT(lower);
+  if (lower->bl_write)
+    {
+      ret = lower->bl_write(lower, buffer, buflen);
+    }
+  else
+    {
+      ret = -ENOSYS;
+    }
+
+  btn_givesem(&priv->bu_exclsem);
+  return (ssize_t)ret;
+}
+#endif
 
 /****************************************************************************
  * Name: btn_ioctl

--- a/drivers/input/uinput.c
+++ b/drivers/input/uinput.c
@@ -1,0 +1,108 @@
+/****************************************************************************
+ * drivers/input/uinput.c
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+#include <sys/types.h>
+
+#include <assert.h>
+#include <debug.h>
+#include <errno.h>
+#include <stdio.h>
+
+#include <nuttx/kmalloc.h>
+#include <nuttx/input/touchscreen.h>
+#include <nuttx/input/uinput.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define UINPUT_NAME_SIZE 32
+
+/****************************************************************************
+ * Private Function Prototypes
+ ****************************************************************************/
+
+static ssize_t uinput_touch_write(FAR struct touch_lowerhalf_s *lower,
+                                  FAR const char *buffer, size_t buflen);
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: uinput_touch_write
+ ****************************************************************************/
+
+static ssize_t uinput_touch_write(FAR struct touch_lowerhalf_s *lower,
+                                  FAR const char *buffer, size_t buflen)
+{
+  FAR const struct touch_sample_s *sample;
+  sample = (FAR const struct touch_sample_s *)buffer;
+
+  if (sample == NULL)
+    {
+      return -EINVAL;
+    }
+
+  touch_event(lower->priv, sample);
+  return buflen;
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: uinput_touch_initialize
+ *
+ * Description:
+ *   Initialized the uinput touchscreen device
+ *
+ * Input Parameters:
+ *   name:      Touchscreen devices name
+ *   maxpoint:  Maximum number of touch points supported.
+ *   buff_nums: Number of the touch points structure.
+ *
+ * Returned Value:
+ *   Zero is returned on success.  Otherwise, a negated errno value is
+ *   returned to indicate the nature of the failure.
+ *
+ ****************************************************************************/
+
+int uinput_touch_initialize(FAR const char *name, int maxpoint, int buffnums)
+{
+  char devname[UINPUT_NAME_SIZE];
+  FAR struct touch_lowerhalf_s *lower;
+
+  lower = kmm_malloc(sizeof(struct touch_lowerhalf_s));
+  if (!lower)
+    {
+      return -ENOMEM;
+    }
+
+  /* Regiest Touchscreen device */
+
+  lower->write    = uinput_touch_write;
+  lower->maxpoint = maxpoint;
+  snprintf(devname, UINPUT_NAME_SIZE, "/dev/%s", name);
+
+  return touch_register(lower, devname, buffnums);
+}

--- a/drivers/input/uinput.c
+++ b/drivers/input/uinput.c
@@ -26,9 +26,10 @@
 #include <errno.h>
 #include <stdio.h>
 
-#include <nuttx/kmalloc.h>
+#include <nuttx/input/buttons.h>
 #include <nuttx/input/touchscreen.h>
 #include <nuttx/input/uinput.h>
+#include <nuttx/kmalloc.h>
 
 /****************************************************************************
  * Pre-processor Definitions
@@ -37,15 +38,48 @@
 #define UINPUT_NAME_SIZE 32
 
 /****************************************************************************
+ * Private Types
+ ****************************************************************************/
+
+struct uinput_button_lowerhalf_s
+{
+  struct btn_lowerhalf_s lower;
+  btn_buttonset_t        buttons;
+  btn_handler_t          handler;
+  FAR void              *arg;
+};
+
+/****************************************************************************
  * Private Function Prototypes
  ****************************************************************************/
 
+#ifdef CONFIG_INPUT_TOUCHSCREEN
 static ssize_t uinput_touch_write(FAR struct touch_lowerhalf_s *lower,
                                   FAR const char *buffer, size_t buflen);
+#endif
+
+#ifdef CONFIG_INPUT_BUTTONS
+static ssize_t uinput_button_write(FAR const struct btn_lowerhalf_s *lower,
+                                   FAR const char *buffer, size_t buflen);
+
+static btn_buttonset_t uinput_button_supported(FAR const struct
+                                               btn_lowerhalf_s *lower);
+
+static btn_buttonset_t uinput_button_buttons(FAR const struct
+                                             btn_lowerhalf_s *lower);
+
+static void uinput_button_enable(FAR const struct btn_lowerhalf_s *lower,
+                                 btn_buttonset_t press,
+                                 btn_buttonset_t release,
+                                 btn_handler_t handler,
+                                 FAR void *arg);
+#endif
 
 /****************************************************************************
  * Private Functions
  ****************************************************************************/
+
+#ifdef CONFIG_INPUT_TOUCHSCREEN
 
 /****************************************************************************
  * Name: uinput_touch_write
@@ -65,6 +99,65 @@ static ssize_t uinput_touch_write(FAR struct touch_lowerhalf_s *lower,
   touch_event(lower->priv, sample);
   return buflen;
 }
+#endif /* CONFIG_INPUT_TOUCHSCREEN */
+
+#ifdef CONFIG_INPUT_BUTTONS
+
+/****************************************************************************
+ * Name: uinput_button_write
+ ****************************************************************************/
+
+static ssize_t uinput_button_write(FAR const struct btn_lowerhalf_s *lower,
+                                   FAR const char *buffer, size_t buflen)
+{
+  FAR struct uinput_button_lowerhalf_s *ubtn_lower =
+             (FAR struct uinput_button_lowerhalf_s *)lower;
+
+  if (buflen != sizeof(btn_buttonset_t))
+    {
+      return -EINVAL;
+    }
+
+  ubtn_lower->buttons = *(btn_buttonset_t *)buffer;
+  ubtn_lower->handler(&ubtn_lower->lower, ubtn_lower->arg);
+
+  return buflen;
+}
+
+/****************************************************************************
+ * Name: uinput_button_supported
+ ****************************************************************************/
+
+static btn_buttonset_t uinput_button_supported(FAR const struct
+                                               btn_lowerhalf_s *lower)
+{
+  return ~0u;
+}
+
+/****************************************************************************
+ * Name: uinput_button_buttons
+ ****************************************************************************/
+
+static btn_buttonset_t
+uinput_button_buttons(FAR const struct btn_lowerhalf_s *lower)
+{
+  FAR struct uinput_button_lowerhalf_s *ubtn_lower =
+             (FAR struct uinput_button_lowerhalf_s *)lower;
+  return ubtn_lower->buttons;
+}
+
+static void uinput_button_enable(FAR const struct btn_lowerhalf_s *lower,
+                                 btn_buttonset_t press,
+                                 btn_buttonset_t release,
+                                 btn_handler_t handler, FAR void *arg)
+{
+  FAR struct uinput_button_lowerhalf_s *ubtn_lower =
+    (FAR struct uinput_button_lowerhalf_s *)lower;
+  ubtn_lower->arg     = arg;
+  ubtn_lower->handler = handler;
+}
+
+#endif /* CONFIG_INPUT_BUTTONS */
 
 /****************************************************************************
  * Public Functions
@@ -106,3 +199,20 @@ int uinput_touch_initialize(FAR const char *name, int maxpoint, int buffnums)
 
   return touch_register(lower, devname, buffnums);
 }
+
+#ifdef CONFIG_INPUT_BUTTONS
+int uinput_button_initialize(FAR const char *name)
+{
+  char devname[UINPUT_NAME_SIZE];
+  FAR struct uinput_button_lowerhalf_s *ubtn_lower;
+
+  ubtn_lower = kmm_zalloc(sizeof(struct uinput_button_lowerhalf_s));
+  ubtn_lower->lower.bl_buttons   = uinput_button_buttons;
+  ubtn_lower->lower.bl_enable    = uinput_button_enable;
+  ubtn_lower->lower.bl_supported = uinput_button_supported;
+  ubtn_lower->lower.bl_write     = uinput_button_write;
+
+  snprintf(devname, UINPUT_NAME_SIZE, "/dev/%s", name);
+  return btn_register(devname, &ubtn_lower->lower);
+}
+#endif /* CONFIG_INPUT_BUTTONS */

--- a/include/nuttx/input/buttons.h
+++ b/include/nuttx/input/buttons.h
@@ -148,6 +148,11 @@ struct btn_lowerhalf_s
   CODE void (*bl_enable)(FAR const struct btn_lowerhalf_s *lower,
                          btn_buttonset_t press, btn_buttonset_t release,
                          btn_handler_t handler, FAR void *arg);
+
+  /* Key write callback function */
+
+  CODE ssize_t (*bl_write)(FAR const struct btn_lowerhalf_s *lower,
+                           FAR const char *buffer, size_t buflen);
 };
 
 /****************************************************************************

--- a/include/nuttx/input/touchscreen.h
+++ b/include/nuttx/input/touchscreen.h
@@ -175,6 +175,25 @@ struct touch_lowerhalf_s
 
   CODE int (*control)(FAR struct touch_lowerhalf_s *lower,
                       int cmd, unsigned long arg);
+
+  /**************************************************************************
+   * Name: write
+   *
+   * Description:
+   *   Users can use this interface to implement custom write.
+   *
+   * Arguments:
+   *   lower   - The instance of lower half of touchscreen device.
+   *   buffer  - User defined specific buffer.
+   *   buflen  - User defined specific buffer size.
+   *
+   * Return Value:
+   *   Number of bytes written；a negated errno value on failure.
+   *
+   **************************************************************************/
+
+  CODE ssize_t (*write)(FAR struct touch_lowerhalf_s *lower,
+                        FAR const char *buffer, size_t buflen);
 };
 
 /****************************************************************************

--- a/include/nuttx/input/uinput.h
+++ b/include/nuttx/input/uinput.h
@@ -1,0 +1,52 @@
+/****************************************************************************
+ * include/nuttx/input/uinput.h
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ****************************************************************************/
+
+#ifndef __INCLUDE_NUTTX_INPUT_UINPUT_H
+#define __INCLUDE_NUTTX_INPUT_UINPUT_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <sys/types.h>
+
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: uinput_touch_initialize
+ *
+ * Description:
+ *   Initialized the uinput touchscreen device
+ *
+ * Input Parameters:
+ *   name:      Touchscreen devices name
+ *   maxpoint:  Maximum number of touch points supported.
+ *   buff_nums: Number of the touch points structure.
+ *
+ * Returned Value:
+ *   Zero is returned on success. Otherwise, a negated errno value is
+ *   returned to indicate the nature of the failure.
+ *
+ ****************************************************************************/
+
+int uinput_touch_initialize(FAR const char *name, int maxpoint,
+                            int buffnums);
+
+#endif /* __INCLUDE_NUTTX_INPUT_UINPUT_H */

--- a/include/nuttx/input/uinput.h
+++ b/include/nuttx/input/uinput.h
@@ -49,4 +49,21 @@
 int uinput_touch_initialize(FAR const char *name, int maxpoint,
                             int buffnums);
 
+/****************************************************************************
+ * Name: uinput_button_initialize
+ *
+ * Description:
+ *   Initialized the uinput button device
+ *
+ * Input Parameters:
+ *   name:      Button devices name
+ *
+ * Returned Value:
+ *   Zero is returned on success. Otherwise, a negated errno value is
+ *   returned to indicate the nature of the failure.
+ *
+ ****************************************************************************/
+
+int uinput_button_initialize(FAR const char *name);
+
 #endif /* __INCLUDE_NUTTX_INPUT_UINPUT_H */


### PR DESCRIPTION
## Summary
Using the uinput device to provide virtual data to the application without the existence of the real device.
For example, provide lvgl with virtual touchscreen data for monkey testing.

It currently contains touchscreen and button, and more devices will be added in the future
## Impact

## Testing

