### PR TITLE
arm: fix FPSCR typos in comments

### DIFF
--- a/arch/arm/src/armv7-a/arm_fullcontextrestore.S
+++ b/arch/arm/src/armv7-a/arm_fullcontextrestore.S
@@ -87,11 +87,11 @@ arm_fullcontextrestore:
 #endif
 
 	/* Load the floating point control and status register.   At the end of the
-	 * vstmia, r1 will point to the FPCSR storage location.
+	 * vstmia, r1 will point to the FPSCR storage location.
 	 */
 
 	ldr		r2, [r1], #4			/* Fetch the floating point control and status register */
-	vmsr		fpscr, r2			/* Restore the FPCSR */
+	vmsr		fpscr, r2			/* Restore the FPSCR */
 #endif
 
 #ifdef CONFIG_BUILD_KERNEL

--- a/arch/arm/src/armv7-a/arm_restorefpu.S
+++ b/arch/arm/src/armv7-a/arm_restorefpu.S
@@ -80,11 +80,11 @@ arm_restorefpu:
 #endif
 
 	/* Load the floating point control and status register.   At the end of the
-	 * vstmia, r1 will point to the FPCSR storage location.
+	 * vstmia, r1 will point to the FPSCR storage location.
 	 */
 
 	ldr		r2, [r1], #4			/* Fetch the floating point control and status register */
-	vmsr		fpscr, r2			/* Restore the FPCSR */
+	vmsr		fpscr, r2			/* Restore the FPSCR */
 	bx		lr
 
 	.size	arm_restorefpu, .-arm_restorefpu

--- a/arch/arm/src/armv7-a/arm_savefpu.S
+++ b/arch/arm/src/armv7-a/arm_savefpu.S
@@ -84,10 +84,10 @@ arm_savefpu:
 #endif
 
 	/* Store the floating point control and status register.  At the end of the
-	 * vstmia, r1 will point to the FPCSR storage location.
+	 * vstmia, r1 will point to the FPSCR storage location.
 	 */
 
-	vmrs		r2, fpscr			/* Fetch the FPCSR */
+	vmrs		r2, fpscr			/* Fetch the FPSCR */
 	str		r2, [r1], #4			/* Save the floating point control and status register */
 	bx		lr
 

--- a/arch/arm/src/armv7-a/arm_saveusercontext.S
+++ b/arch/arm/src/armv7-a/arm_saveusercontext.S
@@ -115,10 +115,10 @@ arm_saveusercontext:
 #endif
 
 	/* Store the floating point control and status register.  At the end of the
-	 * vstmia, r1 will point to the FPCSR storage location.
+	 * vstmia, r1 will point to the FPSCR storage location.
 	 */
 
-	vmrs		r2, fpscr		/* Fetch the FPCSR */
+	vmrs		r2, fpscr		/* Fetch the FPSCR */
 	str		r2, [r1], #4		/* Save the floating point control and status register */
 #endif
 

--- a/arch/arm/src/armv7-m/gnu/arm_fpu.S
+++ b/arch/arm/src/armv7-m/gnu/arm_fpu.S
@@ -87,10 +87,10 @@ arm_savefpu:
 	vstmia		r1!, {s0-s31}			/* Save the full FP context */
 
 	/* Store the floating point control and status register.  At the end of the
-	 * vstmia, r1 will point to the FPCSR storage location.
+	 * vstmia, r1 will point to the FPSCR storage location.
 	 */
 
-	vmrs		r2, fpscr			/* Fetch the FPCSR */
+	vmrs		r2, fpscr			/* Fetch the FPSCR */
 	str		r2, [r1], #4			/* Save the floating point control and status register */
 #else
 	/* Store all floating point registers */
@@ -150,7 +150,7 @@ arm_savefpu:
 
 	/* Store the floating point control and status register */
 
-	fmrx		r2, fpscr			/* Fetch the FPCSR */
+	fmrx		r2, fpscr			/* Fetch the FPSCR */
 	str		r2, [r1], #4			/* Save the floating point control and status register */
 #endif
 	bx		lr
@@ -193,11 +193,11 @@ arm_restorefpu:
 	vldmia		r1!, {s0-s31}			/* Restore the full FP context */
 
 	/* Load the floating point control and status register.   At the end of the
-	 * vstmia, r1 will point to the FPCSR storage location.
+	 * vstmia, r1 will point to the FPSCR storage location.
 	 */
 
 	ldr		r2, [r1], #4			/* Fetch the floating point control and status register */
-	vmsr		fpscr, r2			/* Restore the FPCSR */
+	vmsr		fpscr, r2			/* Restore the FPSCR */
 #else
 	/* Load all floating point registers  Registers are loaded in numeric order,
 	 * s0, s1, ... in increasing address order.
@@ -257,11 +257,11 @@ arm_restorefpu:
 #endif
 
 	/* Load the floating point control and status register.  r1 points t
-	 * the address of the FPCSR register.
+	 * the address of the FPSCR register.
 	 */
 
 	ldr		r2, [r1], #4			/* Fetch the floating point control and status register */
-	fmxr		fpscr, r2			/* Restore the FPCSR */
+	fmxr		fpscr, r2			/* Restore the FPSCR */
 #endif
 	bx		lr
 

--- a/arch/arm/src/armv7-r/arm_fullcontextrestore.S
+++ b/arch/arm/src/armv7-r/arm_fullcontextrestore.S
@@ -86,11 +86,11 @@ arm_fullcontextrestore:
 #endif
 
 	/* Load the floating point control and status register.   At the end of the
-	 * vstmia, r1 will point to the FPCSR storage location.
+	 * vstmia, r1 will point to the FPSCR storage location.
 	 */
 
 	ldr		r2, [r1], #4			/* Fetch the floating point control and status register */
-	vmsr		fpscr, r2			/* Restore the FPCSR */
+	vmsr		fpscr, r2			/* Restore the FPSCR */
 #endif
 
 #ifdef CONFIG_BUILD_PROTECTED

--- a/arch/arm/src/armv7-r/arm_restorefpu.S
+++ b/arch/arm/src/armv7-r/arm_restorefpu.S
@@ -80,11 +80,11 @@ arm_restorefpu:
 #endif
 
 	/* Load the floating point control and status register.   At the end of the
-	 * vstmia, r1 will point to the FPCSR storage location.
+	 * vstmia, r1 will point to the FPSCR storage location.
 	 */
 
 	ldr		r2, [r1], #4			/* Fetch the floating point control and status register */
-	vmsr		fpscr, r2			/* Restore the FPCSR */
+	vmsr		fpscr, r2			/* Restore the FPSCR */
 	bx		lr
 
 	.size	arm_restorefpu, .-arm_restorefpu

--- a/arch/arm/src/armv7-r/arm_savefpu.S
+++ b/arch/arm/src/armv7-r/arm_savefpu.S
@@ -84,10 +84,10 @@ arm_savefpu:
 #endif
 
 	/* Store the floating point control and status register.  At the end of the
-	 * vstmia, r1 will point to the FPCSR storage location.
+	 * vstmia, r1 will point to the FPSCR storage location.
 	 */
 
-	vmrs		r2, fpscr			/* Fetch the FPCSR */
+	vmrs		r2, fpscr			/* Fetch the FPSCR */
 	str		r2, [r1], #4			/* Save the floating point control and status register */
 	bx		lr
 

--- a/arch/arm/src/armv7-r/arm_saveusercontext.S
+++ b/arch/arm/src/armv7-r/arm_saveusercontext.S
@@ -114,10 +114,10 @@ arm_saveusercontext:
 #endif
 
 	/* Store the floating point control and status register.  At the end of the
-	 * vstmia, r1 will point to the FPCSR storage location.
+	 * vstmia, r1 will point to the FPSCR storage location.
 	 */
 
-	vmrs		r2, fpscr		/* Fetch the FPCSR */
+	vmrs		r2, fpscr		/* Fetch the FPSCR */
 	str		r2, [r1], #4		/* Save the floating point control and status register */
 #endif
 

--- a/arch/arm/src/armv8-m/arm_fpu.S
+++ b/arch/arm/src/armv8-m/arm_fpu.S
@@ -87,10 +87,10 @@ arm_savefpu:
 	vstmia		r1!, {s0-s31}			/* Save the full FP context */
 
 	/* Store the floating point control and status register.  At the end of the
-	 * vstmia, r1 will point to the FPCSR storage location.
+	 * vstmia, r1 will point to the FPSCR storage location.
 	 */
 
-	vmrs		r2, fpscr			/* Fetch the FPCSR */
+	vmrs		r2, fpscr			/* Fetch the FPSCR */
 	str		r2, [r1], #4			/* Save the floating point control and status register */
 #else
 	/* Store all floating point registers */
@@ -150,7 +150,7 @@ arm_savefpu:
 
 	/* Store the floating point control and status register */
 
-	fmrx		r2, fpscr			/* Fetch the FPCSR */
+	fmrx		r2, fpscr			/* Fetch the FPSCR */
 	str		r2, [r1], #4			/* Save the floating point control and status register */
 #endif
 	bx		lr
@@ -193,11 +193,11 @@ arm_restorefpu:
 	vldmia		r1!, {s0-s31}			/* Restore the full FP context */
 
 	/* Load the floating point control and status register.   At the end of the
-	 * vstmia, r1 will point to the FPCSR storage location.
+	 * vstmia, r1 will point to the FPSCR storage location.
 	 */
 
 	ldr		r2, [r1], #4			/* Fetch the floating point control and status register */
-	vmsr		fpscr, r2			/* Restore the FPCSR */
+	vmsr		fpscr, r2			/* Restore the FPSCR */
 #else
 	/* Load all floating point registers  Registers are loaded in numeric order,
 	 * s0, s1, ... in increasing address order.
@@ -257,11 +257,11 @@ arm_restorefpu:
 #endif
 
 	/* Load the floating point control and status register.  r1 points t
-	 * the address of the FPCSR register.
+	 * the address of the FPSCR register.
 	 */
 
 	ldr		r2, [r1], #4			/* Fetch the floating point control and status register */
-	fmxr		fpscr, r2			/* Restore the FPCSR */
+	fmxr		fpscr, r2			/* Restore the FPSCR */
 #endif
 	bx		lr
 

--- a/libs/libc/machine/arm/armv7-m/gnu/arch_setjmp.S
+++ b/libs/libc/machine/arm/armv7-m/gnu/arch_setjmp.S
@@ -77,10 +77,10 @@ setjmp:
 	vstmia		r0!, {s16-s31}			/* Save the callee-saved FP registers */
 
 	/* Store the floating point control and status register.  At the end of the
-	 * vstmia, r0 will point to the FPCSR storage location.
+	 * vstmia, r0 will point to the FPSCR storage location.
 	 */
 
-	vmrs		r1, fpscr			/* Fetch the FPCSR */
+	vmrs		r1, fpscr			/* Fetch the FPSCR */
 	str		r1, [r0], #4			/* Save the floating point control and status register */
 							/* DSA: don't need to inc r0 */
 #endif /* CONFIG_ARCH_FPU */
@@ -132,7 +132,7 @@ longjmp:
 
 	ldr		r2, [r0], #4			/* Fetch the floating point control and status register */
 							/* DSA: don't need to inc r0 */
-	vmsr		fpscr, r2			/* Restore the FPCSR */
+	vmsr		fpscr, r2			/* Restore the FPSCR */
 #endif /* CONFIG_ARCH_FPU */
 
 	mov		r0, r1				/* return val */

--- a/libs/libc/machine/arm/armv8-m/gnu/arch_setjmp.S
+++ b/libs/libc/machine/arm/armv8-m/gnu/arch_setjmp.S
@@ -77,10 +77,10 @@ setjmp:
 	vstmia		r0!, {s16-s31}			/* Save the callee-saved FP registers */
 
 	/* Store the floating point control and status register.  At the end of the
-	 * vstmia, r0 will point to the FPCSR storage location.
+	 * vstmia, r0 will point to the FPSCR storage location.
 	 */
 
-	vmrs		r1, fpscr			/* Fetch the FPCSR */
+	vmrs		r1, fpscr			/* Fetch the FPSCR */
 	str		r1, [r0], #4			/* Save the floating point control and status register */
 							/* DSA: don't need to inc r0 */
 #endif /* CONFIG_ARCH_FPU */
@@ -132,7 +132,7 @@ longjmp:
 
 	ldr		r2, [r0], #4			/* Fetch the floating point control and status register */
 							/* DSA: don't need to inc r0 */
-	vmsr		fpscr, r2			/* Restore the FPCSR */
+	vmsr		fpscr, r2			/* Restore the FPSCR */
 #endif /* CONFIG_ARCH_FPU */
 
 	mov		r0, r1				/* return val */


### PR DESCRIPTION
## Summary

"FPSCR" is a correct name for arm Floating-point Status and Control Register.

## Impact

No impacts, only comments.

## Testing

build only.