### PR TITLE
risc-v: Let g_cpu_basestack determined at compile time

### DIFF
--- a/arch/risc-v/src/common/riscv_cpuidlestack.c
+++ b/arch/risc-v/src/common/riscv_cpuidlestack.c
@@ -83,7 +83,7 @@ static uint8_t aligned_data(16) cpu7_idlestack[CONFIG_IDLETHREAD_STACKSIZE];
  * Public Data
  ****************************************************************************/
 
-uint8_t *g_cpu_basestack[CONFIG_SMP_NCPUS] =
+const uint8_t * const g_cpu_basestack[CONFIG_SMP_NCPUS] =
 {
     (uint8_t *)&_ebss,
 #if CONFIG_SMP_NCPUS > 1

--- a/arch/risc-v/src/common/riscv_internal.h
+++ b/arch/risc-v/src/common/riscv_internal.h
@@ -117,7 +117,7 @@ EXTERN uintptr_t g_idle_topstack;
 
 /* Address of per-cpu idle stack base */
 
-EXTERN uint8_t *g_cpu_basestack[CONFIG_SMP_NCPUS];
+EXTERN const uint8_t * const g_cpu_basestack[CONFIG_SMP_NCPUS];
 
 /* Address of the saved user stack pointer */
 

--- a/arch/risc-v/src/k210/k210_head.S
+++ b/arch/risc-v/src/k210/k210_head.S
@@ -53,6 +53,13 @@ __start:
   j    2f
 1:
 
+  /* In case of single CPU config, stop here */
+
+#if !defined(CONFIG_SMP) || (CONFIG_SMP_NCPUS == 1)
+  csrw mie, zero
+  wfi
+#endif
+
   /* To get g_cpu_basestack[mhartid], must get g_cpu_basestack first */
 
   la   t0, g_cpu_basestack
@@ -71,11 +78,6 @@ __start:
   li   t0, CONFIG_IDLETHREAD_STACKSIZE
   add  sp, sp, t0
 
-  /* In case of single CPU config, stop here */
-
-#if !(defined CONFIG_SMP) || (CONFIG_SMP_NCPUS == 1)
-  wfi
-#endif
 2:
 
   /* Disable all interrupts (i.e. timer, external) in mie */


### PR DESCRIPTION
## Summary

The cpux's idle stack is loaded from g_cpu_basestack (data section) now, but on this time it maybe not ready since it is initialized by cpu0, then we must wait for g_cpu_basestack ready before use it.

And use textual label in k210_head.S
## Impact
K210 SMP only
## Testing
K210 QEMU and real device.
