### PR TITLE
Add support for a ROMFS image for MPFS

### DIFF
--- a/arch/risc-v/src/mpfs/Kconfig
+++ b/arch/risc-v/src/mpfs/Kconfig
@@ -137,6 +137,14 @@ config MPFS_EMMCSD_MUX_GPIO
 	---help---
 		External mux GPIO between e.MMC and SD-card
 
+config MPFS_ROMFS_MOUNT
+	bool "Mount the ROMFS file system"
+	depends on FS_ROMFS
+	default n
+	---help---
+		Mount a ROMFS image to /bin mount point. The image must be placed into
+		<arch/board/boot_romfsimg.h>
+
 menu "MPFS Peripheral Support"
 
 # These "hidden" settings determine whether a peripheral option is available

--- a/boards/risc-v/mpfs/common/src/mpfs_boot.c
+++ b/boards/risc-v/mpfs/common/src/mpfs_boot.c
@@ -29,6 +29,8 @@
 #include <nuttx/board.h>
 #include <arch/board/board.h>
 
+#include "board_config.h"
+
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
@@ -56,3 +58,25 @@ void mpfs_boardinitialize(void)
 {
   board_autoled_initialize();
 }
+
+/****************************************************************************
+ * Name: board_late_initialize
+ *
+ * Description:
+ *   If CONFIG_BOARD_LATE_INITIALIZE is selected, then an additional
+ *   initialization call will be performed in the boot-up sequence to a
+ *   function called board_late_initialize(). board_late_initialize() will be
+ *   called immediately after up_initialize() is called and just before the
+ *   initial application is started.  This additional initialization phase
+ *   may be used, for example, to initialize board-specific device drivers.
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_BOARD_LATE_INITIALIZE
+void board_late_initialize(void)
+{
+  /* Perform board initialization */
+
+  mpfs_bringup();
+}
+#endif /* CONFIG_BOARD_LATE_INITIALIZE */

--- a/boards/risc-v/mpfs/icicle/src/mpfs_bringup.c
+++ b/boards/risc-v/mpfs/icicle/src/mpfs_bringup.c
@@ -33,9 +33,22 @@
 #include <nuttx/board.h>
 #include <nuttx/drivers/ramdisk.h>
 
+#ifdef CONFIG_MPFS_ROMFS_MOUNT
+#  include <arch/board/boot_romfsimg.h>
+#endif
+
 #include "board_config.h"
 #include "mpfs_corepwm.h"
 #include "mpfs.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#ifdef CONFIG_MPFS_ROMFS_MOUNT
+#  define SECTORSIZE    512
+#  define NSECTORS(b)   (((b) + SECTORSIZE - 1) / SECTORSIZE)
+#endif /* CONFIG_MPFS_ROMFS_MOUNT */
 
 /****************************************************************************
  * Public Functions
@@ -69,6 +82,26 @@ int mpfs_bringup(void)
       serr("ERROR: Failed to mount procfs at %s: %d\n", "/proc", ret);
     }
 #endif
+
+#ifdef CONFIG_MPFS_ROMFS_MOUNT
+  /* Create a ROM disk for the /bin filesystem */
+
+  ret = romdisk_register(0, romfs_img, NSECTORS(romfs_img_len), SECTORSIZE);
+  if (ret < 0)
+    {
+      serr("ERROR: Failed to register romdisk: %d\n", -ret);
+    }
+  else
+    {
+      /* Mount the file system */
+
+      ret = mount("/dev/ram0", "/bin", "romfs", MS_RDONLY, NULL);
+      if (ret < 0)
+        {
+          serr("ERROR: Failed to mount romfs: %d\n", -ret);
+        }
+    }
+#endif /* CONFIG_MPFS_ROMFS_MOUNT */
 
 #if defined(CONFIG_MPFS_SPI0) || defined(CONFIG_MPFS_SPI1)
   /* Configure SPI peripheral interfaces */


### PR DESCRIPTION
The image must be placed into e.g.:
boards/risc-v/mpfs/icicle/include/boot_romfsimg.h

The image is mounted by mpfs_bringup, which is run by the application
itself, or by board_late_initialize() in the case when
CONFIG_BOARD_LATE_INITIALIZE is defined, e.g. with CONFIG_BUILD_KERNEL