### PR TITLE
toolchain: add libm to EXTRA_LIBS only if it is provided by the compiler

### DIFF
--- a/arch/arm/src/arm/Toolchain.defs
+++ b/arch/arm/src/arm/Toolchain.defs
@@ -104,14 +104,20 @@ OBJDUMP = $(CROSSDEV)objdump
 # Add the builtin library
 
 EXTRA_LIBS += -lgcc
-EXTRA_LIBPATHS += -L ${shell dirname "`$(CC) $(ARCHCPUFLAGS) --print-libgcc-file-name`"}
+EXTRA_LIBPATHS += -L "${shell dirname "`$(CC) $(ARCHCPUFLAGS) --print-libgcc-file-name`"}"
 
 ifneq ($(CONFIG_LIBM),y)
-  EXTRA_LIBS += -lm
-  EXTRA_LIBPATHS += -L ${shell dirname "`$(CC) $(ARCHCPUFLAGS) --print-file-name=libm.a`"}
+  LIBM_PATH = "${shell dirname "`$(CC) $(ARCHCPUFLAGS) --print-file-name=libm.a`"}"
+  
+  # Check if libm is provided by the compiler
+  
+  ifneq ($(LIBM_PATH),".")
+    EXTRA_LIBS += -lm
+    EXTRA_LIBPATHS += -L $(LIBM_PATH)
+  endif
 endif
 
 ifeq ($(CONFIG_LIBSUPCXX),y)
-  EXTRA_LIBS += lsupc++
-  EXTRA_LIBPATHS += -L ${shell dirname "`$(CC) $(ARCHCPUFLAGS) --print-file-name=libsupc++.a`"}
+  EXTRA_LIBS += -lsupc++
+  EXTRA_LIBPATHS += -L "${shell dirname "`$(CC) $(ARCHCPUFLAGS) --print-file-name=libsupc++.a`"}"
 endif

--- a/arch/arm/src/armv6-m/Toolchain.defs
+++ b/arch/arm/src/armv6-m/Toolchain.defs
@@ -99,8 +99,14 @@ EXTRA_LIBS += -lgcc
 EXTRA_LIBPATHS += -L "${shell dirname "`$(CC) $(ARCHCPUFLAGS) --print-libgcc-file-name`"}"
 
 ifneq ($(CONFIG_LIBM),y)
-  EXTRA_LIBS += -lm
-  EXTRA_LIBPATHS += -L "${shell dirname "`$(CC) $(ARCHCPUFLAGS) --print-file-name=libm.a`"}"
+  LIBM_PATH = "${shell dirname "`$(CC) $(ARCHCPUFLAGS) --print-file-name=libm.a`"}"
+  
+  # Check if libm is provided by the compiler
+  
+  ifneq ($(LIBM_PATH),".")
+    EXTRA_LIBS += -lm
+    EXTRA_LIBPATHS += -L $(LIBM_PATH)
+  endif
 endif
 
 ifeq ($(CONFIG_LIBSUPCXX),y)

--- a/arch/arm/src/armv7-a/Toolchain.defs
+++ b/arch/arm/src/armv7-a/Toolchain.defs
@@ -125,8 +125,14 @@ EXTRA_LIBS += -lgcc
 EXTRA_LIBPATHS += -L "${shell dirname "`$(CC) $(ARCHCPUFLAGS) --print-libgcc-file-name`"}"
 
 ifneq ($(CONFIG_LIBM),y)
-  EXTRA_LIBS += -lm
-  EXTRA_LIBPATHS += -L "${shell dirname "`$(CC) $(ARCHCPUFLAGS) --print-file-name=libm.a`"}"
+  LIBM_PATH = "${shell dirname "`$(CC) $(ARCHCPUFLAGS) --print-file-name=libm.a`"}"
+  
+  # Check if libm is provided by the compiler
+  
+  ifneq ($(LIBM_PATH),".")
+    EXTRA_LIBS += -lm
+    EXTRA_LIBPATHS += -L $(LIBM_PATH)
+  endif
 endif
 
 ifeq ($(CONFIG_LIBSUPCXX),y)

--- a/arch/arm/src/armv7-m/Toolchain.defs
+++ b/arch/arm/src/armv7-m/Toolchain.defs
@@ -158,8 +158,14 @@ EXTRA_LIBS += -lgcc
 EXTRA_LIBPATHS += -L "${shell dirname "`$(CC) $(ARCHCPUFLAGS) --print-libgcc-file-name`"}"
 
 ifneq ($(CONFIG_LIBM),y)
-  EXTRA_LIBS += -lm
-  EXTRA_LIBPATHS += -L "${shell dirname "`$(CC) $(ARCHCPUFLAGS) --print-file-name=libm.a`"}"
+  LIBM_PATH = "${shell dirname "`$(CC) $(ARCHCPUFLAGS) --print-file-name=libm.a`"}"
+  
+  # Check if libm is provided by the compiler
+  
+  ifneq ($(LIBM_PATH),".")
+    EXTRA_LIBS += -lm
+    EXTRA_LIBPATHS += -L $(LIBM_PATH)
+  endif
 endif
 
 ifeq ($(CONFIG_LIBSUPCXX),y)

--- a/arch/arm/src/armv7-r/Toolchain.defs
+++ b/arch/arm/src/armv7-r/Toolchain.defs
@@ -107,8 +107,14 @@ EXTRA_LIBS += -lgcc
 EXTRA_LIBPATHS += -L "${shell dirname "`$(CC) $(ARCHCPUFLAGS) --print-libgcc-file-name`"}"
 
 ifneq ($(CONFIG_LIBM),y)
-  EXTRA_LIBS += -lm
-  EXTRA_LIBPATHS += -L "${shell dirname "`$(CC) $(ARCHCPUFLAGS) --print-file-name=libm.a`"}"
+  LIBM_PATH = "${shell dirname "`$(CC) $(ARCHCPUFLAGS) --print-file-name=libm.a`"}"
+  
+  # Check if libm is provided by the compiler
+  
+  ifneq ($(LIBM_PATH),".")
+    EXTRA_LIBS += -lm
+    EXTRA_LIBPATHS += -L $(LIBM_PATH)
+  endif
 endif
 
 ifeq ($(CONFIG_LIBSUPCXX),y)

--- a/arch/arm/src/armv8-m/Toolchain.defs
+++ b/arch/arm/src/armv8-m/Toolchain.defs
@@ -157,8 +157,14 @@ EXTRA_LIBS += -lgcc
 EXTRA_LIBPATHS += -L "${shell dirname "`$(CC) $(ARCHCPUFLAGS) --print-libgcc-file-name`"}"
 
 ifneq ($(CONFIG_LIBM),y)
-  EXTRA_LIBS += -lm
-  EXTRA_LIBPATHS += -L "${shell dirname "`$(CC) $(ARCHCPUFLAGS) --print-file-name=libm.a`"}"
+  LIBM_PATH = "${shell dirname "`$(CC) $(ARCHCPUFLAGS) --print-file-name=libm.a`"}"
+  
+  # Check if libm is provided by the compiler
+  
+  ifneq ($(LIBM_PATH),".")
+    EXTRA_LIBS += -lm
+    EXTRA_LIBPATHS += -L $(LIBM_PATH)
+  endif
 endif
 
 ifeq ($(CONFIG_LIBSUPCXX),y)

--- a/arch/avr/src/avr/Toolchain.defs
+++ b/arch/avr/src/avr/Toolchain.defs
@@ -130,8 +130,14 @@ EXTRA_LIBS += -lgcc
 EXTRA_LIBPATHS += -L "${shell dirname "`$(CC) $(ARCHCPUFLAGS) --print-libgcc-file-name`"}"
 
 ifneq ($(CONFIG_LIBM),y)
-  EXTRA_LIBS += -lm
-  EXTRA_LIBPATHS += -L "${shell dirname "`$(CC) $(ARCHCPUFLAGS) --print-file-name=libm.a`"}"
+  LIBM_PATH = "${shell dirname "`$(CC) $(ARCHCPUFLAGS) --print-file-name=libm.a`"}"
+  
+  # Check if libm is provided by the compiler
+  
+  ifneq ($(LIBM_PATH),".")
+    EXTRA_LIBS += -lm
+    EXTRA_LIBPATHS += -L $(LIBM_PATH)
+  endif
 endif
 
 ifeq ($(CONFIG_LIBSUPCXX),y)

--- a/arch/avr/src/avr32/Toolchain.defs
+++ b/arch/avr/src/avr32/Toolchain.defs
@@ -54,8 +54,14 @@ EXTRA_LIBS += -lgcc
 EXTRA_LIBPATHS += -L "${shell dirname "`$(CC) $(ARCHCPUFLAGS) --print-libgcc-file-name`"}"
 
 ifneq ($(CONFIG_LIBM),y)
-  EXTRA_LIBS += -lm
-  EXTRA_LIBPATHS += -L "${shell dirname "`$(CC) $(ARCHCPUFLAGS) --print-file-name=libm.a`"}"
+  LIBM_PATH = "${shell dirname "`$(CC) $(ARCHCPUFLAGS) --print-file-name=libm.a`"}"
+  
+  # Check if libm is provided by the compiler
+  
+  ifneq ($(LIBM_PATH),".")
+    EXTRA_LIBS += -lm
+    EXTRA_LIBPATHS += -L $(LIBM_PATH)
+  endif
 endif
 
 ifeq ($(CONFIG_LIBSUPCXX),y)

--- a/arch/hc/src/Makefile
+++ b/arch/hc/src/Makefile
@@ -88,16 +88,22 @@ endif
 # Add the builtin library
 
 EXTRA_LIBS += -lgcc
-EXTRA_LIBPATHS += -L "${dir ${shell $(CC) $(ARCHCPUFLAGS) --print-libgcc-file-name}}"
+EXTRA_LIBPATHS += -L "${shell dirname "`$(CC) $(ARCHCPUFLAGS) --print-libgcc-file-name`"}"
 
 ifneq ($(CONFIG_LIBM),y)
-  EXTRA_LIBS += -lm
-  EXTRA_LIBPATHS += -L "${dir ${shell $(CC) $(ARCHCPUFLAGS) --print-file-name=libm.a}}"
+  LIBM_PATH = "${shell dirname "`$(CC) $(ARCHCPUFLAGS) --print-file-name=libm.a`"}"
+  
+  # Check if libm is provided by the compiler
+  
+  ifneq ($(LIBM_PATH),".")
+    EXTRA_LIBS += -lm
+    EXTRA_LIBPATHS += -L $(LIBM_PATH)
+  endif
 endif
 
 ifeq ($(CONFIG_LIBSUPCXX),y)
   EXTRA_LIBS += -lsupc++
-  EXTRA_LIBPATHS += -L "${dir ${shell $(CC) $(ARCHCPUFLAGS) --print-file-name=libsupc++.a}}"
+  EXTRA_LIBPATHS += -L "${shell dirname "`$(CC) $(ARCHCPUFLAGS) --print-file-name=libsupc++.a`"}"
 endif
 
 VPATH = chip:common:$(ARCH_SUBDIR)

--- a/arch/mips/src/mips32/Toolchain.defs
+++ b/arch/mips/src/mips32/Toolchain.defs
@@ -280,14 +280,20 @@ OBJDUMP = $(CROSSDEV)objdump
 # Add the builtin library
 
 EXTRA_LIBS += -lgcc
-EXTRA_LIBPATHS += -L ${shell dirname "`$(CC) $(ARCHCPUFLAGS) --print-libgcc-file-name`"}
+EXTRA_LIBPATHS += -L "${shell dirname "`$(CC) $(ARCHCPUFLAGS) --print-libgcc-file-name`"}"
 
 ifneq ($(CONFIG_LIBM),y)
-  EXTRA_LIBS += -lm
-  EXTRA_LIBPATHS += -L ${shell dirname "`$(CC) $(ARCHCPUFLAGS) --print-file-name=libm.a`"}
+  LIBM_PATH = "${shell dirname "`$(CC) $(ARCHCPUFLAGS) --print-file-name=libm.a`"}"
+  
+  # Check if libm is provided by the compiler
+  
+  ifneq ($(LIBM_PATH),".")
+    EXTRA_LIBS += -lm
+    EXTRA_LIBPATHS += -L $(LIBM_PATH)
+  endif
 endif
 
 ifeq ($(CONFIG_LIBSUPCXX),y)
-  EXTRA_LIBS += lsupc++
-  EXTRA_LIBPATHS += -L ${shell dirname "`$(CC) $(ARCHCPUFLAGS) --print-file-name=libsupc++.a`"}
+  EXTRA_LIBS += -lsupc++
+  EXTRA_LIBPATHS += -L "${shell dirname "`$(CC) $(ARCHCPUFLAGS) --print-file-name=libsupc++.a`"}"
 endif

--- a/arch/misoc/src/lm32/Toolchain.defs
+++ b/arch/misoc/src/lm32/Toolchain.defs
@@ -91,8 +91,14 @@ EXTRA_LIBS += -lgcc
 EXTRA_LIBPATHS += -L "${shell dirname "`$(CC) $(ARCHCPUFLAGS) --print-libgcc-file-name`"}"
 
 ifneq ($(CONFIG_LIBM),y)
-  EXTRA_LIBS += -lm
-  EXTRA_LIBPATHS += -L "${shell dirname "`$(CC) $(ARCHCPUFLAGS) --print-file-name=libm.a`"}"
+  LIBM_PATH = "${shell dirname "`$(CC) $(ARCHCPUFLAGS) --print-file-name=libm.a`"}"
+  
+  # Check if libm is provided by the compiler
+  
+  ifneq ($(LIBM_PATH),".")
+    EXTRA_LIBS += -lm
+    EXTRA_LIBPATHS += -L $(LIBM_PATH)
+  endif
 endif
 
 ifeq ($(CONFIG_LIBSUPCXX),y)

--- a/arch/misoc/src/minerva/Toolchain.defs
+++ b/arch/misoc/src/minerva/Toolchain.defs
@@ -45,8 +45,14 @@ EXTRA_LIBS += -lgcc
 EXTRA_LIBPATHS += -L "${shell dirname "`$(CC) $(ARCHCPUFLAGS) --print-libgcc-file-name`"}"
 
 ifneq ($(CONFIG_LIBM),y)
-  EXTRA_LIBS += -lm
-  EXTRA_LIBPATHS += -L "${shell dirname "`$(CC) $(ARCHCPUFLAGS) --print-file-name=libm.a`"}"
+  LIBM_PATH = "${shell dirname "`$(CC) $(ARCHCPUFLAGS) --print-file-name=libm.a`"}"
+  
+  # Check if libm is provided by the compiler
+  
+  ifneq ($(LIBM_PATH),".")
+    EXTRA_LIBS += -lm
+    EXTRA_LIBPATHS += -L $(LIBM_PATH)
+  endif
 endif
 
 ifeq ($(CONFIG_LIBSUPCXX),y)

--- a/arch/or1k/src/mor1kx/Toolchain.defs
+++ b/arch/or1k/src/mor1kx/Toolchain.defs
@@ -72,8 +72,14 @@ EXTRA_LIBS += -lgcc
 EXTRA_LIBPATHS += -L "${shell dirname "`$(CC) $(ARCHCPUFLAGS) --print-libgcc-file-name`"}"
 
 ifneq ($(CONFIG_LIBM),y)
-  EXTRA_LIBS += -lm
-  EXTRA_LIBPATHS += -L "${shell dirname "`$(CC) $(ARCHCPUFLAGS) --print-file-name=libm.a`"}"
+  LIBM_PATH = "${shell dirname "`$(CC) $(ARCHCPUFLAGS) --print-file-name=libm.a`"}"
+  
+  # Check if libm is provided by the compiler
+  
+  ifneq ($(LIBM_PATH),".")
+    EXTRA_LIBS += -lm
+    EXTRA_LIBPATHS += -L $(LIBM_PATH)
+  endif
 endif
 
 ifeq ($(CONFIG_LIBSUPCXX),y)

--- a/arch/renesas/src/Makefile
+++ b/arch/renesas/src/Makefile
@@ -81,16 +81,22 @@ endif
 # Add the builtin library
 
 EXTRA_LIBS += -lgcc
-EXTRA_LIBPATHS += -L"${shell dirname "`$(CC) $(ARCHCPUFLAGS) --print-libgcc-file-name`"}"
+EXTRA_LIBPATHS += -L""${shell dirname "`$(CC) $(ARCHCPUFLAGS) --print-libgcc-file-name`"}""
 
 ifneq ($(CONFIG_LIBM),y)
-  EXTRA_LIBS += -lm
-  EXTRA_LIBPATHS += -L"${shell dirname "`$(CC) $(ARCHCPUFLAGS) --print-file-name=libm.a`"}"
+  LIBM_PATH = "${shell dirname "`$(CC) $(ARCHCPUFLAGS) --print-file-name=libm.a`"}"
+  
+  # Check if libm is provided by the compiler
+  
+  ifneq ($(LIBM_PATH),".")
+    EXTRA_LIBS += -lm
+    EXTRA_LIBPATHS += -L $(LIBM_PATH)
+  endif
 endif
 
 ifeq ($(CONFIG_LIBSUPCXX),y)
   EXTRA_LIBS += -lsupc++
-  EXTRA_LIBPATHS += -L"${shell dirname "`$(CC) $(ARCHCPUFLAGS) --print-file-name=libsupc++.a`"}"
+  EXTRA_LIBPATHS += -L "${shell dirname "`$(CC) $(ARCHCPUFLAGS) --print-file-name=libsupc++.a`"}"
 endif
 
 VPATH = chip:common

--- a/arch/risc-v/src/common/Toolchain.defs
+++ b/arch/risc-v/src/common/Toolchain.defs
@@ -133,8 +133,14 @@ EXTRA_LIBS += -lgcc
 EXTRA_LIBPATHS += -L "${shell dirname "`$(CC) $(ARCHCPUFLAGS) --print-libgcc-file-name`"}"
 
 ifneq ($(CONFIG_LIBM),y)
-  EXTRA_LIBS += -lm
-  EXTRA_LIBPATHS += -L "${shell dirname "`$(CC) $(ARCHCPUFLAGS) --print-file-name=libm.a`"}"
+  LIBM_PATH = "${shell dirname "`$(CC) $(ARCHCPUFLAGS) --print-file-name=libm.a`"}"
+  
+  # Check if libm is provided by the compiler
+  
+  ifneq ($(LIBM_PATH),".")
+    EXTRA_LIBS += -lm
+    EXTRA_LIBPATHS += -L $(LIBM_PATH)
+  endif
 endif
 
 ifeq ($(CONFIG_LIBSUPCXX),y)

--- a/arch/x86/src/Makefile
+++ b/arch/x86/src/Makefile
@@ -85,16 +85,22 @@ endif
 # Add the builtin library
 
 EXTRA_LIBS += -lgcc
-EXTRA_LIBPATHS += -L "${dir ${shell $(CC) $(ARCHCPUFLAGS) --print-libgcc-file-name}}"
+EXTRA_LIBPATHS += -L "${shell dirname "`$(CC) $(ARCHCPUFLAGS) --print-libgcc-file-name`"}"
 
 ifneq ($(CONFIG_LIBM),y)
-  EXTRA_LIBS += -lm
-  EXTRA_LIBPATHS += -L "${dir ${shell $(CC) $(ARCHCPUFLAGS) --print-file-name=libm.a}}"
+  LIBM_PATH = "${shell dirname "`$(CC) $(ARCHCPUFLAGS) --print-file-name=libm.a`"}"
+  
+  # Check if libm is provided by the compiler
+  
+  ifneq ($(LIBM_PATH),".")
+    EXTRA_LIBS += -lm
+    EXTRA_LIBPATHS += -L $(LIBM_PATH)
+  endif
 endif
 
 ifeq ($(CONFIG_LIBSUPCXX),y)
   EXTRA_LIBS += -lsupc++
-  EXTRA_LIBPATHS += -L "${dir ${shell $(CC) $(ARCHCPUFLAGS) --print-file-name=libsupc++.a}}"
+  EXTRA_LIBPATHS += -L "${shell dirname "`$(CC) $(ARCHCPUFLAGS) --print-file-name=libsupc++.a`"}"
 endif
 
 VPATH = chip:common:$(ARCH_SUBDIR)

--- a/arch/x86_64/src/Makefile
+++ b/arch/x86_64/src/Makefile
@@ -87,16 +87,22 @@ endif
 # Add the builtin library
 
 EXTRA_LIBS += -lgcc
-EXTRA_LIBPATHS += -L "${dir ${shell $(CC) $(ARCHCPUFLAGS) --print-libgcc-file-name}}"
+EXTRA_LIBPATHS += -L "${shell dirname "`$(CC) $(ARCHCPUFLAGS) --print-libgcc-file-name`"}"
 
 ifneq ($(CONFIG_LIBM),y)
-  EXTRA_LIBS += -lm
-  EXTRA_LIBPATHS += -L "${dir ${shell $(CC) $(ARCHCPUFLAGS) --print-file-name=libm.a}}"
+  LIBM_PATH = "${shell dirname "`$(CC) $(ARCHCPUFLAGS) --print-file-name=libm.a`"}"
+  
+  # Check if libm is provided by the compiler
+  
+  ifneq ($(LIBM_PATH),".")
+    EXTRA_LIBS += -lm
+    EXTRA_LIBPATHS += -L $(LIBM_PATH)
+  endif
 endif
 
 ifeq ($(CONFIG_LIBSUPCXX),y)
   EXTRA_LIBS += -lsupc++
-  EXTRA_LIBPATHS += -L "${dir ${shell $(CC) $(ARCHCPUFLAGS) --print-file-name=libsupc++.a}}"
+  EXTRA_LIBPATHS += -L "${shell dirname "`$(CC) $(ARCHCPUFLAGS) --print-file-name=libsupc++.a`"}"
 endif
 
 VPATH = chip:common:$(ARCH_SUBDIR)

--- a/arch/xtensa/src/lx6/Toolchain.defs
+++ b/arch/xtensa/src/lx6/Toolchain.defs
@@ -83,8 +83,14 @@ EXTRA_LIBS += -lgcc
 EXTRA_LIBPATHS += -L "${shell dirname "`$(CC) $(ARCHCPUFLAGS) --print-libgcc-file-name`"}"
 
 ifneq ($(CONFIG_LIBM),y)
-  EXTRA_LIBS += -lm
-  EXTRA_LIBPATHS += -L "${shell dirname "`$(CC) $(ARCHCPUFLAGS) --print-file-name=libm.a`"}"
+  LIBM_PATH = "${shell dirname "`$(CC) $(ARCHCPUFLAGS) --print-file-name=libm.a`"}"
+  
+  # Check if libm is provided by the compiler
+  
+  ifneq ($(LIBM_PATH),".")
+    EXTRA_LIBS += -lm
+    EXTRA_LIBPATHS += -L $(LIBM_PATH)
+  endif
 endif
 
 ifeq ($(CONFIG_LIBSUPCXX),y)

--- a/arch/xtensa/src/lx7/Toolchain.defs
+++ b/arch/xtensa/src/lx7/Toolchain.defs
@@ -83,8 +83,14 @@ EXTRA_LIBS += -lgcc
 EXTRA_LIBPATHS += -L "${shell dirname "`$(CC) $(ARCHCPUFLAGS) --print-libgcc-file-name`"}"
 
 ifneq ($(CONFIG_LIBM),y)
-  EXTRA_LIBS += -lm
-  EXTRA_LIBPATHS += -L "${shell dirname "`$(CC) $(ARCHCPUFLAGS) --print-file-name=libm.a`"}"
+  LIBM_PATH = "${shell dirname "`$(CC) $(ARCHCPUFLAGS) --print-file-name=libm.a`"}"
+  
+  # Check if libm is provided by the compiler
+  
+  ifneq ($(LIBM_PATH),".")
+    EXTRA_LIBS += -lm
+    EXTRA_LIBPATHS += -L $(LIBM_PATH)
+  endif
 endif
 
 ifeq ($(CONFIG_LIBSUPCXX),y)


### PR DESCRIPTION
## Summary
Some toolchains may be built without libm support, but using such toochains should not generate any errors in case if math functions are not used in the program

## Impact
Enable toolchains without libm support

## Testing
Pass CI
