### PR TITLE
arch/sim: Don't include execinfo.h since cygwin doesn't support it

### DIFF
--- a/arch/sim/src/sim/up_hostmisc.c
+++ b/arch/sim/src/sim/up_hostmisc.c
@@ -22,7 +22,6 @@
  * Included Files
  ****************************************************************************/
 
-#include <execinfo.h>
 #include <stdlib.h>
 
 #include "up_internal.h"
@@ -50,7 +49,10 @@ void host_abort(int status)
 
 int host_backtrace(void** array, int size)
 {
-  /* exit the simulation */
-
+#ifdef CONFIG_WINDOWS_CYGWIN
+  return 0;
+#else
+  extern int backtrace(void **array, int size);
   return backtrace(array, size);
+#endif
 }


### PR DESCRIPTION
## Summary
Report here: https://github.com/apache/incubator-nuttx/issues/5621

## Impact
sim on cygwin

## Testing

