### PR TITLE
add support for Neural Networks Menu and runtime

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -2032,6 +2032,10 @@ menu "Open Asymmetric Multi Processing"
 source "openamp/Kconfig"
 endmenu
 
+menu "Neural Network Configuration"
+source "nn/Kconfig"
+endmenu
+
 menu "Application Configuration"
 source "$APPSDIR/Kconfig"
 endmenu

--- a/nn/Kconfig
+++ b/nn/Kconfig
@@ -1,0 +1,16 @@
+#
+# For a description of the syntax of this configuration file,
+# see the file kconfig-language.txt in the NuttX tools repository.
+#
+
+config NN
+	bool "Neural Network support"
+	default n
+	---help---
+		Enable or disable support for Neural Network features
+
+if NN
+
+source "nn/libnnablart/Kconfig"
+
+endif # NN

--- a/nn/libnnablart/Kconfig
+++ b/nn/libnnablart/Kconfig
@@ -1,0 +1,20 @@
+#
+# For a description of the syntax of this configuration file,
+# see the file kconfig-language.txt in the NuttX tools repository.
+#
+
+config NNABLA_RT
+	bool "NNABLA Runtime Libraries"
+	default n
+	---help---
+		This is a runtime library for inference Neural Networks
+		created by Neural Network Libraries.
+		https://github.com/sony/nnabla-c-runtime
+
+if NNABLA_RT
+
+config NNABLA_RT_VER
+	string "Default NNABLA Runtime version"
+	default 1.24.0
+
+endif # NNABLA_RT

--- a/nn/libnnablart/Makefile
+++ b/nn/libnnablart/Makefile
@@ -1,0 +1,153 @@
+############################################################################
+# nn/libnnablart/Makefile
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+include $(TOPDIR)/Make.defs
+
+include nnablart.defs
+
+ifeq ($(CONFIG_NNABLA_RT),y)
+SRC = nnabla-c-runtime/src
+
+CSRCS   += $(SRC)/functions/utilities/accessor.c
+CSRCS   += $(SRC)/functions/utilities/fixedpoint.c
+CSRCS   += $(SRC)/functions/utilities/list.c
+CSRCS   += $(SRC)/functions/utilities/shape.c
+CSRCS   += $(SRC)/functions/implements/activation/sigmoid.c
+CSRCS   += $(SRC)/functions/implements/activation/relu.c
+CSRCS   += $(SRC)/functions/implements/activation/tanh.c
+CSRCS   += $(SRC)/functions/implements/activation/softmax.c
+CSRCS   += $(SRC)/functions/implements/activation/selu.c
+CSRCS   += $(SRC)/functions/implements/activation/elu.c
+CSRCS   += $(SRC)/functions/implements/activation/prelu.c
+CSRCS   += $(SRC)/functions/implements/activation/leakyrelu.c
+CSRCS   += $(SRC)/functions/implements/activation/crelu.c
+CSRCS   += $(SRC)/functions/implements/activation/celu.c
+CSRCS   += $(SRC)/functions/implements/activation/swish.c
+CSRCS   += $(SRC)/functions/implements/math/abs.c
+CSRCS   += $(SRC)/functions/implements/math/batch_matmul.c
+CSRCS   += $(SRC)/functions/implements/math/exp.c
+CSRCS   += $(SRC)/functions/implements/math/identity.c
+CSRCS   += $(SRC)/functions/implements/math/log.c
+CSRCS   += $(SRC)/functions/implements/math/round.c
+CSRCS   += $(SRC)/functions/implements/quantization/binary_tanh.c
+CSRCS   += $(SRC)/functions/implements/quantization/binary_sigmoid.c
+CSRCS   += $(SRC)/functions/implements/quantization/binary_connect_affine.c
+CSRCS   += $(SRC)/functions/implements/quantization/binary_weight_affine.c
+CSRCS   += $(SRC)/functions/implements/arithmetic/add_scalar.c
+CSRCS   += $(SRC)/functions/implements/arithmetic/arithmetic.c
+CSRCS   += $(SRC)/functions/implements/arithmetic/arithmetic_fixed.c
+CSRCS   += $(SRC)/functions/implements/arithmetic/arithmetic_generic.c
+CSRCS   += $(SRC)/functions/implements/arithmetic/div2.c
+CSRCS   += $(SRC)/functions/implements/arithmetic/mul2.c
+CSRCS   += $(SRC)/functions/implements/arithmetic/mul_scalar.c
+CSRCS   += $(SRC)/functions/implements/arithmetic/pow2.c
+CSRCS   += $(SRC)/functions/implements/arithmetic/pow_scalar.c
+CSRCS   += $(SRC)/functions/implements/arithmetic/r_div_scalar.c
+CSRCS   += $(SRC)/functions/implements/arithmetic/r_pow_scalar.c
+CSRCS   += $(SRC)/functions/implements/arithmetic/r_sub_scalar.c
+CSRCS   += $(SRC)/functions/implements/arithmetic/sub2.c
+CSRCS   += $(SRC)/functions/implements/arithmetic/add2.c
+CSRCS   += $(SRC)/functions/implements/logical/maximum_scalar.c
+CSRCS   += $(SRC)/functions/implements/logical/minimum_scalar.c
+CSRCS   += $(SRC)/functions/implements/logical/maximum2.c
+CSRCS   += $(SRC)/functions/implements/logical/minimum2.c
+CSRCS   += $(SRC)/functions/implements/logical/sign.c
+CSRCS   += $(SRC)/functions/implements/array/matrix_diag.c
+CSRCS   += $(SRC)/functions/implements/array/matrix_diag_part.c
+CSRCS   += $(SRC)/functions/implements/array/reshape.c
+CSRCS   += $(SRC)/functions/implements/array/concatenate.c
+CSRCS   += $(SRC)/functions/implements/array/split.c
+CSRCS   += $(SRC)/functions/implements/array/stack.c
+CSRCS   += $(SRC)/functions/implements/array/shift.c
+CSRCS   += $(SRC)/functions/implements/array/slice.c
+CSRCS   += $(SRC)/functions/implements/array/flip.c
+CSRCS   += $(SRC)/functions/implements/array/transpose.c
+CSRCS   += $(SRC)/functions/implements/array/pad.c
+CSRCS   += $(SRC)/functions/implements/neural_network/pooling.c
+CSRCS   += $(SRC)/functions/implements/neural_network/max_pooling.c
+CSRCS   += $(SRC)/functions/implements/neural_network/sum_pooling.c
+CSRCS   += $(SRC)/functions/implements/neural_network/average_pooling.c
+CSRCS   += $(SRC)/functions/implements/neural_network/unpooling.c
+CSRCS   += $(SRC)/functions/implements/neural_network/deconvolution.c
+CSRCS   += $(SRC)/functions/implements/neural_network/affine/affine.c
+CSRCS   += $(SRC)/functions/implements/neural_network/affine/affine_fixed8.c
+CSRCS   += $(SRC)/functions/implements/neural_network/affine/affine_fixed16.c
+CSRCS   += $(SRC)/functions/implements/neural_network/affine/affine_generic.c
+CSRCS   += $(SRC)/functions/implements/neural_network/convolution/convolution.c
+CSRCS   += $(SRC)/functions/implements/neural_network/convolution/convolution_generic.c
+CSRCS   += $(SRC)/functions/implements/neural_network/convolution/convolution_float.c
+CSRCS   += $(SRC)/functions/implements/neural_network/convolution/convolution_int8.c
+CSRCS   += $(SRC)/functions/implements/neural_network/convolution/convolution_int16.c
+CSRCS   += $(SRC)/functions/implements/neural_network/convolution/convolution_common.c
+CSRCS   += $(SRC)/functions/implements/neural_network/convolution/binary_connect_convolution.c
+CSRCS   += $(SRC)/functions/implements/neural_network/convolution/binary_weight_convolution.c
+CSRCS   += $(SRC)/functions/implements/neural_network/convolution/depthwise_convolution.c
+CSRCS   += $(SRC)/functions/implements/normalization/batch_normalization.c
+CSRCS   += $(SRC)/functions/implements/normalization/mean_subtraction.c
+CSRCS   += $(SRC)/functions/implements/stochasticity/dropout.c
+CSRCS   += $(SRC)/functions/implements/reduction/sum.c
+CSRCS   += $(SRC)/functions/implements/unimplemented.c
+CSRCS   += $(SRC)/runtime/function_context.c
+CSRCS   += $(SRC)/runtime/runtime.c
+CSRCS   += $(SRC)/runtime/runtime_internal.c
+endif
+
+CFLAGS += -I$(TOPDIR)/include/nnabla/
+CFLAGS += -Wno-shadow -Wno-format
+
+AOBJS = $(ASRCS:.S=$(OBJEXT))
+COBJS = $(CSRCS:.c=$(OBJEXT))
+
+SRCS = $(ASRCS) $(CSRCS)
+OBJS = $(AOBJS) $(COBJS)
+
+BIN = libnnablart$(LIBEXT)
+
+all: $(BIN)
+.PHONY:  depend clean distclean
+
+$(AOBJS): %$(OBJEXT): %.S
+	$(call ASSEMBLE, $<, $@)
+
+$(COBJS): %$(OBJEXT): %.c
+	$(call COMPILE, $<, $@)
+
+$(BIN): $(OBJS)
+	$(call ARCHIVE, $@, $(OBJS))
+
+makedepfile: $(CSRCS:.c=.ddc) $(ASRCS:.S=.dds)
+	$(call CATFILE, Make.dep, $^)
+	$(call DELFILE, $^)
+
+.depend: Makefile $(SRCS) $(TOPDIR)$(DELIM).config
+	$(Q) $(MAKE) makedepfile
+	$(Q) touch $@
+
+depend: .depend
+
+clean::
+	$(call DELFILE, $(BIN))
+	$(call CLEAN)
+
+distclean:: clean
+	$(call DELFILE, Make.dep)
+	$(call DELFILE, .depend)
+
+-include Make.dep

--- a/nn/libnnablart/nnablart.defs
+++ b/nn/libnnablart/nnablart.defs
@@ -1,0 +1,45 @@
+############################################################################
+# nn/libnnablart/nnablart.defs
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+ifeq ($(CONFIG_NNABLA_RT),y)
+
+nnabla.zip:
+	$(Q) curl -L https://github.com/sony/nnabla-c-runtime/archive/refs/tags/v$(CONFIG_NNABLA_RT_VER).zip -o nnabla.zip
+	$(Q) unzip -o nnabla.zip
+	$(Q) mv nnabla-c-runtime-$(CONFIG_NNABLA_RT_VER) nnabla-c-runtime
+
+.nnabla_headers: nnabla.zip
+	$(shell mkdir -p $(TOPDIR)$(DELIM)include$(DELIM)nnablart$(DELIM))
+	$(eval headers := $(wildcard nnabla-c-runtime$(DELIM)include$(DELIM)nnablart$(DELIM)*.h))
+	$(foreach header,$(headers),$(shell cp -rf $(header) $(TOPDIR)$(DELIM)include$(DELIM)nnablart))
+	touch $@
+
+context:: .nnabla_headers
+
+clean::
+	$(call CLEAN)
+
+distclean::
+	$(call DELDIR, $(TOPDIR)$(DELIM)include$(DELIM)nnabla$(DELIM))
+	$(call DELDIR, nnabla-c-runtime)
+	$(call DELFILE, nnabla.zip)
+	$(call DELFILE, .nnabla_headers)
+
+endif

--- a/tools/Directories.mk
+++ b/tools/Directories.mk
@@ -164,4 +164,11 @@ else
 CLEANDIRS += openamp
 endif
 
+ifeq ($(CONFIG_NNABLA_RT),y)
+KERNDEPDIRS += nn$(DELIM)libnnablart
+CONTEXTDIRS += nn$(DELIM)libnnablart
+else
+CLEANDIRS += nn$(DELIM)libnnablart
+endif
+
 CLEANDIRS += $(KERNDEPDIRS) $(USERDEPDIRS)

--- a/tools/FlatLibs.mk
+++ b/tools/FlatLibs.mk
@@ -132,6 +132,10 @@ ifeq ($(CONFIG_OPENAMP),y)
 NUTTXLIBS += staging$(DELIM)libopenamp$(LIBEXT)
 endif
 
+ifeq ($(CONFIG_NNABLA_RT),y)
+NUTTXLIBS += staging$(DELIM)libnnablart$(LIBEXT)
+endif
+
 # Export all libraries
 
 EXPORTLIBS = $(NUTTXLIBS)

--- a/tools/KernelLibs.mk
+++ b/tools/KernelLibs.mk
@@ -118,6 +118,10 @@ ifeq ($(CONFIG_OPENAMP),y)
 NUTTXLIBS += staging$(DELIM)libopenamp$(LIBEXT)
 endif
 
+ifeq ($(CONFIG_NNABLA_RT),y)
+NUTTXLIBS += staging$(DELIM)libnnablart$(LIBEXT)
+endif
+
 # Export only the user libraries
 
 EXPORTLIBS = $(USERLIBS)

--- a/tools/LibTargets.mk
+++ b/tools/LibTargets.mk
@@ -202,6 +202,12 @@ libs$(DELIM)libdsp$(DELIM)libdsp$(LIBEXT): pass2dep
 staging$(DELIM)libdsp$(LIBEXT): libs$(DELIM)libdsp$(DELIM)libdsp$(LIBEXT)
 	$(Q) $(call INSTALL_LIB,$<,$@)
 
+nn$(DELIM)libnnablart$(DELIM)libnnablart$(LIBEXT): pass2dep
+	$(Q) $(MAKE) -C nn$(DELIM)libnnablart libnnablart$(LIBEXT) EXTRAFLAGS="$(EXTRAFLAGS)"
+
+staging$(DELIM)libnnablart$(LIBEXT): nn$(DELIM)libnnablart$(DELIM)libnnablart$(LIBEXT)
+	$(Q) $(call INSTALL_LIB,$<,$@)
+
 ifeq ($(CONFIG_BUILD_FLAT),y)
 $(APPDIR)$(DELIM)libapps$(LIBEXT): pass2dep
 else


### PR DESCRIPTION
add support for Neural Network menu and NNabla C Runtime

This is a runtime library for inference Neural Network created
by Neural Network Libraries.

Project git: https://github.com/sony/nnabla-c-runtime

It is almost independent from external libraries(depends on C
standard math library) and is written in Pure C (C99).

It has been developed with priority over readability rather than
performance, making it ideal for learning and porting.
It adopts an extensible architecture, and you can use the function
you implemented yourself as necessary for applications that need performance.

Project license : Apache 2.0 License
https://github.com/sony/nnabla-c-runtime/blob/master/LICENSE

Signed-off-by: Alin Jerpelea <alin.jerpelea@sony.com>

## Summary

## Impact

## Testing

