### PR TITLE
espressif: Fix SCHED_CPULOAD feature using Oneshot Timer

### DIFF
--- a/arch/risc-v/src/esp32c3/esp32c3_oneshot.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_oneshot.c
@@ -85,17 +85,13 @@ static int esp32c3_oneshot_handler(int irq, void * context, void *arg)
 {
   int ret = OK;
   struct esp32c3_oneshot_s *oneshot = (struct esp32c3_oneshot_s *)arg;
+  oneshot_handler_t handler;
+  void *handler_arg;
 
-  DEBUGASSERT(oneshot != NULL && oneshot->handler != NULL);
+  DEBUGASSERT(oneshot != NULL);
+  DEBUGASSERT(oneshot->handler != NULL);
 
   tmrinfo("Oneshot handler triggered\n");
-
-  /* Stop timer
-   * Note: It's not necessary to disable the alarm because
-   * it automatically disables each time it expires.
-   */
-
-  ESP32C3_TIM_STOP(oneshot->tim);
 
   /* Disable interrupts */
 
@@ -105,19 +101,24 @@ static int esp32c3_oneshot_handler(int irq, void * context, void *arg)
 
   ret = ESP32C3_TIM_SETISR(oneshot->tim, NULL, NULL);
 
-  /* Call the callback */
-
-  oneshot->handler((void *)oneshot->arg);
-
-  /* Restore state */
-
-  oneshot->running = false;
-  oneshot->handler = NULL;
-  oneshot->arg = NULL;
-
   /* Clear the Interrupt */
 
   ESP32C3_TIM_ACKINT(oneshot->tim);
+
+  /* The timer is no longer running */
+
+  oneshot->running = false;
+
+  /* Forward the event, clearing out any vestiges */
+
+  handler          = (oneshot_handler_t)oneshot->handler;
+  oneshot->handler = NULL;
+  handler_arg      = (void *)oneshot->arg;
+  oneshot->arg     = NULL;
+
+  /* Call the callback */
+
+  handler(handler_arg);
 
   return ret;
 }

--- a/arch/risc-v/src/esp32c3/esp32c3_oneshot_lowerhalf.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_oneshot_lowerhalf.c
@@ -114,20 +114,26 @@ static void esp32c3_oneshot_lh_handler(void *arg)
 {
   struct esp32c3_oneshot_lowerhalf_s *priv =
     (struct esp32c3_oneshot_lowerhalf_s *)arg;
+  oneshot_callback_t callback;
+  FAR void *cb_arg;
 
   DEBUGASSERT(priv != NULL);
   DEBUGASSERT(priv->callback != NULL);
 
   tmrinfo("Oneshot LH handler triggered\n");
 
-  /* Call the callback */
+  /* Sample and nullify BEFORE executing callback (in case the callback
+   * restarts the oneshot).
+   */
 
-  priv->callback(&priv->lh, priv->arg);
-
-  /* Restore state */
-
+  callback       = priv->callback;
+  cb_arg         = priv->arg;
   priv->callback = NULL;
-  priv->arg = NULL;
+  priv->arg      = NULL;
+
+  /* Then perform the callback */
+
+  callback(&priv->lh, cb_arg);
 }
 
 /****************************************************************************

--- a/arch/xtensa/src/esp32/esp32_oneshot_lowerhalf.c
+++ b/arch/xtensa/src/esp32/esp32_oneshot_lowerhalf.c
@@ -117,20 +117,26 @@ static void esp32_oneshot_lh_handler(void *arg)
 {
   struct esp32_oneshot_lowerhalf_s *priv =
     (struct esp32_oneshot_lowerhalf_s *)arg;
+  oneshot_callback_t callback;
+  FAR void *cb_arg;
 
   DEBUGASSERT(priv != NULL);
   DEBUGASSERT(priv->callback != NULL);
 
   tmrinfo("Oneshot LH handler triggered\n");
 
-  /* Call the callback */
+  /* Sample and nullify BEFORE executing callback (in case the callback
+   * restarts the oneshot).
+   */
 
-  priv->callback(&priv->lh, priv->arg);
-
-  /* Restore state */
-
+  callback       = priv->callback;
+  cb_arg         = priv->arg;
   priv->callback = NULL;
-  priv->arg = NULL;
+  priv->arg      = NULL;
+
+  /* Then perform the callback */
+
+  callback(&priv->lh, cb_arg);
 }
 
 /****************************************************************************

--- a/arch/xtensa/src/esp32s2/esp32s2_oneshot_lowerhalf.c
+++ b/arch/xtensa/src/esp32s2/esp32s2_oneshot_lowerhalf.c
@@ -114,20 +114,26 @@ static void esp32s2_oneshot_lh_handler(void *arg)
 {
   struct esp32s2_oneshot_lowerhalf_s *priv =
     (struct esp32s2_oneshot_lowerhalf_s *)arg;
+  oneshot_callback_t callback;
+  FAR void *cb_arg;
 
   DEBUGASSERT(priv != NULL);
   DEBUGASSERT(priv->callback != NULL);
 
   tmrinfo("Oneshot LH handler triggered\n");
 
-  /* Call the callback */
+  /* Sample and nullify BEFORE executing callback (in case the callback
+   * restarts the oneshot).
+   */
 
-  priv->callback(&priv->lh, priv->arg);
-
-  /* Restore state */
-
+  callback       = priv->callback;
+  cb_arg         = priv->arg;
   priv->callback = NULL;
-  priv->arg = NULL;
+  priv->arg      = NULL;
+
+  /* Then perform the callback */
+
+  callback(&priv->lh, cb_arg);
 }
 
 /****************************************************************************


### PR DESCRIPTION
## Summary
This PR intends to fix the Scheduler CPU Load monitoring feature using Oneshot Timer on the following chips:
- **ESP32**
- **ESP32-S2**
- **ESP32-C3**

## Impact
`SCHED_CPULOAD` feature on the mentioned chips.

## Testing
Enable `SCHED_CPULOAD` on the following defconfigs and verify that CPU Load is successfully reported on `ps`:
- `esp32-devkitc:oneshot`
- `esp32s2-saola-1:oneshot`
- `esp32c3-devkit:oneshot`
