### PR TITLE
drivers/mtd/mtd_config.c: enlarge the limits of blocksize in struct m…

### DIFF
--- a/drivers/mtd/mtd_config.c
+++ b/drivers/mtd/mtd_config.c
@@ -77,8 +77,8 @@ struct mtdconfig_struct_s
 {
   FAR struct mtd_dev_s *mtd;  /* Contained MTD interface */
   sem_t        exclsem;       /* Supports mutual exclusion */
-  uint32_t     blocksize :14; /* Size of blocks in contained MTD */
-  uint32_t     erasesize :18; /* Size of erase block  in contained MTD */
+  uint32_t     blocksize;     /* Size of blocks in contained MTD */
+  uint32_t     erasesize;     /* Size of erase block  in contained MTD */
   size_t       nblocks;       /* Number of blocks available */
   size_t       neraseblocks;  /* Number of erase blocks available */
   off_t        readoff;       /* Read offset (for hexdump) */


### PR DESCRIPTION
…tdconfig_struct_s

## Summary
enlarge the limits of blocksize in struct mtdconfig_struct_s
## Impact
The least flash sector size of STM32F4 is 16kB, When mtdconfig used on stm32f4 MCU geo.blocksize in function mtdconfig_register is 0x4000 which is 15bit, and  dev->blocksize = geo.blocksize will result  dev->blocksize = 0, because dev->blocksize limit as 14bit.
## Testing
Tested on STM32F405RGT6 board.

