### PR TITLE
Revert "sim: add CONFIG_SIM_STACKSIZE_ADJUSTMENT to reduce variability"

### DIFF
--- a/arch/sim/Kconfig
+++ b/arch/sim/Kconfig
@@ -135,13 +135,6 @@ config SIM_WALLTIME_SIGNAL
 
 endchoice
 
-config SIM_STACKSIZE_ADJUSTMENT
-	int "The adjustment of stack size for sim"
-	default 65536
-	---help---
-		The adjustment of stack size for sim. When the task is created,
-		the stack size is increased by this amount.
-
 config SIM_HOSTFS
 	bool "Simulated HostFS"
 	depends on FS_HOSTFS

--- a/arch/sim/src/sim/up_createstack.c
+++ b/arch/sim/src/sim/up_createstack.c
@@ -92,8 +92,6 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
   FAR uint8_t *stack_alloc_ptr;
   int ret = ERROR;
 
-  stack_size += CONFIG_SIM_STACKSIZE_ADJUSTMENT;
-
 #ifdef CONFIG_TLS_ALIGNED
   /* The allocated stack size must not exceed the maximum possible for the
    * TLS feature.

--- a/arch/sim/src/sim/up_initialstate.c
+++ b/arch/sim/src/sim/up_initialstate.c
@@ -57,11 +57,9 @@ void up_initial_state(struct tcb_s *tcb)
   if (tcb->pid == 0)
     {
       tcb->stack_alloc_ptr = (void *)(up_getsp() -
-                                      CONFIG_IDLETHREAD_STACKSIZE -
-                                      CONFIG_SIM_STACKSIZE_ADJUSTMENT);
+                                      CONFIG_IDLETHREAD_STACKSIZE);
       tcb->stack_base_ptr  = tcb->stack_alloc_ptr;
-      tcb->adj_stack_size  = CONFIG_IDLETHREAD_STACKSIZE +
-                             CONFIG_SIM_STACKSIZE_ADJUSTMENT;
+      tcb->adj_stack_size  = CONFIG_IDLETHREAD_STACKSIZE;
 
 #ifdef CONFIG_STACK_COLORATION
       /* If stack debug is enabled, then fill the stack with a

--- a/sched/Kconfig
+++ b/sched/Kconfig
@@ -1828,12 +1828,14 @@ menu "Stack and heap information"
 
 config DEFAULT_TASK_STACKSIZE
 	int "The default stack size for tasks"
+	default 65536 if ARCH_SIM
 	default 2048
 	---help---
 		The default stack size for tasks.
 
 config IDLETHREAD_STACKSIZE
 	int "Idle thread stack size"
+	default DEFAULT_TASK_STACKSIZE if ARCH_SIM
 	default 1024
 	---help---
 		The size of the initial stack used by the IDLE thread.  The IDLE thread


### PR DESCRIPTION
## Summary

This reverts commit 6b5a7a73ba76671c81dc70485befb5ed5e818fe0.

Because:

* it broke existing configurations.

* it makes stack-related api very confusing.
  eg. the "stack_size" argument of nxtask_init has different meanings
  depending on "stack".
  eg. pthread_attr_setstack and pthread_attr_setstacksize

* stacksize is inherently arch-dependent.
  the goal to share the same stack size configurations among archs
  is questionable.

## Impact
sim

## Testing

