### PR TITLE
boards/arm/samv7: disable systick no matter if ARMV7M_SYSTICK is enabled or not

### DIFF
--- a/boards/arm/samv7/common/src/sam_boot_image.c
+++ b/boards/arm/samv7/common/src/sam_boot_image.c
@@ -59,9 +59,7 @@ struct arm_vector_table
  ****************************************************************************/
 
 static void cleanup_arm_nvic(void);
-#ifdef CONFIG_ARMV7M_SYSTICK
 static void systick_disable(void);
-#endif
 
 /****************************************************************************
  * Private Functions
@@ -105,7 +103,6 @@ static void cleanup_arm_nvic(void)
     }
 }
 
-#ifdef CONFIG_ARMV7M_SYSTICK
 /****************************************************************************
  * Name:  systick_disable
  *
@@ -126,7 +123,6 @@ static void systick_disable(void)
   putreg32(NVIC_SYSTICK_RELOAD_MASK, NVIC_SYSTICK_RELOAD);
   putreg32(0, NVIC_SYSTICK_CURRENT);
 }
-#endif
 
 /****************************************************************************
  * Public Functions
@@ -160,9 +156,7 @@ int board_boot_image(FAR const char *path, uint32_t hdr_size)
       return bytes < 0 ? bytes : -1;
     }
 
-#ifdef CONFIG_ARMV7M_SYSTICK
   systick_disable();
-#endif
 
   cleanup_arm_nvic();
 


### PR DESCRIPTION
## Summary
NVIC systick is configured in both cases if ARMV7M_SYSTICK is enabled or not. Disable systick during loading of an image unconditionally

## Impact
SAMV7 MCUboot users

## Testing
Tested on custom SAME70 based board
