### PR TITLE
esp32: Few improvements around interrupt handling.

### DIFF
--- a/arch/xtensa/src/esp32/esp32_irq.c
+++ b/arch/xtensa/src/esp32/esp32_irq.c
@@ -452,6 +452,7 @@ static void esp32_free_cpuint(int cpuint)
 void up_irqinitialize(void)
 {
   int i;
+
   for (i = 0; i < NR_IRQS; i++)
     {
       g_irqmap[i] = IRQ_UNMAPPED;
@@ -474,6 +475,22 @@ void up_irqinitialize(void)
   /* Initialize CPU interrupts */
 
   esp32_cpuint_initialize();
+
+  /* Reserve CPU0 interrupt for some special drivers */
+
+#ifdef CONFIG_ESP32_WIRELESS
+  g_cpu0_intmap[ESP32_CPUINT_MAC]  = CPUINT_ASSIGN(ESP32_IRQ_MAC);
+  xtensa_enable_cpuint(&g_intenable[0], 1 << ESP32_CPUINT_MAC);
+#endif
+
+#ifdef CONFIG_ESP32_BLE
+  g_cpu0_intmap[ESP32_PERIPH_BT_BB_NMI] = CPUINT_ASSIGN(ESP32_IRQ_BT_BB_NMI);
+  g_cpu0_intmap[ESP32_PERIPH_RWBT_NMI]  = CPUINT_ASSIGN(ESP32_IRQ_RWBT_NMI);
+  g_cpu0_intmap[ESP32_PERIPH_RWBLE_IRQ] = CPUINT_ASSIGN(ESP32_IRQ_RWBLE_IRQ);
+  xtensa_enable_cpuint(&g_intenable[0], 1 << ESP32_PERIPH_BT_BB_NMI);
+  xtensa_enable_cpuint(&g_intenable[0], 1 << ESP32_PERIPH_RWBT_NMI);
+  xtensa_enable_cpuint(&g_intenable[0], 1 << ESP32_PERIPH_RWBLE_IRQ);
+#endif
 
   /* Attach and enable internal interrupts */
 
@@ -734,22 +751,6 @@ int esp32_cpuint_initialize(void)
   intmap[ESP32_CPUINT_TIMER0] = CPUINT_ASSIGN(XTENSA_IRQ_TIMER0);
   intmap[ESP32_CPUINT_TIMER1] = CPUINT_ASSIGN(XTENSA_IRQ_TIMER1);
   intmap[ESP32_CPUINT_TIMER2] = CPUINT_ASSIGN(XTENSA_IRQ_TIMER2);
-
-  /* Reserve CPU interrupt for some special drivers */
-
-#ifdef CONFIG_ESP32_WIRELESS
-  intmap[ESP32_CPUINT_MAC]    = CPUINT_ASSIGN(ESP32_IRQ_MAC);
-  xtensa_enable_cpuint(&g_intenable[0], 1 << ESP32_CPUINT_MAC);
-#endif
-
-#ifdef CONFIG_ESP32_BLE
-  intmap[ESP32_PERIPH_BT_BB_NMI] = CPUINT_ASSIGN(ESP32_IRQ_BT_BB_NMI);
-  intmap[ESP32_PERIPH_RWBT_NMI]  = CPUINT_ASSIGN(ESP32_IRQ_RWBT_NMI);
-  intmap[ESP32_PERIPH_RWBLE_IRQ] = CPUINT_ASSIGN(ESP32_IRQ_RWBLE_IRQ);
-  xtensa_enable_cpuint(&g_intenable[0], 1 << ESP32_PERIPH_BT_BB_NMI);
-  xtensa_enable_cpuint(&g_intenable[0], 1 << ESP32_PERIPH_RWBT_NMI);
-  xtensa_enable_cpuint(&g_intenable[0], 1 << ESP32_PERIPH_RWBLE_IRQ);
-#endif
 
   return OK;
 }

--- a/arch/xtensa/src/esp32/esp32_irq.c
+++ b/arch/xtensa/src/esp32/esp32_irq.c
@@ -755,7 +755,6 @@ int esp32_cpuint_initialize(void)
    *
    *   CPU interrupt bit           IRQ number
    *   --------------------------- ---------------------
-   *   ESP32_CPUINT_MAC         0  ESP32_IRQ_MAC      4
    *   ESP32_CPUINT_TIMER0      6  XTENSA_IRQ_TIMER0  0
    *   ESP32_CPUINT_SOFTWARE0   7  Not yet defined
    *   ESP32_CPUINT_PROFILING  11  Not yet defined

--- a/arch/xtensa/src/esp32/esp32_irq.c
+++ b/arch/xtensa/src/esp32/esp32_irq.c
@@ -173,9 +173,7 @@ static uint32_t g_cpu0_freeints = ESP32_CPUINT_PERIPHSET &
                                   (~ESP32_WIRELESS_RESERVE_INT &
                                    ~ESP32_BLE_RESERVE_INT);
 #ifdef CONFIG_SMP
-static uint32_t g_cpu1_freeints = ESP32_CPUINT_PERIPHSET &
-                                  (~ESP32_WIRELESS_RESERVE_INT &
-                                   ~ESP32_BLE_RESERVE_INT);
+static uint32_t g_cpu1_freeints = ESP32_CPUINT_PERIPHSET;
 #endif
 
 /* Bitsets for each interrupt priority 1-5 */

--- a/arch/xtensa/src/esp32s2/esp32s2_cpuint.c
+++ b/arch/xtensa/src/esp32s2/esp32s2_cpuint.c
@@ -331,14 +331,13 @@ int esp32s2_cpuint_initialize(void)
 
   /* Special case the 6 internal interrupts.
    *
-   *   CPU interrupt bit           IRQ number
-   *   --------------------------- ---------------------
-   *   ESP32S2_CPUINT_MAC         0  ESP32S2_IRQ_MAC   4
-   *   ESP32S2_CPUINT_TIMER0      6  XTENSA_IRQ_TIMER0 0
+   *   CPU interrupt bit             IRQ number
+   *   ----------------------------  ---------------------
+   *   ESP32S2_CPUINT_TIMER0      6  XTENSA_IRQ_TIMER0  0
    *   ESP32S2_CPUINT_SOFTWARE0   7  Not yet defined
    *   ESP32S2_CPUINT_PROFILING  11  Not yet defined
-   *   ESP32S2_CPUINT_TIMER1     15  XTENSA_IRQ_TIMER1 1
-   *   ESP32S2_CPUINT_TIMER2     16  XTENSA_IRQ_TIMER2 2
+   *   ESP32S2_CPUINT_TIMER1     15  XTENSA_IRQ_TIMER1  1
+   *   ESP32S2_CPUINT_TIMER2     16  XTENSA_IRQ_TIMER2  2
    *   ESP32S2_CPUINT_SOFTWARE1  29  Not yet defined
    */
 

--- a/arch/xtensa/src/esp32s3/esp32s3_irq.c
+++ b/arch/xtensa/src/esp32s3/esp32s3_irq.c
@@ -477,8 +477,8 @@ int esp32s3_cpuint_initialize(void)
 
   /* Special case the 6 internal interrupts.
    *
-   *   CPU interrupt bit           IRQ number
-   *   --------------------------- ---------------------
+   *   CPU interrupt bit             IRQ number
+   *   ----------------------------  ---------------------
    *   ESP32S3_CPUINT_TIMER0      6  XTENSA_IRQ_TIMER0  0
    *   ESP32S3_CPUINT_SOFTWARE0   7  Not yet defined
    *   ESP32S3_CPUINT_PROFILING  11  Not yet defined


### PR DESCRIPTION
## Summary
1. Move interrupt initialisation for special drivers to `up_irqinitialize`.  `esp32_cpuint_initialize` is not a good place as it's also called from CPU1.
2. For internal interrupts use the current CPU to enable them.
3. Don't reserve BT and Wifi CPU interrupts for APP CPU as they are attached only to the PRO CPU.
## Impact
ESP32
## Testing
ESP32 defconfigs.
