### PR TITLE
xtensa/esp32s3: Use the running CPU ID for enabling internal interrupts

### DIFF
--- a/arch/xtensa/src/esp32/esp32_irq.c
+++ b/arch/xtensa/src/esp32/esp32_irq.c
@@ -623,7 +623,7 @@ void up_enable_irq(int irq)
     }
   else
     {
-      /* Retrive the CPU that enabled this interrupt from the IRQ map.
+      /* Retrieve the CPU that enabled this interrupt from the IRQ map.
        *
        * For peripheral interrupts we rely on the interrupt matrix to manage
        * interrupts.  The interrupt matrix registers are available for both

--- a/arch/xtensa/src/esp32s3/esp32s3_irq.c
+++ b/arch/xtensa/src/esp32s3/esp32s3_irq.c
@@ -414,20 +414,38 @@ void up_disable_irq(int irq)
 
 void up_enable_irq(int irq)
 {
-  int cpu = IRQ_GETCPU(g_irqmap[irq]);
   int cpuint = IRQ_GETCPUINT(g_irqmap[irq]);
 
   DEBUGASSERT(cpuint >= 0 && cpuint <= ESP32S3_CPUINT_MAX);
-  DEBUGASSERT(cpu == 0);
 
   if (irq < XTENSA_NIRQ_INTERNAL)
     {
+      /* For internal interrupts, use the current CPU.  We can't enable other
+       * CPUs' internal interrupts.
+       * The CPU interrupt can still be taken from the map as internal
+       * interrupts have the same number for all CPUs.  In this case then
+       * we are just overwriting the cpu part of the map.
+       */
+
+      int cpu = up_cpu_index();
+
       /* Enable the CPU interrupt now for internal CPU. */
 
-      xtensa_enable_cpuint(&g_intenable[cpu], 1ul << cpuint);
+      xtensa_enable_cpuint(&g_intenable[cpu], (1ul << cpuint));
     }
   else
     {
+      /* Retrieve the CPU that enabled this interrupt from the IRQ map.
+       *
+       * For peripheral interrupts we rely on the interrupt matrix to manage
+       * interrupts.  The interrupt matrix registers are available for both
+       * CPUs.
+       */
+
+      int cpu = IRQ_GETCPU(g_irqmap[irq]);
+
+      DEBUGASSERT(cpu == 0);
+
       /* For peripheral interrupts, attach the interrupt to the peripheral;
        * the CPU interrupt was already enabled when allocated.
        */


### PR DESCRIPTION
## Summary
This PR intends to fix a regression on the `esp32s3-devkit` platform, which fails to boot after https://github.com/apache/incubator-nuttx/pull/5542.

It contains a port of one of the fixes brought by https://github.com/apache/incubator-nuttx/pull/5536 for ESP32.

## Impact
Fix for the `esp32s3-devkit` platform.

## Testing
`esp32s3-devkit:nsh` boots as expected once again.

