### PR TITLE
libc/chdir:"PWD" should save absolute path

### DIFF
--- a/libs/libc/unistd/lib_chdir.c
+++ b/libs/libc/unistd/lib_chdir.c
@@ -100,6 +100,7 @@ int chdir(FAR const char *path)
   struct stat buf;
   char *oldpwd;
   char *alloc;
+  char *abspath;
   int errcode;
   int ret;
 
@@ -151,7 +152,15 @@ int chdir(FAR const char *path)
 
   /* Set the cwd to the input 'path' */
 
-  setenv("PWD", path, TRUE);
+  abspath = realpath(path, NULL);
+  if (abspath == NULL)
+    {
+      errcode = ENOENT;
+      goto errout;
+    }
+
+  setenv("PWD", abspath, TRUE);
+  lib_free(abspath);
   sched_unlock();
   return OK;
 


### PR DESCRIPTION
Signed-off-by: anjiahao <anjiahao@xiaomi.com>

## Summary
if "PWD" save a relative path，and then mkdir ，will memory overflow.
## Impact
Nothing
## Testing
daily test
