### PR TITLE
pty: Handle pty ioctl and fcntl to pipe ioctl 

### DIFF
--- a/drivers/serial/ptmx.c
+++ b/drivers/serial/ptmx.c
@@ -220,7 +220,7 @@ static int ptmx_open(FAR struct file *filep)
    */
 
   ret = unregister_driver(devname);
-  DEBUGASSERT(ret >= 0);  /* unregister_driver() should never fail */
+  DEBUGASSERT(ret >= 0 || ret == -EBUSY);  /* unregister_driver() should never fail */
 
   nxsem_post(&g_ptmx.px_exclsem);
   return OK;

--- a/drivers/serial/pty.c
+++ b/drivers/serial/pty.c
@@ -876,7 +876,11 @@ static int pty_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
 
       case FIONBIO:
         {
-          ret = file_ioctl(&dev->pd_sink, cmd, arg);
+          ret = file_ioctl(&dev->pd_src, cmd, arg);
+          if (ret >= 0 || ret == -ENOTTY)
+            {
+              ret = file_ioctl(&dev->pd_sink, cmd, arg);
+            }
         }
         break;
 

--- a/drivers/serial/pty.c
+++ b/drivers/serial/pty.c
@@ -881,6 +881,13 @@ static int pty_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
             {
               ret = file_ioctl(&dev->pd_sink, cmd, arg);
             }
+
+          /* Let the default handler set O_NONBLOCK flags for us. */
+
+          if (ret >= 0)
+            {
+              ret = -ENOTTY;
+            }
         }
         break;
 

--- a/drivers/serial/pty.c
+++ b/drivers/serial/pty.c
@@ -874,6 +874,12 @@ static int pty_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
         }
         break;
 
+      case FIONBIO:
+        {
+          ret = file_ioctl(&dev->pd_sink, cmd, arg);
+        }
+        break;
+
       /* Any unrecognized IOCTL commands will be passed to the contained
        * pipe driver.
        *
@@ -892,7 +898,7 @@ static int pty_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
               ret = file_ioctl(&dev->pd_sink, cmd, arg);
             }
 #else
-          ret = ENOTTY;
+          ret = -ENOTTY;
 #endif
         }
         break;

--- a/fs/vfs/fs_fcntl.c
+++ b/fs/vfs/fs_fcntl.c
@@ -159,11 +159,16 @@ static int file_vfcntl(FAR struct file *filep, int cmd, va_list ap)
 
         {
           int oflags = va_arg(ap, int);
+          int nonblock = !!(oflags & O_NONBLOCK);
 
-          oflags          &=  FFCNTL;
-          filep->f_oflags &= ~FFCNTL;
-          filep->f_oflags |=  oflags;
-          ret              =  OK;
+          ret = file_ioctl(filep, FIONBIO, &nonblock);
+          if (ret == OK)
+            {
+              oflags          &=  (FFCNTL & ~O_NONBLOCK);
+              filep->f_oflags &= ~(FFCNTL & ~O_NONBLOCK);
+              filep->f_oflags |=  oflags;
+              ret              =  OK;
+            }
         }
         break;
 

--- a/fs/vfs/fs_ioctl.c
+++ b/fs/vfs/fs_ioctl.c
@@ -83,14 +83,14 @@ int file_vioctl(FAR struct file *filep, int req, va_list ap)
           FAR int *nonblock = (FAR int *)(uintptr_t)arg;
           if (nonblock && *nonblock)
             {
-              ret = file_fcntl(filep, F_SETFL,
-                              file_fcntl(filep, F_GETFL) | O_NONBLOCK);
+              filep->f_oflags |= O_NONBLOCK;
             }
           else
             {
-              ret = file_fcntl(filep, F_SETFL,
-                              file_fcntl(filep, F_GETFL) & ~O_NONBLOCK);
+              filep->f_oflags &= ~O_NONBLOCK;
             }
+
+          ret = OK;
         }
         break;
 


### PR DESCRIPTION
## Summary
Pty set ioctl FIONBIO and fcntl O_NONBLOCK flags fail, handle pty ioctl and fcntl to pipe ioctl, fix pty ioctl error ret value.

## Impact
Pty

## Testing
Custom application.
