### PR TITLE
arm/backtrace: fix the compile warning

### DIFF
--- a/arch/arm/src/common/arm_backtrace_thumb.c
+++ b/arch/arm/src/common/arm_backtrace_thumb.c
@@ -326,7 +326,7 @@ static int backtrace_push(FAR void *limit, FAR void **sp, FAR void *pc,
       return 0;
     }
 
-  pc = (uintptr_t)pc & 0xfffffffe;
+  pc = (FAR void *)((uintptr_t)pc & 0xfffffffe);
 
   if ((*skip)-- <= 0)
     {
@@ -376,7 +376,7 @@ static int backtrace_branch(FAR void *limit, FAR void *sp,
   for (i = 0; i < size && sp < limit; sp += sizeof(uint32_t))
     {
       addr = *(FAR uint32_t *)sp;
-      if (!in_code_region(addr))
+      if (!in_code_region((FAR void *)addr))
         {
           continue;
         }
@@ -387,7 +387,7 @@ static int backtrace_branch(FAR void *limit, FAR void *sp,
         {
           if ((*skip)-- <= 0)
             {
-              buffer[i++] = addr;
+              buffer[i++] = (FAR void *)addr;
             }
         }
 
@@ -406,7 +406,7 @@ static int backtrace_branch(FAR void *limit, FAR void *sp,
             {
               if ((*skip)-- <= 0)
                 {
-                  buffer[i++] = addr;
+                  buffer[i++] = (FAR void *)addr;
                 }
             }
         }
@@ -551,7 +551,7 @@ int up_backtrace(FAR struct tcb_s *tcb,
 
       flags = enter_critical_section();
 
-      buffer[ret++] = tcb->xcp.regs[REG_PC];
+      buffer[ret++] = (FAR void *)tcb->xcp.regs[REG_PC];
 
       if (ret < size)
         {


### PR DESCRIPTION
## Summary

arm/backtrace: fix the compile warning

## Impact

N/A

## Testing

ci check