### PR TITLE
arch: armv7-a: Fix arm_syscall for SYS_pthread_start

### DIFF
--- a/arch/arm/src/armv7-a/arm_syscall.c
+++ b/arch/arm/src/armv7-a/arm_syscall.c
@@ -302,9 +302,9 @@ uint32_t *arm_syscall(uint32_t *regs)
            *   CSPR = user mode
            */
 
-          regs[REG_PC]   = regs[REG_R0];
-          regs[REG_R0]   = regs[REG_R1];
-          regs[REG_R1]   = regs[REG_R2];
+          regs[REG_PC]   = regs[REG_R1];
+          regs[REG_R0]   = regs[REG_R2];
+          regs[REG_R1]   = regs[REG_R3];
 
           cpsr           = regs[REG_CPSR] & ~PSR_MODE_MASK;
           regs[REG_CPSR] = cpsr | PSR_MODE_USR;


### PR DESCRIPTION
## Summary

- I noticed that pthread always crashes when started
  if CONFIG_BUILD_KERNEL=y
- This commit fixes this issue

## Impact

- None

## Testing

- Tested with sabre-6quad:netknsh (not merged yet)
