### PR TITLE
arch/arm/samv7: add arm_systemreset.c to CMN_CSRCS

### DIFF
--- a/arch/arm/src/samv7/Make.defs
+++ b/arch/arm/src/samv7/Make.defs
@@ -27,13 +27,13 @@ CMN_ASRCS  = arm_saveusercontext.S arm_fullcontextrestore.S
 CMN_ASRCS += arm_testset.S arm_fetchadd.S vfork.S
 
 CMN_CSRCS  = arm_assert.c arm_blocktask.c arm_copyfullstate.c arm_createstack.c
-CMN_CSRCS += arm_doirq.c arm_exit.c arm_hardfault.c arm_initialize.c
-CMN_CSRCS += arm_initialstate.c arm_interruptcontext.c arm_mdelay.c
+CMN_CSRCS += arm_exit.c arm_hardfault.c arm_initialize.c arm_initialstate.c
+CMN_CSRCS += arm_interruptcontext.c arm_mdelay.c arm_udelay.c arm_systemreset.c
 CMN_CSRCS += arm_memfault.c arm_modifyreg8.c arm_modifyreg16.c arm_modifyreg32.c
 CMN_CSRCS += arm_releasepending.c arm_releasestack.c arm_reprioritizertr.c
 CMN_CSRCS += arm_schedulesigaction.c arm_sigdeliver.c arm_stackframe.c
-CMN_CSRCS += arm_svcall.c arm_trigger_irq.c arm_unblocktask.c arm_udelay.c
-CMN_CSRCS += arm_usestack.c arm_vfork.c arm_switchcontext.c arm_puts.c
+CMN_CSRCS += arm_svcall.c arm_trigger_irq.c arm_unblocktask.c arm_usestack.c
+CMN_CSRCS += arm_doirq.c arm_vfork.c arm_switchcontext.c arm_puts.c
 
 # Configuration-dependent common files
 

--- a/arch/arm/src/stm32/Make.defs
+++ b/arch/arm/src/stm32/Make.defs
@@ -23,7 +23,7 @@ CMN_ASRCS += arm_testset.S arm_fetchadd.S vfork.S
 
 CMN_CSRCS  = arm_assert.c arm_blocktask.c arm_copyfullstate.c arm_createstack.c
 CMN_CSRCS += arm_exit.c arm_hardfault.c arm_initialize.c arm_initialstate.c
-CMN_CSRCS += arm_interruptcontext.c arm_memfault.c arm_modifyreg8.c
+CMN_CSRCS += arm_interruptcontext.c arm_memfault.c arm_modifyreg8.c arm_mdelay.c
 CMN_CSRCS += arm_modifyreg16.c arm_modifyreg32.c arm_releasepending.c
 CMN_CSRCS += arm_releasestack.c arm_reprioritizertr.c arm_schedulesigaction.c
 CMN_CSRCS += arm_sigdeliver.c arm_stackframe.c arm_svcall.c arm_systemreset.c
@@ -32,10 +32,6 @@ CMN_CSRCS += arm_doirq.c arm_vfork.c arm_switchcontext.c arm_puts.c
 
 ifeq ($(CONFIG_STM32_TICKLESS_SYSTICK),y)
 CMN_CSRCS += arm_systick.c
-endif
-
-ifneq ($(CONFIG_TIMER_ARCH),y)
-CMN_CSRCS += arm_mdelay.c
 endif
 
 ifeq ($(CONFIG_ARMV7M_STACKCHECK),y)


### PR DESCRIPTION
## Summary
Fix `undefined reference to 'up_systemreset'` for SAMV7 architecture

## Impact
`CONFIG_BOARDCTL_RESET` option is working for SAMV7 based boards

## Testing
Tested on SAME70 based board