### PR TITLE
libdsp:add the calculate of duty now

### DIFF
--- a/include/dsp.h
+++ b/include/dsp.h
@@ -134,6 +134,22 @@
 #define SVM3_BASE_VOLTAGE_GET(vbus) (vbus * SQRT3_BY_THREE_F)
 
 /****************************************************************************
+ * Name: SIGN
+ *
+ * Description:
+ *  Get sign of x
+ *
+ *  Notes:
+ *   if x>0.0:
+ *     sign of x is 1.0
+ *   if x<0.0:
+ *     sign of x is -1.0
+ *
+ ****************************************************************************/
+
+#define SIGN(x)	((x > 0.0f) ? 1.0f : -1.0f)
+
+/****************************************************************************
  * Public Types
  ****************************************************************************/
 
@@ -355,6 +371,7 @@ struct foc_data_f32_s
 
   float vdq_mag_max;         /* Maximum dq voltage magnitude */
   float vab_mod_scale;       /* Voltage alpha-beta modulation scale */
+  float duty_now;            /* Current duty */
 
   phase_angle_f32_t   angle; /* Phase angle */
 };

--- a/include/dspb16.h
+++ b/include/dspb16.h
@@ -124,6 +124,22 @@
 #define SVM3_BASE_VOLTAGE_GET_B16(vbus) (b16mulb16(vbus, SQRT3_BY_THREE_B16))
 
 /****************************************************************************
+ * Name: SIGN_B16
+ *
+ * Description:
+ *  Get sign of x
+ *
+ *  Notes:
+ *   if x>0:
+ *     sign of x is 1
+ *   if x<0:
+ *     sign of x is -1
+ *
+ ****************************************************************************/
+
+#define SIGN_B16(x) ((x > 0) ? ftob16(1.0f) : ftob16(-1.0f))
+
+/****************************************************************************
  * Public Types
  ****************************************************************************/
 
@@ -282,6 +298,7 @@ struct foc_data_b16_s
 
   b16_t vdq_mag_max;         /* Maximum dq voltage magnitude */
   b16_t vab_mod_scale;       /* Voltage alpha-beta modulation scale */
+  b16_t duty_now;            /* Current duty */
 
   phase_angle_b16_t   angle; /* Phase angle */
 };

--- a/libs/libdsp/lib_foc.c
+++ b/libs/libdsp/lib_foc.c
@@ -350,6 +350,7 @@ void foc_iabc_update(FAR struct foc_data_f32_s *foc,
 void foc_voltage_control(FAR struct foc_data_f32_s *foc,
                          FAR dq_frame_f32_t *vdq_ref)
 {
+  FAR dq_frame_f32_t  v_dq_mod;
   LIBDSP_DEBUGASSERT(foc != NULL);
 
   /* Update VDQ request */
@@ -372,6 +373,15 @@ void foc_voltage_control(FAR struct foc_data_f32_s *foc,
 
   foc->v_ab_mod.a = foc->v_ab.a * foc->vab_mod_scale;
   foc->v_ab_mod.b = foc->v_ab.b * foc->vab_mod_scale;
+
+  /* Convert alpha-beta modulation to dq modulation */
+
+  park_transform(&foc->angle, &foc->v_ab_mod, &v_dq_mod);
+
+  /* Update duty cycle now */
+
+  foc->duty_now = SIGN(foc->v_dq.q) *
+                  vector2d_mag(v_dq_mod.d, v_dq_mod.q) / SQRT3_BY_TWO_F;
 }
 
 /****************************************************************************

--- a/libs/libdsp/lib_foc_b16.c
+++ b/libs/libdsp/lib_foc_b16.c
@@ -351,6 +351,7 @@ void foc_iabc_update_b16(FAR struct foc_data_b16_s *foc,
 void foc_voltage_control_b16(FAR struct foc_data_b16_s *foc,
                              FAR dq_frame_b16_t *vdq_ref)
 {
+  dq_frame_b16_t v_dq_mod;
   LIBDSP_DEBUGASSERT(foc != NULL);
 
   /* Update VDQ request */
@@ -373,6 +374,15 @@ void foc_voltage_control_b16(FAR struct foc_data_b16_s *foc,
 
   foc->v_ab_mod.a = b16mulb16(foc->v_ab.a, foc->vab_mod_scale);
   foc->v_ab_mod.b = b16mulb16(foc->v_ab.b, foc->vab_mod_scale);
+
+  /* Convert alpha-beta modulation to dq modulation */
+
+  park_transform_b16(&foc->angle, &foc->v_ab_mod, &v_dq_mod);
+
+  /* Update duty cycle now */
+
+  foc->duty_now = SIGN_B16(foc->v_dq.q) *
+                vector2d_mag_b16(v_dq_mod.d, v_dq_mod.q) / SQRT3_BY_TWO_B16;
 }
 
 /****************************************************************************


### PR DESCRIPTION
## Summary
Add duty_now in struct foc_data_f32_s and calculate it on foc_voltage_control for sensorless observer
## Impact
Has no impact to other foc calculation
## Testing
Tested on b-g431b-esc1
