### PR TITLE
sched: Don't duplicate caller file handler when creating kernel thread 

### DIFF
--- a/fs/inode/fs_files.c
+++ b/fs/inode/fs_files.c
@@ -250,7 +250,8 @@ int files_allocate(FAR struct inode *inode, int oflags, off_t pos,
  *
  ****************************************************************************/
 
-int files_duplist(FAR struct filelist *plist, FAR struct filelist *clist)
+int files_duplist(FAR struct filelist *plist,
+                  FAR struct filelist *clist, bool stdio_only)
 {
   int ret;
   int i;
@@ -264,25 +265,28 @@ int files_duplist(FAR struct filelist *plist, FAR struct filelist *clist)
       return ret;
     }
 
+#ifdef CONFIG_FDCLONE_STDIO
+
+  /* Determine how many file descriptors to clone.  If
+   * CONFIG_FDCLONE_DISABLE is set, no file descriptors will be
+   * cloned.  If CONFIG_FDCLONE_STDIO is set, only the first
+   * three descriptors (stdin, stdout, and stderr) will be
+   * cloned.  Otherwise all file descriptors will be cloned.
+   */
+
+  stdio_only = true;
+#endif
+
   for (i = 0; i < plist->fl_rows; i++)
     {
       for (j = 0; j < CONFIG_NFILE_DESCRIPTORS_PER_BLOCK; j++)
         {
           FAR struct file *filep;
-#ifdef CONFIG_FDCLONE_STDIO
 
-          /* Determine how many file descriptors to clone.  If
-           * CONFIG_FDCLONE_DISABLE is set, no file descriptors will be
-           * cloned.  If CONFIG_FDCLONE_STDIO is set, only the first
-           * three descriptors (stdin, stdout, and stderr) will be
-           * cloned.  Otherwise all file descriptors will be cloned.
-           */
-
-          if (i * CONFIG_NFILE_DESCRIPTORS_PER_BLOCK + j >= 3)
+          if (stdio_only && i * CONFIG_NFILE_DESCRIPTORS_PER_BLOCK + j >= 3)
             {
               goto out;
             }
-#endif
 
           filep = &plist->fl_files[i][j];
           if (filep->f_inode == NULL || (filep->f_oflags & O_CLOEXEC) != 0)

--- a/include/nuttx/fs/fs.h
+++ b/include/nuttx/fs/fs.h
@@ -759,7 +759,8 @@ void files_releaselist(FAR struct filelist *list);
  *
  ****************************************************************************/
 
-int files_duplist(FAR struct filelist *plist, FAR struct filelist *clist);
+int files_duplist(FAR struct filelist *plist,
+                  FAR struct filelist *clist, bool stdio_only);
 
 /****************************************************************************
  * Name: file_dup

--- a/sched/task/task_init.c
+++ b/sched/task/task_init.c
@@ -105,15 +105,7 @@ int nxtask_init(FAR struct task_tcb_s *tcb, const char *name, int priority,
 
   /* Associate file descriptors with the new task */
 
-  if (ttype == TCB_FLAG_TTYPE_KERNEL)
-    {
-      ret = group_setupidlefiles(tcb);
-    }
-  else
-    {
-      ret = group_setuptaskfiles(tcb);
-    }
-
+  ret = group_setuptaskfiles(tcb);
   if (ret < 0)
     {
       goto errout_with_group;


### PR DESCRIPTION
## Summary
Fix the regression made by: https://github.com/apache/incubator-nuttx/pull/5379

## Impact
Kernel thread doesn't inherit the caller file handler anymore

## Testing
Local test
