### PR TITLE
typo: change evernt to event in comments

### DIFF
--- a/arch/arm/src/sam34/sam_hsmci.c
+++ b/arch/arm/src/sam34/sam_hsmci.c
@@ -1964,7 +1964,7 @@ static int sam_waitresponse(FAR struct sdio_dev_s *dev, uint32_t cmd)
 
   for (; ; )
     {
-      /* Did a Command-Response sequence termination evernt occur? */
+      /* Did a Command-Response sequence termination event occur? */
 
       sr      = getreg32(SAM_HSMCI_SR);
       pending = sr & priv->cmdrmask;

--- a/arch/arm/src/sama5/sam_hsmci.c
+++ b/arch/arm/src/sama5/sam_hsmci.c
@@ -2382,7 +2382,7 @@ static int sam_waitresponse(FAR struct sdio_dev_s *dev, uint32_t cmd)
 
   for (; ; )
     {
-      /* Did a Command-Response sequence termination evernt occur? */
+      /* Did a Command-Response sequence termination event occur? */
 
       sr      = sam_getreg(priv, SAM_HSMCI_SR_OFFSET);
       pending = sr & priv->cmdrmask;

--- a/arch/arm/src/samv7/sam_hsmci.c
+++ b/arch/arm/src/samv7/sam_hsmci.c
@@ -2415,7 +2415,7 @@ static int sam_waitresponse(FAR struct sdio_dev_s *dev, uint32_t cmd)
 
   for (; ; )
     {
-      /* Did a Command-Response sequence termination evernt occur? */
+      /* Did a Command-Response sequence termination event occur? */
 
       sr      = sam_getreg(priv, SAM_HSMCI_SR_OFFSET);
       pending = sr & priv->cmdrmask;


### PR DESCRIPTION
## Summary
Typo detected and fixed

## Impact
None

## Testing
Pass CI