### PR TITLE
libc/stdlib: Compile lib_openpty.c without checking CONFIG_SERIAL_TERMIOS

### DIFF
--- a/libs/libc/stdlib/Make.defs
+++ b/libs/libc/stdlib/Make.defs
@@ -34,10 +34,7 @@ CSRCS += lib_mbstowcs.c lib_wcstombs.c
 endif
 
 ifeq ($(CONFIG_PSEUDOTERM),y)
-CSRCS += lib_ptsname.c lib_ptsnamer.c lib_unlockpt.c
-ifeq ($(CONFIG_SERIAL_TERMIOS),y)
-CSRCS += lib_openpty.c
-endif
+CSRCS += lib_ptsname.c lib_ptsnamer.c lib_unlockpt.c lib_openpty.c
 endif
 
 # Add the stdlib directory to the build


### PR DESCRIPTION
## Summary
follow up the following change:
```
commit 4262b09cbf08a6721515531263f28fbd21e547d5
Author: Xiang Xiao <xiaoxiang@xiaomi.com>
Date:   Fri Dec 17 02:58:49 2021 +0800

    libc: Implement terminal api regardless of CONFIG_SERIAL_TERMIOS setting

    since many functions aren't related to termios directly

    Signed-off-by: Xiang Xiao <xiaoxiang@xiaomi.com>
```

## Impact
No

## Testing
Pass CI
