### PR TITLE
idle: remove heap & stack check in idle thread

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -1873,20 +1873,6 @@ config STACK_COLORATION
 
 		Only supported by a few architectures.
 
-config STACK_USAGE_SAFE_PERCENT
-	int "Stack usage safe percent"
-	default 0
-	range 0 100
-	depends on STACK_COLORATION
-	---help---
-		Stack usage percent = up_check_tcbstack() * 100 / tcb->adj_stack_size,
-		this should be lower than STACK_USAGE_SAFE_PERCENT.
-
-		Idle thread will periodically check stack usage when this macro
-		value > 0.
-
-		N.B. This feature should not be used in production code.
-
 config STACK_CANARIES
 	bool "Compiler stack canaries"
 	depends on ARCH_HAVE_STACKCHECK

--- a/mm/mm_heap/mm_sem.c
+++ b/mm/mm_heap/mm_sem.c
@@ -80,13 +80,9 @@ bool mm_takesemaphore(FAR struct mm_heap_s *heap)
 
   if (up_interrupt_context())
     {
-#ifdef CONFIG_DEBUG_MM
-      return _SEM_TRYWAIT(&heap->mm_semaphore) >= 0;
-#else
       /* Can't take semaphore in the interrupt handler */
 
       return false;
-#endif
     }
   else
 #endif

--- a/sched/init/nx_start.c
+++ b/sched/init/nx_start.c
@@ -787,39 +787,6 @@ void nx_start(void)
   sinfo("CPU0: Beginning Idle Loop\n");
   for (; ; )
     {
-#if defined(CONFIG_STACK_COLORATION) && CONFIG_STACK_USAGE_SAFE_PERCENT > 0
-
-      /* Check stack in idle thread */
-
-      for (i = 0; i < g_npidhash; i++)
-        {
-          FAR struct tcb_s *tcb;
-          irqstate_t flags;
-
-          flags = enter_critical_section();
-
-          tcb = g_pidhash[i];
-          if (tcb && (up_check_tcbstack(tcb) * 100 / tcb->adj_stack_size
-                      > CONFIG_STACK_USAGE_SAFE_PERCENT))
-            {
-#if CONFIG_TASK_NAME_SIZE > 0
-              _alert("Stack check failed, pid %d, name %s\n",
-                     tcb->pid, tcb->name);
-#else
-              _alert("Stack check failed, pid %d\n", tcb->pid);
-#endif
-              PANIC();
-            }
-
-          leave_critical_section(flags);
-        }
-
-#endif
-
-      /* Check heap in idle thread */
-
-      kmm_checkcorruption();
-
       /* Perform any processor-specific idle state operations */
 
       up_idle();

--- a/sched/semaphore/sem_trywait.c
+++ b/sched/semaphore/sem_trywait.c
@@ -69,11 +69,9 @@ int nxsem_trywait(FAR sem_t *sem)
   irqstate_t flags;
   int ret;
 
-#ifndef CONFIG_DEBUG_MM
   /* This API should not be called from interrupt handlers */
 
   DEBUGASSERT(sem != NULL && up_interrupt_context() == false);
-#endif
 
   if (sem != NULL)
     {


### PR DESCRIPTION
## Summary
idle: remove heap & stack check in idle thread. See the discussion here: https://github.com/apache/incubator-nuttx/pull/5266

## Impact
idle
heap & stack check

## Testing
VELA

