### PR TITLE
net/tcp(buffered): upgraded the Fast Retransmit algorithm from RFC 2001 to RFC 5681

### DIFF
--- a/net/tcp/Kconfig
+++ b/net/tcp/Kconfig
@@ -83,28 +83,24 @@ config NET_TCP_FAST_RETRANSMIT
 	bool "Enable the Fast Retransmit algorithm"
 	default y
 	---help---
-		RFC2001:
-		3.  Fast Retransmit
-			Modifications to the congestion avoidance algorithm were proposed in
-			1990 [3].  Before describing the change, realize that TCP may
-			generate an immediate acknowledgment (a duplicate ACK) when an out-
-			of-order segment is received (Section 4.2.2.21 of [1], with a note
-			that one reason for doing so was for the experimental fast-
-			retransmit algorithm).  This duplicate ACK should not be delayed.
-			The purpose of this duplicate ACK is to let the other end know that a
-			segment was received out of order, and to tell it what sequence
-			number is expected.
+		RFC 5681:
+		2. DUPLICATE ACKNOWLEDGMENT: An acknowledgment is considered a
+			"duplicate" in the following algorithms when (a) the receiver of
+			the ACK has outstanding data, (b) the incoming acknowledgment
+			carries no data, (c) the SYN and FIN bits are both off, (d) the
+			acknowledgment number is equal to the greatest acknowledgment
+			received on the given connection (TCP.UNA from [RFC793]) and (e)
+			the advertised window in the incoming acknowledgment equals the
+			advertised window in the last incoming acknowledgment.
 
-			Since TCP does not know whether a duplicate ACK is caused by a lost
-			segment or just a reordering of segments, it waits for a small number
-			of duplicate ACKs to be received.  It is assumed that if there is
-			just a reordering of the segments, there will be only one or two
-			duplicate ACKs before the reordered segment is processed, which will
-			then generate a new ACK.  If three or more duplicate ACKs are
-			received in a row, it is a strong indication that a segment has been
-			lost.  TCP then performs a retransmission of what appears to be the
-			missing segment, without waiting for a retransmission timer to
-			expire.
+		3.2. Fast Retransmit
+			The TCP sender SHOULD use the "fast retransmit" algorithm to detect
+			and repair loss, based on incoming duplicate ACKs.  The fast
+			retransmit algorithm uses the arrival of 3 duplicate ACKs (as defined
+			in section 2, without any intervening ACKs which move SND.UNA) as an
+			indication that a segment has been lost.  After receiving 3 duplicate
+			ACKs, TCP performs a retransmission of what appears to be the missing
+			segment, without waiting for the retransmission timer to expire.
 
 config NET_TCP_WINDOW_SCALE
 	bool "Enable TCP/IP Window Scale Option"

--- a/net/tcp/tcp.h
+++ b/net/tcp/tcp.h
@@ -66,9 +66,6 @@
 #  define TCP_WBPKTLEN(wrb)          ((wrb)->wb_iob->io_pktlen)
 #  define TCP_WBSENT(wrb)            ((wrb)->wb_sent)
 #  define TCP_WBNRTX(wrb)            ((wrb)->wb_nrtx)
-#ifdef CONFIG_NET_TCP_FAST_RETRANSMIT
-#  define TCP_WBNACK(wrb)            ((wrb)->wb_nack)
-#endif
 #  define TCP_WBIOB(wrb)             ((wrb)->wb_iob)
 #  define TCP_WBCOPYOUT(wrb,dest,n)  (iob_copyout(dest,(wrb)->wb_iob,(n),0))
 #  define TCP_WBCOPYIN(wrb,src,n,off) \
@@ -262,7 +259,20 @@ struct tcp_conn_s
   uint32_t   isn;         /* Initial sequence number */
   uint32_t   sndseq_max;  /* The sequence number of next not-retransmitted
                            * segment (next greater sndseq) */
-#endif
+
+#ifdef CONFIG_NET_TCP_FAST_RETRANSMIT
+  uint32_t   snd_prev_ack; /* The previous ACKed seq number */
+#ifdef CONFIG_NET_TCP_WINDOW_SCALE
+  uint32_t   snd_prev_wnd; /* The advertised window in the last
+                            * incoming acknowledgment
+                            */
+#else
+  uint16_t   snd_prev_wnd;
+#endif /* CONFIG_NET_TCP_WINDOW_SCALE */
+  int        snd_dup_acks; /* Duplicate ACK counter */
+#endif /* CONFIG_NET_TCP_FAST_RETRANSMIT */
+
+#endif /* CONFIG_NET_TCP_WRITE_BUFFERS */
 
 #ifdef CONFIG_NET_TCPBACKLOG
   /* Listen backlog support
@@ -342,9 +352,6 @@ struct tcp_wrbuffer_s
   uint16_t   wb_sent;      /* Number of bytes sent from the I/O buffer chain */
   uint8_t    wb_nrtx;      /* The number of retransmissions for the last
                             * segment sent */
-#ifdef CONFIG_NET_TCP_FAST_RETRANSMIT
-  uint8_t    wb_nack;      /* The number of ack count */
-#endif
   struct iob_s *wb_iob;    /* Head of the I/O buffer chain */
 };
 #endif

--- a/net/tcp/tcp_send_buffered.c
+++ b/net/tcp/tcp_send_buffered.c
@@ -512,33 +512,6 @@ static uint16_t psock_send_eventhandler(FAR struct net_driver_s *dev,
                         wrb, TCP_WBSEQNO(wrb), TCP_WBPKTLEN(wrb));
                 }
             }
-#ifdef CONFIG_NET_TCP_FAST_RETRANSMIT
-          else if (ackno == TCP_WBSEQNO(wrb))
-            {
-              /* Reset the duplicate ack counter */
-
-              if ((flags & TCP_NEWDATA) != 0)
-                {
-                  TCP_WBNACK(wrb) = 0;
-                }
-
-              /* Duplicate ACK? Retransmit data if need */
-
-              if (++TCP_WBNACK(wrb) == TCP_FAST_RETRANSMISSION_THRESH)
-                {
-                  /* Do fast retransmit */
-
-                  rexmit = true;
-                }
-              else if ((TCP_WBNACK(wrb) > TCP_FAST_RETRANSMISSION_THRESH) &&
-                       TCP_WBNACK(wrb) == sq_count(&conn->unacked_q) - 1)
-                {
-                  /* Reset the duplicate ack counter */
-
-                  TCP_WBNACK(wrb) = 0;
-                }
-            }
-#endif
         }
 
       /* A special case is the head of the write_q which may be partially
@@ -574,6 +547,37 @@ static uint16_t psock_send_eventhandler(FAR struct net_driver_s *dev,
           ninfo("ACK: wrb=%p seqno=%" PRIu32 " pktlen=%u sent=%u\n",
                 wrb, TCP_WBSEQNO(wrb), TCP_WBPKTLEN(wrb), TCP_WBSENT(wrb));
         }
+
+#ifdef CONFIG_NET_TCP_FAST_RETRANSMIT
+      /* Fast Retransmit (RFC 5681): an acknowledgment is considered a
+       * "duplicate" when (a) the receiver of the ACK has outstanding data,
+       * (b) the incoming acknowledgment carries no data, (c) the SYN and
+       * FIN bits are both off, (d) the acknowledgment number is equal to
+       * the greatest acknowledgment received on the given connection
+       * and (e) the advertised window in the incoming acknowledgment equals
+       * the advertised window in the last incoming acknowledgment.
+       */
+
+      if (conn->tx_unacked < conn->sent &&
+          (flags & TCP_NEWDATA) == 0 &&
+          (tcp->flags & (TCP_SYN | TCP_FIN)) == 0 &&
+          ackno == conn->snd_prev_ack &&
+          conn->snd_wnd == conn->snd_prev_wnd)
+        {
+          if (++conn->snd_dup_acks >= TCP_FAST_RETRANSMISSION_THRESH)
+            {
+              rexmit = true;
+              conn->snd_dup_acks = 0;
+            }
+        }
+      else
+        {
+          conn->snd_dup_acks = 0;
+        }
+
+      conn->snd_prev_ack = ackno;
+      conn->snd_prev_wnd = conn->snd_wnd;
+#endif
     }
 
   /* Check for a loss of connection */

--- a/net/tcp/tcp_wrbuffer.c
+++ b/net/tcp/tcp_wrbuffer.c
@@ -239,12 +239,6 @@ void tcp_wrbuffer_release(FAR struct tcp_wrbuffer_s *wrb)
       iob_free_chain(wrb->wb_iob, IOBUSER_NET_TCP_WRITEBUFFER);
     }
 
-#ifdef CONFIG_NET_TCP_FAST_RETRANSMIT
-  /* Reset the ack counter */
-
-  TCP_WBNACK(wrb) = 0;
-#endif
-
   /* Then free the write buffer structure */
 
   sq_addlast(&wrb->wb_node, &g_wrbuffer.freebuffers);


### PR DESCRIPTION
## Summary

net/tcp(buffered): upgraded the Fast Retransmit algorithm from RFC 2001 to RFC 5681.
This PR is similar to tcp_send_unbuffered (PR #5137) and tcp_sendfile (PR #5311), however it replaces the implementation of PR #2414.

## Impact

net/tcp(buffered)

## Testing