### PR TITLE
risc-v/mpfs: OpenSBI: utilize an index2id table

### DIFF
--- a/arch/risc-v/src/mpfs/mpfs_opensbi.c
+++ b/arch/risc-v/src/mpfs/mpfs_opensbi.c
@@ -178,13 +178,27 @@ static struct aclint_mswi_data mpfs_mswi =
   .hart_count     = MPFS_HART_COUNT,
 };
 
-const struct sbi_platform platform =
+/* OpenSBI picks the used and unused harts via the hart_index2id table.
+ * Unused hart is marked with -1.  Mpfs will always have the hart0 unused.
+ */
+
+static const u32 mpfs_hart_index2id[MPFS_HART_COUNT] =
+{
+  [0] = -1,
+  [1] = 1,
+  [2] = 2,
+  [3] = 3,
+  [4] = 4,
+};
+
+static const struct sbi_platform platform =
 {
   .opensbi_version   = OPENSBI_VERSION,
   .platform_version  = SBI_PLATFORM_VERSION(0x0, 0x01),
   .name              = "Microchip PolarFire(R) SoC",
   .features          = SBI_PLATFORM_DEFAULT_FEATURES,
   .hart_count        = MPFS_HART_COUNT,
+  .hart_index2id     = mpfs_hart_index2id,
   .hart_stack_size   = SBI_PLATFORM_DEFAULT_HART_STACK_SIZE,
   .platform_ops_addr = (unsigned long)&platform_ops,
   .firmware_context  = 0


### PR DESCRIPTION
Hart index to hart id table is used to track unused and used harts. This
table is useful when configuring only some of the harts for OpenSBI use.
Mpfs will always have the hart0 unused, so mark it with -1.

Signed-off-by: Eero Nurkkala <eero.nurkkala@offcode.fi>

## Summary

Use the HART index to HART id table as seen in OpenSBI header /include/sbi/sbi_platform.h
Mark mpfs hart0 as unused.

## Impact

No impact

## Testing

Polarfire Icicle Kit, NuttX on hart0 and hart1, while u-boot/Linux combo on hart3 and hart4.
