### PR TITLE
stm32:Add OTG ID GPIO disable

### DIFF
--- a/arch/arm/src/stm32/Kconfig
+++ b/arch/arm/src/stm32/Kconfig
@@ -10828,6 +10828,19 @@ endmenu
 
 comment "USB Device Configuration"
 
+menu "OTG Configuration"
+	depends on STM32_OTGFS
+
+config OTG_ID_GPIO_DISABLE
+	bool "Disable the use of GPIO_OTG_ID pin."
+	default n
+	---help---
+		Disables/Enables the use of GPIO_OTG_ID pin. This allows non OTG use
+		cases to reuse this GPIO pin and ensure it is not set incorrectlty
+		during OS boot.
+
+endmenu
+
 config STM32_USB_ITRMP
 	bool "Re-map USB interrupt"
 	default n if !STM32_CAN1

--- a/arch/arm/src/stm32/stm32_otgfsdev.c
+++ b/arch/arm/src/stm32/stm32_otgfsdev.c
@@ -5623,7 +5623,11 @@ void arm_usbinitialize(void)
 
   stm32_configgpio(GPIO_OTGFS_DM);
   stm32_configgpio(GPIO_OTGFS_DP);
-  stm32_configgpio(GPIO_OTGFS_ID);    /* Only needed for OTG */
+
+  /* Only needed for OTG */
+#ifndef CONFIG_OTG_ID_GPIO_DISABLE
+  stm32_configgpio(GPIO_OTGFS_ID);
+#endif
 
   /* SOF output pin configuration is configurable. */
 


### PR DESCRIPTION
## Summary

Allows one to Disables/Enabled the use of GPIO_OTG_ID pin. This allows non OTG use
cases to reuse this GPIO pin and ensure it is not set incorrectly during OS boot.

## Impact

none - behind a Knob

## Testing

PX4 Matek GPS (STM32F405RG)