### PR TITLE
sched/wdog: fix adding one extra tick to any delay

### DIFF
--- a/sched/wdog/wd_start.c
+++ b/sched/wdog/wd_start.c
@@ -210,7 +210,7 @@ int wd_start(FAR struct wdog_s *wdog, sclock_t delay,
     {
       delay = 1;
     }
-  else if (++delay <= 0)
+  else if ((delay + 1) <= 0)
     {
       delay--;
     }


### PR DESCRIPTION
## Summary
This changes tremendously improve Real-Time performance of the OS and apps since till now an extra system tick was added by wd_start() and that lead to wrong timing in the system for all functionality that relies on wdog

## Impact
All over the system and apps

## Testing
Tested on SAME70-QMTECH board that toggles GPIO periodically. The pulse width and period are right as expected