### PR TITLE
arch/sim: Don't add up_tls_size in up_use_stack before foward to up_create_stack

### DIFF
--- a/arch/sim/src/sim/up_usestack.c
+++ b/arch/sim/src/sim/up_usestack.c
@@ -119,7 +119,6 @@ int up_use_stack(FAR struct tcb_s *tcb, FAR void *stack, size_t stack_size)
    * since it's impossible to extend a preallocated memory in place.
    */
 
-  return up_create_stack(tcb, up_tls_size() + stack_size,
-                         tcb->flags & TCB_FLAG_TTYPE_MASK);
+  return up_create_stack(tcb, stack_size, tcb->flags & TCB_FLAG_TTYPE_MASK);
 #endif
 }


### PR DESCRIPTION
## Summary
@yamt after more thought, I think that we shouldn't add up_tls_size() in sim, because the common code doesn't adjust stack size in case of the stack space is given by caller.

## Impact
sim,

## Testing

