### PR TITLE
libc/sim: Rename arch_setjmp[64].S to arch_setjmp_x86[_64].S

### DIFF
--- a/libs/libc/machine/sim/Make.defs
+++ b/libs/libc/machine/sim/Make.defs
@@ -27,14 +27,14 @@ ifeq ($(CONFIG_LIBC_ARCH_ELF),y)
 CSRCS += arch_elf.c
 endif
 ifeq ($(CONFIG_ARCH_SETJMP_H),y)
-ASRCS += arch_setjmp.S
+ASRCS += arch_setjmp_x86.S
 endif
 else
 ifeq ($(CONFIG_LIBC_ARCH_ELF),y)
 CSRCS += arch_elf64.c
 endif
 ifeq ($(CONFIG_ARCH_SETJMP_H),y)
-ASRCS += arch_setjmp64.S
+ASRCS += arch_setjmp_x86_64.S
 endif
 endif
 else ifeq ($(CONFIG_HOST_X86),y)
@@ -42,7 +42,7 @@ ifeq ($(CONFIG_LIBC_ARCH_ELF),y)
 CSRCS += arch_elf.c
 endif
 ifeq ($(CONFIG_ARCH_SETJMP_H),y)
-ASRCS += arch_setjmp.S
+ASRCS += arch_setjmp_x86.S
 endif
 else ifeq ($(CONFIG_HOST_ARM),y)
 ifeq ($(CONFIG_ARCH_SETJMP_H),y)

--- a/libs/libc/machine/sim/arch_setjmp_x86.S
+++ b/libs/libc/machine/sim/arch_setjmp_x86.S
@@ -1,5 +1,5 @@
 /**************************************************************************
- * libs/libc/machine/sim/arch_setjmp.S
+ * libs/libc/machine/sim/arch_setjmp_x86.S
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/libs/libc/machine/sim/arch_setjmp_x86_64.S
+++ b/libs/libc/machine/sim/arch_setjmp_x86_64.S
@@ -1,5 +1,5 @@
 /**************************************************************************
- * libs/libc/machine/sim/arch_setjmp64.S
+ * libs/libc/machine/sim/arch_setjmp_x86_64.S
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with


### PR DESCRIPTION

Signed-off-by: Xiang Xiao <xiaoxiang@xiaomi.com>

## Summary
to follow other arch/x86 arch/x86_64 convention:
https://github.com/apache/incubator-nuttx/pull/5188

## Impact
Refactor only

## Testing
Pass CI
