### PR TITLE
mm: fix gran_alloc() array index range checking

### DIFF
--- a/mm/mm_gran/mm_granalloc.c
+++ b/mm/mm_gran/mm_granalloc.c
@@ -113,7 +113,7 @@ FAR void *gran_alloc(GRAN_HANDLE handle, size_t size)
 
           /* Get the next entry from the GAT to support a 64 bit shift */
 
-          if (granidx < priv->ngranules)
+          if (granidx + 32 < priv->ngranules)
             {
               next = priv->gat[gatidx + 1];
             }


### PR DESCRIPTION
## Summary

At the last loop `if (granidx < priv->ngranules)` condition is ture,
`priv->gat[gatidx + 1]` reference to out of range.

So, correct condition of next entry is `if (granidx + 32 < priv->ngranules)`.

## Impact

gran_alloc() function use

## Testing

test running on custom Cortex-A9 board.