### PR TITLE
arch:cache: flush/clean dcache all if size large than cache size

### DIFF
--- a/arch/arm/src/a1x/Make.defs
+++ b/arch/arm/src/a1x/Make.defs
@@ -46,6 +46,7 @@ CMN_ASRCS += arm_saveusercontext.S arm_vectoraddrexcptn.S
 CMN_ASRCS += arm_testset.S arm_fetchadd.S vfork.S
 CMN_ASRCS += cp15_coherent_dcache.S cp15_invalidate_dcache.S
 CMN_ASRCS += cp15_clean_dcache.S cp15_flush_dcache.S cp15_invalidate_dcache_all.S
+CMN_ASRCS += cp15_clean_dcache_all.S cp15_flush_dcache_all.S
 
 # Common C source files
 

--- a/arch/arm/src/am335x/Make.defs
+++ b/arch/arm/src/am335x/Make.defs
@@ -46,6 +46,7 @@ CMN_ASRCS += arm_saveusercontext.S arm_vectoraddrexcptn.S
 CMN_ASRCS += arm_testset.S vfork.S
 CMN_ASRCS += cp15_coherent_dcache.S cp15_invalidate_dcache.S
 CMN_ASRCS += cp15_clean_dcache.S cp15_flush_dcache.S cp15_invalidate_dcache_all.S
+CMN_ASRCS += cp15_clean_dcache_all.S cp15_flush_dcache_all.S
 
 # Common C source files
 

--- a/arch/arm/src/armv7-a/arm_cache.c
+++ b/arch/arm/src/armv7-a/arm_cache.c
@@ -139,6 +139,35 @@ void up_clean_dcache(uintptr_t start, uintptr_t end)
 }
 
 /****************************************************************************
+ * Name: up_clean_dcache_all
+ *
+ * Description:
+ *   Clean the entire data cache within the specified region by flushing the
+ *   contents of the data cache to memory.
+ *
+ *   NOTE: This operation is un-necessary if the DCACHE is configured in
+ *   write-through mode.
+ *
+ * Input Parameters:
+ *   None
+ *
+ * Returned Value:
+ *   None
+ *
+ * Assumptions:
+ *   This operation is not atomic.  This function assumes that the caller
+ *   has exclusive access to the address range so that no harm is done if
+ *   the operation is pre-empted.
+ *
+ ****************************************************************************/
+
+void up_clean_dcache_all(void)
+{
+  cp15_clean_dcache_all();
+  l2cc_clean_all();
+}
+
+/****************************************************************************
  * Name: up_flush_dcache
  *
  * Description:
@@ -163,6 +192,34 @@ void up_flush_dcache(uintptr_t start, uintptr_t end)
 {
   cp15_flush_dcache(start, end);
   l2cc_flush(start, end);
+}
+
+/****************************************************************************
+ * Name: up_flush_dcache_all
+ *
+ * Description:
+ *   Flush the entire data cache by cleaning and invalidating the D cache.
+ *
+ *   NOTE: If DCACHE write-through is configured, then this operation is the
+ *   same as up_invalidate_cache_all().
+ *
+ * Input Parameters:
+ *   None
+ *
+ * Returned Value:
+ *   None
+ *
+ * Assumptions:
+ *   This operation is not atomic.  This function assumes that the caller
+ *   has exclusive access to the address range so that no harm is done if
+ *   the operation is pre-empted.
+ *
+ ****************************************************************************/
+
+void up_flush_dcache_all(void)
+{
+  cp15_flush_dcache_all();
+  l2cc_flush_all();
 }
 
 /****************************************************************************

--- a/arch/arm/src/armv7-a/cp15_cacheops.h
+++ b/arch/arm/src/armv7-a/cp15_cacheops.h
@@ -1067,6 +1067,22 @@ void cp15_invalidate_dcache_all(void);
 void cp15_clean_dcache(uintptr_t start, uintptr_t end);
 
 /****************************************************************************
+ * Name: cp15_clean_dcache_all
+ *
+ * Description:
+ *   Clean the entire contents of D cache.
+ *
+ * Input Parameters:
+ *   None
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+void cp15_clean_dcache_all(void);
+
+/****************************************************************************
  * Name: cp15_flush_dcache
  *
  * Description:
@@ -1083,6 +1099,22 @@ void cp15_clean_dcache(uintptr_t start, uintptr_t end);
  ****************************************************************************/
 
 void cp15_flush_dcache(uintptr_t start, uintptr_t end);
+
+/****************************************************************************
+ * Name: cp15_flush_dcache_all
+ *
+ * Description:
+ *   Flush the entire contents of D cache.
+ *
+ * Input Parameters:
+ *   None
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+void cp15_flush_dcache_all(void);
 
 #undef EXTERN
 #ifdef __cplusplus

--- a/arch/arm/src/armv7-a/cp15_clean_dcache_all.S
+++ b/arch/arm/src/armv7-a/cp15_clean_dcache_all.S
@@ -1,0 +1,121 @@
+/****************************************************************************
+ * arch/arm/src/armv7-a/cp15_flush_dcache_all.S
+ *
+ *   Copyright (C) 2013 Gregory Nutt. All rights reserved.
+ *   Author: Gregory Nutt <gnutt@nuttx.org>
+ *
+ * Portions of this file derive from Atmel sample code for the SAMA5D3
+ * Cortex-A5 which also has a modified BSD-style license:
+ *
+ *   Copyright (c) 2012, Atmel Corporation
+ *   All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name NuttX nor Atmel nor the names of the contributors may
+ *    be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/* References:
+ *
+ *  "Cortex-A5 MPCore, Technical Reference Manual", Revision: r0p1,
+ *   Copyright (c) 2010  ARM. All rights reserved. ARM DDI 0434B (ID101810)
+ *  "ARM Architecture Reference Manual, ARMv7-A and ARMv7-R edition",
+ *   Copyright (c) 1996-1998, 2000, 2004-2012 ARM. All rights reserved. ARM
+ *   DDI 0406C.b (ID072512)
+ */
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include "cp15.h"
+
+	.file	"cp15_flush_dcache_all.S"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Symbols
+ ****************************************************************************/
+
+	.globl	cp15_flush_dcache_all
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+	.text
+
+/****************************************************************************
+ * Name: cp15_flush_dcache_all
+ *
+ * Description:
+ *   Invalidate the entire contents of D cache.
+ *
+ * Input Parameters:
+ *   None
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+	.globl	cp15_flush_dcache_all
+	.type	cp15_flush_dcache_all, function
+
+cp15_flush_dcache_all:
+
+	mrc		CP15_CCSIDR(r0)			/* Read the Cache Size Identification Register */
+	ldr		r3, =0x7fff			/* Isolate the NumSets field (bits 13-27) */
+	and		r0, r3, r0, lsr #13		/* r0=NumSets (number of sets - 1) */
+
+	ldr		r3, =0x3ff			/* Isolate the way field (bits 3-12) */
+	add		r4, r3, r0, lsr #3		/* r4=(number of ways - 1) */
+
+	mov		r1, #0				/* r1 = way loop counter */
+way_loop:
+
+	mov		r3, #0				/* r3 = set loop counter */
+set_loop:
+	mov		r2, r1, lsl #30			/* r2 = way loop counter << 30 */
+	orr		r2, r3, lsl #5			/* r2 = set/way cache operation format */
+	mcr		CP15_DCCISW(r2)			/* Data Cache Invalidate by Set/Way */
+	add		r3, r3, #1			/* Increment set counter */
+	cmp		r0, r3				/* Last set? */
+	bne		set_loop			/* Keep looping if not */
+
+	add		r1, r1, #1			/* Increment the way counter */
+	cmp		r4, r1				/* Last way */
+	bne		way_loop			/* Keep looping if not */
+
+	dsb
+	bx		lr
+	.size cp15_flush_dcache_all, . - cp15_flush_dcache_all
+	.end
+

--- a/arch/arm/src/armv7-a/cp15_flush_dcache_all.S
+++ b/arch/arm/src/armv7-a/cp15_flush_dcache_all.S
@@ -1,0 +1,121 @@
+/****************************************************************************
+ * arch/arm/src/armv7-a/cp15_clean_dcache_all.S
+ *
+ *   Copyright (C) 2013 Gregory Nutt. All rights reserved.
+ *   Author: Gregory Nutt <gnutt@nuttx.org>
+ *
+ * Portions of this file derive from Atmel sample code for the SAMA5D3
+ * Cortex-A5 which also has a modified BSD-style license:
+ *
+ *   Copyright (c) 2012, Atmel Corporation
+ *   All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name NuttX nor Atmel nor the names of the contributors may
+ *    be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/* References:
+ *
+ *  "Cortex-A5 MPCore, Technical Reference Manual", Revision: r0p1,
+ *   Copyright (c) 2010  ARM. All rights reserved. ARM DDI 0434B (ID101810)
+ *  "ARM Architecture Reference Manual, ARMv7-A and ARMv7-R edition",
+ *   Copyright (c) 1996-1998, 2000, 2004-2012 ARM. All rights reserved. ARM
+ *   DDI 0406C.b (ID072512)
+ */
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include "cp15.h"
+
+	.file	"cp15_clean_dcache_all.S"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Symbols
+ ****************************************************************************/
+
+	.globl	cp15_clean_dcache_all
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+	.text
+
+/****************************************************************************
+ * Name: cp15_clean_dcache_all
+ *
+ * Description:
+ *   Invalidate the entire contents of D cache.
+ *
+ * Input Parameters:
+ *   None
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+	.globl	cp15_clean_dcache_all
+	.type	cp15_clean_dcache_all, function
+
+cp15_clean_dcache_all:
+
+	mrc		CP15_CCSIDR(r0)			/* Read the Cache Size Identification Register */
+	ldr		r3, =0x7fff			/* Isolate the NumSets field (bits 13-27) */
+	and		r0, r3, r0, lsr #13		/* r0=NumSets (number of sets - 1) */
+
+	ldr		r3, =0x3ff			/* Isolate the way field (bits 3-12) */
+	add		r4, r3, r0, lsr #3		/* r4=(number of ways - 1) */
+
+	mov		r1, #0				/* r1 = way loop counter */
+way_loop:
+
+	mov		r3, #0				/* r3 = set loop counter */
+set_loop:
+	mov		r2, r1, lsl #30			/* r2 = way loop counter << 30 */
+	orr		r2, r3, lsl #5			/* r2 = set/way cache operation format */
+	mcr		CP15_DCCSW(r2)			/* Data Cache Invalidate by Set/Way */
+	add		r3, r3, #1			/* Increment set counter */
+	cmp		r0, r3				/* Last set? */
+	bne		set_loop			/* Keep looping if not */
+
+	add		r1, r1, #1			/* Increment the way counter */
+	cmp		r4, r1				/* Last way */
+	bne		way_loop			/* Keep looping if not */
+
+	dsb
+	bx		lr
+	.size cp15_clean_dcache_all, . - cp15_clean_dcache_all
+	.end
+

--- a/arch/arm/src/armv7-m/arm_cache.c
+++ b/arch/arm/src/armv7-m/arm_cache.c
@@ -536,15 +536,25 @@ void up_clean_dcache(uintptr_t start, uintptr_t end)
   uint32_t ccsidr;
   uint32_t sshift;
   uint32_t ssize;
+  uint32_t sets;
+  uint32_t ways;
 
   /* Get the characteristics of the D-Cache */
 
   ccsidr = getreg32(NVIC_CCSIDR);
   sshift = CCSIDR_LSSHIFT(ccsidr) + 4;   /* log2(cache-line-size-in-bytes) */
+  sets   = CCSIDR_SETS(ccsidr);          /* (Number of sets) - 1 */
+  ways   = CCSIDR_WAYS(ccsidr);          /* (Number of ways) - 1 */
 
   /* Clean the D-Cache over the range of addresses */
 
   ssize  = (1 << sshift);
+
+  if ((end - start) >= ssize * (sets + 1) * (ways + 1))
+    {
+      return up_clean_dcache_all();
+    }
+
   start &= ~(ssize - 1);
   ARM_DSB();
 
@@ -679,15 +689,25 @@ void up_flush_dcache(uintptr_t start, uintptr_t end)
   uint32_t ccsidr;
   uint32_t sshift;
   uint32_t ssize;
+  uint32_t sets;
+  uint32_t ways;
 
   /* Get the characteristics of the D-Cache */
 
   ccsidr = getreg32(NVIC_CCSIDR);
   sshift = CCSIDR_LSSHIFT(ccsidr) + 4;   /* log2(cache-line-size-in-bytes) */
+  sets   = CCSIDR_SETS(ccsidr);          /* (Number of sets) - 1 */
+  ways   = CCSIDR_WAYS(ccsidr);          /* (Number of ways) - 1 */
 
   /* Clean and invalidate the D-Cache over the range of addresses */
 
   ssize  = (1 << sshift);
+
+  if ((end - start) >= ssize * (sets + 1) * (ways + 1))
+    {
+      return up_flush_dcache_all();
+    }
+
   start &= ~(ssize - 1);
   ARM_DSB();
 

--- a/arch/arm/src/armv7-r/arm_cache.c
+++ b/arch/arm/src/armv7-r/arm_cache.c
@@ -139,6 +139,35 @@ void up_clean_dcache(uintptr_t start, uintptr_t end)
 }
 
 /****************************************************************************
+ * Name: up_clean_dcache_all
+ *
+ * Description:
+ *   Clean the entire data cache within the specified region by flushing the
+ *   contents of the data cache to memory.
+ *
+ *   NOTE: This operation is un-necessary if the DCACHE is configured in
+ *   write-through mode.
+ *
+ * Input Parameters:
+ *   None
+ *
+ * Returned Value:
+ *   None
+ *
+ * Assumptions:
+ *   This operation is not atomic.  This function assumes that the caller
+ *   has exclusive access to the address range so that no harm is done if
+ *   the operation is pre-empted.
+ *
+ ****************************************************************************/
+
+void up_clean_dcache_all(void)
+{
+  cp15_clean_dcache_all();
+  l2cc_clean_all();
+}
+
+/****************************************************************************
  * Name: up_flush_dcache
  *
  * Description:
@@ -163,6 +192,34 @@ void up_flush_dcache(uintptr_t start, uintptr_t end)
 {
   cp15_flush_dcache(start, end);
   l2cc_flush(start, end);
+}
+
+/****************************************************************************
+ * Name: up_flush_dcache_all
+ *
+ * Description:
+ *   Flush the entire data cache by cleaning and invalidating the D cache.
+ *
+ *   NOTE: If DCACHE write-through is configured, then this operation is the
+ *   same as up_invalidate_cache_all().
+ *
+ * Input Parameters:
+ *   None
+ *
+ * Returned Value:
+ *   None
+ *
+ * Assumptions:
+ *   This operation is not atomic.  This function assumes that the caller
+ *   has exclusive access to the address range so that no harm is done if
+ *   the operation is pre-empted.
+ *
+ ****************************************************************************/
+
+void up_flush_dcache_all(void)
+{
+  cp15_flush_dcache_all();
+  l2cc_flush_all();
 }
 
 /****************************************************************************

--- a/arch/arm/src/armv7-r/cp15_cacheops.h
+++ b/arch/arm/src/armv7-r/cp15_cacheops.h
@@ -1074,6 +1074,22 @@ void cp15_invalidate_dcache_all(void);
 void cp15_clean_dcache(uintptr_t start, uintptr_t end);
 
 /****************************************************************************
+ * Name: cp15_clean_dcache_all
+ *
+ * Description:
+ *   Clean the entire contents of D cache.
+ *
+ * Input Parameters:
+ *   None
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+void cp15_clean_dcache_all(void);
+
+/****************************************************************************
  * Name: cp15_flush_dcache
  *
  * Description:
@@ -1090,6 +1106,22 @@ void cp15_clean_dcache(uintptr_t start, uintptr_t end);
  ****************************************************************************/
 
 void cp15_flush_dcache(uintptr_t start, uintptr_t end);
+
+/****************************************************************************
+ * Name: cp15_flush_dcache_all
+ *
+ * Description:
+ *   Flush the entire contents of D cache.
+ *
+ * Input Parameters:
+ *   None
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+void cp15_flush_dcache_all(void);
 
 #undef EXTERN
 #ifdef __cplusplus

--- a/arch/arm/src/armv7-r/cp15_clean_dcache_all.S
+++ b/arch/arm/src/armv7-r/cp15_clean_dcache_all.S
@@ -1,0 +1,121 @@
+/****************************************************************************
+ * arch/arm/src/armv7-r/cp15_flush_dcache_all.S
+ *
+ *   Copyright (C) 2013 Gregory Nutt. All rights reserved.
+ *   Author: Gregory Nutt <gnutt@nuttx.org>
+ *
+ * Portions of this file derive from Atmel sample code for the SAMA5D3
+ * Cortex-A5 which also has a modified BSD-style license:
+ *
+ *   Copyright (c) 2012, Atmel Corporation
+ *   All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name NuttX nor Atmel nor the names of the contributors may
+ *    be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/* References:
+ *
+ *  "Cortex-A5 MPCore, Technical Reference Manual", Revision: r0p1,
+ *   Copyright (c) 2010  ARM. All rights reserved. ARM DDI 0434B (ID101810)
+ *  "ARM Architecture Reference Manual, ARMv7-A and ARMv7-R edition",
+ *   Copyright (c) 1996-1998, 2000, 2004-2012 ARM. All rights reserved. ARM
+ *   DDI 0406C.b (ID072512)
+ */
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include "cp15.h"
+
+	.file	"cp15_flush_dcache_all.S"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Symbols
+ ****************************************************************************/
+
+	.globl	cp15_flush_dcache_all
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+	.text
+
+/****************************************************************************
+ * Name: cp15_flush_dcache_all
+ *
+ * Description:
+ *   Invalidate the entire contents of D cache.
+ *
+ * Input Parameters:
+ *   None
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+	.globl	cp15_flush_dcache_all
+	.type	cp15_flush_dcache_all, function
+
+cp15_flush_dcache_all:
+
+	mrc		CP15_CCSIDR(r0)			/* Read the Cache Size Identification Register */
+	ldr		r3, =0x7fff			/* Isolate the NumSets field (bits 13-27) */
+	and		r0, r3, r0, lsr #13		/* r0=NumSets (number of sets - 1) */
+
+	ldr		r3, =0x3ff			/* Isolate the way field (bits 3-12) */
+	add		r4, r3, r0, lsr #3		/* r4=(number of ways - 1) */
+
+	mov		r1, #0				/* r1 = way loop counter */
+way_loop:
+
+	mov		r3, #0				/* r3 = set loop counter */
+set_loop:
+	mov		r2, r1, lsl #30			/* r2 = way loop counter << 30 */
+	orr		r2, r3, lsl #5			/* r2 = set/way cache operation format */
+	mcr		CP15_DCCISW(r2)			/* Data Cache Invalidate by Set/Way */
+	add		r3, r3, #1			/* Increment set counter */
+	cmp		r0, r3				/* Last set? */
+	bne		set_loop			/* Keep looping if not */
+
+	add		r1, r1, #1			/* Increment the way counter */
+	cmp		r4, r1				/* Last way */
+	bne		way_loop			/* Keep looping if not */
+
+	dsb
+	bx		lr
+	.size cp15_flush_dcache_all, . - cp15_flush_dcache_all
+	.end
+

--- a/arch/arm/src/armv7-r/cp15_flush_dcache_all.S
+++ b/arch/arm/src/armv7-r/cp15_flush_dcache_all.S
@@ -1,0 +1,121 @@
+/****************************************************************************
+ * arch/arm/src/armv7-r/cp15_clean_dcache_all.S
+ *
+ *   Copyright (C) 2013 Gregory Nutt. All rights reserved.
+ *   Author: Gregory Nutt <gnutt@nuttx.org>
+ *
+ * Portions of this file derive from Atmel sample code for the SAMA5D3
+ * Cortex-A5 which also has a modified BSD-style license:
+ *
+ *   Copyright (c) 2012, Atmel Corporation
+ *   All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name NuttX nor Atmel nor the names of the contributors may
+ *    be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/* References:
+ *
+ *  "Cortex-A5 MPCore, Technical Reference Manual", Revision: r0p1,
+ *   Copyright (c) 2010  ARM. All rights reserved. ARM DDI 0434B (ID101810)
+ *  "ARM Architecture Reference Manual, ARMv7-A and ARMv7-R edition",
+ *   Copyright (c) 1996-1998, 2000, 2004-2012 ARM. All rights reserved. ARM
+ *   DDI 0406C.b (ID072512)
+ */
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include "cp15.h"
+
+	.file	"cp15_clean_dcache_all.S"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Symbols
+ ****************************************************************************/
+
+	.globl	cp15_clean_dcache_all
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+	.text
+
+/****************************************************************************
+ * Name: cp15_clean_dcache_all
+ *
+ * Description:
+ *   Invalidate the entire contents of D cache.
+ *
+ * Input Parameters:
+ *   None
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+	.globl	cp15_clean_dcache_all
+	.type	cp15_clean_dcache_all, function
+
+cp15_clean_dcache_all:
+
+	mrc		CP15_CCSIDR(r0)			/* Read the Cache Size Identification Register */
+	ldr		r3, =0x7fff			/* Isolate the NumSets field (bits 13-27) */
+	and		r0, r3, r0, lsr #13		/* r0=NumSets (number of sets - 1) */
+
+	ldr		r3, =0x3ff			/* Isolate the way field (bits 3-12) */
+	add		r4, r3, r0, lsr #3		/* r4=(number of ways - 1) */
+
+	mov		r1, #0				/* r1 = way loop counter */
+way_loop:
+
+	mov		r3, #0				/* r3 = set loop counter */
+set_loop:
+	mov		r2, r1, lsl #30			/* r2 = way loop counter << 30 */
+	orr		r2, r3, lsl #5			/* r2 = set/way cache operation format */
+	mcr		CP15_DCCSW(r2)			/* Data Cache Invalidate by Set/Way */
+	add		r3, r3, #1			/* Increment set counter */
+	cmp		r0, r3				/* Last set? */
+	bne		set_loop			/* Keep looping if not */
+
+	add		r1, r1, #1			/* Increment the way counter */
+	cmp		r4, r1				/* Last way */
+	bne		way_loop			/* Keep looping if not */
+
+	dsb
+	bx		lr
+	.size cp15_clean_dcache_all, . - cp15_clean_dcache_all
+	.end
+

--- a/arch/arm/src/armv8-m/arm_cache.c
+++ b/arch/arm/src/armv8-m/arm_cache.c
@@ -536,15 +536,25 @@ void up_clean_dcache(uintptr_t start, uintptr_t end)
   uint32_t ccsidr;
   uint32_t sshift;
   uint32_t ssize;
+  uint32_t sets;
+  uint32_t ways;
 
   /* Get the characteristics of the D-Cache */
 
   ccsidr = getreg32(NVIC_CCSIDR);
   sshift = CCSIDR_LSSHIFT(ccsidr) + 4;   /* log2(cache-line-size-in-bytes) */
+  sets   = CCSIDR_SETS(ccsidr);          /* (Number of sets) - 1 */
+  ways   = CCSIDR_WAYS(ccsidr);          /* (Number of ways) - 1 */
 
   /* Clean the D-Cache over the range of addresses */
 
   ssize  = (1 << sshift);
+
+  if ((end - start) >= ssize * (sets + 1) * (ways + 1))
+    {
+      return up_clean_dcache_all();
+    }
+
   start &= ~(ssize - 1);
   ARM_DSB();
 
@@ -679,15 +689,25 @@ void up_flush_dcache(uintptr_t start, uintptr_t end)
   uint32_t ccsidr;
   uint32_t sshift;
   uint32_t ssize;
+  uint32_t sets;
+  uint32_t ways;
 
   /* Get the characteristics of the D-Cache */
 
   ccsidr = getreg32(NVIC_CCSIDR);
   sshift = CCSIDR_LSSHIFT(ccsidr) + 4;   /* log2(cache-line-size-in-bytes) */
+  sets   = CCSIDR_SETS(ccsidr);          /* (Number of sets) - 1 */
+  ways   = CCSIDR_WAYS(ccsidr);          /* (Number of ways) - 1 */
 
   /* Clean and invalidate the D-Cache over the range of addresses */
 
   ssize  = (1 << sshift);
+
+  if ((end - start) >= ssize * (sets + 1) * (ways + 1))
+    {
+      return up_flush_dcache_all();
+    }
+
   start &= ~(ssize - 1);
   ARM_DSB();
 

--- a/arch/arm/src/imx6/Make.defs
+++ b/arch/arm/src/imx6/Make.defs
@@ -49,6 +49,7 @@ CMN_ASRCS += arm_saveusercontext.S arm_vectoraddrexcptn.S
 CMN_ASRCS += arm_testset.S arm_fetchadd.S vfork.S
 CMN_ASRCS += cp15_coherent_dcache.S cp15_invalidate_dcache.S
 CMN_ASRCS += cp15_clean_dcache.S cp15_flush_dcache.S cp15_invalidate_dcache_all.S
+CMN_ASRCS += cp15_clean_dcache_all.S cp15_flush_dcache_all.S
 
 # Common C source files
 

--- a/arch/arm/src/sama5/Make.defs
+++ b/arch/arm/src/sama5/Make.defs
@@ -46,6 +46,7 @@ CMN_ASRCS += arm_saveusercontext.S arm_vectoraddrexcptn.S
 CMN_ASRCS += arm_testset.S arm_fetchadd.S vfork.S
 CMN_ASRCS += cp15_coherent_dcache.S cp15_invalidate_dcache.S
 CMN_ASRCS += cp15_clean_dcache.S cp15_flush_dcache.S cp15_invalidate_dcache_all.S
+CMN_ASRCS += cp15_clean_dcache_all.S cp15_flush_dcache_all.S
 
 # Configuration dependent assembly language files
 

--- a/arch/arm/src/tms570/Make.defs
+++ b/arch/arm/src/tms570/Make.defs
@@ -30,6 +30,7 @@ CMN_ASRCS += arm_saveusercontext.S arm_vectoraddrexcptn.S
 CMN_ASRCS += arm_testset.S arm_fetchadd.S vfork.S
 CMN_ASRCS += cp15_coherent_dcache.S cp15_invalidate_dcache.S
 CMN_ASRCS += cp15_clean_dcache.S cp15_flush_dcache.S
+CMN_ASRCS += cp15_clean_dcache_all.S cp15_flush_dcache_all.S
 CMN_ASRCS += cp15_invalidate_dcache_all.S
 
 # Configuration dependent assembly language files

--- a/arch/xtensa/src/common/xtensa_cache.c
+++ b/arch/xtensa/src/common/xtensa_cache.c
@@ -418,6 +418,11 @@ void up_clean_dcache(uintptr_t start, uintptr_t end)
 
   start &= ~(XCHAL_DCACHE_LINESIZE - 1);
 
+  if ((end - start) >= XCHAL_DCACHE_SIZE)
+    {
+      return up_clean_dcache_all();
+    }
+
   for (; start < end; start += XCHAL_DCACHE_LINESIZE)
     {
       __asm__ __volatile__ ("dhwb %0, 0\n" : : "r"(start));
@@ -494,6 +499,11 @@ void up_flush_dcache(uintptr_t start, uintptr_t end)
   /* Align to XCHAL_DCACHE_LINESIZE */
 
   start &= ~(XCHAL_DCACHE_LINESIZE - 1);
+
+  if ((end - start) >= XCHAL_DCACHE_SIZE)
+    {
+      return up_clean_dcache_all();
+    }
 
   for (; start < end; start += XCHAL_DCACHE_LINESIZE)
     {


### PR DESCRIPTION
## Summary

This PR contain two commits:

1 arm/xtensa:cache: flush/clean dcache all if size large than cache size
2 armv7-a/r:cache: implemention clean&flush_dcache_all

## Impact

No.

## Testing

We have a testing  on armv8-m  with 32K icache & 32k dcache,  when flush &clean  buffer  with size 1MB。

`up_clean_dcache_all()  run 30 times faster than up_clean_dcache().`

When use this patch, the time is same.




