### PR TITLE
tools: add option to reuse boards common files for custom boards

### DIFF
--- a/tools/Config.mk
+++ b/tools/Config.mk
@@ -145,6 +145,9 @@ else
 endif
 
 BOARD_COMMON_DIR ?= $(wildcard $(BOARD_DIR)$(DELIM)..$(DELIM)common)
+ifeq ($(BOARD_COMMON_DIR),)
+  BOARD_COMMON_DIR = $(wildcard $(TOPDIR)$(DELIM)boards$(DELIM)$(CONFIG_ARCH)$(DELIM)$(CONFIG_ARCH_CHIP)$(DELIM)common)
+endif
 BOARD_DRIVERS_DIR ?= $(wildcard $(BOARD_DIR)$(DELIM)..$(DELIM)drivers)
 ifeq ($(BOARD_DRIVERS_DIR),)
   BOARD_DRIVERS_DIR = $(TOPDIR)$(DELIM)drivers$(DELIM)dummy


### PR DESCRIPTION
## Summary
I'm having a custom board configuration, but still would like to use common code for boards with the same architecture. Add option to reuse boards common files for custom boards

## Impact
None

## Testing
Pass CI
