### PR TITLE
Revert "sched: Don't duplicate caller file handler when creating kernel thread"

### DIFF
--- a/sched/task/task_init.c
+++ b/sched/task/task_init.c
@@ -105,15 +105,7 @@ int nxtask_init(FAR struct task_tcb_s *tcb, const char *name, int priority,
 
   /* Associate file descriptors with the new task */
 
-  if (ttype == TCB_FLAG_TTYPE_KERNEL)
-    {
-      ret = group_setupidlefiles(tcb);
-    }
-  else
-    {
-      ret = group_setuptaskfiles(tcb);
-    }
-
+  ret = group_setuptaskfiles(tcb);
   if (ret < 0)
     {
       goto errout_with_group;


### PR DESCRIPTION
Reverts apache/incubator-nuttx#5379