### PR TITLE
arm/armv7-a: Remove CONFIG_SMP guard from arm_scu.c

### DIFF
--- a/arch/arm/src/armv7-a/arm_scu.c
+++ b/arch/arm/src/armv7-a/arm_scu.c
@@ -32,8 +32,6 @@
 #include "sctlr.h"
 #include "scu.h"
 
-#ifdef CONFIG_SMP
-
 /****************************************************************************
  * Private Functions
  ****************************************************************************/
@@ -208,5 +206,3 @@ void arm_enable_smp(int cpu)
   regval |= SCTLR_C;
   arm_set_sctlr(regval);
 }
-
-#endif


### PR DESCRIPTION
## Summary
since ACTLR.SMP need enable to make cache work on Cortex A7:
https://developer.arm.com/documentation/ddi0464/f/CHDBIEIF

## Impact

## Testing

