### PR TITLE
risc-v: Use _ebss instead of _default_stack_limit as idle stack base

### DIFF
--- a/arch/risc-v/src/c906/c906_memorymap.h
+++ b/arch/risc-v/src/c906/c906_memorymap.h
@@ -25,6 +25,8 @@
  * Included Files
  ****************************************************************************/
 
+#include "riscv_internal.h"
+
 #include "hardware/c906_memorymap.h"
 #include "hardware/c906_uart.h"
 #include "hardware/c906_clint.h"
@@ -35,13 +37,12 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-/* Idle thread stack starts from _default_stack_limit */
+/* Idle thread stack starts from _ebss */
 
 #ifndef __ASSEMBLY__
-extern uintptr_t *_default_stack_limit;
-#define C906_IDLESTACK_BASE  (uintptr_t)&_default_stack_limit
+#define C906_IDLESTACK_BASE  (uintptr_t)&_ebss
 #else
-#define C906_IDLESTACK_BASE  _default_stack_limit
+#define C906_IDLESTACK_BASE  _ebss
 #endif
 
 #define C906_IDLESTACK0_TOP  (C906_IDLESTACK_BASE + CONFIG_IDLETHREAD_STACKSIZE)

--- a/arch/risc-v/src/fe310/fe310_memorymap.h
+++ b/arch/risc-v/src/fe310/fe310_memorymap.h
@@ -25,6 +25,8 @@
  * Included Files
  ****************************************************************************/
 
+#include "riscv_internal.h"
+
 #include "hardware/fe310_memorymap.h"
 #include "hardware/fe310_uart.h"
 #include "hardware/fe310_clint.h"
@@ -36,13 +38,12 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-/* Idle thread stack starts from _default_stack_limit */
+/* Idle thread stack starts from _ebss */
 
 #ifndef __ASSEMBLY__
-extern uintptr_t *_default_stack_limit;
-#define FE310_IDLESTACK_BASE  (uintptr_t)&_default_stack_limit
+#define FE310_IDLESTACK_BASE  (uintptr_t)&_ebss
 #else
-#define FE310_IDLESTACK_BASE  _default_stack_limit
+#define FE310_IDLESTACK_BASE  _ebss
 #endif
 
 #define FE310_IDLESTACK_TOP  (FE310_IDLESTACK_BASE + CONFIG_IDLETHREAD_STACKSIZE)

--- a/arch/risc-v/src/k210/k210_memorymap.h
+++ b/arch/risc-v/src/k210/k210_memorymap.h
@@ -25,6 +25,8 @@
  * Included Files
  ****************************************************************************/
 
+#include "riscv_internal.h"
+
 #include "hardware/k210_memorymap.h"
 #include "hardware/k210_uart.h"
 #include "hardware/k210_clint.h"
@@ -38,10 +40,9 @@
 /* Idle thread stack starts from _ebss */
 
 #ifndef __ASSEMBLY__
-extern uintptr_t *_default_stack_limit;
-#define K210_IDLESTACK_BASE  (uintptr_t)&_default_stack_limit
+#define K210_IDLESTACK_BASE  (uintptr_t)&_ebss
 #else
-#define K210_IDLESTACK_BASE  _default_stack_limit
+#define K210_IDLESTACK_BASE  _ebss
 #endif
 
 #define K210_IDLESTACK0_BASE (K210_IDLESTACK_BASE)

--- a/arch/risc-v/src/mpfs/mpfs_memorymap.h
+++ b/arch/risc-v/src/mpfs/mpfs_memorymap.h
@@ -25,6 +25,8 @@
  * Included Files
  ****************************************************************************/
 
+#include "riscv_internal.h"
+
 #include "hardware/mpfs_clint.h"
 #include "hardware/mpfs_memorymap.h"
 #include "hardware/mpfs_plic.h"
@@ -35,13 +37,12 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-/* Idle thread stack starts from _default_stack_limit */
+/* Idle thread stack starts from _ebss */
 
 #ifndef __ASSEMBLY__
-extern uintptr_t *_default_stack_limit;
-#define MPFS_IDLESTACK_BASE  (uintptr_t)&_default_stack_limit
+#define MPFS_IDLESTACK_BASE  (uintptr_t)&_ebss
 #else
-#define MPFS_IDLESTACK_BASE  _default_stack_limit
+#define MPFS_IDLESTACK_BASE  _ebss
 #endif
 
 #define MPFS_IDLESTACK_SIZE (CONFIG_IDLETHREAD_STACKSIZE & ~15)

--- a/boards/risc-v/c906/smartl-c906/scripts/ld-qemu.script
+++ b/boards/risc-v/c906/smartl-c906/scripts/ld-qemu.script
@@ -74,10 +74,8 @@ SECTIONS
         *(.gnu.linkonce.b.*)
         *(.gnu.linkonce.sb.*)
         *(COMMON)
-        . = ALIGN(4);
-        _ebss = ABSOLUTE(.);
         . = ALIGN(32);
-        _default_stack_limit = ABSOLUTE(.);
+        _ebss = ABSOLUTE(.);
     } > sram
 
     /* Stabs debugging sections. */

--- a/boards/risc-v/c906/smartl-c906/scripts/ld.script
+++ b/boards/risc-v/c906/smartl-c906/scripts/ld.script
@@ -74,10 +74,8 @@ SECTIONS
         *(.gnu.linkonce.b.*)
         *(.gnu.linkonce.sb.*)
         *(COMMON)
-        . = ALIGN(4);
-        _ebss = ABSOLUTE(.);
         . = ALIGN(32);
-        _default_stack_limit = ABSOLUTE(.);
+        _ebss = ABSOLUTE(.);
     } > sram
 
     /* Stabs debugging sections. */

--- a/boards/risc-v/fe310/hifive1-revb/scripts/ld-qemu.script
+++ b/boards/risc-v/fe310/hifive1-revb/scripts/ld-qemu.script
@@ -72,10 +72,8 @@ SECTIONS
         *(.gnu.linkonce.b.*)
         *(.gnu.linkonce.sb.*)
         *(COMMON)
-        . = ALIGN(4);
-        _ebss = ABSOLUTE(.);
         . = ALIGN(32);
-        _default_stack_limit = ABSOLUTE(.);
+        _ebss = ABSOLUTE(.);
     } > sram
 
     /* Stabs debugging sections. */

--- a/boards/risc-v/fe310/hifive1-revb/scripts/ld.script
+++ b/boards/risc-v/fe310/hifive1-revb/scripts/ld.script
@@ -72,10 +72,8 @@ SECTIONS
         *(.gnu.linkonce.b.*)
         *(.gnu.linkonce.sb.*)
         *(COMMON)
-        . = ALIGN(4);
-        _ebss = ABSOLUTE(.);
         . = ALIGN(32);
-        _default_stack_limit = ABSOLUTE(.);
+        _ebss = ABSOLUTE(.);
     } > sram
 
     /* Stabs debugging sections. */

--- a/boards/risc-v/k210/maix-bit/scripts/ld.script
+++ b/boards/risc-v/k210/maix-bit/scripts/ld.script
@@ -79,10 +79,8 @@ SECTIONS
         *(.gnu.linkonce.b.*)
         *(.gnu.linkonce.sb.*)
         *(COMMON)
-        . = ALIGN(4);
-        _ebss = ABSOLUTE(.);
         . = ALIGN(32);
-        _default_stack_limit = ABSOLUTE(.);
+        _ebss = ABSOLUTE(.);
     } > sram
 
     /* Stabs debugging sections. */

--- a/boards/risc-v/mpfs/icicle/scripts/kernel-space.ld
+++ b/boards/risc-v/mpfs/icicle/scripts/kernel-space.ld
@@ -91,14 +91,8 @@ SECTIONS
     /* Page tables here, align to 4K boundary */
     .pgtables : ALIGN(0x1000) {
         *(.pgtables)
-         . = ALIGN(4);
+         . = ALIGN(32);
         _ebss = ABSOLUTE(.);
-    } > ksram
-
-    /* Stack top */
-    .stack_top : {
-        . = ALIGN(32);
-        _default_stack_limit = ABSOLUTE(.);
     } > ksram
 
     /* Stabs debugging sections. */

--- a/boards/risc-v/mpfs/icicle/scripts/ld-envm-opensbi.script
+++ b/boards/risc-v/mpfs/icicle/scripts/ld-envm-opensbi.script
@@ -101,10 +101,8 @@ SECTIONS
         *(.gnu.linkonce.b.*)
         *(.gnu.linkonce.sb.*)
         *(COMMON)
-        . = ALIGN(4);
-        _ebss = ABSOLUTE(.);
         . = ALIGN(32);
-        _default_stack_limit = ABSOLUTE(.);
+        _ebss = ABSOLUTE(.);
     } > l2lim
 
     PROVIDE(__mpfs_nuttx_end = .);

--- a/boards/risc-v/mpfs/icicle/scripts/ld-envm.script
+++ b/boards/risc-v/mpfs/icicle/scripts/ld-envm.script
@@ -75,10 +75,8 @@ SECTIONS
         *(.gnu.linkonce.b.*)
         *(.gnu.linkonce.sb.*)
         *(COMMON)
-        . = ALIGN(4);
-        _ebss = ABSOLUTE(.);
         . = ALIGN(32);
-        _default_stack_limit = ABSOLUTE(.);
+        _ebss = ABSOLUTE(.);
     } > lim
 
     /* Stabs debugging sections. */

--- a/boards/risc-v/mpfs/icicle/scripts/ld.script
+++ b/boards/risc-v/mpfs/icicle/scripts/ld.script
@@ -74,10 +74,8 @@ SECTIONS
         *(.gnu.linkonce.b.*)
         *(.gnu.linkonce.sb.*)
         *(COMMON)
-        . = ALIGN(4);
-        _ebss = ABSOLUTE(.);
         . = ALIGN(32);
-        _default_stack_limit = ABSOLUTE(.);
+        _ebss = ABSOLUTE(.);
     } > sram
 
     /* Stabs debugging sections. */

--- a/boards/risc-v/mpfs/m100pfsevp/scripts/ld-envm.script
+++ b/boards/risc-v/mpfs/m100pfsevp/scripts/ld-envm.script
@@ -75,10 +75,8 @@ SECTIONS
         *(.gnu.linkonce.b.*)
         *(.gnu.linkonce.sb.*)
         *(COMMON)
-        . = ALIGN(4);
-        _ebss = ABSOLUTE(.);
         . = ALIGN(32);
-        _default_stack_limit = ABSOLUTE(.);
+        _ebss = ABSOLUTE(.);
     } > lim
 
     /* Stabs debugging sections. */

--- a/boards/risc-v/mpfs/m100pfsevp/scripts/ld.script
+++ b/boards/risc-v/mpfs/m100pfsevp/scripts/ld.script
@@ -74,10 +74,8 @@ SECTIONS
         *(.gnu.linkonce.b.*)
         *(.gnu.linkonce.sb.*)
         *(COMMON)
-        . = ALIGN(4);
-        _ebss = ABSOLUTE(.);
         . = ALIGN(32);
-        _default_stack_limit = ABSOLUTE(.);
+        _ebss = ABSOLUTE(.);
     } > sram
 
     /* Stabs debugging sections. */


### PR DESCRIPTION
## Summary
Unify the implementation to reduce extra symbol usage.
## Impact
Refactor only
## Testing
CI and K210
