### PR TITLE
arch: arm: Fix make export for armv7-a SoCs

### DIFF
--- a/arch/arm/src/a1x/Make.defs
+++ b/arch/arm/src/a1x/Make.defs
@@ -24,6 +24,9 @@
 HEAD_ASRC  = arm_vectortab.S
 
 ifeq ($(CONFIG_BUILD_KERNEL),y)
+crt0$(OBJEXT): crt0.c
+	$(CC) $(CFLAGS) -c armv7-a$(DELIM)crt0.c -o crt0$(OBJEXT)
+
 STARTUP_OBJS = crt0$(OBJEXT)
 endif
 

--- a/arch/arm/src/am335x/Make.defs
+++ b/arch/arm/src/am335x/Make.defs
@@ -24,6 +24,9 @@
 HEAD_ASRC  = arm_vectortab.S
 
 ifeq ($(CONFIG_BUILD_KERNEL),y)
+crt0$(OBJEXT): crt0.c
+	$(CC) $(CFLAGS) -c armv7-a$(DELIM)crt0.c -o crt0$(OBJEXT)
+
 STARTUP_OBJS = crt0$(OBJEXT)
 endif
 

--- a/arch/arm/src/armv7-a/crt0.c
+++ b/arch/arm/src/armv7-a/crt0.c
@@ -29,6 +29,8 @@
 
 #include <nuttx/addrenv.h>
 
+#include "svcall.h"
+
 #ifdef CONFIG_BUILD_KERNEL
 
 /****************************************************************************

--- a/arch/arm/src/imx6/Make.defs
+++ b/arch/arm/src/imx6/Make.defs
@@ -24,6 +24,9 @@
 HEAD_ASRC  = arm_vectortab.S
 
 ifeq ($(CONFIG_BUILD_KERNEL),y)
+crt0$(OBJEXT): crt0.c
+	$(CC) $(CFLAGS) -c armv7-a$(DELIM)crt0.c -o crt0$(OBJEXT)
+
 STARTUP_OBJS = crt0$(OBJEXT)
 endif
 

--- a/arch/arm/src/sama5/Make.defs
+++ b/arch/arm/src/sama5/Make.defs
@@ -24,6 +24,9 @@
 HEAD_ASRC  = arm_vectortab.S
 
 ifeq ($(CONFIG_BUILD_KERNEL),y)
+crt0$(OBJEXT): crt0.c
+	$(CC) $(CFLAGS) -c armv7-a$(DELIM)crt0.c -o crt0$(OBJEXT)
+
 STARTUP_OBJS = crt0$(OBJEXT)
 endif
 


### PR DESCRIPTION
## Summary

- I noticed that make export does not work with swama5d4-ek:knsh
- This commit fixes this issue.
- NOTE: apps/Makefile also needs to be updated. 
- See https://github.com/apache/incubator-nuttx-apps/pull/980

## Impact

- CONFIG_BUILD_KERNEL=y only

## Testing

- Build (make and make export) with sama5d4-ek:knsh
