### PR TITLE
net/rpmsg: fix the NULL pointer reference on nonblock accept 

### DIFF
--- a/net/rpmsg/rpmsg_sockif.c
+++ b/net/rpmsg/rpmsg_sockif.c
@@ -786,7 +786,7 @@ static int rpmsg_socket_accept(FAR struct socket *psock,
         }
       else
         {
-          if (_SS_ISNONBLOCK(conn->sconn.s_flags))
+          if (_SS_ISNONBLOCK(server->sconn.s_flags))
             {
               ret = -EAGAIN;
               break;


### PR DESCRIPTION
## Summary

net/rpmsg: fix the NULL pointer reference on nonblock accept 

## Impact

N/A

## Testing

ci check

link issue:
@a-lunev 
https://github.com/apache/incubator-nuttx/pull/5434#discussion_r804555083