### PR TITLE
Fix libc:machine:xtensa: fix warning

### DIFF
--- a/arch/xtensa/include/xtensa/core.h
+++ b/arch/xtensa/include/xtensa/core.h
@@ -1393,6 +1393,18 @@
 
 #define XTHAL_INST_ILL            0x000000    /* 3-byte illegal instruction */
 
+/*  Version comparison operators (among major/minor pairs):  */
+
+#define XTHAL_REL_GE(maja,mina, majb,minb)  ((maja) > (majb) || \
+             ((maja) == (majb) && (mina) >= (minb)))
+#define XTHAL_REL_GT(maja,mina, majb,minb)  ((maja) > (majb) || \
+             ((maja) == (majb) && (mina) > (minb)))
+#define XTHAL_REL_LE(maja,mina, majb,minb)  ((maja) < (majb) || \
+             ((maja) == (majb) && (mina) <= (minb)))
+#define XTHAL_REL_LT(maja,mina, majb,minb)  ((maja) < (majb) || \
+             ((maja) == (majb) && (mina) < (minb)))
+#define XTHAL_REL_EQ(maja,mina, majb,minb)  ((maja) == (majb) && (mina) == (minb))
+
 /* Because information as to exactly which hardware version is targeted
  * by a given software build is not always available, compile-time HAL
  * Hardware-Release "_AT" macros are fuzzy (return 0, 1, or XCHAL_MAYBE):

--- a/libs/libc/machine/xtensa/arch_setjmp.S
+++ b/libs/libc/machine/xtensa/arch_setjmp.S
@@ -22,6 +22,7 @@
  * Included Files
  ****************************************************************************/
 
+#include <arch/xtensa/core.h>
 #include <arch/chip/core-isa.h>
 #include <arch/xtensa/xtensa_abi.h>
 
@@ -29,7 +30,7 @@
  * Public Functions
  ****************************************************************************/
 
-#if XCHAL_HAVE_WINDOWED && !__XTENSA_CALL0_ABI__
+#if XCHAL_HAVE_WINDOWED && !defined(__XTENSA_CALL0_ABI___)
 
 /* Windowed ABI:
 


### PR DESCRIPTION
## Summary

patch1 :xtensa: fix `XTHAL_REL_LE` not find
patch2:libc:machine:xtensa: fix warning

## Impact

## Testing

