### PR TITLE
sched/critmonitor: remove the assertion if counter == 0 

### DIFF
--- a/sched/sched/sched_critmonitor.c
+++ b/sched/sched/sched_critmonitor.c
@@ -280,7 +280,6 @@ void nxsched_resume_critmon(FAR struct tcb_s *tcb)
       /* Yes.. Save the start time */
 
       tcb->premp_start = current;
-      DEBUGASSERT(tcb->premp_start != 0);
 
       /* Zero means that the timer is not ready */
 
@@ -310,7 +309,6 @@ void nxsched_resume_critmon(FAR struct tcb_s *tcb)
       /* Yes.. Save the start time */
 
       tcb->crit_start = current;
-      DEBUGASSERT(tcb->crit_start != 0);
 
       if (g_crit_start[cpu] == 0)
         {


### PR DESCRIPTION
## Summary

sched/critmonitor: remove the assertion if counter == 0 

Perf timer interface generally uses the hardware cycle counter
provided by the arch chip directly(such as DWT_CYCCNT(cortex-m)),
CYCCNT is a free running counter and counting upwards.
It wraps around to 0 on overflow.

## Impact

N/A

## Testing

critmon perf test on Cortex-m55