### PR TITLE
arch/Toolchain.defs: Don't expand EXTRA_LIBS immediately

### DIFF
--- a/arch/arm/src/arm/Toolchain.defs
+++ b/arch/arm/src/arm/Toolchain.defs
@@ -103,7 +103,7 @@ OBJDUMP = $(CROSSDEV)objdump
 
 # Add the builtin library
 
-EXTRA_LIBS := ${shell $(CC) $(ARCHCPUFLAGS) --print-file-name=libgcc.a}
+EXTRA_LIBS = ${shell $(CC) $(ARCHCPUFLAGS) --print-file-name=libgcc.a}
 
 ifneq ($(CONFIG_LIBM),y)
   EXTRA_LIBS += ${wildcard ${shell $(CC) $(ARCHCPUFLAGS) --print-file-name=libm.a}}

--- a/arch/arm/src/armv6-m/Toolchain.defs
+++ b/arch/arm/src/armv6-m/Toolchain.defs
@@ -95,7 +95,7 @@ OBJDUMP = $(CROSSDEV)objdump
 
 # Add the builtin library
 
-EXTRA_LIBS := ${shell $(CC) $(ARCHCPUFLAGS) --print-file-name=libgcc.a}
+EXTRA_LIBS = ${shell $(CC) $(ARCHCPUFLAGS) --print-file-name=libgcc.a}
 
 ifneq ($(CONFIG_LIBM),y)
   EXTRA_LIBS += ${wildcard ${shell $(CC) $(ARCHCPUFLAGS) --print-file-name=libm.a}}

--- a/arch/arm/src/armv7-a/Toolchain.defs
+++ b/arch/arm/src/armv7-a/Toolchain.defs
@@ -121,7 +121,7 @@ OBJDUMP = $(CROSSDEV)objdump
 
 # Add the builtin library
 
-EXTRA_LIBS := ${shell $(CC) $(ARCHCPUFLAGS) --print-file-name=libgcc.a}
+EXTRA_LIBS = ${shell $(CC) $(ARCHCPUFLAGS) --print-file-name=libgcc.a}
 
 ifneq ($(CONFIG_LIBM),y)
   EXTRA_LIBS += ${wildcard ${shell $(CC) $(ARCHCPUFLAGS) --print-file-name=libm.a}}

--- a/arch/arm/src/armv7-m/Toolchain.defs
+++ b/arch/arm/src/armv7-m/Toolchain.defs
@@ -154,7 +154,7 @@ OBJDUMP = $(CROSSDEV)objdump
 
 # Add the builtin library
 
-EXTRA_LIBS := ${shell $(CC) $(ARCHCPUFLAGS) --print-file-name=libgcc.a}
+EXTRA_LIBS = ${shell $(CC) $(ARCHCPUFLAGS) --print-file-name=libgcc.a}
 
 ifneq ($(CONFIG_LIBM),y)
   EXTRA_LIBS += ${wildcard ${shell $(CC) $(ARCHCPUFLAGS) --print-file-name=libm.a}}

--- a/arch/arm/src/armv7-r/Toolchain.defs
+++ b/arch/arm/src/armv7-r/Toolchain.defs
@@ -103,7 +103,7 @@ OBJDUMP = $(CROSSDEV)objdump
 
 # Add the builtin library
 
-EXTRA_LIBS := ${shell $(CC) $(ARCHCPUFLAGS) --print-file-name=libgcc.a}
+EXTRA_LIBS = ${shell $(CC) $(ARCHCPUFLAGS) --print-file-name=libgcc.a}
 
 ifneq ($(CONFIG_LIBM),y)
   EXTRA_LIBS += ${wildcard ${shell $(CC) $(ARCHCPUFLAGS) --print-file-name=libm.a}}

--- a/arch/arm/src/armv8-m/Toolchain.defs
+++ b/arch/arm/src/armv8-m/Toolchain.defs
@@ -153,7 +153,7 @@ OBJDUMP = $(CROSSDEV)objdump
 
 # Add the builtin library
 
-EXTRA_LIBS := ${shell $(CC) $(ARCHCPUFLAGS) --print-file-name=libgcc.a}
+EXTRA_LIBS = ${shell $(CC) $(ARCHCPUFLAGS) --print-file-name=libgcc.a}
 
 ifneq ($(CONFIG_LIBM),y)
   EXTRA_LIBS += ${wildcard ${shell $(CC) $(ARCHCPUFLAGS) --print-file-name=libm.a}}

--- a/arch/avr/src/avr/Toolchain.defs
+++ b/arch/avr/src/avr/Toolchain.defs
@@ -126,7 +126,7 @@ OBJDUMP = $(CROSSDEV)objdump
 
 # Add the builtin library
 
-EXTRA_LIBS := ${shell $(CC) $(ARCHCPUFLAGS) --print-file-name=libgcc.a}
+EXTRA_LIBS = ${shell $(CC) $(ARCHCPUFLAGS) --print-file-name=libgcc.a}
 
 ifneq ($(CONFIG_LIBM),y)
   EXTRA_LIBS += ${wildcard ${shell $(CC) $(ARCHCPUFLAGS) --print-file-name=libm.a}}

--- a/arch/avr/src/avr32/Toolchain.defs
+++ b/arch/avr/src/avr32/Toolchain.defs
@@ -50,7 +50,7 @@ OBJDUMP = $(CROSSDEV)objdump
 
 # Add the builtin library
 
-EXTRA_LIBS := ${shell $(CC) $(ARCHCPUFLAGS) --print-file-name=libgcc.a}
+EXTRA_LIBS = ${shell $(CC) $(ARCHCPUFLAGS) --print-file-name=libgcc.a}
 
 ifneq ($(CONFIG_LIBM),y)
   EXTRA_LIBS += ${wildcard ${shell $(CC) $(ARCHCPUFLAGS) --print-file-name=libm.a}}

--- a/arch/hc/src/Makefile
+++ b/arch/hc/src/Makefile
@@ -87,7 +87,7 @@ endif
 
 # Add the builtin library
 
-EXTRA_LIBS := ${shell $(CC) $(ARCHCPUFLAGS) --print-file-name=libgcc.a}
+EXTRA_LIBS = ${shell $(CC) $(ARCHCPUFLAGS) --print-file-name=libgcc.a}
 
 ifneq ($(CONFIG_LIBM),y)
   EXTRA_LIBS += ${wildcard ${shell $(CC) $(ARCHCPUFLAGS) --print-file-name=libm.a}}

--- a/arch/mips/src/mips32/Toolchain.defs
+++ b/arch/mips/src/mips32/Toolchain.defs
@@ -279,7 +279,7 @@ OBJDUMP = $(CROSSDEV)objdump
 
 # Add the builtin library
 
-EXTRA_LIBS := ${shell $(CC) $(ARCHCPUFLAGS) --print-file-name=libgcc.a}
+EXTRA_LIBS = ${shell $(CC) $(ARCHCPUFLAGS) --print-file-name=libgcc.a}
 
 ifneq ($(CONFIG_LIBM),y)
   EXTRA_LIBS += ${wildcard ${shell $(CC) $(ARCHCPUFLAGS) --print-file-name=libm.a}}

--- a/arch/misoc/src/lm32/Toolchain.defs
+++ b/arch/misoc/src/lm32/Toolchain.defs
@@ -87,7 +87,7 @@ OBJDUMP = $(CROSSDEV)objdump
 
 # Add the builtin library
 
-EXTRA_LIBS := ${shell $(CC) $(ARCHCPUFLAGS) --print-file-name=libgcc.a}
+EXTRA_LIBS = ${shell $(CC) $(ARCHCPUFLAGS) --print-file-name=libgcc.a}
 
 ifneq ($(CONFIG_LIBM),y)
   EXTRA_LIBS += ${wildcard ${shell $(CC) $(ARCHCPUFLAGS) --print-file-name=libm.a}}

--- a/arch/misoc/src/minerva/Toolchain.defs
+++ b/arch/misoc/src/minerva/Toolchain.defs
@@ -41,7 +41,7 @@ OBJDUMP = $(CROSSDEV)objdump
 
 # Add the builtin library
 
-EXTRA_LIBS := ${shell $(CC) $(ARCHCPUFLAGS) --print-file-name=libgcc.a}
+EXTRA_LIBS = ${shell $(CC) $(ARCHCPUFLAGS) --print-file-name=libgcc.a}
 
 ifneq ($(CONFIG_LIBM),y)
   EXTRA_LIBS += ${wildcard ${shell $(CC) $(ARCHCPUFLAGS) --print-file-name=libm.a}}

--- a/arch/or1k/src/mor1kx/Toolchain.defs
+++ b/arch/or1k/src/mor1kx/Toolchain.defs
@@ -68,7 +68,7 @@ OBJDUMP = $(CROSSDEV)objdump
 
 # Add the builtin library
 
-EXTRA_LIBS := ${shell $(CC) $(ARCHCPUFLAGS) --print-file-name=libgcc.a}
+EXTRA_LIBS = ${shell $(CC) $(ARCHCPUFLAGS) --print-file-name=libgcc.a}
 
 ifneq ($(CONFIG_LIBM),y)
   EXTRA_LIBS += ${wildcard ${shell $(CC) $(ARCHCPUFLAGS) --print-file-name=libm.a}}

--- a/arch/risc-v/src/common/Toolchain.defs
+++ b/arch/risc-v/src/common/Toolchain.defs
@@ -129,7 +129,7 @@ OBJDUMP = $(CROSSDEV)objdump
 
 # Add the builtin library
 
-EXTRA_LIBS := ${shell $(CC) $(ARCHCPUFLAGS) --print-file-name=libgcc.a}
+EXTRA_LIBS = ${shell $(CC) $(ARCHCPUFLAGS) --print-file-name=libgcc.a}
 
 ifneq ($(CONFIG_LIBM),y)
   EXTRA_LIBS += ${wildcard ${shell $(CC) $(ARCHCPUFLAGS) --print-file-name=libm.a}}

--- a/arch/x86/src/Makefile
+++ b/arch/x86/src/Makefile
@@ -84,7 +84,7 @@ endif
 
 # Add the builtin library
 
-EXTRA_LIBS := ${shell $(CC) $(ARCHCPUFLAGS) --print-file-name=libgcc.a}
+EXTRA_LIBS = ${shell $(CC) $(ARCHCPUFLAGS) --print-file-name=libgcc.a}
 
 ifneq ($(CONFIG_LIBM),y)
   EXTRA_LIBS += ${wildcard ${shell $(CC) $(ARCHCPUFLAGS) --print-file-name=libm.a}}

--- a/arch/x86_64/src/Makefile
+++ b/arch/x86_64/src/Makefile
@@ -86,7 +86,7 @@ endif
 
 # Add the builtin library
 
-EXTRA_LIBS := ${shell $(CC) $(ARCHCPUFLAGS) --print-file-name=libgcc.a}
+EXTRA_LIBS = ${shell $(CC) $(ARCHCPUFLAGS) --print-file-name=libgcc.a}
 
 ifneq ($(CONFIG_LIBM),y)
   EXTRA_LIBS += ${wildcard ${shell $(CC) $(ARCHCPUFLAGS) --print-file-name=libm.a}}

--- a/arch/xtensa/src/lx6/Toolchain.defs
+++ b/arch/xtensa/src/lx6/Toolchain.defs
@@ -79,7 +79,7 @@ OBJDUMP = $(CROSSDEV)objdump
 
 # Add the builtin library
 
-EXTRA_LIBS := ${shell $(CC) $(ARCHCPUFLAGS) --print-file-name=libgcc.a}
+EXTRA_LIBS = ${shell $(CC) $(ARCHCPUFLAGS) --print-file-name=libgcc.a}
 
 ifneq ($(CONFIG_LIBM),y)
   EXTRA_LIBS += ${wildcard ${shell $(CC) $(ARCHCPUFLAGS) --print-file-name=libm.a}}

--- a/arch/xtensa/src/lx7/Toolchain.defs
+++ b/arch/xtensa/src/lx7/Toolchain.defs
@@ -79,7 +79,7 @@ OBJDUMP = $(CROSSDEV)objdump
 
 # Add the builtin library
 
-EXTRA_LIBS := ${shell $(CC) $(ARCHCPUFLAGS) --print-file-name=libgcc.a}
+EXTRA_LIBS = ${shell $(CC) $(ARCHCPUFLAGS) --print-file-name=libgcc.a}
 
 ifneq ($(CONFIG_LIBM),y)
   EXTRA_LIBS += ${wildcard ${shell $(CC) $(ARCHCPUFLAGS) --print-file-name=libm.a}}


### PR DESCRIPTION
## Summary
since board's Make.defs may overwrite ARCHCPUFLAGS, report here: https://github.com/apache/incubator-nuttx/pull/5332

## Impact
board Make.defs overwrite the arch's ARCHCPUFLAGS

## Testing
Pass CI
