### PR TITLE
sim/usrsock: correct the xid type to uint64_t

### DIFF
--- a/arch/sim/src/sim/up_usrsock.c
+++ b/arch/sim/src/sim/up_usrsock.c
@@ -91,7 +91,7 @@ static int usrsock_send(FAR struct usrsock_s *usrsock,
 }
 
 static int usrsock_send_ack(FAR struct usrsock_s *usrsock,
-                            uint8_t xid, int32_t result)
+                            uint64_t xid, int32_t result)
 {
   struct usrsock_message_req_ack_s ack;
 
@@ -106,7 +106,7 @@ static int usrsock_send_ack(FAR struct usrsock_s *usrsock,
 
 static int usrsock_send_dack(FAR struct usrsock_s *usrsock,
                              FAR struct usrsock_message_datareq_ack_s *ack,
-                             uint8_t xid, int32_t result,
+                             uint64_t xid, int32_t result,
                              uint16_t valuelen,
                              uint16_t valuelen_nontrunc)
 {


### PR DESCRIPTION
## Summary

sim/usrsock: correct the xid type to uint64_t
sim/usrsock: add config of native usrsock

## Impact

N/A

## Testing

ci check