### PR TITLE
pipe: Add DEV_PIPE_VFS_PATH to specify the pipe location

### DIFF
--- a/drivers/pipes/Kconfig
+++ b/drivers/pipes/Kconfig
@@ -14,8 +14,7 @@ if PIPES
 
 config DEV_PIPE_MAXSIZE
 	int "Maximum pipe/FIFO size"
-	default 1024 if !DEFAULT_SMALL
-	default 256 if DEFAULT_SMALL
+	default 65535
 	---help---
 		Maximum configurable size of a pipe or FIFO at runtime.
 

--- a/drivers/pipes/Kconfig
+++ b/drivers/pipes/Kconfig
@@ -34,4 +34,10 @@ config DEV_FIFO_SIZE
 		Sets the default size of the FIFO ringbuffer in bytes.  A value of
 		zero disables FIFO support.
 
+config DEV_PIPE_VFS_PATH
+	string "Path to the pipe device"
+	default "/var/pipe"
+	---help---
+		The path to where pipe device will exist in the VFS namespace.
+
 endif # PIPES

--- a/drivers/pipes/pipe.c
+++ b/drivers/pipes/pipe.c
@@ -174,7 +174,7 @@ static int pipe_register(size_t bufsize, int flags,
 
   /* Create a pathname to the pipe device */
 
-  snprintf(devname, namesize, "/dev/pipe%d", pipeno);
+  snprintf(devname, namesize, CONFIG_DEV_PIPE_VFS_PATH"/%d", pipeno);
 
   /* Check if the pipe device has already been created */
 


### PR DESCRIPTION
## Summary
Pair with https://github.com/apache/incubator-nuttx/pull/5422

## Impact
Minor. Pipe is an anonymous object from concept even NuttX give it a name in the implementation level, so nobody should care about pipe name.

## Testing
Pass CI
