### PR TITLE
libc: posix_openpty should use the absolute path("dev/ptmx")

### DIFF
--- a/libs/libc/stdlib/lib_openpty.c
+++ b/libs/libc/stdlib/lib_openpty.c
@@ -68,7 +68,7 @@
 int posix_openpt(int oflag)
 {
 #ifdef CONFIG_PSEUDOTERM_SUSV1
-  return open("dev/ptmx", oflag);
+  return open("/dev/ptmx", oflag);
 #else
   int minor;
 


### PR DESCRIPTION
## Summary
Simple change

## Impact
Minor

## Testing
local test
