### PR TITLE
binfmt: Decouple builtin from binfs file system

### DIFF
--- a/Documentation/reference/user/13_boardctl.rst
+++ b/Documentation/reference/user/13_boardctl.rst
@@ -171,8 +171,7 @@ Symbol Handling
    
    :configuration: This command is always available when
      CONFIG_BUILTIN is enabled, but does nothing unless
-     CONFIG_BUILD_PROTECTED and CONFIG_FS_BINFS are also
-     selected.
+     CONFIG_BUILD_PROTECTED is also selected.
      
 USB
 ---

--- a/binfmt/binfmt.h
+++ b/binfmt/binfmt.h
@@ -131,7 +131,7 @@ void binfmt_freeargv(FAR char * const *argv);
  *
  ****************************************************************************/
 
-#ifdef CONFIG_FS_BINFS
+#ifdef CONFIG_BUILTIN
 int builtin_initialize(void);
 #endif
 
@@ -146,7 +146,7 @@ int builtin_initialize(void);
  *
  ****************************************************************************/
 
-#ifdef CONFIG_FS_BINFS
+#ifdef CONFIG_BUILTIN
 void builtin_uninitialize(void);
 #endif
 

--- a/binfmt/binfmt_initialize.c
+++ b/binfmt/binfmt_initialize.c
@@ -51,7 +51,7 @@ void binfmt_initialize(void)
 {
   int ret;
 
-#ifdef CONFIG_FS_BINFS
+#ifdef CONFIG_BUILTIN
   ret = builtin_initialize();
   if (ret < 0)
     {

--- a/binfmt/builtin.c
+++ b/binfmt/builtin.c
@@ -24,21 +24,15 @@
 
 #include <nuttx/config.h>
 
-#include <sys/types.h>
-#include <sys/ioctl.h>
-
 #include <stdint.h>
 #include <string.h>
-#include <fcntl.h>
 #include <debug.h>
 #include <errno.h>
 
-#include <nuttx/fs/fs.h>
-#include <nuttx/fs/ioctl.h>
 #include <nuttx/binfmt/binfmt.h>
 #include <nuttx/lib/builtin.h>
 
-#ifdef CONFIG_FS_BINFS
+#ifdef CONFIG_BUILTIN
 
 /****************************************************************************
  * Private Function Prototypes
@@ -79,20 +73,9 @@ static int builtin_loadbinary(FAR struct binary_s *binp,
 {
   FAR const struct builtin_s *builtin;
   FAR char *name;
-  struct file file;
   int index;
-  int ret;
 
   binfo("Loading file: %s\n", filename);
-
-  /* Open the binary file for reading (only) */
-
-  ret = file_open(&file, filename, O_RDONLY);
-  if (ret < 0)
-    {
-      berr("ERROR: Failed to open binary %s: %d\n", filename, ret);
-      return ret;
-    }
 
   name = strrchr(filename, '/');
   if (name != NULL)
@@ -106,7 +89,6 @@ static int builtin_loadbinary(FAR struct binary_s *binp,
   if (index < 0)
     {
       berr("ERROR: %s is not a builtin application\n", filename);
-      file_close(&file);
       return index;
     }
 
@@ -118,7 +100,6 @@ static int builtin_loadbinary(FAR struct binary_s *binp,
   binp->entrypt   = builtin->main;
   binp->stacksize = builtin->stacksize;
   binp->priority  = builtin->priority;
-  file_close(&file);
   return OK;
 }
 
@@ -173,4 +154,4 @@ void builtin_uninitialize(void)
   unregister_binfmt(&g_builtin_binfmt);
 }
 
-#endif /* CONFIG_FS_BINFS */
+#endif /* CONFIG_BUILTIN */

--- a/boards/boardctl.c
+++ b/boards/boardctl.c
@@ -54,7 +54,7 @@
 #  include <nuttx/spinlock.h>
 #endif
 
-#if defined(CONFIG_BUILD_PROTECTED) && defined(CONFIG_FS_BINFS)
+#if defined(CONFIG_BUILD_PROTECTED) && defined(CONFIG_BUILTIN)
 #  include <nuttx/lib/builtin.h>
 #endif
 
@@ -592,13 +592,13 @@ int boardctl(unsigned int cmd, uintptr_t arg)
        * ARG:           A pointer to an instance of struct boardioc_builtin_s
        * CONFIGURATION: This BOARDIOC command is always available when
        *                CONFIG_BUILTIN is enabled, but does nothing unless
-       *                CONFIG_BUILD_KERNEL and CONFIG_FS_BINFS are selected.
+       *                CONFIG_BUILD_KERNEL is selected.
        * DEPENDENCIES:  None
        */
 
       case BOARDIOC_BUILTINS:
         {
-#if defined(CONFIG_BUILD_PROTECTED) && defined(CONFIG_FS_BINFS)
+#if defined(CONFIG_BUILD_PROTECTED)
           FAR const struct boardioc_builtin_s *builtin =
             (FAR const struct boardioc_builtin_s *)arg;
 

--- a/include/nuttx/lib/builtin.h
+++ b/include/nuttx/lib/builtin.h
@@ -54,8 +54,7 @@ extern "C"
 #define EXTERN extern
 #endif
 
-#if defined(CONFIG_BUILD_PROTECTED) && defined(CONFIG_FS_BINFS) && \
-    defined(__KERNEL__)
+#if defined(CONFIG_BUILD_PROTECTED) && defined(__KERNEL__)
 /* In the PROTECTED build, the builtin arrays are only needed by BINFS.
  * in this case, the user-space globals are not accessible and must be
  * provided to the OS via the boardctl(BOARDIOC_BUILTINS) call.  In this
@@ -108,8 +107,7 @@ EXTERN const int g_builtin_count;
  *
  ****************************************************************************/
 
-#if defined(CONFIG_BUILD_PROTECTED) && defined(CONFIG_FS_BINFS) && \
-    defined(__KERNEL__)
+#if defined(CONFIG_BUILD_PROTECTED) && defined(__KERNEL__)
 void builtin_setlist(FAR const struct builtin_s *builtins, int count);
 #endif
 

--- a/include/sys/boardctl.h
+++ b/include/sys/boardctl.h
@@ -134,8 +134,7 @@
  * ARG:           A pointer to an instance of struct boardioc_builtin_s
  * CONFIGURATION: This BOARDIOC command is always available when
  *                CONFIG_BUILTIN is enabled, but does nothing unless
- *                CONFIG_BUILD_PROTECTED and CONFIG_FS_BINFS are also
- *                selected.
+ *                CONFIG_BUILD_PROTECTED is also selected.
  * DEPENDENCIES:  None
  *
  * CMD:           BOARDIOC_USBDEV_CONTROL

--- a/libs/libc/builtin/lib_builtin_setlist.c
+++ b/libs/libc/builtin/lib_builtin_setlist.c
@@ -26,8 +26,7 @@
 
 #include <nuttx/lib/builtin.h>
 
-#if defined(CONFIG_BUILD_PROTECTED) && defined(CONFIG_FS_BINFS) && \
-    defined(__KERNEL__)
+#if defined(CONFIG_BUILD_PROTECTED) && defined(__KERNEL__)
 
 /****************************************************************************
  * Public Functions
@@ -71,4 +70,4 @@ void builtin_setlist(FAR const struct builtin_s *builtins, int count)
   g_builtin_count = count;
 }
 
-#endif /* CONFIG_BUILD_PROTECTED && CONFIG_FS_BINFS && __KERNEL__ */
+#endif /* CONFIG_BUILD_PROTECTED && __KERNEL__ */


### PR DESCRIPTION
## Summary

## Impact
Reduce builtin binfmt dependence

## Testing
adb shell work without binfs
