### PR TITLE
tcbinfo: Update tcbinfo struct, Fix the compile warning

### DIFF
--- a/arch/arm/src/arm/arm_tcbinfo.c
+++ b/arch/arm/src/arm/arm_tcbinfo.c
@@ -30,20 +30,11 @@
 #include <arch/irq.h>
 
 /****************************************************************************
- * Public Data
+ * Private Data
  ****************************************************************************/
 
-const struct tcbinfo_s g_tcbinfo =
+static const uint16_t g_reg_offs[] =
 {
-  TCB_PID_OFF,
-  TCB_STATE_OFF,
-  TCB_PRI_OFF,
-#if CONFIG_TASK_NAME_SIZE > 0
-  TCB_NAME_OFF,
-#endif
-
-  XCPTCONTEXT_REGS,
-
   TCB_REG_OFF(REG_R0),
   TCB_REG_OFF(REG_R1),
   TCB_REG_OFF(REG_R2),
@@ -61,6 +52,22 @@ const struct tcbinfo_s g_tcbinfo =
   TCB_REG_OFF(REG_R14),
   TCB_REG_OFF(REG_R15),
   TCB_REG_OFF(REG_CPSR),
+};
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+const struct tcbinfo_s g_tcbinfo =
+{
+  TCB_PID_OFF,
+  TCB_STATE_OFF,
+  TCB_PRI_OFF,
+  TCB_NAME_OFF,
+  XCPTCONTEXT_REGS,
+  {
+    .p = g_reg_offs,
+  },
 };
 
 #endif

--- a/arch/arm/src/armv6-m/arm_tcbinfo.c
+++ b/arch/arm/src/armv6-m/arm_tcbinfo.c
@@ -30,20 +30,11 @@
 #include <arch/irq.h>
 
 /****************************************************************************
- * Public Data
+ * Private Data
  ****************************************************************************/
 
-const struct tcbinfo_s g_tcbinfo =
+static const uint16_t g_reg_offs[] =
 {
-  TCB_PID_OFF,
-  TCB_STATE_OFF,
-  TCB_PRI_OFF,
-#if CONFIG_TASK_NAME_SIZE > 0
-  TCB_NAME_OFF,
-#endif
-
-  XCPTCONTEXT_REGS,
-
   TCB_REG_OFF(REG_R0),
   TCB_REG_OFF(REG_R1),
   TCB_REG_OFF(REG_R2),
@@ -62,12 +53,28 @@ const struct tcbinfo_s g_tcbinfo =
   TCB_REG_OFF(REG_R15),
   TCB_REG_OFF(REG_XPSR),
 
-  0,
+  0,                        /* msp */
   TCB_REG_OFF(REG_R13),
   TCB_REG_OFF(REG_PRIMASK),
-  0,
-  0,
-  0,
+  0,                        /* basepri */
+  0,                        /* faultmask */
+  0,                        /* control */
+};
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+const struct tcbinfo_s g_tcbinfo =
+{
+  TCB_PID_OFF,
+  TCB_STATE_OFF,
+  TCB_PRI_OFF,
+  TCB_NAME_OFF,
+  XCPTCONTEXT_REGS,
+  {
+    .p = g_reg_offs,
+  },
 };
 
 #endif

--- a/arch/arm/src/armv7-a/arm_tcbinfo.c
+++ b/arch/arm/src/armv7-a/arm_tcbinfo.c
@@ -30,20 +30,11 @@
 #include <arch/irq.h>
 
 /****************************************************************************
- * Public Data
+ * Private Data
  ****************************************************************************/
 
-const struct tcbinfo_s g_tcbinfo =
+static const uint16_t g_reg_offs[] =
 {
-  TCB_PID_OFF,
-  TCB_STATE_OFF,
-  TCB_PRI_OFF,
-#if CONFIG_TASK_NAME_SIZE > 0
-  TCB_NAME_OFF,
-#endif
-
-  XCPTCONTEXT_REGS,
-
   TCB_REG_OFF(REG_R0),
   TCB_REG_OFF(REG_R1),
   TCB_REG_OFF(REG_R2),
@@ -101,10 +92,24 @@ const struct tcbinfo_s g_tcbinfo =
 #endif
 
 #ifdef CONFIG_ARCH_FPU
-  0,
   TCB_REG_OFF(REG_FPSCR),
-  0,
 #endif
+};
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+const struct tcbinfo_s g_tcbinfo =
+{
+  TCB_PID_OFF,
+  TCB_STATE_OFF,
+  TCB_PRI_OFF,
+  TCB_NAME_OFF,
+  XCPTCONTEXT_REGS,
+  {
+    .p = g_reg_offs,
+  },
 };
 
 #endif

--- a/arch/arm/src/armv7-m/arm_tcbinfo.c
+++ b/arch/arm/src/armv7-m/arm_tcbinfo.c
@@ -30,20 +30,11 @@
 #include <arch/irq.h>
 
 /****************************************************************************
- * Public Data
+ * Private Data
  ****************************************************************************/
 
-const struct tcbinfo_s g_tcbinfo =
+static const uint16_t g_reg_offs[] =
 {
-  TCB_PID_OFF,
-  TCB_STATE_OFF,
-  TCB_PRI_OFF,
-#if CONFIG_TASK_NAME_SIZE > 0
-  TCB_NAME_OFF,
-#endif
-
-  XCPTCONTEXT_REGS,
-
   TCB_REG_OFF(REG_R0),
   TCB_REG_OFF(REG_R1),
   TCB_REG_OFF(REG_R2),
@@ -62,17 +53,17 @@ const struct tcbinfo_s g_tcbinfo =
   TCB_REG_OFF(REG_R15),
   TCB_REG_OFF(REG_XPSR),
 
-  0,
+  0,                            /* msp */
   TCB_REG_OFF(REG_R13),
 #ifdef CONFIG_ARMV7M_USEBASEPRI
-  0,
+  0,                            /* primask */
   TCB_REG_OFF(REG_BASEPRI),
 #else
   TCB_REG_OFF(REG_PRIMASK),
-  0,
+  0,                            /* basepri */
 #endif
-  0,
-  0,
+  0,                            /* faultmask */
+  0,                            /* control */
 
 #ifdef CONFIG_ARCH_FPU
   TCB_REG_OFF(REG_S0),
@@ -107,10 +98,24 @@ const struct tcbinfo_s g_tcbinfo =
   TCB_REG_OFF(REG_S29),
   TCB_REG_OFF(REG_S30),
   TCB_REG_OFF(REG_S31),
-  0,
   TCB_REG_OFF(REG_FPSCR),
-  0,
 #endif
+};
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+const struct tcbinfo_s g_tcbinfo =
+{
+  TCB_PID_OFF,
+  TCB_STATE_OFF,
+  TCB_PRI_OFF,
+  TCB_NAME_OFF,
+  XCPTCONTEXT_REGS,
+  {
+    .p = g_reg_offs,
+  },
 };
 
 #endif

--- a/arch/arm/src/armv7-r/arm_tcbinfo.c
+++ b/arch/arm/src/armv7-r/arm_tcbinfo.c
@@ -30,20 +30,11 @@
 #include <arch/irq.h>
 
 /****************************************************************************
- * Public Data
+ * Private Data
  ****************************************************************************/
 
-const struct tcbinfo_s g_tcbinfo =
+static const uint16_t g_reg_offs[] =
 {
-  TCB_PID_OFF,
-  TCB_STATE_OFF,
-  TCB_PRI_OFF,
-#if CONFIG_TASK_NAME_SIZE > 0
-  TCB_NAME_OFF,
-#endif
-
-  XCPTCONTEXT_REGS,
-
   TCB_REG_OFF(REG_R0),
   TCB_REG_OFF(REG_R1),
   TCB_REG_OFF(REG_R2),
@@ -101,10 +92,24 @@ const struct tcbinfo_s g_tcbinfo =
 #endif
 
 #ifdef CONFIG_ARCH_FPU
-  0,
   TCB_REG_OFF(REG_FPSCR),
-  0,
 #endif
+};
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+const struct tcbinfo_s g_tcbinfo =
+{
+  TCB_PID_OFF,
+  TCB_STATE_OFF,
+  TCB_PRI_OFF,
+  TCB_NAME_OFF,
+  XCPTCONTEXT_REGS,
+  {
+    .p = g_reg_offs,
+  },
 };
 
 #endif

--- a/arch/arm/src/armv8-m/arm_tcbinfo.c
+++ b/arch/arm/src/armv8-m/arm_tcbinfo.c
@@ -30,20 +30,11 @@
 #include <arch/irq.h>
 
 /****************************************************************************
- * Public Data
+ * Private Data
  ****************************************************************************/
 
-const struct tcbinfo_s g_tcbinfo =
+static const uint16_t g_reg_offs[] =
 {
-  TCB_PID_OFF,
-  TCB_STATE_OFF,
-  TCB_PRI_OFF,
-#if CONFIG_TASK_NAME_SIZE > 0
-  TCB_NAME_OFF,
-#endif
-
-  XCPTCONTEXT_REGS,
-
   TCB_REG_OFF(REG_R0),
   TCB_REG_OFF(REG_R1),
   TCB_REG_OFF(REG_R2),
@@ -62,17 +53,17 @@ const struct tcbinfo_s g_tcbinfo =
   TCB_REG_OFF(REG_R15),
   TCB_REG_OFF(REG_XPSR),
 
-  0,
+  0,                          /* msp */
   TCB_REG_OFF(REG_R13),
 #ifdef CONFIG_ARMV8M_USEBASEPRI
-  0,
+  0,                          /* primask */
   TCB_REG_OFF(REG_BASEPRI),
 #else
   TCB_REG_OFF(REG_PRIMASK),
-  0,
+  0,                          /* basepri */
 #endif
-  0,
-  0,
+  0,                          /* faultmask */
+  0,                          /* control */
 
 #ifdef CONFIG_ARCH_FPU
   TCB_REG_OFF(REG_S0),
@@ -107,10 +98,24 @@ const struct tcbinfo_s g_tcbinfo =
   TCB_REG_OFF(REG_S29),
   TCB_REG_OFF(REG_S30),
   TCB_REG_OFF(REG_S31),
-  0,
   TCB_REG_OFF(REG_FPSCR),
-  0,
 #endif
+};
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+const struct tcbinfo_s g_tcbinfo =
+{
+  TCB_PID_OFF,
+  TCB_STATE_OFF,
+  TCB_PRI_OFF,
+  TCB_NAME_OFF,
+  XCPTCONTEXT_REGS,
+  {
+    .p = g_reg_offs,
+  },
 };
 
 #endif

--- a/arch/risc-v/src/common/riscv_tcbinfo.c
+++ b/arch/risc-v/src/common/riscv_tcbinfo.c
@@ -30,21 +30,12 @@
 #include <arch/irq.h>
 
 /****************************************************************************
- * Public Data
+ * Private Data
  ****************************************************************************/
 
-const struct tcbinfo_s g_tcbinfo =
+static const uint16_t g_reg_offs[] =
 {
-  TCB_PID_OFF,
-  TCB_STATE_OFF,
-  TCB_PRI_OFF,
-#if CONFIG_TASK_NAME_SIZE > 0
-  TCB_NAME_OFF,
-#endif
-
-  XCPTCONTEXT_REGS,
-
-  0,
+  0,                       /* x0 */
   TCB_REG_OFF(REG_X1_NDX),
   TCB_REG_OFF(REG_X2_NDX),
   TCB_REG_OFF(REG_X3_NDX),
@@ -111,10 +102,26 @@ const struct tcbinfo_s g_tcbinfo =
   TCB_REG_OFF(REG_F29_NDX),
   TCB_REG_OFF(REG_F30_NDX),
   TCB_REG_OFF(REG_F31_NDX),
-  0,
-  0,
+  0,                        /* fflags */
+  0,                        /* frm */
   TCB_REG_OFF(REG_FCSR_NDX),
 #endif
+};
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+const struct tcbinfo_s g_tcbinfo =
+{
+  TCB_PID_OFF,
+  TCB_STATE_OFF,
+  TCB_PRI_OFF,
+  TCB_NAME_OFF,
+  XCPTCONTEXT_REGS,
+  {
+    .p = g_reg_offs,
+  },
 };
 
 #endif

--- a/binfmt/libelf/libelf_coredump.c
+++ b/binfmt/libelf/libelf_coredump.c
@@ -247,7 +247,7 @@ static void elf_emit_note_info(FAR struct elf_dumpinfo_s *cinfo)
       for (j = 0; j < ARRAY_SIZE(status.pr_regs); j++)
         {
           status.pr_regs[j] = *(uintptr_t *)((uint8_t *)tcb +
-                                             g_tcbinfo.reg_offs[j]);
+                                             g_tcbinfo.reg_off.p[j]);
         }
 
       elf_emit(cinfo, &status, sizeof(status));

--- a/include/nuttx/sched.h
+++ b/include/nuttx/sched.h
@@ -186,13 +186,15 @@
 #endif
 
 #ifdef CONFIG_DEBUG_TCBINFO
-#  define TCB_PID_OFF                (offsetof(struct tcb_s, pid))
-#  define TCB_STATE_OFF              (offsetof(struct tcb_s, task_state))
-#  define TCB_PRI_OFF                (offsetof(struct tcb_s, sched_priority))
+#  define TCB_PID_OFF                offsetof(struct tcb_s, pid)
+#  define TCB_STATE_OFF              offsetof(struct tcb_s, task_state)
+#  define TCB_PRI_OFF                offsetof(struct tcb_s, sched_priority)
 #if CONFIG_TASK_NAME_SIZE > 0
-#  define TCB_NAME_OFF               (offsetof(struct tcb_s, name))
+#  define TCB_NAME_OFF               offsetof(struct tcb_s, name)
+#else
+#  define TCB_NAME_OFF               0
 #endif
-#  define TCB_REG_OFF(reg)           (offsetof(struct tcb_s, xcp.regs[reg]))
+#  define TCB_REG_OFF(reg)           offsetof(struct tcb_s, xcp.regs[reg])
 #endif
 
 /****************************************************************************
@@ -772,7 +774,7 @@ struct tcbinfo_s
   uint16_t name_off;                     /* Offset of tcb.name              */
   uint16_t reg_num;                      /* Num of regs in tcbinfo.reg_offs */
 
-  /* Offsets of xcp.regs, order in GDB org.gnu.gdb.xxx feature.
+  /* Offset pointer of xcp.regs, order in GDB org.gnu.gdb.xxx feature.
    * Please refer:
    * https://sourceware.org/gdb/current/onlinedocs/gdb/ARM-Features.html
    * https://sourceware.org/gdb/current/onlinedocs/gdb/RISC_002dV-Features
@@ -780,7 +782,11 @@ struct tcbinfo_s
    * value 0: This regsiter was not priovided by NuttX
    */
 
-  uint16_t reg_offs[XCPTCONTEXT_REGS];
+  union
+  {
+    uint8_t       u[8];
+    FAR uint16_t *p;
+  } reg_off;
 };
 #endif
 

--- a/include/nuttx/sched.h
+++ b/include/nuttx/sched.h
@@ -766,7 +766,7 @@ struct pthread_tcb_s
  */
 
 #ifdef CONFIG_DEBUG_TCBINFO
-struct tcbinfo_s
+begin_packed_struct struct tcbinfo_s
 {
   uint16_t pid_off;                      /* Offset of tcb.pid               */
   uint16_t state_off;                    /* Offset of tcb.task_state        */
@@ -787,7 +787,7 @@ struct tcbinfo_s
     uint8_t       u[8];
     FAR uint16_t *p;
   } reg_off;
-};
+} end_packed_struct;
 #endif
 
 /* This is the callback type used by nxsched_foreach() */

--- a/tools/jlink-nuttx.c
+++ b/tools/jlink-nuttx.c
@@ -72,7 +72,7 @@ enum symbol_e
   NSYMBOLS
 };
 
-struct tcbinfo_s
+__attribute__ ((packed)) struct tcbinfo_s
 {
   uint16_t pid_off;
   uint16_t state_off;

--- a/tools/jlink-nuttx.c
+++ b/tools/jlink-nuttx.c
@@ -79,6 +79,11 @@ struct tcbinfo_s
   uint16_t pri_off;
   uint16_t name_off;
   uint16_t reg_num;
+  union
+  {
+    uint8_t  u[8];
+    uint16_t *p;
+  } reg_off;
   uint16_t reg_offs[0];
 };
 
@@ -249,12 +254,21 @@ static int update_tcbinfo(struct plugin_priv_s *priv)
     {
       uint16_t reg_num;
       int ret;
+      uint32_t reg_off;
 
       ret = READU16(g_symbols[TCBINFO].address +
                     offsetof(struct tcbinfo_s, reg_num), &reg_num);
       if (ret != 0 || !reg_num)
         {
           PERROR("error reading regs ret %d\n", ret);
+          return ret;
+        }
+
+      ret = READU32(g_symbols[TCBINFO].address +
+                    offsetof(struct tcbinfo_s, reg_off), &reg_off);
+      if (ret != 0 || !reg_off)
+        {
+          PERROR("error in read regoffs address ret %d\n", ret);
           return ret;
         }
 
@@ -268,10 +282,18 @@ static int update_tcbinfo(struct plugin_priv_s *priv)
         }
 
       ret = READMEM(g_symbols[TCBINFO].address, (char *)priv->tcbinfo,
-                    sizeof(struct tcbinfo_s) + reg_num * sizeof(uint16_t));
-      if (ret != sizeof(struct tcbinfo_s) + reg_num * sizeof(uint16_t))
+                    sizeof(struct tcbinfo_s));
+      if (ret != sizeof(struct tcbinfo_s))
         {
           PERROR("error in read tcbinfo_s ret %d\n", ret);
+          return ret;
+        }
+
+      ret = READMEM(reg_off, (char *)&priv->tcbinfo->reg_offs[0],
+                    reg_num * sizeof(uint16_t));
+      if (ret != reg_num * sizeof(uint16_t))
+        {
+          PERROR("error in read tcbinfo_s reg_offs ret %d\n", ret);
           return ret;
         }
 


### PR DESCRIPTION
## Summary

Update tcbinfo struct, Fix the compile warning. Let's ignore the false nxstyle alarm:
```
Error: /home/runner/work/incubator-nuttx/incubator-nuttx/nuttx/tools/jlink-nuttx.c:387:4: error: Mixed case identifier found
Error: /home/runner/work/incubator-nuttx/incubator-nuttx/nuttx/tools/jlink-nuttx.c:394:9: error: Mixed case identifier found
Error: /home/runner/work/incubator-nuttx/incubator-nuttx/nuttx/tools/jlink-nuttx.c:399:18: error: Mixed case identifier found
Error: /home/runner/work/incubator-nuttx/incubator-nuttx/nuttx/tools/jlink-nuttx.c:404:9: error: Mixed case identifier found
Error: /home/runner/work/incubator-nuttx/incubator-nuttx/nuttx/tools/jlink-nuttx.c:409:9: error: Mixed case identifier found
Error: /home/runner/work/incubator-nuttx/incubator-nuttx/nuttx/tools/jlink-nuttx.c:414:9: error: Mixed case identifier found
Error: /home/runner/work/incubator-nuttx/incubator-nuttx/nuttx/tools/jlink-nuttx.c:429:4: error: Mixed case identifier found
Error: /home/runner/work/incubator-nuttx/incubator-nuttx/nuttx/tools/jlink-nuttx.c:493:4: error: Mixed case identifier found
Error: /home/runner/work/incubator-nuttx/incubator-nuttx/nuttx/tools/jlink-nuttx.c:530:4: error: Mixed case identifier found
Error: /home/runner/work/incubator-nuttx/incubator-nuttx/nuttx/tools/jlink-nuttx.c:567:4: error: Mixed case identifier found
Error: /home/runner/work/incubator-nuttx/incubator-nuttx/nuttx/tools/jlink-nuttx.c:603:4: error: Mixed case identifier found
Error: /home/runner/work/incubator-nuttx/incubator-nuttx/nuttx/tools/jlink-nuttx.c:642:4: error: Mixed case identifier found
Error: Process completed with exit code 1.
```

## Impact

No

## Testing

Testing on m55 with jtag enable.
