### PR TITLE
register_driver: fix driver modes accross the code

### DIFF
--- a/arch/arm/src/cxd56xx/cxd56_ge2d.c
+++ b/arch/arm/src/cxd56xx/cxd56_ge2d.c
@@ -67,7 +67,7 @@ static const struct file_operations g_ge2dfops =
   .close = ge2d_close,
   .read  = ge2d_read,
   .write = ge2d_write,
-  .seek  = 0,
+  .seek  = NULL,
   .ioctl = ge2d_ioctl,
 };
 

--- a/arch/arm/src/cxd56xx/cxd56_sph.c
+++ b/arch/arm/src/cxd56xx/cxd56_sph.c
@@ -92,10 +92,10 @@ static int cxd56_sphirqhandler(int irq, FAR void *context, FAR void *arg);
 static const struct file_operations sph_fops =
 {
   .open  = sph_open,
-  .close = 0,
-  .read  = 0,
-  .write = 0,
-  .seek  = 0,
+  .close = NULL,
+  .read  = NULL,
+  .write = NULL,
+  .seek  = NULL,
   .ioctl = sph_ioctl,
 };
 

--- a/arch/arm/src/cxd56xx/cxd56_uart0.c
+++ b/arch/arm/src/cxd56xx/cxd56_uart0.c
@@ -99,7 +99,7 @@ static const struct file_operations g_uart0fops =
   .close = uart0_close,
   .read  = uart0_read,
   .write = uart0_write,
-  .seek  = 0,
+  .seek  = NULL,
   .ioctl = uart0_ioctl,
 };
 

--- a/arch/arm/src/nrf52/nrf52_rng.c
+++ b/arch/arm/src/nrf52/nrf52_rng.c
@@ -253,7 +253,7 @@ static ssize_t nrf52_rng_read(FAR struct file *filep, FAR char *buffer,
 void devrandom_register(void)
 {
   nrf52_rng_initialize();
-  register_driver("/dev/random", FAR & g_rngops, 0444, NULL);
+  register_driver("/dev/random", &g_rngops, 0444, NULL);
 }
 #endif
 
@@ -277,7 +277,7 @@ void devurandom_register(void)
 #ifndef CONFIG_DEV_RANDOM
   nrf52_rng_initialize();
 #endif
-  register_driver("dev/urandom", FAR & g_rngops, 0444, NULL);
+  register_driver("dev/urandom", &g_rngops, 0444, NULL);
 }
 #endif
 

--- a/arch/arm/src/sama5/sam_trng.c
+++ b/arch/arm/src/sama5/sam_trng.c
@@ -86,6 +86,9 @@ static const struct file_operations g_trngops =
   NULL,            /* seek */
   NULL,            /* ioctl */
   NULL             /* poll */
+#ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
+  , NULL           /* unlink */
+#endif
 };
 
 /****************************************************************************
@@ -400,7 +403,7 @@ void devrandom_register(void)
   ret = sam_rng_initialize();
   if (ret >= 0)
     {
-      ret = register_driver("/dev/random", &g_trngops, 0644, NULL);
+      ret = register_driver("/dev/random", &g_trngops, 0444, NULL);
       if (ret < 0)
         {
           ferr("ERROR: Failed to register /dev/random\n");
@@ -433,7 +436,7 @@ void devurandom_register(void)
   if (ret >= 0)
 #endif
     {
-      ret = register_driver("/dev/urandom", &g_trngops, 0644, NULL);
+      ret = register_driver("/dev/urandom", &g_trngops, 0444, NULL);
       if (ret < 0)
         {
           ferr("ERROR: Failed to register /dev/urandom\n");

--- a/arch/arm/src/sama5/sam_tsd.c
+++ b/arch/arm/src/sama5/sam_tsd.c
@@ -238,6 +238,9 @@ static const struct file_operations g_tsdops =
   NULL,            /* seek */
   sam_tsd_ioctl,   /* ioctl */
   sam_tsd_poll     /* poll */
+#ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
+  , NULL           /* unlink */
+#endif
 };
 
 /* The driver state structure is pre-allocated. */

--- a/arch/arm/src/samv7/sam_trng.c
+++ b/arch/arm/src/samv7/sam_trng.c
@@ -86,6 +86,9 @@ static const struct file_operations g_trngops =
   NULL,            /* seek */
   NULL,            /* ioctl */
   NULL             /* poll */
+#ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
+  , NULL           /* unlink */
+#endif
 };
 
 /****************************************************************************
@@ -402,7 +405,7 @@ void devrandom_register(void)
   ret = sam_rng_initialize();
   if (ret >= 0)
     {
-      ret = register_driver("/dev/random", &g_trngops, 0644, NULL);
+      ret = register_driver("/dev/random", &g_trngops, 0444, NULL);
       if (ret < 0)
         {
           ferr("ERROR: Failed to register /dev/random\n");
@@ -435,7 +438,7 @@ void devurandom_register(void)
   if (ret >= 0)
 #endif
     {
-      ret = register_driver("/dev/urandom", &g_trngops, 0644, NULL);
+      ret = register_driver("/dev/urandom", &g_trngops, 0444, NULL);
       if (ret < 0)
         {
           ferr("ERROR: Failed to register /dev/urandom\n");

--- a/arch/arm/src/stm32l4/stm32l4_rng.c
+++ b/arch/arm/src/stm32l4/stm32l4_rng.c
@@ -82,7 +82,7 @@ static const struct file_operations g_rngops =
   NULL,            /* ioctl */
   NULL             /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
-  , 0              /* unlink */
+  , NULL           /* unlink */
 #endif
 };
 

--- a/arch/x86/src/qemu/qemu_keypad.c
+++ b/arch/x86/src/qemu/qemu_keypad.c
@@ -256,9 +256,13 @@ static const struct file_operations g_keypadops =
   keypad_open,                  /* open */
   keypad_close,                 /* close */
   keypad_read,                  /* read */
-  0,                            /* write */
-  0,                            /* seek */
-  0,                            /* ioctl */
+  NULL,                         /* write */
+  NULL,                         /* seek */
+  NULL,                         /* ioctl */
+  NULL                          /* poll */
+#ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
+  , NULL                        /* unlink */
+#endif
 };
 
 /****************************************************************************

--- a/arch/x86/src/qemu/qemu_vga.c
+++ b/arch/x86/src/qemu/qemu_vga.c
@@ -238,7 +238,11 @@ static const struct file_operations g_vgaops =
   vga_read,                  /* read */
   vga_write,                 /* write */
   vga_seek,                  /* seek */
-  0,                         /* ioctl */
+  NULL,                      /* ioctl */
+  NULL                       /* poll */
+#ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
+  , NULL                     /* unlink */
+#endif
 };
 
 /****************************************************************************

--- a/arch/xtensa/src/esp32/esp32_himem.c
+++ b/arch/xtensa/src/esp32/esp32_himem.c
@@ -151,13 +151,16 @@ irqstate_t spinlock_flags;
 
 static const struct file_operations g_himemfops =
 {
-  himem_open,
-  himem_close,
-  himem_read,
-  himem_write,
-  NULL,
-  himem_ioctl,
-  NULL
+  himem_open,       /* open   */
+  himem_close,      /* close */
+  himem_read,       /* read */
+  himem_write,      /* write */
+  NULL,             /* seek */
+  himem_ioctl,      /* ioctl */
+  NULL              /* poll */
+#ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
+  , NULL            /* unlink */
+#endif
 };
 
 /****************************************************************************

--- a/boards/arm/cxd56xx/drivers/sensors/bmi160_scu.c
+++ b/boards/arm/cxd56xx/drivers/sensors/bmi160_scu.c
@@ -294,9 +294,13 @@ static const struct file_operations g_bmi160gyrofops =
   bmi160_open_gyro,    /* open */
   bmi160_close_gyro,   /* close */
   bmi160_read,         /* read */
-  0,                   /* write */
-  0,                   /* seek */
+  NULL,                /* write */
+  NULL,                /* seek */
   bmi160_ioctl,        /* ioctl */
+  NULL                 /* poll */
+#ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
+  , NULL               /* unlink */
+#endif
 };
 
 static const struct file_operations g_bmi160accelfops =
@@ -304,9 +308,13 @@ static const struct file_operations g_bmi160accelfops =
   bmi160_open_accel,    /* open */
   bmi160_close_accel,   /* close */
   bmi160_read,          /* read */
-  0,                    /* write */
-  0,                    /* seek */
+  NULL,                 /* write */
+  NULL,                 /* seek */
   bmi160_ioctl,         /* ioctl */
+  NULL                  /* poll */
+#ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
+  , NULL                /* unlink */
+#endif
 };
 
 /* SCU instructions for pick gyro sensing data. */

--- a/boards/arm/kl/freedom-kl25z/src/kl_tsi.c
+++ b/boards/arm/kl/freedom-kl25z/src/kl_tsi.c
@@ -83,12 +83,16 @@ static uint8_t const g_chsensor[NSENSORS] =
 
 static const struct file_operations tsi_ops =
 {
-  0,           /* open */
-  0,           /* close */
+  NULL,        /* open */
+  NULL,        /* close */
   tsi_read,    /* read */
-  0,           /* write */
-  0,           /* seek */
-  0,           /* ioctl */
+  NULL,        /* write */
+  NULL,        /* seek */
+  NULL,        /* ioctl */
+  NULL         /* poll */
+#ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
+  , NULL       /* unlink */
+#endif
 };
 
 /****************************************************************************

--- a/boards/arm/kl/freedom-kl26z/src/kl_tsi.c
+++ b/boards/arm/kl/freedom-kl26z/src/kl_tsi.c
@@ -84,12 +84,16 @@ static uint8_t const g_chsensor[NSENSORS] =
 
 static const struct file_operations tsi_ops =
 {
-  0,           /* open */
-  0,           /* close */
+  NULL,        /* open */
+  NULL,        /* close */
   tsi_read,    /* read */
-  0,           /* write */
-  0,           /* seek */
-  0,           /* ioctl */
+  NULL,        /* write */
+  NULL,        /* seek */
+  NULL,        /* ioctl */
+  NULL         /* poll */
+#ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
+  , NULL       /* unlink */
+#endif
 };
 
 /****************************************************************************

--- a/boards/arm/sam34/sam4l-xplained/src/sam_slcd.c
+++ b/boards/arm/sam34/sam4l-xplained/src/sam_slcd.c
@@ -300,13 +300,16 @@ static int slcd_poll(FAR struct file *filep, FAR struct pollfd *fds,
 
 static const struct file_operations g_slcdops =
 {
-  0,             /* open */
-  0,             /* close */
+  NULL,          /* open */
+  NULL,          /* close */
   slcd_read,     /* read */
   slcd_write,    /* write */
-  0,             /* seek */
+  NULL,          /* seek */
   slcd_ioctl,    /* ioctl */
   slcd_poll      /* poll */
+#ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
+  , NULL         /* unlink */
+#endif
 };
 
 /* LCD state data */

--- a/boards/arm/stm32/mikroe-stm32f4/src/stm32_touchscreen.c
+++ b/boards/arm/stm32/mikroe-stm32f4/src/stm32_touchscreen.c
@@ -265,10 +265,13 @@ static const struct file_operations tc_fops =
   tc_open,    /* open */
   tc_close,   /* close */
   tc_read,    /* read */
-  0,          /* write */
-  0,          /* seek */
+  NULL,       /* write */
+  NULL,       /* seek */
   tc_ioctl,   /* ioctl */
   tc_poll     /* poll */
+#ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
+  , NULL      /* unlink */
+#endif
 };
 
 /* If only a single touchscreen device is supported, then the driver state

--- a/boards/arm/stm32/stm32f334-disco/src/stm32_powerled.c
+++ b/boards/arm/stm32/stm32f334-disco/src/stm32_powerled.c
@@ -616,8 +616,7 @@ int stm32_powerled_setup(void)
        * All control should be done via POWERLED character driver.
        */
 
-      ret = powerled_register(CONFIG_EXAMPLES_POWERLED_DEVPATH, powerled,
-                              (void *)lower);
+      ret = powerled_register("/dev/powerled0", powerled, (void *)lower);
       if (ret < 0)
         {
           pwrerr("ERROR: powerled_register failed: %d\n", ret);

--- a/boards/arm/stm32/stm32ldiscovery/src/stm32_lcd.c
+++ b/boards/arm/stm32/stm32ldiscovery/src/stm32_lcd.c
@@ -350,13 +350,16 @@ static int slcd_poll(FAR struct file *filep, FAR struct pollfd *fds,
 
 static const struct file_operations g_slcdops =
 {
-  0,             /* open */
-  0,             /* close */
+  NULL,          /* open */
+  NULL,          /* close */
   slcd_read,     /* read */
   slcd_write,    /* write */
-  0,             /* seek */
+  NULL,          /* seek */
   slcd_ioctl,    /* ioctl */
   slcd_poll      /* poll */
+#ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
+  , NULL         /* unlink */
+#endif
 };
 
 /* LCD state data */

--- a/boards/mips/pic32mx/pic32mx7mmb/src/pic32_touchscreen.c
+++ b/boards/mips/pic32mx/pic32mx7mmb/src/pic32_touchscreen.c
@@ -246,10 +246,13 @@ static const struct file_operations tc_fops =
   tc_open,    /* open */
   tc_close,   /* close */
   tc_read,    /* read */
-  0,          /* write */
-  0,          /* seek */
+  NULL,       /* write */
+  NULL,       /* seek */
   tc_ioctl,   /* ioctl */
   tc_poll     /* poll */
+#ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
+  , NULL      /* unlink */
+#endif
 };
 
 /* If only a single touchscreen device is supported, then the driver state

--- a/boards/mips/pic32mx/sure-pic32mx/src/pic32mx_lcd1602.c
+++ b/boards/mips/pic32mx/sure-pic32mx/src/pic32mx_lcd1602.c
@@ -184,13 +184,16 @@ static int lcd_poll(FAR struct file *filep, FAR struct pollfd *fds,
 
 static const struct file_operations g_lcdops =
 {
-  0,             /* open */
-  0,             /* close */
+  NULL,          /* open */
+  NULL,          /* close */
   lcd_read,      /* read */
   lcd_write,     /* write */
-  0,             /* seek */
+  NULL,          /* seek */
   lcd_ioctl,     /* ioctl */
   lcd_poll       /* poll */
+#ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
+  , NULL         /* unlink */
+#endif
 };
 
 /* This is the driver state structure */

--- a/drivers/analog/dac.c
+++ b/drivers/analog/dac.c
@@ -74,8 +74,6 @@
 
 static int     dac_open(FAR struct file *filep);
 static int     dac_close(FAR struct file *filep);
-static ssize_t dac_read(FAR struct file *filep, FAR char *buffer,
-                 size_t buflen);
 static ssize_t dac_write(FAR struct file *filep, FAR const char *buffer,
                  size_t buflen);
 static int     dac_ioctl(FAR struct file *filep, int cmd, unsigned long arg);
@@ -88,7 +86,7 @@ static const struct file_operations dac_fops =
 {
   dac_open,       /* open */
   dac_close,      /* close */
-  dac_read,       /* read */
+  NULL,           /* read */
   dac_write,      /* write */
   NULL,           /* seek */
   dac_ioctl,      /* ioctl */
@@ -222,16 +220,6 @@ static int dac_close(FAR struct file *filep)
     }
 
   return ret;
-}
-
-/****************************************************************************
- * Name: dac_read
- ****************************************************************************/
-
-static ssize_t dac_read(FAR struct file *filep, FAR char *buffer,
-                        size_t buflen)
-{
-  return 0;
 }
 
 /****************************************************************************

--- a/drivers/analog/opamp.c
+++ b/drivers/analog/opamp.c
@@ -214,7 +214,7 @@ int opamp_register(FAR const char *path, FAR struct opamp_dev_s *dev)
 
   /* Register the OPAMP character driver */
 
-  ret =  register_driver(path, &opamp_fops, 0444, dev);
+  ret = register_driver(path, &opamp_fops, 0444, dev);
   if (ret < 0)
     {
       nxsem_destroy(&dev->ad_closesem);

--- a/drivers/leds/pca9635pw.c
+++ b/drivers/leds/pca9635pw.c
@@ -284,29 +284,30 @@ static int pca9635pw_ioctl(FAR struct file *filep, int cmd,
        * Arg: pca9635pw_brightness_s pointer.
        */
 
-    case PWMIOC_SETLED_BRIGHTNESS:
-      {
-        /* Retrieve the information handed over as argument for this ioctl */
+      case PWMIOC_SETLED_BRIGHTNESS:
+        {
+          /* Retrieve the information handed over as argument for this ioctl
+           */
 
-        FAR const struct pca9635pw_brightness_s *ptr =
-          (FAR const struct pca9635pw_brightness_s *)((uintptr_t)arg);
+          FAR const struct pca9635pw_brightness_s *ptr =
+            (FAR const struct pca9635pw_brightness_s *)((uintptr_t)arg);
 
-        DEBUGASSERT(ptr != NULL);
+          DEBUGASSERT(ptr != NULL);
 
-        /* Set the brighntess of the led */
+          /* Set the brightness of the led */
 
-        ret = pca9635pw_i2c_write_byte(priv, ptr->led, ptr->brightness);
-      }
-      break;
+          ret = pca9635pw_i2c_write_byte(priv, ptr->led, ptr->brightness);
+        }
+        break;
 
-      /* The used ioctl command was invalid */
+        /* The used ioctl command was invalid */
 
-    default:
-      {
-        lcderr("ERROR: Unrecognized cmd: %d\n", cmd);
-        ret = -ENOTTY;
-      }
-      break;
+      default:
+        {
+          lcderr("ERROR: Unrecognized cmd: %d\n", cmd);
+          ret = -ENOTTY;
+        }
+        break;
     }
 
   return ret;
@@ -357,7 +358,7 @@ int pca9635pw_register(FAR const char *devpath, FAR struct i2c_master_s *i2c,
 
   /* Register the character driver */
 
-  int const ret = register_driver(devpath, &g_pca9635pw_fileops, 0666, priv);
+  int const ret = register_driver(devpath, &g_pca9635pw_fileops, 0222, priv);
   if (ret != OK)
     {
       lcderr("ERROR: Failed to register driver: %d\n", ret);

--- a/drivers/motor/foc/foc_dev.c
+++ b/drivers/motor/foc/foc_dev.c
@@ -845,7 +845,7 @@ int foc_register(FAR const char *path, FAR struct foc_dev_s *dev)
 
   /* Register the FOC character driver */
 
-  ret = register_driver(path, &g_foc_fops, 0444, dev);
+  ret = register_driver(path, &g_foc_fops, 0666, dev);
   if (ret < 0)
     {
       nxsem_destroy(&dev->closesem);

--- a/drivers/motor/motor.c
+++ b/drivers/motor/motor.c
@@ -589,7 +589,7 @@ int motor_register(FAR const char *path,
 
   /* Register the motor character driver */
 
-  ret = register_driver(path, &motor_fops, 0444, upper);
+  ret = register_driver(path, &motor_fops, 0666, upper);
   if (ret < 0)
     {
       nxsem_destroy(&upper->closesem);

--- a/drivers/power/battery_charger.c
+++ b/drivers/power/battery_charger.c
@@ -501,7 +501,7 @@ int battery_charger_register(FAR const char *devpath,
 
   /* Register the character driver */
 
-  ret = register_driver(devpath, &g_batteryops, 0555, dev);
+  ret = register_driver(devpath, &g_batteryops, 0666, dev);
   if (ret < 0)
     {
       _err("ERROR: Failed to register driver: %d\n", ret);

--- a/drivers/power/battery_gauge.c
+++ b/drivers/power/battery_gauge.c
@@ -479,7 +479,7 @@ int battery_gauge_register(FAR const char *devpath,
 
   /* Register the character driver */
 
-  ret = register_driver(devpath, &g_batteryops, 0555, dev);
+  ret = register_driver(devpath, &g_batteryops, 0666, dev);
   if (ret < 0)
     {
       _err("ERROR: Failed to register driver: %d\n", ret);

--- a/drivers/power/powerled.c
+++ b/drivers/power/powerled.c
@@ -416,7 +416,7 @@ int powerled_register(FAR const char *path, FAR struct powerled_dev_s *dev,
 
   /* Register the POWERLED character driver */
 
-  ret = register_driver(path, &powerled_fops, 0444, dev);
+  ret = register_driver(path, &powerled_fops, 0666, dev);
   if (ret < 0)
     {
       nxsem_destroy(&dev->closesem);

--- a/drivers/power/smps.c
+++ b/drivers/power/smps.c
@@ -513,7 +513,7 @@ int smps_register(FAR const char *path, FAR struct smps_dev_s *dev,
 
   /* Register the SMPS character driver */
 
-  ret = register_driver(path, &smps_fops, 0444, dev);
+  ret = register_driver(path, &smps_fops, 0666, dev);
   if (ret < 0)
     {
       nxsem_destroy(&dev->closesem);

--- a/drivers/rptun/rptun.c
+++ b/drivers/rptun/rptun.c
@@ -947,7 +947,7 @@ int rptun_initialize(FAR struct rptun_dev_s *dev)
   nxsem_set_protocol(&priv->sem, SEM_PRIO_NONE);
 
   snprintf(name, 32, "/dev/rptun/%s", RPTUN_GET_CPUNAME(dev));
-  ret = register_driver(name, &g_rptun_devops, 0666, priv);
+  ret = register_driver(name, &g_rptun_devops, 0222, priv);
   if (ret < 0)
     {
       goto err_driver;

--- a/drivers/sensors/adxl345_base.c
+++ b/drivers/sensors/adxl345_base.c
@@ -211,7 +211,7 @@ int adxl345_register(ADXL345_HANDLE handle, int minor)
   /* Register the character driver */
 
   snprintf(devname, DEV_NAMELEN, DEV_FORMAT, minor);
-  ret = register_driver(devname, &g_adxl345fops, 0666, priv);
+  ret = register_driver(devname, &g_adxl345fops, 0444, priv);
   if (ret < 0)
     {
       snerr("ERROR: Failed to register driver %s: %d\n", devname, ret);

--- a/drivers/sensors/fxos8700cq.c
+++ b/drivers/sensors/fxos8700cq.c
@@ -441,7 +441,7 @@ int fxos8700cq_register(FAR const char *devpath,
       return ret;
     }
 
-  ret = register_driver(devpath, &g_fxos8700cqfops, 0666, priv);
+  ret = register_driver(devpath, &g_fxos8700cqfops, 0444, priv);
   if (ret < 0)
     {
       snerr("Failed to register driver: %d\n", ret);

--- a/drivers/sensors/xen1210.c
+++ b/drivers/sensors/xen1210.c
@@ -370,7 +370,7 @@ int xen1210_register(XEN1210_HANDLE handle, int minor)
   /* Register the character driver */
 
   snprintf(devname, DEV_NAMELEN, DEV_FORMAT, minor);
-  ret = register_driver(devname, &g_xen1210fops, 0666, priv);
+  ret = register_driver(devname, &g_xen1210fops, 0444, priv);
   if (ret < 0)
     {
       snerr("ERROR: Failed to register driver %s: %d\n", devname, ret);

--- a/include/nuttx/fs/fs.h
+++ b/include/nuttx/fs/fs.h
@@ -226,16 +226,16 @@ struct geometry
 
 struct partition_info_s
 {
-  size_t          numsectors;   /* Number of sectors in the partition */
-  size_t          sectorsize;   /* Size in bytes of a single sector */
-  off_t           startsector;  /* Offset to the first section/block of the
-                                 * managed sub-region */
+  size_t    numsectors;   /* Number of sectors in the partition */
+  size_t    sectorsize;   /* Size in bytes of a single sector */
+  off_t     startsector;  /* Offset to the first section/block of the
+                           * managed sub-region */
 
   /* NULL-terminated string representing the name of the parent node of the
    * partition.
    */
 
-  char            parent[NAME_MAX + 1];
+  char      parent[NAME_MAX + 1];
 };
 
 /* This structure is provided by block devices when they register with the

--- a/sched/semaphore/sem_holder.c
+++ b/sched/semaphore/sem_holder.c
@@ -855,8 +855,8 @@ void nxsem_add_holder_tcb(FAR struct tcb_s *htcb, FAR sem_t *sem)
 {
   FAR struct semholder_s *pholder;
 
-  /* If priority inheritance is disabled for this thread or it is IDLE hread,
-   * then do not add the holder.
+  /* If priority inheritance is disabled for this thread or it is IDLE
+   * thread, then do not add the holder.
    * If there are never holders of the semaphore, the priority
    * inheritance is effectively disabled.
    */


### PR DESCRIPTION
## Summary
State of problem:
- Some drivers that do not support write operations (does not have write handler or ioctl do not perform any write actions) are registered with write permissions
- Some drivers that do not support read operation (does not have read handler or ioctl do not perform any read actions) are registered with read permissions
- Some drivers are registered with execute permissions

Solution:
- Iterate code where register_driver() is used and change 'mode' parameter to reflect the actual read/write operations executed by a driver
- Remove execute permissions from 'mode' parameter

## Impact
All over the project and apps

## Testing
Pass CI