### PR TITLE
net/tcp/sendfile: swapped the location of TCP_DISCONN_EVENTS and TCP_ACKDATA conditions

### DIFF
--- a/net/tcp/tcp_send_unbuffered.c
+++ b/net/tcp/tcp_send_unbuffered.c
@@ -209,6 +209,8 @@ static uint16_t tcpsend_eventhandler(FAR struct net_driver_s *dev,
 
   /* If this packet contains an acknowledgement, then update the count of
    * acknowledged bytes.
+   * This condition is located here for performance reasons
+   * (TCP_ACKDATA is the most frequent event).
    */
 
   if ((flags & TCP_ACKDATA) != 0)
@@ -291,7 +293,10 @@ static uint16_t tcpsend_eventhandler(FAR struct net_driver_s *dev,
       pstate->snd_prev_wnd = conn->snd_wnd;
     }
 
-  /* Check if we are being asked to retransmit data */
+  /* Check if we are being asked to retransmit data.
+   * This condition is located here after TCP_ACKDATA for performance reasons
+   * (TCP_REXMIT is less frequent than TCP_ACKDATA).
+   */
 
   if ((flags & TCP_REXMIT) != 0)
     {
@@ -332,7 +337,10 @@ static uint16_t tcpsend_eventhandler(FAR struct net_driver_s *dev,
       return flags;
     }
 
-  /* Check for a loss of connection */
+  /* Check for a loss of connection.
+   * This condition is located here after both the TCP_ACKDATA and TCP_REXMIT
+   * because TCP_DISCONN_EVENTS is the least frequent event.
+   */
 
   else if ((flags & TCP_DISCONN_EVENTS) != 0)
     {


### PR DESCRIPTION
## Summary

Swapped the location of TCP_DISCONN_EVENTS and TCP_ACKDATA conditions by the following reasons:
1. Unification towards tcp_send_unbuffered.c
2. Slightly better performance in theory (in practice the peak speed is 453 Mbit/s (after) vs 449 Mbit/sec (before) in case of sim:tcpblaster config)
3. This change gets possible as a result of #5252.

## Impact

TCP sendfile

## Testing