### PR TITLE
Sim on MacOS M1: ld needs main() visible.

### DIFF
--- a/arch/sim/src/sim/up_head.c
+++ b/arch/sim/src/sim/up_head.c
@@ -64,6 +64,7 @@ static char g_logbuffer[4096];
  *
  ****************************************************************************/
 
+__attribute__ ((visibility("default")))
 int main(int argc, char **argv, char **envp)
 {
   g_argc = argc;


### PR DESCRIPTION
## Summary
On MacOS simulation can't be linked --> _main() not found.
Visible is controlled via "fvisibility=hidden" in Make.defs
This change explicitly exports main() via an attribute to get the simulation linked.

The attribute is not guarded via HOST_MACOS/HOST_ARM64 assuming the change can be added w/o drawback to all host systems.

This is another small step to get simulation on ARM64 hosts running.Still not complete. As a lot of tweaking is needed to get the simulation linked at all.

## Impact
Simulation targets on all host systems.

## Testing
MacOS Monterey on MacBook Air M1
