### PR TITLE
boards/same70-qmtech: clarify usage of CD signal on SD card connector

### DIFF
--- a/boards/arm/samv7/same70-qmtech/README.txt
+++ b/boards/arm/samv7/same70-qmtech/README.txt
@@ -66,21 +66,21 @@ SD Card
 Card Slot
 ---------
 The SAM E70 QMTECH has one standard SD card connector that is connected to
-the High Speed Multimedia Card Interface (HSMCI) of the SAM
-E70. SD card connector:
+the High Speed Multimedia Card Interface (HSMCI) of the SAM E70.
+SD card connector:
 
-  ------ ----------------- ---------------------
-  SAME70 SAME70            Shared functionality
+  ------ -----------------
+  SAME70 SAME70
   Pin    Function
-  ------ ----------------- ---------------------
+  ------ -----------------
   PA30   MCDA0 (DAT0)
   PA31   MCDA1 (DAT1)
   PA26   MCDA2 (DAT2)
   PA27   MCDA3 (DAT3)
-  PA25   MCCK (CLK)        Shield
+  PA25   MCCK (CLK)
   PA28   MCCDA (CMD)
-  PD17   Card Detect (C/D) Shield
-  ------ ----------------- ---------------------
+  N/A    Card Detect (C/D)
+  ------ -----------------
 
 Configuration Settings
 ----------------------

--- a/boards/arm/samv7/same70-qmtech/src/same70-qmtech.h
+++ b/boards/arm/samv7/same70-qmtech/src/same70-qmtech.h
@@ -144,24 +144,28 @@
 /* HSMCI SD Card Detect
  *
  * The SAM E70 QMTECH has one standard SD card connector that is connected
- * to the High Speed Multimedia Card Interface (HSMCI) of the SAM E70. SD
- * card connector:
+ * to the High Speed Multimedia Card Interface (HSMCI) of the SAM E70.
+ * SD card connector:
  *
- *   ------ ----------------- ---------------------
- *   SAME70 SAME70            Shared functionality
+ *   ------ -----------------
+ *   SAME70 SAME70
  *   Pin    Function
- *   ------ ----------------- ---------------------
+ *   ------ -----------------
  *   PA30   MCDA0 (DAT0)
  *   PA31   MCDA1 (DAT1)
  *   PA26   MCDA2 (DAT2)
- *   PA27   MCDA3 (DAT3)      Camera
- *   PA25   MCCK (CLK)        Shield
+ *   PA27   MCDA3 (DAT3)
+ *   PA25   MCCK (CLK)
  *   PA28   MCCDA (CMD)
- *   PD17   Card Detect (C/D) Shield
- *   ------ ----------------- ---------------------
+ *   N/A    Card Detect (C/D)
+ *   ------ -----------------
+ *
+ * The SD card connector does not have CD signal connected to SAM E70 pin,
+ * but in order to provide automounter support the HW rework can be done and
+ * CD signal can be connected to SAM E70 PD17 (connector J3 pin 17).
  */
 
-#define GPIO_HSMCI0_CD (GPIO_INPUT | GPIO_CFG_PULLDOWN | GPIO_CFG_DEGLITCH | \
+#define GPIO_HSMCI0_CD (GPIO_INPUT | GPIO_CFG_DEFAULT | GPIO_CFG_DEGLITCH | \
                         GPIO_INT_BOTHEDGES | GPIO_PORT_PIOD | GPIO_PIN17)
 #define IRQ_HSMCI0_CD  SAM_IRQ_PD17
 


### PR DESCRIPTION
## Summary
By default SAME70_QMTECH board does not have CD signal routed to SAME70. The HW rework can be done to enable CD signal. Clarify description of SD card connector.
Change configuration of CD pin to get auto unmount work correctly

## Impact
SAME70-QMTECH users

## Testing
Verified that automounter works properly on the board with HW rework