### PR TITLE
net/tcp/udp: remove psock hook to avoid invalid reference

### DIFF
--- a/fs/procfs/fs_procfsproc.c
+++ b/fs/procfs/fs_procfsproc.c
@@ -1177,11 +1177,11 @@ static ssize_t proc_groupfd(FAR struct proc_file_s *procfile,
           if (file->f_inode && INODE_IS_SOCKET(file->f_inode))
             {
               FAR struct socket *socket = file->f_priv;
+              FAR struct socket_conn_s *conn = socket->s_conn;
               linesize   = procfs_snprintf(procfile->line, STATUS_LINELEN,
                                     "%3d %3d %02x",
                                     i * CONFIG_NFILE_DESCRIPTORS_PER_BLOCK +
-                                    j, socket->s_type,
-                                    socket->s_flags);
+                                    j, socket->s_type, conn->s_flags);
               copysize   = procfs_memcpy(procfile->line, linesize, buffer,
                                          remaining, &offset);
 

--- a/include/nuttx/net/net.h
+++ b/include/nuttx/net/net.h
@@ -238,6 +238,8 @@ struct socket_conn_s
 #ifdef CONFIG_NET_SOCKOPTS
   int16_t       s_error;     /* Last error that occurred on this socket */
   sockopt_t     s_options;   /* Selected socket options */
+  socktimeo_t   s_rcvtimeo;  /* Receive timeout value (in deciseconds) */
+  socktimeo_t   s_sndtimeo;  /* Send timeout value (in deciseconds) */
 #endif
 
   /* Connection-specific content may follow */
@@ -258,8 +260,6 @@ struct socket
   /* Socket options */
 
 #ifdef CONFIG_NET_SOCKOPTS
-  socktimeo_t   s_rcvtimeo;  /* Receive timeout value (in deciseconds) */
-  socktimeo_t   s_sndtimeo;  /* Send timeout value (in deciseconds) */
 #ifdef CONFIG_NET_SOLINGER
   socktimeo_t   s_linger;    /* Linger timeout value (in deciseconds) */
 #endif

--- a/include/nuttx/net/net.h
+++ b/include/nuttx/net/net.h
@@ -243,6 +243,9 @@ struct socket_conn_s
 #ifdef CONFIG_NET_SOLINGER
   socktimeo_t   s_linger;    /* Linger timeout value (in deciseconds) */
 #endif
+#ifdef CONFIG_NET_TIMESTAMP
+  int32_t       s_timestamp; /* Socket timestamp enabled/disabled */
+#endif
 #endif
 
   /* Connection-specific content may follow */
@@ -259,15 +262,6 @@ struct socket
   uint8_t       s_domain;    /* IP domain */
   uint8_t       s_type;      /* Protocol type */
   uint8_t       s_proto;     /* Socket Protocol */
-
-  /* Socket options */
-
-#ifdef CONFIG_NET_SOCKOPTS
-#ifdef CONFIG_NET_TIMESTAMP
-  int32_t       s_timestamp; /* Socket timestamp enabled/disabled */
-#endif
-#endif
-
   FAR void     *s_conn;      /* Connection inherits from struct socket_conn_s */
 
   /* Socket interface */

--- a/include/nuttx/net/net.h
+++ b/include/nuttx/net/net.h
@@ -237,6 +237,7 @@ struct socket_conn_s
 
 #ifdef CONFIG_NET_SOCKOPTS
   int16_t       s_error;     /* Last error that occurred on this socket */
+  sockopt_t     s_options;   /* Selected socket options */
 #endif
 
   /* Connection-specific content may follow */
@@ -257,7 +258,6 @@ struct socket
   /* Socket options */
 
 #ifdef CONFIG_NET_SOCKOPTS
-  sockopt_t     s_options;   /* Selected socket options */
   socktimeo_t   s_rcvtimeo;  /* Receive timeout value (in deciseconds) */
   socktimeo_t   s_sndtimeo;  /* Send timeout value (in deciseconds) */
 #ifdef CONFIG_NET_SOLINGER

--- a/include/nuttx/net/net.h
+++ b/include/nuttx/net/net.h
@@ -229,6 +229,10 @@ struct socket_conn_s
   FAR struct devif_callback_s *list;
   FAR struct devif_callback_s *list_tail;
 
+  /* Definitions of 8-bit socket flags */
+
+  uint8_t       s_flags;     /* See _SF_* definitions */
+
   /* Connection-specific content may follow */
 };
 
@@ -243,7 +247,6 @@ struct socket
   uint8_t       s_domain;    /* IP domain */
   uint8_t       s_type;      /* Protocol type */
   uint8_t       s_proto;     /* Socket Protocol */
-  uint8_t       s_flags;     /* See _SF_* definitions */
 
   /* Socket options */
 

--- a/include/nuttx/net/net.h
+++ b/include/nuttx/net/net.h
@@ -240,6 +240,9 @@ struct socket_conn_s
   sockopt_t     s_options;   /* Selected socket options */
   socktimeo_t   s_rcvtimeo;  /* Receive timeout value (in deciseconds) */
   socktimeo_t   s_sndtimeo;  /* Send timeout value (in deciseconds) */
+#ifdef CONFIG_NET_SOLINGER
+  socktimeo_t   s_linger;    /* Linger timeout value (in deciseconds) */
+#endif
 #endif
 
   /* Connection-specific content may follow */
@@ -260,9 +263,6 @@ struct socket
   /* Socket options */
 
 #ifdef CONFIG_NET_SOCKOPTS
-#ifdef CONFIG_NET_SOLINGER
-  socktimeo_t   s_linger;    /* Linger timeout value (in deciseconds) */
-#endif
 #ifdef CONFIG_NET_TIMESTAMP
   int32_t       s_timestamp; /* Socket timestamp enabled/disabled */
 #endif

--- a/include/nuttx/net/net.h
+++ b/include/nuttx/net/net.h
@@ -227,6 +227,7 @@ struct socket_conn_s
    */
 
   FAR struct devif_callback_s *list;
+  FAR struct devif_callback_s *list_tail;
 
   /* Connection-specific content may follow */
 };

--- a/include/nuttx/net/net.h
+++ b/include/nuttx/net/net.h
@@ -264,13 +264,6 @@ struct socket
   /* Socket interface */
 
   FAR const struct sock_intf_s *s_sockif;
-
-#if defined(CONFIG_NET_TCP_WRITE_BUFFERS) || \
-    defined(CONFIG_NET_UDP_WRITE_BUFFERS)
-  /* Callback instance for TCP send() or UDP sendto() */
-
-  FAR struct devif_callback_s *s_sndcb;
-#endif
 };
 
 /****************************************************************************

--- a/include/nuttx/net/net.h
+++ b/include/nuttx/net/net.h
@@ -233,6 +233,12 @@ struct socket_conn_s
 
   uint8_t       s_flags;     /* See _SF_* definitions */
 
+  /* Socket options */
+
+#ifdef CONFIG_NET_SOCKOPTS
+  int16_t       s_error;     /* Last error that occurred on this socket */
+#endif
+
   /* Connection-specific content may follow */
 };
 
@@ -251,7 +257,6 @@ struct socket
   /* Socket options */
 
 #ifdef CONFIG_NET_SOCKOPTS
-  int16_t       s_error;     /* Last error that occurred on this socket */
   sockopt_t     s_options;   /* Selected socket options */
   socktimeo_t   s_rcvtimeo;  /* Receive timeout value (in deciseconds) */
   socktimeo_t   s_sndtimeo;  /* Send timeout value (in deciseconds) */

--- a/net/bluetooth/bluetooth.h
+++ b/net/bluetooth/bluetooth.h
@@ -31,6 +31,8 @@
 #include <sys/socket.h>
 #include <queue.h>
 
+#include <nuttx/net/net.h>
+
 #include <nuttx/wireless/bluetooth/bt_hci.h>
 
 #ifdef CONFIG_NET_BLUETOOTH
@@ -42,9 +44,9 @@
 /* Allocate a new Bluetooth socket data callback */
 
 #define bluetooth_callback_alloc(dev,conn) \
-  devif_callback_alloc(dev, &conn->bc_list, &conn->bc_list_tail)
+  devif_callback_alloc(dev, &conn->bc_conn.list, &conn->bc_conn.list_tail)
 #define bluetooth_callback_free(dev,conn,cb) \
-  devif_conn_callback_free(dev, cb, &conn->bc_list, &conn->bc_list_tail)
+  devif_conn_callback_free(dev, cb, &conn->bc_conn.list, &conn->bc_conn.list_tail)
 
 /* Memory Pools */
 
@@ -78,14 +80,7 @@ struct bluetooth_conn_s
 {
   /* Common prologue of all connection structures. */
 
-  dq_entry_t bc_node;                         /* Supports a doubly linked list */
-
-  /* This is a list of Bluetooth callbacks.  Each callback represents
-   * a thread that is stalled, waiting for a device-specific event.
-   */
-
-  FAR struct devif_callback_s *bc_list;       /* Bluetooth callbacks */
-  FAR struct devif_callback_s *bc_list_tail;  /* Bluetooth callbacks */
+  struct socket_conn_s bc_conn;
 
   /* Bluetooth-specific content follows. */
 

--- a/net/bluetooth/bluetooth_callback.c
+++ b/net/bluetooth/bluetooth_callback.c
@@ -69,7 +69,8 @@ uint16_t bluetooth_callback(FAR struct radio_driver_s *radio,
     {
       /* Perform the callback */
 
-      flags = devif_conn_event(&radio->r_dev, conn, flags, conn->bc_list);
+      flags = devif_conn_event(&radio->r_dev, conn,
+                               flags, conn->bc_conn.list);
     }
 
   return flags;

--- a/net/bluetooth/bluetooth_conn.c
+++ b/net/bluetooth/bluetooth_conn.c
@@ -102,7 +102,7 @@ void bluetooth_conn_initialize(void)
     {
       /* Link each pre-allocated connection structure into the free list. */
 
-      dq_addlast(&g_bluetooth_connections[i].bc_node,
+      dq_addlast(&g_bluetooth_connections[i].bc_conn.node,
                  &g_free_bluetooth_connections);
     }
 #endif
@@ -135,7 +135,7 @@ FAR struct bluetooth_conn_s *bluetooth_conn_alloc(void)
         {
           for (i = 0; i < CONFIG_NET_BLUETOOTH_NCONNS; i++)
             {
-              dq_addlast(&conn[i].bc_node,
+              dq_addlast(&conn[i].bc_conn.node,
                          &g_active_bluetooth_connections);
             }
         }
@@ -152,7 +152,7 @@ FAR struct bluetooth_conn_s *bluetooth_conn_alloc(void)
 
       /* Enqueue the connection into the active list */
 
-      dq_addlast(&conn->bc_node, &g_active_bluetooth_connections);
+      dq_addlast(&conn->bc_conn.node, &g_active_bluetooth_connections);
     }
 
   net_unlock();
@@ -180,7 +180,7 @@ void bluetooth_conn_free(FAR struct bluetooth_conn_s *conn)
   /* Remove the connection from the active list */
 
   net_lock();
-  dq_rem(&conn->bc_node, &g_active_bluetooth_connections);
+  dq_rem(&conn->bc_conn.node, &g_active_bluetooth_connections);
 
   /* Check if there any any frames attached to the container */
 
@@ -209,7 +209,7 @@ void bluetooth_conn_free(FAR struct bluetooth_conn_s *conn)
 
   /* Free the connection */
 
-  dq_addlast(&conn->bc_node, &g_free_bluetooth_connections);
+  dq_addlast(&conn->bc_conn.node, &g_free_bluetooth_connections);
 
   net_unlock();
 }
@@ -236,7 +236,7 @@ FAR struct bluetooth_conn_s *
   for (conn =
        (FAR struct bluetooth_conn_s *)g_active_bluetooth_connections.head;
        conn != NULL;
-       conn = (FAR struct bluetooth_conn_s *)conn->bc_node.flink)
+       conn = (FAR struct bluetooth_conn_s *)conn->bc_conn.node.flink)
     {
       /* match protocol and channel first */
 
@@ -303,7 +303,7 @@ FAR struct bluetooth_conn_s *
     }
   else
     {
-      return (FAR struct bluetooth_conn_s *)conn->bc_node.flink;
+      return (FAR struct bluetooth_conn_s *)conn->bc_conn.node.flink;
     }
 }
 

--- a/net/bluetooth/bluetooth_sendmsg.c
+++ b/net/bluetooth/bluetooth_sendmsg.c
@@ -426,7 +426,7 @@ static ssize_t bluetooth_l2cap_send(FAR struct socket *psock,
   conn = (FAR struct bluetooth_conn_s *)psock->s_conn;
   DEBUGASSERT(conn != NULL);
 
-  if (!_SS_ISCONNECTED(psock->s_flags))
+  if (!_SS_ISCONNECTED(conn->bc_conn.s_flags))
     {
       ret = -ENOTCONN;
     }

--- a/net/bluetooth/bluetooth_sockif.c
+++ b/net/bluetooth/bluetooth_sockif.c
@@ -447,15 +447,18 @@ static int bluetooth_l2cap_bind(FAR struct socket *psock,
    * Only SOCK_RAW is supported
    */
 
-  if (psock->s_type != SOCK_RAW)
+  if (psock == NULL || psock->s_conn == NULL ||
+      psock->s_type != SOCK_RAW)
     {
       nerr("ERROR: Invalid socket type: %u\n", psock->s_type);
       return -EBADF;
     }
 
+  conn = (FAR struct bluetooth_conn_s *)psock->s_conn;
+
   /* Verify that the socket is not already bound. */
 
-  if (_SS_ISBOUND(psock->s_flags))
+  if (_SS_ISBOUND(conn->bc_conn.s_flags))
     {
       nerr("ERROR: Already bound\n");
       return -EINVAL;
@@ -466,8 +469,6 @@ static int bluetooth_l2cap_bind(FAR struct socket *psock,
    * REVISIT: Currently and explicit address must be assigned.  Should we
    * support some moral equivalent to INADDR_ANY?
    */
-
-  conn = (FAR struct bluetooth_conn_s *)psock->s_conn;
 
   conn->bc_proto = psock->s_proto;
 
@@ -519,21 +520,22 @@ static int bluetooth_hci_bind(FAR struct socket *psock,
    * Only SOCK_RAW is supported
    */
 
-  if (psock->s_type != SOCK_RAW)
+  if (psock == NULL || psock->s_conn == NULL ||
+      psock->s_type != SOCK_RAW)
     {
       nerr("ERROR: Invalid socket type: %u\n", psock->s_type);
       return -EBADF;
     }
 
+  conn = (FAR struct bluetooth_conn_s *)psock->s_conn;
+
   /* Verify that the socket is not already bound. */
 
-  if (_SS_ISBOUND(psock->s_flags))
+  if (_SS_ISBOUND(conn->bc_conn.s_flags))
     {
       nerr("ERROR: Already bound\n");
       return -EINVAL;
     }
-
-  conn = (FAR struct bluetooth_conn_s *)psock->s_conn;
 
   conn->bc_proto = psock->s_proto;
   conn->bc_channel = hciaddr->hci_channel;

--- a/net/can/can.h
+++ b/net/can/can.h
@@ -33,6 +33,7 @@
 #include <netpacket/can.h>
 #include <nuttx/semaphore.h>
 #include <nuttx/can.h>
+#include <nuttx/net/net.h>
 #include <nuttx/net/netdev.h>
 
 #include "devif/devif.h"
@@ -51,9 +52,9 @@
 /* Allocate a new packet socket data callback */
 
 #define can_callback_alloc(dev,conn) \
-  devif_callback_alloc(dev, &conn->list, &conn->list_tail)
+  devif_callback_alloc(dev, &conn->sconn.list, &conn->sconn.list_tail)
 #define can_callback_free(dev,conn,cb) \
-  devif_conn_callback_free(dev, cb, &conn->list, &conn->list_tail)
+  devif_conn_callback_free(dev, cb, &conn->sconn.list, &conn->sconn.list_tail)
 
 /****************************************************************************
  * Public Type Definitions
@@ -75,15 +76,7 @@ struct can_conn_s
 {
   /* Common prologue of all connection structures. */
 
-  dq_entry_t node;                   /* Supports a doubly linked list */
-
-  /* This is a list of NetLink connection callbacks.  Each callback
-   * represents a thread that is stalled, waiting for a device-specific
-   * event.
-   */
-
-  FAR struct devif_callback_s *list;      /* NetLink callbacks */
-  FAR struct devif_callback_s *list_tail; /* NetLink callbacks */
+  struct socket_conn_s sconn;
 
   FAR struct net_driver_s *dev;      /* Reference to CAN device */
 

--- a/net/can/can_callback.c
+++ b/net/can/can_callback.c
@@ -123,7 +123,7 @@ uint16_t can_callback(FAR struct net_driver_s *dev,
 #ifdef CONFIG_NET_TIMESTAMP
       /* TIMESTAMP sockopt is activated, create timestamp and copy to iob */
 
-      if (conn->psock->s_timestamp)
+      if (conn->sconn.s_timestamp)
         {
           struct timespec *ts = (struct timespec *)
                                                 &dev->d_appdata[dev->d_len];

--- a/net/can/can_callback.c
+++ b/net/can/can_callback.c
@@ -139,7 +139,7 @@ uint16_t can_callback(FAR struct net_driver_s *dev,
 
       if (net_trylock() == OK)
         {
-          flags = devif_conn_event(dev, conn, flags, conn->list);
+          flags = devif_conn_event(dev, conn, flags, conn->sconn.list);
           net_unlock();
         }
 

--- a/net/can/can_conn.c
+++ b/net/can/can_conn.c
@@ -114,7 +114,7 @@ void can_initialize(void)
     {
       /* Mark the connection closed and move it to the free list */
 
-      dq_addlast(&g_can_connections[i].node, &g_free_can_connections);
+      dq_addlast(&g_can_connections[i].sconn.node, &g_free_can_connections);
     }
 #endif
 }
@@ -146,7 +146,7 @@ FAR struct can_conn_s *can_alloc(void)
         {
           for (i = 0; i < CONFIG_CAN_CONNS; i++)
             {
-              dq_addlast(&conn[i].node, &g_free_can_connections);
+              dq_addlast(&conn[i].sconn.node, &g_free_can_connections);
             }
         }
     }
@@ -175,7 +175,7 @@ FAR struct can_conn_s *can_alloc(void)
 
       /* Enqueue the connection into the active list */
 
-      dq_addlast(&conn->node, &g_active_can_connections);
+      dq_addlast(&conn->sconn.node, &g_active_can_connections);
     }
 
   _can_semgive(&g_free_sem);
@@ -201,7 +201,7 @@ void can_free(FAR struct can_conn_s *conn)
 
   /* Remove the connection from the active list */
 
-  dq_rem(&conn->node, &g_active_can_connections);
+  dq_rem(&conn->sconn.node, &g_active_can_connections);
 
   /* Reset structure */
 
@@ -209,7 +209,7 @@ void can_free(FAR struct can_conn_s *conn)
 
   /* Free the connection */
 
-  dq_addlast(&conn->node, &g_free_can_connections);
+  dq_addlast(&conn->sconn.node, &g_free_can_connections);
   _can_semgive(&g_free_sem);
 }
 
@@ -232,7 +232,7 @@ FAR struct can_conn_s *can_nextconn(FAR struct can_conn_s *conn)
     }
   else
     {
-      return (FAR struct can_conn_s *)conn->node.flink;
+      return (FAR struct can_conn_s *)conn->sconn.node.flink;
     }
 }
 

--- a/net/can/can_recvmsg.c
+++ b/net/can/can_recvmsg.c
@@ -438,9 +438,9 @@ static uint16_t can_recvfrom_eventhandler(FAR struct net_driver_s *dev,
 #endif
             {
 #if defined(CONFIG_NET_TIMESTAMP)
-              if ((conn->psock->s_timestamp && (dev->d_len >
+              if ((conn->sconn.s_timestamp && (dev->d_len >
                   sizeof(struct can_frame) + sizeof(struct timeval)))
-                  || (!conn->psock->s_timestamp && (dev->d_len >
+                  || (!conn->sconn.s_timestamp && (dev->d_len >
                    sizeof(struct can_frame))))
 #else
               if (dev->d_len > sizeof(struct can_frame))
@@ -458,7 +458,7 @@ static uint16_t can_recvfrom_eventhandler(FAR struct net_driver_s *dev,
           can_newdata(dev, pstate);
 
 #ifdef CONFIG_NET_TIMESTAMP
-          if (pstate->pr_sock->s_timestamp)
+          if (conn->sconn.s_timestamp)
             {
               if (pstate->pr_msglen == sizeof(struct timeval))
                 {
@@ -597,7 +597,7 @@ ssize_t can_recvmsg(FAR struct socket *psock, FAR struct msghdr *msg,
   state.pr_buffer = msg->msg_iov->iov_base;
 
 #ifdef CONFIG_NET_TIMESTAMP
-  if (psock->s_timestamp && msg->msg_controllen >=
+  if (conn->sconn.s_timestamp && msg->msg_controllen >=
         (sizeof(struct cmsghdr) + sizeof(struct timeval)))
     {
       struct cmsghdr *cmsg = CMSG_FIRSTHDR(msg);
@@ -629,7 +629,7 @@ ssize_t can_recvmsg(FAR struct socket *psock, FAR struct msghdr *msg,
   if (ret > 0)
     {
 #ifdef CONFIG_NET_TIMESTAMP
-      if (psock->s_timestamp)
+      if (conn->sconn.s_timestamp)
         {
           if (state.pr_msglen == sizeof(struct timeval))
             {

--- a/net/can/can_recvmsg.c
+++ b/net/can/can_recvmsg.c
@@ -652,7 +652,7 @@ ssize_t can_recvmsg(FAR struct socket *psock, FAR struct msghdr *msg,
 
   /* Handle non-blocking CAN sockets */
 
-  if (_SS_ISNONBLOCK(psock->s_flags) || (flags & MSG_DONTWAIT) != 0)
+  if (_SS_ISNONBLOCK(conn->sconn.s_flags) || (flags & MSG_DONTWAIT) != 0)
     {
       /* Return the number of bytes read from the read-ahead buffer if
        * something was received (already in 'ret'); EAGAIN if not.

--- a/net/icmp/icmp.h
+++ b/net/icmp/icmp.h
@@ -34,6 +34,7 @@
 
 #include <nuttx/mm/iob.h>
 #include <nuttx/net/ip.h>
+#include <nuttx/net/net.h>
 #include <nuttx/net/netdev.h>
 
 #if defined(CONFIG_NET_ICMP) && !defined(CONFIG_NET_ICMP_NO_STACK)
@@ -47,9 +48,9 @@
 /* Allocate/free an ICMP data callback */
 
 #define icmp_callback_alloc(dev, conn) \
-  devif_callback_alloc((dev), &(conn)->list, &(conn)->list_tail)
+  devif_callback_alloc((dev), &(conn)->sconn.list, &(conn)->sconn.list_tail)
 #define icmp_callback_free(dev, conn, cb) \
-  devif_conn_callback_free((dev), (cb), &(conn)->list, &(conn)->list_tail)
+  devif_conn_callback_free((dev), (cb), &(conn)->sconn.list, &(conn)->sconn.list_tail)
 
 /****************************************************************************
  * Public types
@@ -77,14 +78,7 @@ struct icmp_conn_s
 {
   /* Common prologue of all connection structures. */
 
-  dq_entry_t node;               /* Supports a doubly linked list */
-
-  /* This is a list of ICMP callbacks.  Each callback represents a thread
-   * that is stalled, waiting for a device-specific event.
-   */
-
-  FAR struct devif_callback_s *list;
-  FAR struct devif_callback_s *list_tail;
+  struct socket_conn_s sconn;
 
   /* ICMP-specific content follows */
 

--- a/net/icmp/icmp_conn.c
+++ b/net/icmp/icmp_conn.c
@@ -91,7 +91,8 @@ void icmp_sock_initialize(void)
     {
       /* Move the connection structure to the free list */
 
-      dq_addlast(&g_icmp_connections[i].node, &g_free_icmp_connections);
+      dq_addlast(&g_icmp_connections[i].sconn.node,
+                 &g_free_icmp_connections);
     }
 #endif
 }
@@ -124,7 +125,8 @@ FAR struct icmp_conn_s *icmp_alloc(void)
             {
               for (ret = 0; ret < CONFIG_NET_ICMP_NCONNS; ret++)
                 {
-                  dq_addlast(&conn[ret].node, &g_free_icmp_connections);
+                  dq_addlast(&conn[ret].sconn.node,
+                             &g_free_icmp_connections);
                 }
             }
         }
@@ -135,7 +137,7 @@ FAR struct icmp_conn_s *icmp_alloc(void)
         {
           /* Enqueue the connection into the active list */
 
-          dq_addlast(&conn->node, &g_active_icmp_connections);
+          dq_addlast(&conn->sconn.node, &g_active_icmp_connections);
         }
 
       nxsem_post(&g_free_sem);
@@ -177,7 +179,7 @@ void icmp_free(FAR struct icmp_conn_s *conn)
     {
       /* Remove the connection from the active list */
 
-      dq_rem(&conn->node, &g_active_icmp_connections);
+      dq_rem(&conn->sconn.node, &g_active_icmp_connections);
 
       /* Clear the connection structure */
 
@@ -185,7 +187,7 @@ void icmp_free(FAR struct icmp_conn_s *conn)
 
       /* Free the connection */
 
-      dq_addlast(&conn->node, &g_free_icmp_connections);
+      dq_addlast(&conn->sconn.node, &g_free_icmp_connections);
     }
 
   nxsem_post(&g_free_sem);
@@ -221,7 +223,7 @@ FAR struct icmp_conn_s *icmp_active(uint16_t id)
 
       /* Look at the next active connection */
 
-      conn = (FAR struct icmp_conn_s *)conn->node.flink;
+      conn = (FAR struct icmp_conn_s *)conn->sconn.node.flink;
     }
 
   return conn;
@@ -246,7 +248,7 @@ FAR struct icmp_conn_s *icmp_nextconn(FAR struct icmp_conn_s *conn)
     }
   else
     {
-      return (FAR struct icmp_conn_s *)conn->node.flink;
+      return (FAR struct icmp_conn_s *)conn->sconn.node.flink;
     }
 }
 

--- a/net/icmp/icmp_input.c
+++ b/net/icmp/icmp_input.c
@@ -332,7 +332,7 @@ void icmp_input(FAR struct net_driver_s *dev)
           goto drop;
         }
 
-      flags = devif_conn_event(dev, conn, ICMP_NEWDATA, conn->list);
+      flags = devif_conn_event(dev, conn, ICMP_NEWDATA, conn->sconn.list);
       if ((flags & ICMP_NEWDATA) != 0)
         {
           uint16_t nbuffered;

--- a/net/icmp/icmp_poll.c
+++ b/net/icmp/icmp_poll.c
@@ -72,7 +72,7 @@ void icmp_poll(FAR struct net_driver_s *dev, FAR struct icmp_conn_s *conn)
 
   /* Perform the application callback */
 
-  devif_conn_event(dev, conn, ICMP_POLL, conn->list);
+  devif_conn_event(dev, conn, ICMP_POLL, conn->sconn.list);
 }
 
 #endif /* CONFIG_NET && CONFIG_NET_ICMP && CONFIG_NET_ICMP_SOCKET */

--- a/net/icmp/icmp_recvmsg.c
+++ b/net/icmp/icmp_recvmsg.c
@@ -450,7 +450,7 @@ ssize_t icmp_recvmsg(FAR struct socket *psock, FAR struct msghdr *msg,
            */
 
           ret = net_timedwait(&state.recv_sem,
-                              _SO_TIMEOUT(psock->s_rcvtimeo));
+                              _SO_TIMEOUT(conn->sconn.s_rcvtimeo));
           if (ret < 0)
             {
               state.recv_result = ret;

--- a/net/icmp/icmp_recvmsg.c
+++ b/net/icmp/icmp_recvmsg.c
@@ -410,7 +410,8 @@ ssize_t icmp_recvmsg(FAR struct socket *psock, FAR struct msghdr *msg,
       ret = icmp_readahead(conn, buf, len,
                            (FAR struct sockaddr_in *)from, fromlen);
     }
-  else if (_SS_ISNONBLOCK(psock->s_flags) || (flags & MSG_DONTWAIT) != 0)
+  else if (_SS_ISNONBLOCK(conn->sconn.s_flags) ||
+           (flags & MSG_DONTWAIT) != 0)
     {
       /* Handle non-blocking ICMP sockets */
 

--- a/net/icmp/icmp_sendmsg.c
+++ b/net/icmp/icmp_sendmsg.c
@@ -418,7 +418,8 @@ ssize_t icmp_sendmsg(FAR struct socket *psock, FAR struct msghdr *msg,
        * net_timedwait will also terminate if a signal is received.
        */
 
-      ret = net_timedwait(&state.snd_sem, _SO_TIMEOUT(psock->s_sndtimeo));
+      ret = net_timedwait(&state.snd_sem,
+                          _SO_TIMEOUT(conn->sconn.s_sndtimeo));
       if (ret < 0)
         {
           if (ret == -ETIMEDOUT)

--- a/net/icmpv6/icmpv6.h
+++ b/net/icmpv6/icmpv6.h
@@ -34,6 +34,7 @@
 
 #include <nuttx/mm/iob.h>
 #include <nuttx/net/ip.h>
+#include <nuttx/net/net.h>
 #include <nuttx/net/netdev.h>
 #include <nuttx/semaphore.h>
 
@@ -48,9 +49,9 @@
 /* Allocate a new ICMPv6 data callback */
 
 #define icmpv6_callback_alloc(dev, conn) \
-  devif_callback_alloc((dev), &(conn)->list, &(conn)->list_tail)
+  devif_callback_alloc((dev), &(conn)->sconn.list, &(conn)->sconn.list_tail)
 #define icmpv6_callback_free(dev, conn, cb) \
-  devif_conn_callback_free((dev), (cb), &(conn)->list, &(conn)->list_tail)
+  devif_conn_callback_free((dev), (cb), &(conn)->sconn.list, &(conn)->sconn.list_tail)
 
 /****************************************************************************
  * Public Type Definitions
@@ -79,14 +80,7 @@ struct icmpv6_conn_s
 {
   /* Common prologue of all connection structures. */
 
-  dq_entry_t node;     /* Supports a double linked list */
-
-  /* This is a list of ICMPV6 callbacks.  Each callback represents a thread
-   * that is stalled, waiting for a device-specific event.
-   */
-
-  FAR struct devif_callback_s *list;
-  FAR struct devif_callback_s *list_tail;
+  struct socket_conn_s sconn;
 
   /* ICMPv6-specific content follows */
 

--- a/net/icmpv6/icmpv6_conn.c
+++ b/net/icmpv6/icmpv6_conn.c
@@ -91,7 +91,8 @@ void icmpv6_sock_initialize(void)
     {
       /* Move the connection structure to the free list */
 
-      dq_addlast(&g_icmpv6_connections[i].node, &g_free_icmpv6_connections);
+      dq_addlast(&g_icmpv6_connections[i].sconn.node,
+                 &g_free_icmpv6_connections);
     }
 #endif
 }
@@ -124,7 +125,8 @@ FAR struct icmpv6_conn_s *icmpv6_alloc(void)
             {
               for (ret = 0; ret < CONFIG_NET_ICMPv6_NCONNS; ret++)
                 {
-                  dq_addlast(&conn[ret].node, &g_free_icmpv6_connections);
+                  dq_addlast(&conn[ret].sconn.node,
+                             &g_free_icmpv6_connections);
                 }
             }
         }
@@ -136,7 +138,7 @@ FAR struct icmpv6_conn_s *icmpv6_alloc(void)
         {
           /* Enqueue the connection into the active list */
 
-          dq_addlast(&conn->node, &g_active_icmpv6_connections);
+          dq_addlast(&conn->sconn.node, &g_active_icmpv6_connections);
         }
 
       nxsem_post(&g_free_sem);
@@ -166,7 +168,7 @@ void icmpv6_free(FAR struct icmpv6_conn_s *conn)
 
   /* Remove the connection from the active list */
 
-  dq_rem(&conn->node, &g_active_icmpv6_connections);
+  dq_rem(&conn->sconn.node, &g_active_icmpv6_connections);
 
   /* Clear the connection structure */
 
@@ -174,7 +176,7 @@ void icmpv6_free(FAR struct icmpv6_conn_s *conn)
 
   /* Free the connection */
 
-  dq_addlast(&conn->node, &g_free_icmpv6_connections);
+  dq_addlast(&conn->sconn.node, &g_free_icmpv6_connections);
   nxsem_post(&g_free_sem);
 }
 
@@ -208,7 +210,7 @@ FAR struct icmpv6_conn_s *icmpv6_active(uint16_t id)
 
       /* Look at the next active connection */
 
-      conn = (FAR struct icmpv6_conn_s *)conn->node.flink;
+      conn = (FAR struct icmpv6_conn_s *)conn->sconn.node.flink;
     }
 
   return conn;
@@ -233,7 +235,7 @@ FAR struct icmpv6_conn_s *icmpv6_nextconn(FAR struct icmpv6_conn_s *conn)
     }
   else
     {
-      return (FAR struct icmpv6_conn_s *)conn->node.flink;
+      return (FAR struct icmpv6_conn_s *)conn->sconn.node.flink;
     }
 }
 

--- a/net/icmpv6/icmpv6_input.c
+++ b/net/icmpv6/icmpv6_input.c
@@ -460,7 +460,7 @@ void icmpv6_input(FAR struct net_driver_s *dev, unsigned int iplen)
 
         /* Dispatch the ECHO reply to the waiting thread */
 
-        flags = devif_conn_event(dev, conn, flags, conn->list);
+        flags = devif_conn_event(dev, conn, flags, conn->sconn.list);
 
         /* Was the ECHO reply consumed by any waiting thread? */
 

--- a/net/icmpv6/icmpv6_poll.c
+++ b/net/icmpv6/icmpv6_poll.c
@@ -74,7 +74,7 @@ void icmpv6_poll(FAR struct net_driver_s *dev,
   /* Perform the application callback */
 
   devif_conn_event(dev, conn, ICMPv6_POLL,
-                   conn ? conn->list : dev->d_conncb);
+                   conn ? conn->sconn.list : dev->d_conncb);
 }
 
 #endif /* CONFIG_NET_ICMPv6_SOCKET || CONFIG_NET_ICMPv6_NEIGHBOR */

--- a/net/icmpv6/icmpv6_recvmsg.c
+++ b/net/icmpv6/icmpv6_recvmsg.c
@@ -459,7 +459,7 @@ ssize_t icmpv6_recvmsg(FAR struct socket *psock, FAR struct msghdr *msg,
            */
 
           ret = net_timedwait(&state.recv_sem,
-                              _SO_TIMEOUT(psock->s_rcvtimeo));
+                              _SO_TIMEOUT(conn->sconn.s_rcvtimeo));
           if (ret < 0)
             {
               state.recv_result = ret;

--- a/net/icmpv6/icmpv6_recvmsg.c
+++ b/net/icmpv6/icmpv6_recvmsg.c
@@ -417,7 +417,8 @@ ssize_t icmpv6_recvmsg(FAR struct socket *psock, FAR struct msghdr *msg,
       ret = icmpv6_readahead(conn, buf, len,
                              (FAR struct sockaddr_in6 *)from, fromlen);
     }
-  else if (_SS_ISNONBLOCK(psock->s_flags) || (flags & MSG_DONTWAIT) != 0)
+  else if (_SS_ISNONBLOCK(conn->sconn.s_flags) ||
+           (flags & MSG_DONTWAIT) != 0)
     {
       /* Handle non-blocking ICMP sockets */
 

--- a/net/icmpv6/icmpv6_sendmsg.c
+++ b/net/icmpv6/icmpv6_sendmsg.c
@@ -409,7 +409,8 @@ ssize_t icmpv6_sendmsg(FAR struct socket *psock, FAR struct msghdr *msg,
        * net_timedwait will also terminate if a signal is received.
        */
 
-      ret = net_timedwait(&state.snd_sem, _SO_TIMEOUT(psock->s_sndtimeo));
+      ret = net_timedwait(&state.snd_sem,
+                          _SO_TIMEOUT(conn->sconn.s_sndtimeo));
       if (ret < 0)
         {
           if (ret == -ETIMEDOUT)

--- a/net/ieee802154/ieee802154.h
+++ b/net/ieee802154/ieee802154.h
@@ -31,6 +31,8 @@
 #include <queue.h>
 #include <netpacket/ieee802154.h>
 
+#include <nuttx/net/net.h>
+
 #ifdef CONFIG_NET_IEEE802154
 
 /****************************************************************************
@@ -40,9 +42,9 @@
 /* Allocate a new IEEE 802.15.4 socket data callback */
 
 #define ieee802154_callback_alloc(dev,conn) \
-  devif_callback_alloc(dev, &conn->list, &conn->list_tail)
+  devif_callback_alloc(dev, &conn->sconn.list, &conn->sconn.list_tail)
 #define ieee802154_callback_free(dev,conn,cb) \
-  devif_conn_callback_free(dev, cb, &conn->list, &conn->list_tail)
+  devif_conn_callback_free(dev, cb, &conn->sconn.list, &conn->sconn.list_tail)
 
 /* Memory Pools */
 
@@ -97,14 +99,7 @@ struct ieee802154_conn_s
 {
   /* Common prologue of all connection structures. */
 
-  dq_entry_t node;                             /* Supports a double linked list */
-
-  /* This is a list of IEEE 802.15.4 callbacks.  Each callback represents
-   * a thread that is stalled, waiting for a device-specific event.
-   */
-
-  FAR struct devif_callback_s *list;
-  FAR struct devif_callback_s *list_tail;
+  struct socket_conn_s sconn;
 
   /* IEEE 802.15.4-specific content follows */
 

--- a/net/ieee802154/ieee802154_callback.c
+++ b/net/ieee802154/ieee802154_callback.c
@@ -66,7 +66,8 @@ uint16_t ieee802154_callback(FAR struct radio_driver_s *radio,
     {
       /* Perform the callback */
 
-      flags = devif_conn_event(&radio->r_dev, conn, flags, conn->list);
+      flags = devif_conn_event(&radio->r_dev, conn, flags,
+                               conn->sconn.list);
     }
 
   return flags;

--- a/net/ieee802154/ieee802154_conn.c
+++ b/net/ieee802154/ieee802154_conn.c
@@ -96,7 +96,7 @@ void ieee802154_conn_initialize(void)
     {
       /* Link each pre-allocated connection structure into the free list. */
 
-      dq_addlast(&g_ieee802154_connections[i].node,
+      dq_addlast(&g_ieee802154_connections[i].sconn.node,
                  &g_free_ieee802154_connections);
     }
 #endif
@@ -129,7 +129,8 @@ FAR struct ieee802154_conn_s *ieee802154_conn_alloc(void)
         {
           for (i = 0; i < CONFIG_NET_IEEE802154_NCONNS; i++)
             {
-              dq_addlast(&conn[i].node, &g_free_ieee802154_connections);
+              dq_addlast(&conn[i].sconn.node,
+                         &g_free_ieee802154_connections);
             }
         }
     }
@@ -139,7 +140,7 @@ FAR struct ieee802154_conn_s *ieee802154_conn_alloc(void)
          dq_remfirst(&g_free_ieee802154_connections);
   if (conn)
     {
-      dq_addlast(&conn->node, &g_active_ieee802154_connections);
+      dq_addlast(&conn->sconn.node, &g_active_ieee802154_connections);
     }
 
   net_unlock();
@@ -167,7 +168,7 @@ void ieee802154_conn_free(FAR struct ieee802154_conn_s *conn)
   /* Remove the connection from the active list */
 
   net_lock();
-  dq_rem(&conn->node, &g_active_ieee802154_connections);
+  dq_rem(&conn->sconn.node, &g_active_ieee802154_connections);
 
   /* Check if there any any frames attached to the container */
 
@@ -196,7 +197,7 @@ void ieee802154_conn_free(FAR struct ieee802154_conn_s *conn)
 
   /* Free the connection */
 
-  dq_addlast(&conn->node, &g_free_ieee802154_connections);
+  dq_addlast(&conn->sconn.node, &g_free_ieee802154_connections);
   net_unlock();
 }
 
@@ -222,7 +223,7 @@ FAR struct ieee802154_conn_s *
   for (conn  = (FAR struct ieee802154_conn_s *)
        g_active_ieee802154_connections.head;
        conn != NULL;
-       conn = (FAR struct ieee802154_conn_s *)conn->node.flink)
+       conn = (FAR struct ieee802154_conn_s *)conn->sconn.node.flink)
     {
       /* Does the destination address match the bound address of the socket.
        *
@@ -300,7 +301,7 @@ FAR struct ieee802154_conn_s *
     }
   else
     {
-      return (FAR struct ieee802154_conn_s *)conn->node.flink;
+      return (FAR struct ieee802154_conn_s *)conn->sconn.node.flink;
     }
 }
 

--- a/net/ieee802154/ieee802154_sendmsg.c
+++ b/net/ieee802154/ieee802154_sendmsg.c
@@ -582,7 +582,7 @@ static ssize_t ieee802154_send(FAR struct socket *psock, FAR const void *buf,
     {
       /* send() may be used only if the socket has been connected. */
 
-      if (!_SS_ISCONNECTED(psock->s_flags) ||
+      if (!_SS_ISCONNECTED(conn->sconn.s_flags) ||
           conn->raddr.s_mode == IEEE802154_ADDRMODE_NONE)
         {
           ret = -ENOTCONN;

--- a/net/ieee802154/ieee802154_sockif.c
+++ b/net/ieee802154/ieee802154_sockif.c
@@ -357,8 +357,8 @@ static int ieee802154_bind(FAR struct socket *psock,
                            socklen_t addrlen)
 {
   FAR const struct sockaddr_ieee802154_s *iaddr;
-  FAR struct radio_driver_s *radio;
   FAR struct ieee802154_conn_s *conn;
+  FAR struct radio_driver_s *radio;
 
   DEBUGASSERT(psock != NULL && addr != NULL);
 
@@ -373,9 +373,11 @@ static int ieee802154_bind(FAR struct socket *psock,
       return -EBADF;
     }
 
+  conn = (FAR struct ieee802154_conn_s *)psock->s_conn;
+
   /* Bind a PF_IEEE802154 socket to an network device. */
 
-  if (psock->s_type != SOCK_DGRAM)
+  if (conn == NULL || psock->s_type != SOCK_DGRAM)
     {
       nerr("ERROR: Invalid socket type: %u\n", psock->s_type);
       return -EBADF;
@@ -383,7 +385,7 @@ static int ieee802154_bind(FAR struct socket *psock,
 
   /* Verify that the socket is not already bound. */
 
-  if (_SS_ISBOUND(psock->s_flags))
+  if (_SS_ISBOUND(conn->sconn.s_flags))
     {
       nerr("ERROR: Already bound\n");
       return -EINVAL;
@@ -402,8 +404,6 @@ static int ieee802154_bind(FAR struct socket *psock,
       nerr("ERROR: No address provided\n");
       return -EADDRNOTAVAIL;
     }
-
-  conn = (FAR struct ieee802154_conn_s *)psock->s_conn;
 
   /* Find the device associated with the requested address */
 

--- a/net/inet/inet_sockif.c
+++ b/net/inet/inet_sockif.c
@@ -716,9 +716,11 @@ static int inet_connect(FAR struct socket *psock,
 #if defined(CONFIG_NET_TCP) && defined(NET_TCP_HAVE_STACK)
       case SOCK_STREAM:
         {
+          FAR struct socket_conn_s *conn = psock->s_conn;
+
           /* Verify that the socket is not already connected */
 
-          if (_SS_ISCONNECTED(psock->s_flags))
+          if (_SS_ISCONNECTED(conn->s_flags))
             {
               return -EISCONN;
             }
@@ -1069,6 +1071,9 @@ static int inet_poll(FAR struct socket *psock, FAR struct pollfd *fds,
 static ssize_t inet_send(FAR struct socket *psock, FAR const void *buf,
                          size_t len, int flags)
 {
+#ifdef NET_UDP_HAVE_STACK
+  FAR struct socket_conn_s *conn = psock->s_conn;
+#endif
   ssize_t ret;
 
   switch (psock->s_type)
@@ -1112,7 +1117,7 @@ static ssize_t inet_send(FAR struct socket *psock, FAR const void *buf,
             {
               /* UDP/IP packet send */
 
-              ret = _SS_ISCONNECTED(psock->s_flags) ?
+              ret = _SS_ISCONNECTED(conn->s_flags) ?
                 psock_udp_sendto(psock, buf, len, 0, NULL, 0) : -ENOTCONN;
             }
 #endif /* NET_UDP_HAVE_STACK */
@@ -1120,7 +1125,7 @@ static ssize_t inet_send(FAR struct socket *psock, FAR const void *buf,
 #elif defined(NET_UDP_HAVE_STACK)
           /* Only UDP/IP packet send */
 
-          ret = _SS_ISCONNECTED(psock->s_flags) ?
+          ret = _SS_ISCONNECTED(conn->s_flags) ?
             psock_udp_sendto(psock, buf, len, 0, NULL, 0) : -ENOTCONN;
 #else
           ret = -ENOSYS;

--- a/net/inet/ipv4_getpeername.c
+++ b/net/inet/ipv4_getpeername.c
@@ -71,6 +71,7 @@ int ipv4_getpeername(FAR struct socket *psock, FAR struct sockaddr *addr,
 {
 #if defined(NET_TCP_HAVE_STACK) || defined(NET_UDP_HAVE_STACK)
   FAR struct sockaddr_in *outaddr = (FAR struct sockaddr_in *)addr;
+  FAR struct socket_conn_s *conn = psock->s_conn;
   in_addr_t ripaddr;
 
   /* Check if enough space has been provided for the full address */
@@ -87,7 +88,7 @@ int ipv4_getpeername(FAR struct socket *psock, FAR struct sockaddr *addr,
 
   /* Verify that the socket has been connected */
 
-  if (_SS_ISCONNECTED(psock->s_flags) == 0)
+  if (_SS_ISCONNECTED(conn->s_flags) == 0)
     {
       return -ENOTCONN;
     }

--- a/net/inet/ipv6_getpeername.c
+++ b/net/inet/ipv6_getpeername.c
@@ -69,6 +69,7 @@
 int ipv6_getpeername(FAR struct socket *psock, FAR struct sockaddr *addr,
                      FAR socklen_t *addrlen)
 {
+  FAR struct socket_conn_s *conn = psock->s_conn;
   FAR struct sockaddr_in6 *outaddr = (FAR struct sockaddr_in6 *)addr;
   net_ipv6addr_t *ripaddr;
 
@@ -86,7 +87,7 @@ int ipv6_getpeername(FAR struct socket *psock, FAR struct sockaddr *addr,
 
   /* Verify that the socket has been connected */
 
-  if (_SS_ISCONNECTED(psock->s_flags) == 0)
+  if (_SS_ISCONNECTED(conn->s_flags) == 0)
     {
       return -ENOTCONN;
     }

--- a/net/local/local.h
+++ b/net/local/local.h
@@ -118,20 +118,7 @@ struct local_conn_s
 {
   /* Common prologue of all connection structures. */
 
-  /* lc_node supports a doubly linked list: Listening SOCK_STREAM servers
-   * will be linked into a list of listeners; SOCK_STREAM clients will be
-   * linked to the lc_conn lists.
-   */
-
-  dq_entry_t lc_node;          /* Supports a doubly linked list */
-
-  /* This is a list of Local connection callbacks.  Each callback represents
-   * a thread that is stalled, waiting for a device-specific event.
-   * REVISIT:  Here for commonality with other connection structures; not
-   * used in the current implementation.
-   */
-
-  FAR struct devif_callback_s *lc_list;
+  struct socket_conn_s lc_conn;
 
   /* Local-socket specific content follows */
 

--- a/net/local/local_accept.c
+++ b/net/local/local_accept.c
@@ -181,8 +181,8 @@ int local_accept(FAR struct socket *psock, FAR struct sockaddr *addr,
                * block.
                */
 
-              ret = local_open_server_tx(conn,
-                                         _SS_ISNONBLOCK(psock->s_flags));
+              ret = local_open_server_tx(
+                      conn, _SS_ISNONBLOCK(conn->lc_conn.s_flags));
               if (ret < 0)
                 {
                   nerr("ERROR: Failed to open write-only FIFOs for %s: %d\n",
@@ -201,8 +201,8 @@ int local_accept(FAR struct socket *psock, FAR struct sockaddr *addr,
                * for writing.
                */
 
-              ret = local_open_server_rx(conn,
-                                         _SS_ISNONBLOCK(psock->s_flags));
+              ret = local_open_server_rx(
+                      conn, _SS_ISNONBLOCK(conn->lc_conn.s_flags));
               if (ret < 0)
                 {
                    nerr("ERROR: Failed to open read-only FIFOs for %s: %d\n",
@@ -254,7 +254,7 @@ int local_accept(FAR struct socket *psock, FAR struct sockaddr *addr,
 
       /* Was the socket opened non-blocking? */
 
-      if (_SS_ISNONBLOCK(psock->s_flags))
+      if (_SS_ISNONBLOCK(server->lc_conn.s_flags))
         {
           /* Yes.. return EAGAIN */
 

--- a/net/local/local_conn.c
+++ b/net/local/local_conn.c
@@ -79,7 +79,7 @@ FAR struct local_conn_s *local_nextconn(FAR struct local_conn_s *conn)
       return (FAR struct local_conn_s *)g_local_connections.head;
     }
 
-  return (FAR struct local_conn_s *)conn->lc_node.flink;
+  return (FAR struct local_conn_s *)conn->lc_conn.node.flink;
 }
 
 /****************************************************************************
@@ -143,7 +143,7 @@ FAR struct local_conn_s *local_alloc(void)
       /* Add the connection structure to the list of listeners */
 
       net_lock();
-      dq_addlast(&conn->lc_node, &g_local_connections);
+      dq_addlast(&conn->lc_conn.node, &g_local_connections);
       net_unlock();
     }
 
@@ -170,7 +170,7 @@ void local_free(FAR struct local_conn_s *conn)
   /* Remove the server from the list of listeners. */
 
   net_lock();
-  dq_rem(&conn->lc_node, &g_local_connections);
+  dq_rem(&conn->lc_conn.node, &g_local_connections);
 
 #ifdef CONFIG_NET_LOCAL_SCM
   if (local_peerconn(conn) && conn->lc_peer)

--- a/net/local/local_connect.c
+++ b/net/local/local_connect.c
@@ -311,8 +311,8 @@ int psock_local_connect(FAR struct socket *psock,
                 if (conn->lc_proto == SOCK_STREAM)
                   {
                     ret =
-                      local_stream_connect(client, conn,
-                                           _SS_ISNONBLOCK(psock->s_flags));
+                      local_stream_connect(
+                        client, conn, _SS_ISNONBLOCK(conn->lc_conn.s_flags));
                   }
 
                 net_unlock();

--- a/net/local/local_listen.c
+++ b/net/local/local_listen.c
@@ -107,8 +107,7 @@ int local_listen(FAR struct socket *psock, int backlog)
     {
       /* The connection should not reside in any other list */
 
-      DEBUGASSERT(server->lc_node.flink == NULL &&
-                  server->lc_node.flink == NULL);
+      DEBUGASSERT(server->lc_node.flink == NULL);
 
       /* And change the server state to listing */
 

--- a/net/local/local_listen.c
+++ b/net/local/local_listen.c
@@ -107,7 +107,7 @@ int local_listen(FAR struct socket *psock, int backlog)
     {
       /* The connection should not reside in any other list */
 
-      DEBUGASSERT(server->lc_node.flink == NULL);
+      DEBUGASSERT(server->lc_conn.node.flink == NULL);
 
       /* And change the server state to listing */
 

--- a/net/local/local_recvmsg.c
+++ b/net/local/local_recvmsg.c
@@ -82,8 +82,8 @@ static int psock_fifo_read(FAR struct socket *psock, FAR void *buf,
            * eventually be reported as ENOTCONN.
            */
 
-          psock->s_flags &= ~(_SF_CONNECTED | _SF_CLOSED);
-          conn->lc_state  = LOCAL_STATE_DISCONNECTED;
+          conn->lc_conn.s_flags &= ~(_SF_CONNECTED | _SF_CLOSED);
+          conn->lc_state = LOCAL_STATE_DISCONNECTED;
 
           /* Did we receive any data? */
 
@@ -330,7 +330,7 @@ psock_dgram_recvfrom(FAR struct socket *psock, FAR void *buf, size_t len,
 
   /* Open the receiving side of the transfer */
 
-  ret = local_open_receiver(conn, _SS_ISNONBLOCK(psock->s_flags) ||
+  ret = local_open_receiver(conn, _SS_ISNONBLOCK(conn->lc_conn.s_flags) ||
                             (flags & MSG_DONTWAIT) != 0);
   if (ret < 0)
     {

--- a/net/local/local_sendmsg.c
+++ b/net/local/local_sendmsg.c
@@ -324,7 +324,7 @@ static ssize_t local_sendto(FAR struct socket *psock,
   /* Open the sending side of the transfer */
 
   ret = local_open_sender(conn, unaddr->sun_path,
-                          _SS_ISNONBLOCK(psock->s_flags) ||
+                          _SS_ISNONBLOCK(conn->lc_conn.s_flags) ||
                           (flags & MSG_DONTWAIT) != 0);
   if (ret < 0)
     {

--- a/net/local/local_sockif.c
+++ b/net/local/local_sockif.c
@@ -515,9 +515,11 @@ static int local_connect(FAR struct socket *psock,
 #ifdef CONFIG_NET_LOCAL_STREAM
       case SOCK_STREAM:
         {
+          FAR struct socket_conn_s *conn = psock->s_conn;
+
           /* Verify that the socket is not already connected */
 
-          if (_SS_ISCONNECTED(psock->s_flags))
+          if (_SS_ISCONNECTED(conn->s_flags))
             {
               return -EISCONN;
             }
@@ -797,7 +799,7 @@ static int local_socketpair(FAR struct socket *psocks[2])
       goto errout;
     }
 
-  nonblock = _SS_ISNONBLOCK(psocks[0]->s_flags);
+  nonblock = _SS_ISNONBLOCK(conns[0]->lc_conn.s_flags);
 
   /* Open the client-side write-only FIFO. */
 

--- a/net/netlink/netlink.h
+++ b/net/netlink/netlink.h
@@ -59,7 +59,7 @@ struct netlink_conn_s
 {
   /* Common prologue of all connection structures. */
 
-  dq_entry_t node;                   /* Supports a doubly linked list */
+  struct socket_conn_s sconn;
 
   /* NetLink-specific content follows */
 

--- a/net/netlink/netlink_conn.c
+++ b/net/netlink/netlink_conn.c
@@ -138,7 +138,7 @@ void netlink_initialize(void)
     {
       /* Mark the connection closed and move it to the free list */
 
-      dq_addlast(&g_netlink_connections[i].node,
+      dq_addlast(&g_netlink_connections[i].sconn.node,
                  &g_free_netlink_connections);
     }
 #endif
@@ -171,7 +171,7 @@ FAR struct netlink_conn_s *netlink_alloc(void)
         {
           for (i = 0; i < CONFIG_NETLINK_CONNS; i++)
             {
-              dq_addlast(&conn[i].node, &g_free_netlink_connections);
+              dq_addlast(&conn[i].sconn.node, &g_free_netlink_connections);
             }
         }
     }
@@ -183,7 +183,7 @@ FAR struct netlink_conn_s *netlink_alloc(void)
     {
       /* Enqueue the connection into the active list */
 
-      dq_addlast(&conn->node, &g_active_netlink_connections);
+      dq_addlast(&conn->sconn.node, &g_active_netlink_connections);
     }
 
   _netlink_semgive(&g_free_sem);
@@ -211,7 +211,7 @@ void netlink_free(FAR struct netlink_conn_s *conn)
 
   /* Remove the connection from the active list */
 
-  dq_rem(&conn->node, &g_active_netlink_connections);
+  dq_rem(&conn->sconn.node, &g_active_netlink_connections);
 
   /* Free any unclaimed responses */
 
@@ -226,7 +226,7 @@ void netlink_free(FAR struct netlink_conn_s *conn)
 
   /* Free the connection */
 
-  dq_addlast(&conn->node, &g_free_netlink_connections);
+  dq_addlast(&conn->sconn.node, &g_free_netlink_connections);
   _netlink_semgive(&g_free_sem);
 }
 
@@ -249,7 +249,7 @@ FAR struct netlink_conn_s *netlink_nextconn(FAR struct netlink_conn_s *conn)
     }
   else
     {
-      return (FAR struct netlink_conn_s *)conn->node.flink;
+      return (FAR struct netlink_conn_s *)conn->sconn.node.flink;
     }
 }
 

--- a/net/netlink/netlink_sockif.c
+++ b/net/netlink/netlink_sockif.c
@@ -761,6 +761,7 @@ static ssize_t netlink_recvmsg(FAR struct socket *psock,
   FAR struct sockaddr *from = msg->msg_name;
   FAR socklen_t *fromlen = &msg->msg_namelen;
   FAR struct netlink_response_s *entry;
+  FAR struct socket_conn_s *conn;
 
   DEBUGASSERT(psock != NULL && psock->s_conn != NULL && buf != NULL);
   DEBUGASSERT(from == NULL ||
@@ -771,11 +772,13 @@ static ssize_t netlink_recvmsg(FAR struct socket *psock,
   entry = netlink_tryget_response(psock->s_conn);
   if (entry == NULL)
     {
+      conn = psock->s_conn;
+
       /* No response is variable, but presumably, one is expected.  Check
        * if the socket has been configured for non-blocking operation.
        */
 
-      if (_SS_ISNONBLOCK(psock->s_flags) || (flags & MSG_DONTWAIT) != 0)
+      if (_SS_ISNONBLOCK(conn->s_flags) || (flags & MSG_DONTWAIT) != 0)
         {
           return -EAGAIN;
         }

--- a/net/pkt/pkt.h
+++ b/net/pkt/pkt.h
@@ -30,6 +30,8 @@
 #include <sys/types.h>
 #include <queue.h>
 
+#include <nuttx/net/net.h>
+
 #ifdef CONFIG_NET_PKT
 
 /****************************************************************************
@@ -39,9 +41,9 @@
 /* Allocate a new packet socket data callback */
 
 #define pkt_callback_alloc(dev,conn) \
-  devif_callback_alloc(dev, &conn->list, &conn->list_tail)
+  devif_callback_alloc(dev, &conn->sconn.list, &conn->sconn.list_tail)
 #define pkt_callback_free(dev,conn,cb) \
-  devif_conn_callback_free(dev, cb, &conn->list, &conn->list_tail)
+  devif_conn_callback_free(dev, cb, &conn->sconn.list, &conn->sconn.list_tail)
 
 /****************************************************************************
  * Public Type Definitions
@@ -55,14 +57,7 @@ struct pkt_conn_s
 {
   /* Common prologue of all connection structures. */
 
-  dq_entry_t node;     /* Supports a double linked list */
-
-  /* This is a list of Pkt connection callbacks.  Each callback represents
-   * a thread that is stalled, waiting for a device-specific event.
-   */
-
-  struct devif_callback_s *list;
-  struct devif_callback_s *list_tail;
+  struct socket_conn_s sconn;
 
   /* Pkt socket-specific content follows */
 

--- a/net/pkt/pkt_callback.c
+++ b/net/pkt/pkt_callback.c
@@ -63,7 +63,7 @@ uint16_t pkt_callback(FAR struct net_driver_s *dev,
     {
       /* Perform the callback */
 
-      flags = devif_conn_event(dev, conn, flags, conn->list);
+      flags = devif_conn_event(dev, conn, flags, conn->sconn.list);
     }
 
   return flags;

--- a/net/pkt/pkt_conn.c
+++ b/net/pkt/pkt_conn.c
@@ -116,7 +116,7 @@ void pkt_initialize(void)
 #ifndef CONFIG_NET_ALLOC_CONNS
   for (i = 0; i < CONFIG_NET_PKT_CONNS; i++)
     {
-      dq_addlast(&g_pkt_connections[i].node, &g_free_pkt_connections);
+      dq_addlast(&g_pkt_connections[i].sconn.node, &g_free_pkt_connections);
     }
 #endif
 }
@@ -148,7 +148,7 @@ FAR struct pkt_conn_s *pkt_alloc(void)
         {
           for (i = 0; i < CONFIG_NET_PKT_CONNS; i++)
             {
-              dq_addlast(&conn[i].node, &g_free_pkt_connections);
+              dq_addlast(&conn[i].sconn.node, &g_free_pkt_connections);
             }
         }
     }
@@ -159,7 +159,7 @@ FAR struct pkt_conn_s *pkt_alloc(void)
     {
       /* Enqueue the connection into the active list */
 
-      dq_addlast(&conn->node, &g_active_pkt_connections);
+      dq_addlast(&conn->sconn.node, &g_active_pkt_connections);
     }
 
   _pkt_semgive(&g_free_sem);
@@ -185,7 +185,7 @@ void pkt_free(FAR struct pkt_conn_s *conn)
 
   /* Remove the connection from the active list */
 
-  dq_rem(&conn->node, &g_active_pkt_connections);
+  dq_rem(&conn->sconn.node, &g_active_pkt_connections);
 
   /* Make sure that the connection is marked as uninitialized */
 
@@ -193,7 +193,7 @@ void pkt_free(FAR struct pkt_conn_s *conn)
 
   /* Free the connection */
 
-  dq_addlast(&conn->node, &g_free_pkt_connections);
+  dq_addlast(&conn->sconn.node, &g_free_pkt_connections);
   _pkt_semgive(&g_free_sem);
 }
 
@@ -227,7 +227,7 @@ FAR struct pkt_conn_s *pkt_active(FAR struct eth_hdr_s *buf)
 
       /* Look at the next active connection */
 
-      conn = (FAR struct pkt_conn_s *)conn->node.flink;
+      conn = (FAR struct pkt_conn_s *)conn->sconn.node.flink;
     }
 
   return conn;
@@ -252,7 +252,7 @@ FAR struct pkt_conn_s *pkt_nextconn(FAR struct pkt_conn_s *conn)
     }
   else
     {
-      return (FAR struct pkt_conn_s *)conn->node.flink;
+      return (FAR struct pkt_conn_s *)conn->sconn.node.flink;
     }
 }
 

--- a/net/rpmsg/rpmsg_sockif.c
+++ b/net/rpmsg/rpmsg_sockif.c
@@ -693,7 +693,7 @@ static int rpmsg_socket_connect_internal(FAR struct socket *psock)
         }
 
       ret = net_timedwait(&conn->sendsem,
-                          _SO_TIMEOUT(psock->s_rcvtimeo));
+                          _SO_TIMEOUT(conn->sconn.s_rcvtimeo));
 
       if (ret < 0)
         {
@@ -953,7 +953,7 @@ static ssize_t rpmsg_socket_send_continuous(FAR struct socket *psock,
           if (!nonblock)
             {
               ret = net_timedwait(&conn->sendsem,
-                                  _SO_TIMEOUT(psock->s_sndtimeo));
+                                  _SO_TIMEOUT(conn->sconn.s_sndtimeo));
               if (!conn->ept.rdev)
                 {
                   ret = -ECONNRESET;
@@ -1051,7 +1051,7 @@ static ssize_t rpmsg_socket_send_single(FAR struct socket *psock,
       if (!nonblock)
         {
           ret = net_timedwait(&conn->sendsem,
-                              _SO_TIMEOUT(psock->s_sndtimeo));
+                              _SO_TIMEOUT(conn->sconn.s_sndtimeo));
           if (!conn->ept.rdev)
             {
               ret = -ECONNRESET;
@@ -1233,7 +1233,7 @@ static ssize_t rpmsg_socket_recvmsg(FAR struct socket *psock,
   rpmsg_socket_unlock(&conn->recvlock);
 
   ret = net_timedwait(&conn->recvsem,
-                      _SO_TIMEOUT(psock->s_rcvtimeo));
+                      _SO_TIMEOUT(conn->sconn.s_rcvtimeo));
   if (!conn->ept.rdev)
     {
       ret = -ECONNRESET;

--- a/net/rpmsg/rpmsg_sockif.c
+++ b/net/rpmsg/rpmsg_sockif.c
@@ -80,6 +80,10 @@ begin_packed_struct struct rpmsg_socket_data_s
 
 struct rpmsg_socket_conn_s
 {
+  /* Common prologue of all connection structures. */
+
+  struct socket_conn_s           sconn;
+
   struct rpmsg_endpoint          ept;
 
   struct sockaddr_rpmsg          rpaddr;
@@ -305,7 +309,7 @@ static int rpmsg_socket_ept_cb(FAR struct rpmsg_endpoint *ept,
 
       if (conn->psock)
         {
-          conn->psock->s_flags |= _SF_CONNECTED;
+          conn->sconn.s_flags |= _SF_CONNECTED;
           _SO_SETERRNO(conn->psock, OK);
         }
 
@@ -649,7 +653,7 @@ static int rpmsg_socket_listen(FAR struct socket *psock, int backlog)
       return -ENOSYS;
     }
 
-  if (!_SS_ISBOUND(psock->s_flags) || backlog <= 0)
+  if (!_SS_ISBOUND(server->sconn.s_flags) || backlog <= 0)
     {
       return -EINVAL;
     }
@@ -683,7 +687,7 @@ static int rpmsg_socket_connect_internal(FAR struct socket *psock)
 
   if (conn->sendsize == 0)
     {
-      if (_SS_ISNONBLOCK(psock->s_flags))
+      if (_SS_ISNONBLOCK(conn->sconn.s_flags))
         {
           return -EINPROGRESS;
         }
@@ -710,7 +714,7 @@ static int rpmsg_socket_connect(FAR struct socket *psock,
   FAR struct rpmsg_socket_conn_s *conn = psock->s_conn;
   int ret;
 
-  if (_SS_ISCONNECTED(psock->s_flags))
+  if (_SS_ISCONNECTED(conn->sconn.s_flags))
     {
       return -EISCONN;
     }
@@ -738,7 +742,7 @@ static int rpmsg_socket_accept(FAR struct socket *psock,
       return -ECONNRESET;
     }
 
-  if (!_SS_ISLISTENING(psock->s_flags))
+  if (!_SS_ISLISTENING(server->sconn.s_flags))
     {
       return -EINVAL;
     }
@@ -782,7 +786,7 @@ static int rpmsg_socket_accept(FAR struct socket *psock,
         }
       else
         {
-          if (_SS_ISNONBLOCK(psock->s_flags))
+          if (_SS_ISNONBLOCK(conn->sconn.s_flags))
             {
               ret = -EAGAIN;
               break;
@@ -839,7 +843,7 @@ static int rpmsg_socket_poll(FAR struct socket *psock,
 
       /* Immediately notify on any of the requested events */
 
-      if (_SS_ISLISTENING(psock->s_flags))
+      if (_SS_ISLISTENING(conn->sconn.s_flags))
         {
           if (conn->backlog == -1)
             {
@@ -852,7 +856,7 @@ static int rpmsg_socket_poll(FAR struct socket *psock,
               eventset |= (fds->events & POLLIN);
             }
         }
-      else if (_SS_ISCONNECTED(psock->s_flags))
+      else if (_SS_ISCONNECTED(conn->sconn.s_flags))
         {
           if (!conn->ept.rdev)
             {
@@ -878,8 +882,8 @@ static int rpmsg_socket_poll(FAR struct socket *psock,
 
           rpmsg_socket_unlock(&conn->recvlock);
         }
-      else if (!_SS_ISCONNECTED(psock->s_flags) &&
-               _SS_ISNONBLOCK(psock->s_flags))
+      else if (!_SS_ISCONNECTED(conn->sconn.s_flags) &&
+               _SS_ISNONBLOCK(conn->sconn.s_flags))
         {
           ret = OK;
         }
@@ -1121,7 +1125,7 @@ static ssize_t rpmsg_socket_sendmsg(FAR struct socket *psock,
   bool nonblock;
   ssize_t ret;
 
-  if (!_SS_ISCONNECTED(psock->s_flags))
+  if (!_SS_ISCONNECTED(conn->sconn.s_flags))
     {
       if (to == NULL)
         {
@@ -1142,7 +1146,8 @@ static ssize_t rpmsg_socket_sendmsg(FAR struct socket *psock,
       return -ECONNRESET;
     }
 
-  nonblock = _SS_ISNONBLOCK(psock->s_flags) || (flags & MSG_DONTWAIT) != 0;
+  nonblock = _SS_ISNONBLOCK(conn->sconn.s_flags) ||
+                            (flags & MSG_DONTWAIT) != 0;
 
   if (psock->s_type == SOCK_STREAM)
     {
@@ -1164,8 +1169,8 @@ static ssize_t rpmsg_socket_recvmsg(FAR struct socket *psock,
   FAR struct rpmsg_socket_conn_s *conn = psock->s_conn;
   ssize_t ret;
 
-  if (psock->s_type != SOCK_STREAM && _SS_ISBOUND(psock->s_flags)
-          && !_SS_ISCONNECTED(psock->s_flags))
+  if (psock->s_type != SOCK_STREAM && _SS_ISBOUND(conn->sconn.s_flags)
+          && !_SS_ISCONNECTED(conn->sconn.s_flags))
     {
       ret = rpmsg_socket_connect_internal(psock);
       if (ret < 0)
@@ -1174,7 +1179,7 @@ static ssize_t rpmsg_socket_recvmsg(FAR struct socket *psock,
         }
     }
 
-  if (!_SS_ISCONNECTED(psock->s_flags))
+  if (!_SS_ISCONNECTED(conn->sconn.s_flags))
     {
       return -EISCONN;
     }
@@ -1216,7 +1221,7 @@ static ssize_t rpmsg_socket_recvmsg(FAR struct socket *psock,
       goto out;
     }
 
-  if (_SS_ISNONBLOCK(psock->s_flags) || (flags & MSG_DONTWAIT) != 0)
+  if (_SS_ISNONBLOCK(conn->sconn.s_flags) || (flags & MSG_DONTWAIT) != 0)
     {
       ret = -EAGAIN;
       goto out;

--- a/net/sixlowpan/sixlowpan_tcpsend.c
+++ b/net/sixlowpan/sixlowpan_tcpsend.c
@@ -799,7 +799,7 @@ ssize_t psock_6lowpan_tcp_send(FAR struct socket *psock, FAR const void *buf,
    */
 
   ret = sixlowpan_send_packet(psock, dev, conn, buf, buflen, &destmac,
-                              _SO_TIMEOUT(psock->s_sndtimeo));
+                              _SO_TIMEOUT(conn->sconn.s_sndtimeo));
   if (ret < 0)
     {
       nerr("ERROR: sixlowpan_send_packet() failed: %d\n", ret);

--- a/net/sixlowpan/sixlowpan_tcpsend.c
+++ b/net/sixlowpan/sixlowpan_tcpsend.c
@@ -401,11 +401,11 @@ static uint16_t tcp_send_eventhandler(FAR struct net_driver_s *dev,
        */
 
       DEBUGASSERT(psock != NULL);
-      if (_SS_ISCONNECTED(psock->s_flags))
+      if (_SS_ISCONNECTED(conn->sconn.s_flags))
         {
           /* Report the disconnection event to all socket clones */
 
-          tcp_lost_connection(psock, sinfo->s_cb, flags);
+          tcp_lost_connection(conn, sinfo->s_cb, flags);
         }
 
       /* Report not connected to the sender */
@@ -730,17 +730,17 @@ ssize_t psock_6lowpan_tcp_send(FAR struct socket *psock, FAR const void *buf,
       return (ssize_t)-EBADF;
     }
 
+  /* Get the underlying TCP connection structure */
+
+  conn = (FAR struct tcp_conn_s *)psock->s_conn;
+
   /* Make sure that this is a connected TCP socket */
 
-  if (psock->s_type != SOCK_STREAM || !_SS_ISCONNECTED(psock->s_flags))
+  if (psock->s_type != SOCK_STREAM || !_SS_ISCONNECTED(conn->sconn.s_flags))
     {
       nerr("ERROR: Not connected\n");
       return (ssize_t)-ENOTCONN;
     }
-
-  /* Get the underlying TCP connection structure */
-
-  conn = (FAR struct tcp_conn_s *)psock->s_conn;
 
 #ifdef CONFIG_NET_IPv4
   /* Ignore if not IPv6 domain */

--- a/net/sixlowpan/sixlowpan_udpsend.c
+++ b/net/sixlowpan/sixlowpan_udpsend.c
@@ -293,8 +293,8 @@ ssize_t psock_6lowpan_udp_sendto(FAR struct socket *psock,
    */
 
   ret = sixlowpan_send(dev,
-                       &conn->list,
-                       &conn->list_tail,
+                       &conn->sconn.list,
+                       &conn->sconn.list_tail,
                        (FAR const struct ipv6_hdr_s *)&ipv6udp,
                        buf, buflen, &destmac,
                        _SO_TIMEOUT(psock->s_sndtimeo));
@@ -349,18 +349,18 @@ ssize_t psock_6lowpan_udp_send(FAR struct socket *psock, FAR const void *buf,
       return (ssize_t)-EBADF;
     }
 
+  /* Get the underlying UDP "connection" structure */
+
+  conn = (FAR struct udp_conn_s *)psock->s_conn;
+
   /* Was the UDP socket connected via connect()? */
 
-  if (psock->s_type != SOCK_DGRAM || !_SS_ISCONNECTED(psock->s_flags))
+  if (psock->s_type != SOCK_DGRAM || !_SS_ISCONNECTED(conn->sconn.s_flags))
     {
       /* No, then it is not legal to call send() with this socket. */
 
       return -ENOTCONN;
     }
-
-  /* Get the underlying UDP "connection" structure */
-
-  conn = (FAR struct udp_conn_s *)psock->s_conn;
 
   /* Ignore if not IPv6 domain */
 

--- a/net/sixlowpan/sixlowpan_udpsend.c
+++ b/net/sixlowpan/sixlowpan_udpsend.c
@@ -297,7 +297,7 @@ ssize_t psock_6lowpan_udp_sendto(FAR struct socket *psock,
                        &conn->sconn.list_tail,
                        (FAR const struct ipv6_hdr_s *)&ipv6udp,
                        buf, buflen, &destmac,
-                       _SO_TIMEOUT(psock->s_sndtimeo));
+                       _SO_TIMEOUT(conn->sconn.s_sndtimeo));
   if (ret < 0)
     {
       nerr("ERROR: sixlowpan_send() failed: %d\n", ret);

--- a/net/socket/bind.c
+++ b/net/socket/bind.c
@@ -92,16 +92,16 @@ int psock_bind(FAR struct socket *psock, const struct sockaddr *addr,
 
   /* Was the bind successful */
 
-  if (ret < 0)
+  if (ret >= 0)
     {
-      return ret;
+      FAR struct socket_conn_s *conn = psock->s_conn;
+
+      /* Mark the socket bound */
+
+      conn->s_flags |= _SF_BOUND;
     }
 
-  /* Mark the socket bound */
-
-  psock->s_flags |= _SF_BOUND;
-
-  return OK;
+  return ret;
 }
 
 /****************************************************************************

--- a/net/socket/connect.c
+++ b/net/socket/connect.c
@@ -137,21 +137,21 @@ int psock_connect(FAR struct socket *psock, FAR const struct sockaddr *addr,
   DEBUGASSERT(psock->s_sockif != NULL &&
               psock->s_sockif->si_connect != NULL);
   ret = psock->s_sockif->si_connect(psock, addr, addrlen);
-  if (ret < 0)
+  if (ret >= 0)
     {
-      return ret;
+      FAR struct socket_conn_s *conn = psock->s_conn;
+
+      if (addr != NULL)
+        {
+          conn->s_flags |= _SF_CONNECTED;
+        }
+      else
+        {
+          conn->s_flags &= ~_SF_CONNECTED;
+        }
     }
 
-  if (addr != NULL)
-    {
-      psock->s_flags |= _SF_CONNECTED;
-    }
-  else
-    {
-      psock->s_flags &= ~_SF_CONNECTED;
-    }
-
-  return OK;
+  return ret;
 }
 
 /****************************************************************************

--- a/net/socket/getsockopt.c
+++ b/net/socket/getsockopt.c
@@ -115,11 +115,11 @@ static int psock_socketlevel_option(FAR struct socket *psock, int option,
 
           if (option == SO_RCVTIMEO)
             {
-              timeo = psock->s_rcvtimeo;
+              timeo = conn->s_rcvtimeo;
             }
           else
             {
-              timeo = psock->s_sndtimeo;
+              timeo = conn->s_sndtimeo;
             }
 
           /* Then return the timeout value to the caller */

--- a/net/socket/getsockopt.c
+++ b/net/socket/getsockopt.c
@@ -255,7 +255,7 @@ static int psock_socketlevel_option(FAR struct socket *psock, int option,
               return -EINVAL;
             }
 
-          *(FAR int *)value = (int)psock->s_timestamp;
+          *(FAR int *)value = (int)conn->s_timestamp;
         }
         break;
 #endif

--- a/net/socket/getsockopt.c
+++ b/net/socket/getsockopt.c
@@ -242,8 +242,8 @@ static int psock_socketlevel_option(FAR struct socket *psock, int option,
               return -EINVAL;
             }
 
-          *(FAR int *)value = (int)psock->s_error;
-          psock->s_error = 0;
+          *(FAR int *)value = (int)conn->s_error;
+          conn->s_error = 0;
         }
         break;
 

--- a/net/socket/getsockopt.c
+++ b/net/socket/getsockopt.c
@@ -80,6 +80,8 @@ static int psock_socketlevel_option(FAR struct socket *psock, int option,
                                     FAR void *value,
                                     FAR socklen_t *value_len)
 {
+  FAR struct socket_conn_s *conn = psock->s_conn;
+
   /* Verify that the socket option if valid (but might not be supported ) */
 
   if (!_SO_GETVALID(option) || !value || !value_len)
@@ -134,11 +136,11 @@ static int psock_socketlevel_option(FAR struct socket *psock, int option,
       {
         if (option == SO_TYPE)
           {
-            FAR struct usrsock_conn_s *conn = psock->s_conn;
+            FAR struct usrsock_conn_s *uconn = psock->s_conn;
 
             /* Return the actual socket type */
 
-            *(FAR int *)value = conn->type;
+            *(FAR int *)value = uconn->type;
             *value_len        = sizeof(int);
 
             return OK;
@@ -156,7 +158,7 @@ static int psock_socketlevel_option(FAR struct socket *psock, int option,
             return -EINVAL;
           }
 
-        *(FAR int *)value = _SS_ISLISTENING(psock->s_flags);
+        *(FAR int *)value = _SS_ISLISTENING(conn->s_flags);
         *value_len        = sizeof(int);
         break;
 

--- a/net/socket/getsockopt.c
+++ b/net/socket/getsockopt.c
@@ -194,7 +194,7 @@ static int psock_socketlevel_option(FAR struct socket *psock, int option,
            * a macro will do.
            */
 
-          optionset         = psock->s_options;
+          optionset         = conn->s_options;
           *(FAR int *)value = _SO_GETOPT(optionset, option);
           *value_len        = sizeof(int);
         }

--- a/net/socket/listen.c
+++ b/net/socket/listen.c
@@ -84,14 +84,17 @@ int psock_listen(FAR struct socket *psock, int backlog)
 
   DEBUGASSERT(psock->s_sockif != NULL && psock->s_sockif->si_listen != NULL);
   ret = psock->s_sockif->si_listen(psock, backlog);
-  if (ret < 0)
+  if (ret >= 0)
+    {
+      FAR struct socket_conn_s *conn = psock->s_conn;
+      conn->s_flags |= _SF_LISTENING;
+    }
+  else
     {
       nerr("ERROR: si_listen failed: %d\n", ret);
-      return ret;
     }
 
-  psock->s_flags |= _SF_LISTENING;
-  return OK;
+  return ret;
 }
 
 /****************************************************************************

--- a/net/socket/net_close.c
+++ b/net/socket/net_close.c
@@ -81,6 +81,8 @@ int psock_close(FAR struct socket *psock)
 
   if (psock->s_conn != NULL)
     {
+      FAR struct socket_conn_s *conn = psock->s_conn;
+
       /* Assume that the socket close operation will be successful.  Save
        * the current flags and mark the socket uninitialized.  This avoids
        * race conditions in the SMP case.  We save the flags as a type
@@ -88,9 +90,9 @@ int psock_close(FAR struct socket *psock)
        * (currently uint8_t).
        */
 
-      unsigned int saveflags = psock->s_flags;
+      unsigned int saveflags = conn->s_flags;
 
-      psock->s_flags &= ~_SF_INITD;
+      conn->s_flags &= ~_SF_INITD;
 
       /* Let the address family's close() method handle the operation */
 
@@ -105,7 +107,7 @@ int psock_close(FAR struct socket *psock)
         {
           /* No.. restore the socket flags */
 
-          psock->s_flags = saveflags;
+          conn->s_flags = saveflags;
           return ret;
         }
     }

--- a/net/socket/net_dup2.c
+++ b/net/socket/net_dup2.c
@@ -78,8 +78,6 @@ int psock_dup2(FAR struct socket *psock1, FAR struct socket *psock2)
   psock2->s_type     = psock1->s_type;      /* Protocol type: Only SOCK_STREAM or SOCK_DGRAM */
   psock2->s_sockif   = psock1->s_sockif;    /* Socket interface */
 #ifdef CONFIG_NET_SOCKOPTS
-  psock2->s_rcvtimeo = psock1->s_rcvtimeo;  /* Receive timeout value (in deciseconds) */
-  psock2->s_sndtimeo = psock1->s_sndtimeo;  /* Send timeout value (in deciseconds) */
 #ifdef CONFIG_NET_SOLINGER
   psock2->s_linger   = psock1->s_linger;    /* Linger timeout value (in deciseconds) */
 #endif

--- a/net/socket/net_dup2.c
+++ b/net/socket/net_dup2.c
@@ -77,7 +77,6 @@ int psock_dup2(FAR struct socket *psock1, FAR struct socket *psock2)
   psock2->s_domain   = psock1->s_domain;    /* IP domain: PF_INET, PF_INET6, or PF_PACKET */
   psock2->s_type     = psock1->s_type;      /* Protocol type: Only SOCK_STREAM or SOCK_DGRAM */
   psock2->s_sockif   = psock1->s_sockif;    /* Socket interface */
-  psock2->s_flags    = psock1->s_flags;     /* See _SF_* definitions */
 #ifdef CONFIG_NET_SOCKOPTS
   psock2->s_options  = psock1->s_options;   /* Selected socket options */
   psock2->s_rcvtimeo = psock1->s_rcvtimeo;  /* Receive timeout value (in deciseconds) */

--- a/net/socket/net_dup2.c
+++ b/net/socket/net_dup2.c
@@ -78,7 +78,6 @@ int psock_dup2(FAR struct socket *psock1, FAR struct socket *psock2)
   psock2->s_type     = psock1->s_type;      /* Protocol type: Only SOCK_STREAM or SOCK_DGRAM */
   psock2->s_sockif   = psock1->s_sockif;    /* Socket interface */
 #ifdef CONFIG_NET_SOCKOPTS
-  psock2->s_options  = psock1->s_options;   /* Selected socket options */
   psock2->s_rcvtimeo = psock1->s_rcvtimeo;  /* Receive timeout value (in deciseconds) */
   psock2->s_sndtimeo = psock1->s_sndtimeo;  /* Send timeout value (in deciseconds) */
 #ifdef CONFIG_NET_SOLINGER

--- a/net/socket/net_dup2.c
+++ b/net/socket/net_dup2.c
@@ -77,11 +77,6 @@ int psock_dup2(FAR struct socket *psock1, FAR struct socket *psock2)
   psock2->s_domain   = psock1->s_domain;    /* IP domain: PF_INET, PF_INET6, or PF_PACKET */
   psock2->s_type     = psock1->s_type;      /* Protocol type: Only SOCK_STREAM or SOCK_DGRAM */
   psock2->s_sockif   = psock1->s_sockif;    /* Socket interface */
-#ifdef CONFIG_NET_SOCKOPTS
-#ifdef CONFIG_NET_SOLINGER
-  psock2->s_linger   = psock1->s_linger;    /* Linger timeout value (in deciseconds) */
-#endif
-#endif
   psock2->s_conn     = psock1->s_conn;      /* UDP or TCP connection structure */
 
   /* Increment the reference count on the underlying connection structure

--- a/net/socket/net_fstat.c
+++ b/net/socket/net_fstat.c
@@ -58,6 +58,7 @@
 
 int psock_fstat(FAR struct socket *psock, FAR struct stat *buf)
 {
+  FAR struct socket_conn_s *conn;
   int ret = OK;
 
   if (psock == NULL)
@@ -82,7 +83,9 @@ int psock_fstat(FAR struct socket *psock, FAR struct stat *buf)
    * devices, each supporting a different MSS.
    */
 
-  if (psock->s_conn == NULL || !_SS_ISCONNECTED(psock->s_flags))
+  conn = psock->s_conn;
+
+  if (conn == NULL || !_SS_ISCONNECTED(conn->s_flags))
     {
       /* Not connected.. Return an optimal blocksize of zero (or, perhaps,
        * even an error?)
@@ -105,14 +108,14 @@ int psock_fstat(FAR struct socket *psock, FAR struct stat *buf)
 #if defined(NET_TCP_HAVE_STACK)
        case SOCK_STREAM:
          {
-           FAR struct tcp_conn_s *conn =
+           FAR struct tcp_conn_s *tcp_conn =
                        (FAR struct tcp_conn_s *)psock->s_conn;
 
            /* For TCP, the MSS is a dynamic value that maintained in the
             * connection structure.
             */
 
-           buf->st_blksize = conn->mss;
+           buf->st_blksize = tcp_conn->mss;
          }
          break;
 #endif
@@ -120,7 +123,7 @@ int psock_fstat(FAR struct socket *psock, FAR struct stat *buf)
 #if defined(NET_UDP_HAVE_STACK)
        case SOCK_DGRAM:
          {
-           FAR struct udp_conn_s *conn =
+           FAR struct udp_conn_s *udp_conn =
                                    (FAR struct udp_conn_s *)psock->s_conn;
            FAR struct net_driver_s *dev;
            uint16_t iplen;
@@ -133,7 +136,7 @@ int psock_fstat(FAR struct socket *psock, FAR struct stat *buf)
             * order to get the MTU and LL_HDRLEN:
             */
 
-           dev = udp_find_raddr_device(conn, NULL);
+           dev = udp_find_raddr_device(udp_conn, NULL);
            if (dev == NULL)
              {
                /* This should never happen except perhaps in some rare race
@@ -150,7 +153,8 @@ int psock_fstat(FAR struct socket *psock, FAR struct stat *buf)
                /* We need the length of the IP header */
 
 #if defined(CONFIG_NET_IPv4) && defined(CONFIG_NET_IPv6)
-               iplen = (conn->domain == PF_INET) ? IPv4_HDRLEN : IPv6_HDRLEN;
+               iplen = (udp_conn->domain == PF_INET) ? IPv4_HDRLEN :
+                                                       IPv6_HDRLEN;
 #elif defined(CONFIG_NET_IPv4)
                iplen = IPv4_HDRLEN;
 #else

--- a/net/socket/net_sendfile.c
+++ b/net/socket/net_sendfile.c
@@ -113,7 +113,6 @@ ssize_t psock_sendfile(FAR struct socket *psock, FAR struct file *infile,
   if (psock == NULL || psock->s_conn == NULL)
     {
       nerr("ERROR: Invalid socket\n");
-      psock->s_error = EBADF;
       return -EBADF;
     }
 
@@ -134,7 +133,8 @@ ssize_t psock_sendfile(FAR struct socket *psock, FAR struct file *infile,
 
   if (ret < 0)
     {
-      psock->s_error = -ret;
+      FAR struct socket_conn_s *conn = psock->s_conn;
+      conn->s_error = -ret;
     }
 
   return ret;

--- a/net/socket/net_vfcntl.c
+++ b/net/socket/net_vfcntl.c
@@ -60,6 +60,7 @@
 
 int psock_vfcntl(FAR struct socket *psock, int cmd, va_list ap)
 {
+  FAR struct socket_conn_s *conn;
   int ret = -EINVAL;
 
   ninfo("sockfd=%p cmd=%d\n", psock, cmd);
@@ -70,6 +71,8 @@ int psock_vfcntl(FAR struct socket *psock, int cmd, va_list ap)
     {
       return -EBADF;
     }
+
+  conn = psock->s_conn;
 
   /* Interrupts must be disabled in order to perform operations on socket
    * structures
@@ -104,7 +107,7 @@ int psock_vfcntl(FAR struct socket *psock, int cmd, va_list ap)
           sockcaps = psock->s_sockif->si_sockcaps(psock);
 
           if ((sockcaps & SOCKCAP_NONBLOCKING) != 0 &&
-              _SS_ISNONBLOCK(psock->s_flags))
+              _SS_ISNONBLOCK(conn->s_flags))
             {
               ret |= O_NONBLOCK;
             }
@@ -138,11 +141,11 @@ int psock_vfcntl(FAR struct socket *psock, int cmd, va_list ap)
             {
                if ((mode & O_NONBLOCK) != 0)
                  {
-                   psock->s_flags |= _SF_NONBLOCK;
+                   conn->s_flags |= _SF_NONBLOCK;
                  }
                else
                  {
-                   psock->s_flags &= ~_SF_NONBLOCK;
+                   conn->s_flags &= ~_SF_NONBLOCK;
                  }
 
                ret = OK;

--- a/net/socket/setsockopt.c
+++ b/net/socket/setsockopt.c
@@ -363,12 +363,12 @@ static int psock_socketlevel_option(FAR struct socket *psock, int option,
           if (setting->l_onoff)
             {
               _SO_SETOPT(conn->s_options, option);
-              psock->s_linger = 10 * setting->l_linger;
+              conn->s_linger = 10 * setting->l_linger;
             }
           else
             {
               _SO_CLROPT(conn->s_options, option);
-              psock->s_linger = 0;
+              conn->s_linger = 0;
             }
 
           net_unlock();

--- a/net/socket/setsockopt.c
+++ b/net/socket/setsockopt.c
@@ -116,11 +116,11 @@ static int psock_socketlevel_option(FAR struct socket *psock, int option,
 
           if (option == SO_RCVTIMEO)
             {
-              psock->s_rcvtimeo = timeo;
+              conn->s_rcvtimeo = timeo;
             }
           else
             {
-              psock->s_sndtimeo = timeo;
+              conn->s_sndtimeo = timeo;
             }
 
           /* Set/clear the corresponding enable/disable bit */

--- a/net/socket/setsockopt.c
+++ b/net/socket/setsockopt.c
@@ -75,6 +75,8 @@ static int psock_socketlevel_option(FAR struct socket *psock, int option,
                                     FAR const void *value,
                                     socklen_t value_len)
 {
+  FAR struct socket_conn_s *conn = psock->s_conn;
+
   /* Verify that the socket option if valid (but might not be supported ) */
 
   if (!_SO_SETVALID(option) || !value)
@@ -125,11 +127,11 @@ static int psock_socketlevel_option(FAR struct socket *psock, int option,
 
           if (timeo)
             {
-              _SO_CLROPT(psock->s_options, option);
+              _SO_CLROPT(conn->s_options, option);
             }
           else
             {
-              _SO_SETOPT(psock->s_options, option);
+              _SO_SETOPT(conn->s_options, option);
             }
 
           return OK;
@@ -304,11 +306,11 @@ static int psock_socketlevel_option(FAR struct socket *psock, int option,
 
           if (setting)
             {
-              _SO_SETOPT(psock->s_options, option);
+              _SO_SETOPT(conn->s_options, option);
             }
           else
             {
-              _SO_CLROPT(psock->s_options, option);
+              _SO_CLROPT(conn->s_options, option);
             }
 
           net_unlock();
@@ -360,12 +362,12 @@ static int psock_socketlevel_option(FAR struct socket *psock, int option,
 
           if (setting->l_onoff)
             {
-              _SO_SETOPT(psock->s_options, option);
+              _SO_SETOPT(conn->s_options, option);
               psock->s_linger = 10 * setting->l_linger;
             }
           else
             {
-              _SO_CLROPT(psock->s_options, option);
+              _SO_CLROPT(conn->s_options, option);
               psock->s_linger = 0;
             }
 

--- a/net/socket/setsockopt.c
+++ b/net/socket/setsockopt.c
@@ -392,7 +392,7 @@ static int psock_socketlevel_option(FAR struct socket *psock, int option,
 
           net_lock();
 
-          psock->s_timestamp = *((FAR int32_t *)value);
+          conn->s_timestamp = *((FAR int32_t *)value);
 
           net_unlock();
         }

--- a/net/socket/socket.c
+++ b/net/socket/socket.c
@@ -87,9 +87,6 @@ int psock_socket(int domain, int type, int protocol,
   psock->s_domain = domain;
   psock->s_proto  = protocol;
   psock->s_conn   = NULL;
-#if defined(CONFIG_NET_TCP_WRITE_BUFFERS) || defined(CONFIG_NET_UDP_WRITE_BUFFERS)
-  psock->s_sndcb  = NULL;
-#endif
 
   if (type & SOCK_NONBLOCK)
     {

--- a/net/socket/socket.c
+++ b/net/socket/socket.c
@@ -87,14 +87,7 @@ int psock_socket(int domain, int type, int protocol,
   psock->s_domain = domain;
   psock->s_proto  = protocol;
   psock->s_conn   = NULL;
-
-  if (type & SOCK_NONBLOCK)
-    {
-      psock->s_flags |= _SF_NONBLOCK;
-    }
-
-  type            &= SOCK_TYPE_MASK;
-  psock->s_type   = type;
+  psock->s_type   = type & SOCK_TYPE_MASK;
 
 #ifdef CONFIG_NET_USRSOCK
   if (domain != PF_LOCAL && domain != PF_UNSPEC && domain != PF_RPMSG)
@@ -111,7 +104,7 @@ int psock_socket(int domain, int type, int protocol,
     {
       /* Get the socket interface */
 
-      sockif = net_sockif(domain, type, protocol);
+      sockif = net_sockif(domain, psock->s_type, protocol);
       if (sockif == NULL)
         {
           nerr("ERROR: socket address family unsupported: %d\n", domain);
@@ -126,16 +119,26 @@ int psock_socket(int domain, int type, int protocol,
       psock->s_sockif = sockif;
 
       ret = sockif->si_setup(psock, protocol);
-      if (ret < 0)
-        {
-          nerr("ERROR: socket si_setup() failed: %d\n", ret);
-          return ret;
-        }
     }
 
-  /* The socket has been successfully initialized */
+  if (ret >= 0)
+    {
+      FAR struct socket_conn_s *conn = psock->s_conn;
 
-  psock->s_flags |= _SF_INITD;
+      if (type & SOCK_NONBLOCK)
+        {
+          conn->s_flags |= _SF_NONBLOCK;
+        }
+
+      /* The socket has been successfully initialized */
+
+      conn->s_flags |= _SF_INITD;
+    }
+  else
+    {
+      nerr("ERROR: socket si_setup() failed: %d\n", ret);
+    }
+
   return ret;
 }
 

--- a/net/socket/socket.h
+++ b/net/socket/socket.h
@@ -95,9 +95,10 @@
 #  define _SO_SETERRNO(s,e) \
     do \
       { \
-        if (s != NULL) \
+        if (s != NULL && (s)->s_conn != NULL) \
           { \
-            s->s_error = (int16_t)e; \
+            FAR struct socket_conn_s *_conn = (s)->s_conn; \
+            _conn->s_error = (int16_t)e; \
           } \
         set_errno(e); \
       } \

--- a/net/tcp/tcp.h
+++ b/net/tcp/tcp.h
@@ -309,6 +309,12 @@ struct tcp_conn_s
   FAR struct devif_callback_s *connevents;
   FAR struct devif_callback_s *connevents_tail;
 
+#if defined(CONFIG_NET_TCP_WRITE_BUFFERS)
+  /* Callback instance for TCP send() */
+
+  FAR struct devif_callback_s *sndcb;
+#endif
+
   /* accept() is called when the TCP logic has created a connection
    *
    *   accept_private: This is private data that will be available to the

--- a/net/tcp/tcp.h
+++ b/net/tcp/tcp.h
@@ -34,6 +34,7 @@
 #include <nuttx/semaphore.h>
 #include <nuttx/mm/iob.h>
 #include <nuttx/net/ip.h>
+#include <nuttx/net/net.h>
 
 #ifdef CONFIG_NET_TCP_NOTIFIER
 #  include <nuttx/wqueue.h>
@@ -54,9 +55,9 @@
  */
 
 #define tcp_callback_alloc(conn) \
-  devif_callback_alloc((conn)->dev, &(conn)->list, &(conn)->list_tail)
+  devif_callback_alloc((conn)->dev, &(conn)->sconn.list, &(conn)->sconn.list_tail)
 #define tcp_callback_free(conn,cb) \
-  devif_conn_callback_free((conn)->dev, (cb), &(conn)->list, &(conn)->list_tail)
+  devif_conn_callback_free((conn)->dev, (cb), &(conn)->sconn.list, &(conn)->sconn.list_tail)
 
 #ifdef CONFIG_NET_TCP_WRITE_BUFFERS
 /* TCP write buffer access macros */
@@ -145,8 +146,6 @@ struct tcp_conn_s
 {
   /* Common prologue of all connection structures. */
 
-  dq_entry_t node;        /* Implements a doubly linked list */
-
   /* TCP callbacks:
    *
    * Data transfer events are retained in 'list'.  Event handlers in 'list'
@@ -171,8 +170,7 @@ struct tcp_conn_s
    *                 then dev->d_len should also be cleared).
    */
 
-  FAR struct devif_callback_s *list;
-  FAR struct devif_callback_s *list_tail;
+  struct socket_conn_s sconn;
 
   /* TCP-specific content follows */
 

--- a/net/tcp/tcp.h
+++ b/net/tcp/tcp.h
@@ -137,7 +137,7 @@ struct tcp_hdr_s;         /* Forward reference */
 
 struct tcp_poll_s
 {
-  FAR struct socket *psock;        /* Needed to handle loss of connection */
+  FAR struct tcp_conn_s *conn;     /* Needed to handle loss of connection */
   struct pollfd *fds;              /* Needed to handle poll events */
   FAR struct devif_callback_s *cb; /* Needed to teardown the poll */
 };
@@ -685,7 +685,7 @@ void tcp_close_monitor(FAR struct socket *psock);
  *   the event handler.
  *
  * Input Parameters:
- *   psock - The TCP socket structure associated.
+ *   conn  - The TCP connection of interest
  *   cb    - devif callback structure
  *   flags - Set of connection events events
  *
@@ -698,7 +698,7 @@ void tcp_close_monitor(FAR struct socket *psock);
  *
  ****************************************************************************/
 
-void tcp_lost_connection(FAR struct socket *psock,
+void tcp_lost_connection(FAR struct tcp_conn_s *conn,
                          FAR struct devif_callback_s *cb, uint16_t flags);
 
 /****************************************************************************
@@ -1540,7 +1540,7 @@ bool tcp_should_send_recvwindow(FAR struct tcp_conn_s *conn);
  *   another means.
  *
  * Input Parameters:
- *   psock    An instance of the internal socket structure.
+ *   conn     The TCP connection of interest
  *
  * Returned Value:
  *   OK
@@ -1554,7 +1554,7 @@ bool tcp_should_send_recvwindow(FAR struct tcp_conn_s *conn);
  *
  ****************************************************************************/
 
-int psock_tcp_cansend(FAR struct socket *psock);
+int psock_tcp_cansend(FAR struct tcp_conn_s *conn);
 
 /****************************************************************************
  * Name: tcp_wrbuffer_initialize

--- a/net/tcp/tcp_accept.c
+++ b/net/tcp/tcp_accept.c
@@ -242,7 +242,7 @@ int psock_tcp_accept(FAR struct socket *psock, FAR struct sockaddr *addr,
    * return EAGAIN if there is no pending connection in the backlog.
    */
 
-  else if (_SS_ISNONBLOCK(psock->s_flags))
+  else if (_SS_ISNONBLOCK(conn->sconn.s_flags))
     {
       return -EAGAIN;
     }

--- a/net/tcp/tcp_callback.c
+++ b/net/tcp/tcp_callback.c
@@ -166,7 +166,7 @@ uint16_t tcp_callback(FAR struct net_driver_s *dev,
    *                 not set, then dev->d_len should also be cleared).
    */
 
-  flags = devif_conn_event(dev, conn, flags, conn->list);
+  flags = devif_conn_event(dev, conn, flags, conn->sconn.list);
 
   /* There may be no new data handler in place at them moment that the new
    * incoming data is received.  If the new incoming data was not handled,

--- a/net/tcp/tcp_close.c
+++ b/net/tcp/tcp_close.c
@@ -285,7 +285,7 @@ static inline int tcp_close_disconnect(FAR struct socket *psock)
     {
       /* Wait until for the buffered TX data to be sent. */
 
-      ret = tcp_txdrain(psock, _SO_TIMEOUT(psock->s_linger));
+      ret = tcp_txdrain(psock, _SO_TIMEOUT(conn->sconn.s_linger));
       if (ret < 0)
         {
           /* tcp_txdrain may fail, but that won't stop us from closing

--- a/net/tcp/tcp_close.c
+++ b/net/tcp/tcp_close.c
@@ -161,18 +161,16 @@ static uint16_t tcp_close_eventhandler(FAR struct net_driver_s *dev,
        */
 
 #ifdef CONFIG_NET_TCP_WRITE_BUFFERS
-      FAR struct socket *psock = pstate->cl_psock;
-
       /* We don't need the send callback anymore. */
 
-      if (psock->s_sndcb != NULL)
+      if (conn->sndcb != NULL)
         {
-          psock->s_sndcb->flags = 0;
-          psock->s_sndcb->event = NULL;
+          conn->sndcb->flags = 0;
+          conn->sndcb->event = NULL;
 
           /* The callback will be freed by tcp_free. */
 
-          psock->s_sndcb = NULL;
+          conn->sndcb = NULL;
         }
 #endif
 

--- a/net/tcp/tcp_close.c
+++ b/net/tcp/tcp_close.c
@@ -281,7 +281,7 @@ static inline int tcp_close_disconnect(FAR struct socket *psock)
    *   state of the option and linger interval.
    */
 
-  if (_SO_GETOPT(psock->s_options, SO_LINGER))
+  if (_SO_GETOPT(conn->sconn.s_options, SO_LINGER))
     {
       /* Wait until for the buffered TX data to be sent. */
 

--- a/net/tcp/tcp_close.c
+++ b/net/tcp/tcp_close.c
@@ -45,8 +45,8 @@
 
 struct tcp_close_s
 {
+  FAR struct tcp_conn_s       *cl_conn;   /* Needed to handle loss of connection */
   FAR struct devif_callback_s *cl_cb;     /* Reference to TCP callback instance */
-  FAR struct socket           *cl_psock;  /* Reference to the TCP socket */
   sem_t                        cl_sem;    /* Signals disconnect completion */
   int                          cl_result; /* The result of the close */
 };
@@ -64,7 +64,7 @@ static uint16_t tcp_close_eventhandler(FAR struct net_driver_s *dev,
                                        uint16_t flags)
 {
   FAR struct tcp_close_s *pstate = (FAR struct tcp_close_s *)pvpriv;
-  FAR struct tcp_conn_s *conn = (FAR struct tcp_conn_s *)pvconn;
+  FAR struct tcp_conn_s *conn = pstate->cl_conn;
 
   DEBUGASSERT(pstate != NULL);
 
@@ -322,7 +322,7 @@ static inline int tcp_close_disconnect(FAR struct socket *psock)
 
       /* Set up for the lingering wait */
 
-      state.cl_psock     = psock;
+      state.cl_conn      = conn;
       state.cl_result    = -EBUSY;
 
       /* This semaphore is used for signaling and, hence, should not have

--- a/net/tcp/tcp_conn.c
+++ b/net/tcp/tcp_conn.c
@@ -317,7 +317,7 @@ static inline FAR struct tcp_conn_s *
 
       /* Look at the next active connection */
 
-      conn = (FAR struct tcp_conn_s *)conn->node.flink;
+      conn = (FAR struct tcp_conn_s *)conn->sconn.node.flink;
     }
 
   return conn;
@@ -384,7 +384,7 @@ static inline FAR struct tcp_conn_s *
 
       /* Look at the next active connection */
 
-      conn = (FAR struct tcp_conn_s *)conn->node.flink;
+      conn = (FAR struct tcp_conn_s *)conn->sconn.node.flink;
     }
 
   return conn;
@@ -555,7 +555,7 @@ FAR struct tcp_conn_s *tcp_alloc_conn(void)
           /* Mark the connection closed and move it to the free list */
 
           conn[i].tcpstateflags = TCP_CLOSED;
-          dq_addlast(&conn[i].node, &g_free_tcp_connections);
+          dq_addlast(&conn[i].sconn.node, &g_free_tcp_connections);
         }
     }
 
@@ -595,7 +595,7 @@ void tcp_initialize(void)
       /* Mark the connection closed and move it to the free list */
 
       g_tcp_connections[i].tcpstateflags = TCP_CLOSED;
-      dq_addlast(&g_tcp_connections[i].node, &g_free_tcp_connections);
+      dq_addlast(&g_tcp_connections[i].sconn.node, &g_free_tcp_connections);
     }
 #endif
 }
@@ -668,7 +668,7 @@ FAR struct tcp_conn_s *tcp_alloc(uint8_t domain)
 
           /* Look at the next active connection */
 
-          tmp = (FAR struct tcp_conn_s *)tmp->node.flink;
+          tmp = (FAR struct tcp_conn_s *)tmp->sconn.node.flink;
         }
 
       /* Did we find a connection that we can re-use? */
@@ -769,7 +769,7 @@ void tcp_free(FAR struct tcp_conn_s *conn)
    * callback for CONFIG_NET_TCP_WRITE_BUFFERS is left.
    */
 
-  for (cb = conn->list; cb; cb = next)
+  for (cb = conn->sconn.list; cb; cb = next)
     {
       next = cb->nxtconn;
       tcp_callback_free(conn, cb);
@@ -783,7 +783,7 @@ void tcp_free(FAR struct tcp_conn_s *conn)
     {
       /* Remove the connection from the active list */
 
-      dq_rem(&conn->node, &g_active_tcp_connections);
+      dq_rem(&conn->sconn.node, &g_active_tcp_connections);
     }
 
   /* Release any read-ahead buffers attached to the connection */
@@ -835,7 +835,7 @@ void tcp_free(FAR struct tcp_conn_s *conn)
   /* Mark the connection available and put it into the free list */
 
   conn->tcpstateflags = TCP_CLOSED;
-  dq_addlast(&conn->node, &g_free_tcp_connections);
+  dq_addlast(&conn->sconn.node, &g_free_tcp_connections);
   net_unlock();
 }
 
@@ -892,7 +892,7 @@ FAR struct tcp_conn_s *tcp_nextconn(FAR struct tcp_conn_s *conn)
     }
   else
     {
-      return (FAR struct tcp_conn_s *)conn->node.flink;
+      return (FAR struct tcp_conn_s *)conn->sconn.node.flink;
     }
 }
 
@@ -1053,7 +1053,7 @@ FAR struct tcp_conn_s *tcp_alloc_accept(FAR struct net_driver_s *dev,
        * Interrupts should already be disabled in this context.
        */
 
-      dq_addlast(&conn->node, &g_active_tcp_connections);
+      dq_addlast(&conn->sconn.node, &g_active_tcp_connections);
     }
 
   return conn;
@@ -1325,7 +1325,7 @@ int tcp_connect(FAR struct tcp_conn_s *conn, FAR const struct sockaddr *addr)
 
   /* And, finally, put the connection structure into the active list. */
 
-  dq_addlast(&conn->node, &g_active_tcp_connections);
+  dq_addlast(&conn->sconn.node, &g_active_tcp_connections);
   ret = OK;
 
 errout_with_lock:

--- a/net/tcp/tcp_connect.c
+++ b/net/tcp/tcp_connect.c
@@ -219,7 +219,10 @@ static uint16_t psock_connect_eventhandler(FAR struct net_driver_s *dev,
       else if ((flags & TCP_CONNECTED) != 0)
         {
           FAR struct socket *psock = pstate->tc_psock;
+          FAR struct socket_conn_s *conn;
           DEBUGASSERT(psock);
+
+          conn = psock->s_conn;
 
           /* Mark the connection bound and connected.  NOTE this is
            * is done here (vs. later) in order to avoid any race condition
@@ -227,7 +230,7 @@ static uint16_t psock_connect_eventhandler(FAR struct net_driver_s *dev,
            * but not necessarily at any time later.
            */
 
-          psock->s_flags |= (_SF_BOUND | _SF_CONNECTED);
+          conn->s_flags |= (_SF_BOUND | _SF_CONNECTED);
 
           /* Indicate that the socket is no longer connected */
 
@@ -293,8 +296,9 @@ static uint16_t psock_connect_eventhandler(FAR struct net_driver_s *dev,
 int psock_tcp_connect(FAR struct socket *psock,
                       FAR const struct sockaddr *addr)
 {
-  struct tcp_connect_s state;
-  int                  ret = OK;
+  FAR struct tcp_conn_s *conn;
+  struct tcp_connect_s   state;
+  int                    ret = OK;
 
   /* Interrupts must be disabled through all of the following because
    * we cannot allow the network callback to occur until we are completely
@@ -303,9 +307,11 @@ int psock_tcp_connect(FAR struct socket *psock,
 
   net_lock();
 
+  conn = psock->s_conn;
+
   /* Get the connection reference from the socket */
 
-  if (!psock->s_conn) /* Should always be non-NULL */
+  if (conn == NULL) /* Should always be non-NULL */
     {
       ret = -EINVAL;
     }
@@ -313,20 +319,20 @@ int psock_tcp_connect(FAR struct socket *psock,
     {
       /* Perform the TCP connection operation */
 
-      ret = tcp_connect(psock->s_conn, addr);
+      ret = tcp_connect(conn, addr);
     }
 
   if (ret >= 0)
     {
       /* Notify the device driver that new connection is available. */
 
-      netdev_txnotify_dev(((FAR struct tcp_conn_s *)psock->s_conn)->dev);
+      netdev_txnotify_dev(conn->dev);
 
       /* Non-blocking connection ? set the socket error
        * and start the monitor
        */
 
-      if (_SS_ISNONBLOCK(psock->s_flags))
+      if (_SS_ISNONBLOCK(conn->sconn.s_flags))
         {
           ret = -EINPROGRESS;
         }
@@ -385,7 +391,7 @@ int psock_tcp_connect(FAR struct socket *psock,
                * happen in this context, but just in case...
                */
 
-              tcp_stop_monitor(psock->s_conn, TCP_ABORT);
+              tcp_stop_monitor(conn, TCP_ABORT);
               ret = ret2;
             }
         }

--- a/net/tcp/tcp_netpoll.c
+++ b/net/tcp/tcp_netpoll.c
@@ -217,7 +217,7 @@ int tcp_pollsetup(FAR struct socket *psock, FAR struct pollfd *fds)
   /* Non-blocking connection ? */
 
   nonblock_conn = (conn->tcpstateflags == TCP_SYN_SENT &&
-                   _SS_ISNONBLOCK(psock->s_flags));
+                   _SS_ISNONBLOCK(conn->sconn.s_flags));
 
   /* Find a container to hold the poll information */
 
@@ -331,8 +331,8 @@ int tcp_pollsetup(FAR struct socket *psock, FAR struct pollfd *fds)
    *    Action: Return with POLLHUP|POLLERR events
    */
 
-  if (!nonblock_conn && !_SS_ISCONNECTED(psock->s_flags) &&
-      !_SS_ISLISTENING(psock->s_flags))
+  if (!nonblock_conn && !_SS_ISCONNECTED(conn->sconn.s_flags) &&
+      !_SS_ISLISTENING(conn->sconn.s_flags))
     {
       /* We were previously connected but lost the connection either due
        * to a graceful shutdown by the remote peer or because of some
@@ -341,7 +341,8 @@ int tcp_pollsetup(FAR struct socket *psock, FAR struct pollfd *fds)
 
       fds->revents |= (POLLERR | POLLHUP);
     }
-  else if (_SS_ISCONNECTED(psock->s_flags) && psock_tcp_cansend(psock) >= 0)
+  else if (_SS_ISCONNECTED(conn->sconn.s_flags) &&
+           psock_tcp_cansend(psock) >= 0)
     {
       fds->revents |= (POLLWRNORM & fds->events);
     }

--- a/net/tcp/tcp_recvfrom.c
+++ b/net/tcp/tcp_recvfrom.c
@@ -741,7 +741,8 @@ ssize_t psock_tcp_recvfrom(FAR struct socket *psock, FAR void *buf,
            * received.
            */
 
-          ret = net_timedwait(&state.ir_sem, _SO_TIMEOUT(psock->s_rcvtimeo));
+          ret = net_timedwait(&state.ir_sem,
+                              _SO_TIMEOUT(conn->sconn.s_rcvtimeo));
           if (ret == -ETIMEDOUT)
             {
               ret = -EAGAIN;

--- a/net/tcp/tcp_recvfrom.c
+++ b/net/tcp/tcp_recvfrom.c
@@ -58,7 +58,7 @@
 
 struct tcp_recvfrom_s
 {
-  FAR struct socket       *ir_sock;      /* The parent socket structure */
+  FAR struct tcp_conn_s   *ir_conn;      /* Connection associated with the socket */
   FAR struct devif_callback_s *ir_cb;    /* Reference to callback instance */
   sem_t                    ir_sem;       /* Semaphore signals recv completion */
   size_t                   ir_buflen;    /* Length of receive buffer */
@@ -170,8 +170,7 @@ static inline uint16_t tcp_newdata(FAR struct net_driver_s *dev,
                                    FAR struct tcp_recvfrom_s *pstate,
                                    uint16_t flags)
 {
-  FAR struct tcp_conn_s *conn = (FAR struct tcp_conn_s *)
-                                pstate->ir_sock->s_conn;
+  FAR struct tcp_conn_s *conn = pstate->ir_conn;
 
   /* Take as much data from the packet as we can */
 
@@ -237,8 +236,7 @@ static inline uint16_t tcp_newdata(FAR struct net_driver_s *dev,
 
 static inline void tcp_readahead(struct tcp_recvfrom_s *pstate)
 {
-  FAR struct tcp_conn_s *conn =
-    (FAR struct tcp_conn_s *)pstate->ir_sock->s_conn;
+  FAR struct tcp_conn_s *conn = pstate->ir_conn;
   FAR struct iob_s *iob;
   int recvlen;
 
@@ -461,8 +459,7 @@ static uint16_t tcp_recvhandler(FAR struct net_driver_s *dev,
 
       else if ((flags & TCP_DISCONN_EVENTS) != 0)
         {
-          FAR struct socket *psock = pstate->ir_sock;
-          FAR struct socket_conn_s *conn;
+          FAR struct tcp_conn_s *conn = pstate->ir_conn;
 
           nwarn("WARNING: Lost connection\n");
 
@@ -471,13 +468,12 @@ static uint16_t tcp_recvhandler(FAR struct net_driver_s *dev,
            * already been disconnected.
            */
 
-          DEBUGASSERT(psock != NULL);
-          conn = psock->s_conn;
-          if (_SS_ISCONNECTED(conn->s_flags))
+          DEBUGASSERT(conn != NULL);
+          if (_SS_ISCONNECTED(conn->sconn.s_flags))
             {
               /* Handle loss-of-connection event */
 
-              tcp_lost_connection(psock, pstate->ir_cb, flags);
+              tcp_lost_connection(conn, pstate->ir_cb, flags);
             }
 
           /* Check if the peer gracefully closed the connection. */
@@ -512,7 +508,7 @@ static uint16_t tcp_recvhandler(FAR struct net_driver_s *dev,
  *   Initialize the state structure
  *
  * Input Parameters:
- *   psock    Pointer to the socket structure for the socket
+ *   conn     The TCP connection of interest
  *   buf      Buffer to receive data
  *   len      Length of buffer
  *   pstate   A pointer to the state structure to be initialized
@@ -524,8 +520,9 @@ static uint16_t tcp_recvhandler(FAR struct net_driver_s *dev,
  *
  ****************************************************************************/
 
-static void tcp_recvfrom_initialize(FAR struct socket *psock, FAR void *buf,
-                                    size_t len, FAR struct sockaddr *infrom,
+static void tcp_recvfrom_initialize(FAR struct tcp_conn_s *conn,
+                                    FAR void *buf, size_t len,
+                                    FAR struct sockaddr *infrom,
                                     FAR socklen_t *fromlen,
                                     FAR struct tcp_recvfrom_s *pstate)
 {
@@ -547,7 +544,7 @@ static void tcp_recvfrom_initialize(FAR struct socket *psock, FAR void *buf,
 
   /* Set up the start time for the timeout */
 
-  pstate->ir_sock      = psock;
+  pstate->ir_conn      = conn;
 }
 
 /* The only un-initialization that has to be performed is destroying the
@@ -643,7 +640,7 @@ ssize_t psock_tcp_recvfrom(FAR struct socket *psock, FAR void *buf,
    * because we don't want anything to happen until we are ready.
    */
 
-  tcp_recvfrom_initialize(psock, buf, len, from, fromlen, &state);
+  tcp_recvfrom_initialize(conn, buf, len, from, fromlen, &state);
 
   /* Handle any any TCP data already buffered in a read-ahead buffer.  NOTE
    * that there may be read-ahead data to be retrieved even after the

--- a/net/tcp/tcp_send_buffered.c
+++ b/net/tcp/tcp_send_buffered.c
@@ -238,10 +238,10 @@ static inline void psock_lost_connection(FAR struct socket *psock,
 
   /* Do not allow any further callbacks */
 
-  if (psock->s_sndcb != NULL)
+  if (conn->sndcb != NULL)
     {
-      psock->s_sndcb->flags = 0;
-      psock->s_sndcb->event = NULL;
+      conn->sndcb->flags = 0;
+      conn->sndcb->event = NULL;
     }
 
   if (conn != NULL)
@@ -414,7 +414,7 @@ static uint16_t psock_send_eventhandler(FAR struct net_driver_s *dev,
         {
           /* Report not connected */
 
-          tcp_lost_connection(psock, psock->s_sndcb, flags);
+          tcp_lost_connection(psock, conn->sndcb, flags);
         }
 
       /* Free write buffers and terminate polling */
@@ -1142,14 +1142,14 @@ ssize_t psock_tcp_send(FAR struct socket *psock, FAR const void *buf,
 
       /* Allocate resources to receive a callback */
 
-      if (psock->s_sndcb == NULL)
+      if (conn->sndcb == NULL)
         {
-          psock->s_sndcb = tcp_callback_alloc(conn);
+          conn->sndcb = tcp_callback_alloc(conn);
         }
 
       /* Test if the callback has been allocated */
 
-      if (psock->s_sndcb == NULL)
+      if (conn->sndcb == NULL)
         {
           /* A buffer allocation error occurred */
 
@@ -1160,10 +1160,10 @@ ssize_t psock_tcp_send(FAR struct socket *psock, FAR const void *buf,
 
       /* Set up the callback in the connection */
 
-      psock->s_sndcb->flags = (TCP_ACKDATA | TCP_REXMIT | TCP_POLL |
+      conn->sndcb->flags = (TCP_ACKDATA | TCP_REXMIT | TCP_POLL |
                                TCP_DISCONN_EVENTS);
-      psock->s_sndcb->priv  = (FAR void *)psock;
-      psock->s_sndcb->event = psock_send_eventhandler;
+      conn->sndcb->priv  = (FAR void *)psock;
+      conn->sndcb->event = psock_send_eventhandler;
 
 #if CONFIG_NET_SEND_BUFSIZE > 0
       /* If the send buffer size exceeds the send limit,

--- a/net/tcp/tcp_send_unbuffered.c
+++ b/net/tcp/tcp_send_unbuffered.c
@@ -374,7 +374,7 @@ static uint16_t tcpsend_eventhandler(FAR struct net_driver_s *dev,
         {
           /* Report not connected */
 
-          tcp_lost_connection(psock, pstate->snd_cb, flags);
+          tcp_lost_connection(conn, pstate->snd_cb, flags);
         }
 
       pstate->snd_sent = -ENOTCONN;
@@ -719,7 +719,7 @@ errout:
  *   write occurs first.
  *
  * Input Parameters:
- *   psock    An instance of the internal socket structure.
+ *   conn     The TCP connection of interest
  *
  * Returned Value:
  *   OK (Always can send).
@@ -729,7 +729,7 @@ errout:
  *
  ****************************************************************************/
 
-int psock_tcp_cansend(FAR struct socket *psock)
+int psock_tcp_cansend(FAR struct tcp_conn_s *conn)
 {
   return OK;
 }

--- a/net/tcp/tcp_send_unbuffered.c
+++ b/net/tcp/tcp_send_unbuffered.c
@@ -666,7 +666,7 @@ ssize_t psock_tcp_send(FAR struct socket *psock,
               uint32_t acked = state.snd_acked;
 
               ret = net_timedwait(&state.snd_sem,
-                                  _SO_TIMEOUT(psock->s_sndtimeo));
+                                  _SO_TIMEOUT(conn->sconn.s_sndtimeo));
               if (ret != -ETIMEDOUT || acked == state.snd_acked)
                 {
                   break; /* Timeout without any progress */

--- a/net/tcp/tcp_send_unbuffered.c
+++ b/net/tcp/tcp_send_unbuffered.c
@@ -370,7 +370,7 @@ static uint16_t tcpsend_eventhandler(FAR struct net_driver_s *dev,
        * already been disconnected.
        */
 
-      if (_SS_ISCONNECTED(psock->s_flags))
+      if (_SS_ISCONNECTED(conn->sconn.s_flags))
         {
           /* Report not connected */
 
@@ -545,12 +545,14 @@ ssize_t psock_tcp_send(FAR struct socket *psock,
       goto errout;
     }
 
+  conn = (FAR struct tcp_conn_s *)psock->s_conn;
+
   /* Check early if this is an un-connected socket, if so, then
    * return -ENOTCONN. Note, we will have to check this again, as we can't
    * guarantee the state won't change until we have the network locked.
    */
 
-  if (!_SS_ISCONNECTED(psock->s_flags))
+  if (!_SS_ISCONNECTED(conn->sconn.s_flags))
     {
       nerr("ERROR: Not connected\n");
       ret = -ENOTCONN;
@@ -558,8 +560,6 @@ ssize_t psock_tcp_send(FAR struct socket *psock,
     }
 
   /* Make sure that we have the IP address mapping */
-
-  conn = (FAR struct tcp_conn_s *)psock->s_conn;
 
 #if defined(CONFIG_NET_ARP_SEND) || defined(CONFIG_NET_ICMPv6_NEIGHBOR)
 #ifdef CONFIG_NET_ARP_SEND
@@ -607,7 +607,7 @@ ssize_t psock_tcp_send(FAR struct socket *psock,
    * state again to ensure the connection is still valid.
    */
 
-  if (!_SS_ISCONNECTED(psock->s_flags))
+  if (!_SS_ISCONNECTED(conn->sconn.s_flags))
     {
       nerr("ERROR: No longer connected\n");
       net_unlock();

--- a/net/tcp/tcp_sendfile.c
+++ b/net/tcp/tcp_sendfile.c
@@ -333,7 +333,7 @@ static uint16_t sendfile_eventhandler(FAR struct net_driver_s *dev,
         {
           /* Report not connected */
 
-          tcp_lost_connection(psock, pstate->snd_cb, flags);
+          tcp_lost_connection(conn, pstate->snd_cb, flags);
         }
 
       /* Report not connected */

--- a/net/tcp/tcp_sendfile.c
+++ b/net/tcp/tcp_sendfile.c
@@ -329,7 +329,7 @@ static uint16_t sendfile_eventhandler(FAR struct net_driver_s *dev,
        * already been disconnected.
        */
 
-      if (_SS_ISCONNECTED(psock->s_flags))
+      if (_SS_ISCONNECTED(conn->sconn.s_flags))
         {
           /* Report not connected */
 
@@ -457,18 +457,18 @@ ssize_t tcp_sendfile(FAR struct socket *psock, FAR struct file *infile,
   off_t startpos;
   int ret;
 
+  conn = psock->s_conn;
+  DEBUGASSERT(conn != NULL);
+
   /* If this is an un-connected socket, then return ENOTCONN */
 
-  if (psock->s_type != SOCK_STREAM || !_SS_ISCONNECTED(psock->s_flags))
+  if (psock->s_type != SOCK_STREAM || !_SS_ISCONNECTED(conn->sconn.s_flags))
     {
       nerr("ERROR: Not connected\n");
       return -ENOTCONN;
     }
 
   /* Make sure that we have the IP address mapping */
-
-  conn = (FAR struct tcp_conn_s *)psock->s_conn;
-  DEBUGASSERT(conn != NULL);
 
 #if defined(CONFIG_NET_ARP_SEND) || defined(CONFIG_NET_ICMPv6_NEIGHBOR)
 #ifdef CONFIG_NET_ARP_SEND

--- a/net/tcp/tcp_sendfile.c
+++ b/net/tcp/tcp_sendfile.c
@@ -568,8 +568,8 @@ ssize_t tcp_sendfile(FAR struct socket *psock, FAR struct file *infile,
     {
       uint32_t acked = state.snd_acked;
 
-      ret = net_timedwait_uninterruptible(&state.snd_sem,
-                                          _SO_TIMEOUT(psock->s_sndtimeo));
+      ret = net_timedwait_uninterruptible(
+              &state.snd_sem, _SO_TIMEOUT(conn->sconn.s_sndtimeo));
       if (ret != -ETIMEDOUT || acked == state.snd_acked)
         {
           break; /* Successful completion or timeout without any progress */

--- a/net/udp/udp.h
+++ b/net/udp/udp.h
@@ -33,6 +33,7 @@
 
 #include <nuttx/semaphore.h>
 #include <nuttx/net/ip.h>
+#include <nuttx/net/net.h>
 #include <nuttx/mm/iob.h>
 
 #ifdef CONFIG_NET_UDP_NOTIFIER
@@ -61,9 +62,9 @@
 /* Allocate a new UDP data callback */
 
 #define udp_callback_alloc(dev,conn) \
-  devif_callback_alloc((dev), &(conn)->list, &(conn)->list_tail)
+  devif_callback_alloc((dev), &(conn)->sconn.list, &(conn)->sconn.list_tail)
 #define udp_callback_free(dev,conn,cb) \
-  devif_conn_callback_free((dev), (cb), &(conn)->list, &(conn)->list_tail)
+  devif_conn_callback_free((dev), (cb), &(conn)->sconn.list, &(conn)->sconn.list_tail)
 
 /* Definitions for the UDP connection struct flag field */
 
@@ -99,14 +100,7 @@ struct udp_conn_s
 {
   /* Common prologue of all connection structures. */
 
-  dq_entry_t node;        /* Supports a doubly linked list */
-
-  /* This is a list of UDP connection callbacks.  Each callback represents
-   * a thread that is stalled, waiting for a device-specific event.
-   */
-
-  FAR struct devif_callback_s *list;
-  FAR struct devif_callback_s *list_tail;
+  struct socket_conn_s sconn;
 
   /* UDP-specific content follows */
 

--- a/net/udp/udp.h
+++ b/net/udp/udp.h
@@ -90,7 +90,7 @@ struct udp_hdr_s;         /* Forward reference */
 
 struct udp_poll_s
 {
-  FAR struct socket *psock;        /* Needed to handle loss of connection */
+  FAR struct udp_conn_s *conn;     /* Needed to handle loss of connection */
   FAR struct net_driver_s *dev;    /* Needed to free the callback structure */
   struct pollfd *fds;              /* Needed to handle poll events */
   FAR struct devif_callback_s *cb; /* Needed to teardown the poll */
@@ -375,7 +375,7 @@ void udp_poll(FAR struct net_driver_s *dev, FAR struct udp_conn_s *conn);
  *   write occurs first.
  *
  * Input Parameters:
- *   psock    An instance of the internal socket structure.
+ *   conn     A reference to UDP connection structure.
  *
  * Returned Value:
  *   -ENOSYS (Function not implemented, always have to wait to send).
@@ -385,7 +385,7 @@ void udp_poll(FAR struct net_driver_s *dev, FAR struct udp_conn_s *conn);
  *
  ****************************************************************************/
 
-int psock_udp_cansend(FAR struct socket *psock);
+int psock_udp_cansend(FAR struct udp_conn_s *conn);
 
 /****************************************************************************
  * Name: udp_send

--- a/net/udp/udp.h
+++ b/net/udp/udp.h
@@ -147,6 +147,10 @@ struct udp_conn_s
 
   sq_queue_t write_q;             /* Write buffering for UDP packets */
   FAR struct net_driver_s *dev;   /* Last device */
+
+  /* Callback instance for UDP sendto() */
+
+  FAR struct devif_callback_s *sndcb;
 #endif
 
   /* The following is a list of poll structures of threads waiting for

--- a/net/udp/udp_callback.c
+++ b/net/udp/udp_callback.c
@@ -317,7 +317,7 @@ uint16_t udp_callback(FAR struct net_driver_s *dev,
     {
       /* Perform the callback */
 
-      flags = devif_conn_event(dev, conn, flags, conn->list);
+      flags = devif_conn_event(dev, conn, flags, conn->sconn.list);
 
       if ((flags & UDP_NEWDATA) != 0)
         {

--- a/net/udp/udp_close.c
+++ b/net/udp/udp_close.c
@@ -131,10 +131,10 @@ int udp_close(FAR struct socket *psock)
 #ifdef CONFIG_NET_UDP_WRITE_BUFFERS
   /* Free any semi-permanent write buffer callback in place. */
 
-  if (psock->s_sndcb != NULL)
+  if (conn->sndcb != NULL)
     {
-      udp_callback_free(conn->dev, conn, psock->s_sndcb);
-      psock->s_sndcb = NULL;
+      udp_callback_free(conn->dev, conn, conn->sndcb);
+      conn->sndcb = NULL;
     }
 #endif
 

--- a/net/udp/udp_close.c
+++ b/net/udp/udp_close.c
@@ -87,7 +87,7 @@ int udp_close(FAR struct socket *psock)
    *   state of the option and linger interval.
    */
 
-  if (_SO_GETOPT(psock->s_options, SO_LINGER))
+  if (_SO_GETOPT(conn->sconn.s_options, SO_LINGER))
     {
       timeout = _SO_TIMEOUT(psock->s_linger);
     }

--- a/net/udp/udp_close.c
+++ b/net/udp/udp_close.c
@@ -89,7 +89,7 @@ int udp_close(FAR struct socket *psock)
 
   if (_SO_GETOPT(conn->sconn.s_options, SO_LINGER))
     {
-      timeout = _SO_TIMEOUT(psock->s_linger);
+      timeout = _SO_TIMEOUT(conn->sconn.s_linger);
     }
 #endif
 

--- a/net/udp/udp_conn.c
+++ b/net/udp/udp_conn.c
@@ -307,7 +307,7 @@ static inline FAR struct udp_conn_s *
 
       /* Look at the next active connection */
 
-      conn = (FAR struct udp_conn_s *)conn->node.flink;
+      conn = (FAR struct udp_conn_s *)conn->sconn.node.flink;
     }
 
   return conn;
@@ -446,7 +446,7 @@ static inline FAR struct udp_conn_s *
 
       /* Look at the next active connection */
 
-      conn = (FAR struct udp_conn_s *)conn->node.flink;
+      conn = (FAR struct udp_conn_s *)conn->sconn.node.flink;
     }
 
   return conn;
@@ -485,7 +485,7 @@ FAR struct udp_conn_s *udp_alloc_conn(void)
           /* Mark the connection closed and move it to the free list */
 
           conn[i].lport = 0;
-          dq_addlast(&conn[i].node, &g_free_udp_connections);
+          dq_addlast(&conn[i].sconn.node, &g_free_udp_connections);
         }
     }
 
@@ -594,7 +594,7 @@ void udp_initialize(void)
       /* Mark the connection closed and move it to the free list */
 
       g_udp_connections[i].lport = 0;
-      dq_addlast(&g_udp_connections[i].node, &g_free_udp_connections);
+      dq_addlast(&g_udp_connections[i].sconn.node, &g_free_udp_connections);
     }
 #endif
 }
@@ -650,7 +650,7 @@ FAR struct udp_conn_s *udp_alloc(uint8_t domain)
 #endif
       /* Enqueue the connection into the active list */
 
-      dq_addlast(&conn->node, &g_active_udp_connections);
+      dq_addlast(&conn->sconn.node, &g_active_udp_connections);
     }
 
   _udp_semgive(&g_free_sem);
@@ -681,7 +681,7 @@ void udp_free(FAR struct udp_conn_s *conn)
 
   /* Remove the connection from the active list */
 
-  dq_rem(&conn->node, &g_active_udp_connections);
+  dq_rem(&conn->sconn.node, &g_active_udp_connections);
 
   /* Release any read-ahead buffers attached to the connection */
 
@@ -706,7 +706,7 @@ void udp_free(FAR struct udp_conn_s *conn)
 
   /* Free the connection */
 
-  dq_addlast(&conn->node, &g_free_udp_connections);
+  dq_addlast(&conn->sconn.node, &g_free_udp_connections);
   _udp_semgive(&g_free_sem);
 }
 
@@ -763,7 +763,7 @@ FAR struct udp_conn_s *udp_nextconn(FAR struct udp_conn_s *conn)
     }
   else
     {
-      return (FAR struct udp_conn_s *)conn->node.flink;
+      return (FAR struct udp_conn_s *)conn->sconn.node.flink;
     }
 }
 

--- a/net/udp/udp_recvfrom.c
+++ b/net/udp/udp_recvfrom.c
@@ -58,7 +58,7 @@
 
 struct udp_recvfrom_s
 {
-  FAR struct socket       *ir_sock;      /* The parent socket structure */
+  FAR struct udp_conn_s   *ir_conn;      /* Connection associated with the socket */
   FAR struct devif_callback_s *ir_cb;    /* Reference to callback instance */
   sem_t                    ir_sem;       /* Semaphore signals recv completion */
   size_t                   ir_buflen;    /* Length of receive buffer */
@@ -181,8 +181,7 @@ static inline void udp_newdata(FAR struct net_driver_s *dev,
 
 static inline void udp_readahead(struct udp_recvfrom_s *pstate)
 {
-  FAR struct udp_conn_s *conn = (FAR struct udp_conn_s *)
-                                pstate->ir_sock->s_conn;
+  FAR struct udp_conn_s *conn = pstate->ir_conn;
   FAR struct iob_s *iob;
   int recvlen;
 
@@ -325,8 +324,7 @@ static inline void udp_sender(FAR struct net_driver_s *dev,
       if (infrom)
         {
 #ifdef CONFIG_NET_IPv6
-          FAR struct udp_conn_s *conn =
-            (FAR struct udp_conn_s *)pstate->ir_sock->s_conn;
+          FAR struct udp_conn_s *conn = pstate->ir_conn;
 
           /* Hybrid dual-stack IPv6/IPv4 implementations recognize a special
            * class of addresses, the IPv4-mapped IPv6 addresses.
@@ -482,7 +480,7 @@ static uint16_t udp_eventhandler(FAR struct net_driver_s *dev,
  *   Initialize the state structure
  *
  * Input Parameters:
- *   psock    Pointer to the socket structure for the socket
+ *   conn     The UDP connection of interest
  *   buf      Buffer to receive data
  *   len      Length of buffer
  *   pstate   A pointer to the state structure to be initialized
@@ -494,8 +492,9 @@ static uint16_t udp_eventhandler(FAR struct net_driver_s *dev,
  *
  ****************************************************************************/
 
-static void udp_recvfrom_initialize(FAR struct socket *psock, FAR void *buf,
-                                    size_t len, FAR struct sockaddr *infrom,
+static void udp_recvfrom_initialize(FAR struct udp_conn_s *conn,
+                                    FAR void *buf, size_t len,
+                                    FAR struct sockaddr *infrom,
                                     FAR socklen_t *fromlen,
                                     FAR struct udp_recvfrom_s *pstate)
 {
@@ -517,7 +516,7 @@ static void udp_recvfrom_initialize(FAR struct socket *psock, FAR void *buf,
 
   /* Set up the start time for the timeout */
 
-  pstate->ir_sock      = psock;
+  pstate->ir_conn      = conn;
 }
 
 /* The only un-initialization that has to be performed is destroying the
@@ -611,7 +610,7 @@ ssize_t psock_udp_recvfrom(FAR struct socket *psock, FAR void *buf,
    */
 
   net_lock();
-  udp_recvfrom_initialize(psock, buf, len, from, fromlen, &state);
+  udp_recvfrom_initialize(conn, buf, len, from, fromlen, &state);
 
   /* Copy the read-ahead data from the packet */
 

--- a/net/udp/udp_recvfrom.c
+++ b/net/udp/udp_recvfrom.c
@@ -674,7 +674,8 @@ ssize_t psock_udp_recvfrom(FAR struct socket *psock, FAR void *buf,
            * received.
            */
 
-          ret = net_timedwait(&state.ir_sem, _SO_TIMEOUT(psock->s_rcvtimeo));
+          ret = net_timedwait(&state.ir_sem,
+                              _SO_TIMEOUT(conn->sconn.s_rcvtimeo));
           if (ret == -ETIMEDOUT)
             {
               ret = -EAGAIN;

--- a/net/udp/udp_recvfrom.c
+++ b/net/udp/udp_recvfrom.c
@@ -627,7 +627,7 @@ ssize_t psock_udp_recvfrom(FAR struct socket *psock, FAR void *buf,
 
   /* Handle non-blocking UDP sockets */
 
-  if (_SS_ISNONBLOCK(psock->s_flags) || (flags & MSG_DONTWAIT) != 0)
+  if (_SS_ISNONBLOCK(conn->sconn.s_flags) || (flags & MSG_DONTWAIT) != 0)
     {
       /* Return the number of bytes read from the read-ahead buffer if
        * something was received (already in 'ret'); EAGAIN if not.

--- a/net/udp/udp_sendto_buffered.c
+++ b/net/udp/udp_sendto_buffered.c
@@ -173,9 +173,9 @@ static void sendto_writebuffer_release(FAR struct socket *psock,
            * enqueued.
            */
 
-          psock->s_sndcb->flags = 0;
-          psock->s_sndcb->priv  = NULL;
-          psock->s_sndcb->event = NULL;
+          conn->sndcb->flags = 0;
+          conn->sndcb->priv  = NULL;
+          conn->sndcb->event = NULL;
           wrb = NULL;
 
 #ifdef CONFIG_NET_UDP_NOTIFIER
@@ -331,24 +331,24 @@ static int sendto_next_transfer(FAR struct socket *psock,
    * callback instance.
    */
 
-  if (psock->s_sndcb != NULL && conn->dev != dev)
+  if (conn->sndcb != NULL && conn->dev != dev)
     {
-      udp_callback_free(conn->dev, conn, psock->s_sndcb);
-      psock->s_sndcb = NULL;
+      udp_callback_free(conn->dev, conn, conn->sndcb);
+      conn->sndcb = NULL;
     }
 
   /* Allocate resources to receive a callback from this device if the
    * callback is not already in place.
    */
 
-  if (psock->s_sndcb == NULL)
+  if (conn->sndcb == NULL)
     {
-      psock->s_sndcb = udp_callback_alloc(dev, conn);
+      conn->sndcb = udp_callback_alloc(dev, conn);
     }
 
   /* Test if the callback has been allocated */
 
-  if (psock->s_sndcb == NULL)
+  if (conn->sndcb == NULL)
     {
       /* A buffer allocation error occurred */
 
@@ -360,9 +360,9 @@ static int sendto_next_transfer(FAR struct socket *psock,
 
   /* Set up the callback in the connection */
 
-  psock->s_sndcb->flags = (UDP_POLL | NETDEV_DOWN);
-  psock->s_sndcb->priv  = (FAR void *)psock;
-  psock->s_sndcb->event = sendto_eventhandler;
+  conn->sndcb->flags = (UDP_POLL | NETDEV_DOWN);
+  conn->sndcb->priv  = (FAR void *)psock;
+  conn->sndcb->event = sendto_eventhandler;
 
   /* Notify the device driver of the availability of TX data */
 

--- a/net/udp/udp_sendto_unbuffered.c
+++ b/net/udp/udp_sendto_unbuffered.c
@@ -510,7 +510,7 @@ errout_with_lock:
  *   write occurs first.
  *
  * Input Parameters:
- *   psock    An instance of the internal socket structure.
+ *   conn     A reference to UDP connection structure.
  *
  * Returned Value:
  *   OK (Always can send).
@@ -520,7 +520,7 @@ errout_with_lock:
  *
  ****************************************************************************/
 
-int psock_udp_cansend(FAR struct socket *psock)
+int psock_udp_cansend(FAR struct udp_conn_s *conn)
 {
   return OK;
 }

--- a/net/udp/udp_sendto_unbuffered.c
+++ b/net/udp/udp_sendto_unbuffered.c
@@ -473,7 +473,8 @@ ssize_t psock_udp_sendto(FAR struct socket *psock, FAR const void *buf,
        * is received.
        */
 
-      ret = net_timedwait(&state.st_sem, _SO_TIMEOUT(psock->s_sndtimeo));
+      ret = net_timedwait(&state.st_sem,
+                          _SO_TIMEOUT(conn->sconn.s_sndtimeo));
       if (ret >= 0)
         {
           /* The result of the sendto operation is the number of bytes

--- a/net/udp/udp_sendto_unbuffered.c
+++ b/net/udp/udp_sendto_unbuffered.c
@@ -264,13 +264,24 @@ ssize_t psock_udp_sendto(FAR struct socket *psock, FAR const void *buf,
   struct sendto_s state;
   int ret;
 
+  /* Verify that the sockfd corresponds to valid, allocated socket */
+
+  if (psock == NULL || psock->s_type != SOCK_DGRAM ||
+      psock->s_conn == NULL)
+    {
+      nerr("ERROR: Invalid socket\n");
+      return -EBADF;
+    }
+
   /* If the UDP socket was previously assigned a remote peer address via
    * connect(), then as with connection-mode socket, sendto() may not be
    * used with a non-NULL destination address.  Normally send() would be
    * used with such connected UDP sockets.
    */
 
-  if (to != NULL && _SS_ISCONNECTED(psock->s_flags))
+  conn = psock->s_conn;
+
+  if (to != NULL && _SS_ISCONNECTED(conn->sconn.s_flags))
     {
       /* EISCONN - A destination address was specified and the socket is
        * already connected.
@@ -283,7 +294,7 @@ ssize_t psock_udp_sendto(FAR struct socket *psock, FAR const void *buf,
    * must be provided.
    */
 
-  else if (to == NULL && !_SS_ISCONNECTED(psock->s_flags))
+  else if (to == NULL && !_SS_ISCONNECTED(conn->sconn.s_flags))
     {
       /* EDESTADDRREQ - The socket is not connection-mode and no peer\
        * address is set.
@@ -291,11 +302,6 @@ ssize_t psock_udp_sendto(FAR struct socket *psock, FAR const void *buf,
 
       return -EDESTADDRREQ;
     }
-
-  /* Get the underlying the UDP connection structure.  */
-
-  conn = (FAR struct udp_conn_s *)psock->s_conn;
-  DEBUGASSERT(conn);
 
 #if defined(CONFIG_NET_ARP_SEND) || defined(CONFIG_NET_ICMPv6_NEIGHBOR)
 #ifdef CONFIG_NET_ARP_SEND
@@ -311,7 +317,7 @@ ssize_t psock_udp_sendto(FAR struct socket *psock, FAR const void *buf,
 
       /* Check if the socket is connection mode */
 
-      if (_SS_ISCONNECTED(psock->s_flags))
+      if (_SS_ISCONNECTED(conn->sconn.s_flags))
         {
           /* Yes.. use the connected remote address (the 'to' address is
            * null).
@@ -350,7 +356,7 @@ ssize_t psock_udp_sendto(FAR struct socket *psock, FAR const void *buf,
 
       /* Check if the socket is connection mode */
 
-      if (_SS_ISCONNECTED(psock->s_flags))
+      if (_SS_ISCONNECTED(conn->sconn.s_flags))
         {
           /* Yes.. use the connected remote address (the 'to' address is
            * null).
@@ -413,7 +419,7 @@ ssize_t psock_udp_sendto(FAR struct socket *psock, FAR const void *buf,
 
   /* Check if the socket is connected */
 
-  if (!_SS_ISCONNECTED(psock->s_flags))
+  if (!_SS_ISCONNECTED(conn->sconn.s_flags))
     {
       /* No.. Call udp_connect() to set the remote address in the connection
        * structure to the sendto() destination address.

--- a/net/usrsock/usrsock.h
+++ b/net/usrsock/usrsock.h
@@ -83,14 +83,7 @@ struct usrsock_conn_s
 {
   /* Common prologue of all connection structures. */
 
-  dq_entry_t node;                   /* Supports a doubly linked list */
-
-  /* This is a list of usrsock callbacks.  Each callback represents a thread
-   * that is stalled, waiting for a specific event.
-   */
-
-  FAR struct devif_callback_s *list; /* Usersock callbacks */
-  FAR struct devif_callback_s *list_tail;
+  struct socket_conn_s sconn;
 
   /* usrsock-specific content follows */
 

--- a/net/usrsock/usrsock_accept.c
+++ b/net/usrsock/usrsock_accept.c
@@ -327,7 +327,7 @@ int usrsock_accept(FAR struct socket *psock, FAR struct sockaddr *addr,
           /* Wait for receive-avail (or abort, or timeout, or signal). */
 
           ret = net_timedwait(&state.reqstate.recvsem,
-                              _SO_TIMEOUT(psock->s_rcvtimeo));
+                              _SO_TIMEOUT(conn->sconn.s_rcvtimeo));
           if (ret < 0)
             {
               if (ret == -ETIMEDOUT)

--- a/net/usrsock/usrsock_accept.c
+++ b/net/usrsock/usrsock_accept.c
@@ -304,7 +304,7 @@ int usrsock_accept(FAR struct socket *psock, FAR struct sockaddr *addr,
 
       if (!(conn->flags & USRSOCK_EVENT_RECVFROM_AVAIL))
         {
-          if (_SS_ISNONBLOCK(psock->s_flags))
+          if (_SS_ISNONBLOCK(conn->sconn.s_flags))
             {
               /* Nothing to receive from daemon side. */
 

--- a/net/usrsock/usrsock_connect.c
+++ b/net/usrsock/usrsock_connect.c
@@ -214,7 +214,7 @@ int usrsock_connect(FAR struct socket *psock,
 
   /* Do not block on waiting for request completion if nonblocking socket. */
 
-  if (!conn->resp.inprogress || !_SS_ISNONBLOCK(psock->s_flags))
+  if (!conn->resp.inprogress || !_SS_ISNONBLOCK(conn->sconn.s_flags))
     {
       /* Wait for completion of request (or signal). */
 

--- a/net/usrsock/usrsock_event.c
+++ b/net/usrsock/usrsock_event.c
@@ -110,7 +110,7 @@ int usrsock_event(FAR struct usrsock_conn_s *conn, uint16_t events)
 
   /* Send events to callbacks */
 
-  devif_conn_event(NULL, conn, events, conn->list);
+  devif_conn_event(NULL, conn, events, conn->sconn.list);
   net_unlock();
 
   return OK;

--- a/net/usrsock/usrsock_poll.c
+++ b/net/usrsock/usrsock_poll.c
@@ -172,7 +172,7 @@ static int usrsock_pollsetup(FAR struct socket *psock,
 
   /* Allocate a usrsock callback structure */
 
-  cb = devif_callback_alloc(NULL, &conn->list, &conn->list_tail);
+  cb = devif_callback_alloc(NULL, &conn->sconn.list, &conn->sconn.list_tail);
   if (cb == NULL)
     {
       ret = -EBUSY;
@@ -318,8 +318,8 @@ static int usrsock_pollteardown(FAR struct socket *psock,
 
       devif_conn_callback_free(NULL,
                                info->cb,
-                               &conn->list,
-                               &conn->list_tail);
+                               &conn->sconn.list,
+                               &conn->sconn.list_tail);
 
       /* Release the poll/select data slot */
 

--- a/net/usrsock/usrsock_recvmsg.c
+++ b/net/usrsock/usrsock_recvmsg.c
@@ -326,7 +326,7 @@ ssize_t usrsock_recvmsg(FAR struct socket *psock, FAR struct msghdr *msg,
           /* Wait for receive-avail (or abort, or timeout, or signal). */
 
           ret = net_timedwait(&state.reqstate.recvsem,
-                              _SO_TIMEOUT(psock->s_rcvtimeo));
+                              _SO_TIMEOUT(conn->sconn.s_rcvtimeo));
           if (ret < 0)
             {
               if (ret == -ETIMEDOUT)

--- a/net/usrsock/usrsock_recvmsg.c
+++ b/net/usrsock/usrsock_recvmsg.c
@@ -302,7 +302,8 @@ ssize_t usrsock_recvmsg(FAR struct socket *psock, FAR struct msghdr *msg,
 
       if (!(conn->flags & USRSOCK_EVENT_RECVFROM_AVAIL))
         {
-          if (_SS_ISNONBLOCK(psock->s_flags) || (flags & MSG_DONTWAIT) != 0)
+          if (_SS_ISNONBLOCK(conn->sconn.s_flags) ||
+              (flags & MSG_DONTWAIT) != 0)
             {
               /* Nothing to receive from daemon side. */
 

--- a/net/usrsock/usrsock_sendmsg.c
+++ b/net/usrsock/usrsock_sendmsg.c
@@ -283,7 +283,8 @@ ssize_t usrsock_sendmsg(FAR struct socket *psock,
 
       if (!(conn->flags & USRSOCK_EVENT_SENDTO_READY))
         {
-          if (_SS_ISNONBLOCK(psock->s_flags) || (flags & MSG_DONTWAIT) != 0)
+          if (_SS_ISNONBLOCK(conn->sconn.s_flags) ||
+              (flags & MSG_DONTWAIT) != 0)
             {
               /* Send busy at daemon side. */
 

--- a/net/usrsock/usrsock_sendmsg.c
+++ b/net/usrsock/usrsock_sendmsg.c
@@ -307,7 +307,7 @@ ssize_t usrsock_sendmsg(FAR struct socket *psock,
           /* Wait for send-ready (or abort, or timeout, or signal). */
 
           ret = net_timedwait(&state.recvsem,
-                              _SO_TIMEOUT(psock->s_sndtimeo));
+                              _SO_TIMEOUT(conn->sconn.s_sndtimeo));
           if (ret < 0)
             {
               if (ret == -ETIMEDOUT)


### PR DESCRIPTION
## Summary

net/tcp/udp: remove psock hook to avoid invalid reference

1. Remove the hook reference to psock in the tcp/udp protocol stack:

Fix the assertion on devif callback if the private data is reference to duplicated socket instance,
if the duplicate socket fd is closed, (dup by task_create/system/exec/dup()/ etc...), the socket handle will change to wild pointer and invalid reference from callback handler:

test demo:

```
int main(int argc, char **argv)
{
  struct sockaddr_in serveraddr;
  int len = sizeof(serveraddr);
  char buf[1400];
  int ret;
  int fd2;
  int fd;

  fd = socket(AF_INET, SOCK_STREAM, 0);
  if (fd < 0)
    return fd;

  serveraddr.sin_family = AF_INET;
  serveraddr.sin_addr.s_addr = inet_addr("192.168.31.43");
  serveraddr.sin_port = htons(atoi("8888"));
  ret = connect(fd, (struct sockaddr*)&serveraddr, len);
  if (ret < 0) {
    close(fd);
    return ret;
  }

  fd2 = dup(fd);
  if (fd2 < 0) {
    close(fd);
    return fd2;
  }

  ret = send(fd, buf, sizeof(buf), 0);
  if (fd > 0)
    close(fd);

  if (fd2 > 0)
    close(fd2);

  return 0;
}
```

run the demo:
```
nsh> hello

Breakpoint 1, psock_close (psock=0xf3dc6340) at socket/net_close.c:64
64	{
(gdb) c
Continuing.
```
**psock: 0xf3dc6340 has been closed.**

```
Breakpoint 1, psock_close (psock=0xf3dc5eb0) at socket/net_close.c:64
64	{
(gdb) c
Continuing.

Breakpoint 2, psock_send_eventhandler (dev=0x565f4480 <g_sim_dev>, pvconn=0xf3dc64f0, pvpriv=0xf3dc6340, flags=65535) at tcp/tcp_send_buffered.c:357
357	{
(gdb) bt
#0  psock_send_eventhandler (dev=0x565f4480 <g_sim_dev>, pvconn=0xf3dc64f0, pvpriv=0xf3dc6340, flags=65535) at tcp/tcp_send_buffered.c:357
#1  0x5657fae6 in devif_conn_event (dev=0x565f4480 <g_sim_dev>, pvconn=0xf3dc64f0, flags=16, list=0xf3dc6498) at devif/devif_callback.c:510
#2  0x56583b8a in tcp_callback (dev=0x565f4480 <g_sim_dev>, conn=0xf3dc64f0, flags=16) at tcp/tcp_callback.c:169
#3  0x56581bb1 in tcp_timer (dev=0x565f4480 <g_sim_dev>, conn=0xf3dc64f0, hsec=0) at tcp/tcp_timer.c:518
#4  0x5657f45b in devif_poll_tcp_timer (dev=0x565f4480 <g_sim_dev>, callback=0x56569267 <netdriver_txpoll>, hsec=0) at devif/devif_poll.c:652
#5  0x5657f5f7 in devif_timer (dev=0x565f4480 <g_sim_dev>, delay=0, callback=0x56569267 <netdriver_txpoll>) at devif/devif_poll.c:862
#6  0x56569434 in netdriver_txavail_work (arg=0x565f4480 <g_sim_dev>) at sim/up_netdriver.c:313
#7  0x5655e9d3 in work_thread (argc=2, argv=0xf3d93ae0) at wqueue/kwork_thread.c:174
#8  0x5655e86b in nxtask_start () at task/task_start.c:125
#9  0xaaaaaaaa in ?? ()
(gdb) c
Continuing.
```
**pvpriv 0xf3dc6340 callback, invalid handler
psock_send_eventhandler (dev=0x565f4480 <g_sim_dev>, pvconn=0xf3dc64f0, pvpriv=0xf3dc6340, flags=65535)**


Crash in psock_send_eventhandler

```
Breakpoint 3, _assert (filename=0x565c72bb "tcp/tcp_send_buffered.c", linenum=377) at assert/lib_assert.c:35
35	{
(gdb) bt
#0  _assert (filename=0x565c72bb "tcp/tcp_send_buffered.c", linenum=377) at assert/lib_assert.c:35
#1  0x565aa84b in psock_send_eventhandler (dev=0x565f4480 <g_sim_dev>, pvconn=0xf3dc64f0, pvpriv=0xf3dc6340, flags=16) at tcp/tcp_send_buffered.c:377
#2  0x5657fae6 in devif_conn_event (dev=0x565f4480 <g_sim_dev>, pvconn=0xf3dc64f0, flags=16, list=0xf3dc6498) at devif/devif_callback.c:510
#3  0x56583b8a in tcp_callback (dev=0x565f4480 <g_sim_dev>, conn=0xf3dc64f0, flags=16) at tcp/tcp_callback.c:169
#4  0x56581bb1 in tcp_timer (dev=0x565f4480 <g_sim_dev>, conn=0xf3dc64f0, hsec=0) at tcp/tcp_timer.c:518
#5  0x5657f45b in devif_poll_tcp_timer (dev=0x565f4480 <g_sim_dev>, callback=0x56569267 <netdriver_txpoll>, hsec=0) at devif/devif_poll.c:652
#6  0x5657f5f7 in devif_timer (dev=0x565f4480 <g_sim_dev>, delay=0, callback=0x56569267 <netdriver_txpoll>) at devif/devif_poll.c:862
#7  0x56569434 in netdriver_txavail_work (arg=0x565f4480 <g_sim_dev>) at sim/up_netdriver.c:313
#8  0x5655e9d3 in work_thread (argc=2, argv=0xf3d93ae0) at wqueue/kwork_thread.c:174
#9  0x5655e86b in nxtask_start () at task/task_start.c:125
#10 0xaaaaaaaa in ?? ()
```

link to:
https://github.com/apache/incubator-nuttx/pull/5252
https://github.com/apache/incubator-nuttx/pull/5373

@yamt @a-lunev 

2. Unify the semantics of socket option for connection:

The attribute of socket option is stored in the socket instance, which is wrong, the semantics of option is for per-connect:

test demo:

```
int main(int argc, char **argv)
{
  struct sockaddr_in serveraddr;
  int len = sizeof(serveraddr);
  struct timeval tv;
  int ret;
  int fd;
  int fd2;

  fd = socket(AF_INET, SOCK_STREAM, 0);
  if (fd < 0)
    return fd;

  serveraddr.sin_family = AF_INET;
  serveraddr.sin_addr.s_addr = inet_addr("192.168.31.43");
  serveraddr.sin_port = htons(atoi("8888"));
  ret = connect(fd, (struct sockaddr*)&serveraddr, len);
  if (ret < 0) {
    close(fd);
    return ret;
  }

  fd2 = dup(fd);
  if (fd2 < 0) {
    close(fd);
    return fd2;
  }

  tv.tv_sec  = 10;
  tv.tv_usec = 0;

  ret = setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, (FAR const void *)&tv, sizeof(struct timeval));
  if (ret >= 0) {
    len = sizeof(struct timeval);
    ret = getsockopt(fd2, SOL_SOCKET, SO_RCVTIMEO, (FAR const void *)&tv, &len);
    if (ret >= 0)
      printf("tv.tv_sec: %d, tv.tv_usec: %d\n", tv.tv_sec, tv.tv_usec);
  }

  if (fd > 0)
    close(fd);

  if (fd2 > 0)
    close(fd2);

  return 0;
}
```

`the SO_RCVTIMEO should be apply to connection instance, not socket:`

nuttx:
```
nsh> hello
tv.tv_sec: 0, tv.tv_usec: 0
```

linux:
```
$ ./a.out 
tv.tv_sec: 10, tv.tv_usec: 0
```

nuttx (after this PR):
```
nsh> hello
tv.tv_sec: 10, tv.tv_usec: 0
```

## Impact

tcp/udp stack

## Testing

ci-check