### PR TITLE
timer: fix operation of periodic timers

### DIFF
--- a/fs/vfs/fs_timerfd.c
+++ b/fs/vfs/fs_timerfd.c
@@ -531,7 +531,11 @@ static void timerfd_timeout(wdparm_t idev)
 
   if (dev->delay)
     {
-      wd_start(&dev->wdog, dev->delay, timerfd_timeout, idev);
+      /* We have to subtract 1 tick because wd_start() will add 1 tick
+       * unconditionally
+       */
+
+      wd_start(&dev->wdog, dev->delay - 1, timerfd_timeout, idev);
     }
 
   spin_unlock_irqrestore(&dev->lock, intflags);

--- a/sched/timer/timer.h
+++ b/sched/timer/timer.h
@@ -55,7 +55,6 @@ struct posix_timer_s
   uint8_t          pt_crefs;       /* Reference count */
   pid_t            pt_owner;       /* Creator of timer */
   int              pt_delay;       /* If non-zero, used to reset repetitive timers */
-  int              pt_last;        /* Last value used to set watchdog */
   struct wdog_s    pt_wdog;        /* The watchdog that provides the timing */
   struct sigevent  pt_event;       /* Notification information */
   struct sigwork_s pt_work;

--- a/sched/timer/timer_settime.c
+++ b/sched/timer/timer_settime.c
@@ -98,8 +98,11 @@ static inline void timer_restart(FAR struct posix_timer_s *timer,
 
   if (timer->pt_delay)
     {
-      timer->pt_last = timer->pt_delay;
-      wd_start(&timer->pt_wdog, timer->pt_delay, timer_timeout, itimer);
+      /* We have to subtract 1 tick because wd_start() will add 1 tick
+       * unconditionally
+       */
+
+      wd_start(&timer->pt_wdog, timer->pt_delay - 1, timer_timeout, itimer);
     }
 }
 
@@ -313,13 +316,9 @@ int timer_settime(timer_t timerid, int flags,
 
   if (delay > 0)
     {
-      /* REVISIT: Should pt_last be sclock_t? Should wd_start delay be
-       *          sclock_t?
-       */
+      /* REVISIT: Should wd_start delay be sclock_t? */
 
-      timer->pt_last = delay;
-      ret = wd_start(&timer->pt_wdog, delay,
-                     timer_timeout, (wdparm_t)timer);
+      ret = wd_start(&timer->pt_wdog, delay, timer_timeout, (wdparm_t)timer);
       if (ret < 0)
         {
           set_errno(-ret);


### PR DESCRIPTION
## Summary
The POSIX timers and timerfd are based on wdog. The `wd_start()` API adds 1 tick to a delay parameter so periodic timers have accumulative error. Subtract 1 tick from delay before calling `wd_start()` from `wdentry` callback to remove accumulative error.

Remove `pt_last` member from `struct posix_timer_s` because it is not used anywhere.

## Impact
POSIX timers and timerfd users

## Testing
WIP
