### PR TITLE
serial/pty: Don't use shced_[lock|unlock] to protect pp_locked 

### DIFF
--- a/drivers/serial/pty.c
+++ b/drivers/serial/pty.c
@@ -255,6 +255,7 @@ static void pty_destroy(FAR struct pty_devpair_s *devpair)
   /* And free the device structure */
 
   nxsem_destroy(&devpair->pp_exclsem);
+  nxsem_destroy(&devpair->pp_slavesem);
   kmm_free(devpair);
 }
 #endif


### PR DESCRIPTION
## Summary
since the sched lock can't work in SMP context

- serial/pty: Destroy pp_slavesem in pty_destroy to avoid the leak

## Impact
Fix the issue on SMP

## Testing
Local test
