### PR TITLE
pthread: add the kernel stack allocation for ADDRENV=y and BUILD_KERNEL

### DIFF
--- a/sched/pthread/pthread_create.c
+++ b/sched/pthread/pthread_create.c
@@ -438,6 +438,17 @@ int nx_pthread_create(pthread_trampoline_t trampoline, FAR pthread_t *thread,
       goto errout_with_join;
     }
 
+#if defined(CONFIG_ARCH_ADDRENV) && defined(CONFIG_BUILD_KERNEL)
+  /* Allocate the kernel stack */
+
+  ret = up_addrenv_kstackalloc(&ptcb->cmn);
+  if (ret < 0)
+    {
+      errcode = ENOMEM;
+      goto errout_with_join;
+    }
+#endif
+
 #ifdef CONFIG_SMP
   /* pthread_setup_scheduler() will set the affinity mask by inheriting the
    * setting from the parent task.  We need to override this setting


### PR DESCRIPTION
## Summary

Add the kernel stack allocation in nx_pthread_create().
When ADDRENV=y and BUILD_KERNEL=y, the kernel stack is required for a task creating.

The kernel stack allocation of the main task is already in binfmt_execmodule.c:exec_module().

## Impact

ADDRENV=y and BUILD_KERNEL=y

## Testing

run programs using pthread on custom Cortex-A9 w/ ADDRENV=y and BUILD_KERNEL.
