### PR TITLE
Fix binfmt for BUILD_KERNEL & ADDRENV

### DIFF
--- a/binfmt/binfmt_execmodule.c
+++ b/binfmt/binfmt_execmodule.c
@@ -160,6 +160,9 @@ int exec_module(FAR const struct binary_s *binp,
       binfmt_freeargv(argv);
       goto errout_with_tcb;
     }
+
+  binfo("Initialize the user heap (heapsize=%d)\n", binp->addrenv.heapsize);
+  umm_initialize((FAR void *)CONFIG_ARCH_HEAP_VBASE, binp->addrenv.heapsize);
 #endif
 
   /* Note that tcb->flags are not modified.  0=normal task */

--- a/mm/umm_heap/umm_heap.h
+++ b/mm/umm_heap/umm_heap.h
@@ -35,7 +35,7 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-#if defined(CONFIG_ARCH_ADDRENV) && defined(__KERNEL__)
+#if defined(CONFIG_ARCH_ADDRENV) && defined(CONFIG_BUILD_KERNEL)
 /* In the kernel build, there are multiple user heaps; one for each task
  * group.  In this build configuration, the user heap structure lies
  * in a reserved region at the beginning of the .bss/.data address


### PR DESCRIPTION
## Summary

- This PR contains 2 commits
- commit1: binfmt: Call umm_initialize() for BUILD_KERNEL & ADDRENV
  - I noticed that the user heap is not initialized correctly
      if BUILD_KERNEL=y and ADDRENV=y
  - This commit fixes this issue
- commit2: Fix umm_heap for BUILD_KERNEL & ADDRENV
  - I noticed that the user heap is corrupted
  - This commit fixes this issue by reverting the change to
     the NuttX-9.0.0

## Impact

 - None

## Testing

- Tested with sabre-6quad:netknsh (not merged yet)