### PR TITLE
pthread/barrier: set the semaphore's protocol to SEM_PRIO_NONE

### DIFF
--- a/libs/libc/pthread/pthread_barrierinit.c
+++ b/libs/libc/pthread/pthread_barrierinit.c
@@ -82,6 +82,7 @@ int pthread_barrier_init(FAR pthread_barrier_t *barrier,
   else
     {
       sem_init(&barrier->sem, 0, 0);
+      sem_setprotocol(&barrier->sem, SEM_PRIO_NONE);
       barrier->count = count;
     }
 


### PR DESCRIPTION
Here the semaphore is only used as a barrier, maintaining the holder list is useless.

Signed-off-by: Zeng Zhaoxiu <walker.zeng@transtekcorp.com>

## Summary

## Impact

## Testing

