### PR TITLE
esp32c3_irq.c: Skip over ECALL instruction.

### DIFF
--- a/arch/risc-v/src/esp32c3/esp32c3_irq.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_irq.c
@@ -376,6 +376,7 @@ void esp32c3_free_cpuint(uint8_t periphid)
 IRAM_ATTR uintptr_t *esp32c3_dispatch_irq(uintptr_t mcause, uintptr_t *regs)
 {
   int irq;
+  uintptr_t *mepc = regs;
 
   if (((MCAUSE_INTERRUPT & mcause) == 0) &&
       (mcause != MCAUSE_ECALL_M))
@@ -428,6 +429,7 @@ IRAM_ATTR uintptr_t *esp32c3_dispatch_irq(uintptr_t mcause, uintptr_t *regs)
     {
       if (mcause == MCAUSE_ECALL_M)
         {
+          *mepc += 4;
           irq_dispatch(ESP32C3_IRQ_ECALL_M, regs);
         }
       else

--- a/arch/risc-v/src/esp32c3/esp32c3_irq.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_irq.c
@@ -438,6 +438,12 @@ IRAM_ATTR uintptr_t *esp32c3_dispatch_irq(uintptr_t mcause, uintptr_t *regs)
         }
     }
 
+  /* If a context switch occurred while processing the interrupt then
+   * CURRENT_REGS may have change value.  If we return any value different
+   * from the input regs, then the lower level will know that a context
+   * switch occurred during interrupt processing.
+   */
+
   regs = (uintptr_t *)CURRENT_REGS;
   CURRENT_REGS = NULL;
 


### PR DESCRIPTION
## Summary
https://github.com/apache/incubator-nuttx/pull/5192 removed skipping ECALL from common code, ESP32-C3 was relaying on that.
## Impact
fix https://github.com/apache/incubator-nuttx/issues/5298
## Testing
ESP32-C3
