### PR TITLE
Rv

### DIFF
--- a/arch/risc-v/include/irq.h
+++ b/arch/risc-v/include/irq.h
@@ -45,6 +45,31 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
+/* Map RISC-V exception code to NuttX IRQ */
+
+/* IRQ 0-15 : (exception:interrupt=0) */
+
+#define RISCV_IRQ_IAMISALIGNED  (0)   /* Instruction Address Misaligned */
+#define RISCV_IRQ_IAFAULT       (1)   /* Instruction Address Fault */
+#define RISCV_IRQ_IINSTRUCTION  (2)   /* Illegal Instruction */
+#define RISCV_IRQ_BPOINT        (3)   /* Break Point */
+#define RISCV_IRQ_LAMISALIGNED  (4)   /* Load Address Misaligned */
+#define RISCV_IRQ_LAFAULT       (5)   /* Load Access Fault */
+#define RISCV_IRQ_SAMISALIGNED  (6)   /* Store/AMO Address Misaligned */
+#define RISCV_IRQ_SAFAULT       (7)   /* Store/AMO Access Fault */
+#define RISCV_IRQ_ECALLU        (8)   /* Environment Call from U-mode */
+                                      /* 9-10: Reserved */
+#define RISCV_IRQ_ECALLM        (11)  /* Environment Call from M-mode */
+                                      /* 12-15: Reserved */
+
+/* IRQ 16- : (async event:interrupt=1) */
+
+#define RISCV_IRQ_ASYNC         (16)
+
+#define RISCV_IRQ_MSOFT         (RISCV_IRQ_ASYNC + 3)  /* Machine Software Int */
+#define RISCV_IRQ_MTIMER        (RISCV_IRQ_ASYNC + 7)  /* Machine Timer Int */
+#define RISCV_IRQ_MEXT          (RISCV_IRQ_ASYNC + 11) /* Machine External Int */
+
 /* Configuration ************************************************************/
 
 /* If this is a kernel build, how many nested system calls should we

--- a/arch/risc-v/include/qemu-rv/irq.h
+++ b/arch/risc-v/include/qemu-rv/irq.h
@@ -33,30 +33,7 @@
 
 /* Map RISC-V exception code to NuttX IRQ */
 
-/* IRQ 0-15 : (exception:interrupt=0) */
-
-#define QEMU_RV_IRQ_IAMISALIGNED  (0) /* Instruction Address Misaligned */
-#define QEMU_RV_IRQ_IAFAULT       (1) /* Instruction Address Fault */
-#define QEMU_RV_IRQ_IINSTRUCTION  (2) /* Illegal Instruction */
-#define QEMU_RV_IRQ_BPOINT        (3) /* Break Point */
-#define QEMU_RV_IRQ_LAMISALIGNED  (4) /* Load Address Misaligned */
-#define QEMU_RV_IRQ_LAFAULT       (5) /* Load Access Fault */
-#define QEMU_RV_IRQ_SAMISALIGNED  (6) /* Store/AMO Address Misaligned */
-#define QEMU_RV_IRQ_SAFAULT       (7) /* Store/AMO Access Fault */
-#define QEMU_RV_IRQ_ECALLU        (8) /* Environment Call from U-mode */
-                                      /* 9-10: Reserved */
-
-#define QEMU_RV_IRQ_ECALLM       (11) /* Environment Call from M-mode */
-                                      /* 12-15: Reserved */
-
-/* IRQ 16- : (async event:interrupt=1) */
-
-#define QEMU_RV_IRQ_ASYNC  (16)
-#define QEMU_RV_IRQ_MSOFT  (QEMU_RV_IRQ_ASYNC + 3)  /* Machine Software Int */
-#define QEMU_RV_IRQ_MTIMER (QEMU_RV_IRQ_ASYNC + 7)  /* Machine Timer Int */
-#define QEMU_RV_IRQ_MEXT   (QEMU_RV_IRQ_ASYNC + 11) /* Machine External Int */
-
-#define QEMU_RV_IRQ_UART0  (QEMU_RV_IRQ_MEXT + 10)
+#define QEMU_RV_IRQ_UART0  (RISCV_IRQ_MEXT + 10)
 
 #define NR_IRQS (QEMU_RV_IRQ_UART0 + 1)
 

--- a/arch/risc-v/src/qemu-rv/qemu_rv_irq.c
+++ b/arch/risc-v/src/qemu-rv/qemu_rv_irq.c
@@ -85,7 +85,7 @@ void up_irqinitialize(void)
 
   /* Attach the ecall interrupt handler */
 
-  irq_attach(QEMU_RV_IRQ_ECALLM, riscv_swint, NULL);
+  irq_attach(RISCV_IRQ_ECALLM, riscv_swint, NULL);
 
 #ifndef CONFIG_SUPPRESS_INTERRUPTS
 
@@ -108,7 +108,7 @@ void up_disable_irq(int irq)
   int extirq;
   uint32_t oldstat;
 
-  if (irq == QEMU_RV_IRQ_MTIMER)
+  if (irq == RISCV_IRQ_MTIMER)
     {
       /* Read mstatus & clear machine timer interrupt enable in mie */
 
@@ -116,9 +116,9 @@ void up_disable_irq(int irq)
                   : "=r"(oldstat)
                   : "r"(MIE_MTIE));
     }
-  else if (irq > QEMU_RV_IRQ_MEXT)
+  else if (irq > RISCV_IRQ_MEXT)
     {
-      extirq = irq - QEMU_RV_IRQ_MEXT;
+      extirq = irq - RISCV_IRQ_MEXT;
 
       /* Clear enable bit for the irq */
 
@@ -147,7 +147,7 @@ void up_enable_irq(int irq)
   int extirq;
   uint32_t oldstat;
 
-  if (irq == QEMU_RV_IRQ_MTIMER)
+  if (irq == RISCV_IRQ_MTIMER)
     {
       /* Read mstatus & set machine timer interrupt enable in mie */
 
@@ -155,9 +155,9 @@ void up_enable_irq(int irq)
                   : "=r"(oldstat)
                   : "r"(MIE_MTIE));
     }
-  else if (irq > QEMU_RV_IRQ_MEXT)
+  else if (irq > RISCV_IRQ_MEXT)
     {
-      extirq = irq - QEMU_RV_IRQ_MEXT;
+      extirq = irq - RISCV_IRQ_MEXT;
 
       /* Set enable bit for the irq */
 

--- a/arch/risc-v/src/qemu-rv/qemu_rv_irq_dispatch.c
+++ b/arch/risc-v/src/qemu-rv/qemu_rv_irq_dispatch.c
@@ -69,7 +69,7 @@ void *riscv_dispatch_irq(uintptr_t vector, uintptr_t *regs)
 
   /* Firstly, check if the irq is machine external interrupt */
 
-  if (QEMU_RV_IRQ_MEXT == irq)
+  if (RISCV_IRQ_MEXT == irq)
     {
       uintptr_t val = getreg32(QEMU_RV_PLIC_CLAIM);
 
@@ -80,7 +80,7 @@ void *riscv_dispatch_irq(uintptr_t vector, uintptr_t *regs)
 
   /* NOTE: In case of ecall, we need to adjust mepc in the context */
 
-  if (QEMU_RV_IRQ_ECALLM == irq)
+  if (RISCV_IRQ_ECALLM == irq)
     {
       *mepc += 4;
     }
@@ -101,11 +101,11 @@ void *riscv_dispatch_irq(uintptr_t vector, uintptr_t *regs)
 
   irq_dispatch(irq, regs);
 
-  if (QEMU_RV_IRQ_MEXT <= irq)
+  if (RISCV_IRQ_MEXT <= irq)
     {
       /* Then write PLIC_CLAIM to clear pending in PLIC */
 
-      putreg32(irq - QEMU_RV_IRQ_MEXT, QEMU_RV_PLIC_CLAIM);
+      putreg32(irq - RISCV_IRQ_MEXT, QEMU_RV_PLIC_CLAIM);
     }
 #endif
 

--- a/arch/risc-v/src/qemu-rv/qemu_rv_timerisr.c
+++ b/arch/risc-v/src/qemu-rv/qemu_rv_timerisr.c
@@ -115,7 +115,7 @@ void up_timer_initialize(void)
 {
   /* Attach timer interrupt handler */
 
-  irq_attach(QEMU_RV_IRQ_MTIMER, qemu_rv_timerisr, NULL);
+  irq_attach(RISCV_IRQ_MTIMER, qemu_rv_timerisr, NULL);
 
   /* Reload CLINT mtimecmp */
 
@@ -123,5 +123,5 @@ void up_timer_initialize(void)
 
   /* And enable the timer interrupt */
 
-  up_enable_irq(QEMU_RV_IRQ_MTIMER);
+  up_enable_irq(RISCV_IRQ_MTIMER);
 }


### PR DESCRIPTION
## Summary
We can move some common irq number definitions from chip specific code to common place since they are same on all risc-v chips, and make it possible to share more irq relative logic like timerisr/irq_dispatch accross risc-v socs.

## Impact
None, rename only.
## Testing
CI and qemu-rv32/rv64
