### PR TITLE
board/esp32: Update esp-wireless-drivers-3rdparty

### DIFF
--- a/arch/risc-v/src/esp32c3/Make.defs
+++ b/arch/risc-v/src/esp32c3/Make.defs
@@ -186,7 +186,7 @@ endif
 
 ifeq ($(CONFIG_ESP32C3_WIRELESS),y)
 WIRELESS_DRV_UNPACK = esp-wireless-drivers-3rdparty
-WIRELESS_DRV_ID     = 055f1ef
+WIRELESS_DRV_ID     = 45701c0
 WIRELESS_DRV_ZIP    = $(WIRELESS_DRV_ID).zip
 WIRELESS_DRV_URL    = https://github.com/espressif/esp-wireless-drivers-3rdparty/archive
 

--- a/arch/xtensa/src/esp32/Make.defs
+++ b/arch/xtensa/src/esp32/Make.defs
@@ -210,7 +210,7 @@ endif
 
 ifeq ($(CONFIG_ESP32_WIRELESS),y)
 WIRELESS_DRV_UNPACK  = esp-wireless-drivers-3rdparty
-WIRELESS_DRV_ID      = 055f1ef
+WIRELESS_DRV_ID      = 45701c0
 WIRELESS_DRV_ZIP     = $(WIRELESS_DRV_ID).zip
 WIRELESS_DRV_URL     = https://github.com/espressif/esp-wireless-drivers-3rdparty/archive
 

--- a/boards/risc-v/esp32c3/esp32c3-devkit/scripts/Make.defs
+++ b/boards/risc-v/esp32c3/esp32c3-devkit/scripts/Make.defs
@@ -41,7 +41,7 @@ ifneq ($(CONFIG_DEBUG_NOOPT),y)
   ARCHOPTIMIZATION += $(MAXOPTIMIZATION) -fno-strict-aliasing
 endif
 
-ARCHCFLAGS = -fno-builtin -ffunction-sections -fdata-sections -msmall-data-limit=0
+ARCHCFLAGS = -fno-common -fno-builtin -ffunction-sections -fdata-sections -msmall-data-limit=0
 ARCHCXXFLAGS = $(ARCHCFLAGS) -fno-exceptions -fcheck-new -fno-rtti
 ARCHWARNINGS = -Wall -Wstrict-prototypes -Wshadow -Wundef
 ARCHWARNINGSXX = -Wall -Wshadow -Wundef

--- a/boards/xtensa/esp32/esp32-devkitc/scripts/Make.defs
+++ b/boards/xtensa/esp32/esp32-devkitc/scripts/Make.defs
@@ -65,7 +65,7 @@ ifneq ($(CONFIG_DEBUG_NOOPT),y)
   ARCHOPTIMIZATION += $(MAXOPTIMIZATION) -fno-strict-aliasing
 endif
 
-ARCHCFLAGS = -fno-builtin -ffunction-sections -fdata-sections -mlongcalls
+ARCHCFLAGS = -fno-common -fno-builtin -ffunction-sections -fdata-sections -mlongcalls
 ARCHCXXFLAGS = $(ARCHCFLAGS) -fno-exceptions -fcheck-new -fno-rtti
 ARCHWARNINGS = -Wall -Wstrict-prototypes -Wshadow -Wundef
 ARCHWARNINGSXX = -Wall -Wshadow -Wundef

--- a/boards/xtensa/esp32/esp32-ethernet-kit/scripts/Make.defs
+++ b/boards/xtensa/esp32/esp32-ethernet-kit/scripts/Make.defs
@@ -65,7 +65,7 @@ ifneq ($(CONFIG_DEBUG_NOOPT),y)
   ARCHOPTIMIZATION += $(MAXOPTIMIZATION) -fno-strict-aliasing
 endif
 
-ARCHCFLAGS = -fno-builtin -ffunction-sections -fdata-sections -mlongcalls
+ARCHCFLAGS = -fno-common -fno-builtin -ffunction-sections -fdata-sections -mlongcalls
 ARCHCXXFLAGS = $(ARCHCFLAGS) -fno-exceptions -fcheck-new -fno-rtti
 ARCHWARNINGS = -Wall -Wstrict-prototypes -Wshadow -Wundef
 ARCHWARNINGSXX = -Wall -Wshadow -Wundef

--- a/boards/xtensa/esp32/esp32-wrover-kit/scripts/Make.defs
+++ b/boards/xtensa/esp32/esp32-wrover-kit/scripts/Make.defs
@@ -65,7 +65,7 @@ ifneq ($(CONFIG_DEBUG_NOOPT),y)
   ARCHOPTIMIZATION += $(MAXOPTIMIZATION) -fno-strict-aliasing
 endif
 
-ARCHCFLAGS = -fno-builtin -ffunction-sections -fdata-sections -mlongcalls
+ARCHCFLAGS = -fno-common -fno-builtin -ffunction-sections -fdata-sections -mlongcalls
 ARCHCXXFLAGS = $(ARCHCFLAGS) -fno-exceptions -fcheck-new -fno-rtti
 ARCHWARNINGS = -Wall -Wstrict-prototypes -Wshadow -Wundef
 ARCHWARNINGSXX = -Wall -Wshadow -Wundef

--- a/boards/xtensa/esp32/ttgo_lora_esp32/scripts/Make.defs
+++ b/boards/xtensa/esp32/ttgo_lora_esp32/scripts/Make.defs
@@ -65,7 +65,7 @@ ifneq ($(CONFIG_DEBUG_NOOPT),y)
   ARCHOPTIMIZATION += $(MAXOPTIMIZATION) -fno-strict-aliasing
 endif
 
-ARCHCFLAGS = -fno-builtin -ffunction-sections -fdata-sections -mlongcalls
+ARCHCFLAGS = -fno-common -fno-builtin -ffunction-sections -fdata-sections -mlongcalls
 ARCHCXXFLAGS = $(ARCHCFLAGS) -fno-exceptions -fcheck-new -fno-rtti
 ARCHWARNINGS = -Wall -Wstrict-prototypes -Wshadow -Wundef
 ARCHWARNINGSXX = -Wall -Wshadow -Wundef


### PR DESCRIPTION
## Summary
and add -fno-common since the symbol duplication is fixed in the new firmware.
depends on patch: https://github.com/espressif/esp-wireless-drivers-3rdparty/pull/1

## Impact
See the discussion here: https://github.com/apache/incubator-nuttx/pull/5553

## Testing
Pass CI.
