### PR TITLE
net/devif: remove invalid NET_IPv4_REASSEMBLY definition

### DIFF
--- a/net/devif/devif_poll.c
+++ b/net/devif/devif_poll.c
@@ -849,7 +849,7 @@ int devif_poll(FAR struct net_driver_s *dev, devif_poll_callback_t callback)
 int devif_timer(FAR struct net_driver_s *dev, int delay,
                 devif_poll_callback_t callback)
 {
-#if defined(CONFIG_NET_IPv4_REASSEMBLY) || defined(NET_TCP_HAVE_STACK)
+#if defined(NET_TCP_HAVE_STACK)
   int hsec = TICK2HSEC(delay);
 #endif
   int bstop = false;


### PR DESCRIPTION


## Summary

net/devif: remove invalid NET_IPv4_REASSEMBLY definition

NET_IPv4_REASSEMBLY has been removed by:
```
--------------------------------------------------------
|  commit 68b526b3354e47ab6654e4621b1421800ca854a0
|  Author: Brennan Ashton <bashton@brennanashton.com>
|  Date:   Tue Dec 1 22:59:00 2020 -0800
|
|      tcp: Remove incomplete support for TCP reassembly
--------------------------------------------------------
```

Signed-off-by: chao.an <anchao@xiaomi.com>

## Impact

N/A

## Testing

ci  check