### PR TITLE
stm32/fdcan: add CAN FD frames support

### DIFF
--- a/arch/arm/src/stm32/Kconfig
+++ b/arch/arm/src/stm32/Kconfig
@@ -10918,6 +10918,7 @@ config STM32_FDCAN_CHARDRIVER
 config STM32_FDCAN_SOCKET
 	bool "STM32 FDCAN SocketCAN support"
 	select NET_CAN_HAVE_ERRORS
+	select NET_CAN_HAVE_CANFD
 
 endchoice # FDCAN character driver or SocketCAN support
 

--- a/arch/arm/src/stm32/stm32_fdcan.c
+++ b/arch/arm/src/stm32/stm32_fdcan.c
@@ -2354,37 +2354,40 @@ static int fdcan_send(FAR struct can_dev_s *dev, FAR struct can_msg_s *msg)
    *   Transfer message ID (ID)          - Value from message structure
    *   Remote Transmission Request (RTR) - Value from message structure
    *   Extended Identifier (XTD)         - Depends on configuration.
+   *   Error state indicator (ESI)       - ESI bit in CAN FD
+   *
+   * Format word T1:
+   *   Data Length Code (DLC)            - Value from message structure
+   *   Bit Rate Switch (BRS)             - Bit rate switching for CAN FD
+   *   FD format (FDF)                   - Frame transmited in CAN FD format
+   *   Event FIFO Control (EFC)          - Do not store events.
+   *   Message Marker (MM)               - Always zero
    */
+
+  txbuffer[0] = 0;
+  txbuffer[1] = 0;
 
 #ifdef CONFIG_CAN_EXTID
   if (msg->cm_hdr.ch_extid)
     {
       DEBUGASSERT(msg->cm_hdr.ch_id <= CAN_MAX_EXTMSGID);
 
-      regval = BUFFER_R0_EXTID(msg->cm_hdr.ch_id) | BUFFER_R0_XTD;
+      txbuffer[0] |= BUFFER_R0_EXTID(msg->cm_hdr.ch_id) | BUFFER_R0_XTD;
     }
   else
 #endif
     {
       DEBUGASSERT(msg->cm_hdr.ch_id <= CAN_MAX_STDMSGID);
 
-      regval = BUFFER_R0_STDID(msg->cm_hdr.ch_id);
+      txbuffer[0] |= BUFFER_R0_STDID(msg->cm_hdr.ch_id);
     }
 
   if (msg->cm_hdr.ch_rtr)
     {
-      regval |= BUFFER_R0_RTR;
+      txbuffer[0] |= BUFFER_R0_RTR;
     }
 
-  txbuffer[0] = regval;
-
-  /* Format word T1:
-   *   Data Length Code (DLC)            - Value from message structure
-   *   Event FIFO Control (EFC)          - Do not store events.
-   *   Message Marker (MM)               - Always zero
-   */
-
-  txbuffer[1] = BUFFER_R1_DLC(msg->cm_hdr.ch_dlc);
+  txbuffer[1] |= BUFFER_R1_DLC(msg->cm_hdr.ch_dlc);
 
   /* Followed by the amount of data corresponding to the DLC (T2..) */
 
@@ -2773,16 +2776,13 @@ static void fdcan_receive(FAR struct can_dev_s *dev,
                           unsigned long nwords)
 {
   struct can_hdr_s hdr;
-  uint32_t         regval = 0;
   int              ret    = 0;
 
   fdcan_dumprxregs(dev->cd_priv, "Before receive");
 
   /* Format the CAN header */
 
-  /* Work R0 contains the CAN ID */
-
-  regval = *rxbuffer++;
+  /* Word R0 contains the CAN ID */
 
 #ifdef CONFIG_CAN_ERRORS
   hdr.ch_error  = 0;
@@ -2791,46 +2791,46 @@ static void fdcan_receive(FAR struct can_dev_s *dev,
 
   /* Extract the RTR bit */
 
-  hdr.ch_rtr = ((regval & BUFFER_R0_RTR) != 0);
+  hdr.ch_rtr = ((rxbuffer[0] & BUFFER_R0_RTR) != 0);
 
 #ifdef CONFIG_CAN_EXTID
-  if ((regval & BUFFER_R0_XTD) != 0)
+  if ((rxbuffer[0] & BUFFER_R0_XTD) != 0)
     {
       /* Save the extended ID of the newly received message */
 
-      hdr.ch_id    = (regval & BUFFER_R0_EXTID_MASK) >>
+      hdr.ch_id    = (rxbuffer[0] & BUFFER_R0_EXTID_MASK) >>
                      BUFFER_R0_EXTID_SHIFT;
       hdr.ch_extid = 1;
     }
   else
     {
-      hdr.ch_id    = (regval & BUFFER_R0_STDID_MASK) >>
+      hdr.ch_id    = (rxbuffer[0] & BUFFER_R0_STDID_MASK) >>
                      BUFFER_R0_STDID_SHIFT;
       hdr.ch_extid = 0;
     }
 
 #else
-  if ((regval & BUFFER_R0_XTD) != 0)
+  if ((rxbuffer[0] & BUFFER_R0_XTD) != 0)
     {
       /* Drop any messages with extended IDs */
+
+      canerr("ERROR: Received message with extended identifier.  Dropped\n");
 
       return;
     }
 
   /* Save the standard ID of the newly received message */
 
-  hdr.ch_id = (regval & BUFFER_R0_STDID_MASK) >> BUFFER_R0_STDID_SHIFT;
+  hdr.ch_id = (rxbuffer[0] & BUFFER_R0_STDID_MASK) >> BUFFER_R0_STDID_SHIFT;
 #endif
 
   /* Word R1 contains the DLC and timestamp */
 
-  regval = *rxbuffer++;
-
-  hdr.ch_dlc = (regval & BUFFER_R1_DLC_MASK) >> BUFFER_R1_DLC_SHIFT;
+  hdr.ch_dlc = (rxbuffer[1] & BUFFER_R1_DLC_MASK) >> BUFFER_R1_DLC_SHIFT;
 
   /* And provide the CAN message to the upper half logic */
 
-  ret = can_receive(dev, &hdr, (FAR uint8_t *)rxbuffer);
+  ret = can_receive(dev, &hdr, (FAR uint8_t *)&rxbuffer[2]);
   if (ret < 0)
     {
       canerr("ERROR: can_receive failed: %d\n", ret);

--- a/net/can/can_recvmsg.c
+++ b/net/can/can_recvmsg.c
@@ -410,7 +410,7 @@ static uint16_t can_recvfrom_eventhandler(FAR struct net_driver_s *dev,
                                           FAR void *pvpriv, uint16_t flags)
 {
   struct can_recvfrom_s *pstate = (struct can_recvfrom_s *)pvpriv;
-#if defined(CONFIG_NET_CANPROTO_OPTIONS) || defined(CONFIG_NET_CAN_CANFD) || \
+#if (defined(CONFIG_NET_CANPROTO_OPTIONS) && defined(CONFIG_NET_CAN_CANFD)) || \
   defined(CONFIG_NET_TIMESTAMP)
   struct can_conn_s *conn = (struct can_conn_s *)pstate->pr_sock->s_conn;
 #endif


### PR DESCRIPTION
## Summary

- stm32/fdcan: use array indexes when accessing RX/TX FIFO
- stm32/fdcan: add CAN FD frames support
- net/can/can_recvmsg.c: fix unused variable 'conn' error

## Impact

## Testing
nucleo-g431rb and b-g431b-esc1 in various configurations (socketCAN + char driver, CAN FD + CAN 2.0)
