### PR TITLE
tools/Config.mk: suppress all normal output for cmp 

### DIFF
--- a/tools/Config.mk
+++ b/tools/Config.mk
@@ -508,7 +508,7 @@ endef
 else
 define TESTANDREPLACEFILE
 	if [ -f $2 ]; then \
-		if cmp $1 $2; then \
+		if cmp -s $1 $2; then \
 			rm -f $1; \
 		else \
 			mv $1 $2; \


### PR DESCRIPTION

## Summary

tools/Config.mk: suppress all normal output for cmp 

Fix build break:
`make: *** No rule to make target 'byte', needed by 'differ'.  Stop.`

Regression by:
```
-----------------------------------------------------
|commit 0951f70df6473cbde0fa338586da51edc604fe8f
|
|    Improve dependencies for include/nuttx/version.h
-----------------------------------------------------

```
Signed-off-by: chao.an <anchao@xiaomi.com>

## Impact

incremental compiles

## Testing
Regenerate the commit id before make:

```
git commit --amend -sm "test"
make
```