### PR TITLE
net/can/can_setsockopt.c: fix assertion, value can be NULL

### DIFF
--- a/net/can/can_setsockopt.c
+++ b/net/can/can_setsockopt.c
@@ -76,7 +76,9 @@ int can_setsockopt(FAR struct socket *psock, int option,
   int ret = OK;
   int count = 0;
 
-  DEBUGASSERT(psock != NULL && value != NULL && psock->s_conn != NULL);
+  DEBUGASSERT(psock != NULL && psock->s_conn != NULL);
+  DEBUGASSERT(value_len == 0 || value != NULL);
+
   conn = (FAR struct can_conn_s *)psock->s_conn;
 
   if (psock->s_type != SOCK_RAW)
@@ -147,9 +149,9 @@ int can_setsockopt(FAR struct socket *psock, int option,
             return -EINVAL;
           }
 
-          conn->fd_frames = *(FAR int32_t *)value;
+        conn->fd_frames = *(FAR int32_t *)value;
 
-          break;
+        break;
 #endif
 
       case CAN_RAW_JOIN_FILTERS:


### PR DESCRIPTION
## Summary
net/can/can_setsockopt.c: fix assertion, value can be NULL

## Impact

## Testing
canutils/cansend with CAN FD frames
