### PR TITLE
tools/nxstyle: fixed "Mixed case identifier found" errors related to sim/wpcap

### DIFF
--- a/tools/nxstyle.c
+++ b/tools/nxstyle.c
@@ -249,6 +249,22 @@ static const char *g_white_list[] =
   "_Erom",
 
   /* Ref:
+   * arch/sim/src/sim/up_wpcap.c
+   */
+
+  "Address",
+  "Description",
+  "FirstUnicastAddress",
+  "GetAdaptersAddresses",
+  "GetProcAddress",
+  "LoadLibrary",
+  "lpSockaddr",
+  "Next",
+  "PhysicalAddressLength",
+  "PhysicalAddress",
+  "WideCharToMultiByte",
+
+  /* Ref:
    * fs/nfs/rpc.h
    * fs/nfs/nfs_proto.h
    * fs/nfs/nfs_mount.h


### PR DESCRIPTION
## Summary

arch/sim/src/sim/up_wpcap.c fails nxstyle check ("Mixed case identifier found" errors). It blocks PR #5343.

## Impact

tools/nxstyle

## Testing