### PR TITLE
net/tcp/sendfile: removed excessive overwrites of conn->sndseq

### DIFF
--- a/net/tcp/tcp_input.c
+++ b/net/tcp/tcp_input.c
@@ -684,9 +684,7 @@ found:
     {
       uint32_t unackseq;
       uint32_t ackseq;
-#ifdef CONFIG_NET_TCP_WRITE_BUFFERS
-      uint32_t sndseq;
-#endif
+
       /* The next sequence number is equal to the current sequence
        * number (sndseq) plus the size of the outstanding, unacknowledged
        * data (tx_unacked).
@@ -739,19 +737,24 @@ found:
         }
 
 #ifdef CONFIG_NET_TCP_WRITE_BUFFERS
-      /* Update sequence number to the unacknowledge sequence number.  If
-       * there is still outstanding, unacknowledged data, then this will
-       * be beyond ackseq.
-       */
-
-      sndseq = tcp_getsequence(conn->sndseq);
-      if (TCP_SEQ_LT(sndseq, ackseq))
+#ifdef CONFIG_NET_SENDFILE
+      if (!conn->sendfile)
+#endif
         {
-          ninfo("sndseq: %08" PRIx32 "->%08" PRIx32
-                " unackseq: %08" PRIx32 " new tx_unacked: %" PRId32 "\n",
-                tcp_getsequence(conn->sndseq), ackseq, unackseq,
-                (uint32_t)conn->tx_unacked);
-          tcp_setsequence(conn->sndseq, ackseq);
+          /* Update sequence number to the unacknowledge sequence number. If
+           * there is still outstanding, unacknowledged data, then this will
+           * be beyond ackseq.
+           */
+
+          uint32_t sndseq = tcp_getsequence(conn->sndseq);
+          if (TCP_SEQ_LT(sndseq, ackseq))
+            {
+              ninfo("sndseq: %08" PRIx32 "->%08" PRIx32
+                    " unackseq: %08" PRIx32 " new tx_unacked: %" PRIu32 "\n",
+                    tcp_getsequence(conn->sndseq), ackseq, unackseq,
+                    (uint32_t)conn->tx_unacked);
+              tcp_setsequence(conn->sndseq, ackseq);
+            }
         }
 #endif
 

--- a/net/tcp/tcp_sendfile.c
+++ b/net/tcp/tcp_sendfile.c
@@ -369,8 +369,6 @@ static uint16_t sendfile_eventhandler(FAR struct net_driver_s *dev,
 
       if ((pstate->snd_sent - pstate->snd_acked + sndlen) < conn->snd_wnd)
         {
-          uint32_t seqno;
-
           /* Then set-up to send that amount of data. (this won't actually
            * happen until the polling cycle completes).
            */
@@ -393,20 +391,6 @@ static uint16_t sendfile_eventhandler(FAR struct net_driver_s *dev,
             }
 
           dev->d_sndlen = sndlen;
-
-          /* Set the sequence number for this packet.  NOTE:  The network
-           * updates sndseq on recept of ACK *before* this function is
-           * called.  In that case sndseq will point to the next
-           * unacknowledge byte (which might have already been sent).  We
-           * will overwrite the value of sndseq here before the packet is
-           * sent.
-           */
-
-          seqno = pstate->snd_sent + pstate->snd_isn;
-          ninfo("SEND: sndseq %08" PRIx32 "->%08" PRIx32 " len: %d\n",
-                tcp_getsequence(conn->sndseq), seqno, ret);
-
-          tcp_setsequence(conn->sndseq, seqno);
 
           /* Notify the device driver of the availability of TX data */
 


### PR DESCRIPTION
## Summary

conn->sndseq was updated in multiple places that was unreasonable and complicated.
This PR is similar to the corresponding PR for tcp_send_unbuffered (#5102)

## Impact

TCP

## Testing

Build NuttX:
```
$ ./tools/configure.sh -l sim:tcpblaster
$ make menuconfig
(enable/disable CONFIG_NETUTILS_NETCAT_SENDFILE,
enable/disable CONFIG_NET_TCP_WRITE_BUFFERS)
$ make
```
Enable TUN/TAP on Linux host:
```
$ sudo setcap cap_net_admin+ep ./nuttx
$ sudo ./tools/simhostroute.sh wlan0 on
```

Run netcat server on Linux host:
`$ netcat -l -p 31337`

Run NuttX on Linux host:
```
$ ./nuttx
NuttShell (NSH) NuttX-10.2.0
nsh> ifconfig eth0 10.0.1.2
nsh> ifup eth0
ifup eth0...OK
```
Start Wireshark (or tcpdump) and capture appeared tap0 interface.

Run in NuttX:
```
nsh> dd if=/dev/zero of=/tmp/test.bin count=1000
nsh> netcat LINUX_HOST_IP_ADDRESS 31337 /tmp/test.bin
```
Observe TCP dump.

Shutdown NuttX:
`nsh> poweroff`

Disable TUN/TAP on Linux host:
`$ sudo ./tools/simhostroute.sh wlan0 off`