### PR TITLE
libs/libc/misc/lib_execinfo.c: fix bad memory access

### DIFF
--- a/libs/libc/misc/lib_execinfo.c
+++ b/libs/libc/misc/lib_execinfo.c
@@ -67,7 +67,7 @@ FAR char **backtrace_symbols(FAR void *const *buffer, int size)
   syms = backtrace_malloc(buffer, size);
   if (syms != NULL)
     {
-      buf = syms[size];
+      buf = (FAR char *)&syms[size];
       for (i = 0; i < size; i++)
         {
           syms[i] = buf;


### PR DESCRIPTION
## Summary
Our CI system found an issue with Clang static analyzer tool:

```
61 | FAR char **backtrace_symbols(FAR void *const *buffer, int size)
-- | --
62 | {
63 | FAR char **syms;
64 | FAR char *buf;
65 | int i;
66 |  
67 | syms = backtrace_malloc(buffer, size);
68 | if (syms != NULL((void*)0))
  | 1Assuming 'syms' is not equal to NULL→ | 1 | Assuming 'syms' is not equal to NULL | →
1 | Assuming 'syms' is not equal to NULL | →
  | 2←Taking true branch→ | 2 | ← | Taking true branch | →
2 | ← | Taking true branch | →
69 | {
70 | buf = syms[size];
  | 3←Assigned value is garbage or undefined | 3 | ← | Assigned value is garbage or undefined
3 | ← | Assigned value is garbage or undefined
71 | for (i = 0; i < size; i++)
72 | {
73 | syms[i] = buf;
74 | buf += sprintf(buf, "%pS", buffer[i]);
75 | buf += 1;
76 | }
77 | }
78 |  
79 | return syms;
80 | }
```
Variable `syms` points to malloc()'ed memory so `syms[size]` aka `*(syms+size)` dereferences a pointer to memory with undefined content, so initially `buf` points to random memory location.

## Impact
Memory corruption

## Testing
Compile testing and static analysis only. We do not use this backtrace mechanism.