### PR TITLE
up_progmem_erasesize for stm32f20xxf40xx_flash.c

### DIFF
--- a/arch/arm/src/stm32/stm32f20xxf40xx_flash.c
+++ b/arch/arm/src/stm32/stm32f20xxf40xx_flash.c
@@ -249,6 +249,11 @@ size_t up_progmem_pagesize(size_t page)
     }
 }
 
+size_t up_progmem_erasesize(size_t block)
+{
+  return up_progmem_pagesize(block);
+}
+
 ssize_t up_progmem_getpage(size_t addr)
 {
   size_t page_end = 0;


### PR DESCRIPTION
## Summary
A compilation error occurred when using mtd_progmem on stm32f4 :
/nuttx/staging/libdrivers.a(mtd_progmem.o): In function `progmem_initialize':
/nuttx/drivers/mtd/mtd_progmem.c:434: undefined reference to `up_progmem_erasesize'
Makefile:164: recipe for target 'nuttx' failed
make[1]: *** [nuttx] Error 1
## Impact
There's no  up_progmem_erasesize in stm32f20xxf40xx_flash.c, but there has up_progmem_erasesize in stm32f10xxf30xx_flash.c
## Testing
tested on stm32f405RGT6
