### PR TITLE
libc: backtrace_malloc change sprintf to snprintf

### DIFF
--- a/libs/libc/misc/lib_execinfo.c
+++ b/libs/libc/misc/lib_execinfo.c
@@ -42,7 +42,7 @@ static FAR char **backtrace_malloc(FAR void *const *buffer, int size)
 
   while (size-- > 0)
     {
-      int ret = sprintf(NULL, "%pS", *buffer++);
+      int ret = snprintf(NULL, 0, "%pS", *buffer++);
       if (ret < 0)
         {
           return NULL;


### PR DESCRIPTION
## Summary
since snprintf can handle NULL pointer but sprintf can't.

## Impact
backtrace_symbols

## Testing

