### PR TITLE
arch/xtensa/esp32: Remove the QEMU special case when initializing the heap.

### DIFF
--- a/arch/xtensa/include/esp32/memory_layout.h
+++ b/arch/xtensa/include/esp32/memory_layout.h
@@ -112,23 +112,9 @@
  *
  * When an internal heap is enabled this region starts at an offset equal to
  * the size of the internal heap.
- *
- * The QEMU bootloader image is slightly different than the chip's one.
- * The ROM on PRO and APP CPUs uses different regions for static data.
- * In QEMU, however, we load only one ROM binary, taken from the PRO CPU,
- * and it is used by both CPUs.  So, in QEMU, if we allocate PRO CPUs region
- * early, it will be clobbered once the APP CPU starts.
- * We can delay the allocation to when everything has started through the
- * board_late_initiliaze hook, as is done for the APP data, however this
- * should be fixed from QEMU side.  The following macros, then, just skip
- * PRO CPU's regions when a QEMU image generation is enabled with SMP.
  */
 
-#if defined(CONFIG_ESP32_QEMU_IMAGE) && defined(CONFIG_SMP)
-#  define HEAP_REGION2_START  0x3ffe7e40
-#else
-#  define HEAP_REGION2_START  0x3ffe0450
-#endif
+#define HEAP_REGION2_START  0x3ffe0450
 
 #ifdef CONFIG_SMP
 #  define HEAP_REGION2_END    0x3ffe3f10

--- a/arch/xtensa/src/esp32/esp32_allocateheap.c
+++ b/arch/xtensa/src/esp32/esp32_allocateheap.c
@@ -116,12 +116,6 @@ void xtensa_add_region(void)
   start = (void *)(HEAP_REGION2_START + XTENSA_IMEM_REGION_SIZE);
   size  = (size_t)(uintptr_t)&_eheap - (size_t)start;
   umm_addregion(start, size);
-
-#else
-#ifdef CONFIG_ESP32_QEMU_IMAGE
-  start = (void *)HEAP_REGION2_START;
-  size  = (size_t)(uintptr_t)&_eheap - (size_t)start;
-  umm_addregion(start, size);
 #else
   start = (void *)HEAP_REGION2_START;
   size  = (size_t)(HEAP_REGION2_END - HEAP_REGION2_START);
@@ -131,9 +125,8 @@ void xtensa_add_region(void)
   size  = (size_t)(uintptr_t)&_eheap - (size_t)start;
   umm_addregion(start, size);
 #endif
-#endif
 
-#if !defined(CONFIG_ESP32_QEMU_IMAGE) && !defined(CONFIG_ESP32_BLE)
+#ifndef CONFIG_ESP32_BLE
   start = (void *)HEAP_REGION0_START;
   size  = (size_t)(HEAP_REGION0_END - HEAP_REGION0_START);
   umm_addregion(start, size);


### PR DESCRIPTION
## Summary
QEMU had a different ROM image that used the regions of PRO CPU for both
CPUs.  This was causing crashes when running SMP mode as the heap was
being corrupted when the APP CPU starts.

QEMU is now loading the same image as the hardware chip and thus this
special case doesn't exist anymore.
## Impact
ESP32 SMP in QEMU
## Testing
ESP32 boards.
