### PR TITLE
Minor fix for ptmx driver

### DIFF
--- a/drivers/serial/ptmx.c
+++ b/drivers/serial/ptmx.c
@@ -306,7 +306,7 @@ void ptmx_minor_free(uint8_t minor)
   index = minor >> 5;
   bitno = minor & 31;
 
-  DEBUGASSERT((g_ptmx.px_alloctab[index] |= (1 << bitno)) != 0);
+  DEBUGASSERT((g_ptmx.px_alloctab[index] & (1 << bitno)) != 0);
   g_ptmx.px_alloctab[index] &= ~(1 << bitno);
 
   /* Reset the next pointer if the one just released has a lower value */

--- a/drivers/serial/ptmx.c
+++ b/drivers/serial/ptmx.c
@@ -299,6 +299,8 @@ void ptmx_minor_free(uint8_t minor)
   int index;
   int bitno;
 
+  nxsem_wait_uninterruptible(&g_ptmx.px_exclsem);
+
   /* Free the address by clearing the associated bit in the px_alloctab[]; */
 
   index = minor >> 5;
@@ -313,4 +315,6 @@ void ptmx_minor_free(uint8_t minor)
     {
       g_ptmx.px_next = minor;
     }
+
+  nxsem_post(&g_ptmx.px_exclsem);
 }


### PR DESCRIPTION
## Summary

- serial/ptmx: Add lock to avoid the race condition in ptmx_minor_free 
- serial/ptmx: Fix the typo error in ptmx_minor_free

## Impact
Minor

## Testing
Pass CI
