### PR TITLE
sched: Mark pthread as non-cancelable to avoid additional calls to pthread_exit()

### DIFF
--- a/libs/libc/pthread/pthread_exit.c
+++ b/libs/libc/pthread/pthread_exit.c
@@ -54,6 +54,15 @@
 
 void pthread_exit(FAR void *exit_value)
 {
+  /* Mark the pthread as non-cancelable to avoid additional calls to
+   * pthread_exit() due to any cancellation point logic that might get
+   * kicked off by actions taken during pthread_exit processing.
+   */
+
+#ifdef CONFIG_CANCELLATION_POINTS
+  task_setcancelstate(TASK_CANCEL_DISABLE, NULL);
+#endif
+
 #ifdef CONFIG_PTHREAD_CLEANUP
   pthread_cleanup_popall(up_tls_info());
 #endif

--- a/sched/pthread/pthread_exit.c
+++ b/sched/pthread/pthread_exit.c
@@ -78,17 +78,6 @@ void nx_pthread_exit(FAR void *exit_value)
 
   nxsig_procmask(SIG_SETMASK, &set, NULL);
 
-#ifdef CONFIG_CANCELLATION_POINTS
-  /* Mark the pthread as non-cancelable to avoid additional calls to
-   * pthread_exit() due to any cancellation point logic that might get
-   * kicked off by actions taken during pthread_exit processing.
-   */
-
-  tcb->flags  |=  TCB_FLAG_NONCANCELABLE;
-  tcb->flags  &= ~TCB_FLAG_CANCEL_PENDING;
-  tcb->cpcount = 0;
-#endif
-
   /* Complete pending join operations */
 
   status = pthread_completejoin(getpid(), exit_value);


### PR DESCRIPTION
## Summary
Fix the issue found in #5382 
## Impact
Cancellation point
## Testing
sim:ostest
