### PR TITLE
arch/arm/samv7: fix leaving from critical section in HSMCI callback

### DIFF
--- a/arch/arm/src/sama5/sam_hsmci.c
+++ b/arch/arm/src/sama5/sam_hsmci.c
@@ -3116,6 +3116,7 @@ static void sam_callback(void *arg)
             {
               /* No... return without performing the callback */
 
+              leave_critical_section(flags);
               return;
             }
         }
@@ -3127,6 +3128,7 @@ static void sam_callback(void *arg)
             {
               /* No... return without performing the callback */
 
+              leave_critical_section(flags);
               return;
             }
         }

--- a/arch/arm/src/samv7/sam_hsmci.c
+++ b/arch/arm/src/samv7/sam_hsmci.c
@@ -3182,6 +3182,7 @@ static void sam_callback(void *arg)
             {
               /* No... return without performing the callback */
 
+              leave_critical_section(flags);
               return;
             }
         }
@@ -3193,6 +3194,7 @@ static void sam_callback(void *arg)
             {
               /* No... return without performing the callback */
 
+              leave_critical_section(flags);
               return;
             }
         }


### PR DESCRIPTION
## Summary
Interrupts are not restored properly in case of occurrence of SD card false positive interrupt events from CD pin.

## Impact
SAMV7 and SAMA5 based boards

## Testing
Verified with SAME70-QMTECH board
