### PR TITLE
tcp: added debug asserts and logging to investigate the rare (conn->dev == NULL) bug in callback handlers

### DIFF
--- a/net/inet/inet_sockif.c
+++ b/net/inet/inet_sockif.c
@@ -157,6 +157,12 @@ static int inet_tcp_alloc(FAR struct socket *psock)
   DEBUGASSERT(conn->crefs == 0);
   conn->crefs = 1;
 
+  /* It is expected the socket has not yet been associated with
+   * any other connection.
+   */
+
+  DEBUGASSERT(psock->s_conn == NULL);
+
   /* Save the pre-allocated connection in the socket structure */
 
   psock->s_conn = conn;

--- a/net/tcp/Make.defs
+++ b/net/tcp/Make.defs
@@ -60,7 +60,7 @@ NET_CSRCS += tcp_recvwindow.c tcp_netpoll.c tcp_ioctl.c
 ifeq ($(CONFIG_NET_TCP_WRITE_BUFFERS),y)
 NET_CSRCS += tcp_wrbuffer.c
 ifeq ($(CONFIG_DEBUG_FEATURES),y)
-NET_CSRCS += tcp_wrbuffer_dump.c
+NET_CSRCS += tcp_dump.c
 endif
 endif
 

--- a/net/tcp/tcp.h
+++ b/net/tcp/tcp.h
@@ -311,6 +311,10 @@ struct tcp_conn_s
   /* Callback instance for TCP send() */
 
   FAR struct devif_callback_s *sndcb;
+
+#ifdef CONFIG_DEBUG_ASSERTIONS
+  int sndcb_alloc_cnt;    /* The callback allocation counter */
+#endif
 #endif
 
   /* accept() is called when the TCP logic has created a connection
@@ -1642,6 +1646,22 @@ void tcp_wrbuffer_release(FAR struct tcp_wrbuffer_s *wrb);
 #ifdef CONFIG_NET_TCP_WRITE_BUFFERS
 int tcp_wrbuffer_test(void);
 #endif /* CONFIG_NET_TCP_WRITE_BUFFERS */
+
+/****************************************************************************
+ * Name: tcp_event_handler_dump
+ *
+ * Description:
+ *  Dump the TCP event handler related variables
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_DEBUG_FEATURES
+void tcp_event_handler_dump(FAR struct net_driver_s *dev,
+                            FAR void *pvconn,
+                            FAR void *pvpriv,
+                            uint16_t flags,
+                            FAR struct tcp_conn_s *conn);
+#endif
 
 /****************************************************************************
  * Name: tcp_wrbuffer_dump

--- a/net/tcp/tcp_dump.c
+++ b/net/tcp/tcp_dump.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * net/tcp/tcp_wrbuffer_dump.c
+ * net/tcp/tcp_dump.c
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -39,12 +39,41 @@
  ****************************************************************************/
 
 /****************************************************************************
+ * Name: tcp_event_handler_dump
+ *
+ * Description:
+ *  Dump the TCP event handler related variables
+ *
+ ****************************************************************************/
+
+void tcp_event_handler_dump(FAR struct net_driver_s *dev,
+                            FAR void *pvconn,
+                            FAR void *pvpriv,
+                            uint16_t flags,
+                            FAR struct tcp_conn_s *conn)
+{
+  nerr("ERROR: conn->dev == NULL or pvconn != conn:"
+       " dev=%p pvconn=%p pvpriv=%p flags=0x%04x"
+       " conn->dev=%p conn->flags=0x%04x tcpstateflags=0x%02x crefs=%d"
+       " isn=%" PRIu32 " sndseq=%" PRIu32
+       " tx_unacked=%" PRId32 " sent=%" PRId32
+       " conn=%p s_flags=0x%02x\n",
+       dev, pvconn, pvpriv, flags,
+       conn->dev, conn->flags, conn->tcpstateflags, conn->crefs,
+       conn->isn, tcp_getsequence(conn->sndseq),
+       (uint32_t)conn->tx_unacked, conn->sent,
+       conn, conn->sconn.s_flags);
+}
+
+/****************************************************************************
  * Name: tcp_wrbuffer_dump
  *
  * Description:
  *  Dump the contents of a write buffer
  *
  ****************************************************************************/
+
+#ifdef CONFIG_NET_TCP_WRITE_BUFFERS
 
 void tcp_wrbuffer_dump(FAR const char *msg, FAR struct tcp_wrbuffer_s *wrb,
                        unsigned int len, unsigned int offset)
@@ -53,5 +82,7 @@ void tcp_wrbuffer_dump(FAR const char *msg, FAR struct tcp_wrbuffer_s *wrb,
          msg, wrb, TCP_WBSEQNO(wrb), TCP_WBSENT(wrb), TCP_WBNRTX(wrb));
   iob_dump("I/O Buffer Chain", TCP_WBIOB(wrb), len, offset);
 }
+
+#endif
 
 #endif /* CONFIG_DEBUG_FEATURES */

--- a/net/tcp/tcp_send_buffered.c
+++ b/net/tcp/tcp_send_buffered.c
@@ -371,6 +371,19 @@ static uint16_t psock_send_eventhandler(FAR struct net_driver_s *dev,
 
   DEBUGASSERT(conn != NULL);
 
+#ifdef CONFIG_DEBUG_FEATURES
+  if (conn->dev == NULL || (pvconn != conn && pvconn != NULL))
+    {
+      tcp_event_handler_dump(dev, pvconn, pvpriv, flags, conn);
+    }
+#endif
+
+  /* If pvconn is not NULL, make sure that pvconn refers to the same
+   * connection as the socket is bound to.
+   */
+
+  DEBUGASSERT(pvconn == conn || pvconn == NULL);
+
   /* The TCP socket is connected and, hence, should be bound to a device.
    * Make sure that the polling device is the one that we are bound to.
    */
@@ -1141,6 +1154,20 @@ ssize_t psock_tcp_send(FAR struct socket *psock, FAR const void *buf,
       if (conn->sndcb == NULL)
         {
           conn->sndcb = tcp_callback_alloc(conn);
+
+#ifdef CONFIG_DEBUG_ASSERTIONS
+          if (conn->sndcb != NULL)
+            {
+              conn->sndcb_alloc_cnt++;
+
+              /* The callback is allowed to be allocated only once.
+               * This is to catch a potential re-allocation after
+               * conn->sndcb was set to NULL.
+               */
+
+              DEBUGASSERT(conn->sndcb_alloc_cnt == 1);
+            }
+#endif
         }
 
       /* Test if the callback has been allocated */

--- a/net/tcp/tcp_send_unbuffered.c
+++ b/net/tcp/tcp_send_unbuffered.c
@@ -196,6 +196,19 @@ static uint16_t tcpsend_eventhandler(FAR struct net_driver_s *dev,
   conn = psock->s_conn;
   DEBUGASSERT(conn != NULL);
 
+#ifdef CONFIG_DEBUG_NET_ERROR
+  if (conn->dev == NULL || (pvconn != conn && pvconn != NULL))
+    {
+      tcp_event_handler_dump(dev, pvconn, pvpriv, flags, conn);
+    }
+#endif
+
+  /* If pvconn is not NULL, make sure that pvconn refers to the same
+   * connection as the socket is bound to.
+   */
+
+  DEBUGASSERT(pvconn == conn || pvconn == NULL);
+
   /* The TCP socket is connected and, hence, should be bound to a device.
    * Make sure that the polling device is the one that we are bound to.
    */

--- a/net/tcp/tcp_sendfile.c
+++ b/net/tcp/tcp_sendfile.c
@@ -150,6 +150,19 @@ static uint16_t sendfile_eventhandler(FAR struct net_driver_s *dev,
   conn = psock->s_conn;
   DEBUGASSERT(conn != NULL);
 
+#ifdef CONFIG_DEBUG_NET_ERROR
+  if (conn->dev == NULL || (pvconn != conn && pvconn != NULL))
+    {
+      tcp_event_handler_dump(dev, pvconn, pvpriv, flags, conn);
+    }
+#endif
+
+  /* If pvconn is not NULL, make sure that pvconn refers to the same
+   * connection as the socket is bound to.
+   */
+
+  DEBUGASSERT(pvconn == conn || pvconn == NULL);
+
   /* The TCP socket is connected and, hence, should be bound to a device.
    * Make sure that the polling device is the own that we are bound to.
    */


### PR DESCRIPTION
## Summary

Added debug asserts and logging to investigate the rare (conn->dev == NULL) bug in TCP callback handlers.
The discussion of the noticed bug started here: https://github.com/apache/incubator-nuttx/pull/5252#pullrequestreview-861912204

As it turned out, the issue was mentioned initially in 2015 here: https://github.com/apache/incubator-nuttx/blob/63071a563a1f7646dab9a6bd718d8b4b550471c4/net/socket/net_monitor.c#L166

## Impact

TCP

## Testing

CONFIG_DEBUG_ASSERTIONS and CONFIG_DEBUG_NET_ERROR need to be enabled.