### PR TITLE
Fix broken bl602 flash due to partition_table being incorrectly marked as unused

### DIFF
--- a/arch/arm/src/cxd56xx/cxd56_farapi.c
+++ b/arch/arm/src/cxd56xx/cxd56_farapi.c
@@ -182,7 +182,7 @@ static int cxd56_farapidonehandler(int cpuid, int protoid,
  * Public Functions
  ****************************************************************************/
 
-unused_code
+used_code
 void farapi_main(int id, void *arg, struct modulelist_s *mlist)
 {
   struct farmsg_s msg;

--- a/arch/risc-v/src/bl602/bl602_start.c
+++ b/arch/risc-v/src/bl602/bl602_start.c
@@ -76,7 +76,7 @@ uint8_t g_idle_stack[BL602_IDLESTACK_SIZE]
  * g_boot2_partition_table in linker script
  */
 
-static struct boot2_partition_table_s g_boot2_partition_table unused_data;
+static struct boot2_partition_table_s g_boot2_partition_table used_data;
 
 /****************************************************************************
  * Public Data

--- a/include/nuttx/compiler.h
+++ b/include/nuttx/compiler.h
@@ -186,10 +186,12 @@
 #  endif
 #endif
 
-/* The unsued code or data */
+/* The unused code or data */
 
 #  define unused_code __attribute__((unused))
 #  define unused_data __attribute__((unused))
+#  define used_code __attribute__((used))
+#  define used_data __attribute__((used))
 
 /* Some versions of GCC have a separate __syslog__ format.
  * http://mail-index.netbsd.org/source-changes/2015/10/14/msg069435.html
@@ -452,6 +454,8 @@
 
 #  define unused_code
 #  define unused_data
+#  define used_code
+#  define used_data
 
 #  define formatlike(a)
 #  define printflike(a, b)
@@ -591,6 +595,8 @@
 #  define nostackprotect_function
 #  define unused_code
 #  define unused_data
+#  define used_code
+#  define used_data
 #  define formatlike(a)
 #  define printflike(a, b)
 #  define sysloglike(a, b)
@@ -702,6 +708,8 @@
 #  define nostackprotect_function
 #  define unused_code
 #  define unused_data
+#  define used_code
+#  define used_data
 #  define formatlike(a)
 #  define printflike(a, b)
 #  define sysloglike(a, b)
@@ -768,6 +776,8 @@
 #  define nostackprotect_function
 #  define unused_code
 #  define unused_data
+#  define used_code
+#  define used_data
 #  define formatlike(a)
 #  define printflike(a, b)
 #  define sysloglike(a, b)


### PR DESCRIPTION
## Summary
Commit 5d1a444812f46b3f841ea2f09b1dd6be9725ec15 (from #4238) replaced `__attribute__ ((unused))` with `unused_code` but two instances of `__attribute__ ((used))` were also incorrectly replaced. Add `used_code`/`used_data` and used them instead.

This resulted in the bl602 `boot2_partition_table` being zero size in the final binary, which means that the code in bl602_head.S no longer copied it into RAM. The result of which is that the `boot2_flash_cfg` data was read from the wrong offset and all flash ops would hang. 

## Impact
Restoring the partition table size means that the flash config is valid, and flash ops (and the `bl602evb:spiflash` config) work again. cxd56 farapi_main had the same issue, although it's referenced in a different way so the compiler probably didn't omit it from the final link.

## Testing
`bl602evb:spiflash` demo from #2659 now works