### PR TITLE
sched: Don't duplicate caller file handler when creating kernel thread

### DIFF
--- a/sched/task/task_init.c
+++ b/sched/task/task_init.c
@@ -105,7 +105,15 @@ int nxtask_init(FAR struct task_tcb_s *tcb, const char *name, int priority,
 
   /* Associate file descriptors with the new task */
 
-  ret = group_setuptaskfiles(tcb);
+  if (ttype == TCB_FLAG_TTYPE_KERNEL)
+    {
+      ret = group_setupidlefiles(tcb);
+    }
+  else
+    {
+      ret = group_setuptaskfiles(tcb);
+    }
+
   if (ret < 0)
     {
       goto errout_with_group;


### PR DESCRIPTION
## Summary
kernel thread should have only the starndard file i/o just like idle thread

## Impact
Kernel thread doesn't inherit the caller file handler anymore

## Testing

