### PR TITLE
pfocfs: add newline /proc/*/loadavg snprintf format

### DIFF
--- a/fs/procfs/fs_procfsproc.c
+++ b/fs/procfs/fs_procfsproc.c
@@ -754,7 +754,7 @@ static ssize_t proc_loadavg(FAR struct proc_file_s *procfile,
     }
 
   linesize = procfs_snprintf(procfile->line, STATUS_LINELEN,
-                             "%3" PRId32 ".%01" PRId32 "%%",
+                             "%3" PRId32 ".%01" PRId32 "%%\n",
                              intpart, fracpart);
   copysize = procfs_memcpy(procfile->line, linesize, buffer, buflen,
                            &offset);


### PR DESCRIPTION
## Summary

Add newline to snprintf format for /proc/*/loadavg.

current:
```
nsh> cat /proc/5/loadavg
  0.1%nsh>
```
this patch:
```
nsh> cat /proc/5/loadavg
  0.0%
nsh> 
```

## Impact

/proc/*/loadavg (CONFIG_SCHED_CPULOAD=y)

## Testing

cat loadavg on nsh (sabre-6quad:smp qemu)
