### PR TITLE
arch/ceva: Remove B2C and C2B

### DIFF
--- a/arch/ceva/src/common/up_checkstack.c
+++ b/arch/ceva/src/common/up_checkstack.c
@@ -77,7 +77,7 @@ static size_t do_stackcheck(uintptr_t alloc, size_t size, bool int_stack)
     {
       /* Skip over the TLS data structure at the bottom of the stack */
 
-      DEBUGASSERT(alloc & (B2C(TLS_STACK_ALIGN) - 1) == 0);
+      DEBUGASSERT(alloc & (TLS_STACK_ALIGN - 1) == 0);
       start = alloc + sizeof(struct tls_info_s);
     }
   else

--- a/arch/ceva/src/common/up_createstack.c
+++ b/arch/ceva/src/common/up_createstack.c
@@ -96,10 +96,6 @@
 
 int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
 {
-  /* Conver the stack size unit from byte to char */
-
-  stack_size = B2C(stack_size);
-
 #ifdef CONFIG_TLS
   /* Add the size of the TLS information structure */
 
@@ -109,10 +105,10 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
    * TLS feature.
    */
 
-  DEBUGASSERT(stack_size <= B2C(TLS_MAXSTACK));
-  if (stack_size >= B2C(TLS_MAXSTACK))
+  DEBUGASSERT(stack_size <= TLS_MAXSTACK);
+  if (stack_size >= TLS_MAXSTACK)
     {
-      stack_size = B2C(TLS_MAXSTACK);
+      stack_size = TLS_MAXSTACK;
     }
 #endif
 
@@ -145,7 +141,7 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
         {
           tcb->stack_alloc_ptr = mm_memalign(
                       KMM_HEAP(CONFIG_ARCH_KERNEL_STACK_HEAP),
-                      B2C(TLS_STACK_ALIGN), stack_size);
+                      TLS_STACK_ALIGN, stack_size);
         }
       else
 #endif
@@ -154,7 +150,7 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
 
           tcb->stack_alloc_ptr = mm_memalign(
                       UMM_HEAP(CONFIG_ARCH_STACK_HEAP),
-                      B2C(TLS_STACK_ALIGN), stack_size);
+                      TLS_STACK_ALIGN, stack_size);
         }
 
 #else /* CONFIG_TLS */

--- a/arch/ceva/src/common/up_internal.h
+++ b/arch/ceva/src/common/up_internal.h
@@ -80,7 +80,7 @@
 #define _DATA_INIT     ((const void *)&_eronly)
 #define _START_DATA    ((void *)&_sdata)
 #define _END_DATA      ((void *)&_edata)
-#define _START_HEAP    ((void *)&_ebss + B2C(CONFIG_IDLETHREAD_STACKSIZE))
+#define _START_HEAP    ((void *)&_ebss + CONFIG_IDLETHREAD_STACKSIZE)
 #define _END_HEAP      ((void *)&_eheap)
 #define _END_MEM       ((void *)~0)
 

--- a/arch/ceva/src/common/up_start.c
+++ b/arch/ceva/src/common/up_start.c
@@ -245,7 +245,7 @@ static void init_kernelspace(void)
     g_idle_topstack - g_idle_basestack);
 #ifdef CONFIG_STACK_COLORATION
   up_stack_color(g_idle_basestack,
-    g_idle_topstack - g_idle_basestack - B2C(256));
+    g_idle_topstack - g_idle_basestack - 256);
 #endif
 }
 

--- a/arch/ceva/src/common/up_usestack.c
+++ b/arch/ceva/src/common/up_usestack.c
@@ -81,7 +81,7 @@ int up_use_stack(FAR struct tcb_s *tcb, FAR void *stack, size_t stack_size)
 #ifdef CONFIG_TLS
   /* Make certain that the user provided stack is properly aligned */
 
-  DEBUGASSERT((uintptr_t)stack & (B2C(TLS_STACK_ALIGN) - 1) == 0);
+  DEBUGASSERT((uintptr_t)stack & (TLS_STACK_ALIGN - 1) == 0);
 #else
   DEBUGASSERT((uintptr_t)stack & STACK_ALIGN_MASK == 0);
 #endif

--- a/arch/ceva/src/common/up_vfork.c
+++ b/arch/ceva/src/common/up_vfork.c
@@ -111,7 +111,7 @@ pid_t up_vfork(const uint32_t *regs)
 
   /* Allocate the stack for the TCB */
 
-  ret = up_create_stack((FAR struct tcb_s *)child, C2B(stacksize + argsize),
+  ret = up_create_stack((FAR struct tcb_s *)child, stacksize + argsize,
                         parent->flags & TCB_FLAG_TTYPE_MASK);
   if (ret != OK)
     {


### PR DESCRIPTION
## Summary
since TL420 doesn't support anymore, we
can safely remove the special hack for it

## Impact
ceva

## Testing

