### PR TITLE
sim/netdev,tapdev: implemented emulation of TX done and RX ready interrupts

### DIFF
--- a/arch/sim/src/sim/up_internal.h
+++ b/arch/sim/src/sim/up_internal.h
@@ -247,52 +247,58 @@ int sim_ajoy_initialize(void);
 /* up_tapdev.c **************************************************************/
 
 #if defined(CONFIG_SIM_NETDEV_TAP) && !defined(__CYGWIN__)
-void tapdev_init(void);
+void tapdev_init(void *priv,
+                 void (*tx_done_intr_cb)(void *priv),
+                 void (*rx_ready_intr_cb)(void *priv));
 int tapdev_avail(void);
 unsigned int tapdev_read(unsigned char *buf, unsigned int buflen);
 void tapdev_send(unsigned char *buf, unsigned int buflen);
 void tapdev_ifup(in_addr_t ifaddr);
 void tapdev_ifdown(void);
 
-#  define netdev_init()           tapdev_init()
-#  define netdev_avail()          tapdev_avail()
-#  define netdev_read(buf,buflen) tapdev_read(buf,buflen)
-#  define netdev_send(buf,buflen) tapdev_send(buf,buflen)
-#  define netdev_ifup(ifaddr)     tapdev_ifup(ifaddr)
-#  define netdev_ifdown()         tapdev_ifdown()
+#  define netdev_init(priv,txcb,rxcb) tapdev_init(priv,txcb,rxcb)
+#  define netdev_avail()              tapdev_avail()
+#  define netdev_read(buf,buflen)     tapdev_read(buf,buflen)
+#  define netdev_send(buf,buflen)     tapdev_send(buf,buflen)
+#  define netdev_ifup(ifaddr)         tapdev_ifup(ifaddr)
+#  define netdev_ifdown()             tapdev_ifdown()
 #endif
 
 /* up_wpcap.c ***************************************************************/
 
 #if defined(CONFIG_SIM_NETDEV_TAP) && defined(__CYGWIN__)
-void wpcap_init(void);
+void wpcap_init(void *priv,
+                void (*tx_done_intr_cb)(void *priv),
+                void (*rx_ready_intr_cb)(void *priv));
 unsigned int wpcap_read(unsigned char *buf, unsigned int buflen);
 void wpcap_send(unsigned char *buf, unsigned int buflen);
 
-#  define netdev_init()           wpcap_init()
-#  define netdev_avail()          1
-#  define netdev_read(buf,buflen) wpcap_read(buf,buflen)
-#  define netdev_send(buf,buflen) wpcap_send(buf,buflen)
-#  define netdev_ifup(ifaddr)     {}
-#  define netdev_ifdown()         {}
+#  define netdev_init(priv,txcb,rxcb) wpcap_init(priv,txcb,rxcb)
+#  define netdev_avail()              1
+#  define netdev_read(buf,buflen)     wpcap_read(buf,buflen)
+#  define netdev_send(buf,buflen)     wpcap_send(buf,buflen)
+#  define netdev_ifup(ifaddr)         {}
+#  define netdev_ifdown()             {}
 #endif
 
 /* up_vpnkit.c **************************************************************/
 
 #if defined(CONFIG_SIM_NETDEV_VPNKIT)
-void vpnkit_init(void);
+void vpnkit_init(void *priv,
+                 void (*tx_done_intr_cb)(void *priv),
+                 void (*rx_ready_intr_cb)(void *priv));
 int vpnkit_avail(void);
 unsigned int vpnkit_read(unsigned char *buf, unsigned int buflen);
 void vpnkit_send(unsigned char *buf, unsigned int buflen);
 void vpnkit_ifup(in_addr_t ifaddr);
 void vpnkit_ifdown(void);
 
-#  define netdev_init()           vpnkit_init()
-#  define netdev_avail()          vpnkit_avail()
-#  define netdev_read(buf,buflen) vpnkit_read(buf,buflen)
-#  define netdev_send(buf,buflen) vpnkit_send(buf,buflen)
-#  define netdev_ifup(ifaddr)     vpnkit_ifup(ifaddr)
-#  define netdev_ifdown()         vpnkit_ifdown()
+#  define netdev_init(priv,txcb,rxcb) vpnkit_init(priv,txcb,rxcb)
+#  define netdev_avail()              vpnkit_avail()
+#  define netdev_read(buf,buflen)     vpnkit_read(buf,buflen)
+#  define netdev_send(buf,buflen)     vpnkit_send(buf,buflen)
+#  define netdev_ifup(ifaddr)         vpnkit_ifup(ifaddr)
+#  define netdev_ifdown()             vpnkit_ifdown()
 #endif
 
 /* up_netdriver.c ***********************************************************/

--- a/arch/sim/src/sim/up_vpnkit.c
+++ b/arch/sim/src/sim/up_vpnkit.c
@@ -131,8 +131,12 @@ static void vpnkit_disconnect(void)
  *
  ****************************************************************************/
 
-void vpnkit_init(void)
+void vpnkit_init(void *priv,
+                 void (*tx_done_intr_cb)(void *priv),
+                 void (*rx_ready_intr_cb)(void *priv))
 {
+  /* TODO: support emulation of TX done and RX ready interrupts */
+
   vpnkit_connect();
 }
 

--- a/arch/sim/src/sim/up_wpcap.c
+++ b/arch/sim/src/sim/up_wpcap.c
@@ -256,10 +256,14 @@ static void set_ethaddr(struct in_addr addr)
  * Public Functions
  ****************************************************************************/
 
-void wpcap_init(void)
+void wpcap_init(void *priv,
+                void (*tx_done_intr_cb)(void *priv),
+                void (*rx_ready_intr_cb)(void *priv))
 {
   struct in_addr addr;
   FARPROC dlladdr;
+
+  /* TODO: support emulation of TX done and RX ready interrupts */
 
   addr.s_addr = HTONL(WCAP_IPADDR);
   syslog(LOG_INFO, "wpcap_init: IP address: %s\n", inet_ntoa(addr));

--- a/net/tcp/tcp_sendfile.c
+++ b/net/tcp/tcp_sendfile.c
@@ -307,10 +307,6 @@ static uint16_t sendfile_eventhandler(FAR struct net_driver_s *dev,
 
       dev->d_sndlen = sndlen;
 
-      /* Notify the device driver of the availability of TX data */
-
-      tcp_send_txnotify(psock, conn);
-
       /* Continue waiting */
 
       return flags;
@@ -388,10 +384,6 @@ static uint16_t sendfile_eventhandler(FAR struct net_driver_s *dev,
             }
 
           dev->d_sndlen = sndlen;
-
-          /* Notify the device driver of the availability of TX data */
-
-          tcp_send_txnotify(psock, conn);
 
           /* Update the amount of data sent (but not necessarily ACKed) */
 


### PR DESCRIPTION
## Summary

Implemented emulation of TX done and RX ready interrupts in sim/netdev + sim/tapdev, and removed two tcp_send_txnotify() calls from tcp_sendfile (they are not needed anymore).

As a result, the TX throughput of tcp_send_buffered is increased from 36.7 Kbit/s up to 201 Mbit/s,
the TX throughput of tcp_send_unbuffered is increased from 205 Kbit/s up to 391 Mbit/s on average.
The TX throughput of tcp_sendfile is unchanged (about 453 Mbit/s).
The RX throughput of tcp_recvfrom is increased from 159 Mbit/s (#5313) up to 207 Mbit/s.

send buffered=y sendfile=n (NuttX iperf client): TX throughput = 201 Mbit/s
send buffered=y sendfile=n (NuttX netcat client): TX throughput = 94 Mbit/s

send buffered=y sendfile=y (NuttX iperf client): TX throughput = 197 Mbit/s
send buffered=y sendfile=y (NuttX netcat client): TX throughput = 453 Mbit/s

send buffered=n sendfile=n (NuttX iperf client): TX throughput = 391 Mbit/s
send buffered=n sendfile=n (NuttX netcat client): TX throughput = 205 Kbit/s

send buffered=n sendfile=y (NuttX iperf client): TX throughput = 391 Mbit/s
send buffered=n sendfile=y (NuttX netcat client): TX throughput = 453 Mbit/s

send buffered=y/n sendfile=y/n (NuttX iperf server): RX throughput = 207 Mbit/s

## Impact

arch/sim/netdev
arch/sim/tapdev
TCP sendfile

## Testing

**Testing TCP RX throughput:**

Build NuttX:
```
$ ./tools/configure.sh -l sim:tcpblaster
$ make menuconfig (enable CONFIG_NETUTILS_IPERF, set CONFIG_NETUTILS_IPERFTEST_DEVNAME=eth0)
$ make
```
Enable TUN/TAP on Linux host:
```
$ sudo setcap cap_net_admin+ep ./nuttx
$ sudo ./tools/simhostroute.sh wlan0 on
```

Run NuttX on Linux host:
```
$ ./nuttx
NuttShell (NSH) NuttX-10.2.0
nsh> ifconfig eth0 10.0.1.2
nsh> ifup eth0
ifup eth0...OK
nsh> nsh> iperf -s -p 5471 -i 1
```

Start iperf on Linux host:
```
$ iperf -c 10.0.1.2 -p 5471 -i 1 -t 10
------------------------------------------------------------
Client connecting to 10.0.1.2, TCP port 5471
TCP window size: 45.0 KByte (default)
------------------------------------------------------------
[  3] local 192.168.1.68 port 60658 connected with 10.0.1.2 port 5471
[ ID] Interval       Transfer     Bandwidth
[  3]  0.0- 1.0 sec  24.4 MBytes   204 Mbits/sec
[  3]  1.0- 2.0 sec  24.8 MBytes   208 Mbits/sec
[  3]  2.0- 3.0 sec  24.9 MBytes   209 Mbits/sec
[  3]  3.0- 4.0 sec  24.9 MBytes   209 Mbits/sec
[  3]  4.0- 5.0 sec  24.5 MBytes   206 Mbits/sec
[  3]  5.0- 6.0 sec  24.6 MBytes   207 Mbits/sec
[  3]  6.0- 7.0 sec  25.2 MBytes   212 Mbits/sec
[  3]  7.0- 8.0 sec  23.8 MBytes   199 Mbits/sec
[  3]  8.0- 9.0 sec  24.6 MBytes   207 Mbits/sec
[  3]  9.0-10.0 sec  24.9 MBytes   209 Mbits/sec
[  3]  0.0-10.0 sec   247 MBytes   207 Mbits/sec
```

Shutdown NuttX:
`nsh> poweroff`

Disable TUN/TAP on Linux host:
`$ sudo ./tools/simhostroute.sh wlan0 off`

**Testing TCP TX throughput (NuttX iperf client):**

Start iperf server on Linux host:
`$ iperf -s -p 5471 -i 1 -w 416K`

Start iperf client on NuttX:
`nsh> iperf -c LINUX_HOST_IP_ADDRESS -p 5471 -i 1 -t 10`

**Testing TCP TX throughput (NuttX netcat client):**

Start iperf server on Linux host:
`$ iperf -s -p 31337 -i 1 -w 416K`

Start netcat client on NuttX:
```
nsh> dd if=/dev/zero of=/tmp/test.bin count=100000
nsh> netcat LINUX_HOST_IP_ADDRESS 31337 /tmp/test.bin

```