### PR TITLE
net/ioballoc: add support of alloc with timeout net_iobtimedalloc()

### DIFF
--- a/include/nuttx/net/net.h
+++ b/include/nuttx/net/net.h
@@ -460,6 +460,36 @@ int net_timedwait_uninterruptible(sem_t *sem, unsigned int timeout);
 
 int net_lockedwait_uninterruptible(sem_t *sem);
 
+#ifdef CONFIG_MM_IOB
+
+/****************************************************************************
+ * Name: net_iobtimedalloc
+ *
+ * Description:
+ *   Allocate an IOB.  If no IOBs are available, then atomically wait for
+ *   for the IOB while temporarily releasing the lock on the network.
+ *   This function is wrapped version of net_ioballoc(), this wait will
+ *   be terminated when the specified timeout expires.
+ *
+ *   Caution should be utilized.  Because the network lock is relinquished
+ *   during the wait, there could be changes in the network state that occur
+ *   before the lock is recovered.  Your design should account for this
+ *   possibility.
+ *
+ * Input Parameters:
+ *   throttled  - An indication of the IOB allocation is "throttled"
+ *   timeout    - The relative time to wait until a timeout is declared.
+ *   consumerid - id representing who is consuming the IOB
+ *
+ * Returned Value:
+ *   A pointer to the newly allocated IOB is returned on success.  NULL is
+ *   returned on any allocation failure.
+ *
+ ****************************************************************************/
+
+FAR struct iob_s *net_iobtimedalloc(bool throttled, unsigned int timeout,
+                                    enum iob_user_e consumerid);
+
 /****************************************************************************
  * Name: net_ioballoc
  *
@@ -473,7 +503,8 @@ int net_lockedwait_uninterruptible(sem_t *sem);
  *   possibility.
  *
  * Input Parameters:
- *   throttled - An indication of the IOB allocation is "throttled"
+ *   throttled  - An indication of the IOB allocation is "throttled"
+ *   consumerid - id representing who is consuming the IOB
  *
  * Returned Value:
  *   A pointer to the newly allocated IOB is returned on success.  NULL is
@@ -481,7 +512,6 @@ int net_lockedwait_uninterruptible(sem_t *sem);
  *
  ****************************************************************************/
 
-#ifdef CONFIG_MM_IOB
 FAR struct iob_s *net_ioballoc(bool throttled, enum iob_user_e consumerid);
 #endif
 

--- a/net/tcp/tcp.h
+++ b/net/tcp/tcp.h
@@ -1548,6 +1548,30 @@ int psock_tcp_cansend(FAR struct tcp_conn_s *conn);
 void tcp_wrbuffer_initialize(void);
 #endif /* CONFIG_NET_TCP_WRITE_BUFFERS */
 
+#ifdef CONFIG_NET_TCP_WRITE_BUFFERS
+
+struct tcp_wrbuffer_s;
+
+/****************************************************************************
+ * Name: tcp_wrbuffer_timedalloc
+ *
+ * Description:
+ *   Allocate a TCP write buffer by taking a pre-allocated buffer from
+ *   the free list.  This function is called from TCP logic when a buffer
+ *   of TCP data is about to sent
+ *   This function is wrapped version of tcp_wrbuffer_alloc(),
+ *   this wait will be terminated when the specified timeout expires.
+ *
+ * Input Parameters:
+ *   timeout   - The relative time to wait until a timeout is declared.
+ *
+ * Assumptions:
+ *   Called from user logic with the network locked.
+ *
+ ****************************************************************************/
+
+FAR struct tcp_wrbuffer_s *tcp_wrbuffer_timedalloc(unsigned int timeout);
+
 /****************************************************************************
  * Name: tcp_wrbuffer_alloc
  *
@@ -1564,8 +1588,6 @@ void tcp_wrbuffer_initialize(void);
  *
  ****************************************************************************/
 
-#ifdef CONFIG_NET_TCP_WRITE_BUFFERS
-struct tcp_wrbuffer_s;
 FAR struct tcp_wrbuffer_s *tcp_wrbuffer_alloc(void);
 
 /****************************************************************************

--- a/net/utils/net_lock.c
+++ b/net/utils/net_lock.c
@@ -451,6 +451,59 @@ int net_lockedwait_uninterruptible(sem_t *sem)
   return net_timedwait_uninterruptible(sem, UINT_MAX);
 }
 
+#ifdef CONFIG_MM_IOB
+
+/****************************************************************************
+ * Name: net_timedalloc
+ *
+ * Description:
+ *   Allocate an IOB.  If no IOBs are available, then atomically wait for
+ *   for the IOB while temporarily releasing the lock on the network.
+ *   This function is wrapped version of nxsem_timedwait(), this wait will
+ *   be terminated when the specified timeout expires.
+ *
+ *   Caution should be utilized.  Because the network lock is relinquished
+ *   during the wait, there could be changes in the network state that occur
+ *   before the lock is recovered.  Your design should account for this
+ *   possibility.
+ *
+ * Input Parameters:
+ *   throttled  - An indication of the IOB allocation is "throttled"
+ *   timeout    - The relative time to wait until a timeout is declared.
+ *   consumerid - id representing who is consuming the IOB
+ *
+ * Returned Value:
+ *   A pointer to the newly allocated IOB is returned on success.  NULL is
+ *   returned on any allocation failure.
+ *
+ ****************************************************************************/
+
+FAR struct iob_s *net_iobtimedalloc(bool throttled, unsigned int timeout,
+                                    enum iob_user_e consumerid)
+{
+  FAR struct iob_s *iob;
+
+  iob = iob_tryalloc(throttled, consumerid);
+  if (iob == NULL && timeout != 0)
+    {
+      unsigned int count;
+      int blresult;
+
+      /* There are no buffers available now.  We will have to wait for one to
+       * become available. But let's not do that with the network locked.
+       */
+
+      blresult = net_breaklock(&count);
+      iob      = iob_timedalloc(throttled, timeout, consumerid);
+      if (blresult >= 0)
+        {
+          net_restorelock(count);
+        }
+    }
+
+  return iob;
+}
+
 /****************************************************************************
  * Name: net_ioballoc
  *
@@ -464,7 +517,8 @@ int net_lockedwait_uninterruptible(sem_t *sem)
  *   possibility.
  *
  * Input Parameters:
- *   throttled - An indication of the IOB allocation is "throttled"
+ *   throttled  - An indication of the IOB allocation is "throttled"
+ *   consumerid - id representing who is consuming the IOB
  *
  * Returned Value:
  *   A pointer to the newly allocated IOB is returned on success.  NULL is
@@ -472,29 +526,8 @@ int net_lockedwait_uninterruptible(sem_t *sem)
  *
  ****************************************************************************/
 
-#ifdef CONFIG_MM_IOB
 FAR struct iob_s *net_ioballoc(bool throttled, enum iob_user_e consumerid)
 {
-  FAR struct iob_s *iob;
-
-  iob = iob_tryalloc(throttled, consumerid);
-  if (iob == NULL)
-    {
-      unsigned int count;
-      int blresult;
-
-      /* There are no buffers available now.  We will have to wait for one to
-       * become available. But let's not do that with the network locked.
-       */
-
-      blresult = net_breaklock(&count);
-      iob      = iob_alloc(throttled, consumerid);
-      if (blresult >= 0)
-        {
-          net_restorelock(count);
-        }
-    }
-
-  return iob;
+  return net_iobtimedalloc(throttled, UINT_MAX, consumerid);
 }
 #endif


### PR DESCRIPTION
## Summary

net/ioballoc: add support of alloc with timeout net_iobtimedalloc()
net/tcp: add interface tcp_wrbuffer_timedalloc()

## Impact

N/A

## Testing

ci check