### PR TITLE
libs/libc/machine/sim/arch_elf64.c: Implement R_X86_64_PC64

### DIFF
--- a/libs/libc/machine/sim/arch_elf64.c
+++ b/libs/libc/machine/sim/arch_elf64.c
@@ -47,6 +47,7 @@
 #define R_X86_64_PLT32  4
 #define R_X86_64_32     10
 #define R_X86_64_32S    11
+#define R_X86_64_PC64   24
 
 /****************************************************************************
  * Private Data Types
@@ -180,6 +181,10 @@ int up_relocateadd(FAR const Elf64_Rela *rel, FAR const Elf64_Sym *sym,
           }
 
         *(uint32_t *)addr = value;
+        break;
+      case R_X86_64_PC64:  /* S + A - P */
+        value = sym->st_value + rel->r_addend - addr;
+        *(uint64_t *)addr = value;
         break;
       case R_X86_64_32:  /* S + A */
       case R_X86_64_32S: /* S + A */


### PR DESCRIPTION
## Summary
This relocation type is often found in eh_frame with -mcmodel=large
## Impact
x86-64 sim
## Testing
tested with my local app.