### PR TITLE
arch/arm/samv7: fix peripheral id shift during transmit xdma configuration

### DIFF
--- a/arch/arm/src/samv7/sam_xdmac.c
+++ b/arch/arm/src/samv7/sam_xdmac.c
@@ -785,7 +785,7 @@ static inline uint32_t sam_txcc(struct sam_xdmach_s *xdmach)
       /* Look up the DMA channel code for TX:  Peripheral is the sink. */
 
       field   = sam_sink_channel(xdmach, pid);
-      regval |= (field << XDMACH_CC_CSIZE_SHIFT);
+      regval |= (field << XDMACH_CC_PERID_SHIFT);
 
 #if 0 /* Not supported */
       /* 10. Set SWREQ to use software request (only relevant for a


### PR DESCRIPTION
## Summary
Now TX via SPI is working. I have still problems with the size of the dma data burst, but this is something different...
## Impact

## Testing
Should be tested also on SD-Card driver DMA...
