### PR TITLE
net/sixlowpan: fix compile warning

### DIFF
--- a/net/sixlowpan/sixlowpan_input.c
+++ b/net/sixlowpan/sixlowpan_input.c
@@ -63,6 +63,7 @@
 #include "nuttx/wireless/ieee802154/ieee802154_mac.h"
 
 #ifdef CONFIG_NET_PKT
+#  include <nuttx/net/pkt.h>
 #  include "pkt/pkt.h"
 #endif
 


### PR DESCRIPTION
## Summary

net/sixlowpan: fix compile warning

```
sixlowpan/sixlowpan_input.c: In function ‘sixlowpan_dispatch’:
sixlowpan/sixlowpan_input.c:629:3: warning: implicit declaration of function ‘pkt_input’;
                                   did you mean ‘ipv6_input’? [-Wimplicit-function-declaration]
  629 |   pkt_input(&radio->r_dev);
      |   ^~~~~~~~~
      |   ipv6_input
```

Signed-off-by: chao.an <anchao@xiaomi.com>


## Impact

N/A

## Testing

ci check