### PR TITLE
risc-v/mpfs: switch to NuttX types for opensbi

### DIFF
--- a/arch/risc-v/src/Makefile
+++ b/arch/risc-v/src/Makefile
@@ -38,9 +38,10 @@ INCLUDES += ${shell $(INCDIR) "$(CC)" $(ARCH_SRCDIR)$(DELIM)chip}
 INCLUDES += ${shell $(INCDIR) "$(CC)" $(ARCH_SRCDIR)$(DELIM)common}
 INCLUDES += ${shell $(INCDIR) "$(CC)" $(ARCH_SRCDIR)$(DELIM)$(ARCH_SUBDIR)}
 INCLUDES += ${shell $(INCDIR) "$(CC)" $(TOPDIR)$(DELIM)sched}
-#ifeq ($(CONFIG_OPENSBI),y)
+ifeq ($(CONFIG_OPENSBI),y)
+INCLUDES += $(shell $(INCDIR) "$(CC)" $(ARCH_SRCDIR)$(DELIM)opensbi)
 INCLUDES += $(shell $(INCDIR) "$(CC)" $(ARCH_SRCDIR)$(DELIM)opensbi$(DELIM)opensbi-3rdparty$(DELIM)include)
-#endif
+endif
 
 CPPFLAGS += $(INCLUDES)
 CFLAGS += $(INCLUDES)

--- a/arch/risc-v/src/mpfs/mpfs_opensbi.c
+++ b/arch/risc-v/src/mpfs/mpfs_opensbi.c
@@ -23,36 +23,27 @@
  ****************************************************************************/
 
 #include <nuttx/config.h>
+
 #include <assert.h>
 #include <errno.h>
 #include <stdint.h>
-#include <riscv_arch.h>
+
+#include "riscv_internal.h"
+#include "riscv_arch.h"
 
 #include <hardware/mpfs_plic.h>
 #include <hardware/mpfs_memorymap.h>
 #include <hardware/mpfs_clint.h>
 #include <hardware/mpfs_sysreg.h>
 
-/* OpenSBI will also define NULL. Undefine NULL in order to avoid warning:
- * 'warning: "NULL" redefined'
- */
-
-#ifdef NULL
-  #undef NULL
-#endif
-
 #include <sbi/sbi_types.h>
 #include <sbi/riscv_atomic.h>
-#include <sbi/riscv_asm.h>
 #include <sbi/riscv_io.h>
-#include <sbi/riscv_encoding.h>
 #include <sbi/sbi_hart.h>
 #include <sbi/sbi_console.h>
 #include <sbi/sbi_platform.h>
-#include <sbi/sbi_domain.h>
 #include <sbi/sbi_timer.h>
 #include <sbi/sbi_init.h>
-#include <sbi/sbi_scratch.h>
 #include <sbi_utils/irqchip/plic.h>
 #include <sbi_utils/ipi/aclint_mswi.h>
 #include <sbi_utils/timer/aclint_mtimer.h>
@@ -114,16 +105,6 @@ static int  mpfs_opensbi_console_init(void);
 static int  mpfs_irqchip_init(bool cold_boot);
 static int  mpfs_ipi_init(bool cold_boot);
 static int  mpfs_timer_init(bool cold_boot);
-
-/****************************************************************************
- * Extern Function Declarations
- ****************************************************************************/
-
-/* riscv_internal.h cannot be included due to a number of redefinition
- * conflicts.  Thus, define the riscv_lowputc() with the extern definition.
- */
-
-extern void riscv_lowputc(char ch);
 
 /****************************************************************************
  * Private Data

--- a/arch/risc-v/src/opensbi/0001-fix-redefinition-warnings-with-NuttX.patch
+++ b/arch/risc-v/src/opensbi/0001-fix-redefinition-warnings-with-NuttX.patch
@@ -1,0 +1,424 @@
+From eeaa7a46c8f5ed915869c597e45c6c1678555f04 Mon Sep 17 00:00:00 2001
+From: Petro Karashchenko <petro.karashchenko@gmail.com>
+Date: Fri, 21 Jan 2022 13:00:31 +0200
+Subject: [PATCH] include: fix redefinition warnings when compiling with NuttX
+
+Signed-off-by: Petro Karashchenko <petro.karashchenko@gmail.com>
+---
+ opensbi/opensbi-3rdparty/include/sbi/riscv_encoding.h | 228 +++++++++++++++++++++++++++++++++++
+ 1 file changed, 228 insertions(+)
+
+diff --git opensbi/opensbi-3rdparty/include/sbi/riscv_encoding.h opensbi/opensbi-3rdparty/include/sbi/riscv_encoding.h
+index 8a29f8e..04fba73 100644
+--- opensbi/opensbi-3rdparty/include/sbi/riscv_encoding.h
++++ opensbi/opensbi-3rdparty/include/sbi/riscv_encoding.h
+@@ -14,16 +14,22 @@
+ 
+ /* clang-format off */
+ #define MSTATUS_SIE			_UL(0x00000002)
++#ifndef MSTATUS_MIE
+ #define MSTATUS_MIE			_UL(0x00000008)
++#endif
+ #define MSTATUS_SPIE_SHIFT		5
+ #define MSTATUS_SPIE			(_UL(1) << MSTATUS_SPIE_SHIFT)
+ #define MSTATUS_UBE			_UL(0x00000040)
++#ifndef MSTATUS_MPIE
+ #define MSTATUS_MPIE			_UL(0x00000080)
++#endif
+ #define MSTATUS_SPP_SHIFT		8
+ #define MSTATUS_SPP			(_UL(1) << MSTATUS_SPP_SHIFT)
+ #define MSTATUS_MPP_SHIFT		11
+ #define MSTATUS_MPP			(_UL(3) << MSTATUS_MPP_SHIFT)
++#ifndef MSTATUS_FS
+ #define MSTATUS_FS			_UL(0x00006000)
++#endif
+ #define MSTATUS_XS			_UL(0x00018000)
+ #define MSTATUS_VS			_UL(0x01800000)
+ #define MSTATUS_MPRV			_UL(0x00020000)
+@@ -93,7 +99,9 @@
+ #define MIP_MSIP			(_UL(1) << IRQ_M_SOFT)
+ #define MIP_STIP			(_UL(1) << IRQ_S_TIMER)
+ #define MIP_VSTIP			(_UL(1) << IRQ_VS_TIMER)
++#ifndef MIP_MTIP
+ #define MIP_MTIP			(_UL(1) << IRQ_M_TIMER)
++#endif
+ #define MIP_SEIP			(_UL(1) << IRQ_S_EXT)
+ #define MIP_VSEIP			(_UL(1) << IRQ_VS_EXT)
+ #define MIP_MEIP			(_UL(1) << IRQ_M_EXT)
+@@ -218,9 +226,15 @@
+ #define CSR_FCSR			0x003
+ 
+ /* User Counters/Timers */
++#ifndef CSR_CYCLE
+ #define CSR_CYCLE			0xc00
++#endif
++#ifndef CSR_TIME
+ #define CSR_TIME			0xc01
++#endif
++#ifndef CSR_INSTRET
+ #define CSR_INSTRET			0xc02
++#endif
+ #define CSR_HPMCOUNTER3			0xc03
+ #define CSR_HPMCOUNTER4			0xc04
+ #define CSR_HPMCOUNTER5			0xc05
+@@ -250,9 +264,15 @@
+ #define CSR_HPMCOUNTER29		0xc1d
+ #define CSR_HPMCOUNTER30		0xc1e
+ #define CSR_HPMCOUNTER31		0xc1f
++#ifndef CSR_CYCLEH
+ #define CSR_CYCLEH			0xc80
++#endif
++#ifndef CSR_TIMEH
+ #define CSR_TIMEH			0xc81
++#endif
++#ifndef CSR_INSTRETH
+ #define CSR_INSTRETH			0xc82
++#endif
+ #define CSR_HPMCOUNTER3H		0xc83
+ #define CSR_HPMCOUNTER4H		0xc84
+ #define CSR_HPMCOUNTER5H		0xc85
+@@ -341,10 +361,18 @@
+ /* ===== Machine-level CSRs ===== */
+ 
+ /* Machine Information Registers */
++#ifndef CSR_MVENDORID
+ #define CSR_MVENDORID			0xf11
++#endif
++#ifndef CSR_MARCHID
+ #define CSR_MARCHID			0xf12
++#endif
++#ifndef CSR_MIMPID
+ #define CSR_MIMPID			0xf13
++#endif
++#ifndef CSR_MHARTID
+ #define CSR_MHARTID			0xf14
++#endif
+ 
+ /* Machine Trap Setup */
+ #define CSR_MSTATUS			0x300
+@@ -366,38 +394,102 @@
+ #define CSR_MTVAL2			0x34b
+ 
+ /* Machine Memory Protection */
++#ifndef CSR_PMPCFG0
+ #define CSR_PMPCFG0			0x3a0
++#endif
++#ifndef CSR_PMPCFG1
+ #define CSR_PMPCFG1			0x3a1
++#endif
++#ifndef CSR_PMPCFG2
+ #define CSR_PMPCFG2			0x3a2
++#endif
++#ifndef CSR_PMPCFG3
+ #define CSR_PMPCFG3			0x3a3
++#endif
++#ifndef CSR_PMPCFG4
+ #define CSR_PMPCFG4			0x3a4
++#endif
++#ifndef CSR_PMPCFG5
+ #define CSR_PMPCFG5			0x3a5
++#endif
++#ifndef CSR_PMPCFG6
+ #define CSR_PMPCFG6			0x3a6
++#endif
++#ifndef CSR_PMPCFG7
+ #define CSR_PMPCFG7			0x3a7
++#endif
++#ifndef CSR_PMPCFG8
+ #define CSR_PMPCFG8			0x3a8
++#endif
++#ifndef CSR_PMPCFG9
+ #define CSR_PMPCFG9			0x3a9
++#endif
++#ifndef CSR_PMPCFG10
+ #define CSR_PMPCFG10			0x3aa
++#endif
++#ifndef CSR_PMPCFG11
+ #define CSR_PMPCFG11			0x3ab
++#endif
++#ifndef CSR_PMPCFG12
+ #define CSR_PMPCFG12			0x3ac
++#endif
++#ifndef CSR_PMPCFG13
+ #define CSR_PMPCFG13			0x3ad
++#endif
++#ifndef CSR_PMPCFG14
+ #define CSR_PMPCFG14			0x3ae
++#endif
++#ifndef CSR_PMPCFG15
+ #define CSR_PMPCFG15			0x3af
++#endif
++#ifndef CSR_PMPADDR0
+ #define CSR_PMPADDR0			0x3b0
++#endif
++#ifndef CSR_PMPADDR1
+ #define CSR_PMPADDR1			0x3b1
++#endif
++#ifndef CSR_PMPADDR2
+ #define CSR_PMPADDR2			0x3b2
++#endif
++#ifndef CSR_PMPADDR3
+ #define CSR_PMPADDR3			0x3b3
++#endif
++#ifndef CSR_PMPADDR4
+ #define CSR_PMPADDR4			0x3b4
++#endif
++#ifndef CSR_PMPADDR5
+ #define CSR_PMPADDR5			0x3b5
++#endif
++#ifndef CSR_PMPADDR6
+ #define CSR_PMPADDR6			0x3b6
++#endif
++#ifndef CSR_PMPADDR7
+ #define CSR_PMPADDR7			0x3b7
++#endif
++#ifndef CSR_PMPADDR8
+ #define CSR_PMPADDR8			0x3b8
++#endif
++#ifndef CSR_PMPADDR9
+ #define CSR_PMPADDR9			0x3b9
++#endif
++#ifndef CSR_PMPADDR10
+ #define CSR_PMPADDR10			0x3ba
++#endif
++#ifndef CSR_PMPADDR11
+ #define CSR_PMPADDR11			0x3bb
++#endif
++#ifndef CSR_PMPADDR12
+ #define CSR_PMPADDR12			0x3bc
++#endif
++#ifndef CSR_PMPADDR13
+ #define CSR_PMPADDR13			0x3bd
++#endif
++#ifndef CSR_PMPADDR14
+ #define CSR_PMPADDR14			0x3be
++#endif
++#ifndef CSR_PMPADDR15
+ #define CSR_PMPADDR15			0x3bf
++#endif
+ #define CSR_PMPADDR16			0x3c0
+ #define CSR_PMPADDR17			0x3c1
+ #define CSR_PMPADDR18			0x3c2
+@@ -448,68 +540,192 @@
+ #define CSR_PMPADDR63			0x3ef
+ 
+ /* Machine Counters/Timers */
++#ifndef CSR_MCYCLE
+ #define CSR_MCYCLE			0xb00
++#endif
++#ifndef CSR_MINSTRET
+ #define CSR_MINSTRET			0xb02
++#endif
++#ifndef CSR_MHPMCOUNTER3
+ #define CSR_MHPMCOUNTER3		0xb03
++#endif
++#ifndef CSR_MHPMCOUNTER4
+ #define CSR_MHPMCOUNTER4		0xb04
++#endif
++#ifndef CSR_MHPMCOUNTER5
+ #define CSR_MHPMCOUNTER5		0xb05
++#endif
++#ifndef CSR_MHPMCOUNTER6
+ #define CSR_MHPMCOUNTER6		0xb06
++#endif
++#ifndef CSR_MHPMCOUNTER7
+ #define CSR_MHPMCOUNTER7		0xb07
++#endif
++#ifndef CSR_MHPMCOUNTER8
+ #define CSR_MHPMCOUNTER8		0xb08
++#endif
++#ifndef CSR_MHPMCOUNTER9
+ #define CSR_MHPMCOUNTER9		0xb09
++#endif
++#ifndef CSR_MHPMCOUNTER10
+ #define CSR_MHPMCOUNTER10		0xb0a
++#endif
++#ifndef CSR_MHPMCOUNTER11
+ #define CSR_MHPMCOUNTER11		0xb0b
++#endif
++#ifndef CSR_MHPMCOUNTER12
+ #define CSR_MHPMCOUNTER12		0xb0c
++#endif
++#ifndef CSR_MHPMCOUNTER13
+ #define CSR_MHPMCOUNTER13		0xb0d
++#endif
++#ifndef CSR_MHPMCOUNTER14
+ #define CSR_MHPMCOUNTER14		0xb0e
++#endif
++#ifndef CSR_MHPMCOUNTER15
+ #define CSR_MHPMCOUNTER15		0xb0f
++#endif
++#ifndef CSR_MHPMCOUNTER16
+ #define CSR_MHPMCOUNTER16		0xb10
++#endif
++#ifndef CSR_MHPMCOUNTER17
+ #define CSR_MHPMCOUNTER17		0xb11
++#endif
++#ifndef CSR_MHPMCOUNTER18
+ #define CSR_MHPMCOUNTER18		0xb12
++#endif
++#ifndef CSR_MHPMCOUNTER19
+ #define CSR_MHPMCOUNTER19		0xb13
++#endif
++#ifndef CSR_MHPMCOUNTER20
+ #define CSR_MHPMCOUNTER20		0xb14
++#endif
++#ifndef CSR_MHPMCOUNTER21
+ #define CSR_MHPMCOUNTER21		0xb15
++#endif
++#ifndef CSR_MHPMCOUNTER22
+ #define CSR_MHPMCOUNTER22		0xb16
++#endif
++#ifndef CSR_MHPMCOUNTER23
+ #define CSR_MHPMCOUNTER23		0xb17
++#endif
++#ifndef CSR_MHPMCOUNTER24
+ #define CSR_MHPMCOUNTER24		0xb18
++#endif
++#ifndef CSR_MHPMCOUNTER25
+ #define CSR_MHPMCOUNTER25		0xb19
++#endif
++#ifndef CSR_MHPMCOUNTER26
+ #define CSR_MHPMCOUNTER26		0xb1a
++#endif
++#ifndef CSR_MHPMCOUNTER27
+ #define CSR_MHPMCOUNTER27		0xb1b
++#endif
++#ifndef CSR_MHPMCOUNTER28
+ #define CSR_MHPMCOUNTER28		0xb1c
++#endif
++#ifndef CSR_MHPMCOUNTER29
+ #define CSR_MHPMCOUNTER29		0xb1d
++#endif
++#ifndef CSR_MHPMCOUNTER30
+ #define CSR_MHPMCOUNTER30		0xb1e
++#endif
++#ifndef CSR_MHPMCOUNTER31
+ #define CSR_MHPMCOUNTER31		0xb1f
++#endif
++#ifndef CSR_MCYCLEH
+ #define CSR_MCYCLEH			0xb80
++#endif
++#ifndef CSR_MINSTRETH
+ #define CSR_MINSTRETH			0xb82
++#endif
++#ifndef CSR_MHPMCOUNTER3H
+ #define CSR_MHPMCOUNTER3H		0xb83
++#endif
++#ifndef CSR_MHPMCOUNTER4H
+ #define CSR_MHPMCOUNTER4H		0xb84
++#endif
++#ifndef CSR_MHPMCOUNTER5H
+ #define CSR_MHPMCOUNTER5H		0xb85
++#endif
++#ifndef CSR_MHPMCOUNTER6H
+ #define CSR_MHPMCOUNTER6H		0xb86
++#endif
++#ifndef CSR_MHPMCOUNTER7H
+ #define CSR_MHPMCOUNTER7H		0xb87
++#endif
++#ifndef CSR_MHPMCOUNTER8H
+ #define CSR_MHPMCOUNTER8H		0xb88
++#endif
++#ifndef CSR_MHPMCOUNTER9H
+ #define CSR_MHPMCOUNTER9H		0xb89
++#endif
++#ifndef CSR_MHPMCOUNTER10H
+ #define CSR_MHPMCOUNTER10H		0xb8a
++#endif
++#ifndef CSR_MHPMCOUNTER11H
+ #define CSR_MHPMCOUNTER11H		0xb8b
++#endif
++#ifndef CSR_MHPMCOUNTER12H
+ #define CSR_MHPMCOUNTER12H		0xb8c
++#endif
++#ifndef CSR_MHPMCOUNTER13H
+ #define CSR_MHPMCOUNTER13H		0xb8d
++#endif
++#ifndef CSR_MHPMCOUNTER14H
+ #define CSR_MHPMCOUNTER14H		0xb8e
++#endif
++#ifndef CSR_MHPMCOUNTER15H
+ #define CSR_MHPMCOUNTER15H		0xb8f
++#endif
++#ifndef CSR_MHPMCOUNTER16H
+ #define CSR_MHPMCOUNTER16H		0xb90
++#endif
++#ifndef CSR_MHPMCOUNTER17H
+ #define CSR_MHPMCOUNTER17H		0xb91
++#endif
++#ifndef CSR_MHPMCOUNTER18H
+ #define CSR_MHPMCOUNTER18H		0xb92
++#endif
++#ifndef CSR_MHPMCOUNTER19H
+ #define CSR_MHPMCOUNTER19H		0xb93
++#endif
++#ifndef CSR_MHPMCOUNTER20H
+ #define CSR_MHPMCOUNTER20H		0xb94
++#endif
++#ifndef CSR_MHPMCOUNTER21H
+ #define CSR_MHPMCOUNTER21H		0xb95
++#endif
++#ifndef CSR_MHPMCOUNTER22H
+ #define CSR_MHPMCOUNTER22H		0xb96
++#endif
++#ifndef CSR_MHPMCOUNTER23H
+ #define CSR_MHPMCOUNTER23H		0xb97
++#endif
++#ifndef CSR_MHPMCOUNTER24H
+ #define CSR_MHPMCOUNTER24H		0xb98
++#endif
++#ifndef CSR_MHPMCOUNTER25H
+ #define CSR_MHPMCOUNTER25H		0xb99
++#endif
++#ifndef CSR_MHPMCOUNTER26H
+ #define CSR_MHPMCOUNTER26H		0xb9a
++#endif
++#ifndef CSR_MHPMCOUNTER27H
+ #define CSR_MHPMCOUNTER27H		0xb9b
++#endif
++#ifndef CSR_MHPMCOUNTER28H
+ #define CSR_MHPMCOUNTER28H		0xb9c
++#endif
++#ifndef CSR_MHPMCOUNTER29H
+ #define CSR_MHPMCOUNTER29H		0xb9d
++#endif
++#ifndef CSR_MHPMCOUNTER30H
+ #define CSR_MHPMCOUNTER30H		0xb9e
++#endif
++#ifndef CSR_MHPMCOUNTER31H
+ #define CSR_MHPMCOUNTER31H		0xb9f
++#endif
+ 
+ /* Machine Counter Setup */
+ #define CSR_MCOUNTINHIBIT		0x320
+@@ -578,14 +794,26 @@
+ #define CSR_SCOUNTOVF			0xda0
+ 
+ /* Debug/Trace Registers */
++#ifndef CSR_TSELECT
+ #define CSR_TSELECT			0x7a0
++#endif
++#ifndef CSR_TDATA1
+ #define CSR_TDATA1			0x7a1
++#endif
++#ifndef CSR_TDATA2
+ #define CSR_TDATA2			0x7a2
++#endif
++#ifndef CSR_TDATA3
+ #define CSR_TDATA3			0x7a3
++#endif
+ 
+ /* Debug Mode Registers */
++#ifndef CSR_DCSR
+ #define CSR_DCSR			0x7b0
++#endif
++#ifndef CSR_DPC
+ #define CSR_DPC				0x7b1
++#endif
+ #define CSR_DSCRATCH0			0x7b2
+ #define CSR_DSCRATCH1			0x7b3
+ 
+-- 
+2.32.0
+

--- a/arch/risc-v/src/opensbi/Kconfig
+++ b/arch/risc-v/src/opensbi/Kconfig
@@ -9,4 +9,4 @@ config OPENSBI
 	default n
 	---help---
 		Enable or disable Open Source Supervisor Binary Interface (OpenSBI) features
-                for RISC-V.
+		for RISC-V.

--- a/arch/risc-v/src/opensbi/Make.defs
+++ b/arch/risc-v/src/opensbi/Make.defs
@@ -37,6 +37,8 @@ OPENSBI_URL     = https://github.com/riscv-software-src/opensbi/tarball
 OPENSBI_TARBALL = opensbi.tar.gz
 OPENSBI_DIR     = riscv-software-src-opensbi-48f91ee
 
+CFLAGS += -DOPENSBI_EXTERNAL_SBI_TYPES=nuttx_sbi_types.h
+
 $(OPENSBI_TARBALL):
 	$(Q) echo "Downloading: OpenSBI"
 	$(Q) curl -L $(OPENSBI_URL)/$(OPENSBI_COMMIT) -o opensbi/$(OPENSBI_TARBALL)
@@ -45,6 +47,7 @@ $(OPENSBI_TARBALL):
 	$(Q) echo "Unpacking: OpenSBI"
 	$(Q) tar xzf opensbi/$(OPENSBI_TARBALL) -C opensbi
 	$(Q) mv opensbi/$(OPENSBI_DIR) opensbi/$(OPENSBI_UNPACK)
+	$(Q) patch -p0 < opensbi/0001-fix-redefinition-warnings-with-NuttX.patch
 	$(Q) touch opensbi/.opensbi_unpack
 
 context:: .opensbi_unpack

--- a/arch/risc-v/src/opensbi/nuttx_sbi_types.h
+++ b/arch/risc-v/src/opensbi/nuttx_sbi_types.h
@@ -1,0 +1,83 @@
+/****************************************************************************
+ * arch/risc-v/src/opensbi/nuttx_sbi_types.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __ARCH_RISCV_SRC_OPENSBI_NUTTX_SBI_TYPES_H
+#define __ARCH_RISCV_SRC_OPENSBI_NUTTX_SBI_TYPES_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+#include <nuttx/compiler.h>
+#include <nuttx/nuttx.h>
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <inttypes.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#ifdef CONFIG_ARCH_RV32
+#  define PRILX             "08" PRIxPTR
+#else
+#  define PRILX             "016" PRIxPTR
+#endif
+
+#define __packed            end_packed_struct
+#define __noreturn          noreturn_function
+#define __aligned(x)        aligned_data(x)
+
+#define likely(x)           __builtin_expect((x), 1)
+#define unlikely(x)         __builtin_expect((x), 0)
+
+#define array_size(x)       (sizeof(x) / sizeof((x)[0]))
+
+#define MAX(a, b)           ((a) > (b) ? (a) : (b))
+#define MIN(a, b)           ((a) < (b) ? (a) : (b))
+#define CLAMP(a, lo, hi)    MIN(MAX(a, lo), hi)
+
+#define ROUNDUP(a, b)       ((((a) - 1) / (b) + 1) * (b))
+#define ROUNDDOWN(a, b)     ((a) / (b) * (b))
+
+/****************************************************************************
+ * Type Definitions
+ ****************************************************************************/
+
+typedef int8_t              s8;
+typedef uint8_t             u8;
+
+typedef int16_t             s16;
+typedef uint16_t            u16;
+
+typedef int32_t             s32;
+typedef uint32_t            u32;
+
+typedef int64_t             s64;
+typedef uint64_t            u64;
+
+typedef uintptr_t           virtual_addr_t;
+typedef uintptr_t           virtual_size_t;
+typedef uintptr_t           physical_addr_t;
+typedef uintptr_t           physical_size_t;
+
+#endif /* __ARCH_RISCV_SRC_OPENSBI_NUTTX_SBI_TYPES_H */


### PR DESCRIPTION
## Summary
switch to NuttX types for opensbi

## Impact
`mpfs_opensbi.c` can compiled without warnings / errors
no `extern void riscv_lowputc(char ch);` is required

## Testing
Pass CI
Pass local build after distclean
