### PR TITLE
pthread: Add len argument to pthread_getname_np

### DIFF
--- a/include/pthread.h
+++ b/include/pthread.h
@@ -29,8 +29,6 @@
 #include <nuttx/compiler.h>  /* Compiler settings, noreturn_function */
 
 #include <sys/types.h>       /* Needed for general types */
-#include <sys/prctl.h>       /* Needed by pthread_[set|get]name_np */
-
 #include <stdint.h>          /* C99 fixed width integer types */
 #include <stdbool.h>         /* C99 boolean types */
 #include <unistd.h>          /* For getpid */
@@ -187,18 +185,6 @@
 #define _PTHREAD_MFLAGS_ROBUST        (1 << 0) /* Robust (NORMAL) mutex */
 #define _PTHREAD_MFLAGS_INCONSISTENT  (1 << 1) /* Mutex is in an inconsistent state */
 #define _PTHREAD_MFLAGS_NRECOVERABLE  (1 << 2) /* Inconsistent mutex has been unlocked */
-
-/* Definitions to map some non-standard, BSD thread management interfaces to
- * the non-standard Linux-like prctl() interface.  Since these are simple
- * mappings to prctl, they will return 0 on success and -1 on failure with the
- * error number in errno.  This is an inconsistency with the pthread interfaces.
- */
-
-#define pthread_setname_np(thread, name) \
-  prctl((int)PR_SET_NAME_EXT, (char*)name, (int)thread)
-
-#define pthread_getname_np(thread, name) \
-  prctl((int)PR_GET_NAME_EXT, (char*)name, (int)thread)
 
 /********************************************************************************
  * Public Type Definitions
@@ -483,6 +469,11 @@ int pthread_attr_setstack(FAR pthread_attr_t *attr,
                           FAR void *stackaddr, long stacksize);
 int pthread_attr_getstack(FAR pthread_attr_t *attr,
                           FAR void **stackaddr, FAR long *stacksize);
+
+/* Set or get the name of a thread */
+
+int pthread_setname_np(pthread_t thread, FAR const char *name);
+int pthread_getname_np(pthread_t thread, FAR char *name, size_t len);
 
 /* Get run-time stack address and size */
 

--- a/libs/libc/pthread/Make.defs
+++ b/libs/libc/pthread/Make.defs
@@ -41,6 +41,7 @@ CSRCS += pthread_condattr_init.c pthread_condattr_destroy.c
 CSRCS += pthread_condattr_setclock.c pthread_condattr_getclock.c
 CSRCS += pthread_condinit.c pthread_conddestroy.c pthread_condtimedwait.c
 CSRCS += pthread_create.c pthread_exit.c
+CSRCS += pthread_setname_np.c pthread_getname_np.c
 CSRCS += pthread_get_stackaddr_np.c pthread_get_stacksize_np.c
 CSRCS += pthread_mutexattr_init.c pthread_mutexattr_destroy.c
 CSRCS += pthread_mutexattr_getpshared.c pthread_mutexattr_setpshared.c

--- a/libs/libc/pthread/pthread_getname_np.c
+++ b/libs/libc/pthread/pthread_getname_np.c
@@ -1,0 +1,60 @@
+/****************************************************************************
+ * libs/libc/pthread/pthread_getname_np.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <sys/prctl.h>
+#include <errno.h>
+#include <pthread.h>
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: pthread_getname_np
+ *
+ * Description:
+ *   Get the name of a thread
+ *
+ * Parameters:
+ *   thread - The thread whose name is to be retrieved
+ *   name   - The buffer to return the thread name
+ *   len    - The number of bytes available in name
+ *
+ * Returned Value:
+ *   On success, these functions return 0;
+ *   on error, they return a nonzero error number.
+ *
+ ****************************************************************************/
+
+int pthread_getname_np(pthread_t thread, FAR char *name, size_t len)
+{
+  if (len <= CONFIG_TASK_NAME_SIZE)
+    {
+      return ERANGE;
+    }
+
+  return prctl(PR_GET_NAME_EXT, name, (int)thread) < 0 ? get_errno() : 0;
+}

--- a/libs/libc/pthread/pthread_setname_np.c
+++ b/libs/libc/pthread/pthread_setname_np.c
@@ -1,0 +1,54 @@
+/****************************************************************************
+ * libs/libc/pthread/pthread_setname_np.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <sys/prctl.h>
+#include <errno.h>
+#include <pthread.h>
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: pthread_setname_np
+ *
+ * Description:
+ *   Set the name of a thread
+ *
+ * Parameters:
+ *   thread - The thread whose name is to be changed
+ *   name   - The new thread name
+ *
+ * Returned Value:
+ *   On success, these functions return 0;
+ *   on error, they return a nonzero error number.
+ *
+ ****************************************************************************/
+
+int pthread_setname_np(pthread_t thread, FAR const char *name)
+{
+  return prctl(PR_SET_NAME_EXT, name, (int)thread) < 0 ? get_errno() : 0;
+}


### PR DESCRIPTION
## Summary
follow the spec:
https://man7.org/linux/man-pages/man3/pthread_setname_np.3.html

## Impact
the caller of pthread_getname_np

## Testing
Pass CI
