### PR TITLE
arch/arm/samv7/sam_progmem: insert DMB instruction into data write loop

### DIFF
--- a/arch/arm/src/samv7/sam_progmem.c
+++ b/arch/arm/src/samv7/sam_progmem.c
@@ -582,6 +582,10 @@ ssize_t up_progmem_write(size_t address, const void *buffer, size_t buflen)
       for (i = 0; i < SAMV7_PAGE_WORDS; i++)
         {
           *dest++ = *src++;
+
+#ifdef CONFIG_ARMV7M_DCACHE_WRITETHROUGH
+          ARM_DMB();
+#endif
         }
 
       /* Flush the data cache to memory */


### PR DESCRIPTION
## Summary
This change fix the regression that was introduced with https://github.com/apache/incubator-nuttx/pull/4904

In case if D-Cache is configured in Write-Through mode there is Cortex-M7 erata 1313001 that describes a situation when linefill buffer or cache contains stale data. Even if progmem write loop does not fully matches the description there is a possibility to program stale data if there is no DMB instruction after each write operation to progmem latch buffer.

## Impact
SAMv7 based devices

## Testing
Tested with multiple progmem reprogramming cycles on custom SAME70 based board with `CONFIG_ARMV7M_DCACHE_WRITETHROUGH=y`. No stale data are observed in flash.