### PR TITLE
arch/xtensa/esp32s2_irq.c: Correctly enable the software interrupt.

### DIFF
--- a/arch/xtensa/src/esp32s2/esp32s2_irq.c
+++ b/arch/xtensa/src/esp32s2/esp32s2_irq.c
@@ -112,6 +112,6 @@ void up_irqinitialize(void)
 
   /* Enable the software interrupt. */
 
-  up_enable_irq(XTENSA_IRQ_SWINT);
+  up_enable_irq(ESP32S2_CPUINT_SOFTWARE1);
 }
 


### PR DESCRIPTION

## Summary
IRQ number was used to enable the interrupt while ESP32-S2 API use the CPU interrupt.
## Impact
ESP32-S2
## Testing
Tested with https://github.com/apache/incubator-nuttx/pull/5336
