### PR TITLE
sched/mqueue: remove unused leave_cancellation_point

### DIFF
--- a/sched/mqueue/mq_timedsend.c
+++ b/sched/mqueue/mq_timedsend.c
@@ -148,8 +148,8 @@ int file_mq_timedsend(FAR struct file *mq, FAR const char *msg,
 {
   FAR struct tcb_s *rtcb = this_task();
   FAR struct inode *inode = mq->f_inode;
-  FAR struct mqueue_msg_s *mqmsg = NULL;
   FAR struct mqueue_inode_s *msgq;
+  FAR struct mqueue_msg_s *mqmsg;
   irqstate_t flags;
   sclock_t ticks;
   int result;
@@ -288,7 +288,6 @@ int file_mq_timedsend(FAR struct file *mq, FAR const char *msg,
   ret = nxmq_do_send(msgq, mqmsg, msg, msglen, prio);
 
   sched_unlock();
-  leave_cancellation_point();
   return ret;
 
   /* Exit here with (1) the scheduler locked, (2) a message allocated, (3) a


### PR DESCRIPTION

## Summary

sched/mqueue: remove unused leave_cancellation_point

should be removed by:

```
commit fca07be1df52595d494c7524d17fb9294c385d5c
Author: Gregory Nutt <gnutt@nuttx.org>
Date:   Tue Oct 10 08:43:10 2017 -0600

    Squashed commit of the following:

        Change all calls to mq_send() and mq_timedsend() in the OS to calls to
        nxmq_send() and nxmq_timedsend(), making appropriate changes for differences
        in return values.

        sched/mqueue:  Add internal function nxmq_send() and nxmq_timedsend() that are
        equivalent to mq_send() and mq_timedsend() except that they do not create
        cancellation points and do to not modify the errno variable.
```

Signed-off-by: chao.an <anchao@xiaomi.com>


## Impact

N/A

## Testing

ci check