### PR TITLE
boards/arm/samv7: fix build error when automount is enabled

### DIFF
--- a/boards/arm/samv7/common/src/sam_automount.c
+++ b/boards/arm/samv7/common/src/sam_automount.c
@@ -97,7 +97,7 @@ static const struct sam_automount_config_s g_hsmci0config =
     .enable     = sam_enable,
     .inserted   = sam_inserted
   },
-  .hsmci        = HSMCI0_SLOTNO,
+  .hsmci        = 0,
   .state        = &g_hsmci0state
 };
 #endif
@@ -250,7 +250,7 @@ void sam_automount_initialize(void)
   /* Initialize the HSMCI0 auto-mounter */
 
   handle = automount_initialize(&g_hsmci0config.lower);
-  if (!handle)
+  if (handle == NULL)
     {
       ferr("ERROR: Failed to initialize auto-mounter for HSMCI0\n");
     }
@@ -291,7 +291,7 @@ void sam_automount_event(int slotno, bool inserted)
 #ifdef CONFIG_SAMV7_HSMCI0_AUTOMOUNT
   /* Is this a change in the HSMCI0 insertion state? */
 
-  if (slotno == HSMCI0_SLOTNO)
+  if (g_hsmci0config.hsmci == slotno)
     {
       /* Yes.. Select the HSMCI0 automounter */
 

--- a/boards/arm/samv7/same70-qmtech/src/sam_bringup.c
+++ b/boards/arm/samv7/same70-qmtech/src/sam_bringup.c
@@ -107,15 +107,15 @@ int sam_bringup(void)
 
       /* Mount the volume on HSMCI0 */
 
-      ret = nx_mount(CONFIG_SAME70QMTECH_HSMCI0_MOUNT_BLKDEV,
-                     CONFIG_SAME70QMTECH_HSMCI0_MOUNT_MOUNTPOINT,
-                     CONFIG_SAME70QMTECH_HSMCI0_MOUNT_FSTYPE,
+      ret = nx_mount(CONFIG_SAMV7_HSMCI0_MOUNT_BLKDEV,
+                     CONFIG_SAMV7_HSMCI0_MOUNT_MOUNTPOINT,
+                     CONFIG_SAMV7_HSMCI0_MOUNT_FSTYPE,
                      0, NULL);
 
       if (ret < 0)
         {
           syslog(LOG_ERR, "ERROR: Failed to mount %s: %d\n",
-                 CONFIG_SAME70QMTECH_HSMCI0_MOUNT_MOUNTPOINT, ret);
+                 CONFIG_SAMV7_HSMCI0_MOUNT_MOUNTPOINT, ret);
         }
     }
 

--- a/boards/arm/samv7/same70-xplained/src/sam_bringup.c
+++ b/boards/arm/samv7/same70-xplained/src/sam_bringup.c
@@ -198,15 +198,15 @@ int sam_bringup(void)
 
       /* Mount the volume on HSMCI0 */
 
-      ret = nx_mount(CONFIG_SAME70XPLAINED_HSMCI0_MOUNT_BLKDEV,
-                     CONFIG_SAME70XPLAINED_HSMCI0_MOUNT_MOUNTPOINT,
-                     CONFIG_SAME70XPLAINED_HSMCI0_MOUNT_FSTYPE,
+      ret = nx_mount(CONFIG_SAMV7_HSMCI0_MOUNT_BLKDEV,
+                     CONFIG_SAMV7_HSMCI0_MOUNT_MOUNTPOINT,
+                     CONFIG_SAMV7_HSMCI0_MOUNT_FSTYPE,
                      0, NULL);
 
       if (ret < 0)
         {
           syslog(LOG_ERR, "ERROR: Failed to mount %s: %d\n",
-                 CONFIG_SAME70XPLAINED_HSMCI0_MOUNT_MOUNTPOINT, ret);
+                 CONFIG_SAMV7_HSMCI0_MOUNT_MOUNTPOINT, ret);
         }
     }
 

--- a/boards/arm/samv7/samv71-xult/src/sam_bringup.c
+++ b/boards/arm/samv7/samv71-xult/src/sam_bringup.c
@@ -315,15 +315,15 @@ int sam_bringup(void)
 
       /* Mount the volume on HSMCI0 */
 
-      ret = nx_mount(CONFIG_SAMV71XULT_HSMCI0_MOUNT_BLKDEV,
-                     CONFIG_SAMV71XULT_HSMCI0_MOUNT_MOUNTPOINT,
-                     CONFIG_SAMV71XULT_HSMCI0_MOUNT_FSTYPE,
+      ret = nx_mount(CONFIG_SAMV7_HSMCI0_MOUNT_BLKDEV,
+                     CONFIG_SAMV7_HSMCI0_MOUNT_MOUNTPOINT,
+                     CONFIG_SAMV7_HSMCI0_MOUNT_FSTYPE,
                      0, NULL);
 
       if (ret < 0)
         {
           syslog(LOG_ERR, "ERROR: Failed to mount %s: %d\n",
-                 CONFIG_SAMV71XULT_HSMCI0_MOUNT_MOUNTPOINT, ret);
+                 CONFIG_SAMV7_HSMCI0_MOUNT_MOUNTPOINT, ret);
         }
     }
 


### PR DESCRIPTION
## Summary
same70-qmtech build fails if automount is enabled. `HSMCI0_SLOTNO` is undefined in `boards/arm/samv7/common/src/sam_automount.c`. Rework logic to keep the same behavior but get rid of `HSMCI0_SLOTNO` references.

## Impact
SAMv7 based boards

## Testing
Pass CI.
same70-qmtech:nsh build succeeds if automount is enabled