### PR TITLE
drivers/sensors: fix Kconfig warning

### DIFF
--- a/drivers/sensors/Kconfig
+++ b/drivers/sensors/Kconfig
@@ -585,13 +585,13 @@ config MS5611_SPI
 	---help---
 		Enables support for the SPI interface.
 
+endchoice
+
 config MS5611_THREAD_STACKSIZE
 	int "Worker thread stack size"
 	default 1024
 	---help---
 		The stack size for the worker thread
-
-endchoice
 
 config MS5611_I2C_FREQUENCY
 	int "MS5611 I2C frequency"


### PR DESCRIPTION
## Summary

drivers/sensors: fix Kconfig warning

drivers/sensors/Kconfig:590:warning: defaults for choice values not supported

## Impact

N/A

## Testing

CI-check