### PR TITLE
os init_state: add new state OSINIT_OSIDLELOOP

### DIFF
--- a/drivers/power/pm_register.c
+++ b/drivers/power/pm_register.c
@@ -62,19 +62,11 @@ int pm_register(FAR struct pm_callback_s *callbacks)
 
   /* Add the new entry to the end of the list of registered callbacks */
 
-  if (OSINIT_OS_READY())
-    {
-      ret = pm_lock();
-      if (ret == OK)
-        {
-          dq_addlast(&callbacks->entry, &g_pmglobals.registry);
-          pm_unlock();
-        }
-    }
-  else
+  ret = pm_lock();
+  if (ret == OK)
     {
       dq_addlast(&callbacks->entry, &g_pmglobals.registry);
-      ret = OK;
+      pm_unlock();
     }
 
   return ret;

--- a/include/nuttx/init.h
+++ b/include/nuttx/init.h
@@ -41,6 +41,7 @@
 #define OSINIT_MM_READY()        (g_nx_initstate >= OSINIT_MEMORY)
 #define OSINIT_HW_READY()        (g_nx_initstate >= OSINIT_HARDWARE)
 #define OSINIT_OS_READY()        (g_nx_initstate >= OSINIT_OSREADY)
+#define OSINIT_IDLELOOP()        (g_nx_initstate >= OSINIT_IDLELOOP)
 #define OSINIT_OS_INITIALIZING() (g_nx_initstate  < OSINIT_OSREADY)
 
 /****************************************************************************
@@ -65,8 +66,9 @@ enum nx_initstate_e
                           * to support the hardware are also available but
                           * the OS has not yet completed its full
                           * initialization. */
-  OSINIT_OSREADY   = 5   /* The OS is fully initialized and multi-tasking is
+  OSINIT_OSREADY   = 5,  /* The OS is fully initialized and multi-tasking is
                           * active. */
+  OSINIT_IDLELOOP  = 6   /* The OS enter idle loop */
 };
 
 /****************************************************************************

--- a/sched/init/nx_start.c
+++ b/sched/init/nx_start.c
@@ -776,6 +776,10 @@ void nx_start(void)
 
   DEBUGVERIFY(nx_bringup());
 
+  /* Enter to idleloop */
+
+  g_nx_initstate = OSINIT_IDLELOOP;
+
   /* Let other threads have access to the memory manager */
 
   sched_unlock();

--- a/sched/semaphore/sem_trywait.c
+++ b/sched/semaphore/sem_trywait.c
@@ -29,6 +29,7 @@
 #include <assert.h>
 #include <errno.h>
 
+#include <nuttx/init.h>
 #include <nuttx/irq.h>
 #include <nuttx/arch.h>
 
@@ -69,9 +70,10 @@ int nxsem_trywait(FAR sem_t *sem)
   irqstate_t flags;
   int ret;
 
-  /* This API should not be called from interrupt handlers */
+  /* This API should not be called from interrupt handlers & idleloop */
 
   DEBUGASSERT(sem != NULL && up_interrupt_context() == false);
+  DEBUGASSERT(OSINIT_IDLELOOP() && !sched_idletask());
 
   if (sem != NULL)
     {

--- a/sched/semaphore/sem_wait.c
+++ b/sched/semaphore/sem_wait.c
@@ -28,6 +28,7 @@
 #include <errno.h>
 #include <assert.h>
 
+#include <nuttx/init.h>
 #include <nuttx/irq.h>
 #include <nuttx/arch.h>
 #include <nuttx/cancelpt.h>
@@ -73,9 +74,10 @@ int nxsem_wait(FAR sem_t *sem)
   irqstate_t flags;
   int ret = -EINVAL;
 
-  /* This API should not be called from interrupt handlers */
+  /* This API should not be called from interrupt handlers & idleloop */
 
   DEBUGASSERT(sem != NULL && up_interrupt_context() == false);
+  DEBUGASSERT(OSINIT_IDLELOOP() && !sched_idletask());
 
   /* The following operations must be performed with interrupts
    * disabled because nxsem_post() may be called from an interrupt


### PR DESCRIPTION
## Summary

os init_state: add new state OSINIT_OSIDLELOOP

This is for distinguish we are in init idle or idle loop.
Use for assertion for sem_trywait & sem_wait

## Impact

wait/try wait in IDLE thread

## Testing

VELA

