### PR TITLE
net/tcp/sendfile: fixed an issue with unackseq calculation.

### DIFF
--- a/net/tcp/tcp_input.c
+++ b/net/tcp/tcp_input.c
@@ -692,8 +692,17 @@ found:
        * data (tx_unacked).
        */
 
-#ifdef CONFIG_NET_TCP_WRITE_BUFFERS
+#if defined(CONFIG_NET_TCP_WRITE_BUFFERS) && !defined(CONFIG_NET_SENDFILE)
       unackseq = conn->sndseq_max;
+#elif defined(CONFIG_NET_TCP_WRITE_BUFFERS) && defined(CONFIG_NET_SENDFILE)
+      if (!conn->sendfile)
+        {
+          unackseq = conn->sndseq_max;
+        }
+      else
+        {
+          unackseq = tcp_getsequence(conn->sndseq);
+        }
 #else
       unackseq = tcp_getsequence(conn->sndseq);
 #endif


### PR DESCRIPTION
Wrong unackseq calculation locked conn->tx_unacked at non-zero values even if all ACKs were received.
This RP fixes the same issue as it was with tcp_send_unbuffered (#4656). And this PR extends #5239 fix.

## Summary

## Impact

TCP

## Testing

Build NuttX:
```
$ ./tools/configure.sh -l sim:tcpblaster
$ make menuconfig
(enable/disable CONFIG_NETUTILS_NETCAT_SENDFILE,
enable/disable CONFIG_NET_TCP_WRITE_BUFFERS)
$ make
```
Enable TUN/TAP on Linux host:
```
$ sudo setcap cap_net_admin+ep ./nuttx
$ sudo ./tools/simhostroute.sh wlan0 on
```

Run netcat server on Linux host:
`$ netcat -l -p 31337`

Run NuttX on Linux host:
```
$ ./nuttx
NuttShell (NSH) NuttX-10.2.0
nsh> ifconfig eth0 10.0.1.2
nsh> ifup eth0
ifup eth0...OK
```
Start Wireshark (or tcpdump) and capture appeared tap0 interface.

Run in NuttX:
```
nsh> dd if=/dev/zero of=/tmp/test.bin count=1000
nsh> netcat LINUX_HOST_IP_ADDRESS 31337 /tmp/test.bin
```
Observe TCP dump.

Shutdown NuttX:
`nsh> poweroff`

Disable TUN/TAP on Linux host:
`$ sudo ./tools/simhostroute.sh wlan0 off`