### PR TITLE
Imx6 thumb

### DIFF
--- a/arch/arm/Kconfig
+++ b/arch/arm/Kconfig
@@ -80,6 +80,7 @@ config ARCH_CHIP_IMX1
 config ARCH_CHIP_IMX6
 	bool "NXP/Freescale iMX.6"
 	select ARCH_CORTEXA9
+	select ARM_THUMB
 	select ARMV7A_HAVE_L2CC_PL310
 	select ARCH_HAVE_FPU
 	select ARCH_HAVE_TRUSTZONE

--- a/boards/arm/imx6/sabre-6quad/scripts/Make.defs
+++ b/boards/arm/imx6/sabre-6quad/scripts/Make.defs
@@ -34,7 +34,7 @@ ifneq ($(CONFIG_DEBUG_NOOPT),y)
   ARCHOPTIMIZATION += $(MAXOPTIMIZATION) -fno-strict-aliasing
 endif
 
-ARCHCPUFLAGS = -mcpu=cortex-a9 -mfpu=vfpv4-d16
+ARCHCPUFLAGS = -mcpu=cortex-a9 -mfpu=vfpv4-d16 -mthumb
 ARCHCFLAGS = -fno-common -fno-builtin -ffunction-sections -fdata-sections
 ARCHCXXFLAGS = -fno-common -fno-builtin -fno-exceptions -fcheck-new -fno-rtti
 ARCHWARNINGS = -Wall -Wstrict-prototypes -Wshadow -Wundef

--- a/libs/libc/machine/arm/armv7-a/arch_elf.c
+++ b/libs/libc/machine/arm/armv7-a/arch_elf.c
@@ -174,9 +174,9 @@ int up_relocate(FAR const Elf32_Rel *rel, FAR const Elf32_Sym *sym,
         offset += sym->st_value - addr;
 
 #ifdef CONFIG_ARM_THUMB
-        if (offset & 2 || offset < (int32_t) 0xfe000000 ||
+        if ((offset & 2) != 0 || offset < (int32_t) 0xfe000000 ||
 #else
-        if (offset & 3 || offset < (int32_t) 0xfe000000 ||
+        if ((offset & 3) != 0 || offset < (int32_t) 0xfe000000 ||
 #endif
             offset >= (int32_t) 0x02000000)
           {

--- a/libs/libc/machine/arm/armv7-a/arch_elf.c
+++ b/libs/libc/machine/arm/armv7-a/arch_elf.c
@@ -86,7 +86,11 @@ bool up_checkarch(FAR const Elf32_Ehdr *ehdr)
 
   /* Make sure the entry point address is properly aligned */
 
+#ifdef CONFIG_ARM_THUMB
+  if ((ehdr->e_entry & 2) != 0)
+#else
   if ((ehdr->e_entry & 3) != 0)
+#endif
     {
       berr("ERROR: Entry point is not properly aligned: %08" PRIx32 "\n",
            ehdr->e_entry);
@@ -126,6 +130,11 @@ int up_relocate(FAR const Elf32_Rel *rel, FAR const Elf32_Sym *sym,
   int32_t offset;
   unsigned int relotype;
 
+#ifdef CONFIG_ARM_THUMB
+  uint32_t upper_insn;
+  uint32_t lower_insn;
+#endif
+
   /* All relocations except R_ARM_V4BX depend upon having valid symbol
    * information.
    */
@@ -163,7 +172,12 @@ int up_relocate(FAR const Elf32_Rel *rel, FAR const Elf32_Sym *sym,
           }
 
         offset += sym->st_value - addr;
+
+#ifdef CONFIG_ARM_THUMB
+        if (offset & 2 || offset < (int32_t) 0xfe000000 ||
+#else
         if (offset & 3 || offset < (int32_t) 0xfe000000 ||
+#endif
             offset >= (int32_t) 0x02000000)
           {
             berr("ERROR: PC24 [%" PRId32 "] relocation out of range, "
@@ -241,6 +255,216 @@ int up_relocate(FAR const Elf32_Rel *rel, FAR const Elf32_Sym *sym,
         *(uint32_t *)addr |= ((offset & 0xf000) << 4) | (offset & 0x0fff);
       }
       break;
+
+#ifdef CONFIG_ARM_THUMB
+    case R_ARM_THM_MOVW_ABS_NC:
+    case R_ARM_THM_MOVT_ABS:
+      {
+        /* Thumb BL and B.W instructions. Encoding:
+         *
+         * upper_insn:
+         *
+         *  1   1   1   1   1   1
+         *  5   4   3   2   1   0   9  8  7  6  5  4  3  2  1  0 Instruction
+         * +----------+---+--------------------------+----------+
+         * |1   1   1 |OP1|     OP2                  |          | 32-Bit
+         * +----------+---+--+-----+-----------------+----------+
+         * |1   1   1 | 1   0|  i  |1  0  1  1  0  0 |  imm4    | MOVT
+         * +----------+------+-----+-----------------+----------+
+         *
+         * lower_insn:
+         *
+         *  1   1   1   1   1   1
+         *  5   4   3   2   1   0   9  8  7  6  5  4  3  2  1  0 Instructions
+         * +---+-------------------------------------------------+
+         * |OP |                                                 | 32-Bit
+         * +---+----------+--------+-----------------------------+
+         * |0  |   imm3   |   Rd   |          imm8               | MOVT
+         * +---+----------+--------+-----------------------------+
+         *
+         * The 16-bit immediate value is encoded in these bits:
+         *
+         *   i    = imm16[11]    = upper_insn[10]
+         *   imm4 = imm16[12:15] = upper_insn[3:0]
+         *   imm3 = imm16[8:10]  = lower_insn[14:12]
+         *   imm8 = imm16[0:7]   = lower_insn[7:0]
+         */
+
+        upper_insn = (uint32_t)(*(uint16_t *)addr);
+        lower_insn = (uint32_t)(*(uint16_t *)(addr + 2));
+
+        binfo("Performing THM_MOVx [%" PRId32 "] link "
+              "at addr=%08lx [%04x %04x] to sym=%p st_value=%08lx\n",
+              ELF32_R_TYPE(rel->r_info), (long)addr,
+              (int)upper_insn, (int)lower_insn,
+              sym, (long)sym->st_value);
+
+        /* Extract the 16-bit offset from the 32-bit instruction */
+
+        offset = ((upper_insn & 0x000f) << 12) | /* imm4 -> imm16[8:10] */
+                 ((upper_insn & 0x0400) << 1) |  /* i    -> imm16[11] */
+                 ((lower_insn & 0x7000) >> 4) |  /* imm3 -> imm16[8:10] */
+                  (lower_insn & 0x00ff);         /* imm8 -> imm16[0:7] */
+
+        /* And perform the relocation */
+
+        binfo("  offset=%08lx branch target=%08lx\n",
+              (long)offset, offset + sym->st_value);
+
+        offset += sym->st_value;
+
+        /* Update the immediate value in the instruction.
+         * For MOVW we want the bottom 16-bits; for MOVT we want
+         * the top 16-bits.
+         */
+
+        if (ELF32_R_TYPE(rel->r_info) == R_ARM_THM_MOVT_ABS)
+          {
+            offset >>= 16;
+          }
+
+        upper_insn = ((upper_insn & 0xfbf0) | ((offset & 0xf000) >> 12) |
+                      ((offset & 0x0800) >> 1));
+        *(uint16_t *)addr = (uint16_t)upper_insn;
+
+        lower_insn = ((lower_insn & 0x8f00) | ((offset & 0x0700) << 4) |
+                      (offset & 0x00ff));
+        *(uint16_t *)(addr + 2) = (uint16_t)lower_insn;
+
+        binfo("  insn [%04x %04x]\n",
+             (int)upper_insn, (int)lower_insn);
+      }
+      break;
+
+    case R_ARM_THM_CALL:
+    case R_ARM_THM_JUMP24:
+      {
+        uint32_t S;
+        uint32_t J1;
+        uint32_t J2;
+
+        /* Thumb BL and B.W instructions. Encoding:
+         *
+         * upper_insn:
+         *
+         *  1   1   1   1   1   1
+         *  5   4   3   2   1   0   9  8  7  6  5  4  3  2  1  0 Instructions
+         * +----------+---+--------------------------+----------+
+         * |1   1   1 |OP1|     OP2                  |          | 32-Bit
+         * +----------+---+--+-----+-----------------+----------+
+         * |1   1   1 | 1   0|  S  |        imm10               | BL
+         * +----------+------+-----+----------------------------+
+         *
+         * lower_insn:
+         *
+         *  1   1   1   1   1   1
+         *  5   4   3   2   1   0  9  8  7  6  5  4   3  2  1  0 Instructions
+         * +---+------------------------------------------------+
+         * |OP |                                                | 32-Bit
+         * +---+--+---+---+---+---------------------------------+
+         * |1   1 |J1 | 1 |J2 |            imm11                | BL
+         * +------+---+---+---+--------------------------------+
+         *
+         * The branch target is encoded in these bits:
+         *
+         *   S     = upper_insn[10]
+         *   imm10 = upper_insn[0:9]
+         *   imm11 = lower_insn[0:10]
+         *   J1    = lower_insn[13]
+         *   J2    = lower_insn[11]
+         */
+
+        upper_insn = (uint32_t)(*(uint16_t *)addr);
+        lower_insn = (uint32_t)(*(uint16_t *)(addr + 2));
+
+        binfo("Performing THM_JUMP24 [%" PRId32 "] link "
+              "at addr=%08lx [%04x %04x] to sym=%p st_value=%08lx\n",
+              ELF32_R_TYPE(rel->r_info), (long)addr,
+              (int)upper_insn, (int)lower_insn,
+              sym, (long)sym->st_value);
+
+        /* Extract the 25-bit offset from the 32-bit instruction:
+         *
+         *   offset[24]    = S
+         *   offset[23]    = ~(J1 ^ S)
+         *   offset[22]    = ~(J2 ^ S)]
+         *   offset[12:21] = imm10
+         *   offset[1:11]  = imm11
+         *   offset[0]     = 0
+         */
+
+        S   = (upper_insn >> 10) & 1;
+        J1  = (lower_insn >> 13) & 1;
+        J2  = (lower_insn >> 11) & 1;
+
+        offset = (S << 24) |                       /* S -   > offset[24] */
+                 ((~(J1 ^ S) & 1) << 23) |         /* J1    -> offset[23] */
+                 ((~(J2 ^ S) & 1) << 22) |         /* J2    -> offset[22] */
+                 ((upper_insn & 0x03ff) << 12) |   /* imm10 -> offset[12:21] */
+                 ((lower_insn & 0x07ff) << 1);     /* imm11 -> offset[1:11] */
+                                                   /* 0     -> offset[0] */
+
+        /* Sign extend */
+
+        if (offset & 0x01000000)
+          {
+            offset -= 0x02000000;
+          }
+
+        /* And perform the relocation */
+
+        binfo("  S=%" PRId32 " J1=%" PRId32 " J2=%" PRId32
+              " offset=%08" PRIx32 " branch target=%08lx\n",
+              S, J1, J2, offset, offset + sym->st_value - addr);
+
+        offset += sym->st_value - addr;
+
+        /* Is this a function symbol?  If so, then the branch target must be
+         * an odd Thumb address
+         */
+
+        if (ELF32_ST_TYPE(sym->st_info) == STT_FUNC && (offset & 1) == 0)
+          {
+            berr("ERROR:   ERROR: JUMP24 [%" PRId32 "] "
+                 "requires odd offset, offset=%08lx\n",
+                 ELF32_R_TYPE(rel->r_info), offset);
+
+            return -EINVAL;
+          }
+
+        /* Check the range of the offset */
+
+        if (offset < (int32_t)0xff000000 || offset >= (int32_t)0x01000000)
+          {
+            berr("ERROR:   ERROR: JUMP24 [%" PRId32 "] "
+                 "relocation out of range, branch target=%08lx\n",
+                 ELF32_R_TYPE(rel->r_info), offset);
+
+            return -EINVAL;
+          }
+
+        /* Now, reconstruct the 32-bit instruction using the new, relocated
+         * branch target.
+         */
+
+        S  = (offset >> 24) & 1;
+        J1 = S ^ (~(offset >> 23) & 1);
+        J2 = S ^ (~(offset >> 22) & 1);
+
+        upper_insn = ((upper_insn & 0xf800) | (S << 10) |
+                      ((offset >> 12) & 0x03ff));
+        *(uint16_t *)addr = (uint16_t)upper_insn;
+
+        lower_insn = ((lower_insn & 0xd000) | (J1 << 13) | (J2 << 11) |
+                      ((offset >> 1) & 0x07ff));
+        *(uint16_t *)(addr + 2) = (uint16_t)lower_insn;
+
+        binfo("  S=%" PRId32 " J1=%" PRId32 " J2=%" PRId32
+              " insn [%04" PRIx32 " %04" PRIx32 "]\n",
+              S, J1, J2, upper_insn, lower_insn);
+      }
+      break;
+#endif /* CONFIG_ARM_THUMB */
 
     default:
       berr("ERROR: Unsupported relocation: %" PRId32 "\n",


### PR DESCRIPTION
## Summary

- This PR contains the following 2 commits
- commit1: libs: armv7-a: Add thumb support to arch_elf.c
- commit2: arch, board: Add thumb support to i.MX6

## Impact

- i.MX6 only

## Testing

- Tested with sabre-6quad:smp (QEMU, Dev board)
- Tested with sabre-6quad:netnsh (QEMU)
- Tested with sabre-6quad:netknsh (QEMU, not merged yet)
