### PR TITLE
net/can: remove psock reference from can connect

### DIFF
--- a/net/can/can.h
+++ b/net/can/can.h
@@ -111,10 +111,6 @@ struct can_conn_s
   int32_t tx_deadline;
 # endif
 #endif
-
-#ifdef CONFIG_NET_TIMESTAMP
-  FAR struct socket *psock; /* Needed to get SO_TIMESTAMP value */
-#endif
 };
 
 /****************************************************************************

--- a/net/can/can_sockif.c
+++ b/net/can/can_sockif.c
@@ -221,12 +221,6 @@ static int can_setup(FAR struct socket *psock, int protocol)
           return -ENOMEM;
         }
 
-#ifdef CONFIG_NET_TIMESTAMP
-      /* Store psock in conn se we can read the SO_TIMESTAMP value */
-
-      conn->psock = psock;
-#endif
-
       /* Initialize the connection instance */
 
       conn->protocol = (uint8_t)protocol;


### PR DESCRIPTION
## Summary

net/can: remove psock reference from can connect

remove the psock back reference since timestamp
has been migrated to can_conn_s

Signed-off-by: chao.an <anchao@xiaomi.com>

## Impact

N/A

## Testing

ci check