### PR TITLE
ci: Install Rust via RUN.

### DIFF
--- a/tools/ci/docker/linux/Dockerfile
+++ b/tools/ci/docker/linux/Dockerfile
@@ -191,6 +191,12 @@ RUN cd renesas-tools/source/newlib && \
 RUN cd /tools/renesas-tools/build/gcc && \
   make && make install
 
+# Install Rust and targets supported from NuttX
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y && \
+  $HOME/.cargo/bin/rustup target add thumbv6m-none-eabi && \
+  $HOME/.cargo/bin/rustup target add thumbv7m-none-eabi
+ENV PATH="$HOME/.cargo/bin:$PATH"
+
 ###############################################################################
 # Final Docker image used for running CI system.  This includes all toolchains
 # supported by the CI system.
@@ -227,7 +233,6 @@ RUN apt-get update -qq && DEBIAN_FRONTEND="noninteractive" apt-get install -y -q
   python3 \
   python3-pip \
   python-is-python3 \
-  rustc \
   u-boot-tools \
   unzip \
   wget \


### PR DESCRIPTION
## Summary
Install Rust via RUN.
This way rustup is installed, too.
Via rustup the additional targets can be installed.
Initially support for v6m and v7m targets is installed.

## Impact
ci se-tup

## Testing
partly via command line on MacOS/Linux.
