### PR TITLE
net/tcp/sendfile: notify the device driver of the availability of TX data on TCP retransmission

### DIFF
--- a/net/tcp/tcp_sendfile.c
+++ b/net/tcp/tcp_sendfile.c
@@ -354,6 +354,10 @@ static uint16_t sendfile_eventhandler(FAR struct net_driver_s *dev,
 
       dev->d_sndlen = sndlen;
 
+      /* Notify the device driver of the availability of TX data */
+
+      tcp_send_txnotify(psock, conn);
+
       /* Continue waiting */
 
       return flags;


### PR DESCRIPTION
## Summary

Notify the device driver of the availability of TX data on TCP retransmission (as well as on sending normal TCP packets).

## Impact

TCP sendfile

## Testing

Activate emulating packet loss on Linux host:
`$ sudo iptables -A INPUT -p tcp --dport 31337 -m statistic --mode random --probability 0.01 -j DROP`

Build NuttX:
```
$ ./tools/configure.sh -l sim:tcpblaster
$ make menuconfig (enable CONFIG_NETUTILS_NETCAT_SENDFILE, enable/disable CONFIG_NET_TCP_WRITE_BUFFERS)
$ make
```
Enable TUN/TAP on Linux host:
```
$ sudo setcap cap_net_admin+ep ./nuttx
$ sudo ./tools/simhostroute.sh wlan0 on
```
Run netcat server on Linux host:
`$ netcat -l -p 31337`

Run NuttX on Linux host:
```
$ ./nuttx
NuttShell (NSH) NuttX-10.2.0
nsh> ifconfig eth0 10.0.1.2
nsh> ifup eth0
ifup eth0...OK
```
Start Wireshark (or tcpdump) and capture appeared tap0 interface.

Run in NuttX:
```
nsh> dd if=/dev/zero of=/tmp/test.bin count=1000
nsh> netcat LINUX_HOST_IP_ADDRESS 31337 /tmp/test.bin
```

Observe packet loss -> duplicate ACKs -> Fast Retransmit in TCP dump.

Shutdown NuttX:
`nsh> poweroff`

Disable TUN/TAP on Linux host:
`$ sudo ./tools/simhostroute.sh wlan0 off`

Deactivate emulating packet loss on Linux host:
`$ sudo iptables -D INPUT -p tcp --dport 31337 -m statistic --mode random --probability 0.01 -j DROP`