### PR TITLE
arch/arm: replace SYS_syscall_return hardcode from syscall

### DIFF
--- a/arch/arm/src/armv6-m/arm_svcall.c
+++ b/arch/arm/src/armv6-m/arm_svcall.c
@@ -95,8 +95,9 @@ static void dispatch_syscall(void)
     " add sp, sp, #12\n"          /* Destroy the stack frame */
     " pop {r4, r5}\n"             /* Recover R4 and R5 */
     " mov r2, r0\n"               /* R2=Save return value in R2 */
-    " mov r0, #3\n"               /* R0=SYS_syscall_return */
-    " svc %0\n"::"i"(SYS_syscall) /* Return from the SYSCALL */
+    " mov r0, %0\n"               /* R0=SYS_syscall_return */
+    " svc %1\n"::"i"(SYS_syscall_return),
+                 "i"(SYS_syscall) /* Return from the SYSCALL */
   );
 }
 #endif

--- a/arch/arm/src/armv7-a/arm_syscall.c
+++ b/arch/arm/src/armv7-a/arm_syscall.c
@@ -96,8 +96,9 @@ static void dispatch_syscall(void)
     " ldr lr, [sp, #12]\n"         /* Restore lr */
     " add sp, sp, #16\n"           /* Destroy the stack frame */
     " mov r2, r0\n"                /* R2=Save return value in R2 */
-    " mov r0, #0\n"                /* R0=SYS_syscall_return */
-    " svc %0\n"::"i"(SYS_syscall)  /* Return from the SYSCALL */
+    " mov r0, %0\n"                /* R0=SYS_syscall_return */
+    " svc %1\n"::"i"(SYS_syscall_return),
+                 "i"(SYS_syscall)  /* Return from the SYSCALL */
   );
 }
 #endif

--- a/arch/arm/src/armv7-a/crt0.c
+++ b/arch/arm/src/armv7-a/crt0.c
@@ -79,9 +79,10 @@ static void sig_trampoline(void)
     " blx  ip\n"         /* Call the signal handler */
     " pop  {r2}\n"       /* Recover LR in R2 */
     " mov  lr, r2\n"     /* Restore LR */
-    " mov  r0, #5\n"     /* SYS_signal_handler_return */
-    " svc %0\n"          /* Return from the SYSCALL */
-    ::"i"(SYS_syscall)
+    " mov  r0, %0\n"     /* SYS_signal_handler_return */
+    " svc %1\n"          /* Return from the SYSCALL */
+    ::"i"(SYS_signal_handler_return),
+      "i"(SYS_syscall)
   );
 }
 

--- a/arch/arm/src/armv7-m/arm_svcall.c
+++ b/arch/arm/src/armv7-m/arm_svcall.c
@@ -103,8 +103,9 @@ static void dispatch_syscall(void)
       " ldr r2, [sp, #16]\n"         /* Restore (orig_SP - new_SP) value */
       " add sp, sp, r2\n"            /* Restore SP */
       " mov r2, r0\n"                /* R2=Save return value in R2 */
-      " mov r0, #3\n"                /* R0=SYS_syscall_return */
-      " svc %0\n"::"i"(SYS_syscall)  /* Return from the SYSCALL */
+      " mov r0, %0\n"                /* R0=SYS_syscall_return */
+      " svc %1\n"::"i"(SYS_syscall_return),
+                   "i"(SYS_syscall)  /* Return from the SYSCALL */
     );
 }
 #endif

--- a/arch/arm/src/armv7-r/arm_syscall.c
+++ b/arch/arm/src/armv7-r/arm_syscall.c
@@ -93,8 +93,9 @@ static void dispatch_syscall(void)
     " ldr lr, [sp, #12]\n"         /* Restore lr */
     " add sp, sp, #16\n"           /* Destroy the stack frame */
     " mov r2, r0\n"                /* R2=Save return value in R2 */
-    " mov r0, #0\n"                /* R0=SYS_syscall_return */
-    " svc %0\n"::"i"(SYS_syscall)  /* Return from the SYSCALL */
+    " mov r0, %0\n"                /* R0=SYS_syscall_return */
+    " svc %1\n"::"i"(SYS_syscall_return),
+                 "i"(SYS_syscall)  /* Return from the SYSCALL */
   );
 }
 #endif

--- a/arch/arm/src/armv8-m/arm_svcall.c
+++ b/arch/arm/src/armv8-m/arm_svcall.c
@@ -102,8 +102,9 @@ static void dispatch_syscall(void)
       " ldr r2, [sp, #16]\n"         /* Restore (orig_SP - new_SP) value */
       " add sp, sp, r2\n"            /* Restore SP */
       " mov r2, r0\n"                /* R2=Save return value in R2 */
-      " mov r0, #3\n"                /* R0=SYS_syscall_return */
-      " svc %0\n"::"i"(SYS_syscall)  /* Return from the SYSCALL */
+      " mov r0, %0\n"                /* R0=SYS_syscall_return */
+      " svc %1\n"::"i"(SYS_syscall_return),
+                   "i"(SYS_syscall)  /* Return from the SYSCALL */
     );
 }
 #endif


### PR DESCRIPTION
## Summary

arch/arm: replace SYS_syscall_return hardcode from syscall

## Impact

N/A

## Testing

run ostest on flat / kernel mode, ci check