### PR TITLE
i2c: Add TCA9548A I2C Multiplexer

### DIFF
--- a/boards/xtensa/esp32/common/include/esp32_tca9548a.h
+++ b/boards/xtensa/esp32/common/include/esp32_tca9548a.h
@@ -1,5 +1,5 @@
 /****************************************************************************
- * boards/xtensa/esp32/common/src/esp32_ms5611.c
+ * boards/xtensa/esp32/common/include/esp32_tca9548a.h
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -18,36 +18,36 @@
  *
  ****************************************************************************/
 
+#ifndef __BOARDS_XTENSA_ESP32_COMMON_INCLUDE_ESP32_TCA9548A_H
+#define __BOARDS_XTENSA_ESP32_COMMON_INCLUDE_ESP32_TCA9548A_H
+
 /****************************************************************************
  * Included Files
  ****************************************************************************/
 
 #include <nuttx/config.h>
 
-#include <stdio.h>
-#include <debug.h>
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
 
-#include <nuttx/arch.h>
-#include <nuttx/sensors/ms5611.h>
-#include <nuttx/i2c/i2c_master.h>
-
-#include "esp32_board_i2c.h"
-#include "esp32_i2c.h"
-#include "esp32_ms5611.h"
-
-#ifdef CONFIG_I2CMULTIPLEXER_TCA9548A
-#  include "esp32_tca9548a.h"
+#ifdef __cplusplus
+#define EXTERN extern "C"
+extern "C"
+{
+#else
+#define EXTERN extern
 #endif
 
 /****************************************************************************
- * Public Functions
+ * Public Function Prototypes
  ****************************************************************************/
 
 /****************************************************************************
- * Name: board_ms5611_initialize
+ * Name: board_tca9548a_initialize
  *
  * Description:
- *   Initialize and register the MS5611 Pressure Sensor driver.
+ *   Initialize and register the TCA9548A Pressure Sensor driver.
  *
  * Input Parameters:
  *   devno - The device number, used to build the device path as /dev/pressN
@@ -58,42 +58,31 @@
  *
  ****************************************************************************/
 
-int board_ms5611_initialize(int devno, int busno)
-{
-  struct i2c_master_s *i2c;
-  int ret;
+int board_tca9548a_initialize(int devno, int busno);
 
-  sninfo("Initializing MS5611!\n");
+/****************************************************************************
+ * Name: esp32_i2cmux_getmaster
+ *
+ * Description:
+ *   Returns an I2C Master for TCA9548A multiplexer channel.
+ *
+ *   NOTE: esp32_i2cmux_getmaster() is generic name, it can be used to return
+ *   an I2C Master for others I2C Master, not only TCA9548A.
+ *
+ * Input Parameters:
+ *   devno   - The device number, it is the TCA9548A I2C_Addr minus 0x70.
+ *   channel - The TCA9548A's channel where the device will be added.
+ *
+ * Returned Value:
+ *   Common i2c multiplexer device instance; NULL on failure.
+ *
+ ****************************************************************************/
 
-  /* Initialize MS5611 */
+struct i2c_master_s *esp32_i2cmux_getmaster(int devno, uint8_t channel);
 
-#ifdef CONFIG_BOARD_HAVE_I2CMUX
-  /* We will use the devno as channel to avoid modifying the
-   * board_ms5611_initialize() function. If you connected your
-   * MS5611 to another channel, pass it to the devno of the
-   * board_ms5611_initialize() function.
-   */
-
-  i2c = esp32_i2cmux_getmaster(busno, devno);
-#else
-  i2c = esp32_i2cbus_initialize(busno);
+#undef EXTERN
+#ifdef __cplusplus
+}
 #endif
 
-  if (i2c != NULL)
-    {
-      /* Then try to register the barometer sensor in I2C0 */
-
-      ret = ms5611_register(i2c, devno, MS5611_ADDR0);
-      if (ret < 0)
-        {
-          snerr("ERROR: Error registering MS5611 in I2C%d\n", busno);
-        }
-    }
-  else
-    {
-      ret = -ENODEV;
-    }
-
-  return ret;
-}
-
+#endif /* __BOARDS_XTENSA_ESP32_COMMON_INCLUDE_ESP32_TCA9548A_H */

--- a/boards/xtensa/esp32/common/src/Make.defs
+++ b/boards/xtensa/esp32/common/src/Make.defs
@@ -30,6 +30,10 @@ ifeq ($(CONFIG_I2C_DRIVER),y)
   CSRCS += esp32_board_i2c.c
 endif
 
+ifeq ($(CONFIG_I2CMULTIPLEXER_TCA9548A),y)
+  CSRCS += esp32_tca9548a.c
+endif
+
 ifeq ($(CONFIG_ESP32_SPI),y)
   CSRCS += esp32_board_spi.c
 endif

--- a/boards/xtensa/esp32/common/src/esp32_tca9548a.c
+++ b/boards/xtensa/esp32/common/src/esp32_tca9548a.c
@@ -1,0 +1,156 @@
+/****************************************************************************
+ * boards/xtensa/esp32/common/src/esp32_tca9548a.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <stdio.h>
+#include <debug.h>
+
+#include <nuttx/arch.h>
+#include <nuttx/i2c/i2c_master.h>
+#include <nuttx/i2c/tca9548a.h>
+
+#include "esp32_board_i2c.h"
+#include "esp32_i2c.h"
+#include "esp32_tca9548a.h"
+
+struct tca9548a_dev_s *g_tca9448a_devs[8] =
+{
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL
+};
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: board_tca9548a_initialize
+ *
+ * Description:
+ *   Initialize and register the TCA9548A Multiplexer.
+ *
+ * Input Parameters:
+ *   devno - The device number associated to I2C address, 0=0x70 ... 7=0x77
+ *   busno - The I2C bus number
+ *
+ * Returned Value:
+ *   Zero (OK) on success; a negated errno value on failure.
+ *
+ ****************************************************************************/
+
+int board_tca9548a_initialize(int devno, int busno)
+{
+  struct i2c_master_s *i2c;
+  uint8_t addr;
+
+  i2cinfo("Initializing TCA9548A!\n");
+
+  /* TCA9548A valid addresses are 0:0x70 - 7:0x77 */
+
+  addr = TCA9548A_BASEADDR0 + devno;
+
+  if (addr < TCA9548A_BASEADDR0 || addr > TCA9548A_BASEADDR7)
+    {
+      i2cerr("Invalid devno: %d! Valid range: 0 to 7!\n", devno);
+      return -EINVAL;
+    }
+
+  /* Initialize TCA9548A */
+
+  i2c = esp32_i2cbus_initialize(busno);
+  if (i2c != NULL)
+    {
+      /* Check if this position is not used */
+
+      if (g_tca9448a_devs[devno] != NULL)
+        {
+          i2cerr("ERROR: This tca9548a_devs[%d] is in use!\n", devno);
+          return -EFAULT;
+        }
+
+      /* Then try to initialize the TCA9548A */
+
+      g_tca9448a_devs[devno] = tca9548a_initialize(i2c, addr);
+
+      if (g_tca9448a_devs[devno] == NULL)
+        {
+          i2cerr("ERROR: Error registering TCA9548A in I2C%d\n", busno);
+          return -ENODEV;
+        }
+    }
+  else
+    {
+      return -ENODEV;
+    }
+
+  return OK;
+}
+
+/****************************************************************************
+ * Name: esp32_i2cmux_getmaster
+ *
+ * Description:
+ *   Returns an I2C Master for TCA9548A multiplexer channel.
+ *
+ *   NOTE: esp32_i2cmux_getmaster() is generic name, it can be used to return
+ *   an I2C Master for others I2C Master, not only TCA9548A.
+ *
+ * Input Parameters:
+ *   devno   - The device number, it is the TCA9548A I2C_Addr minus 0x70.
+ *   channel - The TCA9548A's channel where the device will be added.
+ *
+ * Returned Value:
+ *   Common i2c multiplexer device instance; NULL on failure.
+ *
+ ****************************************************************************/
+
+struct i2c_master_s *esp32_i2cmux_getmaster(int devno, uint8_t channel)
+{
+  int addr = devno + TCA9548A_BASEADDR0;
+
+  /* Check if we have a valid device number */
+
+  if (addr < TCA9548A_BASEADDR0 || addr > TCA9548A_BASEADDR7)
+    {
+      i2cerr("Invalid devno: %d! Valid range: 0 to 7!\n", devno);
+      return NULL;
+    }
+
+  /* Check if we have a valid channel */
+
+  if (channel > TCA9548A_SEL_CH7)
+    {
+      snerr("Invalid channel: %d! Valid range: 0 to 7!\n", channel);
+      return NULL;
+    }
+
+  return tca9548a_lower_half(g_tca9448a_devs[devno], channel);
+}

--- a/boards/xtensa/esp32/esp32-devkitc/src/esp32_bringup.c
+++ b/boards/xtensa/esp32/esp32-devkitc/src/esp32_bringup.c
@@ -81,6 +81,10 @@
 #  include "esp32_board_i2c.h"
 #endif
 
+#ifdef CONFIG_I2CMULTIPLEXER_TCA9548A
+#  include "esp32_tca9548a.h"
+#endif
+
 #ifdef CONFIG_SENSORS_BMP180
 #  include "esp32_bmp180.h"
 #endif
@@ -366,6 +370,21 @@ int esp32_bringup(void)
   if (ret < 0)
     {
       syslog(LOG_ERR, "Failed to initialize GPIO Driver: %d\n", ret);
+    }
+#endif
+
+  /* Register the TCA9548A Multiplexer before others I2C drivers to allow it
+   * be used by other drivers. Look at esp32_ms5611.c how to use it.
+   */
+
+#ifdef CONFIG_I2CMULTIPLEXER_TCA9548A
+  /* Add the TCA9548A Mux as device 0 (0x70) in I2C Bus 0 */
+
+  ret = board_tca9548a_initialize(0, 0);
+  if (ret < 0)
+    {
+      syslog(LOG_ERR, "Failed to initialize TCA9548A driver: %d\n", ret);
+      return ret;
     }
 #endif
 

--- a/drivers/i2c/Kconfig
+++ b/drivers/i2c/Kconfig
@@ -7,6 +7,10 @@ config ARCH_HAVE_I2CRESET
 	bool
 	default n
 
+config BOARD_HAVE_I2CMUX
+	bool
+	default n
+
 menuconfig I2C
 	bool "I2C Driver Support"
 	default n
@@ -94,8 +98,17 @@ config I2CMULTIPLEXER_PCA9540BDP
 	bool "PCA9540BDP NXP multiplexer"
 	default n
 	depends on I2C
+	select BOARD_HAVE_I2CMUX
 	---help---
 		Enable support for the NXP PCA9540BDP i2c multiplexer
+
+config I2CMULTIPLEXER_TCA9548A
+	bool "TCA9548A TI multiplexer"
+	default n
+	depends on I2C
+	select BOARD_HAVE_I2CMUX
+	---help---
+		Enable support for the TI TCA9548A i2c multiplexer
 
 # put more i2c mux devices here
 

--- a/drivers/i2c/Make.defs
+++ b/drivers/i2c/Make.defs
@@ -38,6 +38,10 @@ ifeq ($(CONFIG_I2CMULTIPLEXER_PCA9540BDP),y)
 CSRCS += pca9540bdp.c
 endif
 
+ifeq ($(CONFIG_I2CMULTIPLEXER_TCA9548A),y)
+CSRCS += tca9548a.c
+endif
+
 # Include I2C device driver build support
 
 DEPPATH += --dep-path i2c

--- a/drivers/i2c/tca9548a.c
+++ b/drivers/i2c/tca9548a.c
@@ -1,0 +1,412 @@
+/****************************************************************************
+ * drivers/i2c/tca9548a.c
+ * Driver for the TCA9448A i2c multiplexer
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <stdlib.h>
+#include <fixedmath.h>
+#include <assert.h>
+#include <errno.h>
+#include <debug.h>
+
+#include <nuttx/kmalloc.h>
+#include <nuttx/fs/fs.h>
+#include <nuttx/i2c/i2c_master.h>
+#include <nuttx/i2c/tca9548a.h>
+
+#ifdef CONFIG_I2CMULTIPLEXER_TCA9548A
+
+#ifndef CONFIG_TCA9548A_I2C_FREQUENCY
+#  define CONFIG_TCA9548A_I2C_FREQUENCY    400000
+#endif
+
+/****************************************************************************
+ * Private Function Prototypes
+ ****************************************************************************/
+
+/* I2C Helpers */
+
+static int tca9548a_write_config(FAR struct tca9548a_dev_s *priv,
+                                 uint8_t regvalue);
+static int tca9548a_read_config(FAR struct tca9548a_dev_s *priv,
+                                FAR uint8_t *regvalue);
+
+/* Other helpers */
+
+static int tca9548a_select_channel(FAR struct tca9548a_dev_s *priv,
+                                   uint8_t val);
+
+/* I2C multiplexer vtable */
+
+static int tca9548a_transfer_on_channel (FAR struct i2c_master_s *dev,
+                                         FAR struct i2c_msg_s *msgs,
+                                         int count);
+#ifdef CONFIG_I2C_RESET
+static int tca9548a_reset_on_channel (FAR struct i2c_master_s *dev);
+#endif
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+static const struct i2c_ops_s g_i2cmux_ops =
+{
+  tca9548a_transfer_on_channel
+#ifdef CONFIG_I2C_RESET
+  , tca9548a_reset_on_channel
+#endif
+};
+
+/****************************************************************************
+ * Private Types
+ ****************************************************************************/
+
+struct i2c_channel_dev_s
+{
+  FAR struct i2c_master_s vi2c;      /* Nested structure to allow casting as
+                                      * public i2c master */
+  uint8_t channel;                   /* Associated channel on the mux */
+  FAR struct tca9548a_dev_s *dev;    /* Associated device */
+};
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: tca9548a_write_config
+ *
+ * Description:
+ *   Write to the mux register of TCA9548A.
+ *
+ * Input Parameters:
+ *   priv     - A pointer to the TCA9548A device structure.
+ *   regvalue - The value that will be written.
+ *
+ * Returned Value:
+ *   OK on success or a negative error.
+ *
+ ****************************************************************************/
+
+static int tca9548a_write_config(FAR struct tca9548a_dev_s *priv,
+                                 uint8_t regvalue)
+{
+  struct i2c_config_s iconf;
+  int ret;
+
+  iconf.frequency = CONFIG_TCA9548A_I2C_FREQUENCY;
+  iconf.address   = priv->addr;
+  iconf.addrlen   = 7;
+
+  ret = i2c_write(priv->i2c, &iconf, &regvalue, 1);
+
+  i2cinfo("Write to address 0x%02X; register value: 0x%02x ret: %d\n",
+          priv->addr, regvalue, ret);
+  return ret;
+}
+
+/****************************************************************************
+ * Name: tca9548a_read_config
+ *
+ * Description:
+ *   Read the mux register from TCA9548A.
+ *
+ * Input Parameters:
+ *   priv     - A pointer to the TCA9548A device structure.
+ *   regvalue - A pointer to a buffer into which data will be received.
+ *
+ * Returned Value:
+ *   OK on success or a negative error.
+ *
+ ****************************************************************************/
+
+static int tca9548a_read_config(FAR struct tca9548a_dev_s *priv,
+                                FAR uint8_t *regvalue)
+{
+  struct i2c_config_s iconf;
+  int ret;
+
+  iconf.frequency = CONFIG_TCA9548A_I2C_FREQUENCY;
+  iconf.address   = priv->addr;
+  iconf.addrlen   = 7;
+
+  ret = i2c_read(priv->i2c, &iconf, regvalue, 1);
+
+  i2cinfo("Read from address: 0x%02X; register value: 0x%02x ret: %d\n",
+          priv->addr, *regvalue, ret);
+  return ret;
+}
+
+/****************************************************************************
+ * Name: tca9548a_select_channel
+ *
+ * Description:
+ *   Helper function to select a channel in the TCA9548A. The TCA9548A allows
+ *   to select more than 1 channel at same time, but here we are forcing it
+ *   to only enable a single channel by time. It will avoid collision in case
+ *   where two devices with same address are connected to two channels.
+ *
+ * Input Parameters:
+ *   dev  - Pointer to the (virtual) i2c_master_s.
+ *   val  - The channel to be selected.
+ *
+ * Returned Value:
+ *   OK on success or a negative error.
+ *
+ ****************************************************************************/
+
+static int tca9548a_select_channel(FAR struct tca9548a_dev_s *priv,
+                                   uint8_t val)
+{
+  int ret;
+
+  if (val > TCA9548A_SEL_CH7)
+    {
+      /* channel not existent/supported */
+
+      return -EINVAL;
+    }
+
+  if ((priv->state & (1 << val)) != 0)
+    {
+      /* channel already selected */
+
+      return OK;
+    }
+
+  /* Try to setup the new channel */
+
+  ret = tca9548a_write_config(priv, 1 << val);
+  if (ret < 0)
+    {
+      return -ECOMM;
+    }
+
+  /* Modify state. Selecting a channel always enables the device */
+
+  priv->state = 1 << val;
+
+  return OK;
+}
+
+/****************************************************************************
+ * Name: tca9548a_transfer_on_channel
+ *
+ * Description:
+ *   Transfer an I2C message over the TCA9548A multiplexer. This function is
+ *   attached to the virtual i2c_master ".transfer()" pointer. This way every
+ *   time an I2C message is sent it is called and it starts sending a command
+ *   to TCA9548A setup the right channel defined to this i2c_master. All the
+ *   expected messages are then transfered to the I2C device connected the
+ *   this selected channel.
+ *
+ * Input Parameters:
+ *   dev   - Pointer to the (virtual) i2c_master_s.
+ *   msgs  - the i2c message to be send to a device connected on TCA9548A.
+ *   count - Number of messages to be send.
+ *
+ * Returned Value:
+ *   OK on success or a negative error.
+ *
+ ****************************************************************************/
+
+static int tca9548a_transfer_on_channel(FAR struct i2c_master_s *dev,
+                                        FAR struct i2c_msg_s *msgs,
+                                        int count)
+{
+  FAR struct i2c_channel_dev_s *ch_dev = (FAR struct i2c_channel_dev_s *)dev;
+  FAR struct tca9548a_dev_s *priv = ch_dev->dev;
+  int ret;
+
+  /* select the mux channel */
+
+  if (tca9548a_select_channel(priv, ch_dev->channel) != OK)
+    {
+      i2cerr("Could not select proper mux channel\n");
+      return -ECOMM;  /* Signal error condition */
+    }
+
+  /* Resume the i2c transfer to the device connected to the mux channel */
+
+  ret = I2C_TRANSFER(priv->i2c, msgs, count);
+  i2cinfo("Selected channel %d and resumed transfer. Result: %d\n",
+          ch_dev->channel, ret);
+  return ret;
+}
+
+/****************************************************************************
+ * Name: tca9548a_reset_on_channel
+ *
+ * Description:
+ *   Reset the I2C device connected to the current channel
+ *
+ * Input Parameters:
+ *   dev  - Pointer to the (virtual) i2c_master_s.
+ *
+ * Returned Value:
+ *   OK on success or a negative error.
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_I2C_RESET
+static int tca9548a_reset_on_channel(FAR struct i2c_master_s *dev)
+{
+  FAR struct i2c_channel_dev_s *ch_dev = (struct i2c_channel_dev_s *)dev;
+  FAR struct tca9548a_dev_s *priv = ch_dev->dev;
+  int channel = ch_dev->channel;
+  int ret;
+
+  /* select the mux channel */
+
+  if (tca9548a_select_channel(priv, channel) != OK)
+    {
+      i2cerr("Could not select proper mux channel\n");
+      return -ECOMM;  /* signal error condition */
+    }
+
+  /* resume the i2c reset for the device connected to the mux channel */
+
+  ret = I2C_RESET(priv->i2c);
+  return ret;
+}
+#endif
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: tca9548a_lower_half
+ *
+ * Description:
+ *   Initialize the lower half of the TCA9548A by creating an i2c_master_s
+ *   for the virtual i2c master and link it to the associated TCA9548A and
+ *   its channel.
+ *
+ * Input Parameters:
+ *   dev  - Pointer to the associated TCA9548A
+ *   channel - The channel number as defined in tca9548a.h
+ *
+ * Returned Value:
+ *   Common i2c multiplexer device instance; NULL on failure.
+ *
+ ****************************************************************************/
+
+FAR struct i2c_master_s *
+  tca9548a_lower_half(FAR struct tca9548a_dev_s *dev, uint8_t channel)
+{
+  FAR struct i2c_channel_dev_s *channel_dev;
+
+  /* Sanity check */
+
+  DEBUGASSERT(dev != NULL);
+
+  /* Initialize the i2c_channel_dev_s device structure */
+
+  channel_dev = (FAR struct i2c_channel_dev_s *)
+                kmm_malloc(sizeof(struct i2c_channel_dev_s));
+
+  if (channel_dev == NULL)
+    {
+      i2cerr("ERROR: Failed to allocate i2c channel lower half instance\n");
+      return NULL;
+    }
+
+  /* set vi2c ops to their implementations */
+
+  channel_dev->vi2c.ops = &g_i2cmux_ops;
+
+  /* save state variables */
+
+  channel_dev->dev  = dev;
+  channel_dev->channel = channel;
+
+  return &channel_dev->vi2c;
+}
+
+/****************************************************************************
+ * Name: tca9548a_initialize
+ *
+ * Description:
+ *   Initialize the TCA9548A device.
+ *
+ * Input Parameters:
+ *   i2c  - An instance of the I2C interface to use to communicate with
+ *          TCA9548A
+ *   addr - The I2C address of the TCA9548A. The base I2C address of the
+ *          TCA9548A is 0x70.
+ *
+ * Returned Value:
+ *   Common i2c multiplexer device instance; NULL on failure.
+ *
+ ****************************************************************************/
+
+FAR struct tca9548a_dev_s *
+  tca9548a_initialize(FAR struct i2c_master_s *i2c, uint8_t addr)
+{
+  FAR struct tca9548a_dev_s *priv;
+
+  /* Sanity check */
+
+  DEBUGASSERT(i2c != NULL);
+
+  /* Initialize the TCA9548A device structure */
+
+  priv = (FAR struct tca9548a_dev_s *)
+    kmm_malloc(sizeof(struct tca9548a_dev_s));
+
+  if (priv == NULL)
+    {
+      i2cerr("ERROR: Failed to allocate instance\n");
+      return NULL;
+    }
+
+  priv->i2c        = i2c;
+  priv->addr       = addr;
+  priv->state      = 0x00;
+
+  if (tca9548a_read_config(priv, &priv->state) != OK)
+    {
+      i2cerr("Could not read initial state from the device\n");
+      kmm_free(priv);
+      return NULL;  /* signal error condition */
+    }
+
+  i2cinfo("Initial device state: %d\n", priv->state);
+
+  if (tca9548a_select_channel(priv, TCA9548A_SEL_CH0) != OK)
+    {
+      i2cerr("Could not select mux channel 0\n");
+      kmm_free(priv);
+      return NULL;  /* signal error condition */
+    }
+
+  i2cinfo("TCA9548A (addr=0x%02x) set up with channel %d\n", priv->addr,
+          TCA9548A_SEL_CH0);
+
+  return priv;
+}
+
+#endif /* CONFIG_I2CMULTIPLEXER_TCA9548A */

--- a/include/nuttx/i2c/tca9548a.h
+++ b/include/nuttx/i2c/tca9548a.h
@@ -1,0 +1,126 @@
+/****************************************************************************
+ * include/nuttx/i2c/tca9548a.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __INCLUDE_NUTTX_I2C_TCA9548A_H
+#define __INCLUDE_NUTTX_I2C_TCA9548A_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+#include <sys/ioctl.h>
+#include <nuttx/i2c/i2c_master.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/* It is possible to config. TCA9548A to communicate from 0x70-0x77 */
+
+#define TCA9548A_BASEADDR0    0x70
+#define TCA9548A_BASEADDR1    0x71
+#define TCA9548A_BASEADDR2    0x72
+#define TCA9548A_BASEADDR3    0x73
+#define TCA9548A_BASEADDR4    0x74
+#define TCA9548A_BASEADDR5    0x75
+#define TCA9548A_BASEADDR6    0x76
+#define TCA9548A_BASEADDR7    0x77
+
+/* The TCA9548A can multiplex up to 8 channels */
+
+#define TCA9548A_SEL_CH0      0x0
+#define TCA9548A_SEL_CH1      0x1
+#define TCA9548A_SEL_CH2      0x2
+#define TCA9548A_SEL_CH3      0x3
+#define TCA9548A_SEL_CH4      0x4
+#define TCA9548A_SEL_CH5      0x5
+#define TCA9548A_SEL_CH6      0x6
+#define TCA9548A_SEL_CH7      0x7
+
+/****************************************************************************
+ * Public Types
+ ****************************************************************************/
+
+struct tca9548a_dev_s
+{
+  FAR struct i2c_master_s *i2c;      /* I2C interface */
+  uint8_t addr;
+  uint8_t state;                     /* Control register state */
+};
+
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
+
+#ifdef __cplusplus
+#define EXTERN extern "C"
+extern "C"
+{
+#else
+#define EXTERN extern
+#endif
+
+/****************************************************************************
+ * Name: tca9548a_lower_half
+ *
+ * Description:
+ *   Initialize the lower half of the TCA9548A by creating a i2c_master_s
+ *   for the virtual i2c master and link it to the associated TCA9548A and
+ *   its port.
+ *
+ * Input Parameters:
+ *   dev     - Pointer to the associated TCA9548A
+ *   channel - The channel number to be selected to communicate
+ *
+ * Returned Value:
+ *   Common i2c multiplexer device instance; NULL on failure.
+ *
+ ****************************************************************************/
+
+FAR struct i2c_master_s *
+  tca9548a_lower_half(FAR struct tca9548a_dev_s *dev, uint8_t channel);
+
+/****************************************************************************
+ * Name: tca9548a_initialize
+ *
+ * Description:
+ *   Initialize the TCA9548A device.
+ *
+ * Input Parameters:
+ *   i2c  - An instance of the I2C interface to use to communicate with
+ *          TCA9548A
+ *   addr - The I2C address of the TCA9548A.  The base I2C address of the
+ *          TCA9548A is 0x70.
+ *
+ * Returned Value:
+ *   Common i2c multiplexer device instance; NULL on failure.
+ *
+ ****************************************************************************/
+
+FAR struct tca9548a_dev_s *tca9548a_initialize(FAR struct i2c_master_s *i2c,
+                                               uint8_t addr);
+
+#undef EXTERN
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __INCLUDE_NUTTX_I2C_TCA9548A_H */


### PR DESCRIPTION
## Summary
Add TCA9548A I2C Multiplexer
## Impact
NuttX users will be able to use up to 8 I2C devices even when they have same I2C address.
## Testing
ESP32-Devkit + TCA9548A HW-617 module
