### PR TITLE
arch: Add xxx_tcbinfo.c to SoC level Make.defs

### DIFF
--- a/arch/arm/src/a1x/Make.defs
+++ b/arch/arm/src/a1x/Make.defs
@@ -59,7 +59,7 @@ CMN_CSRCS += arm_assert.c arm_blocktask.c arm_copyfullstate.c arm_dataabort.c
 CMN_CSRCS += arm_doirq.c arm_initialstate.c arm_mmu.c arm_prefetchabort.c
 CMN_CSRCS += arm_releasepending.c arm_reprioritizertr.c
 CMN_CSRCS += arm_schedulesigaction.c arm_sigdeliver.c arm_syscall.c
-CMN_CSRCS += arm_unblocktask.c arm_undefinedinsn.c
+CMN_CSRCS += arm_unblocktask.c arm_undefinedinsn.c arm_tcbinfo.c
 
 # Use common heap allocation for now (may need to be customized later)
 

--- a/arch/arm/src/am335x/Make.defs
+++ b/arch/arm/src/am335x/Make.defs
@@ -59,7 +59,7 @@ CMN_CSRCS += arm_assert.c arm_blocktask.c arm_copyfullstate.c arm_dataabort.c
 CMN_CSRCS += arm_doirq.c arm_initialstate.c arm_mmu.c arm_prefetchabort.c
 CMN_CSRCS += arm_releasepending.c arm_reprioritizertr.c
 CMN_CSRCS += arm_schedulesigaction.c arm_sigdeliver.c arm_syscall.c
-CMN_CSRCS += arm_unblocktask.c arm_undefinedinsn.c
+CMN_CSRCS += arm_unblocktask.c arm_undefinedinsn.c arm_tcbinfo.c
 
 # Use common heap allocation for now (may need to be customized later)
 

--- a/arch/arm/src/c5471/Make.defs
+++ b/arch/arm/src/c5471/Make.defs
@@ -28,7 +28,7 @@ CMN_CSRCS += arm_exit.c arm_initialize.c arm_initialstate.c arm_interruptcontext
 CMN_CSRCS += arm_prefetchabort.c arm_releasepending.c arm_releasestack.c
 CMN_CSRCS += arm_reprioritizertr.c arm_schedulesigaction.c arm_sigdeliver.c
 CMN_CSRCS += arm_stackframe.c arm_syscall.c arm_unblocktask.c arm_undefinedinsn.c
-CMN_CSRCS += arm_usestack.c arm_vfork.c arm_puts.c
+CMN_CSRCS += arm_usestack.c arm_vfork.c arm_puts.c arm_tcbinfo.c
 
 ifneq ($(CONFIG_ARCH_IDLE_CUSTOM),y)
 CMN_CSRCS += arm_idle.c

--- a/arch/arm/src/cxd56xx/Make.defs
+++ b/arch/arm/src/cxd56xx/Make.defs
@@ -33,6 +33,7 @@ CMN_CSRCS += arm_releasepending.c arm_releasestack.c arm_reprioritizertr.c
 CMN_CSRCS += arm_schedulesigaction.c arm_sigdeliver.c arm_stackframe.c
 CMN_CSRCS += arm_unblocktask.c arm_usestack.c arm_doirq.c arm_hardfault.c
 CMN_CSRCS += arm_svcall.c arm_vfork.c arm_switchcontext.c arm_puts.c
+CMN_CSRCS += arm_tcbinfo.c
 
 ifeq ($(CONFIG_ARMV7M_LAZYFPU),y)
 CMN_ASRCS += arm_lazyexception.S

--- a/arch/arm/src/dm320/Make.defs
+++ b/arch/arm/src/dm320/Make.defs
@@ -30,6 +30,7 @@ CMN_CSRCS += arm_prefetchabort.c arm_releasepending.c arm_releasestack.c
 CMN_CSRCS += arm_reprioritizertr.c arm_schedulesigaction.c
 CMN_CSRCS += arm_sigdeliver.c arm_stackframe.c arm_syscall.c arm_unblocktask.c
 CMN_CSRCS += arm_undefinedinsn.c arm_usestack.c arm_vfork.c arm_puts.c
+CMN_CSRCS += arm_tcbinfo.c
 
 ifneq ($(CONFIG_ARCH_IDLE_CUSTOM),y)
 CMN_CSRCS += arm_idle.c

--- a/arch/arm/src/efm32/Make.defs
+++ b/arch/arm/src/efm32/Make.defs
@@ -29,7 +29,7 @@ CMN_CSRCS += arm_modifyreg16.c arm_modifyreg32.c arm_releasepending.c
 CMN_CSRCS += arm_releasestack.c arm_reprioritizertr.c arm_schedulesigaction.c
 CMN_CSRCS += arm_sigdeliver.c arm_stackframe.c arm_svcall.c arm_systemreset.c
 CMN_CSRCS += arm_trigger_irq.c arm_udelay.c arm_unblocktask.c arm_usestack.c arm_vfork.c
-CMN_CSRCS += arm_switchcontext.c arm_puts.c
+CMN_CSRCS += arm_switchcontext.c arm_puts.c arm_tcbinfo.c
 
 ifeq ($(CONFIG_ARMV7M_LAZYFPU),y)
 CMN_ASRCS += arm_lazyexception.S

--- a/arch/arm/src/eoss3/Make.defs
+++ b/arch/arm/src/eoss3/Make.defs
@@ -29,7 +29,7 @@ CMN_CSRCS += arm_modifyreg16.c arm_modifyreg32.c arm_releasepending.c
 CMN_CSRCS += arm_releasestack.c arm_reprioritizertr.c arm_schedulesigaction.c
 CMN_CSRCS += arm_sigdeliver.c arm_stackframe.c arm_svcall.c arm_systemreset.c
 CMN_CSRCS += arm_trigger_irq.c arm_udelay.c arm_unblocktask.c arm_usestack.c arm_vfork.c
-CMN_CSRCS += arm_switchcontext.c arm_puts.c
+CMN_CSRCS += arm_switchcontext.c arm_puts.c arm_tcbinfo.c
 
 ifeq ($(CONFIG_ARMV7M_LAZYFPU),y)
 CMN_ASRCS += arm_lazyexception.S

--- a/arch/arm/src/imx1/Make.defs
+++ b/arch/arm/src/imx1/Make.defs
@@ -29,6 +29,7 @@ CMN_CSRCS += arm_prefetchabort.c arm_releasepending.c arm_releasestack.c
 CMN_CSRCS += arm_reprioritizertr.c arm_schedulesigaction.c
 CMN_CSRCS += arm_sigdeliver.c arm_stackframe.c arm_syscall.c arm_unblocktask.c
 CMN_CSRCS += arm_undefinedinsn.c arm_usestack.c arm_vfork.c arm_puts.c
+CMN_CSRCS += arm_tcbinfo.c
 
 ifneq ($(CONFIG_ARCH_IDLE_CUSTOM),y)
 CMN_CSRCS += arm_idle.c

--- a/arch/arm/src/imx6/Make.defs
+++ b/arch/arm/src/imx6/Make.defs
@@ -62,7 +62,7 @@ CMN_CSRCS += arm_assert.c arm_blocktask.c arm_copyfullstate.c arm_dataabort.c
 CMN_CSRCS += arm_doirq.c arm_gicv2.c arm_initialstate.c arm_mmu.c
 CMN_CSRCS += arm_prefetchabort.c arm_releasepending.c arm_reprioritizertr.c
 CMN_CSRCS += arm_schedulesigaction.c arm_sigdeliver.c arm_syscall.c
-CMN_CSRCS += arm_unblocktask.c arm_undefinedinsn.c
+CMN_CSRCS += arm_unblocktask.c arm_undefinedinsn.c arm_tcbinfo.c
 
 ifeq ($(CONFIG_ARM_SEMIHOSTING_HOSTFS),y)
 CMN_CSRCS += arm_hostfs.c

--- a/arch/arm/src/imxrt/Make.defs
+++ b/arch/arm/src/imxrt/Make.defs
@@ -31,7 +31,7 @@ CMN_CSRCS += arm_releasepending.c arm_releasestack.c arm_reprioritizertr.c
 CMN_CSRCS += arm_schedulesigaction.c arm_sigdeliver.c arm_stackframe.c
 CMN_CSRCS += arm_unblocktask.c arm_usestack.c arm_doirq.c arm_hardfault.c
 CMN_CSRCS += arm_svcall.c arm_vfork.c arm_trigger_irq.c arm_systemreset.c
-CMN_CSRCS += arm_switchcontext.c arm_puts.c
+CMN_CSRCS += arm_switchcontext.c arm_puts.c arm_tcbinfo.c
 
 ifeq ($(CONFIG_ARMV7M_STACKCHECK),y)
 CMN_CSRCS += arm_stackcheck.c

--- a/arch/arm/src/kinetis/Make.defs
+++ b/arch/arm/src/kinetis/Make.defs
@@ -29,6 +29,7 @@ CMN_CSRCS += arm_reprioritizertr.c arm_schedulesigaction.c arm_releasepending.c
 CMN_CSRCS += arm_sigdeliver.c arm_stackframe.c arm_unblocktask.c arm_usestack.c
 CMN_CSRCS += arm_doirq.c arm_hardfault.c arm_svcall.c arm_vfork.c
 CMN_CSRCS += arm_systemreset.c arm_trigger_irq.c arm_switchcontext.c arm_puts.c
+CMN_CSRCS += arm_tcbinfo.c
 
 ifeq ($(CONFIG_ARMV7M_STACKCHECK),y)
 CMN_CSRCS += arm_stackcheck.c

--- a/arch/arm/src/kl/Make.defs
+++ b/arch/arm/src/kl/Make.defs
@@ -29,7 +29,7 @@ CMN_CSRCS += arm_releasepending.c arm_releasestack.c arm_reprioritizertr.c
 CMN_CSRCS += arm_schedulesigaction.c arm_sigdeliver.c arm_stackframe.c
 CMN_CSRCS += arm_systemreset.c arm_unblocktask.c arm_usestack.c arm_doirq.c
 CMN_CSRCS += arm_hardfault.c arm_svcall.c arm_vectors.c arm_vfork.c
-CMN_CSRCS += arm_switchcontext.c
+CMN_CSRCS += arm_switchcontext.c arm_tcbinfo.c
 
 ifeq ($(CONFIG_BUILD_PROTECTED),y)
 CMN_CSRCS += arm_task_start.c arm_pthread_start.c

--- a/arch/arm/src/lc823450/Make.defs
+++ b/arch/arm/src/lc823450/Make.defs
@@ -29,7 +29,7 @@ CMN_CSRCS += arm_releasepending.c arm_releasestack.c arm_reprioritizertr.c
 CMN_CSRCS += arm_schedulesigaction.c arm_sigdeliver.c arm_systemreset.c
 CMN_CSRCS += arm_unblocktask.c arm_usestack.c arm_doirq.c arm_hardfault.c
 CMN_CSRCS += arm_svcall.c arm_vfork.c arm_trigger_irq.c arm_switchcontext.c
-CMN_CSRCS += arm_puts.c
+CMN_CSRCS += arm_puts.c arm_tcbinfo.c
 
 # CMN_CSRCS += up_dwt.c
 

--- a/arch/arm/src/lpc17xx_40xx/Make.defs
+++ b/arch/arm/src/lpc17xx_40xx/Make.defs
@@ -31,7 +31,7 @@ CMN_CSRCS += arm_releasestack.c arm_reprioritizertr.c arm_schedulesigaction.c
 CMN_CSRCS += arm_sigdeliver.c arm_stackframe.c arm_trigger_irq.c
 CMN_CSRCS += arm_unblocktask.c arm_usestack.c arm_doirq.c arm_hardfault.c
 CMN_CSRCS += arm_svcall.c arm_checkstack.c arm_vfork.c arm_switchcontext.c
-CMN_CSRCS += arm_systemreset.c arm_puts.c
+CMN_CSRCS += arm_systemreset.c arm_puts.c arm_tcbinfo.c
 
 ifeq ($(CONFIG_ARMV7M_STACKCHECK),y)
 CMN_CSRCS += arm_stackcheck.c

--- a/arch/arm/src/lpc214x/Make.defs
+++ b/arch/arm/src/lpc214x/Make.defs
@@ -30,7 +30,7 @@ CMN_CSRCS += arm_interruptcontext.c arm_prefetchabort.c arm_releasepending.c
 CMN_CSRCS += arm_releasestack.c arm_reprioritizertr.c arm_stackframe.c
 CMN_CSRCS += arm_syscall.c arm_unblocktask.c arm_undefinedinsn.c arm_usestack.c
 CMN_CSRCS += arm_schedulesigaction.c arm_sigdeliver.c
-CMN_CSRCS += arm_lowputs.c arm_vfork.c arm_puts.c
+CMN_CSRCS += arm_lowputs.c arm_vfork.c arm_puts.c arm_tcbinfo.c
 
 ifneq ($(CONFIG_ARCH_IDLE_CUSTOM),y)
 CMN_CSRCS += arm_idle.c

--- a/arch/arm/src/lpc2378/Make.defs
+++ b/arch/arm/src/lpc2378/Make.defs
@@ -29,7 +29,7 @@ CMN_CSRCS += arm_interruptcontext.c arm_prefetchabort.c arm_releasepending.c
 CMN_CSRCS += arm_releasestack.c arm_reprioritizertr.c arm_stackframe.c
 CMN_CSRCS += arm_syscall.c arm_unblocktask.c arm_undefinedinsn.c
 CMN_CSRCS += arm_usestack.c arm_lowputs.c arm_vfork.c
-CMN_CSRCS += arm_schedulesigaction.c arm_sigdeliver.c arm_puts.c
+CMN_CSRCS += arm_schedulesigaction.c arm_sigdeliver.c arm_puts.c arm_tcbinfo.c
 
 ifneq ($(CONFIG_ARCH_IDLE_CUSTOM),y)
 CMN_CSRCS += arm_idle.c

--- a/arch/arm/src/lpc31xx/Make.defs
+++ b/arch/arm/src/lpc31xx/Make.defs
@@ -31,6 +31,7 @@ CMN_CSRCS += arm_prefetchabort.c arm_releasepending.c arm_releasestack.c
 CMN_CSRCS += arm_reprioritizertr.c arm_schedulesigaction.c
 CMN_CSRCS += arm_sigdeliver.c arm_stackframe.c arm_syscall.c arm_unblocktask.c
 CMN_CSRCS += arm_undefinedinsn.c arm_usestack.c arm_vfork.c arm_puts.c
+CMN_CSRCS += arm_tcbinfo.c
 
 ifneq ($(CONFIG_ARCH_IDLE_CUSTOM),y)
 CMN_CSRCS += arm_idle.c

--- a/arch/arm/src/lpc43xx/Make.defs
+++ b/arch/arm/src/lpc43xx/Make.defs
@@ -29,6 +29,7 @@ CMN_CSRCS += arm_releasepending.c arm_releasestack.c arm_reprioritizertr.c
 CMN_CSRCS += arm_schedulesigaction.c arm_sigdeliver.c arm_stackframe.c
 CMN_CSRCS += arm_svcall.c arm_trigger_irq.c arm_unblocktask.c arm_udelay.c
 CMN_CSRCS += arm_usestack.c arm_vfork.c arm_switchcontext.c arm_puts.c
+CMN_CSRCS += arm_tcbinfo.c
 
 ifeq ($(CONFIG_ARMV7M_LAZYFPU),y)
 CMN_ASRCS += arm_lazyexception.S

--- a/arch/arm/src/lpc54xx/Make.defs
+++ b/arch/arm/src/lpc54xx/Make.defs
@@ -29,6 +29,7 @@ CMN_CSRCS += arm_releasepending.c arm_releasestack.c arm_reprioritizertr.c
 CMN_CSRCS += arm_schedulesigaction.c arm_sigdeliver.c arm_stackframe.c
 CMN_CSRCS += arm_svcall.c arm_trigger_irq.c arm_unblocktask.c arm_udelay.c
 CMN_CSRCS += arm_usestack.c arm_vfork.c arm_switchcontext.c arm_puts.c
+CMN_CSRCS += arm_tcbinfo.c
 
 ifeq ($(CONFIG_ARMV7M_LAZYFPU),y)
 CMN_ASRCS += arm_lazyexception.S

--- a/arch/arm/src/max326xx/Make.defs
+++ b/arch/arm/src/max326xx/Make.defs
@@ -31,7 +31,7 @@ CMN_CSRCS += arm_modifyreg32.c arm_releasepending.c arm_releasestack.c
 CMN_CSRCS += arm_reprioritizertr.c arm_schedulesigaction.c arm_sigdeliver.c
 CMN_CSRCS += arm_stackframe.c arm_svcall.c arm_trigger_irq.c arm_unblocktask.c
 CMN_CSRCS += arm_udelay.c arm_usestack.c arm_vfork.c arm_switchcontext.c
-CMN_CSRCS += arm_puts.c
+CMN_CSRCS += arm_puts.c arm_tcbinfo.c
 
 ifeq ($(CONFIG_ARMV7M_LAZYFPU),y)
 CMN_ASRCS += arm_lazyexception.S

--- a/arch/arm/src/moxart/Make.defs
+++ b/arch/arm/src/moxart/Make.defs
@@ -29,7 +29,7 @@ CMN_CSRCS += arm_interruptcontext.c arm_prefetchabort.c arm_releasepending.c
 CMN_CSRCS += arm_releasestack.c arm_reprioritizertr.c arm_schedulesigaction.c
 CMN_CSRCS += arm_sigdeliver.c arm_stackframe.c arm_syscall.c arm_unblocktask.c
 CMN_CSRCS += arm_undefinedinsn.c arm_usestack.c arm_vfork.c arm_etherstub.c
-CMN_CSRCS += arm_puts.c
+CMN_CSRCS += arm_puts.c arm_tcbinfo.c
 
 CHIP_ASRCS  = moxart_lowputc.S
 

--- a/arch/arm/src/nrf52/Make.defs
+++ b/arch/arm/src/nrf52/Make.defs
@@ -29,7 +29,7 @@ CMN_CSRCS += arm_modifyreg32.c arm_releasepending.c arm_releasestack.c
 CMN_CSRCS += arm_reprioritizertr.c arm_schedulesigaction.c arm_sigdeliver.c
 CMN_CSRCS += arm_stackframe.c arm_svcall.c arm_trigger_irq.c arm_udelay.c
 CMN_CSRCS += arm_unblocktask.c arm_usestack.c arm_vfork.c arm_systemreset.c
-CMN_CSRCS += arm_switchcontext.c arm_puts.c
+CMN_CSRCS += arm_switchcontext.c arm_puts.c arm_tcbinfo.c
 
 ifeq ($(CONFIG_NRF52_SYSTIMER_SYSTICK),y)
 CMN_CSRCS += arm_systick.c nrf52_systick.c

--- a/arch/arm/src/nuc1xx/Make.defs
+++ b/arch/arm/src/nuc1xx/Make.defs
@@ -29,7 +29,7 @@ CMN_CSRCS += arm_releasepending.c arm_releasestack.c arm_reprioritizertr.c
 CMN_CSRCS += arm_schedulesigaction.c arm_sigdeliver.c arm_stackframe.c
 CMN_CSRCS += arm_systemreset.c arm_unblocktask.c arm_usestack.c arm_doirq.c
 CMN_CSRCS += arm_hardfault.c arm_svcall.c arm_vectors.c arm_vfork.c
-CMN_CSRCS += arm_switchcontext.c arm_puts.c
+CMN_CSRCS += arm_switchcontext.c arm_puts.c arm_tcbinfo.c
 
 ifeq ($(CONFIG_BUILD_PROTECTED),y)
 CMN_CSRCS += arm_task_start.c arm_pthread_start.c

--- a/arch/arm/src/phy62xx/Make.defs
+++ b/arch/arm/src/phy62xx/Make.defs
@@ -33,7 +33,7 @@ CMN_CSRCS += arm_systemreset.c arm_unblocktask.c arm_usestack.c arm_doirq.c
 #CMN_CSRCS += arm_hardfault.c arm_svcall.c arm_vectors.c arm_vfork.c
 CMN_CSRCS += phy62xx_hardfault.c arm_svcall.c arm_vectors.c arm_vfork.c
 #CMN_CSRCS += arm_etherstub.c
-CMN_CSRCS += arm_switchcontext.c
+CMN_CSRCS += arm_switchcontext.c arm_tcbinfo.c
 
 ifeq ($(CONFIG_BUILD_PROTECTED),y)
 CMN_CSRCS += arm_task_start.c arm_pthread_start.c

--- a/arch/arm/src/rp2040/Make.defs
+++ b/arch/arm/src/rp2040/Make.defs
@@ -29,7 +29,7 @@ CMN_CSRCS += arm_releasepending.c arm_releasestack.c arm_reprioritizertr.c
 CMN_CSRCS += arm_schedulesigaction.c arm_sigdeliver.c arm_stackframe.c
 CMN_CSRCS += arm_systemreset.c arm_unblocktask.c arm_usestack.c arm_doirq.c
 CMN_CSRCS += arm_hardfault.c arm_svcall.c arm_vectors.c arm_vfork.c
-CMN_CSRCS += arm_switchcontext.c arm_puts.c
+CMN_CSRCS += arm_switchcontext.c arm_puts.c arm_tcbinfo.c
 
 ifeq ($(CONFIG_ARCH_RAMVECTORS),y)
 CMN_CSRCS += arm_ramvec_initialize.c arm_ramvec_attach.c

--- a/arch/arm/src/rtl8720c/Make.defs
+++ b/arch/arm/src/rtl8720c/Make.defs
@@ -42,7 +42,7 @@ CMN_CSRCS += arm_itm_syslog.c arm_memfault.c arm_mpu.c arm_ramvec_attach.c
 CMN_CSRCS += arm_ramvec_initialize.c arm_releasepending.c arm_reprioritizertr.c
 CMN_CSRCS += arm_schedulesigaction.c arm_sigdeliver.c arm_signal_dispatch.c
 CMN_CSRCS += arm_stackcheck.c arm_svcall.c arm_systick.c arm_unblocktask.c
-CMN_CSRCS += arm_switchcontext.c
+CMN_CSRCS += arm_switchcontext.c arm_tcbinfo.c
 
 # arch/arm/src/rtl8720c
 #

--- a/arch/arm/src/s32k1xx/Make.defs
+++ b/arch/arm/src/s32k1xx/Make.defs
@@ -24,6 +24,7 @@ CMN_CSRCS  = arm_allocateheap.c arm_exit.c arm_initialize.c arm_interruptcontext
 CMN_CSRCS += arm_lowputs.c arm_mdelay.c arm_modifyreg8.c arm_modifyreg16.c
 CMN_CSRCS += arm_modifyreg32.c arm_puts.c arm_releasestack.c arm_stackframe.c
 CMN_CSRCS += arm_task_start.c arm_udelay.c arm_usestack.c arm_vfork.c
+CMN_CSRCS += arm_tcbinfo.c
 
 ifeq ($(CONFIG_STACK_COLORATION),y)
 CMN_CSRCS += arm_checkstack.c

--- a/arch/arm/src/sam34/Make.defs
+++ b/arch/arm/src/sam34/Make.defs
@@ -33,6 +33,7 @@ CMN_CSRCS += arm_releasepending.c arm_releasestack.c arm_reprioritizertr.c
 CMN_CSRCS += arm_schedulesigaction.c arm_sigdeliver.c arm_stackframe.c
 CMN_CSRCS += arm_svcall.c arm_trigger_irq.c arm_unblocktask.c arm_udelay.c
 CMN_CSRCS += arm_usestack.c arm_vfork.c arm_switchcontext.c arm_puts.c
+CMN_CSRCS += arm_tcbinfo.c
 
 ifneq ($(CONFIG_SMP),y)
 ifneq ($(CONFIG_ARCH_IDLE_CUSTOM),y)

--- a/arch/arm/src/sama5/Make.defs
+++ b/arch/arm/src/sama5/Make.defs
@@ -61,7 +61,7 @@ CMN_CSRCS += arm_assert.c arm_blocktask.c arm_copyfullstate.c arm_dataabort.c
 CMN_CSRCS += arm_doirq.c arm_initialstate.c arm_mmu.c arm_prefetchabort.c
 CMN_CSRCS += arm_releasepending.c arm_reprioritizertr.c
 CMN_CSRCS += arm_schedulesigaction.c arm_sigdeliver.c arm_syscall.c
-CMN_CSRCS += arm_unblocktask.c arm_undefinedinsn.c
+CMN_CSRCS += arm_unblocktask.c arm_undefinedinsn.c arm_tcbinfo.c
 
 # Configuration dependent C files
 

--- a/arch/arm/src/samd2l2/Make.defs
+++ b/arch/arm/src/samd2l2/Make.defs
@@ -29,7 +29,7 @@ CMN_CSRCS += arm_releasepending.c arm_releasestack.c arm_reprioritizertr.c
 CMN_CSRCS += arm_schedulesigaction.c arm_sigdeliver.c arm_stackframe.c
 CMN_CSRCS += arm_systemreset.c arm_unblocktask.c arm_usestack.c arm_doirq.c
 CMN_CSRCS += arm_hardfault.c arm_svcall.c arm_vectors.c arm_vfork.c
-CMN_CSRCS += arm_switchcontext.c arm_puts.c
+CMN_CSRCS += arm_switchcontext.c arm_puts.c arm_tcbinfo.c
 
 ifeq ($(CONFIG_BUILD_PROTECTED),y)
 CMN_CSRCS += arm_task_start.c arm_pthread_start.c

--- a/arch/arm/src/samd5e5/Make.defs
+++ b/arch/arm/src/samd5e5/Make.defs
@@ -33,6 +33,7 @@ CMN_CSRCS += arm_releasestack.c arm_reprioritizertr.c arm_schedulesigaction.c
 CMN_CSRCS += arm_sigdeliver.c arm_stackframe.c arm_svcall.c arm_trigger_irq.c
 CMN_CSRCS += arm_unblocktask.c arm_udelay.c arm_usestack.c arm_doirq.c
 CMN_CSRCS += arm_hardfault.c arm_vfork.c arm_switchcontext.c arm_puts.c
+CMN_CSRCS += arm_tcbinfo.c
 
 # Configuration-dependent common files
 

--- a/arch/arm/src/samv7/Make.defs
+++ b/arch/arm/src/samv7/Make.defs
@@ -34,6 +34,7 @@ CMN_CSRCS += arm_releasepending.c arm_releasestack.c arm_reprioritizertr.c
 CMN_CSRCS += arm_schedulesigaction.c arm_sigdeliver.c arm_stackframe.c
 CMN_CSRCS += arm_svcall.c arm_trigger_irq.c arm_unblocktask.c arm_usestack.c
 CMN_CSRCS += arm_doirq.c arm_vfork.c arm_switchcontext.c arm_puts.c
+CMN_CSRCS += arm_tcbinfo.c
 
 # Configuration-dependent common files
 

--- a/arch/arm/src/stm32/Make.defs
+++ b/arch/arm/src/stm32/Make.defs
@@ -29,6 +29,7 @@ CMN_CSRCS += arm_releasestack.c arm_reprioritizertr.c arm_schedulesigaction.c
 CMN_CSRCS += arm_sigdeliver.c arm_stackframe.c arm_svcall.c arm_systemreset.c
 CMN_CSRCS += arm_trigger_irq.c arm_unblocktask.c arm_udelay.c arm_usestack.c
 CMN_CSRCS += arm_doirq.c arm_vfork.c arm_switchcontext.c arm_puts.c
+CMN_CSRCS += arm_tcbinfo.c
 
 ifeq ($(CONFIG_STM32_TICKLESS_SYSTICK),y)
 CMN_CSRCS += arm_systick.c

--- a/arch/arm/src/stm32f0l0g0/Make.defs
+++ b/arch/arm/src/stm32f0l0g0/Make.defs
@@ -29,7 +29,7 @@ CMN_CSRCS += arm_releasepending.c arm_releasestack.c arm_reprioritizertr.c
 CMN_CSRCS += arm_schedulesigaction.c arm_sigdeliver.c arm_stackframe.c
 CMN_CSRCS += arm_systemreset.c arm_unblocktask.c arm_usestack.c arm_doirq.c
 CMN_CSRCS += arm_hardfault.c arm_svcall.c arm_vectors.c arm_vfork.c
-CMN_CSRCS += arm_switchcontext.c
+CMN_CSRCS += arm_switchcontext.c arm_tcbinfo.c
 
 ifeq ($(CONFIG_BUILD_PROTECTED),y)
 CMN_CSRCS += arm_task_start.c arm_pthread_start.c

--- a/arch/arm/src/stm32f7/Make.defs
+++ b/arch/arm/src/stm32f7/Make.defs
@@ -34,6 +34,7 @@ CMN_CSRCS += arm_releasepending.c arm_releasestack.c arm_reprioritizertr.c
 CMN_CSRCS += arm_schedulesigaction.c arm_sigdeliver.c arm_stackframe.c
 CMN_CSRCS += arm_svcall.c arm_systemreset.c arm_trigger_irq.c arm_unblocktask.c
 CMN_CSRCS += arm_udelay.c arm_usestack.c arm_vfork.c arm_switchcontext.c arm_puts.c
+CMN_CSRCS += arm_tcbinfo.c
 
 ifneq ($(CONFIG_ARCH_IDLE_CUSTOM),y)
 CMN_CSRCS += arm_idle.c

--- a/arch/arm/src/stm32h7/Make.defs
+++ b/arch/arm/src/stm32h7/Make.defs
@@ -34,6 +34,7 @@ CMN_CSRCS += arm_releasepending.c arm_releasestack.c arm_reprioritizertr.c
 CMN_CSRCS += arm_schedulesigaction.c arm_sigdeliver.c arm_stackframe.c arm_svcall.c
 CMN_CSRCS += arm_systemreset.c arm_trigger_irq.c arm_udelay.c arm_unblocktask.c
 CMN_CSRCS += arm_usestack.c arm_vfork.c arm_switchcontext.c arm_puts.c
+CMN_CSRCS += arm_tcbinfo.c
 
 # Configuration-dependent common files
 

--- a/arch/arm/src/stm32l4/Make.defs
+++ b/arch/arm/src/stm32l4/Make.defs
@@ -34,7 +34,7 @@ CMN_CSRCS += arm_releasepending.c arm_releasestack.c arm_reprioritizertr.c
 CMN_CSRCS += arm_schedulesigaction.c arm_sigdeliver.c arm_stackframe.c
 CMN_CSRCS += arm_svcall.c arm_systemreset.c arm_trigger_irq.c arm_udelay.c
 CMN_CSRCS += arm_unblocktask.c arm_usestack.c arm_vfork.c arm_switchcontext.c
-CMN_CSRCS += arm_puts.c
+CMN_CSRCS += arm_puts.c arm_tcbinfo.c
 
 # Configuration-dependent common files
 

--- a/arch/arm/src/stm32l5/Make.defs
+++ b/arch/arm/src/stm32l5/Make.defs
@@ -39,7 +39,7 @@ CMN_CSRCS += arm_releasepending.c arm_releasestack.c arm_reprioritizertr.c
 CMN_CSRCS += arm_schedulesigaction.c arm_sigdeliver.c arm_stackframe.c
 CMN_CSRCS += arm_svcall.c arm_systemreset.c arm_trigger_irq.c arm_udelay.c
 CMN_CSRCS += arm_unblocktask.c arm_usestack.c arm_vfork.c arm_switchcontext.c
-CMN_CSRCS += arm_puts.c
+CMN_CSRCS += arm_puts.c arm_tcbinfo.c
 
 # Configuration-dependent common files
 

--- a/arch/arm/src/str71x/Make.defs
+++ b/arch/arm/src/str71x/Make.defs
@@ -30,7 +30,7 @@ CMN_CSRCS += arm_interruptcontext.c arm_prefetchabort.c arm_releasepending.c
 CMN_CSRCS += arm_releasestack.c arm_reprioritizertr.c arm_stackframe.c
 CMN_CSRCS += arm_syscall.c arm_unblocktask.c arm_undefinedinsn.c arm_usestack.c
 CMN_CSRCS += arm_schedulesigaction.c arm_sigdeliver.c
-CMN_CSRCS += arm_lowputs.c arm_vfork.c arm_puts.c
+CMN_CSRCS += arm_lowputs.c arm_vfork.c arm_puts.c arm_tcbinfo.c
 
 ifneq ($(CONFIG_ARCH_IDLE_CUSTOM),y)
 CMN_CSRCS += arm_idle.c

--- a/arch/arm/src/tiva/Make.defs
+++ b/arch/arm/src/tiva/Make.defs
@@ -29,6 +29,7 @@ CMN_CSRCS += arm_releasepending.c arm_releasestack.c arm_reprioritizertr.c
 CMN_CSRCS += arm_schedulesigaction.c arm_sigdeliver.c arm_stackframe.c
 CMN_CSRCS += arm_svcall.c arm_trigger_irq.c arm_unblocktask.c arm_udelay.c
 CMN_CSRCS += arm_usestack.c arm_vfork.c arm_switchcontext.c arm_puts.c
+CMN_CSRCS += arm_tcbinfo.c
 
 ifeq ($(CONFIG_ARM_SEMIHOSTING_HOSTFS),y)
   CMN_CSRCS += arm_hostfs.c

--- a/arch/arm/src/tms570/Make.defs
+++ b/arch/arm/src/tms570/Make.defs
@@ -31,7 +31,7 @@ CMN_ASRCS += arm_testset.S arm_fetchadd.S vfork.S
 CMN_ASRCS += cp15_coherent_dcache.S cp15_invalidate_dcache.S
 CMN_ASRCS += cp15_clean_dcache.S cp15_flush_dcache.S
 CMN_ASRCS += cp15_clean_dcache_all.S cp15_flush_dcache_all.S
-CMN_ASRCS += cp15_invalidate_dcache_all.S cp15_cache_size.S
+CMN_ASRCS += cp15_invalidate_dcache_all.S cp15_cache_size.S arm_tcbinfo.c
 
 # Configuration dependent assembly language files
 

--- a/arch/arm/src/xmc4/Make.defs
+++ b/arch/arm/src/xmc4/Make.defs
@@ -28,7 +28,7 @@ CMN_CSRCS += arm_modifyreg8.c arm_modifyreg16.c arm_modifyreg32.c
 CMN_CSRCS += arm_releasestack.c arm_reprioritizertr.c arm_schedulesigaction.c
 CMN_CSRCS += arm_releasepending.c arm_sigdeliver.c arm_stackframe.c arm_svcall.c
 CMN_CSRCS += arm_systemreset.c arm_udelay.c arm_unblocktask.c arm_usestack.c
-CMN_CSRCS += arm_vfork.c arm_switchcontext.c arm_puts.c
+CMN_CSRCS += arm_vfork.c arm_switchcontext.c arm_puts.c arm_tcbinfo.c
 
 ifeq ($(CONFIG_ARMV7M_STACKCHECK),y)
 CMN_CSRCS += arm_stackcheck.c

--- a/arch/risc-v/src/bl602/Make.defs
+++ b/arch/risc-v/src/bl602/Make.defs
@@ -33,7 +33,7 @@ CMN_CSRCS += riscv_interruptcontext.c riscv_modifyreg32.c riscv_puts.c riscv_mde
 CMN_CSRCS += riscv_releasepending.c riscv_reprioritizertr.c riscv_copyfullstate.c
 CMN_CSRCS += riscv_releasestack.c riscv_stackframe.c riscv_schedulesigaction.c
 CMN_CSRCS += riscv_sigdeliver.c riscv_udelay.c riscv_unblocktask.c riscv_usestack.c
-CMN_CSRCS += riscv_idle.c
+CMN_CSRCS += riscv_idle.c riscv_tcbinfo.c
 
 ifeq ($(CONFIG_SCHED_BACKTRACE),y)
 CMN_CSRCS += riscv_backtrace.c

--- a/arch/risc-v/src/c906/Make.defs
+++ b/arch/risc-v/src/c906/Make.defs
@@ -34,6 +34,7 @@ CMN_CSRCS += riscv_releasepending.c riscv_reprioritizertr.c
 CMN_CSRCS += riscv_releasestack.c riscv_stackframe.c riscv_schedulesigaction.c
 CMN_CSRCS += riscv_sigdeliver.c riscv_unblocktask.c riscv_usestack.c
 CMN_CSRCS += riscv_mdelay.c riscv_copyfullstate.c riscv_idle.c
+CMN_CSRCS += riscv_tcbinfo.c
 
 ifeq ($(CONFIG_SCHED_BACKTRACE),y)
 CMN_CSRCS += riscv_backtrace.c

--- a/arch/risc-v/src/esp32c3/Make.defs
+++ b/arch/risc-v/src/esp32c3/Make.defs
@@ -36,6 +36,7 @@ CMN_CSRCS += riscv_interruptcontext.c riscv_modifyreg32.c riscv_puts.c riscv_mde
 CMN_CSRCS += riscv_releasepending.c riscv_reprioritizertr.c riscv_copyfullstate.c
 CMN_CSRCS += riscv_releasestack.c riscv_stackframe.c riscv_schedulesigaction.c
 CMN_CSRCS += riscv_sigdeliver.c riscv_udelay.c riscv_unblocktask.c riscv_usestack.c
+CMN_CSRCS += riscv_tcbinfo.c
 
 ifeq ($(CONFIG_SCHED_BACKTRACE),y)
 CMN_CSRCS += riscv_backtrace.c

--- a/arch/risc-v/src/fe310/Make.defs
+++ b/arch/risc-v/src/fe310/Make.defs
@@ -33,7 +33,7 @@ CMN_CSRCS += riscv_interruptcontext.c riscv_modifyreg32.c riscv_puts.c riscv_mde
 CMN_CSRCS += riscv_releasepending.c riscv_reprioritizertr.c riscv_copyfullstate.c
 CMN_CSRCS += riscv_releasestack.c riscv_stackframe.c riscv_schedulesigaction.c
 CMN_CSRCS += riscv_sigdeliver.c riscv_udelay.c riscv_unblocktask.c riscv_usestack.c
-CMN_CSRCS += riscv_idle.c
+CMN_CSRCS += riscv_idle.c riscv_tcbinfo.c
 
 ifeq ($(CONFIG_SCHED_BACKTRACE),y)
 CMN_CSRCS += riscv_backtrace.c

--- a/arch/risc-v/src/k210/Make.defs
+++ b/arch/risc-v/src/k210/Make.defs
@@ -34,6 +34,7 @@ CMN_CSRCS += riscv_releasepending.c riscv_reprioritizertr.c
 CMN_CSRCS += riscv_releasestack.c riscv_stackframe.c riscv_schedulesigaction.c
 CMN_CSRCS += riscv_sigdeliver.c riscv_unblocktask.c riscv_usestack.c
 CMN_CSRCS += riscv_mdelay.c riscv_copyfullstate.c riscv_idle.c
+CMN_CSRCS += riscv_tcbinfo.c
 
 ifeq ($(CONFIG_SMP), y)
 CMN_CSRCS += riscv_cpuindex.c riscv_cpupause.c riscv_cpustart.c

--- a/arch/risc-v/src/litex/Make.defs
+++ b/arch/risc-v/src/litex/Make.defs
@@ -33,7 +33,7 @@ CMN_CSRCS += riscv_interruptcontext.c riscv_modifyreg32.c riscv_puts.c riscv_mde
 CMN_CSRCS += riscv_releasepending.c riscv_reprioritizertr.c riscv_copyfullstate.c
 CMN_CSRCS += riscv_releasestack.c riscv_stackframe.c riscv_schedulesigaction.c
 CMN_CSRCS += riscv_sigdeliver.c riscv_udelay.c riscv_unblocktask.c riscv_usestack.c
-CMN_CSRCS += riscv_idle.c
+CMN_CSRCS += riscv_idle.c riscv_tcbinfo.c
 
 ifeq ($(CONFIG_SCHED_BACKTRACE),y)
 CMN_CSRCS += riscv_backtrace.c

--- a/arch/risc-v/src/mpfs/Make.defs
+++ b/arch/risc-v/src/mpfs/Make.defs
@@ -31,7 +31,7 @@ CMN_CSRCS += riscv_releasepending.c riscv_reprioritizertr.c
 CMN_CSRCS += riscv_releasestack.c riscv_stackframe.c riscv_schedulesigaction.c
 CMN_CSRCS += riscv_sigdeliver.c riscv_unblocktask.c riscv_usestack.c
 CMN_CSRCS += riscv_mdelay.c riscv_udelay.c riscv_copyfullstate.c
-CMN_CSRCS += riscv_idle.c
+CMN_CSRCS += riscv_idle.c riscv_tcbinfo.c
 
 ifeq ($(CONFIG_SCHED_BACKTRACE),y)
 CMN_CSRCS += riscv_backtrace.c

--- a/arch/risc-v/src/qemu-rv/Make.defs
+++ b/arch/risc-v/src/qemu-rv/Make.defs
@@ -33,7 +33,7 @@ CMN_CSRCS += riscv_interruptcontext.c riscv_modifyreg32.c riscv_puts.c
 CMN_CSRCS += riscv_releasepending.c riscv_reprioritizertr.c riscv_copyfullstate.c
 CMN_CSRCS += riscv_releasestack.c riscv_stackframe.c riscv_schedulesigaction.c
 CMN_CSRCS += riscv_sigdeliver.c riscv_unblocktask.c riscv_usestack.c
-CMN_CSRCS += riscv_idle.c
+CMN_CSRCS += riscv_idle.c riscv_tcbinfo.c
 
 ifeq ($(CONFIG_SCHED_BACKTRACE),y)
 CMN_CSRCS += riscv_backtrace.c

--- a/arch/risc-v/src/rv32m1/Make.defs
+++ b/arch/risc-v/src/rv32m1/Make.defs
@@ -33,7 +33,7 @@ CMN_CSRCS += riscv_interruptcontext.c riscv_modifyreg32.c riscv_puts.c
 CMN_CSRCS += riscv_releasepending.c riscv_reprioritizertr.c riscv_copyfullstate.c
 CMN_CSRCS += riscv_releasestack.c riscv_stackframe.c riscv_schedulesigaction.c
 CMN_CSRCS += riscv_sigdeliver.c riscv_unblocktask.c riscv_usestack.c
-CMN_CSRCS += riscv_idle.c
+CMN_CSRCS += riscv_idle.c riscv_tcbinfo.c
 
 ifeq ($(CONFIG_SCHED_BACKTRACE),y)
 CMN_CSRCS += riscv_backtrace.c


### PR DESCRIPTION
## Summary
Fix build break with CONFIG_DEBUG_TCBINFO enabled.
## Impact
None
## Testing
CI and custom board
