### PR TITLE
drivers/timers: Add weak_function for up_ function

### DIFF
--- a/drivers/timers/arch_alarm.c
+++ b/drivers/timers/arch_alarm.c
@@ -204,7 +204,7 @@ void up_alarm_set_lowerhalf(FAR struct oneshot_lowerhalf_s *lower)
  ****************************************************************************/
 
 #ifdef CONFIG_CLOCK_TIMEKEEPING
-int up_timer_getcounter(FAR uint64_t *cycles)
+int weak_function up_timer_getcounter(FAR uint64_t *cycles)
 {
   int ret = -EAGAIN;
 
@@ -222,7 +222,7 @@ int up_timer_getcounter(FAR uint64_t *cycles)
   return ret;
 }
 
-void up_timer_getmask(FAR uint64_t *mask)
+void weak_function up_timer_getmask(FAR uint64_t *mask)
 {
   *mask = 0;
 
@@ -249,7 +249,7 @@ void up_timer_getmask(FAR uint64_t *mask)
 #endif
 
 #if defined(CONFIG_SCHED_TICKLESS)
-int up_timer_gettime(FAR struct timespec *ts)
+int weak_function up_timer_gettime(FAR struct timespec *ts)
 {
   int ret = -EAGAIN;
 
@@ -297,7 +297,7 @@ int up_timer_gettime(FAR struct timespec *ts)
  ****************************************************************************/
 
 #ifdef CONFIG_SCHED_TICKLESS
-int up_alarm_cancel(FAR struct timespec *ts)
+int weak_function up_alarm_cancel(FAR struct timespec *ts)
 {
   int ret = -EAGAIN;
 
@@ -336,7 +336,7 @@ int up_alarm_cancel(FAR struct timespec *ts)
  ****************************************************************************/
 
 #ifdef CONFIG_SCHED_TICKLESS
-int up_alarm_start(FAR const struct timespec *ts)
+int weak_function up_alarm_start(FAR const struct timespec *ts)
 {
   int ret = -EAGAIN;
 
@@ -373,7 +373,7 @@ int up_alarm_start(FAR const struct timespec *ts)
  *   units.
  ****************************************************************************/
 
-uint32_t up_perf_gettime(void)
+uint32_t weak_function up_perf_gettime(void)
 {
   uint32_t ret = 0;
 
@@ -388,7 +388,7 @@ uint32_t up_perf_gettime(void)
   return ret;
 }
 
-void up_perf_convert(uint32_t elapsed, FAR struct timespec *ts)
+void weak_function up_perf_convert(uint32_t elapsed, FAR struct timespec *ts)
 {
   timespec_from_usec(ts, elapsed);
 }
@@ -402,7 +402,7 @@ void up_perf_convert(uint32_t elapsed, FAR struct timespec *ts)
  *
  ****************************************************************************/
 
-void up_mdelay(unsigned int milliseconds)
+void weak_function up_mdelay(unsigned int milliseconds)
 {
   up_udelay(USEC_PER_MSEC * milliseconds);
 }
@@ -417,7 +417,7 @@ void up_mdelay(unsigned int milliseconds)
  *
  ****************************************************************************/
 
-void up_udelay(useconds_t microseconds)
+void weak_function up_udelay(useconds_t microseconds)
 {
   if (g_oneshot_lower != NULL)
     {

--- a/drivers/timers/arch_rtc.c
+++ b/drivers/timers/arch_rtc.c
@@ -82,7 +82,7 @@ void up_rtc_set_lowerhalf(FAR struct rtc_lowerhalf_s *lower, bool sync)
  ****************************************************************************/
 
 #ifndef CONFIG_RTC_HIRES
-time_t up_rtc_time(void)
+time_t weak_function up_rtc_time(void)
 {
   time_t time = 0;
 
@@ -117,7 +117,7 @@ time_t up_rtc_time(void)
  ****************************************************************************/
 
 #ifdef CONFIG_RTC_HIRES
-int up_rtc_gettime(FAR struct timespec *tp)
+int weak_function up_rtc_gettime(FAR struct timespec *tp)
 {
   int ret = -EAGAIN;
 
@@ -161,7 +161,7 @@ int up_rtc_gettime(FAR struct timespec *tp)
  ****************************************************************************/
 
 #ifdef CONFIG_RTC_DATETIME
-int up_rtc_getdatetime(FAR struct tm *tp)
+int weak_function up_rtc_getdatetime(FAR struct tm *tp)
 {
   int ret = -EAGAIN;
 
@@ -205,7 +205,8 @@ int up_rtc_getdatetime(FAR struct tm *tp)
  ****************************************************************************/
 
 #if defined(CONFIG_RTC_DATETIME) && defined(CONFIG_ARCH_HAVE_RTC_SUBSECONDS)
-int up_rtc_getdatetime_with_subseconds(FAR struct tm *tp, FAR long *nsec)
+int weak_function up_rtc_getdatetime_with_subseconds(FAR struct tm *tp,
+                                                     FAR long *nsec)
 {
   int ret = -EAGAIN;
 
@@ -240,7 +241,7 @@ int up_rtc_getdatetime_with_subseconds(FAR struct tm *tp, FAR long *nsec)
  *
  ****************************************************************************/
 
-int up_rtc_settime(FAR const struct timespec *tp)
+int weak_function up_rtc_settime(FAR const struct timespec *tp)
 {
   int ret = -EAGAIN;
 

--- a/drivers/timers/arch_timer.c
+++ b/drivers/timers/arch_timer.c
@@ -269,7 +269,7 @@ void up_timer_set_lowerhalf(FAR struct timer_lowerhalf_s *lower)
  ****************************************************************************/
 
 #ifdef CONFIG_CLOCK_TIMEKEEPING
-int up_timer_getcounter(FAR uint64_t *cycles)
+int weak_function up_timer_getcounter(FAR uint64_t *cycles)
 {
   int ret = -EAGAIN;
 
@@ -282,7 +282,7 @@ int up_timer_getcounter(FAR uint64_t *cycles)
   return ret;
 }
 
-void up_timer_getmask(FAR uint64_t *mask)
+void weak_function up_timer_getmask(FAR uint64_t *mask)
 {
   uint32_t maxticks = g_timer.maxtimeout / USEC_PER_TICK;
 
@@ -301,7 +301,7 @@ void up_timer_getmask(FAR uint64_t *mask)
 #endif
 
 #if defined(CONFIG_SCHED_TICKLESS)
-int up_timer_gettime(FAR struct timespec *ts)
+int weak_function up_timer_gettime(FAR struct timespec *ts)
 {
   int ret = -EAGAIN;
 
@@ -352,7 +352,7 @@ int up_timer_gettime(FAR struct timespec *ts)
  ****************************************************************************/
 
 #ifdef CONFIG_SCHED_TICKLESS
-int up_timer_cancel(FAR struct timespec *ts)
+int weak_function up_timer_cancel(FAR struct timespec *ts)
 {
   int ret = -EAGAIN;
 
@@ -392,7 +392,7 @@ int up_timer_cancel(FAR struct timespec *ts)
  ****************************************************************************/
 
 #ifdef CONFIG_SCHED_TICKLESS
-int up_timer_start(FAR const struct timespec *ts)
+int weak_function up_timer_start(FAR const struct timespec *ts)
 {
   int ret = -EAGAIN;
 
@@ -425,7 +425,7 @@ int up_timer_start(FAR const struct timespec *ts)
  *   units.
  ****************************************************************************/
 
-uint32_t up_perf_gettime(void)
+uint32_t weak_function up_perf_gettime(void)
 {
   uint32_t ret = 0;
 
@@ -437,7 +437,7 @@ uint32_t up_perf_gettime(void)
   return ret;
 }
 
-void up_perf_convert(uint32_t elapsed, FAR struct timespec *ts)
+void weak_function up_perf_convert(uint32_t elapsed, FAR struct timespec *ts)
 {
   timespec_from_usec(ts, elapsed);
 }
@@ -451,7 +451,7 @@ void up_perf_convert(uint32_t elapsed, FAR struct timespec *ts)
  *
  ****************************************************************************/
 
-void up_mdelay(unsigned int milliseconds)
+void weak_function up_mdelay(unsigned int milliseconds)
 {
   up_udelay(USEC_PER_MSEC * milliseconds);
 }
@@ -466,7 +466,7 @@ void up_mdelay(unsigned int milliseconds)
  *
  ****************************************************************************/
 
-void up_udelay(useconds_t microseconds)
+void weak_function up_udelay(useconds_t microseconds)
 {
   if (g_timer.lower != NULL)
     {


### PR DESCRIPTION
## Summary
so the user could replace the implementation if need

## Impact
Can replace the default implementation

## Testing
Pass CI
