### PR TITLE
devif/ipv6_input.c: fix compile warning 

### DIFF
--- a/net/devif/ipv6_input.c
+++ b/net/devif/ipv6_input.c
@@ -341,9 +341,9 @@ int ipv6_input(FAR struct net_driver_s *dev)
        * ffx2 are interface-local, and therefore, should not be forwarded
        */
 
-      if ((ipv6->destipaddr[0] & HTONS(0xff0f) != HTONS(0xff00)) &&
-          (ipv6->destipaddr[0] & HTONS(0xff0f) != HTONS(0xff01)) &&
-          (ipv6->destipaddr[0] & HTONS(0xff0f) != HTONS(0xff02)))
+      if (((ipv6->destipaddr[0] & HTONS(0xff0f)) != HTONS(0xff00)) &&
+          ((ipv6->destipaddr[0] & HTONS(0xff0f)) != HTONS(0xff01)) &&
+          ((ipv6->destipaddr[0] & HTONS(0xff0f)) != HTONS(0xff02)))
         {
           /* Forward broadcast packets */
 


### PR DESCRIPTION
## Summary

[devif/ipv6_input.c: fix compile warning](https://github.com/apache/incubator-nuttx/commit/c6160a0461b9e4bd2aa8d572d26f08de2303839e)
[sim/dynconns: add more net config into ci check](https://github.com/apache/incubator-nuttx/commit/68220e7c93bb13fcb70b6a35ed28746b7c9df457)

## Impact

N/A

## Testing

ci check