### PR TITLE
Mpfs opensbi redefinition fixes

### DIFF
--- a/arch/risc-v/src/mpfs/mpfs_opensbi.c
+++ b/arch/risc-v/src/mpfs/mpfs_opensbi.c
@@ -26,7 +26,6 @@
 #include <assert.h>
 #include <errno.h>
 #include <stdint.h>
-#include <riscv_internal.h>
 #include <riscv_arch.h>
 
 #include <hardware/mpfs_plic.h>
@@ -117,6 +116,16 @@ static int  mpfs_opensbi_console_init(void);
 static int  mpfs_irqchip_init(bool cold_boot);
 static int  mpfs_ipi_init(bool cold_boot);
 static int  mpfs_timer_init(bool cold_boot);
+
+/****************************************************************************
+ * Extern Function Declarations
+ ****************************************************************************/
+
+/* riscv_internal.h cannot be included due to a number of redefinition
+ * conflicts.  Thus, define the riscv_lowputc() with the extern definition.
+ */
+
+extern void riscv_lowputc(char ch);
 
 /****************************************************************************
  * Private Data

--- a/arch/risc-v/src/mpfs/mpfs_opensbi.c
+++ b/arch/risc-v/src/mpfs/mpfs_opensbi.c
@@ -414,14 +414,6 @@ static int mpfs_early_init(bool cold_boot)
   modifyreg32(MPFS_SYSREG_SOFT_RESET_CR, 0, SYSREG_SOFT_RESET_CR_MMC);
   modifyreg32(MPFS_SYSREG_SOFT_RESET_CR, SYSREG_SOFT_RESET_CR_MMC, 0);
 
-  /* U-boot will use serial console 1, just turn on MMUART1 clocks now in
-   * order to see also u-boot traces.
-   */
-
-  modifyreg32(MPFS_SYSREG_SOFT_RESET_CR, SYSREG_SOFT_RESET_CR_MMUART1, 0);
-  modifyreg32(MPFS_SYSREG_SUBBLK_CLOCK_CR, 0,
-              SYSREG_SUBBLK_CLOCK_CR_MMUART1);
-
   /* There are other clocks that need to be enabled for the Linux kernel to
    * run. For now, turn on all the clocks.
    */


### PR DESCRIPTION
## Summary

PR #5264 fails due to OpenSBI dependency to riscv_internal.h.
There's been efforts to use OPENSBI_EXTERNAL_SBI_TYPES, but then many NuttX header files would need to be collected to form such an entry. Updating it would be pointless, as OpenSBI is rather seen as a separate entity. We'd like to have less dependency to any OpenSBI headers. The unfortunate file mpfs_opensbi.c is in the middle of both: it needs some NuttX headers but also some OpenSBI headers.

Also remove unnecessary uart1 reset on a separate patch.

## Impact

No impact, PR #5264 will pass

## Testing

Polarfire Icicle board