### PR TITLE
risc-v/esp32c3: Enable Timer Groups clocks on timer initialization

### DIFF
--- a/arch/risc-v/src/esp32c3/esp32c3_tim.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_tim.c
@@ -917,6 +917,10 @@ struct esp32c3_tim_dev_s *esp32c3_tim_init(int timer)
       case 0:
         {
           tim = &g_esp32c3_tim0_priv;
+
+          modifyreg32(SYSTEM_PERIP_CLK_EN0_REG, 0, SYSTEM_TIMERGROUP_CLK_EN);
+          modifyreg32(SYSTEM_PERIP_RST_EN0_REG, SYSTEM_TIMERGROUP_RST_M, 0);
+
           break;
         }
 #endif
@@ -925,6 +929,11 @@ struct esp32c3_tim_dev_s *esp32c3_tim_init(int timer)
       case 1:
         {
           tim = &g_esp32c3_tim1_priv;
+
+          modifyreg32(SYSTEM_PERIP_CLK_EN0_REG, 0,
+                      SYSTEM_TIMERGROUP1_CLK_EN);
+          modifyreg32(SYSTEM_PERIP_RST_EN0_REG, SYSTEM_TIMERGROUP1_RST_M, 0);
+
           break;
         }
 #endif

--- a/drivers/timers/oneshot.c
+++ b/drivers/timers/oneshot.c
@@ -331,7 +331,7 @@ int oneshot_register(FAR const char *devname,
   FAR struct oneshot_dev_s *priv;
   int ret;
 
-  sninfo("devname=%s lower=%p\n", devname, lower);
+  tmrinfo("devname=%s lower=%p\n", devname, lower);
   DEBUGASSERT(devname != NULL && lower != NULL);
 
   /* Allocate a new oneshot timer driver instance */
@@ -341,7 +341,7 @@ int oneshot_register(FAR const char *devname,
 
   if (!priv)
     {
-      snerr("ERROR: Failed to allocate device structure\n");
+      tmrerr("ERROR: Failed to allocate device structure\n");
       return -ENOMEM;
     }
 
@@ -355,7 +355,7 @@ int oneshot_register(FAR const char *devname,
   ret = register_driver(devname, &g_oneshot_ops, 0666, priv);
   if (ret < 0)
     {
-      snerr("ERROR: register_driver failed: %d\n", ret);
+      tmrerr("ERROR: register_driver failed: %d\n", ret);
       nxsem_destroy(&priv->od_exclsem);
       kmm_free(priv);
     }


### PR DESCRIPTION
## Summary
This PR intends to fix a regression with **TIMER 1** of **ESP32-C3** not properly working and, as a consequence, breaking Oneshot Timer as well.

## Impact
Platforms based on **ESP32-C3** chips.

## Testing
Tested with the following scenarios:
- `esp32c3-devkit:timer`, executing `timer -d /dev/timer1`
- `esp32c3-devkit:oneshot`, executing `oneshot`.
