### PR TITLE
sched/tcbinfo: Fix warning by discarded qualifiers

### DIFF
--- a/include/nuttx/sched.h
+++ b/include/nuttx/sched.h
@@ -782,8 +782,8 @@ begin_packed_struct struct tcbinfo_s
 
   union
   {
-    uint8_t       u[8];
-    FAR uint16_t *p;
+    uint8_t             u[8];
+    FAR const uint16_t *p;
   } reg_off;
 } end_packed_struct;
 #endif


### PR DESCRIPTION
## Summary
Fix:
```
common/riscv_tcbinfo.c:123:10: warning: initialization discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
  123 |     .p = g_reg_offs,
```
## Impact
None
## Testing
CI
