### PR TITLE
arch/z80: fix garbage collector option to linker for ez80

### DIFF
--- a/arch/z80/src/ez80/Toolchain.defs
+++ b/arch/z80/src/ez80/Toolchain.defs
@@ -64,7 +64,7 @@ ARCHASMINCLUDES = -include chip/clang-compat.asm
 ARCHASMLIST =
 ARCHASMWARNINGS = -W
 
-LDFLAGS += -gc-sections
+LDFLAGS += --gc-sections
 
 # Tool names/paths.
 


### PR DESCRIPTION
## Summary
Fix garbage collector option to linker for ez80

## Impact
ez80 users

## Testing
Pass CI