### PR TITLE
tools/Unix.mk: silence output from version.sh

### DIFF
--- a/tools/Unix.mk
+++ b/tools/Unix.mk
@@ -46,7 +46,7 @@ else
 # Only update .version if the contents of version.tmp actually changes
 # Note: this is executed before any rule is run
 
-$(shell tools/version.sh .version.tmp)
+$(shell tools/version.sh .version.tmp > /dev/null)
 $(shell $(call TESTANDREPLACEFILE, .version.tmp, .version))
 endif
 


### PR DESCRIPTION
## Summary

This fixes error:

  tools/Unix.mk:49: *** missing separator. Stop.

that happens if tools/version.sh is invoked on a git repository that contains no tags.
$(shell) works like backsticks so without this any output from version.sh is parsed as part of Makefile text.

See https://github.com/apache/incubator-nuttx/issues/5324
(For some reason the issue was closed without actually fixing it.)

## Impact
Only affects repositories where version.sh outputs any diagnostics to stdout

## Testing

