### PR TITLE
net: use HTONS, NTOHS, HTONL, NTOHL macro in kernel code

### DIFF
--- a/arch/arm/src/c5471/c5471_ethernet.c
+++ b/arch/arm/src/c5471/c5471_ethernet.c
@@ -946,7 +946,7 @@ static int c5471_transmit(struct c5471_driver_s *priv)
         {
           /* 16-bits at a time. */
 
-          packetmem[i] = htons(((uint16_t *)dev->d_buf)[j]);
+          packetmem[i] = HTONS(((uint16_t *)dev->d_buf)[j]);
         }
 
       putreg32(((getreg32(priv->c_rxcpudesc) & ~EIM_RXDESC_BYTEMASK) |
@@ -1257,7 +1257,7 @@ static void c5471_receive(struct c5471_driver_s *priv)
                * 16-bits at a time.
                */
 
-              ((uint16_t *)dev->d_buf)[j] = htons(packetmem[i]);
+              ((uint16_t *)dev->d_buf)[j] = HTONS(packetmem[i]);
             }
         }
       else
@@ -1314,7 +1314,7 @@ static void c5471_receive(struct c5471_driver_s *priv)
 
       dev->d_len = packetlen;
       ninfo("Received packet, packetlen: %d type: %02x\n",
-            packetlen, ntohs(BUF->type));
+            packetlen, NTOHS(BUF->type));
       c5471_dumpbuffer("Received packet", dev->d_buf, dev->d_len);
 
 #ifdef CONFIG_NET_PKT

--- a/arch/arm/src/imx6/imx_enet.c
+++ b/arch/arm/src/imx6/imx_enet.c
@@ -817,7 +817,7 @@ static inline void imx_dispatch(FAR struct imx_driver_s *priv)
 #ifdef CONFIG_NET_ARP
   /* Check for an ARP packet */
 
-  if (BUF->type == htons(ETHTYPE_ARP))
+  if (BUF->type == HTONS(ETHTYPE_ARP))
     {
       NETDEV_RXARP(&priv->dev);
       arp_arpin(&priv->dev);

--- a/arch/arm/src/imxrt/imxrt_enet.c
+++ b/arch/arm/src/imxrt/imxrt_enet.c
@@ -775,7 +775,7 @@ static inline void imxrt_dispatch(FAR struct imxrt_driver_s *priv)
 #ifdef CONFIG_NET_ARP
   /* Check for an ARP packet */
 
-  if (BUF->type == htons(ETHTYPE_ARP))
+  if (BUF->type == HTONS(ETHTYPE_ARP))
     {
       NETDEV_RXARP(&priv->dev);
       arp_arpin(&priv->dev);

--- a/arch/arm/src/kinetis/kinetis_enet.c
+++ b/arch/arm/src/kinetis/kinetis_enet.c
@@ -718,7 +718,7 @@ static void kinetis_receive(FAR struct kinetis_driver_s *priv)
       else
 #endif
 #ifdef CONFIG_NET_ARP
-      if (BUF->type == htons(ETHTYPE_ARP))
+      if (BUF->type == HTONS(ETHTYPE_ARP))
         {
           NETDEV_RXARP(&priv->dev);
           arp_arpin(&priv->dev);

--- a/arch/arm/src/lpc17xx_40xx/lpc17_40_ethernet.c
+++ b/arch/arm/src/lpc17xx_40xx/lpc17_40_ethernet.c
@@ -1041,7 +1041,7 @@ static void lpc17_40_rxdone_work(FAR void *arg)
           else
 #endif
 #ifdef CONFIG_NET_ARP
-          if (BUF->type == htons(ETHTYPE_ARP))
+          if (BUF->type == HTONS(ETHTYPE_ARP))
             {
               NETDEV_RXARP(&priv->lp_dev);
               arp_arpin(&priv->lp_dev);

--- a/arch/arm/src/lpc43xx/lpc43_ethernet.c
+++ b/arch/arm/src/lpc43xx/lpc43_ethernet.c
@@ -1718,7 +1718,7 @@ static void lpc43_receive(FAR struct lpc43_ethmac_s *priv)
       else
 #endif /* CONFIG_NET_IPv6 */
 #ifdef CONFIG_NET_ARP
-      if (BUF->type == htons(ETHTYPE_ARP))
+      if (BUF->type == HTONS(ETHTYPE_ARP))
         {
           ninfo("ARP frame\n");
 

--- a/arch/arm/src/lpc54xx/lpc54_ethernet.c
+++ b/arch/arm/src/lpc54xx/lpc54_ethernet.c
@@ -1005,7 +1005,7 @@ static void lpc54_eth_rxdispatch(struct lpc54_ethdriver_s *priv)
   else
 #endif
 #ifdef CONFIG_NET_ARP
-  if (ETHBUF->type == htons(ETHTYPE_ARP))
+  if (ETHBUF->type == HTONS(ETHTYPE_ARP))
     {
       struct lpc54_txring_s *txring;
       unsigned int chan;

--- a/arch/arm/src/rtl8720c/amebaz_netdev.c
+++ b/arch/arm/src/rtl8720c/amebaz_netdev.c
@@ -195,7 +195,7 @@ void amebaz_netdev_notify_receive(FAR struct amebaz_dev_s *priv,
         {
 #endif
 #ifdef CONFIG_NET_ARP
-          if (hdr->type == htons(ETHTYPE_ARP))
+          if (hdr->type == HTONS(ETHTYPE_ARP))
             {
               arp_arpin(&priv->dev);
               NETDEV_RXARP(&priv->dev);

--- a/arch/arm/src/s32k1xx/s32k1xx_enet.c
+++ b/arch/arm/src/s32k1xx/s32k1xx_enet.c
@@ -770,7 +770,7 @@ static inline void s32k1xx_dispatch(FAR struct s32k1xx_driver_s *priv)
 #ifdef CONFIG_NET_ARP
   /* Check for an ARP packet */
 
-  if (BUF->type == htons(ETHTYPE_ARP))
+  if (BUF->type == HTONS(ETHTYPE_ARP))
     {
       NETDEV_RXARP(&priv->dev);
       arp_arpin(&priv->dev);

--- a/arch/arm/src/sam34/sam_emac.c
+++ b/arch/arm/src/sam34/sam_emac.c
@@ -1299,7 +1299,7 @@ static void sam_receive(struct sam_emac_s *priv)
       else
 #endif
 #ifdef CONFIG_NET_ARP
-      if (BUF->type == htons(ETHTYPE_ARP))
+      if (BUF->type == HTONS(ETHTYPE_ARP))
         {
           ninfo("ARP frame\n");
 

--- a/arch/arm/src/sama5/sam_emaca.c
+++ b/arch/arm/src/sama5/sam_emaca.c
@@ -1362,7 +1362,7 @@ static void sam_receive(struct sam_emac_s *priv)
       else
 #endif
 #ifdef CONFIG_NET_ARP
-      if (BUF->type == htons(ETHTYPE_ARP))
+      if (BUF->type == HTONS(ETHTYPE_ARP))
         {
           ninfo("ARP frame\n");
 

--- a/arch/arm/src/sama5/sam_emacb.c
+++ b/arch/arm/src/sama5/sam_emacb.c
@@ -1673,7 +1673,7 @@ static void sam_receive(struct sam_emac_s *priv)
       else
 #endif
 #ifdef CONFIG_NET_ARP
-      if (BUF->type == htons(ETHTYPE_ARP))
+      if (BUF->type == HTONS(ETHTYPE_ARP))
         {
           ninfo("ARP frame\n");
 

--- a/arch/arm/src/sama5/sam_gmac.c
+++ b/arch/arm/src/sama5/sam_gmac.c
@@ -1308,7 +1308,7 @@ static void sam_receive(struct sam_gmac_s *priv)
       else
 #endif
 #ifdef CONFIG_NET_ARP
-      if (BUF->type == htons(ETHTYPE_ARP))
+      if (BUF->type == HTONS(ETHTYPE_ARP))
         {
           ninfo("ARP frame\n");
 

--- a/arch/arm/src/samd5e5/sam_gmac.c
+++ b/arch/arm/src/samd5e5/sam_gmac.c
@@ -1291,7 +1291,7 @@ static void sam_receive(struct sam_gmac_s *priv)
       else
 #endif
 #ifdef CONFIG_NET_ARP
-      if (BUF->type == htons(ETHTYPE_ARP))
+      if (BUF->type == HTONS(ETHTYPE_ARP))
         {
           ninfo("ARP frame\n");
 

--- a/arch/arm/src/samv7/sam_emac.c
+++ b/arch/arm/src/samv7/sam_emac.c
@@ -2013,7 +2013,7 @@ static void sam_receive(struct sam_emac_s *priv, int qid)
       else
 #endif
 #ifdef CONFIG_NET_ARP
-      if (BUF->type == htons(ETHTYPE_ARP))
+      if (BUF->type == HTONS(ETHTYPE_ARP))
         {
           ninfo("ARP frame\n");
           NETDEV_RXARP(&priv->dev);

--- a/arch/arm/src/stm32/stm32_eth.c
+++ b/arch/arm/src/stm32/stm32_eth.c
@@ -1839,7 +1839,7 @@ static void stm32_receive(FAR struct stm32_ethmac_s *priv)
       else
 #endif
 #ifdef CONFIG_NET_ARP
-      if (BUF->type == htons(ETHTYPE_ARP))
+      if (BUF->type == HTONS(ETHTYPE_ARP))
         {
           ninfo("ARP frame\n");
 
@@ -3690,7 +3690,7 @@ static int stm32_ethreset(FAR struct stm32_ethmac_s *priv)
   while (((stm32_getreg(STM32_ETH_DMABMR) & ETH_DMABMR_SR) != 0) &&
          retries > 0)
     {
-      retries --;
+      retries--;
       up_mdelay(10);
     }
 

--- a/arch/arm/src/stm32f7/stm32_ethernet.c
+++ b/arch/arm/src/stm32f7/stm32_ethernet.c
@@ -1920,7 +1920,7 @@ static void stm32_receive(struct stm32_ethmac_s *priv)
       else
 #endif
 #ifdef CONFIG_NET_ARP
-      if (BUF->type == htons(ETHTYPE_ARP))
+      if (BUF->type == HTONS(ETHTYPE_ARP))
         {
           ninfo("ARP frame\n");
 

--- a/arch/arm/src/stm32h7/stm32_ethernet.c
+++ b/arch/arm/src/stm32h7/stm32_ethernet.c
@@ -2027,7 +2027,7 @@ static void stm32_receive(struct stm32_ethmac_s *priv)
       else
 #endif
 #ifdef CONFIG_NET_ARP
-      if (BUF->type == htons(ETHTYPE_ARP))
+      if (BUF->type == HTONS(ETHTYPE_ARP))
         {
           ninfo("ARP frame\n");
 

--- a/arch/arm/src/tiva/lm/lm3s_ethernet.c
+++ b/arch/arm/src/tiva/lm/lm3s_ethernet.c
@@ -892,7 +892,7 @@ static void tiva_receive(struct tiva_driver_s *priv)
       else
 #endif
 #ifdef CONFIG_NET_ARP
-      if (ETHBUF->type == htons(ETHTYPE_ARP))
+      if (ETHBUF->type == HTONS(ETHTYPE_ARP))
         {
           ninfo("ARP packet received (%02x)\n", ETHBUF->type);
           NETDEV_RXARP(&priv->ld_dev);
@@ -912,7 +912,7 @@ static void tiva_receive(struct tiva_driver_s *priv)
 #endif
         {
           nwarn("WARNING: Unsupported packet type dropped (%02x)\n",
-                  htons(ETHBUF->type));
+                HTONS(ETHBUF->type));
           NETDEV_RXDROPPED(&priv->ld_dev);
         }
     }

--- a/arch/arm/src/tiva/tm4c/tm4c_ethernet.c
+++ b/arch/arm/src/tiva/tm4c/tm4c_ethernet.c
@@ -1815,7 +1815,7 @@ static void tiva_receive(FAR struct tiva_ethmac_s *priv)
       else
 #endif
 #ifdef CONFIG_NET_ARP
-      if (BUF->type == htons(ETHTYPE_ARP))
+      if (BUF->type == HTONS(ETHTYPE_ARP))
         {
           ninfo("ARP frame\n");
 

--- a/arch/hc/src/m9s12/m9s12_ethernet.c
+++ b/arch/hc/src/m9s12/m9s12_ethernet.c
@@ -370,7 +370,7 @@ static void emac_receive(FAR struct emac_driver_s *priv)
       else
 #endif
 #ifdef CONFIG_NET_ARP
-      if (BUF->type == htons(ETHTYPE_ARP))
+      if (BUF->type == HTONS(ETHTYPE_ARP))
         {
           arp_arpin(&priv->d_dev);
 

--- a/arch/mips/src/pic32mx/pic32mx_ethernet.c
+++ b/arch/mips/src/pic32mx/pic32mx_ethernet.c
@@ -1549,7 +1549,7 @@ static void pic32mx_rxdone(struct pic32mx_driver_s *priv)
           else
 #endif
 #ifdef CONFIG_NET_ARP
-          if (BUF->type == htons(ETHTYPE_ARP))
+          if (BUF->type == HTONS(ETHTYPE_ARP))
             {
               /* Handle the incoming ARP packet */
 
@@ -1572,7 +1572,7 @@ static void pic32mx_rxdone(struct pic32mx_driver_s *priv)
               /* Unrecognized... drop it. */
 
               nerr("ERROR: Unrecognized packet type dropped: %04x\n",
-                   ntohs(BUF->type));
+                   NTOHS(BUF->type));
               NETDEV_RXDROPPED(&priv->pd_dev);
             }
 

--- a/arch/mips/src/pic32mz/pic32mz_ethernet.c
+++ b/arch/mips/src/pic32mz/pic32mz_ethernet.c
@@ -1666,7 +1666,7 @@ static void pic32mz_rxdone(struct pic32mz_driver_s *priv)
           else
 #endif
 #ifdef CONFIG_NET_ARP
-          if (BUF->type == htons(ETHTYPE_ARP))
+          if (BUF->type == HTONS(ETHTYPE_ARP))
             {
               /* Handle the incoming ARP packet */
 
@@ -1689,7 +1689,7 @@ static void pic32mz_rxdone(struct pic32mz_driver_s *priv)
               /* Unrecognized... drop it. */
 
               nwarn("WARNING: Unrecognized packet type dropped: %04x\n",
-                    ntohs(BUF->type));
+                    NTOHS(BUF->type));
               NETDEV_RXDROPPED(&priv->pd_dev);
             }
 

--- a/arch/misoc/src/common/misoc_net.c
+++ b/arch/misoc/src/common/misoc_net.c
@@ -489,7 +489,7 @@ static void misoc_net_receive(FAR struct misoc_net_driver_s *priv)
       else
 #endif
 #ifdef CONFIG_NET_ARP
-      if (BUF->type == htons(ETHTYPE_ARP))
+      if (BUF->type == HTONS(ETHTYPE_ARP))
         {
           arp_arpin(&priv->misoc_net_dev);
           NETDEV_RXARP(&priv->misoc_net_dev);

--- a/arch/renesas/src/rx65n/rx65n_eth.c
+++ b/arch/renesas/src/rx65n/rx65n_eth.c
@@ -1635,7 +1635,7 @@ static void rx65n_receive(FAR struct rx65n_ethmac_s *priv)
       else
 #endif
 #ifdef CONFIG_NET_ARP
-  if (BUF->type == htons(ETHTYPE_ARP))
+  if (BUF->type == HTONS(ETHTYPE_ARP))
         {
           ninfo("ARP frame\n");
 
@@ -3646,7 +3646,7 @@ static int rx65n_ethreset(FAR struct rx65n_ethmac_s *priv)
   while (((rx65n_getreg(RX65N_ETHD_EDMR) & ETHD_EDMR_SWR) != 0) &&
          retries > 0)
     {
-      retries --;
+      retries--;
       up_mdelay(10);
     }
 
@@ -3703,7 +3703,7 @@ static int rx65n_macconfig(FAR struct rx65n_ethmac_s *priv)
   while (((rx65n_getreg(RX65N_ETHD_EDMR) & ETHD_EDMR_SWR) != 0) &&
          retries > 0)
     {
-      retries --;
+      retries--;
       up_mdelay(10);
     }
 

--- a/arch/risc-v/src/bl602/bl602_netdev.c
+++ b/arch/risc-v/src/bl602/bl602_netdev.c
@@ -607,7 +607,7 @@ static void bl602_net_receive(struct bl602_net_driver_s *priv)
 #ifdef CONFIG_NET_ARP
   /* Check for an ARP packet */
 
-  if (BUF->type == htons(ETHTYPE_ARP))
+  if (BUF->type == HTONS(ETHTYPE_ARP))
     {
       /* Dispatch ARP packet to the network layer */
 

--- a/arch/risc-v/src/esp32c3/esp32c3_wlan.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_wlan.c
@@ -805,7 +805,7 @@ static void wlan_rxpoll(void *arg)
       else
 #endif
 #ifdef CONFIG_NET_ARP
-      if (eth_hdr->type == htons(ETHTYPE_ARP))
+      if (eth_hdr->type == HTONS(ETHTYPE_ARP))
         {
           ninfo("ARP frame\n");
 

--- a/arch/sim/src/sim/up_netdriver.c
+++ b/arch/sim/src/sim/up_netdriver.c
@@ -185,7 +185,7 @@ static void netdriver_recv_work(FAR void *arg)
           else
 #endif/* CONFIG_NET_IPv6 */
 #ifdef CONFIG_NET_ARP
-          if (eth->type == htons(ETHTYPE_ARP))
+          if (eth->type == HTONS(ETHTYPE_ARP))
             {
               ninfo("ARP frame\n");
               NETDEV_RXARP(dev);

--- a/arch/sim/src/sim/up_wpcap.c
+++ b/arch/sim/src/sim/up_wpcap.c
@@ -261,7 +261,7 @@ void wpcap_init(void)
   struct in_addr addr;
   FARPROC dlladdr;
 
-  addr.s_addr = htonl(WCAP_IPADDR);
+  addr.s_addr = HTONL(WCAP_IPADDR);
   syslog(LOG_INFO, "wpcap_init: IP address: %s\n", inet_ntoa(addr));
 
   wpcap = LoadLibrary("wpcap.dll");

--- a/arch/xtensa/src/esp32/esp32_emac.c
+++ b/arch/xtensa/src/esp32/esp32_emac.c
@@ -1449,7 +1449,7 @@ static void emac_rx_interrupt_work(void *arg)
       else
 #endif
 #ifdef CONFIG_NET_ARP
-      if (eth_hdr->type == htons(ETHTYPE_ARP))
+      if (eth_hdr->type == HTONS(ETHTYPE_ARP))
         {
           ninfo("ARP frame\n");
 

--- a/arch/xtensa/src/esp32/esp32_wlan.c
+++ b/arch/xtensa/src/esp32/esp32_wlan.c
@@ -802,7 +802,7 @@ static void wlan_rxpoll(void *arg)
       else
 #endif
 #ifdef CONFIG_NET_ARP
-      if (eth_hdr->type == htons(ETHTYPE_ARP))
+      if (eth_hdr->type == HTONS(ETHTYPE_ARP))
         {
           ninfo("ARP frame\n");
 

--- a/arch/z80/src/ez80/ez80_emac.c
+++ b/arch/z80/src/ez80/ez80_emac.c
@@ -1496,7 +1496,7 @@ static int ez80emac_receive(struct ez80emac_driver_s *priv)
       else
 #endif
 #ifdef CONFIG_NET_ARP
-      if (ETHBUF->type == htons(ETHTYPE_ARP))
+      if (ETHBUF->type == HTONS(ETHTYPE_ARP))
         {
           ninfo("ARP packet received (%02x)\n", ETHBUF->type);
           EMAC_STAT(priv, rx_arp);

--- a/binfmt/libnxflat/libnxflat_bind.c
+++ b/binfmt/libnxflat/libnxflat_bind.c
@@ -221,8 +221,8 @@ static inline int nxflat_gotrelocs(FAR struct nxflat_loadinfo_s *loadinfo)
 
   /* From this, we can get the offset to the list of relocation entries */
 
-  offset  = ntohl(hdr->h_relocstart);
-  nrelocs = ntohs(hdr->h_reloccount);
+  offset  = NTOHL(hdr->h_relocstart);
+  nrelocs = NTOHS(hdr->h_reloccount);
   binfo("offset: %08lx nrelocs: %d\n", (long)offset, nrelocs);
 
   /* The value of the relocation list that we get from the header is a
@@ -395,8 +395,8 @@ static inline int nxflat_bindimports(FAR struct nxflat_loadinfo_s *loadinfo,
    * this module and the number of symbols imported by this module.
    */
 
-  offset   = ntohl(hdr->h_importsymbols);
-  nimports = ntohs(hdr->h_importcount);
+  offset   = NTOHL(hdr->h_importsymbols);
+  nimports = NTOHS(hdr->h_importcount);
   binfo("Imports offset: %08" PRIx32 " nimports: %d\n", offset, nimports);
 
   /* The import[] table resides within the D-Space allocation.  If

--- a/binfmt/libnxflat/libnxflat_init.c
+++ b/binfmt/libnxflat/libnxflat_init.c
@@ -137,9 +137,9 @@ int nxflat_init(const char *filename, struct nxflat_loadinfo_s *loadinfo)
    * network order.
    */
 
-  datastart             = ntohl(loadinfo->header.h_datastart);
-  dataend               = ntohl(loadinfo->header.h_dataend);
-  bssend                = ntohl(loadinfo->header.h_bssend);
+  datastart             = NTOHL(loadinfo->header.h_datastart);
+  dataend               = NTOHL(loadinfo->header.h_dataend);
+  bssend                = NTOHL(loadinfo->header.h_bssend);
 
   /* And put this information into the loadinfo structure as well.
    *
@@ -150,12 +150,12 @@ int nxflat_init(const char *filename, struct nxflat_loadinfo_s *loadinfo)
    *   bsssize    = the address range from dataend up to bssend.
    */
 
-  loadinfo->entryoffs   = ntohl(loadinfo->header.h_entry);
+  loadinfo->entryoffs   = NTOHL(loadinfo->header.h_entry);
   loadinfo->isize       = datastart;
 
   loadinfo->datasize    = dataend - datastart;
   loadinfo->bsssize     = bssend - dataend;
-  loadinfo->stacksize   = ntohl(loadinfo->header.h_stacksize);
+  loadinfo->stacksize   = NTOHL(loadinfo->header.h_stacksize);
 
   /* This is the initial dspace size.  We'll re-calculate this later
    * after the memory has been allocated.
@@ -167,7 +167,7 @@ int nxflat_init(const char *filename, struct nxflat_loadinfo_s *loadinfo)
    * this later).
    */
 
-  loadinfo->relocstart  = ntohl(loadinfo->header.h_relocstart);
+  loadinfo->relocstart  = NTOHL(loadinfo->header.h_relocstart);
   loadinfo->reloccount  = ntohs(loadinfo->header.h_reloccount);
 
   return 0;

--- a/drivers/net/dm90x0.c
+++ b/drivers/net/dm90x0.c
@@ -1019,7 +1019,7 @@ static void dm9x_receive(FAR struct dm9x_driver_s *priv)
           else
 #endif
 #ifdef CONFIG_NET_ARP
-          if (BUF->type == htons(ETHTYPE_ARP))
+          if (BUF->type == HTONS(ETHTYPE_ARP))
             {
               arp_arpin(&priv->dm_dev);
               NETDEV_RXARP(&priv->dm_dev);

--- a/drivers/net/enc28j60.c
+++ b/drivers/net/enc28j60.c
@@ -1461,7 +1461,7 @@ static void enc_rxdispatch(FAR struct enc_driver_s *priv)
   else
 #endif
 #ifdef CONFIG_NET_ARP
-  if (BUF->type == htons(ETHTYPE_ARP))
+  if (BUF->type == HTONS(ETHTYPE_ARP))
     {
       ninfo("ARP packet received (%02x)\n", BUF->type);
       NETDEV_RXARP(&priv->dev);
@@ -1481,7 +1481,7 @@ static void enc_rxdispatch(FAR struct enc_driver_s *priv)
 #endif
     {
       nwarn("WARNING: Unsupported packet type dropped (%02x)\n",
-            htons(BUF->type));
+            HTONS(BUF->type));
       NETDEV_RXDROPPED(&priv->dev);
     }
 }

--- a/drivers/net/encx24j600.c
+++ b/drivers/net/encx24j600.c
@@ -1561,7 +1561,7 @@ static void enc_rxdispatch(FAR struct enc_driver_s *priv)
       else
 #endif
 #ifdef CONFIG_NET_ARP
-      if (BUF->type == htons(ETHTYPE_ARP))
+      if (BUF->type == HTONS(ETHTYPE_ARP))
         {
           ninfo("ARP packet received (%02x)\n", BUF->type);
           NETDEV_RXARP(&priv->dev);
@@ -1590,7 +1590,7 @@ static void enc_rxdispatch(FAR struct enc_driver_s *priv)
           enc_rxrmpkt(priv, descr);
 
           nerr("ERROR: Unsupported packet type dropped (%02x)\n",
-               htons(BUF->type));
+               HTONS(BUF->type));
           NETDEV_RXDROPPED(&priv->dev);
         }
 

--- a/drivers/net/ftmac100.c
+++ b/drivers/net/ftmac100.c
@@ -767,7 +767,7 @@ static void ftmac100_receive(FAR struct ftmac100_driver_s *priv)
       else
 #endif
 #ifdef CONFIG_NET_ARP
-      if (BUF->type == htons(ETHTYPE_ARP))
+      if (BUF->type == HTONS(ETHTYPE_ARP))
         {
           arp_arpin(&priv->ft_dev);
 

--- a/drivers/net/lan91c111.c
+++ b/drivers/net/lan91c111.c
@@ -722,7 +722,7 @@ static void lan91c111_receive(FAR struct net_driver_s *dev)
   else
 #endif
 #ifdef CONFIG_NET_ARP
-  if (eth->type == htons(ETHTYPE_ARP))
+  if (eth->type == HTONS(ETHTYPE_ARP))
     {
       ninfo("ARP frame\n");
       NETDEV_RXARP(dev);

--- a/drivers/net/loopback.c
+++ b/drivers/net/loopback.c
@@ -294,10 +294,10 @@ static int lo_ifup(FAR struct net_driver_s *dev)
 #endif
 #ifdef CONFIG_NET_IPv6
   ninfo("Bringing up: %04x:%04x:%04x:%04x:%04x:%04x:%04x:%04x\n",
-        ntohs(dev->d_ipv6addr[0]), ntohs(dev->d_ipv6addr[1]),
-        ntohs(dev->d_ipv6addr[2]), ntohs(dev->d_ipv6addr[3]),
-        ntohs(dev->d_ipv6addr[4]), ntohs(dev->d_ipv6addr[5]),
-        ntohs(dev->d_ipv6addr[6]), ntohs(dev->d_ipv6addr[7]));
+        NTOHS(dev->d_ipv6addr[0]), NTOHS(dev->d_ipv6addr[1]),
+        NTOHS(dev->d_ipv6addr[2]), NTOHS(dev->d_ipv6addr[3]),
+        NTOHS(dev->d_ipv6addr[4]), NTOHS(dev->d_ipv6addr[5]),
+        NTOHS(dev->d_ipv6addr[6]), NTOHS(dev->d_ipv6addr[7]));
 #endif
 
   /* Set and activate a timer process */

--- a/drivers/net/rpmsgdrv.c
+++ b/drivers/net/rpmsgdrv.c
@@ -898,7 +898,7 @@ static int net_rpmsg_drv_ifup(FAR struct net_driver_s *dev)
       };
 
       dnsaddr.sin_family = AF_INET;
-      dnsaddr.sin_port   = htons(DNS_DEFAULT_PORT);
+      dnsaddr.sin_port   = HTONS(DNS_DEFAULT_PORT);
       memcpy(&dnsaddr.sin_addr, &msg.dnsaddr, sizeof(msg.dnsaddr));
 
       dns_add_nameserver((FAR const struct sockaddr *)&dnsaddr,
@@ -914,7 +914,7 @@ static int net_rpmsg_drv_ifup(FAR struct net_driver_s *dev)
       };
 
       dnsaddr.sin6_family = AF_INET6;
-      dnsaddr.sin6_port   = htons(DNS_DEFAULT_PORT);
+      dnsaddr.sin6_port   = HTONS(DNS_DEFAULT_PORT);
       memcpy(&dnsaddr.sin6_addr, msg.ipv6dnsaddr, sizeof(msg.ipv6dnsaddr));
 
       dns_add_nameserver((FAR const struct sockaddr *)&dnsaddr,

--- a/drivers/net/skeleton.c
+++ b/drivers/net/skeleton.c
@@ -447,7 +447,7 @@ static void skel_receive(FAR struct skel_driver_s *priv)
 #ifdef CONFIG_NET_ARP
       /* Check for an ARP packet */
 
-      if (BUF->type == htons(ETHTYPE_ARP))
+      if (BUF->type == HTONS(ETHTYPE_ARP))
         {
           /* Dispatch ARP packet to the network layer */
 

--- a/drivers/net/tun.c
+++ b/drivers/net/tun.c
@@ -605,7 +605,7 @@ static void tun_net_receive_tap(FAR struct tun_device_s *priv)
   else
 #endif
 #ifdef CONFIG_NET_ARP
-  if (BUF->type == htons(ETHTYPE_ARP))
+  if (BUF->type == HTONS(ETHTYPE_ARP))
     {
       arp_arpin(&priv->dev);
       NETDEV_RXARP(&priv->dev);

--- a/drivers/usbdev/cdcecm.c
+++ b/drivers/usbdev/cdcecm.c
@@ -532,7 +532,7 @@ static void cdcecm_receive(FAR struct cdcecm_driver_s *self)
   else
 #endif
 #ifdef CONFIG_NET_ARP
-  if (BUF->type == htons(ETHTYPE_ARP))
+  if (BUF->type == HTONS(ETHTYPE_ARP))
     {
       /* Dispatch ARP packet to the network layer */
 

--- a/drivers/usbdev/rndis.c
+++ b/drivers/usbdev/rndis.c
@@ -939,7 +939,7 @@ static void rndis_rxdispatch(FAR void *arg)
   else
 #endif
 #ifdef CONFIG_NET_ARP
-  if (hdr->type == htons(ETHTYPE_ARP))
+  if (hdr->type == HTONS(ETHTYPE_ARP))
     {
       NETDEV_RXARP(&priv->netdev);
 
@@ -954,7 +954,7 @@ static void rndis_rxdispatch(FAR void *arg)
 #endif
     {
       uerr("ERROR: Unsupported packet type dropped (%02x)\n",
-           htons(hdr->type));
+           HTONS(hdr->type));
       NETDEV_RXDROPPED(&priv->netdev);
       priv->netdev.d_len = 0;
     }

--- a/drivers/video/vnc/vnc_server.c
+++ b/drivers/video/vnc/vnc_server.c
@@ -155,7 +155,7 @@ static int vnc_connect(FAR struct vnc_session_s *session, int port)
   /* Create a listening socket */
 
   addr.sin_family = AF_INET;
-  addr.sin_port = htons(port);
+  addr.sin_port = HTONS(port);
   addr.sin_addr.s_addr = INADDR_ANY;
 
   ret = psock_socket(AF_INET, SOCK_STREAM, 0, &session->listen);

--- a/drivers/wireless/gs2200m.c
+++ b/drivers/wireless/gs2200m.c
@@ -1308,7 +1308,7 @@ static void _parse_pkt_in_s4(FAR struct pkt_ctx_s *pkt_ctx,
       wlinfo("from (%s:%s)\n", addr, port);
 
       inet_aton(addr, &pkt_dat->addr.sin_addr);
-      pkt_dat->addr.sin_port = htons((uint16_t)atoi(port));
+      pkt_dat->addr.sin_port = HTONS((uint16_t)atoi(port));
 
       /* Skip until data length */
 
@@ -2030,7 +2030,7 @@ static enum pkt_type_e gs2200m_send_bulk(FAR struct gs2200m_dev_s *dev,
   else
     {
       wlinfo("** addr=%s port=%d\n", inet_ntoa(msg->addr.sin_addr),
-             ntohs(msg->addr.sin_port));
+             NTOHS(msg->addr.sin_port));
 
       /* NOTE: See 7.5.3.2 Bulk Data Handling for UDP
        * <ESC>Y<CID><IP address>:<port>:<Data Length xxxx 4 ascii char><data>
@@ -2038,7 +2038,7 @@ static enum pkt_type_e gs2200m_send_bulk(FAR struct gs2200m_dev_s *dev,
 
       snprintf(cmd, sizeof(cmd), "%cY%c%s:%d:%s",
                ASCII_ESC, msg->cid,
-               inet_ntoa(msg->addr.sin_addr), ntohs(msg->addr.sin_port),
+               inet_ntoa(msg->addr.sin_addr), NTOHS(msg->addr.sin_port),
                digits);
     }
 
@@ -2221,12 +2221,12 @@ static enum pkt_type_e gs2200m_get_cstatus(FAR struct gs2200m_dev_s *dev,
 
           if (msg->local)
             {
-              msg->addr.sin_port = htons(p[0]);
+              msg->addr.sin_port = HTONS(p[0]);
             }
           else
             {
               char addr[20];
-              msg->addr.sin_port = htons(p[1]);
+              msg->addr.sin_port = HTONS(p[1]);
               snprintf(addr, sizeof(addr),
                        "%d.%d.%d.%d", a[0], a[1], a[2], a[3]);
               inet_aton(addr, &msg->addr.sin_addr);

--- a/drivers/wireless/ieee80211/bcm43xxx/bcmf_netdev.c
+++ b/drivers/wireless/ieee80211/bcm43xxx/bcmf_netdev.c
@@ -369,7 +369,7 @@ static void bcmf_receive(FAR struct bcmf_dev_s *priv)
       else
 #endif
 #ifdef CONFIG_NET_ARP
-      if (BUF->type == htons(ETHTYPE_ARP))
+      if (BUF->type == HTONS(ETHTYPE_ARP))
         {
           arp_arpin(&priv->bc_dev);
           NETDEV_RXARP(&priv->bc_dev);

--- a/fs/nfs/rpc_clnt.c
+++ b/fs/nfs/rpc_clnt.c
@@ -196,7 +196,7 @@ static int rpcclnt_socket(FAR struct rpcclnt *rpc, in_port_t rport)
       if (rport != 0)
         {
           sin = (FAR struct sockaddr_in6 *)&raddr;
-          sin->sin6_port = htons(rport);
+          sin->sin6_port = HTONS(rport);
         }
 
       sin = (FAR struct sockaddr_in6 *)&laddr;
@@ -210,7 +210,7 @@ static int rpcclnt_socket(FAR struct rpcclnt *rpc, in_port_t rport)
       if (rport != 0)
         {
           sin = (FAR struct sockaddr_in *)&raddr;
-          sin->sin_port = htons(rport);
+          sin->sin_port = HTONS(rport);
         }
 
       sin = (FAR struct sockaddr_in *)&laddr;

--- a/fs/userfs/fs_userfs.c
+++ b/fs/userfs/fs_userfs.c
@@ -1430,7 +1430,7 @@ static int userfs_bind(FAR struct inode *blkdriver, FAR const void *data,
   /* Preset the server address */
 
   priv->server.sin_family      = AF_INET;
-  priv->server.sin_port        = htons(config->portno);
+  priv->server.sin_port        = HTONS(config->portno);
   priv->server.sin_addr.s_addr = HTONL(INADDR_LOOPBACK);
 
   /* Create a LocalHost UDP client socket */

--- a/include/nuttx/net/ip.h
+++ b/include/nuttx/net/ip.h
@@ -304,7 +304,7 @@ extern "C"
  *
  ****************************************************************************/
 
-#define ip6_addr(addr, addr0,addr1,addr2,addr3,addr4,addr5,addr6,addr7) \
+#define ip6_addr(addr,addr0,addr1,addr2,addr3,addr4,addr5,addr6,addr7) \
   do { \
     ((FAR uint16_t *)(addr))[0] = HTONS((addr0)); \
     ((FAR uint16_t *)(addr))[1] = HTONS((addr1)); \

--- a/libs/libc/net/lib_htons.c
+++ b/libs/libc/net/lib_htons.c
@@ -41,6 +41,6 @@ uint16_t ntohs(uint16_t ns)
 #ifdef CONFIG_ENDIAN_BIG
   return ns;
 #else
-  return htons(ns);
+  return HTONS(ns);
 #endif
 }

--- a/libs/libc/net/lib_inetntop.c
+++ b/libs/libc/net/lib_inetntop.c
@@ -194,7 +194,7 @@ static int inet_ipv6_ntop(FAR const void *src, FAR char *dest,
 
   while (offset < 8)
     {
-      warray[offset] = ntohs(in6_addr->s6_addr16[offset]);
+      warray[offset] = NTOHS(in6_addr->s6_addr16[offset]);
       if (warray[offset] == 0)
         {
           entry = offset;
@@ -203,7 +203,7 @@ static int inet_ipv6_ntop(FAR const void *src, FAR char *dest,
 
           while (offset < 8)
             {
-              warray[offset] = ntohs(in6_addr->s6_addr16[offset]);
+              warray[offset] = NTOHS(in6_addr->s6_addr16[offset]);
               if (warray[offset] != 0)
                 {
                   break;

--- a/libs/libc/netdb/lib_dnsaddserver.c
+++ b/libs/libc/netdb/lib_dnsaddserver.c
@@ -107,7 +107,7 @@ int dns_add_nameserver(FAR const struct sockaddr *addr, socklen_t addrlen)
 #ifdef CONFIG_NETDB_RESOLVCONF_NONSTDPORT
           /* Get the port number */
 
-          port = ntohs(in4->sin_port);
+          port = NTOHS(in4->sin_port);
 #endif
         }
     }
@@ -140,7 +140,7 @@ int dns_add_nameserver(FAR const struct sockaddr *addr, socklen_t addrlen)
 #ifdef CONFIG_NETDB_RESOLVCONF_NONSTDPORT
           /* Get the port number */
 
-          port = ntohs(in6->sin6_port);
+          port = NTOHS(in6->sin6_port);
 #endif
         }
     }

--- a/libs/libc/netdb/lib_dnsforeach.c
+++ b/libs/libc/netdb/lib_dnsforeach.c
@@ -167,7 +167,7 @@ int dns_foreach_nameserver(dns_callback_t callback, FAR void *arg)
                   tmp = atoi(portstr);
                   if (tmp != 0)
                     {
-                      port = htons(tmp);
+                      port = HTONS(tmp);
                     }
                 }
             }

--- a/libs/libc/netdb/lib_dnsquery.c
+++ b/libs/libc/netdb/lib_dnsquery.c
@@ -219,7 +219,7 @@ static int dns_send_query(int sd, FAR const char *name,
 
   hdr               = (FAR struct dns_header_s *)buffer;
   memset(hdr, 0, sizeof(*hdr));
-  hdr->id           = htons(id);
+  hdr->id           = HTONS(id);
   hdr->flags1       = DNS_FLAG1_RD;
   hdr->numquestions = HTONS(1);
 
@@ -279,7 +279,7 @@ static int dns_send_query(int sd, FAR const char *name,
   *dest++ = (DNS_CLASS_IN >> 8);   /* DNS record class (big endian) */
   *dest++ = (DNS_CLASS_IN & 0xff);
 
-  qinfo->rectype = htons(rectype);
+  qinfo->rectype = HTONS(rectype);
   qinfo->id      = hdr->id;
 
   /* Send the request */
@@ -367,12 +367,12 @@ static int dns_recv_response(int sd, FAR union dns_addr_u *addr, int naddr,
   hdr         = (FAR struct dns_header_s *)buffer;
   endofbuffer = (FAR uint8_t *)buffer + ret;
 
-  ninfo("ID %d\n", ntohs(hdr->id));
+  ninfo("ID %d\n", NTOHS(hdr->id));
   ninfo("Query %d\n", hdr->flags1 & DNS_FLAG1_RESPONSE);
   ninfo("Error %d\n", hdr->flags2 & DNS_FLAG2_ERR_MASK);
   ninfo("Num questions %d, answers %d, authrr %d, extrarr %d\n",
-        ntohs(hdr->numquestions), ntohs(hdr->numanswers),
-        ntohs(hdr->numauthrr), ntohs(hdr->numextrarr));
+        NTOHS(hdr->numquestions), NTOHS(hdr->numanswers),
+        NTOHS(hdr->numauthrr), NTOHS(hdr->numextrarr));
 
   /* Check for error */
 
@@ -387,7 +387,7 @@ static int dns_recv_response(int sd, FAR union dns_addr_u *addr, int naddr,
   if (hdr->id != qinfo->id)
     {
       nerr("ERROR: DNS wrong response ID (expected %d, got %d)\n",
-           ntohs(qinfo->id), ntohs(hdr->id));
+           NTOHS(qinfo->id), NTOHS(hdr->id));
       return -EBADMSG;
     }
 
@@ -395,8 +395,8 @@ static int dns_recv_response(int sd, FAR union dns_addr_u *addr, int naddr,
    * and the extrarr are simply discarded.
    */
 
-  nquestions = ntohs(hdr->numquestions);
-  nanswers   = ntohs(hdr->numanswers);
+  nquestions = NTOHS(hdr->numquestions);
+  nanswers   = NTOHS(hdr->numanswers);
 
   /* We only ever send queries with one question. */
 
@@ -472,9 +472,9 @@ static int dns_recv_response(int sd, FAR union dns_addr_u *addr, int naddr,
       ans = (FAR struct dns_answer_s *)nameptr;
 
       ninfo("Answer: type=%04x, class=%04x, ttl=%06x, length=%04x\n",
-            ntohs(ans->type), ntohs(ans->class),
-            (ntohs(ans->ttl[0]) << 16) | ntohs(ans->ttl[1]),
-            ntohs(ans->len));
+            NTOHS(ans->type), NTOHS(ans->class),
+            (NTOHS(ans->ttl[0]) << 16) | NTOHS(ans->ttl[1]),
+            NTOHS(ans->len));
 
       /* Check for IPv4/6 address type and Internet class. Others are
        * discarded.
@@ -520,14 +520,14 @@ static int dns_recv_response(int sd, FAR union dns_addr_u *addr, int naddr,
           nameptr += 10 + 16;
 
           ninfo("IPv6 address: %04x:%04x:%04x:%04x:%04x:%04x:%04x:%04x\n",
-                ntohs(ans->u.ipv6.s6_addr16[0]),
-                ntohs(ans->u.ipv6.s6_addr16[1]),
-                ntohs(ans->u.ipv6.s6_addr16[2]),
-                ntohs(ans->u.ipv6.s6_addr16[3]),
-                ntohs(ans->u.ipv6.s6_addr16[4]),
-                ntohs(ans->u.ipv6.s6_addr16[5]),
-                ntohs(ans->u.ipv6.s6_addr16[6]),
-                ntohs(ans->u.ipv6.s6_addr16[7]));
+                NTOHS(ans->u.ipv6.s6_addr16[0]),
+                NTOHS(ans->u.ipv6.s6_addr16[1]),
+                NTOHS(ans->u.ipv6.s6_addr16[2]),
+                NTOHS(ans->u.ipv6.s6_addr16[3]),
+                NTOHS(ans->u.ipv6.s6_addr16[4]),
+                NTOHS(ans->u.ipv6.s6_addr16[5]),
+                NTOHS(ans->u.ipv6.s6_addr16[6]),
+                NTOHS(ans->u.ipv6.s6_addr16[7]));
 
           inaddr                  = &addr[naddr_read].ipv6;
           inaddr->sin6_family     = AF_INET6;
@@ -543,7 +543,7 @@ static int dns_recv_response(int sd, FAR union dns_addr_u *addr, int naddr,
       else
 #endif
         {
-          nameptr = nameptr + 10 + ntohs(ans->len);
+          nameptr = nameptr + 10 + NTOHS(ans->len);
         }
     }
 

--- a/libs/libc/netdb/lib_getaddrinfo.c
+++ b/libs/libc/netdb/lib_getaddrinfo.c
@@ -173,7 +173,7 @@ int getaddrinfo(FAR const char *hostname, FAR const char *servname,
         {
           /* Force network byte order */
 
-          port = htons(port);
+          port = HTONS(port);
         }
       else if ((flags & AI_NUMERICSERV) != 0)
         {

--- a/libs/libc/netdb/lib_getnameinfo.c
+++ b/libs/libc/netdb/lib_getnameinfo.c
@@ -58,7 +58,7 @@ int getnameinfo(FAR const struct sockaddr *addr, socklen_t addrlen,
       FAR const struct sockaddr_in *sa_in;
 
       sa_in = (FAR const struct sockaddr_in *)addr;
-      port = ntohs(sa_in->sin_port);
+      port = NTOHS(sa_in->sin_port);
       saddr = &sa_in->sin_addr;
       saddr_len = sizeof(sa_in->sin_addr);
     }
@@ -69,7 +69,7 @@ int getnameinfo(FAR const struct sockaddr *addr, socklen_t addrlen,
       FAR const struct sockaddr_in6 *sa_in6;
 
       sa_in6 = (FAR const struct sockaddr_in6 *)addr;
-      port = ntohs(sa_in6->sin6_port);
+      port = NTOHS(sa_in6->sin6_port);
       saddr = &sa_in6->sin6_addr;
       saddr_len = sizeof(sa_in6->sin6_addr);
     }

--- a/libs/libc/netdb/lib_getservbynamer.c
+++ b/libs/libc/netdb/lib_getservbynamer.c
@@ -97,7 +97,7 @@ int getservbyname_r(FAR const char *name, FAR const char *proto,
         {
           result_buf->s_name = (FAR char *)name;
           result_buf->s_aliases = NULL;
-          result_buf->s_port = htons(g_services_db[i].s_port);
+          result_buf->s_port = HTONS(g_services_db[i].s_port);
 
           if (g_services_db[i].s_protocol == IPPROTO_TCP)
             {

--- a/libs/libc/netdb/lib_getservbyportr.c
+++ b/libs/libc/netdb/lib_getservbyportr.c
@@ -81,7 +81,7 @@ int getservbyport_r(int port, FAR const char *proto,
         {
           result_buf->s_name = (FAR char *)g_services_db[i].s_name;
           result_buf->s_aliases = NULL;
-          result_buf->s_port = htons(port);
+          result_buf->s_port = HTONS(port);
 
           if (g_services_db[i].s_protocol == IPPROTO_TCP)
             {

--- a/libs/libc/netdb/lib_rexec.c
+++ b/libs/libc/netdb/lib_rexec.c
@@ -68,7 +68,7 @@ int rexec_af(FAR char **ahost, int inport, FAR const char *user,
       return -1;
     }
 
-  snprintf(port_str, sizeof(port_str), "%d", ntohs(inport));
+  snprintf(port_str, sizeof(port_str), "%d", NTOHS(inport));
 
   memset(&hints, 0, sizeof(hints));
   hints.ai_family = af;

--- a/libs/libc/userfs/lib_userfs.c
+++ b/libs/libc/userfs/lib_userfs.c
@@ -1043,7 +1043,7 @@ int userfs_run(FAR const char *mountpt,
   /* Bind the socket to a server port number */
 
   server.sin_family      = AF_INET;
-  server.sin_port        = htons(config.portno);
+  server.sin_port        = HTONS(config.portno);
   server.sin_addr.s_addr = HTONL(INADDR_LOOPBACK);
 
   ret = bind(info->sockfd, (struct sockaddr *)&server,

--- a/net/icmpv6/icmpv6_autoconfig.c
+++ b/net/icmpv6/icmpv6_autoconfig.c
@@ -314,10 +314,10 @@ int icmpv6_autoconfig(FAR struct net_driver_s *dev)
   icmpv6_linkipaddr(dev, lladdr);
 
   ninfo("lladdr=%04x:%04x:%04x:%04x:%04x:%04x:%04x:%04x\n",
-        ntohs(lladdr[0]), ntohs(lladdr[1]),
-        ntohs(lladdr[2]), ntohs(lladdr[3]),
-        ntohs(lladdr[4]), ntohs(lladdr[5]),
-        ntohs(lladdr[6]), ntohs(lladdr[7]));
+        NTOHS(lladdr[0]), NTOHS(lladdr[1]),
+        NTOHS(lladdr[2]), NTOHS(lladdr[3]),
+        NTOHS(lladdr[4]), NTOHS(lladdr[5]),
+        NTOHS(lladdr[6]), NTOHS(lladdr[7]));
 
 #ifdef CONFIG_NET_ICMPv6_NEIGHBOR
   /* 2. Link-Local Address Uniqueness Test:  The node tests to ensure that

--- a/net/icmpv6/icmpv6_rnotify.c
+++ b/net/icmpv6/icmpv6_rnotify.c
@@ -103,10 +103,10 @@ static void icmpv6_setaddresses(FAR struct net_driver_s *dev,
   net_ipv6_pref2mask(preflen, dev->d_ipv6netmask);
 
   ninfo("preflen=%d netmask=%04x:%04x:%04x:%04x:%04x:%04x:%04x:%04x\n",
-        preflen, ntohs(dev->d_ipv6netmask[0]), ntohs(dev->d_ipv6netmask[1]),
-        ntohs(dev->d_ipv6netmask[2]), ntohs(dev->d_ipv6netmask[3]),
-        ntohs(dev->d_ipv6netmask[4]), ntohs(dev->d_ipv6netmask[5]),
-        ntohs(dev->d_ipv6netmask[6]), ntohs(dev->d_ipv6netmask[7]));
+        preflen, NTOHS(dev->d_ipv6netmask[0]), NTOHS(dev->d_ipv6netmask[1]),
+        NTOHS(dev->d_ipv6netmask[2]), NTOHS(dev->d_ipv6netmask[3]),
+        NTOHS(dev->d_ipv6netmask[4]), NTOHS(dev->d_ipv6netmask[5]),
+        NTOHS(dev->d_ipv6netmask[6]), NTOHS(dev->d_ipv6netmask[7]));
 
   /* Copy prefix to the current IPv6 address, applying the mask */
 
@@ -117,24 +117,24 @@ static void icmpv6_setaddresses(FAR struct net_driver_s *dev,
     }
 
   ninfo("prefix=%04x:%04x:%04x:%04x:%04x:%04x:%04x:%04x\n",
-        ntohs(prefix[0]), ntohs(prefix[1]), ntohs(prefix[2]),
-        ntohs(prefix[3]), ntohs(prefix[4]), ntohs(prefix[5]),
-        ntohs(prefix[6]), ntohs(prefix[7]));
+        NTOHS(prefix[0]), NTOHS(prefix[1]), NTOHS(prefix[2]),
+        NTOHS(prefix[3]), NTOHS(prefix[4]), NTOHS(prefix[5]),
+        NTOHS(prefix[6]), NTOHS(prefix[7]));
   ninfo("IP address=%04x:%04x:%04x:%04x:%04x:%04x:%04x:%04x\n",
-        ntohs(dev->d_ipv6addr[0]), ntohs(dev->d_ipv6addr[1]),
-        ntohs(dev->d_ipv6addr[2]), ntohs(dev->d_ipv6addr[3]),
-        ntohs(dev->d_ipv6addr[4]), ntohs(dev->d_ipv6addr[5]),
-        ntohs(dev->d_ipv6addr[6]), ntohs(dev->d_ipv6addr[7]));
+        NTOHS(dev->d_ipv6addr[0]), NTOHS(dev->d_ipv6addr[1]),
+        NTOHS(dev->d_ipv6addr[2]), NTOHS(dev->d_ipv6addr[3]),
+        NTOHS(dev->d_ipv6addr[4]), NTOHS(dev->d_ipv6addr[5]),
+        NTOHS(dev->d_ipv6addr[6]), NTOHS(dev->d_ipv6addr[7]));
 
   /* Finally, copy the router address */
 
   net_ipv6addr_copy(dev->d_ipv6draddr, draddr);
 
   ninfo("DR address=%04x:%04x:%04x:%04x:%04x:%04x:%04x:%04x\n",
-        ntohs(dev->d_ipv6draddr[0]), ntohs(dev->d_ipv6draddr[1]),
-        ntohs(dev->d_ipv6draddr[2]), ntohs(dev->d_ipv6draddr[3]),
-        ntohs(dev->d_ipv6draddr[4]), ntohs(dev->d_ipv6draddr[5]),
-        ntohs(dev->d_ipv6draddr[6]), ntohs(dev->d_ipv6draddr[7]));
+        NTOHS(dev->d_ipv6draddr[0]), NTOHS(dev->d_ipv6draddr[1]),
+        NTOHS(dev->d_ipv6draddr[2]), NTOHS(dev->d_ipv6draddr[3]),
+        NTOHS(dev->d_ipv6draddr[4]), NTOHS(dev->d_ipv6draddr[5]),
+        NTOHS(dev->d_ipv6draddr[6]), NTOHS(dev->d_ipv6draddr[7]));
 
   net_unlock();
 }

--- a/net/inet/inet_sockif.c
+++ b/net/inet/inet_sockif.c
@@ -1382,7 +1382,7 @@ static int inet_socketpair(FAR struct socket *psocks[2])
       len = sizeof(addr[0].inaddr);
       memset(&addr[0], 0, len);
       addr[0].inaddr.sin_family = psocks[0]->s_domain;
-      addr[0].inaddr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+      addr[0].inaddr.sin_addr.s_addr = HTONL(INADDR_LOOPBACK);
     }
 
   memcpy(&addr[1], &addr[0], len);

--- a/net/ipforward/ipv4_forward.c
+++ b/net/ipforward/ipv4_forward.c
@@ -179,7 +179,7 @@ static int ipv4_decr_ttl(FAR struct ipv4_hdr_s *ipv4)
     }
   else
     {
-      sum = htons(sum);
+      sum = HTONS(sum);
     }
 
   ipv4->ipchksum = ~sum;

--- a/net/neighbor/neighbor_dumpentry.c
+++ b/net/neighbor/neighbor_dumpentry.c
@@ -122,10 +122,10 @@ void neighbor_dumpentry(FAR const char *msg,
 {
   ninfo("%s: %04x:%04x:%04x:%04x:%04x:%04x:%04x:%04x\n",
         msg,
-        ntohs(neighbor->ne_ipaddr[0]), ntohs(neighbor->ne_ipaddr[1]),
-        ntohs(neighbor->ne_ipaddr[2]), ntohs(neighbor->ne_ipaddr[3]),
-        ntohs(neighbor->ne_ipaddr[4]), ntohs(neighbor->ne_ipaddr[5]),
-        ntohs(neighbor->ne_ipaddr[6]), ntohs(neighbor->ne_ipaddr[7]));
+        NTOHS(neighbor->ne_ipaddr[0]), NTOHS(neighbor->ne_ipaddr[1]),
+        NTOHS(neighbor->ne_ipaddr[2]), NTOHS(neighbor->ne_ipaddr[3]),
+        NTOHS(neighbor->ne_ipaddr[4]), NTOHS(neighbor->ne_ipaddr[5]),
+        NTOHS(neighbor->ne_ipaddr[6]), NTOHS(neighbor->ne_ipaddr[7]));
 
   neighbor_dump_address(&neighbor->ne_addr.u,
                         neighbor->ne_addr.na_llsize);
@@ -151,9 +151,9 @@ void neighbor_dumpipaddr(FAR const char *msg,
 {
   ninfo("%s: %04x:%04x:%04x:%04x:%04x:%04x:%04x:%04x\n",
         msg,
-        ntohs(ipaddr[0]), ntohs(ipaddr[1]), ntohs(ipaddr[2]),
-        ntohs(ipaddr[3]), ntohs(ipaddr[4]), ntohs(ipaddr[5]),
-        ntohs(ipaddr[6]), ntohs(ipaddr[7]));
+        NTOHS(ipaddr[0]), NTOHS(ipaddr[1]), NTOHS(ipaddr[2]),
+        NTOHS(ipaddr[3]), NTOHS(ipaddr[4]), NTOHS(ipaddr[5]),
+        NTOHS(ipaddr[6]), NTOHS(ipaddr[7]));
 }
 
 #endif /* CONFIG_DEBUG_NET_INFO */

--- a/net/route/net_del_fileroute.c
+++ b/net/route/net_del_fileroute.c
@@ -96,7 +96,7 @@ static int net_match_ipv4(FAR struct net_route_ipv4_s *route, FAR void *arg)
   net_ipv4_dumproute("Comparing", route);
   ninfo("With:\n");
   ninfo("  target=%08lx netmask=%08lx\n",
-        htonl(match->target), htonl(match->netmask));
+        HTONL(match->target), HTONL(match->netmask));
 
   if (net_ipv4addr_maskcmp(route->target, match->target, match->netmask) &&
       net_ipv4addr_cmp(route->netmask, match->netmask))
@@ -128,15 +128,15 @@ static int net_match_ipv6(FAR struct net_route_ipv6_s *route, FAR void *arg)
   net_ipv6_dumproute("Comparing", route);
   ninfo("With:\n");
   ninfo("  target:  %04x:%04x:%04x:%04x:%04x:%04x:%04x:%04x\n",
-        htons(match->target[0]),  htons(match->target[1]),
-        htons(match->target[2]),  htons(match->target[3]),
-        htons(match->target[4]),  htons(match->target[5]),
-        htons(match->target[6]),  htons(match->target[7]));
+        HTONS(match->target[0]),  HTONS(match->target[1]),
+        HTONS(match->target[2]),  HTONS(match->target[3]),
+        HTONS(match->target[4]),  HTONS(match->target[5]),
+        HTONS(match->target[6]),  HTONS(match->target[7]));
   ninfo("  netmask: %04x:%04x:%04x:%04x:%04x:%04x:%04x:%04x\n",
-        htons(match->netmask[0]), htons(match->netmask[1]),
-        htons(match->netmask[2]), htons(match->netmask[3]),
-        htons(match->netmask[4]), htons(match->netmask[5]),
-        htons(match->netmask[6]), htons(match->netmask[7]));
+        HTONS(match->netmask[0]), HTONS(match->netmask[1]),
+        HTONS(match->netmask[2]), HTONS(match->netmask[3]),
+        HTONS(match->netmask[4]), HTONS(match->netmask[5]),
+        HTONS(match->netmask[6]), HTONS(match->netmask[7]));
 
   if (net_ipv6addr_maskcmp(route->target, match->target, match->netmask) &&
       net_ipv6addr_cmp(route->netmask, match->netmask))

--- a/net/route/net_del_ramroute.c
+++ b/net/route/net_del_ramroute.c
@@ -91,7 +91,7 @@ static int net_match_ipv4(FAR struct net_route_ipv4_s *route, FAR void *arg)
   net_ipv4_dumproute("Comparing", route);
   ninfo("With:\n");
   ninfo("  target=%08lx netmask=%08lx\n",
-        htonl(match->target), htonl(match->netmask));
+        HTONL(match->target), HTONL(match->netmask));
 
   if (net_ipv4addr_maskcmp(route->target, match->target, match->netmask) &&
       net_ipv4addr_cmp(route->netmask, match->netmask))
@@ -139,15 +139,15 @@ static int net_match_ipv6(
   net_ipv6_dumproute("Comparing", route);
   ninfo("With:\n");
   ninfo("  target:  %04x:%04x:%04x:%04x:%04x:%04x:%04x:%04x\n",
-        htons(match->target[0]),  htons(match->target[1]),
-        htons(match->target[2]),  htons(match->target[3]),
-        htons(match->target[4]),  htons(match->target[5]),
-        htons(match->target[6]),  htons(match->target[7]));
+        HTONS(match->target[0]),  HTONS(match->target[1]),
+        HTONS(match->target[2]),  HTONS(match->target[3]),
+        HTONS(match->target[4]),  HTONS(match->target[5]),
+        HTONS(match->target[6]),  HTONS(match->target[7]));
   ninfo("  netmask: %04x:%04x:%04x:%04x:%04x:%04x:%04x:%04x\n",
-        htons(match->netmask[0]), htons(match->netmask[1]),
-        htons(match->netmask[2]), htons(match->netmask[3]),
-        htons(match->netmask[4]), htons(match->netmask[5]),
-        htons(match->netmask[6]), htons(match->netmask[7]));
+        HTONS(match->netmask[0]), HTONS(match->netmask[1]),
+        HTONS(match->netmask[2]), HTONS(match->netmask[3]),
+        HTONS(match->netmask[4]), HTONS(match->netmask[5]),
+        HTONS(match->netmask[6]), HTONS(match->netmask[7]));
 
   if (net_ipv6addr_maskcmp(route->target, match->target, match->netmask) &&
       net_ipv6addr_cmp(route->netmask, match->netmask))

--- a/net/route/net_dumproute.c
+++ b/net/route/net_dumproute.c
@@ -55,7 +55,7 @@ void net_ipv4_dumproute(FAR const char *msg,
 {
   ninfo("%s:\n", msg);
   ninfo("  target=%08lx netmask=%08lx router=%08lx\n",
-        htonl(route->target), htonl(route->netmask), htonl(route->router));
+        HTONL(route->target), HTONL(route->netmask), HTONL(route->router));
 }
 #endif
 
@@ -65,20 +65,20 @@ void net_ipv6_dumproute(FAR const char *msg,
 {
   ninfo("%s:\n", msg);
   ninfo("  target:  %04x:%04x:%04x:%04x:%04x:%04x:%04x:%04x\n",
-        htons(route->target[0]),  htons(route->target[1]),
-        htons(route->target[2]),  htons(route->target[3]),
-        htons(route->target[4]),  htons(route->target[5]),
-        htons(route->target[6]),  htons(route->target[7]));
+        HTONS(route->target[0]),  HTONS(route->target[1]),
+        HTONS(route->target[2]),  HTONS(route->target[3]),
+        HTONS(route->target[4]),  HTONS(route->target[5]),
+        HTONS(route->target[6]),  HTONS(route->target[7]));
   ninfo("  netmask: %04x:%04x:%04x:%04x:%04x:%04x:%04x:%04x\n",
-        htons(route->netmask[0]), htons(route->netmask[1]),
-        htons(route->netmask[2]), htons(route->netmask[3]),
-        htons(route->netmask[4]), htons(route->netmask[5]),
-        htons(route->netmask[6]), htons(route->netmask[7]));
+        HTONS(route->netmask[0]), HTONS(route->netmask[1]),
+        HTONS(route->netmask[2]), HTONS(route->netmask[3]),
+        HTONS(route->netmask[4]), HTONS(route->netmask[5]),
+        HTONS(route->netmask[6]), HTONS(route->netmask[7]));
   ninfo("  router:  %04x:%04x:%04x:%04x:%04x:%04x:%04x:%04x\n",
-        htons(route->router[0]),  htons(route->router[1]),
-        htons(route->router[2]),  htons(route->router[3]),
-        htons(route->router[4]),  htons(route->router[5]),
-        htons(route->router[6]),  htons(route->router[7]));
+        HTONS(route->router[0]),  HTONS(route->router[1]),
+        HTONS(route->router[2]),  HTONS(route->router[3]),
+        HTONS(route->router[4]),  HTONS(route->router[5]),
+        HTONS(route->router[6]),  HTONS(route->router[7]));
 }
 #endif
 

--- a/net/sixlowpan/sixlowpan_hc06.c
+++ b/net/sixlowpan/sixlowpan_hc06.c
@@ -245,9 +245,9 @@ static FAR struct sixlowpan_addrcontext_s *
           ninfo("Context found for "
                 "ipaddr=%04x:%04x:%04x:%04x:%04x:%04x:%04x:%04x "
                 "Context: %d\n",
-                ntohs(ipaddr[0]), ntohs(ipaddr[1]), ntohs(ipaddr[2]),
-                ntohs(ipaddr[3]), ntohs(ipaddr[4]), ntohs(ipaddr[5]),
-                ntohs(ipaddr[6]), ntohs(ipaddr[7]),
+                NTOHS(ipaddr[0]), NTOHS(ipaddr[1]), NTOHS(ipaddr[2]),
+                NTOHS(ipaddr[3]), NTOHS(ipaddr[4]), NTOHS(ipaddr[5]),
+                NTOHS(ipaddr[6]), NTOHS(ipaddr[7]),
                 g_hc06_addrcontexts[i].number);
 
           return &g_hc06_addrcontexts[i];
@@ -324,10 +324,10 @@ static uint8_t compress_tagaddr(FAR const net_ipv6addr_t ipaddr,
 #ifdef CONFIG_DEBUG_NET_INFO
   ninfo("Compressing bitpos=%u addrlen=%u\n", bitpos, macaddr->nv_addrlen);
   ninfo("            ipaddr=%04x:%04x:%04x:%04x:%04x:%04x:%04x:%04x\n",
-        ntohs(ipaddr[0]), ntohs(ipaddr[1]),
-        ntohs(ipaddr[2]), ntohs(ipaddr[3]),
-        ntohs(ipaddr[4]), ntohs(ipaddr[5]),
-        ntohs(ipaddr[6]), ntohs(ipaddr[7]));
+        NTOHS(ipaddr[0]), NTOHS(ipaddr[1]),
+        NTOHS(ipaddr[2]), NTOHS(ipaddr[3]),
+        NTOHS(ipaddr[4]), NTOHS(ipaddr[5]),
+        NTOHS(ipaddr[6]), NTOHS(ipaddr[7]));
 
   switch (macaddr->nv_addrlen)
     {
@@ -376,9 +376,9 @@ static uint8_t compress_laddr(FAR const net_ipv6addr_t srcipaddr,
 #ifdef CONFIG_DEBUG_NET_INFO
   ninfo("Compressing bitpos=%u\n", bitpos);
   ninfo("            srcipaddr=%04x:%04x:%04x:%04x:%04x:%04x:%04x:%04x\n",
-        ntohs(srcipaddr[0]), ntohs(srcipaddr[1]), ntohs(srcipaddr[2]),
-        ntohs(srcipaddr[3]), ntohs(srcipaddr[4]), ntohs(srcipaddr[5]),
-        ntohs(srcipaddr[6]), ntohs(srcipaddr[7]));
+        NTOHS(srcipaddr[0]), NTOHS(srcipaddr[1]), NTOHS(srcipaddr[2]),
+        NTOHS(srcipaddr[3]), NTOHS(srcipaddr[4]), NTOHS(srcipaddr[5]),
+        NTOHS(srcipaddr[6]), NTOHS(srcipaddr[7]));
 
   switch (macaddr->nv_addrlen)
     {
@@ -562,10 +562,10 @@ static void uncompress_addr(FAR const struct netdev_varaddr_s *addr,
   ninfo("Uncompressing %d + %d "
         "ipaddr=%04x:%04x:%04x:%04x:%04x:%04x:%04x:%04x\n",
         prefcount, postcount,
-        ntohs(ipaddr[0]), ntohs(ipaddr[1]),
-        ntohs(ipaddr[2]), ntohs(ipaddr[3]),
-        ntohs(ipaddr[4]), ntohs(ipaddr[5]),
-        ntohs(ipaddr[6]), ntohs(ipaddr[7]));
+        NTOHS(ipaddr[0]), NTOHS(ipaddr[1]),
+        NTOHS(ipaddr[2]), NTOHS(ipaddr[3]),
+        NTOHS(ipaddr[4]), NTOHS(ipaddr[5]),
+        NTOHS(ipaddr[6]), NTOHS(ipaddr[7]));
 }
 
 /****************************************************************************
@@ -931,10 +931,10 @@ int sixlowpan_compresshdr_hc06(FAR struct radio_driver_s *radio,
 
       ninfo("Uncompressable "
             "srcipaddr=%04x:%04x:%04x:%04x:%04x:%04x:%04x:%04x\n",
-            ntohs(ipv6->srcipaddr[0]), ntohs(ipv6->srcipaddr[1]),
-            ntohs(ipv6->srcipaddr[2]), ntohs(ipv6->srcipaddr[3]),
-            ntohs(ipv6->srcipaddr[4]), ntohs(ipv6->srcipaddr[5]),
-            ntohs(ipv6->srcipaddr[6]), ntohs(ipv6->srcipaddr[7]));
+            NTOHS(ipv6->srcipaddr[0]), NTOHS(ipv6->srcipaddr[1]),
+            NTOHS(ipv6->srcipaddr[2]), NTOHS(ipv6->srcipaddr[3]),
+            NTOHS(ipv6->srcipaddr[4]), NTOHS(ipv6->srcipaddr[5]),
+            NTOHS(ipv6->srcipaddr[6]), NTOHS(ipv6->srcipaddr[7]));
 
       iphc1 |= SIXLOWPAN_IPHC_SAM_128;   /* 128-bits */
       memcpy(g_hc06ptr, ipv6->srcipaddr, 16);
@@ -1051,12 +1051,12 @@ int sixlowpan_compresshdr_hc06(FAR struct radio_driver_s *radio,
         (FAR struct udp_hdr_s *)((FAR uint8_t *)ipv6 + IPv6_HDRLEN);
 
       ninfo("Uncompressed UDP ports: srcport=%04x destport=%04x\n",
-            ntohs(udp->srcport), ntohs(udp->destport));
+            NTOHS(udp->srcport), NTOHS(udp->destport));
 
       /* Mask out the last 4 bits can be used as a mask */
 
-      if (((ntohs(udp->srcport) & 0xfff0) == SIXLOWPAN_UDP_4_BIT_PORT_MIN) &&
-          ((ntohs(udp->destport) & 0xfff0) == SIXLOWPAN_UDP_4_BIT_PORT_MIN))
+      if (((NTOHS(udp->srcport) & 0xfff0) == SIXLOWPAN_UDP_4_BIT_PORT_MIN) &&
+          ((NTOHS(udp->destport) & 0xfff0) == SIXLOWPAN_UDP_4_BIT_PORT_MIN))
         {
           /* We can compress 12 bits of both source and dest */
 
@@ -1065,14 +1065,14 @@ int sixlowpan_compresshdr_hc06(FAR struct radio_driver_s *radio,
           ninfo("Remove 12b of both source & dest with prefix 0xf0b*\n");
 
           *(g_hc06ptr + 1) =
-            (uint8_t)((ntohs(udp->srcport) -
+            (uint8_t)((NTOHS(udp->srcport) -
              SIXLOWPAN_UDP_4_BIT_PORT_MIN) << 4) +
-            (uint8_t)((ntohs(udp->destport) -
+            (uint8_t)((NTOHS(udp->destport) -
              SIXLOWPAN_UDP_4_BIT_PORT_MIN));
 
           g_hc06ptr += 2;
         }
-      else if ((ntohs(udp->destport) & 0xff00) ==
+      else if ((NTOHS(udp->destport) & 0xff00) ==
                SIXLOWPAN_UDP_8_BIT_PORT_MIN)
         {
           /* We can compress 8 bits of dest, leave source. */
@@ -1083,11 +1083,11 @@ int sixlowpan_compresshdr_hc06(FAR struct radio_driver_s *radio,
 
           memcpy(g_hc06ptr + 1, &udp->srcport, 2);
           *(g_hc06ptr + 3) =
-            (uint8_t) ((ntohs(udp->destport) -
+            (uint8_t) ((NTOHS(udp->destport) -
                         SIXLOWPAN_UDP_8_BIT_PORT_MIN));
           g_hc06ptr += 4;
         }
-      else if ((ntohs(udp->srcport) & 0xff00) ==
+      else if ((NTOHS(udp->srcport) & 0xff00) ==
                SIXLOWPAN_UDP_8_BIT_PORT_MIN)
         {
           /* We can compress 8 bits of src, leave dest.
@@ -1100,7 +1100,7 @@ int sixlowpan_compresshdr_hc06(FAR struct radio_driver_s *radio,
                 "leave dest. hch: %u\n", *g_hc06ptr);
 
           *(g_hc06ptr + 1) =
-            (uint8_t)((ntohs(udp->srcport) - SIXLOWPAN_UDP_8_BIT_PORT_MIN));
+            (uint8_t)((NTOHS(udp->srcport) - SIXLOWPAN_UDP_8_BIT_PORT_MIN));
 
           memcpy(g_hc06ptr + 2, &udp->destport, 2);
           g_hc06ptr += 4;
@@ -1462,7 +1462,7 @@ void sixlowpan_uncompresshdr_hc06(FAR struct radio_driver_s *radio,
               memcpy(&udp->destport, g_hc06ptr + 3, 2);
 
               ninfo("Uncompressed UDP ports (ptr+5): %x, %x\n",
-                     htons(udp->srcport), htons(udp->destport));
+                    HTONS(udp->srcport), HTONS(udp->destport));
 
               g_hc06ptr += 5;
               break;
@@ -1477,10 +1477,10 @@ void sixlowpan_uncompresshdr_hc06(FAR struct radio_driver_s *radio,
 
               memcpy(&udp->srcport, g_hc06ptr + 1, 2);
               udp->destport =
-                htons(SIXLOWPAN_UDP_8_BIT_PORT_MIN + (*(g_hc06ptr + 3)));
+                HTONS(SIXLOWPAN_UDP_8_BIT_PORT_MIN + (*(g_hc06ptr + 3)));
 
               ninfo("Uncompressed UDP ports (ptr+4): %x, %x\n",
-                     htons(udp->srcport), htons(udp->destport));
+                    HTONS(udp->srcport), HTONS(udp->destport));
 
               g_hc06ptr += 4;
               break;
@@ -1494,11 +1494,11 @@ void sixlowpan_uncompresshdr_hc06(FAR struct radio_driver_s *radio,
               ninfo("Decompressing source\n");
 
               udp->srcport =
-                htons(SIXLOWPAN_UDP_8_BIT_PORT_MIN + (*(g_hc06ptr + 1)));
+                HTONS(SIXLOWPAN_UDP_8_BIT_PORT_MIN + (*(g_hc06ptr + 1)));
               memcpy(&udp->destport, g_hc06ptr + 2, 2);
 
               ninfo("Uncompressed UDP ports (ptr+4): %x, %x\n",
-                     htons(udp->srcport), htons(udp->destport));
+                    HTONS(udp->srcport), HTONS(udp->destport));
 
               g_hc06ptr += 4;
               break;
@@ -1508,14 +1508,14 @@ void sixlowpan_uncompresshdr_hc06(FAR struct radio_driver_s *radio,
               /* 1 byte for NHC, 1 byte for ports */
 
               udp->srcport =
-                htons(SIXLOWPAN_UDP_4_BIT_PORT_MIN +
+                HTONS(SIXLOWPAN_UDP_4_BIT_PORT_MIN +
                           (*(g_hc06ptr + 1) >> 4));
               udp->destport =
-                htons(SIXLOWPAN_UDP_4_BIT_PORT_MIN +
+                HTONS(SIXLOWPAN_UDP_4_BIT_PORT_MIN +
                           ((*(g_hc06ptr + 1)) & 0x0f));
 
               ninfo("Uncompressed UDP ports (ptr+2): %x, %x\n",
-                     htons(udp->srcport), htons(udp->destport));
+                    HTONS(udp->srcport), HTONS(udp->destport));
 
               g_hc06ptr += 2;
               break;

--- a/net/sixlowpan/sixlowpan_hc1.c
+++ b/net/sixlowpan/sixlowpan_hc1.c
@@ -213,10 +213,10 @@ int sixlowpan_compresshdr_hc1(FAR struct radio_driver_s *radio,
             ninfo("local/remote port %04x/%04x\n",
                    udp->srcport, udp->destport);
 
-            if (ntohs(udp->srcport)  >=  CONFIG_NET_6LOWPAN_MINPORT &&
-                ntohs(udp->srcport)  <  (CONFIG_NET_6LOWPAN_MINPORT + 16) &&
-                ntohs(udp->destport) >=  CONFIG_NET_6LOWPAN_MINPORT &&
-                ntohs(udp->destport) <  (CONFIG_NET_6LOWPAN_MINPORT + 16))
+            if (NTOHS(udp->srcport)  >=  CONFIG_NET_6LOWPAN_MINPORT &&
+                NTOHS(udp->srcport)  <  (CONFIG_NET_6LOWPAN_MINPORT + 16) &&
+                NTOHS(udp->destport) >=  CONFIG_NET_6LOWPAN_MINPORT &&
+                NTOHS(udp->destport) <  (CONFIG_NET_6LOWPAN_MINPORT + 16))
               {
                 FAR uint8_t *hcudp = fptr + g_frame_hdrlen;
 
@@ -229,9 +229,9 @@ int sixlowpan_compresshdr_hc1(FAR struct radio_driver_s *radio,
                 hcudp[SIXLOWPAN_HC1_HC_UDP_UDP_ENCODING] = 0xe0;
                 hcudp[SIXLOWPAN_HC1_HC_UDP_TTL]          = ipv6->ttl;
                 hcudp[SIXLOWPAN_HC1_HC_UDP_PORTS]        =
-                  (uint8_t)((ntohs(udp->srcport) -
+                  (uint8_t)((NTOHS(udp->srcport) -
                             CONFIG_NET_6LOWPAN_MINPORT) << 4) +
-                  (uint8_t)((ntohs(udp->destport) -
+                  (uint8_t)((NTOHS(udp->destport) -
                             CONFIG_NET_6LOWPAN_MINPORT));
 
                 memcpy(&hcudp[SIXLOWPAN_HC1_HC_UDP_CHKSUM],
@@ -370,10 +370,10 @@ int sixlowpan_uncompresshdr_hc1(FAR struct radio_driver_s *radio,
             /* UDP ports, len, checksum */
 
             udp->srcport =
-              htons(CONFIG_NET_6LOWPAN_MINPORT +
+              HTONS(CONFIG_NET_6LOWPAN_MINPORT +
                     (hcudp[SIXLOWPAN_HC1_HC_UDP_PORTS] >> 4));
             udp->destport =
-              htons(CONFIG_NET_6LOWPAN_MINPORT +
+              HTONS(CONFIG_NET_6LOWPAN_MINPORT +
                     (hcudp[SIXLOWPAN_HC1_HC_UDP_PORTS] & 0x0f));
 
             ninfo("UDP srcport=%04x destport=%04x\n",
@@ -425,10 +425,10 @@ int sixlowpan_uncompresshdr_hc1(FAR struct radio_driver_s *radio,
     }
 
   ninfo("srcipaddr=%04x:%04x:%04x:%04x:%04x:%04x:%04x:%04x\n",
-        ntohs(ipv6->srcipaddr[0]), ntohs(ipv6->srcipaddr[1]),
-        ntohs(ipv6->srcipaddr[2]), ntohs(ipv6->srcipaddr[3]),
-        ntohs(ipv6->srcipaddr[4]), ntohs(ipv6->srcipaddr[5]),
-        ntohs(ipv6->srcipaddr[6]), ntohs(ipv6->srcipaddr[7]));
+        NTOHS(ipv6->srcipaddr[0]), NTOHS(ipv6->srcipaddr[1]),
+        NTOHS(ipv6->srcipaddr[2]), NTOHS(ipv6->srcipaddr[3]),
+        NTOHS(ipv6->srcipaddr[4]), NTOHS(ipv6->srcipaddr[5]),
+        NTOHS(ipv6->srcipaddr[6]), NTOHS(ipv6->srcipaddr[7]));
 
   if ((hc1[SIXLOWPAN_HC1_ENCODING] & SIXLOWPAN_HC1_DESTADDR_MASK) ==
       SIXLOWPAN_HC1_DESTADDR_PCIC)
@@ -450,10 +450,10 @@ int sixlowpan_uncompresshdr_hc1(FAR struct radio_driver_s *radio,
     }
 
   ninfo("destipaddr=%04x:%04x:%04x:%04x:%04x:%04x:%04x:%04x\n",
-        ntohs(ipv6->destipaddr[0]), ntohs(ipv6->destipaddr[1]),
-        ntohs(ipv6->destipaddr[2]), ntohs(ipv6->destipaddr[3]),
-        ntohs(ipv6->destipaddr[4]), ntohs(ipv6->destipaddr[5]),
-        ntohs(ipv6->destipaddr[6]), ntohs(ipv6->destipaddr[7]));
+        NTOHS(ipv6->destipaddr[0]), NTOHS(ipv6->destipaddr[1]),
+        NTOHS(ipv6->destipaddr[2]), NTOHS(ipv6->destipaddr[3]),
+        NTOHS(ipv6->destipaddr[4]), NTOHS(ipv6->destipaddr[5]),
+        NTOHS(ipv6->destipaddr[6]), NTOHS(ipv6->destipaddr[7]));
 
   /* IP length field. */
 

--- a/net/sixlowpan/sixlowpan_tcpsend.c
+++ b/net/sixlowpan/sixlowpan_tcpsend.c
@@ -156,7 +156,7 @@ static uint16_t sixlowpan_tcp_chksum(FAR const struct ipv6tcp_hdr_s *ipv6tcp,
   /* Sum payload data. */
 
   sum = chksum(sum, buf, buflen);
-  return (sum == 0) ? 0xffff : htons(sum);
+  return (sum == 0) ? 0xffff : HTONS(sum);
 }
 
 /****************************************************************************

--- a/net/sixlowpan/sixlowpan_udpsend.c
+++ b/net/sixlowpan/sixlowpan_udpsend.c
@@ -105,7 +105,7 @@ static uint16_t sixlowpan_udp_chksum(FAR const struct ipv6udp_hdr_s *ipv6udp,
   /* Sum payload data. */
 
   sum = chksum(sum, buf, buflen);
-  return (sum == 0) ? 0xffff : htons(sum);
+  return (sum == 0) ? 0xffff : HTONS(sum);
 }
 #endif
 
@@ -261,7 +261,7 @@ ssize_t psock_6lowpan_udp_sendto(FAR struct socket *psock,
 
   ipv6udp.udp.srcport     = conn->lport;
   ipv6udp.udp.destport    = to6->sin6_port;
-  ipv6udp.udp.udplen      = htons(iplen);
+  ipv6udp.udp.udplen      = HTONS(iplen);
   ipv6udp.udp.udpchksum   = 0;
 
 #ifdef CONFIG_NET_UDP_CHECKSUMS

--- a/net/tcp/tcp_conn.c
+++ b/net/tcp/tcp_conn.c
@@ -234,7 +234,7 @@ static int tcp_selectport(uint8_t domain,
               g_last_tcp_port = 4096;
             }
 
-          portno = htons(g_last_tcp_port);
+          portno = HTONS(g_last_tcp_port);
         }
       while (tcp_listener(domain, ipaddr, portno));
     }

--- a/net/tcp/tcp_input.c
+++ b/net/tcp/tcp_input.c
@@ -828,8 +828,7 @@ found:
                  */
 
                 nwarn("WARNING: Listen canceled while waiting for ACK on "
-                      "port %d\n",
-                      ntohs(tcp->destport));
+                      "port %d\n", NTOHS(tcp->destport));
 
                 /* Free the connection structure */
 

--- a/net/udp/udp_conn.c
+++ b/net/udp/udp_conn.c
@@ -555,7 +555,7 @@ uint16_t udp_select_port(uint8_t domain, FAR union ip_binding_u *u)
           g_last_udp_port = 4096;
         }
     }
-  while (udp_find_conn(domain, u, htons(g_last_udp_port)) != NULL);
+  while (udp_find_conn(domain, u, HTONS(g_last_udp_port)) != NULL);
 
   /* Initialize and return the connection structure, bind it to the
    * port number
@@ -833,7 +833,7 @@ int udp_bind(FAR struct udp_conn_s *conn, FAR const struct sockaddr *addr)
     {
       /* Yes.. Select any unused local port number */
 
-      conn->lport = htons(udp_select_port(conn->domain, &conn->u));
+      conn->lport = HTONS(udp_select_port(conn->domain, &conn->u));
       ret         = OK;
     }
   else
@@ -903,7 +903,7 @@ int udp_connect(FAR struct udp_conn_s *conn, FAR const struct sockaddr *addr)
        * connection structure.
        */
 
-      conn->lport = htons(udp_select_port(conn->domain, &conn->u));
+      conn->lport = HTONS(udp_select_port(conn->domain, &conn->u));
     }
 
   /* Is there a remote port (rport)? */

--- a/net/udp/udp_sendto_buffered.c
+++ b/net/udp/udp_sendto_buffered.c
@@ -299,7 +299,7 @@ static int sendto_next_transfer(FAR struct socket *psock,
        * connection structure.
        */
 
-      conn->lport = htons(udp_select_port(conn->domain, &conn->u));
+      conn->lport = HTONS(udp_select_port(conn->domain, &conn->u));
     }
 
   /* Get the device that will handle the remote packet transfers.  This

--- a/net/utils/net_chksum.c
+++ b/net/utils/net_chksum.c
@@ -119,7 +119,7 @@ uint16_t chksum(uint16_t sum, FAR const uint8_t *data, uint16_t len)
 #ifndef CONFIG_NET_ARCH_CHKSUM
 uint16_t net_chksum(FAR uint16_t *data, uint16_t len)
 {
-  return htons(chksum(0, (uint8_t *)data, len));
+  return HTONS(chksum(0, (uint8_t *)data, len));
 }
 #endif /* CONFIG_NET_ARCH_CHKSUM */
 

--- a/net/utils/net_ipchksum.c
+++ b/net/utils/net_ipchksum.c
@@ -101,7 +101,7 @@ uint16_t ipv4_upperlayer_chksum(FAR struct net_driver_s *dev, uint8_t proto)
   /* Sum IP payload data. */
 
   sum = chksum(sum, &dev->d_buf[iphdrlen + NET_LL_HDRLEN(dev)], upperlen);
-  return (sum == 0) ? 0xffff : htons(sum);
+  return (sum == 0) ? 0xffff : HTONS(sum);
 }
 #endif /* CONFIG_NET_ARCH_CHKSUM */
 
@@ -168,7 +168,7 @@ uint16_t ipv6_upperlayer_chksum(FAR struct net_driver_s *dev,
   /* Sum IP payload data. */
 
   sum = chksum(sum, &dev->d_buf[NET_LL_HDRLEN(dev) + iplen], upperlen);
-  return (sum == 0) ? 0xffff : htons(sum);
+  return (sum == 0) ? 0xffff : HTONS(sum);
 }
 #endif /* CONFIG_NET_ARCH_CHKSUM */
 
@@ -201,7 +201,7 @@ uint16_t ipv4_chksum(FAR struct net_driver_s *dev)
   iphdrlen = (ipv4->vhl & IPv4_HLMASK) << 2;
 
   sum = chksum(0, &dev->d_buf[NET_LL_HDRLEN(dev)], iphdrlen);
-  return (sum == 0) ? 0xffff : htons(sum);
+  return (sum == 0) ? 0xffff : HTONS(sum);
 }
 #endif /* CONFIG_NET_ARCH_CHKSUM */
 

--- a/net/utils/net_ipv6_mask2pref.c
+++ b/net/utils/net_ipv6_mask2pref.c
@@ -155,7 +155,7 @@ uint8_t net_ipv6_mask2pref(FAR const uint16_t *mask)
 
   if (i < 8)
     {
-      preflen += net_msbits16(ntohs(mask[i]));
+      preflen += net_msbits16(NTOHS(mask[i]));
     }
 
   /* Return the prefix length */


### PR DESCRIPTION
## Summary
Currently in the kernel code we have a mix of byte convert functions like `htons` and byte convert macro like `HTONS` used in code. Switch to byte convert macro in all possible places in the kernel code.

## Impact
No functional changes

## Testing
Pass CI