### PR TITLE
binfmt/libelf: Implement sh_addralign handling

### DIFF
--- a/binfmt/elf.c
+++ b/binfmt/elf.c
@@ -112,6 +112,8 @@ static void elf_dumploadinfo(FAR struct elf_loadinfo_s *loadinfo)
   binfo("  dataalloc:    %08lx\n", (long)loadinfo->dataalloc);
   binfo("  textsize:     %ld\n",   (long)loadinfo->textsize);
   binfo("  datasize:     %ld\n",   (long)loadinfo->datasize);
+  binfo("  textalign:    %zu\n",   loadinfo->textalign);
+  binfo("  dataalign:    %zu\n",   loadinfo->dataalign);
   binfo("  filelen:      %ld\n",   (long)loadinfo->filelen);
 #ifdef CONFIG_BINFMT_CONSTRUCTORS
   binfo("  ctoralloc:    %08lx\n", (long)loadinfo->ctoralloc);

--- a/include/nuttx/binfmt/elf.h
+++ b/include/nuttx/binfmt/elf.h
@@ -95,10 +95,9 @@ struct elf_loadinfo_s
   uintptr_t         textalloc;   /* .text memory allocated when ELF file was loaded */
   uintptr_t         dataalloc;   /* .bss/.data memory allocated when ELF file was loaded */
   size_t            textsize;    /* Size of the ELF .text memory allocation */
-#ifdef CONFIG_ARCH_USE_TEXT_HEAP
-  size_t            textalign;   /* Necessary alignment of .text */
-#endif
   size_t            datasize;    /* Size of the ELF .bss/.data memory allocation */
+  size_t            textalign;   /* Necessary alignment of .text */
+  size_t            dataalign;   /* Necessary alignment of .bss/.data */
   off_t             filelen;     /* Length of the entire ELF file */
 
   Elf_Ehdr          ehdr;        /* Buffered ELF file header */


### PR DESCRIPTION
## Summary

Basically, mirror the following two commits from modlib.
It's shame we have two copies of elf loaders.

```
commit 51490bad551737ce8210c196ce962fd28121a97d
Author: YAMAMOTO Takashi <yamamoto@midokura.com>
Date:   Wed Apr 14 17:07:39 2021 +0900

    modlib: Implement sh_addralign handling

    I've seen a module with 16 bytes .rodata alignment for xmm operations.
    It was getting SEGV on sim/Linux because of the alignment issue.
    The same module binary seems working fine after applying this patch.

    Also, tested on sim/macOS and esp32 on qemu,
    using a module with an artificially large alignment. (64 bytes)
```

```
commit 418e11b8b38855eacf55deea8d658c5760b51488
Author: YAMAMOTO Takashi <yamamoto@midokura.com>
Date:   Thu Apr 15 11:33:48 2021 +0900

    modlib: Always use separate allocation for text and data

    Pros:

    * Reduce code differences
    * Smaller allocations for !CONFIG_ARCH_USE_MODULE_TEXT

    Cons:

    * Likely to use more memory for !CONFIG_ARCH_USE_MODULE_TEXT in total

    Tested with:

    * sim:module on macOS
    * esp32-devkit:nsh + CONFIG_MODULE on qemu
    * lm3s6965-ek:qemu-protected + CONFIG_EXAMPLES_SOTEST on qemu
```

## Impact
binfmt elf

## Testing
this fixed the immediate crash of my app on sim/linux.