### PR TITLE
mm: Add memory dump function when enable CONFIG_DEBUG_MM

### DIFF
--- a/arch/sim/src/sim/up_heap.c
+++ b/arch/sim/src/sim/up_heap.c
@@ -389,6 +389,18 @@ int mm_mallinfo(FAR struct mm_heap_s *heap, FAR struct mallinfo *info)
   return 0;
 }
 
+/****************************************************************************
+ * Name: mm_memdump
+ *
+ * Description:
+ *   mm_memdump returns a memory info about specified pid of task/thread.
+ *
+ ****************************************************************************/
+
+void mm_memdump(FAR struct mm_heap_s *heap, pid_t pid)
+{
+}
+
 #ifdef CONFIG_DEBUG_MM
 
 /****************************************************************************

--- a/fs/procfs/Kconfig
+++ b/fs/procfs/Kconfig
@@ -96,6 +96,10 @@ config FS_PROCFS_EXCLUDE_MEMINFO
 	bool "Exclude meminfo"
 	default n
 
+config FS_PROCFS_EXCLUDE_MEMDUMP
+	bool "Exclude memdump"
+	default n
+
 config FS_PROCFS_INCLUDE_PROGMEM
 	bool "Include prog mem"
 	default n

--- a/fs/procfs/fs_procfs.c
+++ b/fs/procfs/fs_procfs.c
@@ -66,6 +66,7 @@ extern const struct procfs_operations irq_operations;
 extern const struct procfs_operations cpuload_operations;
 extern const struct procfs_operations critmon_operations;
 extern const struct procfs_operations meminfo_operations;
+extern const struct procfs_operations memdump_operations;
 extern const struct procfs_operations iobinfo_operations;
 extern const struct procfs_operations module_operations;
 extern const struct procfs_operations uptime_operations;
@@ -115,6 +116,9 @@ static const struct procfs_entry_s g_procfs_entries[] =
 
 #ifndef CONFIG_FS_PROCFS_EXCLUDE_MEMINFO
   { "meminfo",       &meminfo_operations,         PROCFS_FILE_TYPE   },
+#ifndef CONFIG_FS_PROCFS_EXCLUDE_MEMDUMP
+  { "memdump",       &memdump_operations,         PROCFS_FILE_TYPE   },
+#endif
 #endif
 
 #if defined(CONFIG_MM_IOB) && !defined(CONFIG_FS_PROCFS_EXCLUDE_IOBINFO)

--- a/fs/procfs/fs_procfsmeminfo.c
+++ b/fs/procfs/fs_procfsmeminfo.c
@@ -415,15 +415,21 @@ static ssize_t memdump_read(FAR struct file *filep, FAR char *buffer,
   procfile = (FAR struct meminfo_file_s *)filep->f_priv;
   DEBUGASSERT(procfile);
 
+#ifdef CONFIG_DEBUG_MM
+  linesize  = procfs_snprintf(procfile->line, MEMINFO_LINELEN,
+                              "usage: <pid/used/free>\n"
+                              "pid: dump pid allocated node\n");
+#else
   linesize  = procfs_snprintf(procfile->line, MEMINFO_LINELEN,
                               "usage: <used/free>\n");
+#endif
 
   copysize  = procfs_memcpy(procfile->line, linesize, buffer, buflen,
                             &offset);
   totalsize = copysize;
   buffer   += copysize;
   buflen   -= copysize;
-  linesize  = procfs_snprintf(procfile->line, MEMINFO_LINELEN, "%s",
+  linesize  = procfs_snprintf(procfile->line, MEMINFO_LINELEN,
                               "used: dump all allocated node\n"
                               "free: dump all free node\n");
 
@@ -462,6 +468,10 @@ static ssize_t memdump_write(FAR struct file *filep, FAR const char *buffer,
       case 'f':
         pid = -2;
         break;
+#ifdef CONFIG_DEBUG_MM
+      default:
+        pid = atoi(buffer);
+#endif
     }
 
   for (entry = g_procfs_meminfo; entry != NULL; entry = entry->next)

--- a/fs/procfs/fs_procfsmeminfo.c
+++ b/fs/procfs/fs_procfsmeminfo.c
@@ -94,6 +94,12 @@ static void    meminfo_progmem(FAR struct progmem_info_s *progmem);
 static int     meminfo_open(FAR struct file *filep, FAR const char *relpath,
                  int oflags, mode_t mode);
 static int     meminfo_close(FAR struct file *filep);
+#ifndef CONFIG_FS_PROCFS_EXCLUDE_MEMDUMP
+static ssize_t memdump_read(FAR struct file *filep, FAR char *buffer,
+                             size_t buflen);
+static ssize_t memdump_write(FAR struct file *filep, FAR const char *buffer,
+                             size_t buflen);
+#endif
 static ssize_t meminfo_read(FAR struct file *filep, FAR char *buffer,
                  size_t buflen);
 static int     meminfo_dup(FAR const struct file *oldp,
@@ -122,6 +128,22 @@ const struct procfs_operations meminfo_operations =
   NULL,           /* rewinddir */
   meminfo_stat    /* stat */
 };
+
+#ifndef CONFIG_FS_PROCFS_EXCLUDE_MEMDUMP
+const struct procfs_operations memdump_operations =
+{
+  meminfo_open,   /* open */
+  meminfo_close,  /* close */
+  memdump_read,   /* read */
+  memdump_write,  /* write */
+  meminfo_dup,    /* dup */
+  NULL,           /* opendir */
+  NULL,           /* closedir */
+  NULL,           /* readdir */
+  NULL,           /* rewinddir */
+  meminfo_stat    /* stat */
+};
+#endif
 
 FAR struct procfs_meminfo_entry_s *g_procfs_meminfo = NULL;
 
@@ -206,22 +228,9 @@ static int meminfo_open(FAR struct file *filep, FAR const char *relpath,
 
   finfo("Open '%s'\n", relpath);
 
-  /* PROCFS is read-only.  Any attempt to open with any kind of write
-   * access is not permitted.
-   *
-   * REVISIT:  Write-able proc files could be quite useful.
-   */
-
-  if ((oflags & O_WRONLY) != 0 || (oflags & O_RDONLY) == 0)
-    {
-      ferr("ERROR: Only O_RDONLY supported\n");
-      return -EACCES;
-    }
-
   /* Allocate a container to hold the file attributes */
 
-  procfile = (FAR struct meminfo_file_s *)
-    kmm_zalloc(sizeof(struct meminfo_file_s));
+  procfile = kmm_zalloc(sizeof(struct meminfo_file_s));
   if (!procfile)
     {
       ferr("ERROR: Failed to allocate file attributes\n");
@@ -230,7 +239,7 @@ static int meminfo_open(FAR struct file *filep, FAR const char *relpath,
 
   /* Save the attributes as the open-specific state in filep->f_priv */
 
-  filep->f_priv = (FAR void *)procfile;
+  filep->f_priv = procfile;
   return OK;
 }
 
@@ -381,6 +390,88 @@ static ssize_t meminfo_read(FAR struct file *filep, FAR char *buffer,
   filep->f_pos += totalsize;
   return totalsize;
 }
+
+/****************************************************************************
+ * Name: memdump_read
+ ****************************************************************************/
+
+#ifndef CONFIG_FS_PROCFS_EXCLUDE_MEMDUMP
+static ssize_t memdump_read(FAR struct file *filep, FAR char *buffer,
+                            size_t buflen)
+{
+  FAR struct meminfo_file_s *procfile;
+  size_t linesize;
+  size_t copysize;
+  size_t totalsize;
+  off_t offset;
+
+  finfo("buffer=%p buflen=%d\n", buffer, (int)buflen);
+
+  DEBUGASSERT(filep != NULL && buffer != NULL && buflen > 0);
+  offset = filep->f_pos;
+
+  /* Recover our private data from the struct file instance */
+
+  procfile = (FAR struct meminfo_file_s *)filep->f_priv;
+  DEBUGASSERT(procfile);
+
+  linesize  = procfs_snprintf(procfile->line, MEMINFO_LINELEN,
+                              "usage: <used/free>\n");
+
+  copysize  = procfs_memcpy(procfile->line, linesize, buffer, buflen,
+                            &offset);
+  totalsize = copysize;
+  buffer   += copysize;
+  buflen   -= copysize;
+  linesize  = procfs_snprintf(procfile->line, MEMINFO_LINELEN, "%s",
+                              "used: dump all allocated node\n"
+                              "free: dump all free node\n");
+
+  totalsize += procfs_memcpy(procfile->line, linesize, buffer, buflen,
+                             &offset);
+  filep->f_pos += totalsize;
+  return totalsize;
+}
+#endif
+
+/****************************************************************************
+ * Name: memdump_write
+ ****************************************************************************/
+
+#ifndef CONFIG_FS_PROCFS_EXCLUDE_MEMDUMP
+static ssize_t memdump_write(FAR struct file *filep, FAR const char *buffer,
+                             size_t buflen)
+{
+  FAR const struct procfs_meminfo_entry_s *entry;
+  FAR struct meminfo_file_s *procfile;
+  pid_t pid = -1;
+
+  DEBUGASSERT(filep != NULL && buffer != NULL && buflen > 0);
+
+  /* Recover our private data from the struct file instance */
+
+  procfile = filep->f_priv;
+  DEBUGASSERT(procfile);
+
+  switch (buffer[0])
+    {
+      case 'u':
+        pid = -1;
+        break;
+
+      case 'f':
+        pid = -2;
+        break;
+    }
+
+  for (entry = g_procfs_meminfo; entry != NULL; entry = entry->next)
+    {
+      mm_memdump(entry->user_data, pid);
+    }
+
+  return buflen;
+}
+#endif
 
 /****************************************************************************
  * Name: meminfo_dup

--- a/include/malloc.h
+++ b/include/malloc.h
@@ -52,6 +52,15 @@ struct mallinfo
                  * by free (not in use) chunks. */
 };
 
+#ifdef CONFIG_DEBUG_MM
+struct mallinfo_task
+{
+  pid_t pid;    /* The pid of task */
+  int aordblks; /* This is the number of allocated (in use) chunks for task */
+  int uordblks; /* This is the total size of memory occupied for task */
+};
+#endif
+
 /****************************************************************************
  * Public Function Prototypes
  ****************************************************************************/
@@ -63,6 +72,9 @@ extern "C"
 
 struct mallinfo mallinfo(void);
 size_t malloc_size(FAR void *ptr);
+#ifdef CONFIG_DEBUG_MM
+struct mallinfo_task mallinfo_task(pid_t pid);
+#endif
 
 #if defined(__cplusplus)
 }

--- a/include/nuttx/mm/mm.h
+++ b/include/nuttx/mm/mm.h
@@ -296,6 +296,7 @@ void kmm_extend(FAR void *mem, size_t size, int region);
 
 struct mallinfo; /* Forward reference */
 int mm_mallinfo(FAR struct mm_heap_s *heap, FAR struct mallinfo *info);
+void mm_memdump(FAR struct mm_heap_s *heap, pid_t pid);
 
 /* Functions contained in kmm_mallinfo.c ************************************/
 

--- a/include/nuttx/mm/mm.h
+++ b/include/nuttx/mm/mm.h
@@ -296,13 +296,16 @@ void kmm_extend(FAR void *mem, size_t size, int region);
 
 struct mallinfo; /* Forward reference */
 int mm_mallinfo(FAR struct mm_heap_s *heap, FAR struct mallinfo *info);
-void mm_memdump(FAR struct mm_heap_s *heap, pid_t pid);
 
 /* Functions contained in kmm_mallinfo.c ************************************/
 
 #ifdef CONFIG_MM_KERNEL_HEAP
 struct mallinfo kmm_mallinfo(void);
 #endif
+
+/* Functions contained in mm_memdump.c **************************************/
+
+void mm_memdump(FAR struct mm_heap_s *heap, pid_t pid);
 
 #ifdef CONFIG_DEBUG_MM
 /* Functions contained in mm_checkcorruption.c ******************************/

--- a/include/nuttx/mm/mm.h
+++ b/include/nuttx/mm/mm.h
@@ -296,11 +296,19 @@ void kmm_extend(FAR void *mem, size_t size, int region);
 
 struct mallinfo; /* Forward reference */
 int mm_mallinfo(FAR struct mm_heap_s *heap, FAR struct mallinfo *info);
+#ifdef CONFIG_DEBUG_MM
+struct mallinfo_task; /* Forward reference */
+int mm_mallinfo_task(FAR struct mm_heap_s *heap,
+                     FAR struct mallinfo_task *info);
+#endif
 
 /* Functions contained in kmm_mallinfo.c ************************************/
 
 #ifdef CONFIG_MM_KERNEL_HEAP
 struct mallinfo kmm_mallinfo(void);
+#  ifdef CONFIG_DEBUG_MM
+struct mallinfo_task kmm_mallinfo_task(pid_t pid);
+#  endif
 #endif
 
 /* Functions contained in mm_memdump.c **************************************/

--- a/mm/kmm_heap/kmm_mallinfo.c
+++ b/mm/kmm_heap/kmm_mallinfo.c
@@ -50,4 +50,23 @@ struct mallinfo kmm_mallinfo(void)
   return info;
 }
 
+/****************************************************************************
+ * Name: kmm_mallinfo_task
+ *
+ * Description:
+ *   kmm_mallinfo_task returns a copy of updated current heap information of
+ *   task with specified pid for the user heap.
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_DEBUG_MM
+struct mallinfo_task kmm_mallinfo_task(pid_t pid)
+{
+  struct mallinfo_task info;
+
+  info.pid = pid;
+  mm_mallinfo_task(g_kmmheap, &info);
+  return info;
+}
+#endif
 #endif /* CONFIG_MM_KERNEL_HEAP */

--- a/mm/mm_heap/Make.defs
+++ b/mm/mm_heap/Make.defs
@@ -25,7 +25,7 @@ ifeq ($(CONFIG_MM_DEFAULT_MANAGER),y)
 CSRCS += mm_initialize.c mm_sem.c mm_addfreechunk.c mm_size2ndx.c
 CSRCS += mm_malloc_size.c mm_shrinkchunk.c mm_brkaddr.c mm_calloc.c
 CSRCS += mm_extend.c mm_free.c mm_mallinfo.c mm_malloc.c mm_foreach.c
-CSRCS += mm_memalign.c mm_realloc.c mm_zalloc.c mm_heapmember.c
+CSRCS += mm_memalign.c mm_realloc.c mm_zalloc.c mm_heapmember.c mm_memdump.c
 
 ifeq ($(CONFIG_DEBUG_MM),y)
 CSRCS += mm_checkcorruption.c

--- a/mm/mm_heap/mm_initialize.c
+++ b/mm/mm_heap/mm_initialize.c
@@ -182,15 +182,6 @@ FAR struct mm_heap_s *mm_initialize(FAR const char *name,
   heapsize -= sizeof(struct mm_heap_s);
   heapstart = (FAR char *)heap_adj + sizeof(struct mm_heap_s);
 
-  /* The following two lines have cause problems for some older ZiLog
-   * compilers in the past (but not the more recent).  Life is easier if we
-   * just the suppress them altogther for those tools.
-   */
-
-#ifndef __ZILOG__
-  CHECK_ALLOCNODE_SIZE;
-  CHECK_FREENODE_SIZE;
-#endif
   DEBUGASSERT(MM_MIN_CHUNK >= SIZEOF_MM_FREENODE);
   DEBUGASSERT(MM_MIN_CHUNK >= SIZEOF_MM_ALLOCNODE);
 

--- a/mm/mm_heap/mm_initialize.c
+++ b/mm/mm_heap/mm_initialize.c
@@ -117,6 +117,7 @@ void mm_addregion(FAR struct mm_heap_s *heap, FAR void *heapstart,
 
   heap->mm_heapstart[IDX]            = (FAR struct mm_allocnode_s *)
                                        heapbase;
+  MM_ADD_BACKTRACE(heap->mm_heapstart[IDX]);
   heap->mm_heapstart[IDX]->size      = SIZEOF_MM_ALLOCNODE;
   heap->mm_heapstart[IDX]->preceding = MM_ALLOC_BIT;
   node                               = (FAR struct mm_freenode_s *)
@@ -127,6 +128,7 @@ void mm_addregion(FAR struct mm_heap_s *heap, FAR void *heapstart,
                                        (heapend - SIZEOF_MM_ALLOCNODE);
   heap->mm_heapend[IDX]->size        = SIZEOF_MM_ALLOCNODE;
   heap->mm_heapend[IDX]->preceding   = node->size | MM_ALLOC_BIT;
+  MM_ADD_BACKTRACE(heap->mm_heapend[IDX]);
 
 #undef IDX
 

--- a/mm/mm_heap/mm_mallinfo.c
+++ b/mm/mm_heap/mm_mallinfo.c
@@ -75,6 +75,26 @@ static void mallinfo_handler(FAR struct mm_allocnode_s *node, FAR void *arg)
     }
 }
 
+#ifdef CONFIG_DEBUG_MM
+static void mallinfo_task_handler(FAR struct mm_allocnode_s *node,
+                                  FAR void *arg)
+{
+  FAR struct mallinfo_task *info = arg;
+
+  /* Check if the node corresponds to an allocated memory chunk */
+
+  if ((node->preceding & MM_ALLOC_BIT) != 0)
+    {
+      DEBUGASSERT(node->size >= SIZEOF_MM_ALLOCNODE);
+      if (node->pid == info->pid)
+        {
+          info->aordblks++;
+          info->uordblks += node->size;
+        }
+    }
+}
+#endif
+
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
@@ -107,3 +127,25 @@ int mm_mallinfo(FAR struct mm_heap_s *heap, FAR struct mallinfo *info)
 
   return OK;
 }
+
+/****************************************************************************
+ * Name: mm_mallinfo_task
+ *
+ * Description:
+ *   mallinfo returns a copy of updated current heap information for task
+ *   with pid.
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_DEBUG_MM
+int mm_mallinfo_task(FAR struct mm_heap_s *heap,
+                     FAR struct mallinfo_task *info)
+{
+  DEBUGASSERT(info);
+
+  info->uordblks = 0;
+  info->aordblks = 0;
+  mm_foreach(heap, mallinfo_task_handler, info);
+  return OK;
+}
+#endif

--- a/mm/mm_heap/mm_malloc.c
+++ b/mm/mm_heap/mm_malloc.c
@@ -244,6 +244,8 @@ FAR void *mm_malloc(FAR struct mm_heap_s *heap, size_t size)
   else
     {
       mwarn("WARNING: Allocation failed, size %zu\n", alignsize);
+      mm_memdump(heap, -1);
+      DEBUGASSERT(false);
     }
 #endif
 

--- a/mm/mm_heap/mm_malloc.c
+++ b/mm/mm_heap/mm_malloc.c
@@ -223,6 +223,7 @@ FAR void *mm_malloc(FAR struct mm_heap_s *heap, size_t size)
       /* Handle the case of an exact size match */
 
       node->preceding |= MM_ALLOC_BIT;
+      MM_ADD_BACKTRACE(node);
       ret = (FAR void *)((FAR char *)node + SIZEOF_MM_ALLOCNODE);
     }
 

--- a/mm/mm_heap/mm_memalign.c
+++ b/mm/mm_heap/mm_memalign.c
@@ -178,6 +178,7 @@ FAR void *mm_memalign(FAR struct mm_heap_s *heap, size_t alignment,
 
       newnode->size = (size_t)next - (size_t)newnode;
       newnode->preceding = precedingsize | MM_ALLOC_BIT;
+      MM_ADD_BACKTRACE(newnode);
 
       /* Reduce the size of the original chunk and mark it not allocated, */
 

--- a/mm/mm_heap/mm_memdump.c
+++ b/mm/mm_heap/mm_memdump.c
@@ -1,0 +1,121 @@
+/****************************************************************************
+ * mm/mm_heap/mm_memdump.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <stdio.h>
+#include <malloc.h>
+#include <assert.h>
+#include <debug.h>
+
+#include <nuttx/mm/mm.h>
+
+#include "mm_heap/mm.h"
+
+struct memdump_info_s
+{
+  pid_t pid;
+  int   blks;
+  int   size;
+};
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+static void memdump_handler(FAR struct mm_allocnode_s *node, FAR void *arg)
+{
+  FAR struct memdump_info_s *info = arg;
+
+  if ((node->preceding & MM_ALLOC_BIT) != 0)
+    {
+      DEBUGASSERT(node->size >= SIZEOF_MM_ALLOCNODE);
+      if (info->pid == -1)
+        {
+          info->blks++;
+          info->size += node->size;
+          syslog(LOG_INFO, "%12p%12" PRIu32 "\n",
+                 ((FAR char *)node + SIZEOF_MM_ALLOCNODE),
+                 node->size);
+        }
+    }
+  else
+    {
+      FAR struct mm_freenode_s *fnode = (FAR void *)node;
+
+      DEBUGASSERT(node->size >= SIZEOF_MM_FREENODE);
+      DEBUGASSERT(fnode->blink->flink == fnode);
+      DEBUGASSERT(fnode->blink->size <= fnode->size);
+      DEBUGASSERT(fnode->flink == NULL ||
+                  fnode->flink->blink == fnode);
+      DEBUGASSERT(fnode->flink == NULL ||
+                  fnode->flink->size == 0 ||
+                  fnode->flink->size >= fnode->size);
+
+      if (info->pid == -2)
+        {
+          info->blks++;
+          info->size += node->size;
+          syslog(LOG_INFO, "%12p%12" PRIu32 "\n",
+                 ((FAR char *)node + SIZEOF_MM_ALLOCNODE),
+                 node->size);
+        }
+    }
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: mm_memdump
+ *
+ * Description:
+ *   mm_memdump returns a memory info about specified pid of task/thread.
+ *
+ ****************************************************************************/
+
+void mm_memdump(FAR struct mm_heap_s *heap, pid_t pid)
+{
+  struct memdump_info_s info;
+
+  if (pid == -1)
+    {
+      syslog(LOG_INFO, "Dump all used memory node info:\n");
+    }
+  else if (pid == -2)
+    {
+      syslog(LOG_INFO, "Dump all free memory node info:\n");
+    }
+
+  syslog(LOG_INFO, "%12s%12s\n", "Address", "Size");
+
+  info.blks = 0;
+  info.size = 0;
+  info.pid  = pid;
+  mm_foreach(heap, memdump_handler, &info);
+
+  syslog(LOG_INFO, "%12s%12s\n", "Total Blks", "Total Size");
+  syslog(LOG_INFO, "%12d%12d\n", info.blks, info.size);
+}

--- a/mm/mm_heap/mm_memdump.c
+++ b/mm/mm_heap/mm_memdump.c
@@ -33,6 +33,20 @@
 
 #include "mm_heap/mm.h"
 
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#if UINTPTR_MAX <= UINT32_MAX
+#  define MM_PTR_FMT_WIDTH 11
+#elif UINTPTR_MAX <= UINT64_MAX
+#  define MM_PTR_FMT_WIDTH 19
+#endif
+
+/****************************************************************************
+ * Private Types
+ ****************************************************************************/
+
 struct memdump_info_s
 {
   pid_t pid;
@@ -51,13 +65,32 @@ static void memdump_handler(FAR struct mm_allocnode_s *node, FAR void *arg)
   if ((node->preceding & MM_ALLOC_BIT) != 0)
     {
       DEBUGASSERT(node->size >= SIZEOF_MM_ALLOCNODE);
+#ifndef CONFIG_DEBUG_MM
       if (info->pid == -1)
+#else
+      if (info->pid == -1 || node->pid == info->pid)
+#endif
         {
+#ifndef CONFIG_DEBUG_MM
+          syslog(LOG_INFO, "%12zu%*p\n",
+                 (size_t)node->size, MM_PTR_FMT_WIDTH,
+                 ((FAR char *)node + SIZEOF_MM_ALLOCNODE));
+#else
+          int i;
+          char buf[MM_BACKTRACE_DEPTH * MM_PTR_FMT_WIDTH + 1];
+
+          for (i = 0; i < MM_BACKTRACE_DEPTH && node->backtrace[i]; i++)
+            {
+              sprintf(buf + i * MM_PTR_FMT_WIDTH, " %*p",
+                      MM_PTR_FMT_WIDTH - 3, node->backtrace[i]);
+            }
+
+          syslog(LOG_INFO, "%6d%12zu%*p%s\n",
+                 (int)node->pid, (size_t)node->size, MM_PTR_FMT_WIDTH,
+                 ((FAR char *)node + SIZEOF_MM_ALLOCNODE), buf);
+#endif
           info->blks++;
           info->size += node->size;
-          syslog(LOG_INFO, "%12p%12" PRIu32 "\n",
-                 ((FAR char *)node + SIZEOF_MM_ALLOCNODE),
-                 node->size);
         }
     }
   else
@@ -73,13 +106,13 @@ static void memdump_handler(FAR struct mm_allocnode_s *node, FAR void *arg)
                   fnode->flink->size == 0 ||
                   fnode->flink->size >= fnode->size);
 
-      if (info->pid == -2)
+      if (info->pid <= -2)
         {
           info->blks++;
           info->size += node->size;
-          syslog(LOG_INFO, "%12p%12" PRIu32 "\n",
-                 ((FAR char *)node + SIZEOF_MM_ALLOCNODE),
-                 node->size);
+          syslog(LOG_INFO, "%12zu%*p\n",
+                 (size_t)node->size, MM_PTR_FMT_WIDTH,
+                 ((FAR char *)node + SIZEOF_MM_ALLOCNODE));
         }
     }
 }
@@ -93,23 +126,31 @@ static void memdump_handler(FAR struct mm_allocnode_s *node, FAR void *arg)
  *
  * Description:
  *   mm_memdump returns a memory info about specified pid of task/thread.
- *
+ *   if pid equals -1, this function will dump all allocated node and output
+ *   backtrace for every allocated node for this heap, if pid equals -2, this
+ *   function will dump all free node for this heap, and if pid is greater
+ *   than or equal to 0, will dump pid allocated node and output backtrace.
  ****************************************************************************/
 
 void mm_memdump(FAR struct mm_heap_s *heap, pid_t pid)
 {
   struct memdump_info_s info;
 
-  if (pid == -1)
+  if (pid >= -1)
     {
       syslog(LOG_INFO, "Dump all used memory node info:\n");
+#ifndef CONFIG_DEBUG_MM
+      syslog(LOG_INFO, "%12s%*s\n", "Size", MM_PTR_FMT_WIDTH, "Address");
+#else
+      syslog(LOG_INFO, "%6s%12s%*s %s\n", "PID", "Size", MM_PTR_FMT_WIDTH,
+             "Address", "Backtrace");
+#endif
     }
-  else if (pid == -2)
+  else
     {
       syslog(LOG_INFO, "Dump all free memory node info:\n");
+      syslog(LOG_INFO, "%12s%*s\n", "Size", MM_PTR_FMT_WIDTH, "Address");
     }
-
-  syslog(LOG_INFO, "%12s%12s\n", "Address", "Size");
 
   info.blks = 0;
   info.size = 0;

--- a/mm/mm_heap/mm_memdump.c
+++ b/mm/mm_heap/mm_memdump.c
@@ -77,12 +77,14 @@ static void memdump_handler(FAR struct mm_allocnode_s *node, FAR void *arg)
                  ((FAR char *)node + SIZEOF_MM_ALLOCNODE));
 #else
           int i;
+          FAR const char *format = " %0*p";
           char buf[MM_BACKTRACE_DEPTH * MM_PTR_FMT_WIDTH + 1];
 
+          buf[0] = '\0';
           for (i = 0; i < MM_BACKTRACE_DEPTH && node->backtrace[i]; i++)
             {
-              sprintf(buf + i * MM_PTR_FMT_WIDTH, " %*p",
-                      MM_PTR_FMT_WIDTH - 3, node->backtrace[i]);
+              sprintf(buf + i * MM_PTR_FMT_WIDTH, format,
+                      MM_PTR_FMT_WIDTH - 1, node->backtrace[i]);
             }
 
           syslog(LOG_INFO, "%6d%12zu%*p%s\n",

--- a/mm/mm_heap/mm_realloc.c
+++ b/mm/mm_heap/mm_realloc.c
@@ -128,6 +128,8 @@ FAR void *mm_realloc(FAR struct mm_heap_s *heap, FAR void *oldmem,
                        oldsize - oldnode->size);
         }
 
+      MM_ADD_BACKTRACE(oldnode);
+
       /* Then return the original address */
 
       mm_givesemaphore(heap);
@@ -331,6 +333,8 @@ FAR void *mm_realloc(FAR struct mm_heap_s *heap, FAR void *oldmem,
                                      (andbeyond->preceding & MM_ALLOC_BIT);
             }
         }
+
+      MM_ADD_BACKTRACE((FAR char *)newmem - SIZEOF_MM_ALLOCNODE);
 
       mm_givesemaphore(heap);
 

--- a/mm/umm_heap/umm_mallinfo.c
+++ b/mm/umm_heap/umm_mallinfo.c
@@ -49,3 +49,23 @@ struct mallinfo mallinfo(void)
   mm_mallinfo(USR_HEAP, &info);
   return info;
 }
+
+/****************************************************************************
+ * Name: mallinfo_task
+ *
+ * Description:
+ *   mallinfo_task returns a copy of updated current heap information of
+ *   task with specified pid for the user heap.
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_DEBUG_MM
+struct mallinfo_task mallinfo_task(pid_t pid)
+{
+  struct mallinfo_task info;
+
+  info.pid = pid;
+  mm_mallinfo_task(USR_HEAP, &info);
+  return info;
+}
+#endif


### PR DESCRIPTION
## Summary
Add memory dump function when enable CONFIG_DEBUG_MM.

When we enable CONFIG_DEBUG_MM, this patch will add backtrace and pid info to every allocated memory node, so it will waste some memory(36bytes when pointer size is 4byte) to fill debug info and slow down the speed of allocate memory. But it has particularly great benefits for debug memory issue, examples: memory leak, memory fragment, memory action...

we can use the following several wethods to look memory info for every task
1. `ps` , the HEAP column of ps will print heap alloc size for every task.
```
ap> ps
  PID GROUP PRI POLICY   TYPE    NPX STATE    EVENT     SIGMASK      HEAP  STACK   USED  FILLED    CPU COMMAND
    0     0   0 FIFO     Kthread N-- Ready              00000000 00060524 003048 000856  28.0%   99.4% Idle Task
    1     1 224 FIFO     Kthread --- Waiting  Semaphore 00000000 00000000 002016 000608  30.1%    0.0% hpwork 0x3c476038
    2     2 100 FIFO     Kthread --- Waiting  Semaphore 00000000 00000000 002016 000672  33.3%    0.0% lpwork 0x3c476044
    3    15 100 FIFO     pthread --- Waiting  Semaphore 00000000 00000320 002048 001424  69.5%    0.0% pt-0x2c636b65 0x3c4fc3bc
    4    15 100 FIFO     pthread --- Waiting  Semaphore 00000000 00000256 002048 001008  49.2%    0.0% pt-0x2c636b65 0x3c4fc3bc
    5    15 100 FIFO     pthread --- Waiting  Semaphore 00000000 00000000 002048 001008  49.2%    0.0% pt-0x2c636b65 0x3c4fc3bc
    6    15 100 FIFO     pthread --- Waiting  Semaphore 00000000 00000000 002048 001008  49.2%    0.0% pt-0x2c636b65 0x3c4fc3bc
```
2. `cat /proc/pid/heap`, it will display short info about this task,  examples: 
```
ap> cat proc/35/heap
AllocSize:  16192
AllocBlks:  40
```
3. `memdump pid` and `echo pid > /proc/memdump`,  it will show detail backtrace info for every allocated node of this task. examples:
```
ap> echo 35 > /proc/memdump
[ 5286.767232] [ 9] [  INFO] [ap] Dump all used memory node info:
[ 5286.767884] [ 9] [  INFO] [ap]    PID        Size    Address Backtrace
[ 5286.769569] [ 9] [  INFO] [ap]     35          64 0x3c55d4d8 0x2c5b0ef6 0x2c5a9bee 0x2c767c40 0x2c76dbb6 0x2c777ad4 0x2c76c468 0x2c7813a6 0x2c5a0072
[ 5286.771200] [ 9] [  INFO] [ap]     35          64 0x3c55d518 0x2c5b0ef6 0x2c5a9bee 0x2c767c40 0x2c76dbb6 0x2c777adc 0x2c76c468 0x2c7813a6 0x2c5a0072
[ 5286.772831] [ 9] [  INFO] [ap]     35          64 0x3c55d558 0x2c5b0ef6 0x2c5a9bee 0x2c767c40 0x2c76dbb6 0x2c777ae4 0x2c76c468 0x2c7813a6 0x2c5a0072
[ 5286.774516] [ 9] [  INFO] [ap]     35          64 0x3c55d598 0x2c5b0ef6 0x2c5a9bee 0x2c767c40 0x2c76dbb6 0x2c777aec 0x2c76c468 0x2c7813a6 0x2c5a0072
[ 5286.776201] [ 9] [  INFO] [ap]     35          64 0x3c55d5d8 0x2c5b0ef6 0x2c5a9bee 0x2c767dc0 0x2c777b2e 0x2c76c468 0x2c7813a6 0x2c5a0072 0x2c5876de
[ 5286.777832] [ 9] [  INFO] [ap]     35         128 0x3c55d618 0x2c5b0ef6 0x2c5a9bee 0x2c767e9a 0x2c777b3a 0x2c76c468 0x2c7813a6 0x2c5a0072 0x2c5876de
[ 5286.779517] [ 9] [  INFO] [ap]     35          64 0x3c55d698 0x2c5b0ef6 0x2c5a9bee 0x2c767c40 0x2c767ed0 0x2c777b3a 0x2c76c468 0x2c7813a6 0x2c5a0072
[ 5286.781474] [ 9] [  INFO] [ap]     35          64 0x3c566398 0x2c5b0ef6 0x2c5a9bee 0x2c767c40 0x2c76dbb6 0x2c76c42e 0x2c7813a6 0x2c5a0072 0x2c5876de
[ 5286.783105] [ 9] [  INFO] [ap]     35          64 0x3c5663d8 0x2c5b0ef6 0x2c5a9bee 0x2c767c40 0x2c76dbb6 0x2c76c436 0x2c7813a6 0x2c5a0072 0x2c5876de
[ 5286.784735] [ 9] [  INFO] [ap]     35          64 0x3c566418 0x2c5b0ef6 0x2c5a9bee 0x2c767c40 0x2c76dbb6 0x2c76c43e 0x2c7813a6 0x2c5a0072 0x2c5876de
[ 5286.786692] [ 9] [  INFO] [ap]     35         128 0x3c5e8618 0x2c5b0ef6 0x2c5a9bee 0x2c5aa110 0x2c8566c0 0x2c85ab7a 0x2c85ae64 0x2c767ec4 0x2c777b3a
[ 5286.788323] [ 9] [  INFO] [ap]     35         192 0x3c5e8698 0x2c5b0ef6 0x2c5a9bee 0x2c5aa110 0x2c5837da 0x2c85ab8e 0x2c85ae64 0x2c767ec4 0x2c777b3a
[ 5286.789954] [ 9] [  INFO] [ap]     35          64 0x3c5e8758 0x2c5b0ef6 0x2c5a9bee 0x2c767d90 0x2c767ed8 0x2c777b3a 0x2c76c468 0x2c7813a6 0x2c5a0072
[ 5286.791639] [ 9] [  INFO] [ap]     35          64 0x3c5e8798 0x2c5b0ef6 0x2c5a9bee 0x2c767c40 0x2c76dbb6 0x2c777b84 0x2c76c468 0x2c7813a6 0x2c5a0072
[ 5286.793324] [ 9] [  INFO] [ap]     35          64 0x3c5e87d8 0x2c5b0ef6 0x2c5a9bee 0x2c767fe8 0x2c777bae 0x2c76c468 0x2c7813a6 0x2c5a0072 0x2c5876de
[ 5286.795064] [ 9] [  INFO] [ap]     35         448 0x3c5e8818 0x2c5b0ef6 0x2c5a9bee 0x2c5aa110 0x2c5824be 0x2c58726a 0x2c58715a 0x2c76801a 0x2c777bae
[ 5286.796640] [ 9] [  INFO] [ap]     35          64 0x3c5e89d8 0x2c5b0ef6 0x2c5a9bee 0x2c767fe8 0x2c777bae 0x2c76d5d2 0x2c781394 0x2c5a0072 0x2c5876de
[ 5286.798325] [ 9] [  INFO] [ap]     35         512 0x3c5e8a18 0x2c5b0ef6 0x2c5a9bee 0x2c5aa110 0x2c587142 0x2c76801a 0x2c777bae 0x2c76c468 0x2c7813a6
[ 5286.800010] [ 9] [  INFO] [ap]     35         256 0x3c5e8c18 0x2c5b0ef6 0x2c5a9bee 0x2c5aa110 0x2c5824c8 0x2c58726a 0x2c58715a 0x2c76801a 0x2c777bae
[ 5286.801641] [ 9] [  INFO] [ap]     35         128 0x3c5e8d18 0x2c5b0ef6 0x2c5a9bee 0x2c582186 0x2c5824dc 0x2c58726a 0x2c58715a 0x2c76801a 0x2c777bae
[ 5286.803326] [ 9] [  INFO] [ap]     35          64 0x3c5e8d98 0x2c5b0ef6 0x2c5a9f0a 0x2c855520 0x2c8558aa 0x2c582814 0x2c587274 0x2c58715a 0x2c76801a
[ 5286.805066] [ 9] [  INFO] [ap]     35         256 0x3c5e8dd8 0x2c5b0ef6 0x2c5a9bee 0x2c5aa110 0x2c855538 0x2c8558aa 0x2c582814 0x2c587274 0x2c58715a
[ 5286.806697] [ 9] [  INFO] [ap]     35          64 0x3c5e8ed8 0x2c5b0ef6 0x2c5a9bee 0x2c85beac 0x2c856fdc 0x2c8558bc 0x2c582814 0x2c587274 0x2c58715a
[ 5286.808327] [ 9] [  INFO] [ap]     35         256 0x3c5e8f18 0x2c5b0ef6 0x2c5a9bee 0x2c5aa110 0x2c855538 0x2c8558aa 0x2c582814 0x2c587274 0x2c58715a
[ 5286.810013] [ 9] [  INFO] [ap]     35         128 0x3c5e9018 0x2c5b0ef6 0x2c5a9bee 0x2c5aa110 0x2c58f312 0x2c856f9c 0x2c8558bc 0x2c582814 0x2c587274
[ 5286.811698] [ 9] [  INFO] [ap]     35         128 0x3c5e9098 0x2c5b0ef6 0x2c5a9bee 0x2c5aa666 0x2c58f330 0x2c856f9c 0x2c8558bc 0x2c582814 0x2c587274
[ 5286.813328] [ 9] [  INFO] [ap]     35         256 0x3c5e9118 0x2c5b0ef6 0x2c5a9bee 0x2c5aa110 0x2c855538 0x2c8558aa 0x2c582814 0x2c587274 0x2c58715a
[ 5286.815068] [ 9] [  INFO] [ap]     35         128 0x3c5e9218 0x2c5b0ef6 0x2c5a9bee 0x2c5aa110 0x2c58f312 0x2c856f9c 0x2c8558bc 0x2c582814 0x2c587274
[ 5286.816699] [ 9] [  INFO] [ap]     35         128 0x3c5e9298 0x2c5b0ef6 0x2c5a9bee 0x2c5aa666 0x2c58f330 0x2c856f9c 0x2c8558bc 0x2c582814 0x2c587274
[ 5286.818330] [ 9] [  INFO] [ap]     35         256 0x3c5e9318 0x2c5b0ef6 0x2c5a9bee 0x2c5aa110 0x2c855538 0x2c8558aa 0x2c582814 0x2c587274 0x2c58715a
[ 5286.820015] [ 9] [  INFO] [ap]     35         128 0x3c5e9418 0x2c5b0ef6 0x2c5a9bee 0x2c5aa110 0x2c592f40 0x2c856f9c 0x2c8558bc 0x2c582814 0x2c587274
[ 5286.821700] [ 9] [  INFO] [ap]     35         128 0x3c5e9498 0x2c5b0ef6 0x2c5a9bee 0x2c5aa666 0x2c592f4e 0x2c856f9c 0x2c8558bc 0x2c582814 0x2c587274
[ 5286.823331] [ 9] [  INFO] [ap]     35         256 0x3c5e9518 0x2c5b0ef6 0x2c5a9bee 0x2c5aa110 0x2c855538 0x2c8558aa 0x2c582814 0x2c587274 0x2c58715a
[ 5286.825016] [ 9] [  INFO] [ap]     35         512 0x3c5e9618 0x2c5b0ef6 0x2c5a9bee 0x2c76dc14 0x2c76df66 0x2c7720a4 0x2c76c488 0x2c7813a6 0x2c5a0072
[ 5286.826701] [ 9] [  INFO] [ap]     35         128 0x3c5e9a98 0x2c5b0ef6 0x2c5a9bee 0x2c5aa110 0x2c8566c0 0x2c85ab7a 0x2c85ae64 0x2c767ec4 0x2c769fcc
[ 5286.828386] [ 9] [  INFO] [ap]     35         192 0x3c5e9b18 0x2c5b0ef6 0x2c5a9bee 0x2c5aa110 0x2c5837da 0x2c85ab8e 0x2c85ae64 0x2c767ec4 0x2c769fcc
[ 5286.830017] [ 9] [  INFO] [ap]     35          64 0x3c5e9bd8 0x2c5b0ef6 0x2c5a9bee 0x2c767c40 0x2c76dbb6 0x2c76c416 0x2c7813a6 0x2c5a0072 0x2c5876de
[ 5286.831702] [ 9] [  INFO] [ap]     35          64 0x3c5e9c18 0x2c5b0ef6 0x2c5a9bee 0x2c767c40 0x2c76dbb6 0x2c76c422 0x2c7813a6 0x2c5a0072 0x2c5876de
[ 5286.833387] [ 9] [  INFO] [ap]     35       10368 0x3c5ec558 0x2c5b0ef6 0x2c5a9bee 0x2c5b0b0c 0x2c5872ee 0x2c58715a 0x2c76801a 0x2c777bae 0x2c76c468
[ 5286.835018] [ 9] [  INFO] [ap]     35          64 0x3c5eedd8 0x2c5b0ef6 0x2c5a9bee 0x2c582554 0x2c5872c4 0x2c58715a 0x2c76801a 0x2c777bae 0x2c76c468
[ 5286.837899] [ 9] [  INFO] [ap]   Total Blks  Total Size
[ 5286.838497] [ 9] [  INFO] [ap]           40       16192
```
4. `memdump free` and  `echo free > /proc/memdump`, we can get free heap info (address and size) by this cmd. examples:
```
ap> echo free > /proc/memdump
[ 5627.704827] [ 9] [  INFO] [ap] Dump all free memory node info:
[ 5627.705479] [ 9] [  INFO] [ap]         Size    Address
[ 5627.706566] [ 9] [  INFO] [ap]          128 0x3c5089d8
[ 5627.707110] [ 9] [  INFO] [ap]       131136 0x3c50b918
[ 5627.707816] [ 9] [  INFO] [ap]          128 0x3c553658
[ 5627.709175] [ 9] [  INFO] [ap]           64 0x3c5e9958
[ 5627.710045] [ 9] [  INFO] [ap]        20928 0x3c868b58
[ 5627.711567] [ 9] [  INFO] [ap]       194240 0x3ca09b98
[ 5627.712111] [ 9] [  INFO] [ap]     15874920 0x3ccdc498
[ 5627.712763] [ 9] [  INFO] [ap]   Total Blks  Total Size
[ 5627.713415] [ 9] [  INFO] [ap]            7    16221544
```
5. `memdump` and `echo used > /proc/memdump`, this cmd will all allocated memory detail info, include backtrace, address, pid and size.  And we can use tools/parsememdump.py to parse this result. examples:
```
ap> memdump
[ 5921.423624] [ 9] [  INFO] [ap] Dump all used memory node info:
[ 5921.424331] [ 9] [  INFO] [ap]    PID        Size    Address Backtrace
[ 5921.425146] [ 9] [  INFO] [ap]      0          44 0x3c4b576c
[ 5921.425907] [ 9] [  INFO] [ap]      3          64 0x3c4b5798 0x2c5b0ef6 0x2c5a9bee 0x2c582554 0x2c5872c4 0x2c587220 0x2c597ba0 0x2c5ac864 0x000514a6
[ 5921.427484] [ 9] [  INFO] [ap]      0         448 0x3c4b57d8 0x2c5b0ef6
[ 5921.428353] [ 9] [  INFO] [ap]      0         256 0x3c4b5998 0x2c5b0ef6
[ 5921.429223] [ 9] [  INFO] [ap]      0          64 0x3c4b5a98 0x2c5b0ef6 0x2c5a9bee 0x2c582554 0x000512a8 0x2c8913fe 0x2c300056
[ 5921.430637] [ 9] [  INFO] [ap]      0         128 0x3c4b5ad8 0x2c5b0ef6 0x2c5a9bee 0x2c5aa110 0x2c8565dc 0x000512d2 0x2c8913fe 0x2c300056
[ 5921.432213] [ 9] [  INFO] [ap]      0         128 0x3c4b5b58 0x2c5b0ef6 0x2c5a9bee 0x2c5aa110 0x2c5ab4a8 0x2c581d4c 0x2c582eea 0x2c582d56 0x2c5aaa5c
[ 5921.433898] [ 9] [  INFO] [ap]      0          64 0x3c4b5bd8 0x2c5b0ef6 0x2c5a9bee 0x2c5aa110 0x2c59b49a 0x2c5ac75c 0x2c581d50 0x2c582eea 0x2c582d56
[ 5921.435583] [ 9] [  INFO] [ap]      0         128 0x3c4b5c18 0x2c5b0ef6 0x2c5a9bee 0x2c5aa110 0x2c597902 0x2c59b4c6 0x2c5ac75c 0x2c581d50 0x2c582eea
[ 5921.437214] [ 9] [  INFO] [ap]      0         192 0x3c4b5c98 0x2c5b0ef6 0x2c5a9bee 0x2c5aa110 0x2c59ba20 0x2c5ac76c 0x2c581d50 0x2c582eea 0x2c582d56
...
[ 5927.434333] [ 9] [  INFO] [ap]     15       38784 0x3c9ce8d8 0x2c5b0ef6 0x2c5a9bee 0x2c845a06 0x2c844a12 0x2c844cc6 0x2c840cbe 0x2c840e8a 0x2c840310
[ 5927.436018] [ 9] [  INFO] [ap]     15       38784 0x3c9d8058 0x2c5b0ef6 0x2c5a9bee 0x2c845a06 0x2c844a12 0x2c844cc6 0x2c840cbe 0x2c840e8a 0x2c840310
[ 5927.437649] [ 9] [  INFO] [ap]     15       38976 0x3c9e17d8 0x2c5b0ef6 0x2c5a9bee 0x2c7bb4c6 0x2c79fcba 0x2c79f318 0x2c79c09e 0x2c7af502 0x2c79a898
[ 5927.439334] [ 9] [  INFO] [ap]     15       36352 0x3c9eb018 0x2c5b0ef6 0x2c5a9bee 0x2c7bb4c6 0x2c79fcba 0x2c79f318 0x2c79c09e 0x2c7af502 0x2c79a898
[ 5927.441019] [ 9] [  INFO] [ap]     15       48640 0x3c9f3e18 0x2c5b0ef6 0x2c5a9bee 0x2c7bb4c6 0x2c79fcba 0x2c79f318 0x2c79c09e 0x2c7af502 0x2c79a898
[ 5927.442650] [ 9] [  INFO] [ap]     15       40832 0x3c9ffc18 0x2c5b0ef6 0x2c5a9bee 0x2c7bb4c6 0x2c79fcba 0x2c79f318 0x2c79c09e 0x2c7af502 0x2c79a898
[ 5927.444335] [ 9] [  INFO] [ap]     15      921664 0x3ca39258 0x2c5b0ef6 0x2c5a9bee 0x2c8458b4 0x2c844a08 0x2c844cc6 0x2c841d88 0x2c840328 0x2c83cb22
[ 5927.446020] [ 9] [  INFO] [ap]     15      921856 0x3cb1a298 0x2c5b0ef6 0x2c5a9bee 0x2c7bb4c6 0x2c79fcba 0x2c79f318 0x2c79c09e 0x2c7af502 0x2c79a898
[ 5927.447651] [ 9] [  INFO] [ap]     15      921856 0x3cbfb398 0x2c5b0ef6 0x2c5a9bee 0x2c7bb4c6 0x2c79fcba 0x2c79f318 0x2c79c09e 0x2c7af502 0x2c79a898
[ 5927.449282] [ 9] [  INFO] [ap]   Total Blks  Total Size
[ 5927.449934] [ 9] [  INFO] [ap]         3621     8200748
```
parse result by `./parsememdump.py -f log.txt -e nuttx.elf`
The cnt is the number of memory node for the same backtrace and size in task with specified pid .
```
...
cnt   size   pid   addr         mem
47    256    15    0x3c5e2ad8   0x2c869f2e 0x2c868d3e 0x2c869844 0x2c869f2e 0x2c8677f6 0x2c83fdb4 
    draw_rect_path
    /home/djz/workspace/test/m1_new/apps/graphics/lvgl/lv_porting/lv_gpu_draw_rect.c:549
    malloc_float_path_data
    /home/djz/workspace/test/m1_new/apps/graphics/lvgl/lv_porting/lv_gpu_draw.c:84
    draw_bg_path
    /home/djz/workspace/test/m1_new/apps/graphics/lvgl/lv_porting/lv_gpu_draw_rect.c:479
    draw_rect_path
    /home/djz/workspace/test/m1_new/apps/graphics/lvgl/lv_porting/lv_gpu_draw_rect.c:549
    lv_draw_rect_gpu
    /home/djz/workspace/test/m1_new/apps/graphics/lvgl/lv_porting/lv_gpu_interface.c:230
    lv_obj_draw
    /home/djz/workspace/test/m1_new/apps/graphics/lvgl/./lvgl/src/core/lv_obj.c:544
...
```
6. Other cmd:
  `cat /proc/memdump`, this cmd will output usage about memdump
```
ap> cat proc/memdump
usage: <pid/used/free>
pid: dump pid allocated node
used: dump all allocated node
free: dump all free node
```

## Impact
add memory debug function.
## Testing
board test and daily test.
