### PR TITLE
RISC-V MMU: Add missing implementation for PTE getter

### DIFF
--- a/arch/risc-v/src/common/riscv_mmu.c
+++ b/arch/risc-v/src/common/riscv_mmu.c
@@ -100,6 +100,19 @@ void mmu_ln_setentry(uint32_t ptlevel, uintptr_t lnvaddr, uintptr_t paddr,
   mmu_invalidate_tlb_by_vaddr(vaddr);
 }
 
+uintptr_t mmu_ln_getentry(uint32_t ptlevel, uintptr_t lnvaddr,
+                          uintptr_t vaddr)
+{
+  uintptr_t *lntable = (uintptr_t *)lnvaddr;
+  uint32_t  index;
+
+  DEBUGASSERT(ptlevel > 0 && ptlevel <= RV_MMU_PT_LEVELS);
+
+  index = (vaddr >> RV_MMU_VADDR_SHIFT(ptlevel)) & RV_MMU_VPN_MASK;
+
+  return lntable[index];
+}
+
 void mmu_ln_map_region(uint32_t ptlevel, uintptr_t lnvaddr, uintptr_t paddr,
                        uintptr_t vaddr, size_t size, uint32_t mmuflags)
 {


### PR DESCRIPTION
For some reason this implementation was (mistakenly) left out from the patch
that was supposed to have it.
