### PR TITLE
armv7-a: fix gtm.h GTM_COMP1 and GTM_AUTO defines

### DIFF
--- a/arch/arm/src/armv7-a/gtm.h
+++ b/arch/arm/src/armv7-a/gtm.h
@@ -57,8 +57,8 @@
 #define GTM_CTRL               (MPCORE_GTM_VBASE+GTM_CTRL_OFFSET)
 #define GTM_STA                (MPCORE_GTM_VBASE+GTM_STA_OFFSET)
 #define GTM_COMP0              (MPCORE_GTM_VBASE+GTM_COMP0_OFFSET)
-#define GTM_COMP1              (MPCORE_GTM_VBASE+COMPARE1_OFFSET)
-#define GTM_AUTO               (MPCORE_GTM_VBASE+AUTO_OFFSET)
+#define GTM_COMP1              (MPCORE_GTM_VBASE+GTM_COMP1_OFFSET)
+#define GTM_AUTO               (MPCORE_GTM_VBASE+GTM_AUTO_OFFSET)
 
 /* GTM Register Bit Definitions *********************************************/
 


### PR DESCRIPTION
## Summary

Correct GTM_COMP1 and GTM_AUTO defines in armv7-a's gtm.h.

## Impact

armv7-a's global timer.
(Currently these macros are not used.)

## Testing

build only