### PR TITLE
boards/sim/sim/sim/scripts/Make.defs: CELFFLAGS += -mcmodel=large

### DIFF
--- a/boards/sim/sim/sim/scripts/Make.defs
+++ b/boards/sim/sim/sim/scripts/Make.defs
@@ -196,6 +196,11 @@ CXXELFFLAGS = $(CXXFLAGS)
 # -fno-pic to avoid GOT relocations
 CELFFLAGS += -fno-pic
 CXXELFFLAGS += -fno-pic
+ifeq ($(CONFIG_LIBC_ARCH_ELF_64BIT),y)
+  # See the comment on CMODULEFLAGS above.
+  CELFFLAGS += -mcmodel=large
+  CXXELFFLAGS += -mcmodel=large
+endif
 
 LDELFFLAGS = -r -e main
 ifeq ($(CONFIG_CYGWIN_WINTOOL),y)


### PR DESCRIPTION
## Summary

We load the code into NuttX heap, which can be too far from
the usual code segments for the relocation types used by the
default "small" model to reach.

This worked around out of range relocations seen with my local app.

## Impact
x86-64 sim elf

## Testing
Tested with my local app.