### PR TITLE
dp83848c ethernet phy interrupt support

### DIFF
--- a/arch/arm/src/stm32/stm32_eth.c
+++ b/arch/arm/src/stm32/stm32_eth.c
@@ -200,7 +200,9 @@
 #  elif defined( CONFIG_ETH0_PHY_KSZ90x1)
 #    error missing logic
 #  elif defined( CONFIG_ETH0_PHY_DP83848C)
-#    error missing logic
+#    define MII_INT_REG    MII_DP83848C_MISR
+#    define MII_INT_SETEN  MII_DP83848C_LINK_INT_EN
+#    define MII_INT_CLREN  0
 #  elif defined( CONFIG_ETH0_PHY_LAN8720)
 #    error missing logic
 #  elif defined( CONFIG_ETH0_PHY_LAN8740)
@@ -2995,6 +2997,10 @@ static int stm32_phyintenable(struct stm32_ethmac_s *priv)
     {
       /* Enable link up/down interrupts */
 
+#ifdef CONFIG_ETH0_PHY_DP83848C
+      ret = stm32_phywrite(CONFIG_STM32_PHYADDR, MII_DP83848C_MICR,
+                           MII_DP83848C_INT_EN | MII_DP83848C_INT_OEN);
+#endif
       ret = stm32_phywrite(CONFIG_STM32_PHYADDR, MII_INT_REG,
                            (phyval & ~MII_INT_CLREN) | MII_INT_SETEN);
     }

--- a/include/nuttx/net/mii.h
+++ b/include/nuttx/net/mii.h
@@ -808,6 +808,29 @@
 #  define MII_CONFIG2_SLP_T_4             (2 << MII_CONFIG2_SLP_T_SHIFT)  /* sleep request timeout 4 ms */
 #  define MII_CONFIG2_SLP_T_16            (3 << MII_CONFIG2_SLP_T_SHIFT)  /* sleep request timeout 16 ms */
 
+/* DP83848C-specific register bit settings **********************************/
+
+/* DP83848C Register 0x11: Interrupt control/status */
+#define MII_DP83848C_INT_TEST         (1 << 2)  /* Test Interrupt */
+#define MII_DP83848C_INT_EN           (1 << 1)  /* Interrupt enable */
+#define MII_DP83848C_INT_OEN          (1 << 0)  /* Interrupt output enable */
+
+/* DP83848C Register 0x12: Interrupt control/status */
+#define MII_DP83848C_ED_INT           (1 << 14) /* Energy Detect interrupt: */
+#define MII_DP83848C_LINK_INT         (1 << 13) /* Change of Link Status interrupt: */
+#define MII_DP83848C_SPD_INT          (1 << 12) /* Change of speed status interrupt: */
+#define MII_DP83848C_DUP_INT          (1 << 11) /* Change of duplex status interrupt: */
+#define MII_DP83848C_ANC_INT          (1 << 10) /* Auto-Negotiation Complete interrupt: */
+#define MII_DP83848C_FHF_INT          (1 << 9)  /* False Carrier Counter half-full interrupt: */
+#define MII_DP83848C_RHF_INT          (1 << 8)  /* Receive Error Counter half-full interrupt: */
+#define MII_DP83848C_ED_INT_EN        (1 << 6)  /* Enable Interrupt on energy detect event. */
+#define MII_DP83848C_LINK_INT_EN      (1 << 5)  /* Enable Interrupt on change of link status. */
+#define MII_DP83848C_SPD_INT_EN       (1 << 4)  /* Enable Interrupt on change of speed status. */
+#define MII_DP83848C_DUP_INT_EN       (1 << 3)  /* Enable Interrupt on change of duplex status. */
+#define MII_DP83848C_ANC_INT_EN       (1 << 2)  /* Enable Interrupt on Auto-negotiation complete event. */
+#define MII_DP83848C_FHF_INT_EN       (1 << 1)  /* Enable Interrupt on False Carrier Counter Register half-full event. */
+#define MII_DP83848C_RHF_INT_EN       (1 << 0)  /* Enable Interrupt on Receive Error Counter Register half-full event. */
+
 /****************************************************************************
  * Type Definitions
  ****************************************************************************/


### PR DESCRIPTION
## Summary
stm32 dp83848c ethernet phy interrupt support

## Impact

## Testing
stm32f407zg+dp83848c phy
interrupt enable
CONFIG_ETH0_PHY_DP83848C=y

CONFIG_STM32_RMII=y
CONFIG_STM32_AUTONEG=y
CONFIG_STM32_PHYADDR=1
CONFIG_STM32_PHYSR=16
CONFIG_STM32_PHYSR_100MBPS=0x0000
CONFIG_STM32_PHYSR_FULLDUPLEX=0x0004
CONFIG_STM32_PHYSR_MODE=0x0004
CONFIG_STM32_PHYSR_SPEED=0x0002
