### PR TITLE
symtab: just retun NULL for NULL symtab

### DIFF
--- a/libs/libc/symtab/symtab_findbyname.c
+++ b/libs/libc/symtab/symtab_findbyname.c
@@ -60,6 +60,12 @@ symtab_findbyname(FAR const struct symtab_s *symtab,
   int cmp;
 #endif
 
+  if (symtab == NULL)
+    {
+      DEBUGASSERT(nsyms == 0);
+      return NULL;
+    }
+
 #ifdef CONFIG_SYMTAB_DECORATED
   if (name[0] == '_')
     {
@@ -67,7 +73,7 @@ symtab_findbyname(FAR const struct symtab_s *symtab,
     }
 #endif
 
-  DEBUGASSERT(symtab != NULL && name != NULL);
+  DEBUGASSERT(name != NULL);
 
 #ifdef CONFIG_SYMTAB_ORDEREDBYNAME
   while (low < high)

--- a/libs/libc/symtab/symtab_findbyvalue.c
+++ b/libs/libc/symtab/symtab_findbyvalue.c
@@ -62,7 +62,11 @@ symtab_findbyvalue(FAR const struct symtab_s *symtab,
   int low  = 0;
 #endif
 
-  DEBUGASSERT(symtab != NULL);
+  if (symtab == NULL)
+    {
+      DEBUGASSERT(nsyms == 0);
+      return NULL;
+    }
 
 #ifdef CONFIG_SYMTAB_ORDEREDBYVALUE
 


### PR DESCRIPTION
## Summary
make symtab_findbyname and symtab_findbyvalue return an error when symtab is not available.
so that the caller of the api like posix_spawn can handle the error.

## Impact

## Testing
tested with a private app on sim/Linux.