### PR TITLE
libs/libnx: handle the bad message correctly

### DIFF
--- a/libs/libnx/nxmu/nx_eventhandler.c
+++ b/libs/libnx/nxmu/nx_eventhandler.c
@@ -146,7 +146,11 @@ int nx_eventhandler(NXHANDLE handle)
     }
   while (nbytes < 0);
 
-  DEBUGASSERT(nbytes >= sizeof(struct nxclimsg_s));
+  if (nbytes < sizeof(struct nxclimsg_s))
+    {
+      _NX_SETERRNO(EBADMSG);
+      return ERROR;
+    }
 
   /* Dispatch the message appropriately */
 


### PR DESCRIPTION
## Summary

libs/libnx: handle the bad message correctly

```
$ arm-none-eabi-gcc -c -g -Os -mcpu=cortex-m0 -isystem "include" -I "libs/libnx"   nxmu/nx_eventhandler.c -o  bin/nx_eventhandler.o
/tmp/ccpLXGgi.s: Assembler messages:
/tmp/ccpLXGgi.s: Error: unaligned opcodes detected in executable segment
```

This issue only reproduced if run "**-g -Os -mcpu=cortex-m0**" at same time.

```
$ arm-none-eabi-gcc -v
gcc version 10.3.1 20210621 (release) (GNU Arm Embedded Toolchain 10.3-2021.07)

$ arm-none-eabi-gcc -c -g -Os -mcpu=cortex-m0 -isystem "include" -I "libs/libnx"   nxmu/nx_eventhandler.c -o  bin/nx_eventhandler.o
/tmp/ccpLXGgi.s: Assembler messages:
/tmp/ccpLXGgi.s: Error: unaligned opcodes detected in executable segment

break line:
106 int nx_eventhandler(NXHANDLE handle)
107 {
...
121           int errcode = _NX_GETERRNO(nbytes);
...
```

Signed-off-by: chao.an <anchao@xiaomi.com>

## Impact

link issue: https://github.com/apache/incubator-nuttx/issues/5449

## Testing

ci check