### PR TITLE
Unify the pseudo file object path naming

### DIFF
--- a/fs/mount/fs_automount.c
+++ b/fs/mount/fs_automount.c
@@ -54,15 +54,6 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-/* Configuration ************************************************************
- *
- * CONFIG_FS_AUTOMOUNTER - Enables AUTOMOUNT support
- */
-
-#ifndef CONFIG_FS_AUTOMOUNTER_VFS_PATH
-#  define CONFIG_FS_AUTOMOUNTER_VFS_PATH "/var"
-#endif
-
 /* Pre-requisites */
 
 #ifndef CONFIG_SCHED_WORKQUEUE

--- a/fs/mqueue/Kconfig
+++ b/fs/mqueue/Kconfig
@@ -5,7 +5,7 @@
 
 if !DISABLE_MQUEUE
 
-config FS_MQUEUE_MPATH
+config FS_MQUEUE_VFS_PATH
 	string "Path to message queue"
 	default "/var/mqueue"
 	---help---

--- a/fs/mqueue/mq_open.c
+++ b/fs/mqueue/mq_open.c
@@ -177,7 +177,7 @@ static int file_mq_vopen(FAR struct file *mq, FAR const char *mq_name,
       goto errout;
     }
 
-  if (sizeof(CONFIG_FS_MQUEUE_MPATH) + 1 + strlen(mq_name)
+  if (sizeof(CONFIG_FS_MQUEUE_VFS_PATH) + 1 + strlen(mq_name)
       >= MAX_MQUEUE_PATH)
     {
       ret = -ENAMETOOLONG;
@@ -199,7 +199,7 @@ static int file_mq_vopen(FAR struct file *mq, FAR const char *mq_name,
   mode &= ~umask;
 
   /* Skip over any leading '/'.  All message queue paths are relative to
-   * CONFIG_FS_MQUEUE_MPATH.
+   * CONFIG_FS_MQUEUE_VFS_PATH.
    */
 
   while (*mq_name == '/')
@@ -209,7 +209,8 @@ static int file_mq_vopen(FAR struct file *mq, FAR const char *mq_name,
 
   /* Get the full path to the message queue */
 
-  snprintf(fullpath, MAX_MQUEUE_PATH, CONFIG_FS_MQUEUE_MPATH "/%s", mq_name);
+  snprintf(fullpath, MAX_MQUEUE_PATH,
+           CONFIG_FS_MQUEUE_VFS_PATH "/%s", mq_name);
 
   /* Make sure that the check for the existence of the message queue
    * and the creation of the message queue are atomic with respect to

--- a/fs/mqueue/mq_unlink.c
+++ b/fs/mqueue/mq_unlink.c
@@ -105,7 +105,8 @@ int file_mq_unlink(FAR const char *mq_name)
 
   /* Get the full path to the message queue */
 
-  snprintf(fullpath, MAX_MQUEUE_PATH, CONFIG_FS_MQUEUE_MPATH "/%s", mq_name);
+  snprintf(fullpath, MAX_MQUEUE_PATH,
+           CONFIG_FS_MQUEUE_VFS_PATH "/%s", mq_name);
 
   /* Get the inode for this message queue. */
 

--- a/fs/mqueue/mqueue.h
+++ b/fs/mqueue/mqueue.h
@@ -31,12 +31,6 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-/* Configuration ************************************************************/
-
-#ifndef CONFIG_FS_MQUEUE_MPATH
-#  define CONFIG_FS_MQUEUE_MPATH "/var/mqueue"
-#endif
-
 /* Sizes of things */
 
 #define MAX_MQUEUE_PATH 64

--- a/fs/semaphore/Kconfig
+++ b/fs/semaphore/Kconfig
@@ -13,7 +13,7 @@ if FS_NAMED_SEMAPHORES
 
 config FS_NAMED_SEMAPHORES_VFS_PATH
 	string "Path to semaphore storage"
-	default "/var/lock"
+	default "/var/sem"
 	---help---
 		The path to where named semaphores will exist in the VFS namespace.
 

--- a/fs/semaphore/Kconfig
+++ b/fs/semaphore/Kconfig
@@ -11,7 +11,7 @@ config FS_NAMED_SEMAPHORES
 
 if FS_NAMED_SEMAPHORES
 
-config FS_NAMED_SEMPATH
+config FS_NAMED_SEMAPHORES_VFS_PATH
 	string "Path to semaphore storage"
 	default "/var/lock"
 	---help---

--- a/fs/semaphore/sem_open.c
+++ b/fs/semaphore/sem_open.c
@@ -114,7 +114,8 @@ FAR sem_t *sem_open(FAR const char *name, int oflags, ...)
 
   /* Get the full path to the semaphore */
 
-  snprintf(fullpath, MAX_SEMPATH, CONFIG_FS_NAMED_SEMPATH "/%s", name);
+  snprintf(fullpath, MAX_SEMPATH,
+           CONFIG_FS_NAMED_SEMAPHORES_VFS_PATH "/%s", name);
 
   /* Get the inode for this semaphore.  This should succeed if the
    * semaphore has already been created.  In this case, inode_find()

--- a/fs/semaphore/sem_unlink.c
+++ b/fs/semaphore/sem_unlink.c
@@ -72,7 +72,8 @@ int sem_unlink(FAR const char *name)
 
   /* Get the full path to the semaphore */
 
-  snprintf(fullpath, MAX_SEMPATH, CONFIG_FS_NAMED_SEMPATH "/%s", name);
+  snprintf(fullpath, MAX_SEMPATH,
+           CONFIG_FS_NAMED_SEMAPHORES_VFS_PATH "/%s", name);
 
   /* Get the inode for this semaphore. */
 

--- a/fs/shm/Kconfig
+++ b/fs/shm/Kconfig
@@ -12,7 +12,7 @@ config FS_SHM
 
 if FS_SHM
 
-config FS_SHMPATH
+config FS_SHM_VFS_PATH
 	string "Path to shared memory object storage"
 	default "/var/shm"
 	---help---

--- a/fs/vfs/fs_eventfd.c
+++ b/fs/vfs/fs_eventfd.c
@@ -37,19 +37,6 @@
 #include "inode/inode.h"
 
 /****************************************************************************
- * Pre-processor Definitions
- ****************************************************************************/
-
-#ifndef CONFIG_EVENT_FD_VFS_PATH
-#define CONFIG_EVENT_FD_VFS_PATH "/var/event"
-#endif
-
-#ifndef CONFIG_EVENT_FD_NPOLLWAITERS
-/* Maximum number of threads than can be waiting for POLL events */
-#define CONFIG_EVENT_FD_NPOLLWAITERS 2
-#endif
-
-/****************************************************************************
  * Private Types
  ****************************************************************************/
 

--- a/fs/vfs/fs_timerfd.c
+++ b/fs/vfs/fs_timerfd.c
@@ -45,15 +45,6 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-#ifndef CONFIG_TIMER_FD_VFS_PATH
-#define CONFIG_TIMER_FD_VFS_PATH "/var/timer"
-#endif
-
-#ifndef CONFIG_TIMER_FD_NPOLLWAITERS
-/* Maximum number of threads than can be waiting for POLL events */
-#define CONFIG_TIMER_FD_NPOLLWAITERS 2
-#endif
-
 #define TIMER_FD_WORK LPWORK
 
 /****************************************************************************


### PR DESCRIPTION
## Summary

- fs: Remove the unnecessary Kconfig definition
- shm: Rename FS_SHMPATH to FS_SHM_VFS_PATH
- mqueue: Rename FS_MQUEUE_MPATH to FS_MQUEUE_VFS_PATH
- semaphore: Rename FS_NAMED_SEMPATH to FS_NAMED_SEMAPHORES_VFS_PATH
- semaphore: Change FS_NAMED_SEMPATH from "/var/lock" to "/var/sem"

## Impact
Minor, since nobody change the default setting.

## Testing
Pass CI
