### PR TITLE
boards/arm/samv7/same70-qmtech: enable slow crystal

### DIFF
--- a/boards/arm/samv7/same70-qmtech/include/board.h
+++ b/boards/arm/samv7/same70-qmtech/include/board.h
@@ -45,13 +45,11 @@
  *                       Prescalar = 1 to generate MCK = 120MHz
  *   CPU clock: 120MHz
  *
- * There can be two on-board crystals.  However, the 32.768 crystal is not
- * populated on the stock SAME70.  The fallback is to use th on-chip, slow RC
- * oscillator which has a frequency of 22-42 KHz, nominally 32 KHz.
+ * There are two on-board crystals:
  */
 
-#undef  BOARD_HAVE_SLOWXTAL                   /* Slow crystal not populated */
-#define BOARD_SLOWCLK_FREQUENCY    (32000)    /* 32 KHz RC oscillator (nominal)  */
+#define BOARD_HAVE_SLOWXTAL        1          /* Slow crystal is populated */
+#define BOARD_SLOWCLK_FREQUENCY    (32768)    /* 32.768 kHz slow crystal oscillator */
 #define BOARD_MAINOSC_FREQUENCY    (12000000) /* 12 MHz main oscillator */
 
 /* Main oscillator register settings.

--- a/boards/arm/samv7/same70-xplained/include/board.h
+++ b/boards/arm/samv7/same70-xplained/include/board.h
@@ -46,8 +46,8 @@
  *   CPU clock: 120MHz
  *
  * There can be two on-board crystals.  However, the 32.768 crystal is not
- * populated on the stock SAME70.  The fallback is to use th on-chip, slow RC
- * oscillator which has a frequency of 22-42 KHz, nominally 32 KHz.
+ * populated on the stock SAME70.  The fallback is to use the on-chip, slow
+ * RC oscillator which has a frequency of 22-42 KHz, nominally 32 KHz.
  */
 
 #undef  BOARD_HAVE_SLOWXTAL                   /* Slow crystal not populated */

--- a/boards/arm/samv7/samv71-xult/include/board.h
+++ b/boards/arm/samv7/samv71-xult/include/board.h
@@ -41,16 +41,15 @@
  *
  * 300MHz Settings:
  *   PLLA: PLL Divider = 1, Multiplier = 20 to generate PLLACK = 240MHz
- *   Master Clock (MCK):
- *      Source = PLLACK,
- *      Prescalar = 1 to generate MCK = 120MHz
+ *   Master Clock (MCK): Source = PLLACK,
+ *                       Prescalar = 1 to generate MCK = 120MHz
  *   CPU clock: 120MHz
  *
  * There are two on-board crystals:
  */
 
 #define BOARD_HAVE_SLOWXTAL        1          /* Slow crystal is populated */
-#define BOARD_SLOWCLK_FREQUENCY    (32768)    /* 32.768 KHz slow crystal oscillator */
+#define BOARD_SLOWCLK_FREQUENCY    (32768)    /* 32.768 kHz slow crystal oscillator */
 #define BOARD_MAINOSC_FREQUENCY    (12000000) /* 12 MHz main oscillator */
 
 /* Main oscillator register settings.


### PR DESCRIPTION
## Summary
SAME70-QMTECH has 32kHz oscillator installed. Enable it.

## Impact
None

## Testing
Pass CI