### PR TITLE
arch/sim: Always typedef xcpt_reg_t to unsigned long

### DIFF
--- a/arch/sim/include/setjmp.h
+++ b/arch/sim/include/setjmp.h
@@ -111,12 +111,7 @@
 
 #ifndef __ASSEMBLY__
 
-#if defined(CONFIG_HOST_X86_64) && !defined(CONFIG_SIM_M32)
 typedef unsigned long xcpt_reg_t;
-#else
-typedef unsigned int xcpt_reg_t;
-#endif
-
 typedef xcpt_reg_t jmp_buf[XCPTCONTEXT_REGS];
 #endif
 

--- a/arch/sim/include/types.h
+++ b/arch/sim/include/types.h
@@ -92,27 +92,6 @@ typedef __WCHAR_TYPE__     _wchar_t;
 typedef int                _wchar_t;
 #endif
 
-#if defined(CONFIG_HOST_X86_64) && !defined(CONFIG_SIM_M32)
-/* 64-bit build on 64-bit machine: A size is 8 bytes */
-
-#if defined(__SIZE_TYPE__)
-/* If __SIZE_TYPE__ is defined we define ssize_t based on size_t.
- * We simply change "unsigned" to "signed" for this single definition
- * to make sure ssize_t and size_t only differ by their signedness.
- */
-
-#define unsigned signed
-typedef __SIZE_TYPE__      _ssize_t;
-#undef unsigned
-typedef __SIZE_TYPE__      _size_t;
-#else
-typedef signed long long   _ssize_t;
-typedef unsigned long long _size_t;
-#endif
-
-#else
-/* 32-bit build on 32- or 64-bit machine: A size is 4 bytes */
-
 #if defined(__SIZE_TYPE__)
 /* If __SIZE_TYPE__ is defined we define ssize_t based on size_t.
  * We simply change "unsigned" to "signed" for this single definition
@@ -129,8 +108,6 @@ typedef unsigned long      _size_t;
 #else
 typedef signed int         _ssize_t;
 typedef unsigned int       _size_t;
-#endif
-
 #endif
 
 /* This is the size of the interrupt state save returned by

--- a/arch/sim/src/sim/up_copyfullstate.c
+++ b/arch/sim/src/sim/up_copyfullstate.c
@@ -41,11 +41,7 @@
  *
  ****************************************************************************/
 
-#if defined(CONFIG_HOST_X86_64) && !defined(CONFIG_SIM_M32)
 void up_copyfullstate(unsigned long *dest, unsigned long *src)
-#else
-void up_copyfullstate(uint32_t *dest, uint32_t *src)
-#endif
 {
   int i;
 

--- a/arch/sim/src/sim/up_internal.h
+++ b/arch/sim/src/sim/up_internal.h
@@ -125,12 +125,7 @@ extern char **g_argv;
 
 /* Context switching */
 
-#if defined(CONFIG_HOST_X86_64) && !defined(CONFIG_SIM_M32)
 void up_copyfullstate(unsigned long *dest, unsigned long *src);
-#else
-void up_copyfullstate(uint32_t *dest, uint32_t *src);
-#endif
-
 void *up_doirq(int irq, void *regs);
 
 /* up_hostmisc.c ************************************************************/

--- a/arch/sim/src/sim/up_vfork.c
+++ b/arch/sim/src/sim/up_vfork.c
@@ -93,8 +93,8 @@ pid_t up_vfork(const xcpt_reg_t *context)
   xcpt_reg_t stackutil;
 
   sinfo("vfork context [%p]:\n", context);
-  sinfo("  frame pointer:%08" PRIxPTR " sp:%08" PRIxPTR " pc:%08" PRIxPTR ""
-        "\n", context[JB_FP], context[JB_SP], context[JB_PC]);
+  sinfo("  frame pointer:%08lx sp:%08lx pc:%08lx\n",
+        context[JB_FP], context[JB_SP], context[JB_PC]);
 
   /* Allocate and initialize a TCB for the child task. */
 
@@ -118,7 +118,7 @@ pid_t up_vfork(const xcpt_reg_t *context)
   DEBUGASSERT(stacktop > context[JB_SP]);
   stackutil = stacktop - context[JB_SP];
 
-  sinfo("Parent: stackutil:%" PRIuPTR "\n", stackutil);
+  sinfo("Parent: stackutil:%lu\n", stackutil);
 
   /* Make some feeble effort to preserve the stack contents.  This is
    * feeble because the stack surely contains invalid pointers and other
@@ -144,9 +144,9 @@ pid_t up_vfork(const xcpt_reg_t *context)
       newfp = context[JB_FP];
     }
 
-  sinfo("Old stack top:%08" PRIxPTR " SP:%08" PRIxPTR " FP:%08" PRIxPTR "\n",
+  sinfo("Old stack top:%08lx SP:%08lx FP:%08lx\n",
         stacktop, context[JB_SP], context[JB_FP]);
-  sinfo("New stack top:%08" PRIxPTR " SP:%08" PRIxPTR " FP:%08" PRIxPTR "\n",
+  sinfo("New stack top:%08lx SP:%08lx FP:%08lx\n",
         newtop, newsp, newfp);
 
   /* Update the stack pointer, frame pointer, and volatile registers.  When

--- a/arch/sim/src/sim/up_vfork.c
+++ b/arch/sim/src/sim/up_vfork.c
@@ -93,7 +93,7 @@ pid_t up_vfork(const xcpt_reg_t *context)
   xcpt_reg_t stackutil;
 
   sinfo("vfork context [%p]:\n", context);
-  sinfo("  frame pointer:%08lx sp:%08lx pc:%08lx\n",
+  sinfo("  frame pointer:%lx sp:%lx pc:%lx\n",
         context[JB_FP], context[JB_SP], context[JB_PC]);
 
   /* Allocate and initialize a TCB for the child task. */
@@ -144,9 +144,9 @@ pid_t up_vfork(const xcpt_reg_t *context)
       newfp = context[JB_FP];
     }
 
-  sinfo("Old stack top:%08lx SP:%08lx FP:%08lx\n",
+  sinfo("Old stack top:%lx SP:%lx FP:%lx\n",
         stacktop, context[JB_SP], context[JB_FP]);
-  sinfo("New stack top:%08lx SP:%08lx FP:%08lx\n",
+  sinfo("New stack top:%lx SP:%lx FP:%lx\n",
         newtop, newsp, newfp);
 
   /* Update the stack pointer, frame pointer, and volatile registers.  When


### PR DESCRIPTION
## Summary
to simplify the code logic. See discussion here: #5401

## Impact
No, code refactor.

## Testing
sim:smp and sim:ostest
