### PR TITLE
armv7-a/r:cache: add cp15_cache_size function and use flush/clean_all if size large than cache size

### DIFF
--- a/arch/arm/src/a1x/Make.defs
+++ b/arch/arm/src/a1x/Make.defs
@@ -46,7 +46,7 @@ CMN_ASRCS += arm_saveusercontext.S arm_vectoraddrexcptn.S
 CMN_ASRCS += arm_testset.S arm_fetchadd.S vfork.S
 CMN_ASRCS += cp15_coherent_dcache.S cp15_invalidate_dcache.S
 CMN_ASRCS += cp15_clean_dcache.S cp15_flush_dcache.S cp15_invalidate_dcache_all.S
-CMN_ASRCS += cp15_clean_dcache_all.S cp15_flush_dcache_all.S
+CMN_ASRCS += cp15_clean_dcache_all.S cp15_flush_dcache_all.S cp15_cache_size.S
 
 # Common C source files
 

--- a/arch/arm/src/am335x/Make.defs
+++ b/arch/arm/src/am335x/Make.defs
@@ -46,7 +46,7 @@ CMN_ASRCS += arm_saveusercontext.S arm_vectoraddrexcptn.S
 CMN_ASRCS += arm_testset.S vfork.S
 CMN_ASRCS += cp15_coherent_dcache.S cp15_invalidate_dcache.S
 CMN_ASRCS += cp15_clean_dcache.S cp15_flush_dcache.S cp15_invalidate_dcache_all.S
-CMN_ASRCS += cp15_clean_dcache_all.S cp15_flush_dcache_all.S
+CMN_ASRCS += cp15_clean_dcache_all.S cp15_flush_dcache_all.S cp15_cache_size.S
 
 # Common C source files
 

--- a/arch/arm/src/armv7-a/arm_cache.c
+++ b/arch/arm/src/armv7-a/arm_cache.c
@@ -134,7 +134,15 @@ void up_invalidate_icache_all(void)
 
 void up_clean_dcache(uintptr_t start, uintptr_t end)
 {
-  cp15_clean_dcache(start, end);
+  if (cp15_cache_size() < (end - start))
+    {
+      cp15_clean_dcache(start, end);
+    }
+  else
+    {
+      cp15_clean_dcache_all();
+    }
+
   l2cc_clean(start, end);
 }
 
@@ -190,7 +198,15 @@ void up_clean_dcache_all(void)
 
 void up_flush_dcache(uintptr_t start, uintptr_t end)
 {
-  cp15_flush_dcache(start, end);
+  if (cp15_cache_size() < (end - start))
+    {
+      cp15_flush_dcache(start, end);
+    }
+  else
+    {
+      cp15_flush_dcache_all();
+    }
+
   l2cc_flush(start, end);
 }
 

--- a/arch/arm/src/armv7-a/cp15_cache_size.S
+++ b/arch/arm/src/armv7-a/cp15_cache_size.S
@@ -1,0 +1,85 @@
+/****************************************************************************
+ * arch/arm/src/armv7-a/cp15_cache_size.S
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include "cp15.h"
+
+	.file	"cp15_cache_size.S"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Symbols
+ ****************************************************************************/
+
+	.globl	cp15_cache_size
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+	.text
+
+/****************************************************************************
+ * Name: cp15_cache_size
+ *
+ * Description:
+ *   Get cp15 cache size in byte
+ *
+ * Input Parameters:
+ *   None
+ *
+ * Returned Value:
+ *   Cache size in byte
+ *
+ ****************************************************************************/
+
+	.globl	cp15_cache_size
+	.type	cp15_cache_size, function
+
+cp15_cache_size:
+
+	mrc		CP15_CCSIDR(r0)			/* Read the Cache Size Identification Register */
+
+	ldr		r3, =0x7fff			/* Isolate the NumSets field (bits 13-27) */
+	and		r2, r3, r0, lsr #13		/* r2=NumSets (number of sets - 1) */
+	add		r2, #1
+
+	ldr		r3, =0x3ff			/* Isolate the way field (bits 3-12) */
+	and		r1, r3, r0, lsr #3		/* r1=(number of ways - 1) */
+	add		r1, #1
+
+	ldr		r3,=0x7				/* Isolate the LineSize field (bits 0-2) */
+	and		r0, r3				/* r0=(Log2LineSize - 2) in word */
+	add		r0, #4				/* r0=Log2lineSize in byte */
+
+	mul		r2, r1, r2			/* r2=Sets*Ways */
+	lsl		r0, r2, r0			/* r0=Sets*Ways*LineSize */
+
+	bx		lr
+
+	.size cp15_cache_size, . - cp15_cache_size
+	.end

--- a/arch/arm/src/armv7-a/cp15_cacheops.h
+++ b/arch/arm/src/armv7-a/cp15_cacheops.h
@@ -1116,6 +1116,22 @@ void cp15_flush_dcache(uintptr_t start, uintptr_t end);
 
 void cp15_flush_dcache_all(void);
 
+/****************************************************************************
+ * Name: cp15_cache_size
+ *
+ * Description:
+ *   Get cp15 cache size in byte
+ *
+ * Input Parameters:
+ *   None
+ *
+ * Returned Value:
+ *   Cache size in byte
+ *
+ ****************************************************************************/
+
+uint32_t cp15_cache_size(void);
+
 #undef EXTERN
 #ifdef __cplusplus
 }

--- a/arch/arm/src/armv7-r/arm_cache.c
+++ b/arch/arm/src/armv7-r/arm_cache.c
@@ -134,7 +134,15 @@ void up_invalidate_icache_all(void)
 
 void up_clean_dcache(uintptr_t start, uintptr_t end)
 {
-  cp15_clean_dcache(start, end);
+  if (cp15_cache_size() < (end - start))
+    {
+      cp15_clean_dcache(start, end);
+    }
+  else
+    {
+      cp15_clean_dcache_all();
+    }
+
   l2cc_clean(start, end);
 }
 
@@ -190,7 +198,15 @@ void up_clean_dcache_all(void)
 
 void up_flush_dcache(uintptr_t start, uintptr_t end)
 {
-  cp15_flush_dcache(start, end);
+  if (cp15_cache_size() < (end - start))
+    {
+      cp15_flush_dcache(start, end);
+    }
+  else
+    {
+      cp15_flush_dcache_all();
+    }
+
   l2cc_flush(start, end);
 }
 

--- a/arch/arm/src/armv7-r/cp15_cache_size.S
+++ b/arch/arm/src/armv7-r/cp15_cache_size.S
@@ -1,0 +1,84 @@
+/****************************************************************************
+ * arch/arm/src/armv7-r/cp15_cache_size.S
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include "cp15.h"
+
+	.file	"cp15_cache_size.S"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Symbols
+ ****************************************************************************/
+
+	.globl	cp15_cache_size
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+	.text
+
+/****************************************************************************
+ * Name: cp15_cache_size
+ *
+ * Description:
+ *   Get cp15 cache size in byte
+ *
+ * Input Parameters:
+ *   None
+ *
+ * Returned Value:
+ *   Cache size in byte
+ *
+ ****************************************************************************/
+
+	.globl	cp15_cache_size
+	.type	cp15_cache_size, function
+
+cp15_cache_size:
+
+	mrc		CP15_CCSIDR(r0)			/* Read the Cache Size Identification Register */
+
+	ldr		r3, =0x7fff			/* Isolate the NumSets field (bits 13-27) */
+	and		r2, r3, r0, lsr #13		/* r2=NumSets (number of sets - 1) */
+	add		r2, #1
+
+	ldr		r3, =0x3ff			/* Isolate the way field (bits 3-12) */
+	and		r1, r3, r0, lsr #3		/* r1=(number of ways - 1) */
+	add		r1, #1
+
+	ldr		r3,=0x7				/* Isolate the LineSize field (bits 0-2) */
+	and		r0, r3				/* r0=(Log2LineSize - 2) in word */
+	add		r0, #4				/* r0=Log2lineSize in byte */
+
+	mul		r2, r1, r2			/* r2=Sets*Ways */
+	lsl		r0, r2, r0			/* r0=Sets*Ways*LineSize */
+
+	bx		lr
+
+	.size cp15_cache_size, . - cp15_cache_size
+	.end

--- a/arch/arm/src/armv7-r/cp15_cacheops.h
+++ b/arch/arm/src/armv7-r/cp15_cacheops.h
@@ -1123,6 +1123,22 @@ void cp15_flush_dcache(uintptr_t start, uintptr_t end);
 
 void cp15_flush_dcache_all(void);
 
+/****************************************************************************
+ * Name: cp15_cache_size
+ *
+ * Description:
+ *   Get cp15 cache size in byte
+ *
+ * Input Parameters:
+ *   None
+ *
+ * Returned Value:
+ *   Cache size in byte
+ *
+ ****************************************************************************/
+
+uint32_t cp15_cache_size(void);
+
 #undef EXTERN
 #ifdef __cplusplus
 }

--- a/arch/arm/src/imx6/Make.defs
+++ b/arch/arm/src/imx6/Make.defs
@@ -49,7 +49,7 @@ CMN_ASRCS += arm_saveusercontext.S arm_vectoraddrexcptn.S
 CMN_ASRCS += arm_testset.S arm_fetchadd.S vfork.S
 CMN_ASRCS += cp15_coherent_dcache.S cp15_invalidate_dcache.S
 CMN_ASRCS += cp15_clean_dcache.S cp15_flush_dcache.S cp15_invalidate_dcache_all.S
-CMN_ASRCS += cp15_clean_dcache_all.S cp15_flush_dcache_all.S
+CMN_ASRCS += cp15_clean_dcache_all.S cp15_flush_dcache_all.S cp15_cache_size.S
 
 # Common C source files
 

--- a/arch/arm/src/sama5/Make.defs
+++ b/arch/arm/src/sama5/Make.defs
@@ -46,7 +46,7 @@ CMN_ASRCS += arm_saveusercontext.S arm_vectoraddrexcptn.S
 CMN_ASRCS += arm_testset.S arm_fetchadd.S vfork.S
 CMN_ASRCS += cp15_coherent_dcache.S cp15_invalidate_dcache.S
 CMN_ASRCS += cp15_clean_dcache.S cp15_flush_dcache.S cp15_invalidate_dcache_all.S
-CMN_ASRCS += cp15_clean_dcache_all.S cp15_flush_dcache_all.S
+CMN_ASRCS += cp15_clean_dcache_all.S cp15_flush_dcache_all.S cp15_cache_size.S
 
 # Configuration dependent assembly language files
 

--- a/arch/arm/src/tms570/Make.defs
+++ b/arch/arm/src/tms570/Make.defs
@@ -31,7 +31,7 @@ CMN_ASRCS += arm_testset.S arm_fetchadd.S vfork.S
 CMN_ASRCS += cp15_coherent_dcache.S cp15_invalidate_dcache.S
 CMN_ASRCS += cp15_clean_dcache.S cp15_flush_dcache.S
 CMN_ASRCS += cp15_clean_dcache_all.S cp15_flush_dcache_all.S
-CMN_ASRCS += cp15_invalidate_dcache_all.S
+CMN_ASRCS += cp15_invalidate_dcache_all.S cp15_cache_size.S
 
 # Configuration dependent assembly language files
 


### PR DESCRIPTION
patch 1 : Add cp15_cache_size function for armv7-a/r
patch 2: use flush/clean_all if size large than cache size

## Summary
For better cache performance. when flush/clean cache size large than cache size, use flush/clean_all instead 

## Impact

## Testing

Testing in Qemu , cache size  16K
Testing in our smp armv7-a board, cache size 32K

