### PR TITLE
netdev/lladdrsize: remove invalid duplicate case

### DIFF
--- a/net/netdev/netdev_lladdrsize.c
+++ b/net/netdev/netdev_lladdrsize.c
@@ -115,16 +115,6 @@ int netdev_lladdrsize(FAR struct net_driver_s *dev)
 #endif
 
 #ifdef CONFIG_NET_6LOWPAN
-#ifdef CONFIG_WIRELESS_BLUETOOTH
-      case NET_LL_BLUETOOTH:
-        {
-          /* 6LoWPAN can be configured to use either extended or short
-           * addressing.
-           */
-
-          return BLUETOOTH_HDRLEN;
-        }
-#endif /* CONFIG_WIRELESS_BLUETOOTH */
 
 #ifdef CONFIG_WIRELESS_IEEE802154
       case NET_LL_IEEE802154:
@@ -141,11 +131,11 @@ int netdev_lladdrsize(FAR struct net_driver_s *dev)
         }
 #endif /* CONFIG_WIRELESS_IEEE802154 */
 
-#if defined(CONFIG_WIRELESS_PKTRADIO) || defined(CONFIG_NET_BLUETOOTH)
+#if defined(CONFIG_WIRELESS_PKTRADIO) || defined(CONFIG_WIRELESS_BLUETOOTH)
 #ifdef CONFIG_WIRELESS_PKTRADIO
       case NET_LL_PKTRADIO:
 #endif
-#ifdef CONFIG_NET_BLUETOOTH
+#ifdef CONFIG_WIRELESS_BLUETOOTH
       case NET_LL_BLUETOOTH:
 #endif
         {
@@ -153,7 +143,7 @@ int netdev_lladdrsize(FAR struct net_driver_s *dev)
 
            return netdev_pktradio_addrlen(dev);
         }
-#endif /* CONFIG_WIRELESS_PKTRADIO || CONFIG_NET_BLUETOOTH */
+#endif /* CONFIG_WIRELESS_PKTRADIO || CONFIG_WIRELESS_BLUETOOTH */
 #endif /* CONFIG_NET_6LOWPAN */
 
        default:


### PR DESCRIPTION


## Summary

netdev/lladdrsize: remove invalid duplicate case

error:
```
--------------------------------------
netdev/netdev_lladdrsize.c: In function ‘netdev_lladdrsize’:
netdev/netdev_lladdrsize.c:148:7: error: duplicate case value
  148 |       case NET_LL_BLUETOOTH:
      |       ^~~~
netdev/netdev_lladdrsize.c:119:7: note: previously used here
  119 |       case NET_LL_BLUETOOTH:
      |       ^~~~
```

BLUETOOTH_HDRLEN has been removed by:
```
---------------------------------
|commit aae0d92598b14a6f760e7e7baf191b59387d539c
|Author: Gregory Nutt <gnutt@nuttx.org>
|Date:   Sun Apr 1 15:21:58 2018 -0600
|
|wireless/bluetooth and net/bluetooth:
|
|Clean up some garbage left in Kconfig file that broke 'make menuconfig'.
|Clean up some craziness with Bluetooth frame length definitions.
```

Signed-off-by: chao.an <anchao@xiaomi.com>

## Impact

N/A

## Testing

ci-check