### PR TITLE
vncserver: Corret size calculation of rfb_setencodings_s

### DIFF
--- a/include/nuttx/video/rfb.h
+++ b/include/nuttx/video/rfb.h
@@ -356,7 +356,7 @@ struct rfb_setencodings_s
 };
 
 #define SIZEOF_RFB_SETENCODINGS_S(n) \
-  (sizeof(struct rfb_setencodings_s) + (((n) - 1) << 2))
+  (sizeof(struct rfb_setencodings_s) + ((n) == 0 ? -4 : ((n) - 1) << 2))
 
 /* 6.4.3 FramebufferUpdateRequest
  *


### PR DESCRIPTION

## Summary
Fix
```
video/vnc/vnc_negotiate.c:426:29: warning: shifting a negative signed value is undefined [-Wshift-negative-value]
      DEBUGASSERT(nrecvd >= SIZEOF_RFB_SETENCODINGS_S(0));
      ~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/huang/Work/nx/nuttx/include/nuttx/video/rfb.h:359:51: note: expanded from macro 'SIZEOF_RFB_SETENCODINGS_S'
  (sizeof(struct rfb_setencodings_s) + (((n) - 1) << 2))
                                                  ^
/home/huang/Work/nx/nuttx/include/assert.h:56:33: note: expanded from macro 'DEBUGASSERT'
                         ~~~~~~~^~
/home/huang/Work/nx/nuttx/include/assert.h:51:37: note: expanded from macro 'ASSERT'
```

## Impact
VNC Server
## Testing
sim:vncserver
