### PR TITLE
sim: detect clang native compiler on MacOS.

### DIFF
--- a/arch/sim/src/Makefile
+++ b/arch/sim/src/Makefile
@@ -285,11 +285,14 @@ nuttx-names.dat: nuttx-names.in
 nuttx$(EXEEXT): libarch$(LIBEXT) board/libboard$(LIBEXT) $(HEADOBJ) $(LINKOBJS) $(HOSTOBJS) nuttx-names.dat
 	$(Q) echo "LD:  nuttx$(EXEEXT)"
 	$(Q) $(LD) -r $(LDLINKFLAGS) $(RELPATHS) $(EXTRA_LIBPATHS) -o nuttx.rel $(REQUIREDOBJS) $(LDSTARTGROUP) $(RELLIBS) $(EXTRA_LIBS) $(LDENDGROUP)
+ifeq ("$(shell $(CC) --version | grep clang)","")
+   # none clang based native compilers need opjcopy to build simulation
 	$(Q) $(OBJCOPY) --redefine-syms=nuttx-names.dat nuttx.rel
 	$(Q) $(CC) $(CCLINKFLAGS) -Wl,-verbose 2>&1 | \
 	     sed -e '/====/,/====/!d;//d' -e 's/__executable_start/_stext/g' -e 's/__init_array_start/_sinit/g' \
 	         -e 's/__init_array_end/_einit/g' -e 's/__fini_array_start/_sfini/g' -e 's/__fini_array_end/_efini/g' >nuttx.ld
 	$(Q) echo "__init_array_start = .; __init_array_end = .; __fini_array_start = .; __fini_array_end = .;" >>nuttx.ld
+endif
 	$(if $(CONFIG_HAVE_CXX),\
 	$(Q) "$(CXX)" $(CCLINKFLAGS) $(LIBPATHS) $(ARCHSCRIPT) -o $(TOPDIR)/$@ $(HEADOBJ) nuttx.rel $(HOSTOBJS) $(STDLIBS),\
 	$(Q) "$(CC)" $(CCLINKFLAGS) $(LIBPATHS) $(ARCHSCRIPT) -o $(TOPDIR)/$@ $(HEADOBJ) nuttx.rel $(HOSTOBJS) $(STDLIBS))

--- a/arch/sim/src/sim/up_head.c
+++ b/arch/sim/src/sim/up_head.c
@@ -64,6 +64,7 @@ static char g_logbuffer[4096];
  *
  ****************************************************************************/
 
+__attribute__ ((visibility("default")))
 int main(int argc, char **argv, char **envp)
 {
   g_argc = argc;

--- a/arch/sim/src/sim/up_interruptcontext.c
+++ b/arch/sim/src/sim/up_interruptcontext.c
@@ -51,6 +51,7 @@ bool up_interrupt_context(void)
  * Name: up_doirq
  ****************************************************************************/
 
+__attribute__ ((visibility("default")))
 void *up_doirq(int irq, void *context)
 {
   /* Allocate temporary context on the stack */

--- a/arch/sim/src/sim/up_netdriver.c
+++ b/arch/sim/src/sim/up_netdriver.c
@@ -399,6 +399,7 @@ int netdriver_init(void)
   return netdev_register(dev, NET_LL_ETHERNET);
 }
 
+__attribute__ ((visibility("default")))
 void netdriver_setmacaddr(unsigned char *macaddr)
 {
   memcpy(g_sim_dev.d_mac.ether.ether_addr_octet, macaddr, IFHWADDRLEN);

--- a/arch/sim/src/sim/up_smpsignal.c
+++ b/arch/sim/src/sim/up_smpsignal.c
@@ -217,6 +217,7 @@ int up_cpu_paused(int cpu)
  *
  ****************************************************************************/
 
+__attribute__ ((visibility("default")))
 void up_cpu_started(void)
 {
 #ifdef CONFIG_SCHED_INSTRUMENTATION
@@ -285,6 +286,7 @@ int up_cpu_start(int cpu)
  *   On success returns OK (0), otherwise a negative value.
  ****************************************************************************/
 
+__attribute__ ((visibility("default")))
 int up_init_ipi(int irq)
 {
   up_enable_irq(irq);


### PR DESCRIPTION
## Summary
Detect clang native compiler on MacOS.
In case clang based compiler is used, skip objcopy step in final build step.

## Impact
Simulation on MacOS.

## Testing
MacBook Pro Late 2013 running Big Sur (X86_64)
Testing on MacBook Air 2020 running Monterey (ARM64) will be part of separate PR.