### PR TITLE
boards: sabre-6quad: Add -fno-common to Make.defs

### DIFF
--- a/arch/arm/src/rtl8720c/Toolchain.defs
+++ b/arch/arm/src/rtl8720c/Toolchain.defs
@@ -50,8 +50,8 @@ ifneq ($(CONFIG_ARMV8M_STACKCHECK),y)
 endif
 endif
 
-ARCHCFLAGS = -fno-builtin -march=armv8-m.main+dsp -mthumb -mfloat-abi=soft -D__thumb2__ -g -gdwarf-3 -Os  -fno-tree-scev-cprop
-ARCHCXXFLAGS = -fno-builtin -nostdinc++ -std=c++11
+ARCHCFLAGS = -fno-common -fno-builtin -march=armv8-m.main+dsp -mthumb -mfloat-abi=soft -D__thumb2__ -g -gdwarf-3 -Os  -fno-tree-scev-cprop
+ARCHCXXFLAGS = -fno-common -fno-builtin -nostdinc++ -std=c++11
 ifneq ($(CONFIG_CXX_EXCEPTION),y)
   ARCHCXXFLAGS += -fno-exceptions -fcheck-new -fno-rtti
 endif
@@ -66,15 +66,15 @@ AFLAGS := $(CFLAGS) -D__ASSEMBLY__
 
 # ELF module definitions
 
-CELFFLAGS = $(CFLAGS) -mlong-calls -fno-common
-CXXELFFLAGS = $(CXXFLAGS) -mlong-calls -fno-common
+CELFFLAGS = $(CFLAGS) -mlong-calls
+CXXELFFLAGS = $(CXXFLAGS) -mlong-calls
 AELFFLAGS = $(AFLAGS)
 LDELFFLAGS = -r -e main -Bstatic $(LDFLAGS)
 LDELFFLAGS += -T $(TOPDIR)/binfmt/libelf/gnu-elf.ld
 
 # Loadable module definitions
 
-CMODULEFLAGS = $(CFLAGS) -mlong-calls -fno-common
+CMODULEFLAGS = $(CFLAGS) -mlong-calls
 
 LDMODULEFLAGS = -r -e module_initialize $(LDFLAGS)
 ifeq ($(WINTOOL),y)

--- a/boards/arm/imx6/sabre-6quad/scripts/Make.defs
+++ b/boards/arm/imx6/sabre-6quad/scripts/Make.defs
@@ -39,8 +39,8 @@ ifneq ($(CONFIG_DEBUG_NOOPT),y)
 endif
 
 ARCHCPUFLAGS = -mcpu=cortex-a9 -mfpu=vfpv4-d16
-ARCHCFLAGS = -fno-builtin -ffunction-sections -fdata-sections
-ARCHCXXFLAGS = -fno-builtin -fno-exceptions -fcheck-new -fno-rtti
+ARCHCFLAGS = -fno-common -fno-builtin -ffunction-sections -fdata-sections
+ARCHCXXFLAGS = -fno-common -fno-builtin -fno-exceptions -fcheck-new -fno-rtti
 ARCHWARNINGS = -Wall -Wstrict-prototypes -Wshadow -Wundef
 ARCHWARNINGSXX = -Wall -Wshadow -Wundef
 ARCHPICFLAGS = -fpic -msingle-pic-base -mpic-register=r10

--- a/boards/arm/sama5/sama5d4-ek/configs/knsh/Make.defs
+++ b/boards/arm/sama5/sama5d4-ek/configs/knsh/Make.defs
@@ -49,14 +49,11 @@ ifneq ($(CONFIG_DEBUG_NOOPT),y)
 endif
 
 ARCHCPUFLAGS = -mcpu=cortex-a5 -mfpu=vfpv4-d16
-ARCHCFLAGS = -fno-builtin
-ARCHCXXFLAGS = -fno-builtin -fno-exceptions -fcheck-new -fno-rtti
+ARCHCFLAGS = -fno-common -fno-builtin
+ARCHCXXFLAGS = -fno-common -fno-builtin -fno-exceptions -fcheck-new -fno-rtti
 ARCHWARNINGS = -Wall -Wstrict-prototypes -Wshadow -Wundef
 ARCHWARNINGSXX = -Wall -Wshadow -Wundef
 ARCHPICFLAGS = -fpic -msingle-pic-base -mpic-register=r10
-
-ARCHCFLAGS += -fno-common
-ARCHCXXFLAGS += -fno-common
 
 CFLAGS := $(ARCHCFLAGS) $(ARCHWARNINGS) $(ARCHOPTIMIZATION) $(ARCHCPUFLAGS) $(ARCHINCLUDES) $(ARCHDEFINES) $(EXTRAFLAGS) -pipe
 CPICFLAGS = $(ARCHPICFLAGS) $(CFLAGS)

--- a/boards/risc-v/bl602/bl602evb/scripts/Make.defs
+++ b/boards/risc-v/bl602/bl602evb/scripts/Make.defs
@@ -45,8 +45,8 @@ ifneq ($(CONFIG_DEBUG_NOOPT),y)
 endif
 
 ARCHCPUFLAGS += -mno-relax
-ARCHCFLAGS = -fno-builtin -ffunction-sections -fdata-sections
-ARCHCXXFLAGS = -fno-builtin -ffunction-sections -fdata-sections -fno-exceptions -fcheck-new -std=c++17 -D__NuttX__ -pipe -nostdinc++
+ARCHCFLAGS = -fno-common -fno-builtin -ffunction-sections -fdata-sections
+ARCHCXXFLAGS = -fno-common -fno-builtin -ffunction-sections -fdata-sections -fno-exceptions -fcheck-new -std=c++17 -D__NuttX__ -pipe -nostdinc++
 ARCHWARNINGS = -Wall -Wstrict-prototypes -Wshadow -Wundef
 ARCHWARNINGSXX = -Wall -Wshadow -Wundef
 ARCHPICFLAGS = -fpic -msingle-pic-base -mpic-register=r10
@@ -66,8 +66,8 @@ AFLAGS += $(CFLAGS) -D__ASSEMBLY__ $(ASARCHCPUFLAGS)
 
 # ELF module definitions
 
-CELFFLAGS = $(CFLAGS) -fno-common
-CXXELFFLAGS = $(CXXFLAGS) -fno-common
+CELFFLAGS = $(CFLAGS)
+CXXELFFLAGS = $(CXXFLAGS)
 
 LDELFFLAGS = -melf32lriscv -r -e main
 ifeq ($(CONFIG_CYGWIN_WINTOOL),y)

--- a/boards/risc-v/c906/smartl-c906/scripts/Make.defs
+++ b/boards/risc-v/c906/smartl-c906/scripts/Make.defs
@@ -52,8 +52,8 @@ endif
 
 ARCHCPUFLAGS += -mcmodel=medany
 
-ARCHCFLAGS = -fno-builtin -ffunction-sections -fdata-sections
-ARCHCXXFLAGS = -fno-builtin -fno-exceptions -fcheck-new -fno-rtti
+ARCHCFLAGS = -fno-common -fno-builtin -ffunction-sections -fdata-sections
+ARCHCXXFLAGS = -fno-common -fno-builtin -fno-exceptions -fcheck-new -fno-rtti
 ARCHWARNINGS = -Wall -Wstrict-prototypes -Wshadow -Wundef
 ARCHWARNINGSXX = -Wall -Wshadow -Wundef
 
@@ -77,8 +77,8 @@ endif
 
 # ELF module definitions
 
-CELFFLAGS = $(CFLAGS) -fno-common
-CXXELFFLAGS = $(CXXFLAGS) -fno-common
+CELFFLAGS = $(CFLAGS)
+CXXELFFLAGS = $(CXXFLAGS)
 
 LDELFFLAGS = -r -e main
 ifeq ($(CONFIG_CYGWIN_WINTOOL),y)

--- a/boards/risc-v/mpfs/icicle/scripts/Make.defs
+++ b/boards/risc-v/mpfs/icicle/scripts/Make.defs
@@ -69,8 +69,8 @@ endif
 
 ARCHCPUFLAGS += -mcmodel=medany
 
-ARCHCFLAGS = -fno-builtin -ffunction-sections -fdata-sections
-ARCHCXXFLAGS = -fno-builtin -fno-exceptions -fcheck-new -fno-rtti
+ARCHCFLAGS = -fno-common -fno-builtin -ffunction-sections -fdata-sections
+ARCHCXXFLAGS = -fno-common -fno-builtin -fno-exceptions -fcheck-new -fno-rtti
 ARCHWARNINGS = -Wall -Wstrict-prototypes -Wshadow -Wundef
 ARCHWARNINGSXX = -Wall -Wshadow -Wundef
 
@@ -94,8 +94,8 @@ endif
 
 # ELF module definitions
 
-CELFFLAGS = $(CFLAGS) -fno-common
-CXXELFFLAGS = $(CXXFLAGS) -fno-common
+CELFFLAGS = $(CFLAGS)
+CXXELFFLAGS = $(CXXFLAGS)
 
 LDELFFLAGS = -r -e main
 ifeq ($(CONFIG_CYGWIN_WINTOOL),y)

--- a/boards/risc-v/mpfs/m100pfsevp/scripts/Make.defs
+++ b/boards/risc-v/mpfs/m100pfsevp/scripts/Make.defs
@@ -52,8 +52,8 @@ endif
 
 ARCHCPUFLAGS += -mcmodel=medany
 
-ARCHCFLAGS = -fno-builtin -ffunction-sections -fdata-sections
-ARCHCXXFLAGS = -fno-builtin -fno-exceptions -fcheck-new -fno-rtti
+ARCHCFLAGS = -fno-common -fno-builtin -ffunction-sections -fdata-sections
+ARCHCXXFLAGS = -fno-common -fno-builtin -fno-exceptions -fcheck-new -fno-rtti
 ARCHWARNINGS = -Wall -Wstrict-prototypes -Wshadow -Wundef
 ARCHWARNINGSXX = -Wall -Wshadow -Wundef
 
@@ -77,8 +77,8 @@ endif
 
 # ELF module definitions
 
-CELFFLAGS = $(CFLAGS) -fno-common
-CXXELFFLAGS = $(CXXFLAGS) -fno-common
+CELFFLAGS = $(CFLAGS)
+CXXELFFLAGS = $(CXXFLAGS)
 
 LDELFFLAGS = -r -e main
 ifeq ($(CONFIG_CYGWIN_WINTOOL),y)


### PR DESCRIPTION
## Summary

- I noticed that the following error happened when loading the init
  'elf_symvalue: SHN_COMMON: Re-compile with -fno-common'
- This commit fixes this issue

## Impact

- sabre-6quad only

## Testing

- Tested with sabre-6quad:netknsh (not merged yet)
