### PR TITLE
bug patch for frexpf function

### DIFF
--- a/libs/libc/math/lib_frexpf.c
+++ b/libs/libc/math/lib_frexpf.c
@@ -37,6 +37,21 @@
 
 float frexpf(float x, int *exponent)
 {
-  *exponent = (int)ceilf(log2f(x));
-  return x / ldexpf(1.0F, *exponent);
+  float res;
+
+  *exponent = (int)ceilf(log2f(fabsf(x)));
+  res = x / ldexpf(1.0F, *exponent);
+  if (res >= 1.0)
+    {
+      res -= 0.5;
+      *exponent += 1;
+    }
+
+  if (res <= -1.0)
+    {
+      res += 0.5;
+      *exponent += 1;
+    }
+
+  return res;
 }


### PR DESCRIPTION
## Summary
there's lack a fabsf for x in 
float frexpf(float x, int *exponent)
{
  *exponent = (int)ceilf(log2f(x));
  return x / ldexpf(1.0F, *exponent);
}
## Impact
when input x<0,the result of
frexpf(x, e) is wrong
## Testing
tested on stm32f405RGT6,after the patch:
input  number = -60;	
float sig = frexpf(number, &e);
sig = -0.9375
e = 6;
