### PR TITLE
Garbage configuration setting in EFM32 code

### DIFF
--- a/arch/arm/src/efm32/efm32_start.c
+++ b/arch/arm/src/efm32/efm32_start.c
@@ -259,7 +259,7 @@ void __start(void)
    * segments.
    */
 
-#ifdef CONFIG_NUTTX_KERNEL
+#ifdef CONFIG_BUILD_PROTECTED
   efm32_userspace();
   showprogress('E');
 #endif


### PR DESCRIPTION
## Summary

arch/arm/src/efm32/efm32_start.c:

      /* For the case of the separate user-/kernel-space build, perform whatever
       * platform specific initialization of the user memory is required.
      * Normally this just means initializing the user space .data and .bss
       * segments.
       */

    #ifdef CONFIG_NUTTX_KERNEL
      efm32_userspace();
      showprogress('E');
    #endif

But there is no CONFIG_NUTTX_KERNEL configuration setting.  Comparing this to other architectures it is clear this should be

    #ifdef CONFIG_BUILD_PROTECTED

Compare to arch/arm/src/stm32/stm32_start.c for one:

      /* For the case of the separate user-/kernel-space build, perform whatever
       * platform specific initialization of the user memory is required.
       * Normally this just means initializing the user space .data and .bss
       * segments.
       */

    #ifdef CONFIG_BUILD_PROTECTED
      stm32_userspace();
      showprogress('E');
    #endif

## Impact

None except for any protected mode EFM32 builds.  If there were any this, this would fix them.  There aren't.

## Testing

There is no obvious way to test this other than by getting out a EFM32 board, creating and debugging a protected mode build, and verifying that .bss and .data are initialized.  Not worth the effort.

