### PR TITLE
mm: fix #if condition of g_mmheap for BUILD_KERNEL and ADDRENV

### DIFF
--- a/mm/umm_heap/umm_globals.c
+++ b/mm/umm_heap/umm_globals.c
@@ -32,7 +32,7 @@
  * Public Data
  ****************************************************************************/
 
-#if defined(CONFIG_ARCH_ADDRENV) && defined(__KERNEL__)
+#if defined(CONFIG_ARCH_ADDRENV) && defined(CONFIG_BUILD_KERNEL)
 /* In the kernel build, there a multiple user heaps; one for each task
  * group.  In this build configuration, the user heap structure lies
  * in a reserved region at the beginning of the .bss/.data address


### PR DESCRIPTION
## Summary

When BUILD_KERNEL=y and ADDRENV=y, "g_mmheap" is not required.
`__KERNEL__` is only defned in the kernel binary, so use `CONFIG_BUILD_KERNEL` in this code.

related to PR #5522

## Impact

BUILD_KERNEL=y and ADDRENV=y

## Testing

run programs on custom Cortex-A9 board
