### PR TITLE
arch: Decouple up_critmon_[gettime|convert] from critmon

### DIFF
--- a/boards/arm/stm32/omnibusf4/src/Make.defs
+++ b/boards/arm/stm32/omnibusf4/src/Make.defs
@@ -20,7 +20,7 @@
 
 include $(TOPDIR)/Make.defs
 
-CSRCS = stm32_boot.c stm32_bringup.c stm32_spi.c stm32_userleds.c
+CSRCS = stm32_boot.c stm32_bringup.c stm32_spi.c stm32_userleds.c stm32_perfcount.c
 
 ifeq ($(CONFIG_SENSORS_MPU60X0),y)
 CSRCS += stm32_mpu6000.c
@@ -28,10 +28,6 @@ endif
 
 ifeq ($(CONFIG_VIDEO_MAX7456),y)
 CSRCS += stm32_max7456.c
-endif
-
-ifeq ($(CONFIG_SCHED_CRITMONITOR),y)
-CSRCS += stm32_critmon.c
 endif
 
 ifeq ($(CONFIG_STM32_OTGFS),y)

--- a/boards/arm/stm32/omnibusf4/src/stm32_perfcount.c
+++ b/boards/arm/stm32/omnibusf4/src/stm32_perfcount.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * boards/arm/stm32/stm32f4discovery/src/stm32_critmon.c
+ * boards/arm/stm32/omnibusf4/src/stm32_perfcount.c
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -34,26 +34,24 @@
 
 #include <arch/board/board.h>
 
-#ifdef CONFIG_SCHED_CRITMONITOR
-
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
 
 /****************************************************************************
- * Name: up_critmon_gettime
+ * Name: up_perf_gettime
  ****************************************************************************/
 
-uint32_t up_critmon_gettime(void)
+uint32_t up_perf_gettime(void)
 {
   return getreg32(DWT_CYCCNT);
 }
 
 /****************************************************************************
- * Name: up_critmon_gettime
+ * Name: up_perf_convert
  ****************************************************************************/
 
-void up_critmon_convert(uint32_t elapsed, FAR struct timespec *ts)
+void up_perf_convert(uint32_t elapsed, FAR struct timespec *ts)
 {
   b32_t b32elapsed;
 
@@ -61,5 +59,3 @@ void up_critmon_convert(uint32_t elapsed, FAR struct timespec *ts)
   ts->tv_sec  = b32toi(b32elapsed);
   ts->tv_nsec = NSEC_PER_SEC * b32frac(b32elapsed) / b32ONE;
 }
-
-#endif /* CONFIG_SCHED_CRITMONITOR */

--- a/boards/arm/stm32/stm32f4discovery/src/Make.defs
+++ b/boards/arm/stm32/stm32f4discovery/src/Make.defs
@@ -20,16 +20,12 @@
 
 include $(TOPDIR)/Make.defs
 
-CSRCS = stm32_boot.c stm32_bringup.c stm32_spi.c
+CSRCS = stm32_boot.c stm32_bringup.c stm32_spi.c stm32_perfcount.c
 
 ifeq ($(CONFIG_ARCH_LEDS),y)
 CSRCS += stm32_autoleds.c
 else
 CSRCS += stm32_userleds.c
-endif
-
-ifeq ($(CONFIG_SCHED_CRITMONITOR),y)
-CSRCS += stm32_critmon.c
 endif
 
 ifeq ($(CONFIG_AUDIO_CS43L22),y)

--- a/boards/arm/stm32/stm32f4discovery/src/stm32_perfcount.c
+++ b/boards/arm/stm32/stm32f4discovery/src/stm32_perfcount.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * boards/arm/stm32/omnibusf4/src/stm32_critmon.c
+ * boards/arm/stm32/stm32f4discovery/src/stm32_perfcount.c
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -34,26 +34,24 @@
 
 #include <arch/board/board.h>
 
-#ifdef CONFIG_SCHED_CRITMONITOR
-
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
 
 /****************************************************************************
- * Name: up_critmon_gettime
+ * Name: up_perf_gettime
  ****************************************************************************/
 
-uint32_t up_critmon_gettime(void)
+uint32_t up_perf_gettime(void)
 {
   return getreg32(DWT_CYCCNT);
 }
 
 /****************************************************************************
- * Name: up_critmon_gettime
+ * Name: up_perf_convert
  ****************************************************************************/
 
-void up_critmon_convert(uint32_t elapsed, FAR struct timespec *ts)
+void up_perf_convert(uint32_t elapsed, FAR struct timespec *ts)
 {
   b32_t b32elapsed;
 
@@ -61,5 +59,3 @@ void up_critmon_convert(uint32_t elapsed, FAR struct timespec *ts)
   ts->tv_sec  = b32toi(b32elapsed);
   ts->tv_nsec = NSEC_PER_SEC * b32frac(b32elapsed) / b32ONE;
 }
-
-#endif /* CONFIG_SCHED_CRITMONITOR */

--- a/drivers/timers/arch_alarm.c
+++ b/drivers/timers/arch_alarm.c
@@ -355,7 +355,7 @@ int up_alarm_start(FAR const struct timespec *ts)
 #endif
 
 /****************************************************************************
- * Name: up_critmon_*
+ * Name: up_perf_*
  *
  * Description:
  *   The first interface simply provides the current time value in unknown
@@ -373,8 +373,7 @@ int up_alarm_start(FAR const struct timespec *ts)
  *   units.
  ****************************************************************************/
 
-#ifdef CONFIG_SCHED_CRITMONITOR
-uint32_t up_critmon_gettime(void)
+uint32_t up_perf_gettime(void)
 {
   uint32_t ret = 0;
 
@@ -389,11 +388,10 @@ uint32_t up_critmon_gettime(void)
   return ret;
 }
 
-void up_critmon_convert(uint32_t elapsed, FAR struct timespec *ts)
+void up_perf_convert(uint32_t elapsed, FAR struct timespec *ts)
 {
   timespec_from_usec(ts, elapsed);
 }
-#endif
 
 /****************************************************************************
  * Name: up_mdelay

--- a/drivers/timers/arch_timer.c
+++ b/drivers/timers/arch_timer.c
@@ -68,8 +68,6 @@ static struct arch_timer_s g_timer;
  * Private Functions
  ****************************************************************************/
 
-#if defined(CONFIG_SCHED_TICKLESS) || defined(CONFIG_SCHED_CRITMONITOR) \
-    || defined(CONFIG_SCHED_IRQMONITOR_GETTIME)
 static inline void timespec_from_usec(FAR struct timespec *ts,
                                       uint64_t microseconds)
 {
@@ -77,7 +75,6 @@ static inline void timespec_from_usec(FAR struct timespec *ts,
   microseconds -= (uint64_t)ts->tv_sec * USEC_PER_SEC;
   ts->tv_nsec   = microseconds * NSEC_PER_USEC;
 }
-#endif
 
 #ifdef CONFIG_SCHED_TICKLESS
 static inline uint64_t timespec_to_usec(const FAR struct timespec *ts)
@@ -410,7 +407,7 @@ int up_timer_start(FAR const struct timespec *ts)
 #endif
 
 /****************************************************************************
- * Name: up_critmon_*
+ * Name: up_perf_*
  *
  * Description:
  *   The first interface simply provides the current time value in unknown
@@ -428,8 +425,7 @@ int up_timer_start(FAR const struct timespec *ts)
  *   units.
  ****************************************************************************/
 
-#ifdef CONFIG_SCHED_CRITMONITOR
-uint32_t up_critmon_gettime(void)
+uint32_t up_perf_gettime(void)
 {
   uint32_t ret = 0;
 
@@ -441,11 +437,10 @@ uint32_t up_critmon_gettime(void)
   return ret;
 }
 
-void up_critmon_convert(uint32_t elapsed, FAR struct timespec *ts)
+void up_perf_convert(uint32_t elapsed, FAR struct timespec *ts)
 {
   timespec_from_usec(ts, elapsed);
 }
-#endif
 
 /****************************************************************************
  * Name: up_mdelay

--- a/fs/procfs/fs_procfscritmon.c
+++ b/fs/procfs/fs_procfscritmon.c
@@ -193,7 +193,7 @@ static ssize_t critmon_read_cpu(FAR struct critmon_file_s *attr,
 
   if (g_premp_max[cpu] > 0)
     {
-      up_critmon_convert(g_premp_max[cpu], &maxtime);
+      up_perf_convert(g_premp_max[cpu], &maxtime);
     }
   else
     {
@@ -225,7 +225,7 @@ static ssize_t critmon_read_cpu(FAR struct critmon_file_s *attr,
 
   if (g_crit_max[cpu] > 0)
     {
-      up_critmon_convert(g_crit_max[cpu], &maxtime);
+      up_perf_convert(g_crit_max[cpu], &maxtime);
     }
   else
     {

--- a/fs/procfs/fs_procfsproc.c
+++ b/fs/procfs/fs_procfsproc.c
@@ -785,7 +785,7 @@ static ssize_t proc_critmon(FAR struct proc_file_s *procfile,
 
   if (tcb->premp_max > 0)
     {
-      up_critmon_convert(tcb->premp_max, &maxtime);
+      up_perf_convert(tcb->premp_max, &maxtime);
     }
   else
     {
@@ -818,7 +818,7 @@ static ssize_t proc_critmon(FAR struct proc_file_s *procfile,
 
   if (tcb->crit_max > 0)
     {
-      up_critmon_convert(tcb->crit_max, &maxtime);
+      up_perf_convert(tcb->crit_max, &maxtime);
     }
   else
     {
@@ -851,7 +851,7 @@ static ssize_t proc_critmon(FAR struct proc_file_s *procfile,
 
   if (tcb->run_max > 0)
     {
-      up_critmon_convert(tcb->run_max, &maxtime);
+      up_perf_convert(tcb->run_max, &maxtime);
     }
   else
     {

--- a/include/nuttx/arch.h
+++ b/include/nuttx/arch.h
@@ -2558,7 +2558,7 @@ void arch_sporadic_resume(FAR struct tcb_s *tcb);
 #endif
 
 /****************************************************************************
- * Name: up_critmon_*
+ * Name: up_perf_*
  *
  * Description:
  *   The first interface simply provides the current time value in unknown
@@ -2576,10 +2576,8 @@ void arch_sporadic_resume(FAR struct tcb_s *tcb);
  *   units.
  ****************************************************************************/
 
-#ifdef CONFIG_SCHED_CRITMONITOR
-uint32_t up_critmon_gettime(void);
-void up_critmon_convert(uint32_t elapsed, FAR struct timespec *ts);
-#endif
+uint32_t up_perf_gettime(void);
+void up_perf_convert(uint32_t elapsed, FAR struct timespec *ts);
 
 #undef EXTERN
 #if defined(__cplusplus)

--- a/sched/Kconfig
+++ b/sched/Kconfig
@@ -742,26 +742,6 @@ config SCHED_CRITMONITOR
 		adds jitter in the time from when the event is posted in the
 		interrupt handler until the task that responds to the event can run.
 
-		If this option is selected, then the following interfaces must be
-		provided by platform-specific logic:
-
-			uint32_t up_critmon_gettime(void);
-			void up_critmon_convert(uint32_t elapsed, FAR struct timespec *ts);
-
-		The first interface simply provides the current time value in unknown
-		units.  NOTE:  This function may be called early before the timer has
-		been initialized.  In that event, the function should just return a
-		start time of zero.
-
-		Nothing is assumed about the units of this time value.  The following
-		are assumed, however: (1) The time is an unsigned integer value, (2)
-		the time is monotonically increasing, and (3) the elapsed time (also
-		in unknown units) can be obtained by subtracting a start time from
-		the current time.
-
-		The second interface simply converts an elapsed time into well known
-		units for presentation by the ProcFS file system.
-
 if SCHED_CRITMONITOR
 
 config SCHED_CRITMONITOR_MAXTIME_THREAD

--- a/sched/irq/irq_dispatch.c
+++ b/sched/irq/irq_dispatch.c
@@ -80,10 +80,10 @@
          struct timespec delta; \
          uint32_t start; \
          uint32_t elapsed; \
-         start = up_critmon_gettime(); \
+         start = up_perf_gettime(); \
          vector(irq, context, arg); \
-         elapsed = up_critmon_gettime() - start; \
-         up_critmon_convert(elapsed, &delta); \
+         elapsed = up_perf_gettime() - start; \
+         up_perf_convert(elapsed, &delta); \
          if (delta.tv_nsec > g_irqvector[ndx].time) \
            { \
              g_irqvector[ndx].time = delta.tv_nsec; \

--- a/sched/sched/sched_critmonitor.c
+++ b/sched/sched/sched_critmonitor.c
@@ -142,7 +142,7 @@ void nxsched_critmon_preemption(FAR struct tcb_s *tcb, bool state)
 
       /* Disabling.. Save the thread start time */
 
-      tcb->premp_start = up_critmon_gettime();
+      tcb->premp_start = up_perf_gettime();
 
       /* Zero means that the timer is not ready */
 
@@ -157,7 +157,7 @@ void nxsched_critmon_preemption(FAR struct tcb_s *tcb, bool state)
     {
       /* Re-enabling.. Check for the max elapsed time */
 
-      uint32_t now     = up_critmon_gettime();
+      uint32_t now     = up_perf_gettime();
       uint32_t elapsed = now - tcb->premp_start;
 
       DEBUGASSERT(now != 0);
@@ -207,7 +207,7 @@ void nxsched_critmon_csection(FAR struct tcb_s *tcb, bool state)
       /* Entering... Save the start time. */
 
       DEBUGASSERT(tcb->crit_start == 0);
-      tcb->crit_start = up_critmon_gettime();
+      tcb->crit_start = up_perf_gettime();
 
       /* Zero means that the timer is not ready */
 
@@ -222,7 +222,7 @@ void nxsched_critmon_csection(FAR struct tcb_s *tcb, bool state)
     {
       /* Leaving .. Check for the max elapsed time */
 
-      uint32_t now     = up_critmon_gettime();
+      uint32_t now     = up_perf_gettime();
       uint32_t elapsed = now - tcb->crit_start;
 
       DEBUGASSERT(now != 0);
@@ -264,7 +264,7 @@ void nxsched_critmon_csection(FAR struct tcb_s *tcb, bool state)
 
 void nxsched_resume_critmon(FAR struct tcb_s *tcb)
 {
-  uint32_t current = up_critmon_gettime();
+  uint32_t current = up_perf_gettime();
   int cpu = this_cpu();
   uint32_t elapsed;
 
@@ -347,7 +347,7 @@ void nxsched_resume_critmon(FAR struct tcb_s *tcb)
 
 void nxsched_suspend_critmon(FAR struct tcb_s *tcb)
 {
-  uint32_t current = up_critmon_gettime();
+  uint32_t current = up_perf_gettime();
   uint32_t elapsed = current - tcb->run_start;
 
   tcb->run_start = 0;

--- a/sched/wdog/wd_start.c
+++ b/sched/wdog/wd_start.c
@@ -60,9 +60,9 @@
        { \
          uint32_t start; \
          uint32_t elapsed; \
-         start = up_critmon_gettime(); \
+         start = up_perf_gettime(); \
          func(arg); \
-         elapsed = up_critmon_gettime() - start; \
+         elapsed = up_perf_gettime() - start; \
          if (elapsed > CONFIG_SCHED_CRITMONITOR_MAXTIME_WDOG) \
            { \
              serr("WDOG %p, %s IRQ, execute too long %"PRIu32"\n", \

--- a/sched/wqueue/kwork_thread.c
+++ b/sched/wqueue/kwork_thread.c
@@ -52,9 +52,9 @@
        { \
          uint32_t start; \
          uint32_t elapsed; \
-         start = up_critmon_gettime(); \
+         start = up_perf_gettime(); \
          worker(arg); \
-         elapsed = up_critmon_gettime() - start; \
+         elapsed = up_perf_gettime() - start; \
          if (elapsed > CONFIG_SCHED_CRITMONITOR_MAXTIME_WQUEUE) \
            { \
              serr("WORKER %p execute too long %"PRIu32"\n", \


### PR DESCRIPTION
## Summary
and rename to up_perf_[gettime|convert] since it's useful in other case

## Impact
Refactor only

## Testing
Pass CI
