### PR TITLE
stm32{f|h}7:Fixed typo in Kconfig help

### DIFF
--- a/arch/arm/src/stm32f7/Kconfig
+++ b/arch/arm/src/stm32f7/Kconfig
@@ -1741,7 +1741,7 @@ config OTG_ID_GPIO_DISABLE
 	bool "Disable the use of GPIO_OTG_ID pin."
 	default n
 	---help---
-		Disables/Enabled the use of GPIO_OTG_ID pin. This allows non OTG use
+		Disables/Enables the use of GPIO_OTG_ID pin. This allows non OTG use
 		cases to reuse this GPIO pin and ensure it is not set incorrectlty
 		during OS boot.
 

--- a/arch/arm/src/stm32h7/Kconfig
+++ b/arch/arm/src/stm32h7/Kconfig
@@ -891,7 +891,7 @@ config OTG_ID_GPIO_DISABLE
 	bool "Disable the use of GPIO_OTG_ID pin."
 	default n
 	---help---
-		Disables/Enabled the use of GPIO_OTG_ID pin. This allows non OTG use
+		Disables/Enables the use of GPIO_OTG_ID pin. This allows non OTG use
 		cases to reuse this GPIO pin and ensure it is not set incorrectlty
 		during OS boot.
 


### PR DESCRIPTION
## Summary

Fix error caught in https://github.com/apache/incubator-nuttx/pull/5370#pullrequestreview-866776152

## Impact
None

## Testing
None
