### PR TITLE
esp32c3: Fix issue #5377 UART1 not working because clock as disabled

### DIFF
--- a/arch/risc-v/src/esp32c3/esp32c3_lowputc.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_lowputc.c
@@ -667,6 +667,31 @@ void esp32c3_lowputc_rst_rxfifo(const struct esp32c3_uart_s *priv)
 }
 
 /****************************************************************************
+ * Name: esp32c3_lowputc_enable_sysclk
+ *
+ * Description:
+ *   Enable clock for the UART using the System register.
+ *
+ * Parameters:
+ *   priv           - Pointer to the private driver struct.
+ *
+ ****************************************************************************/
+
+void esp32c3_lowputc_enable_sysclk(const struct esp32c3_uart_s *priv)
+{
+  if (priv->id == 0)
+    {
+      modifyreg32(SYSTEM_PERIP_CLK_EN0_REG, 0,
+                  SYSTEM_UART_CLK_EN_M);
+    }
+  else
+    {
+      modifyreg32(SYSTEM_PERIP_CLK_EN0_REG, 0,
+                  SYSTEM_UART1_CLK_EN_M);
+    }
+}
+
+/****************************************************************************
  * Name: esp32c3_lowputc_disable_all_uart_int
  *
  * Description:
@@ -836,12 +861,14 @@ void esp32c3_lowsetup(void)
 
 #ifdef CONFIG_ESP32C3_UART0
 
+  esp32c3_lowputc_enable_sysclk(&g_uart0_config);
   esp32c3_lowputc_config_pins(&g_uart0_config);
 
 #endif
 
 #ifdef CONFIG_ESP32C3_UART1
 
+  esp32c3_lowputc_enable_sysclk(&g_uart1_config);
   esp32c3_lowputc_config_pins(&g_uart1_config);
 
 #endif

--- a/arch/risc-v/src/esp32c3/esp32c3_lowputc.h
+++ b/arch/risc-v/src/esp32c3/esp32c3_lowputc.h
@@ -410,6 +410,19 @@ void esp32c3_lowputc_rst_txfifo(const struct esp32c3_uart_s *priv);
 void esp32c3_lowputc_rst_rxfifo(const struct esp32c3_uart_s *priv);
 
 /****************************************************************************
+ * Name: esp32c3_lowputc_enable_sysclk
+ *
+ * Description:
+ *   Enable clock for the UART using the System register.
+ *
+ * Parameters:
+ *   priv           - Pointer to the private driver struct.
+ *
+ ****************************************************************************/
+
+void esp32c3_lowputc_enable_sysclk(const struct esp32c3_uart_s *priv);
+
+/****************************************************************************
  * Name: esp32c3_lowputc_disable_all_uart_int
  *
  * Description:

--- a/arch/risc-v/src/esp32c3/esp32c3_serial.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_serial.c
@@ -335,6 +335,10 @@ static int esp32c3_setup(struct uart_dev_s *dev)
   modifyreg32(UART_MEM_CONF_REG(priv->id), UART_TX_SIZE_M | UART_RX_SIZE_M,
               (1 << UART_TX_SIZE_S) | (1 << UART_RX_SIZE_S));
 
+  /* Enable the UART Clock */
+
+  esp32c3_lowputc_enable_sysclk(priv);
+
   /* Configure the UART Baud Rate */
 
   esp32c3_lowputc_baud(priv);


### PR DESCRIPTION
## Summary
Fix issue #5377 UART1 not working because clock as disabled
## Impact
Users will be able to use UART1
## Testing
ESP32C3-Devkitc
