### PR TITLE
boards: cxd56xx: audio: Support I2S input

### DIFF
--- a/arch/arm/include/cxd56xx/audio.h
+++ b/arch/arm/include/cxd56xx/audio.h
@@ -232,6 +232,14 @@ enum cxd56_audio_dma_path_e
 
   CXD56_AUDIO_DMA_PATH_MIC_TO_MEM = 0,
 
+  /* I2S0 to memory */
+
+  CXD56_AUDIO_DMA_PATH_I2S0_TO_MEM,
+
+  /* I2S1 to memory */
+
+  CXD56_AUDIO_DMA_PATH_I2S1_TO_MEM,
+
   /* Memory to BUS I/F1 */
 
   CXD56_AUDIO_DMA_PATH_MEM_TO_BUSIF1,
@@ -294,11 +302,19 @@ enum cxd56_audio_dma_e
 
   CXD56_AUDIO_DMAC_MIC = 0,
 
-  /* I2S_OUT */
+  /* I2S1 Input */
+
+  CXD56_AUDIO_DMAC_I2S0_UP,
+
+  /* I2S1 Output */
 
   CXD56_AUDIO_DMAC_I2S0_DOWN,
 
-  /* I2S2_OUT */
+  /* I2S2 Input */
+
+  CXD56_AUDIO_DMAC_I2S1_UP,
+
+  /* I2S2 Output */
 
   CXD56_AUDIO_DMAC_I2S1_DOWN
 };

--- a/boards/arm/cxd56xx/drivers/audio/cxd56_audio_ac_reg.c
+++ b/boards/arm/cxd56xx/drivers/audio/cxd56_audio_ac_reg.c
@@ -100,6 +100,10 @@
 #define SRCIN_SEL_CODECDSP_MIX 3
 
 /****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
+
+/****************************************************************************
  * Private Data
  ****************************************************************************/
 
@@ -429,6 +433,10 @@ const struct audio_ac_reg_s g_ac_reg[RI_REG_MAX_ENTRY] =
   {0x0700, 31,  1, 0x00000000},  /* DUMMY_31 (0x00) */
   {0x0780,  0,  1, 0x00000000},  /* RAM_RW_EN (0x00) */
 };
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
 
 /****************************************************************************
  * Private Functions
@@ -845,15 +853,7 @@ static CXD56_AUDIO_ECODE set_srcin_sel(AC_REG_ID ac_reg_id,
         break;
 
       case CXD56_AUDIO_SIG_MIX:
-        if ((read_ac_reg(RI_COD_INSEL2) == COD_INSEL_SRC1)
-         || (read_ac_reg(RI_COD_INSEL3) == COD_INSEL_SRC1))
-          {
-            return CXD56_AUDIO_ECODE_REG_AC_SEL_INV;
-          }
-        else
-          {
-            val = SRCIN_SEL_CODECDSP_MIX;
-          }
+        val = SRCIN_SEL_CODECDSP_MIX;
         break;
 
       default:

--- a/boards/arm/cxd56xx/drivers/audio/cxd56_audio_bca_reg.c
+++ b/boards/arm/cxd56xx/drivers/audio/cxd56_audio_bca_reg.c
@@ -360,49 +360,89 @@ void enable_mic_in_fmt16(uint8_t mic_num)
       write_bca_reg(mic_ch_sell[i], TRANS_CH_NO_SELECT);
     }
 
-  write_bca_reg(BCA_CLK_EN_AHBMASTER_MIC_EN, 1);
-  write_bca_reg(BCA_MIC_IN_START_ADR,      0x00000000);
-  write_bca_reg(BCA_MIC_IN_SAMPLE_NO,      0);
+  write_bca_reg(BCA_CLK_EN_AHBMASTER_MIC_EN,  1);
+  write_bca_reg(BCA_MIC_IN_START_ADR,         0x00000000);
+  write_bca_reg(BCA_MIC_IN_SAMPLE_NO,         0);
+}
+
+void enable_i2s1_in_fmt24(void)
+{
+  write_bca_reg(BCA_I2S1_IN_BITWT,            0);
+  write_bca_reg(BCA_I2S1_IN_CH2_SEL,          I2S_IN_SEL_SRC1R);
+  write_bca_reg(BCA_I2S1_IN_CH1_SEL,          I2S_IN_SEL_SRC1L);
+  write_bca_reg(BCA_CLK_EN_AHBMASTER_I2S1_EN, 1);
+  write_bca_reg(BCA_I2S1_IN_START_ADR,        0x00000000);
+  write_bca_reg(BCA_I2S1_IN_SAMPLE_NO,        0);
+}
+
+void enable_i2s1_in_fmt16(void)
+{
+  write_bca_reg(BCA_I2S1_IN_BITWT,            1);
+  write_bca_reg(BCA_I2S1_IN_CH2_SEL,          I2S_IN_SEL_UNUSE);
+  write_bca_reg(BCA_I2S1_IN_CH1_SEL,          I2S_IN_SEL_SRC1L);
+  write_bca_reg(BCA_CLK_EN_AHBMASTER_I2S1_EN, 1);
+  write_bca_reg(BCA_I2S1_IN_START_ADR,        0x00000000);
+  write_bca_reg(BCA_I2S1_IN_SAMPLE_NO,        0);
+}
+
+void enable_i2s2_in_fmt24(void)
+{
+  write_bca_reg(BCA_I2S2_IN_BITWT,            0);
+  write_bca_reg(BCA_I2S2_IN_CH2_SEL,          I2S_IN_SEL_SRC1R);
+  write_bca_reg(BCA_I2S2_IN_CH1_SEL,          I2S_IN_SEL_SRC1L);
+  write_bca_reg(BCA_CLK_EN_AHBMASTER_I2S2_EN, 1);
+  write_bca_reg(BCA_I2S2_IN_START_ADR,        0x00000000);
+  write_bca_reg(BCA_I2S2_IN_SAMPLE_NO,        0);
+}
+
+void enable_i2s2_in_fmt16(void)
+{
+  write_bca_reg(BCA_I2S2_IN_BITWT,            0);
+  write_bca_reg(BCA_I2S2_IN_CH2_SEL,          I2S_IN_SEL_UNUSE);
+  write_bca_reg(BCA_I2S2_IN_CH1_SEL,          I2S_IN_SEL_SRC1L);
+  write_bca_reg(BCA_CLK_EN_AHBMASTER_I2S2_EN, 1);
+  write_bca_reg(BCA_I2S2_IN_START_ADR,        0x00000000);
+  write_bca_reg(BCA_I2S2_IN_SAMPLE_NO,        0);
 }
 
 void enable_i2s1_out_fmt24(void)
 {
-  write_bca_reg(BCA_I2S1_OUT_SD1_L_SEL,     I2S_OUT_SEL_SD1L);
-  write_bca_reg(BCA_I2S1_OUT_SD1_R_SEL,     I2S_OUT_SEL_SD1R);
-  write_bca_reg(BCA_I2S1_OUT_BITWT,         0);
+  write_bca_reg(BCA_I2S1_OUT_SD1_L_SEL,       I2S_OUT_SEL_SD1L);
+  write_bca_reg(BCA_I2S1_OUT_SD1_R_SEL,       I2S_OUT_SEL_SD1R);
+  write_bca_reg(BCA_I2S1_OUT_BITWT,           0);
   write_bca_reg(BCA_CLK_EN_AHBMASTER_I2S1_EN, 1);
-  write_bca_reg(BCA_I2S1_OUT_START_ADR,     0x00000000);
-  write_bca_reg(BCA_I2S2_OUT_SAMPLE_NO,     0);
+  write_bca_reg(BCA_I2S1_OUT_START_ADR,       0x00000000);
+  write_bca_reg(BCA_I2S2_OUT_SAMPLE_NO,       0);
 }
 
 void enable_i2s1_out_fmt16(void)
 {
-  write_bca_reg(BCA_I2S1_OUT_SD1_L_SEL,     I2S_OUT_SEL_SD1L);
-  write_bca_reg(BCA_I2S1_OUT_SD1_R_SEL,     I2S_OUT_SEL_SD1R);
-  write_bca_reg(BCA_I2S1_OUT_BITWT,         1);
+  write_bca_reg(BCA_I2S1_OUT_SD1_L_SEL,       I2S_OUT_SEL_SD1L);
+  write_bca_reg(BCA_I2S1_OUT_SD1_R_SEL,       I2S_OUT_SEL_SD1R);
+  write_bca_reg(BCA_I2S1_OUT_BITWT,           1);
   write_bca_reg(BCA_CLK_EN_AHBMASTER_I2S1_EN, 1);
-  write_bca_reg(BCA_I2S1_OUT_START_ADR,     0x00000000);
-  write_bca_reg(BCA_I2S2_OUT_SAMPLE_NO,     0);
+  write_bca_reg(BCA_I2S1_OUT_START_ADR,       0x00000000);
+  write_bca_reg(BCA_I2S2_OUT_SAMPLE_NO,       0);
 }
 
 void enable_i2s2_out_fmt24(void)
 {
-  write_bca_reg(BCA_I2S2_OUT_SD1_L_SEL,     I2S_OUT_SEL_SD1L);
-  write_bca_reg(BCA_I2S2_OUT_SD1_R_SEL,     I2S_OUT_SEL_SD1R);
-  write_bca_reg(BCA_I2S2_OUT_BITWT,         0);
+  write_bca_reg(BCA_I2S2_OUT_SD1_L_SEL,       I2S_OUT_SEL_SD1L);
+  write_bca_reg(BCA_I2S2_OUT_SD1_R_SEL,       I2S_OUT_SEL_SD1R);
+  write_bca_reg(BCA_I2S2_OUT_BITWT,           0);
   write_bca_reg(BCA_CLK_EN_AHBMASTER_I2S2_EN, 1);
-  write_bca_reg(BCA_I2S2_OUT_START_ADR,     0x00000000);
-  write_bca_reg(BCA_I2S2_OUT_SAMPLE_NO,     0);
+  write_bca_reg(BCA_I2S2_OUT_START_ADR,       0x00000000);
+  write_bca_reg(BCA_I2S2_OUT_SAMPLE_NO,       0);
 }
 
 void enable_i2s2_out_fmt16(void)
 {
-  write_bca_reg(BCA_I2S2_OUT_SD1_L_SEL,     I2S_OUT_SEL_SD1L);
-  write_bca_reg(BCA_I2S2_OUT_SD1_R_SEL,     I2S_OUT_SEL_SD1R);
-  write_bca_reg(BCA_I2S2_OUT_BITWT,         1);
+  write_bca_reg(BCA_I2S2_OUT_SD1_L_SEL,       I2S_OUT_SEL_SD1L);
+  write_bca_reg(BCA_I2S2_OUT_SD1_R_SEL,       I2S_OUT_SEL_SD1R);
+  write_bca_reg(BCA_I2S2_OUT_BITWT,           1);
   write_bca_reg(BCA_CLK_EN_AHBMASTER_I2S2_EN, 1);
-  write_bca_reg(BCA_I2S2_OUT_START_ADR,     0x00000000);
-  write_bca_reg(BCA_I2S2_OUT_SAMPLE_NO,     0);
+  write_bca_reg(BCA_I2S2_OUT_START_ADR,       0x00000000);
+  write_bca_reg(BCA_I2S2_OUT_SAMPLE_NO,       0);
 }
 
 /****************************************************************************
@@ -444,8 +484,14 @@ void cxd56_audio_bca_reg_en_fmt24(cxd56_audio_dma_t handle, uint8_t ch_num)
       case CXD56_AUDIO_DMAC_MIC:
         enable_mic_in_fmt24(ch_num);
         break;
+      case CXD56_AUDIO_DMAC_I2S0_UP:
+        enable_i2s1_in_fmt24();
+        break;
       case CXD56_AUDIO_DMAC_I2S0_DOWN:
         enable_i2s1_out_fmt24();
+        break;
+      case CXD56_AUDIO_DMAC_I2S1_UP:
+        enable_i2s2_in_fmt24();
         break;
       default:
         enable_i2s2_out_fmt24();
@@ -460,8 +506,14 @@ void cxd56_audio_bca_reg_en_fmt16(cxd56_audio_dma_t handle, uint8_t ch_num)
       case CXD56_AUDIO_DMAC_MIC:
         enable_mic_in_fmt16(ch_num);
         break;
+      case CXD56_AUDIO_DMAC_I2S0_UP:
+        enable_i2s1_in_fmt16();
+        break;
       case CXD56_AUDIO_DMAC_I2S0_DOWN:
         enable_i2s1_out_fmt16();
+        break;
+      case CXD56_AUDIO_DMAC_I2S1_UP:
+        enable_i2s2_in_fmt16();
         break;
       default:
         enable_i2s2_out_fmt16();
@@ -483,10 +535,20 @@ void cxd56_audio_bca_reg_get_dma_mstate(cxd56_audio_dma_t handle,
         reg_id_error  = BCA_MIC_IN_ERROR_SETTING;
         reg_id_monbuf = BCA_MIC_IN_MONBUF;
         break;
+      case CXD56_AUDIO_DMAC_I2S0_UP:
+        reg_id_start  = BCA_I2S1_IN_MON_START;
+        reg_id_error  = BCA_I2S1_IN_MON_ERROR_SETTING;
+        reg_id_monbuf = BCA_I2S1_IN_MON_MONBUF;
+        break;
       case CXD56_AUDIO_DMAC_I2S0_DOWN:
         reg_id_start  = BCA_I2S1_OUT_MON_START;
         reg_id_error  = BCA_I2S1_OUT_MON_ERROR_SETTING;
         reg_id_monbuf = BCA_I2S1_OUT_MON_MONBUF;
+        break;
+      case CXD56_AUDIO_DMAC_I2S1_UP:
+        reg_id_start  = BCA_I2S2_IN_MON_START;
+        reg_id_error  = BCA_I2S2_IN_MON_ERROR_SETTING;
+        reg_id_monbuf = BCA_I2S2_IN_MON_MONBUF;
         break;
       default:
         reg_id_start  = BCA_I2S2_OUT_MON_START;
@@ -565,8 +627,16 @@ void cxd56_audio_bca_reg_mask_done_int(cxd56_audio_dma_t handle)
         reg_id = BCA_MIC_INT_MASK_DONE_MIC;
         break;
 
+      case CXD56_AUDIO_DMAC_I2S0_UP:
+        reg_id = BCA_I2S1_INT_MASK_DONE_I2SI;
+        break;
+
       case CXD56_AUDIO_DMAC_I2S0_DOWN:
         reg_id = BCA_I2S1_INT_MASK_DONE_I2SO;
+        break;
+
+      case CXD56_AUDIO_DMAC_I2S1_UP:
+        reg_id = BCA_I2S2_INT_MASK_DONE_I2SI;
         break;
 
       default:
@@ -587,8 +657,16 @@ void cxd56_audio_bca_reg_unmask_done_int(cxd56_audio_dma_t handle)
         reg_id = BCA_MIC_INT_MASK_DONE_MIC;
         break;
 
+      case CXD56_AUDIO_DMAC_I2S0_UP:
+        reg_id = BCA_I2S1_INT_MASK_DONE_I2SI;
+        break;
+
       case CXD56_AUDIO_DMAC_I2S0_DOWN:
         reg_id = BCA_I2S1_INT_MASK_DONE_I2SO;
+        break;
+
+      case CXD56_AUDIO_DMAC_I2S1_UP:
+        reg_id = BCA_I2S2_INT_MASK_DONE_I2SI;
         break;
 
       default:
@@ -608,8 +686,16 @@ void cxd56_audio_bca_reg_clear_done_int(cxd56_audio_dma_t handle)
         reg_id = BCA_MIC_INT_CTRL_DONE_MIC;
         break;
 
+      case CXD56_AUDIO_DMAC_I2S0_UP:
+        reg_id = BCA_I2S1_INT_CTRL_DONE_I2SI;
+        break;
+
       case CXD56_AUDIO_DMAC_I2S0_DOWN:
         reg_id = BCA_I2S1_INT_CTRL_DONE_I2SO;
+        break;
+
+      case CXD56_AUDIO_DMAC_I2S1_UP:
+        reg_id = BCA_I2S2_INT_CTRL_DONE_I2SI;
         break;
 
       default:
@@ -626,11 +712,19 @@ bool cxd56_audio_bca_reg_is_dma_fifo_empty(cxd56_audio_dma_t handle)
   switch (handle)
     {
       case CXD56_AUDIO_DMAC_MIC:
+        reg_id = BCA_MIC_IN_RTD_TRG;
+        break;
+
+      case CXD56_AUDIO_DMAC_I2S0_UP:
         reg_id = BCA_I2S1_IN_RTD_TRG;
         break;
 
       case CXD56_AUDIO_DMAC_I2S0_DOWN:
-        reg_id = BCA_I2S1_IN_RTD_TRG;
+        reg_id = BCA_I2S1_OUT_RTD_TRG;
+        break;
+
+      case CXD56_AUDIO_DMAC_I2S1_UP:
+        reg_id = BCA_I2S2_IN_RTD_TRG;
         break;
 
       default:
@@ -655,8 +749,16 @@ void cxd56_audio_bca_reg_mask_err_int(cxd56_audio_dma_t handle)
         reg_id = BCA_MIC_INT_MASK_ERR_MIC;
         break;
 
+      case CXD56_AUDIO_DMAC_I2S0_UP:
+        reg_id = BCA_I2S1_INT_MASK_ERR_I2SI;
+        break;
+
       case CXD56_AUDIO_DMAC_I2S0_DOWN:
         reg_id = BCA_I2S1_INT_MASK_ERR_I2SO;
+        break;
+
+      case CXD56_AUDIO_DMAC_I2S1_UP:
+        reg_id = BCA_I2S2_INT_MASK_ERR_I2SI;
         break;
 
       default:
@@ -676,8 +778,16 @@ void cxd56_audio_bca_reg_unmask_err_int(cxd56_audio_dma_t handle)
         reg_id = BCA_MIC_INT_MASK_ERR_MIC;
         break;
 
+      case CXD56_AUDIO_DMAC_I2S0_UP:
+        reg_id = BCA_I2S1_INT_MASK_ERR_I2SI;
+        break;
+
       case CXD56_AUDIO_DMAC_I2S0_DOWN:
         reg_id = BCA_I2S1_INT_MASK_ERR_I2SO;
+        break;
+
+      case CXD56_AUDIO_DMAC_I2S1_UP:
+        reg_id = BCA_I2S2_INT_MASK_ERR_I2SI;
         break;
 
       default:
@@ -697,8 +807,16 @@ void cxd56_audio_bca_reg_clear_err_int(cxd56_audio_dma_t handle)
         reg_id = BCA_MIC_INT_CTRL_ERR_MIC;
         break;
 
+      case CXD56_AUDIO_DMAC_I2S0_UP:
+        reg_id = BCA_I2S1_INT_CTRL_ERR_I2SI;
+        break;
+
       case CXD56_AUDIO_DMAC_I2S0_DOWN:
         reg_id = BCA_I2S1_INT_CTRL_ERR_I2SO;
+        break;
+
+      case CXD56_AUDIO_DMAC_I2S1_UP:
+        reg_id = BCA_I2S2_INT_CTRL_ERR_I2SI;
         break;
 
       default:
@@ -718,8 +836,13 @@ void cxd56_audio_bca_reg_mask_cmb_int(cxd56_audio_dma_t handle)
         reg_id = BCA_MIC_INT_MASK_CMB_MIC;
         break;
 
+      case CXD56_AUDIO_DMAC_I2S0_UP:
       case CXD56_AUDIO_DMAC_I2S0_DOWN:
         reg_id = BCA_I2S1_INT_MASK_CMB_I2S;
+        break;
+
+      case CXD56_AUDIO_DMAC_I2S1_UP:
+        reg_id = BCA_I2S2_INT_MASK_CMB_I2S;
         break;
 
       default:
@@ -739,8 +862,13 @@ void cxd56_audio_bca_reg_unmask_cmb_int(cxd56_audio_dma_t handle)
         reg_id = BCA_MIC_INT_MASK_CMB_MIC;
         break;
 
+      case CXD56_AUDIO_DMAC_I2S0_UP:
       case CXD56_AUDIO_DMAC_I2S0_DOWN:
         reg_id = BCA_I2S1_INT_MASK_CMB_I2S;
+        break;
+
+      case CXD56_AUDIO_DMAC_I2S1_UP:
+        reg_id = BCA_I2S2_INT_MASK_CMB_I2S;
         break;
 
       default:
@@ -760,8 +888,13 @@ void cxd56_audio_bca_reg_clear_cmb_int(cxd56_audio_dma_t handle)
         reg_id = BCA_MIC_INT_CTRL_CMB_MIC;
         break;
 
+      case CXD56_AUDIO_DMAC_I2S0_UP:
       case CXD56_AUDIO_DMAC_I2S0_DOWN:
         reg_id = BCA_I2S1_INT_CTRL_CMB_I2S;
+        break;
+
+      case CXD56_AUDIO_DMAC_I2S1_UP:
+        reg_id = BCA_I2S2_INT_CTRL_CMB_I2S;
         break;
 
       default:
@@ -791,8 +924,13 @@ void cxd56_audio_bca_reg_mask_bus_int(cxd56_audio_dma_t handle)
         reg_id = AHB_MASTER_MIC_MASK;
         break;
 
+      case CXD56_AUDIO_DMAC_I2S0_UP:
       case CXD56_AUDIO_DMAC_I2S0_DOWN:
         reg_id = AHB_MASTER_I2S1_MASK;
+        break;
+
+      case CXD56_AUDIO_DMAC_I2S1_UP:
+        reg_id = AHB_MASTER_I2S2_MASK;
         break;
 
       default:
@@ -814,9 +952,19 @@ void cxd56_audio_bca_reg_unmask_bus_int(cxd56_audio_dma_t handle)
         val    = 0x00000303;
         break;
 
+      case CXD56_AUDIO_DMAC_I2S0_UP:
+        reg_id = AHB_MASTER_I2S1_MASK;
+        val    = 0x00000101;
+        break;
+
       case CXD56_AUDIO_DMAC_I2S0_DOWN:
         reg_id = AHB_MASTER_I2S1_MASK;
         val    = 0x00000202;
+        break;
+
+      case CXD56_AUDIO_DMAC_I2S1_UP:
+        reg_id = AHB_MASTER_I2S2_MASK;
+        val    = 0x00000101;
         break;
 
       default:
@@ -839,8 +987,16 @@ void cxd56_audio_bca_reg_set_start_addr(cxd56_audio_dma_t handle,
         reg_id = BCA_MIC_IN_START_ADR;
         break;
 
+      case CXD56_AUDIO_DMAC_I2S0_UP:
+        reg_id = BCA_I2S1_IN_START_ADR;
+        break;
+
       case CXD56_AUDIO_DMAC_I2S0_DOWN:
         reg_id = BCA_I2S1_OUT_START_ADR;
+        break;
+
+      case CXD56_AUDIO_DMAC_I2S1_UP:
+        reg_id = BCA_I2S2_IN_START_ADR;
         break;
 
       default:
@@ -862,8 +1018,16 @@ void cxd56_audio_bca_reg_set_sample_no(cxd56_audio_dma_t handle,
         reg_id = BCA_MIC_IN_SAMPLE_NO;
         break;
 
+      case CXD56_AUDIO_DMAC_I2S0_UP:
+        reg_id = BCA_I2S1_IN_SAMPLE_NO;
+        break;
+
       case CXD56_AUDIO_DMAC_I2S0_DOWN:
         reg_id = BCA_I2S1_OUT_SAMPLE_NO;
+        break;
+
+      case CXD56_AUDIO_DMAC_I2S1_UP:
+        reg_id = BCA_I2S2_IN_SAMPLE_NO;
         break;
 
       default:
@@ -886,8 +1050,16 @@ void cxd56_audio_bca_reg_start_dma(cxd56_audio_dma_t handle,
         reg_id = BCA_MIC_IN_RTD_TRG;
         break;
 
+      case CXD56_AUDIO_DMAC_I2S0_UP:
+        reg_id = BCA_I2S1_IN_RTD_TRG;
+        break;
+
       case CXD56_AUDIO_DMAC_I2S0_DOWN:
         reg_id = BCA_I2S1_OUT_RTD_TRG;
+        break;
+
+      case CXD56_AUDIO_DMAC_I2S1_UP:
+        reg_id = BCA_I2S2_IN_RTD_TRG;
         break;
 
       default:
@@ -908,8 +1080,16 @@ void cxd56_audio_bca_reg_stop_dma(cxd56_audio_dma_t handle)
         reg_id = BCA_MIC_IN_RTD_TRG;
         break;
 
+      case CXD56_AUDIO_DMAC_I2S0_UP:
+        reg_id = BCA_I2S1_IN_RTD_TRG;
+        break;
+
       case CXD56_AUDIO_DMAC_I2S0_DOWN:
         reg_id = BCA_I2S1_OUT_RTD_TRG;
+        break;
+
+      case CXD56_AUDIO_DMAC_I2S1_UP:
+        reg_id = BCA_I2S2_IN_RTD_TRG;
         break;
 
       default:
@@ -930,8 +1110,16 @@ bool cxd56_audio_bca_reg_is_done_int(cxd56_audio_dma_t handle)
         reg_id = BCA_MIC_INT_CTRL_DONE_MIC;
         break;
 
+      case CXD56_AUDIO_DMAC_I2S0_UP:
+        reg_id = BCA_I2S1_INT_CTRL_DONE_I2SI;
+        break;
+
       case CXD56_AUDIO_DMAC_I2S0_DOWN:
         reg_id = BCA_I2S1_INT_CTRL_DONE_I2SO;
+        break;
+
+      case CXD56_AUDIO_DMAC_I2S1_UP:
+        reg_id = BCA_I2S2_INT_CTRL_DONE_I2SI;
         break;
 
       default:
@@ -957,8 +1145,16 @@ bool cxd56_audio_bca_reg_is_err_int(cxd56_audio_dma_t handle)
         reg_id = BCA_MIC_INT_CTRL_ERR_MIC;
         break;
 
+      case CXD56_AUDIO_DMAC_I2S0_UP:
+        reg_id = BCA_I2S1_INT_CTRL_ERR_I2SI;
+        break;
+
       case CXD56_AUDIO_DMAC_I2S0_DOWN:
         reg_id = BCA_I2S1_INT_CTRL_ERR_I2SO;
+        break;
+
+      case CXD56_AUDIO_DMAC_I2S1_UP:
+        reg_id = BCA_I2S2_INT_CTRL_ERR_I2SI;
         break;
 
       default:
@@ -984,8 +1180,13 @@ bool cxd56_audio_bca_reg_is_smp_int(cxd56_audio_dma_t handle)
         reg_id = BCA_MIC_INT_CTRL_SMP_MIC;
         break;
 
+      case CXD56_AUDIO_DMAC_I2S0_UP:
       case CXD56_AUDIO_DMAC_I2S0_DOWN:
         reg_id = BCA_I2S1_INT_CTRL_SMP_I2S;
+        break;
+
+      case CXD56_AUDIO_DMAC_I2S1_UP:
+        reg_id = BCA_I2S2_INT_CTRL_SMP_I2S;
         break;
 
       default:
@@ -1010,12 +1211,17 @@ void cxd56_audio_bca_reg_mask_smp_int(cxd56_audio_dma_t handle)
         reg_id = BCA_MIC_INT_MASK_SMP_MIC;
         break;
 
+      case CXD56_AUDIO_DMAC_I2S0_UP:
       case CXD56_AUDIO_DMAC_I2S0_DOWN:
         reg_id = BCA_I2S1_INT_MASK_SMP_I2S;
         break;
 
+      case CXD56_AUDIO_DMAC_I2S1_UP:
+        reg_id = BCA_I2S2_INT_MASK_SMP_I2S;
+        break;
+
       default:
-        reg_id = BCA_I2S1_INT_MASK_SMP_I2S;
+        reg_id = BCA_I2S2_INT_MASK_SMP_I2S;
         break;
     }
 
@@ -1031,12 +1237,17 @@ void cxd56_audio_bca_reg_unmask_smp_int(cxd56_audio_dma_t handle)
         reg_id = BCA_MIC_INT_MASK_SMP_MIC;
         break;
 
+      case CXD56_AUDIO_DMAC_I2S0_UP:
       case CXD56_AUDIO_DMAC_I2S0_DOWN:
         reg_id = BCA_I2S1_INT_MASK_SMP_I2S;
         break;
 
+      case CXD56_AUDIO_DMAC_I2S1_UP:
+        reg_id = BCA_I2S2_INT_MASK_SMP_I2S;
+        break;
+
       default:
-        reg_id = BCA_I2S1_INT_MASK_SMP_I2S;
+        reg_id = BCA_I2S2_INT_MASK_SMP_I2S;
         break;
     }
 
@@ -1052,8 +1263,13 @@ void cxd56_audio_bca_reg_clear_smp_int(cxd56_audio_dma_t handle)
         reg_id = BCA_MIC_INT_CTRL_SMP_MIC;
         break;
 
+      case CXD56_AUDIO_DMAC_I2S0_UP:
       case CXD56_AUDIO_DMAC_I2S0_DOWN:
         reg_id = BCA_I2S1_INT_CTRL_SMP_I2S;
+        break;
+
+      case CXD56_AUDIO_DMAC_I2S1_UP:
+        reg_id = BCA_I2S2_INT_CTRL_SMP_I2S;
         break;
 
       default:
@@ -1073,8 +1289,16 @@ uint32_t cxd56_audio_bca_reg_get_mon_state_err(cxd56_audio_dma_t handle)
         reg_id = BCA_MIC_IN_ERROR_SETTING;
         break;
 
+      case CXD56_AUDIO_DMAC_I2S0_UP:
+        reg_id = BCA_I2S1_IN_MON_ERROR_SETTING;
+        break;
+
       case CXD56_AUDIO_DMAC_I2S0_DOWN:
         reg_id = BCA_I2S1_OUT_MON_ERROR_SETTING;
+        break;
+
+      case CXD56_AUDIO_DMAC_I2S1_UP:
+        reg_id = BCA_I2S2_IN_MON_ERROR_SETTING;
         break;
 
       default:
@@ -1094,8 +1318,16 @@ uint32_t cxd56_audio_bca_reg_get_mon_state_start(cxd56_audio_dma_t handle)
         reg_id = BCA_MIC_IN_START;
         break;
 
+      case CXD56_AUDIO_DMAC_I2S0_UP:
+        reg_id = BCA_I2S1_IN_MON_START;
+        break;
+
       case CXD56_AUDIO_DMAC_I2S0_DOWN:
         reg_id = BCA_I2S1_OUT_MON_START;
+        break;
+
+      case CXD56_AUDIO_DMAC_I2S1_UP:
+        reg_id = BCA_I2S2_IN_MON_START;
         break;
 
       default:
@@ -1115,8 +1347,16 @@ uint32_t cxd56_audio_bca_reg_get_mon_state_buf(cxd56_audio_dma_t handle)
         reg_id = BCA_MIC_IN_MONBUF;
         break;
 
+      case CXD56_AUDIO_DMAC_I2S0_UP:
+        reg_id = BCA_I2S1_IN_MON_MONBUF;
+        break;
+
       case CXD56_AUDIO_DMAC_I2S0_DOWN:
         reg_id = BCA_I2S1_OUT_MON_MONBUF;
+        break;
+
+      case CXD56_AUDIO_DMAC_I2S1_UP:
+        reg_id = BCA_I2S2_IN_MON_MONBUF;
         break;
 
       default:
@@ -1136,8 +1376,16 @@ uint32_t cxd56_audio_bca_reg_get_dma_state(cxd56_audio_dma_t handle)
         reg_id = BCA_MIC_IN_RTD_TRG;
         break;
 
+      case CXD56_AUDIO_DMAC_I2S0_UP:
+        reg_id = BCA_I2S1_IN_RTD_TRG;
+        break;
+
       case CXD56_AUDIO_DMAC_I2S0_DOWN:
         reg_id = BCA_I2S1_OUT_RTD_TRG;
+        break;
+
+      case CXD56_AUDIO_DMAC_I2S1_UP:
+        reg_id = BCA_I2S2_IN_RTD_TRG;
         break;
 
       default:
@@ -1158,8 +1406,16 @@ void cxd56_audio_bca_reg_reset_chsel(cxd56_audio_dma_t handle)
         reg_id = BCA_MIC_IN_CH8_SEL;
         break;
 
+      case CXD56_AUDIO_DMAC_I2S0_UP:
+        reg_id = BCA_I2S1_IN_CH2_SEL;
+        break;
+
       case CXD56_AUDIO_DMAC_I2S0_DOWN:
         reg_id = BCA_I2S1_OUT_SD1_R_SEL;
+        break;
+
+      case CXD56_AUDIO_DMAC_I2S1_UP:
+        reg_id = BCA_I2S2_IN_CH2_SEL;
         break;
 
       default:

--- a/boards/arm/cxd56xx/drivers/audio/cxd56_audio_dma.c
+++ b/boards/arm/cxd56xx/drivers/audio/cxd56_audio_dma.c
@@ -94,6 +94,8 @@ static bool s_work_arroud_dmac[DMA_HANDLE_MAX_NUM] =
 {
   true,
   true,
+  true,
+  true,
   true
 };
 
@@ -146,6 +148,14 @@ static CXD56_AUDIO_ECODE get_dma_handle(cxd56_audio_dma_path_t path,
         *handle = CXD56_AUDIO_DMAC_MIC;
         break;
 
+      case CXD56_AUDIO_DMA_PATH_I2S0_TO_MEM:
+        *handle = CXD56_AUDIO_DMAC_I2S0_UP;
+        break;
+
+      case CXD56_AUDIO_DMA_PATH_I2S1_TO_MEM:
+        *handle = CXD56_AUDIO_DMAC_I2S1_UP;
+        break;
+
       case CXD56_AUDIO_DMA_PATH_MEM_TO_BUSIF1:
         *handle = CXD56_AUDIO_DMAC_I2S0_DOWN;
         break;
@@ -168,6 +178,14 @@ static CXD56_AUDIO_ECODE get_dma_path(cxd56_audio_dma_t handle,
     {
       case CXD56_AUDIO_DMAC_MIC:
         *path = CXD56_AUDIO_DMA_PATH_MIC_TO_MEM;
+        break;
+
+      case CXD56_AUDIO_DMAC_I2S0_UP:
+        *path = CXD56_AUDIO_DMA_PATH_I2S0_TO_MEM;
+        break;
+
+      case CXD56_AUDIO_DMAC_I2S1_UP:
+        *path = CXD56_AUDIO_DMA_PATH_I2S1_TO_MEM;
         break;
 
       case CXD56_AUDIO_DMAC_I2S0_DOWN:
@@ -603,6 +621,12 @@ void cxd56_audio_dma_int_handler(void)
 
       /* Check done complete state. */
 
+      if (int_i2s & DMA_STATE_BIT_I2S_IN_DONE)
+        {
+          (*g_dma_cb[CXD56_AUDIO_DMAC_I2S0_UP])(CXD56_AUDIO_DMAC_I2S0_UP,
+                                               CXD56_AUDIO_ECODE_DMA_CMPLT);
+        }
+
       if (int_i2s & DMA_STATE_BIT_I2S_OUT_DONE)
         {
           (*g_dma_cb[CXD56_AUDIO_DMAC_I2S0_DOWN])(CXD56_AUDIO_DMAC_I2S0_DOWN,
@@ -610,6 +634,16 @@ void cxd56_audio_dma_int_handler(void)
         }
 
       /* Check transfer err state. */
+
+      if (int_i2s & DMA_STATE_BIT_I2S_IN_ERR)
+        {
+          cxd56_audio_bca_reg_mask_err_int(CXD56_AUDIO_DMAC_I2S0_UP);
+
+          cxd56_audio_bca_reg_clear_err_int(CXD56_AUDIO_DMAC_I2S0_UP);
+
+          (*g_dma_cb[CXD56_AUDIO_DMAC_I2S0_UP])(CXD56_AUDIO_DMAC_I2S0_UP,
+                                               CXD56_AUDIO_ECODE_DMA_TRANS);
+        }
 
       if (int_i2s & DMA_STATE_BIT_I2S_OUT_ERR)
         {
@@ -640,6 +674,12 @@ void cxd56_audio_dma_int_handler(void)
     {
       /* Clear interrupt. */
 
+      if (int_i2s2 & DMA_STATE_BIT_I2S_IN_DONE)
+        {
+          (*g_dma_cb[CXD56_AUDIO_DMAC_I2S1_UP])(CXD56_AUDIO_DMAC_I2S1_UP,
+                                                CXD56_AUDIO_ECODE_DMA_CMPLT);
+        }
+
       cxd56_audio_bca_reg_clear_dma_done_state_i2s2(int_i2s2);
 
       /* Check done complete state. */
@@ -652,6 +692,16 @@ void cxd56_audio_dma_int_handler(void)
         }
 
       /* Check transfer err state. */
+
+      if (int_i2s2 & DMA_STATE_BIT_I2S_IN_ERR)
+        {
+          cxd56_audio_bca_reg_mask_err_int(CXD56_AUDIO_DMAC_I2S1_UP);
+
+          cxd56_audio_bca_reg_clear_err_int(CXD56_AUDIO_DMAC_I2S1_UP);
+
+          (*g_dma_cb[CXD56_AUDIO_DMAC_I2S1_UP])(CXD56_AUDIO_DMAC_I2S1_UP,
+                                                CXD56_AUDIO_ECODE_DMA_TRANS);
+        }
 
       if (int_i2s2 & DMA_STATE_BIT_I2S_OUT_ERR)
         {


### PR DESCRIPTION
## Summary
Enable the driver setting of I2S input.

## Impact
Only spresense board.

## Testing
Confirmed that recording is possible from I2S input. 
