### PR TITLE
sched/semaphore/sem_clockwait: fix typo in comment

### DIFF
--- a/sched/semaphore/sem_clockwait.c
+++ b/sched/semaphore/sem_clockwait.c
@@ -187,7 +187,7 @@ out:
 }
 
 /****************************************************************************
- * Name: nxsem_timedwait_uninterruptible
+ * Name: nxsem_clockwait_uninterruptible
  *
  * Description:
  *   This function is wrapped version of nxsem_timedwait(), which is


### PR DESCRIPTION
## Summary
Typo detected

## Impact
None

## Testing
Pass CI
