### PR TITLE
Fix JLinkGDBServer crash attaching to target

### DIFF
--- a/tools/jlink-nuttx.c
+++ b/tools/jlink-nuttx.c
@@ -35,7 +35,7 @@
 
 /* Marcos for J-Link plugin API */
 
-#define PLUGIN_VER                100
+#define API_VER                   101
 #define DISPLAY_LENGTH            256
 #define THREADID_BASE             1
 
@@ -414,7 +414,32 @@ int RTOS_Init(const struct jlink_ops_s *api, uint32_t core)
 
 uint32_t RTOS_GetVersion(void)
 {
-  return PLUGIN_VER;
+  return API_VER;
+}
+
+int RTOS_UpdateThreads(void)
+{
+  int ret;
+
+  ret = update_tcbinfo(&g_plugin_priv);
+  if (ret)
+    {
+      return ret;
+    }
+
+  ret = update_pidhash(&g_plugin_priv);
+  if (ret)
+    {
+      return ret;
+    }
+
+  ret = normalize_tcb(&g_plugin_priv);
+  if (ret)
+    {
+      return ret;
+    }
+
+  return 0;
 }
 
 struct symbols_s *RTOS_GetSymbols(void)
@@ -424,6 +449,11 @@ struct symbols_s *RTOS_GetSymbols(void)
 
 uint32_t RTOS_GetNumThreads(void)
 {
+  if (g_plugin_priv.ntcb == 0)
+    {
+      RTOS_UpdateThreads();
+    }
+
   return g_plugin_priv.ntcb;
 }
 
@@ -655,31 +685,6 @@ int RTOS_SetThreadRegList(char *hexreglist, uint32_t threadid)
         {
           return -1;
         }
-    }
-
-  return 0;
-}
-
-int RTOS_UpdateThreads(void)
-{
-  int ret;
-
-  ret = update_tcbinfo(&g_plugin_priv);
-  if (ret)
-    {
-      return ret;
-    }
-
-  ret = update_pidhash(&g_plugin_priv);
-  if (ret)
-    {
-      return ret;
-    }
-
-  ret = normalize_tcb(&g_plugin_priv);
-  if (ret)
-    {
-      return ret;
     }
 
   return 0;


### PR DESCRIPTION
If attaching to a target that is already running JLinkGDBServer calls
RTOS_GetNumThreads() without a prior call to RTOS_UpdateThreads().  So
do this within RTOS_GetNumThreads() if g_plugin_priv.ntcb has not yet
been initialized.

Note: If after attaching the debugger to the target, the target is
resumed and then stopped again, the RTOS_UpdateThreads is actually
called.  Thus, we are not running on stale thread data in this case.

I also changed PLUGIN_VER to API_VER and its value to 101, as
RTOS_GetVersion() does not query the version of the plugin, but the API
version implemented by the plugin, which in our case is 1.1.

Signed-off-by: Michael Jung <mijung@gmx.net>