### PR TITLE
joystick/buttons: Fix the event lose between the invocation of poll 

### DIFF
--- a/drivers/input/ajoystick.c
+++ b/drivers/input/ajoystick.c
@@ -99,6 +99,7 @@ struct ajoy_open_s
    * driver events.
    */
 
+  bool ao_pollpending;
   FAR struct pollfd *ao_fds[CONFIG_INPUT_AJOYSTICK_NPOLLWAITERS];
 };
 
@@ -174,7 +175,6 @@ static void ajoy_enable(FAR struct ajoy_upperhalf_s *priv)
   ajoy_buttonset_t press;
   ajoy_buttonset_t release;
   irqstate_t flags;
-  int i;
 
   DEBUGASSERT(priv);
   lower = priv->au_lower;
@@ -193,19 +193,8 @@ static void ajoy_enable(FAR struct ajoy_upperhalf_s *priv)
 
   for (opriv = priv->au_open; opriv; opriv = opriv->ao_flink)
     {
-      /* Are there any poll waiters? */
-
-      for (i = 0; i < CONFIG_INPUT_AJOYSTICK_NPOLLWAITERS; i++)
-        {
-          if (opriv->ao_fds[i])
-            {
-              /* Yes.. OR in the poll event buttons */
-
-              press   |= opriv->ao_pollevents.ap_press;
-              release |= opriv->ao_pollevents.ap_release;
-              break;
-            }
-        }
+      press   |= opriv->ao_pollevents.ap_press;
+      release |= opriv->ao_pollevents.ap_release;
 
       /* OR in the signal events */
 
@@ -285,8 +274,8 @@ static void ajoy_sample(FAR struct ajoy_upperhalf_s *priv)
    * newly released.
    */
 
-  change  = sample ^ priv->au_sample;
-  press   = change & sample;
+  change = sample ^ priv->au_sample;
+  press  = change & sample;
 
   DEBUGASSERT(lower->al_supported);
   release = change & (lower->al_supported(lower) & ~sample);
@@ -300,6 +289,8 @@ static void ajoy_sample(FAR struct ajoy_upperhalf_s *priv)
       if ((press & opriv->ao_pollevents.ap_press)     != 0 ||
           (release & opriv->ao_pollevents.ap_release) != 0)
         {
+          opriv->ao_pollpending = true;
+
           /* Yes.. Notify all waiters */
 
           for (i = 0; i < CONFIG_INPUT_AJOYSTICK_NPOLLWAITERS; i++)
@@ -384,6 +375,10 @@ static int ajoy_open(FAR struct file *filep)
 
   opriv->ao_flink = priv->au_open;
   priv->au_open = opriv;
+
+  /* Enable/disable interrupt handling */
+
+  ajoy_enable(priv);
 
   /* Attach the open structure to the file structure */
 
@@ -498,11 +493,13 @@ static ssize_t ajoy_read(FAR struct file *filep, FAR char *buffer,
                          size_t len)
 {
   FAR struct inode *inode;
+  FAR struct ajoy_open_s *opriv;
   FAR struct ajoy_upperhalf_s *priv;
   FAR const struct ajoy_lowerhalf_s *lower;
   int ret;
 
   DEBUGASSERT(filep && filep->f_inode);
+  opriv = filep->f_priv;
   inode = filep->f_inode;
   DEBUGASSERT(inode->i_private);
   priv  = (FAR struct ajoy_upperhalf_s *)inode->i_private;
@@ -535,6 +532,7 @@ static ssize_t ajoy_read(FAR struct file *filep, FAR char *buffer,
   ret = lower->al_sample(lower, (FAR struct ajoy_sample_s *)buffer);
   if (ret >= 0)
     {
+      opriv->ao_pollpending = false;
       ret = sizeof(struct ajoy_sample_s);
     }
 
@@ -717,6 +715,19 @@ static int ajoy_poll(FAR struct file *filep, FAR struct pollfd *fds,
 
               opriv->ao_fds[i] = fds;
               fds->priv = &opriv->ao_fds[i];
+
+              /* Report if the event is pending */
+
+              if (opriv->ao_pollpending)
+                {
+                  fds->revents |= (fds->events & POLLIN);
+                  if (fds->revents != 0)
+                    {
+                      iinfo("Report events: %02x\n", fds->revents);
+                      nxsem_post(fds->sem);
+                    }
+                }
+
               break;
             }
         }
@@ -769,7 +780,7 @@ errout_with_dusem:
  *
  * Input Parameters:
  *   devname - The name of the analog joystick device to be registers.
- *     This should be a string of the form "/priv/ajoyN" where N is the
+ *     This should be a string of the form "/dev/ajoyN" where N is the
  *     minor device number.
  *   lower - An instance of the platform-specific analog joystick lower
  *     half driver.

--- a/drivers/input/button_upper.c
+++ b/drivers/input/button_upper.c
@@ -95,6 +95,7 @@ struct btn_open_s
    * driver events.
    */
 
+  bool bo_pending;
   FAR struct pollfd *bo_fds[CONFIG_INPUT_BUTTONS_NPOLLWAITERS];
 };
 
@@ -281,6 +282,10 @@ static void btn_sample(FAR struct btn_upperhalf_s *priv)
 
   for (opriv = priv->bu_open; opriv; opriv = opriv->bo_flink)
     {
+      /* Always set bo_pending true, only clear it after button read */
+
+      opriv->bo_pending = true;
+
       /* Have any poll events occurred? */
 
       if ((press & opriv->bo_pollevents.bp_press)     != 0 ||
@@ -488,11 +493,13 @@ static ssize_t btn_read(FAR struct file *filep, FAR char *buffer,
                         size_t len)
 {
   FAR struct inode *inode;
+  FAR struct btn_open_s *opriv;
   FAR struct btn_upperhalf_s *priv;
   FAR const struct btn_lowerhalf_s *lower;
   int ret;
 
   DEBUGASSERT(filep && filep->f_inode);
+  opriv = filep->f_priv;
   inode = filep->f_inode;
   DEBUGASSERT(inode->i_private);
   priv  = (FAR struct btn_upperhalf_s *)inode->i_private;
@@ -523,6 +530,7 @@ static ssize_t btn_read(FAR struct file *filep, FAR char *buffer,
   lower = priv->bu_lower;
   DEBUGASSERT(lower && lower->bl_buttons);
   *(FAR btn_buttonset_t *)buffer = lower->bl_buttons(lower);
+  opriv->bo_pending = false;
 
   btn_givesem(&priv->bu_exclsem);
   return (ssize_t)sizeof(btn_buttonset_t);
@@ -759,6 +767,19 @@ static int btn_poll(FAR struct file *filep, FAR struct pollfd *fds,
 
               opriv->bo_fds[i] = fds;
               fds->priv = &opriv->bo_fds[i];
+
+              /* Report if the event is pending */
+
+              if (opriv->bo_pending)
+                {
+                  fds->revents |= (fds->events & POLLIN);
+                  if (fds->revents != 0)
+                    {
+                      iinfo("Report events: %02x\n", fds->revents);
+                      nxsem_post(fds->sem);
+                    }
+                }
+
               break;
             }
         }

--- a/drivers/input/djoystick.c
+++ b/drivers/input/djoystick.c
@@ -99,6 +99,7 @@ struct djoy_open_s
    * driver events.
    */
 
+  bool do_pollpending;
   FAR struct pollfd *do_fds[CONFIG_INPUT_DJOYSTICK_NPOLLWAITERS];
 };
 
@@ -174,7 +175,6 @@ static void djoy_enable(FAR struct djoy_upperhalf_s *priv)
   djoy_buttonset_t press;
   djoy_buttonset_t release;
   irqstate_t flags;
-  int i;
 
   DEBUGASSERT(priv);
   lower = priv->du_lower;
@@ -193,19 +193,8 @@ static void djoy_enable(FAR struct djoy_upperhalf_s *priv)
 
   for (opriv = priv->du_open; opriv; opriv = opriv->do_flink)
     {
-      /* Are there any poll waiters? */
-
-      for (i = 0; i < CONFIG_INPUT_DJOYSTICK_NPOLLWAITERS; i++)
-        {
-          if (opriv->do_fds[i])
-            {
-              /* Yes.. OR in the poll event buttons */
-
-              press   |= opriv->do_pollevents.dp_press;
-              release |= opriv->do_pollevents.dp_release;
-              break;
-            }
-        }
+      press   |= opriv->do_pollevents.dp_press;
+      release |= opriv->do_pollevents.dp_release;
 
       /* OR in the signal events */
 
@@ -285,8 +274,8 @@ static void djoy_sample(FAR struct djoy_upperhalf_s *priv)
    * newly released.
    */
 
-  change  = sample ^ priv->du_sample;
-  press   = change & sample;
+  change = sample ^ priv->du_sample;
+  press  = change & sample;
 
   DEBUGASSERT(lower->dl_supported);
   release = change & (lower->dl_supported(lower) & ~sample);
@@ -300,6 +289,8 @@ static void djoy_sample(FAR struct djoy_upperhalf_s *priv)
       if ((press & opriv->do_pollevents.dp_press)     != 0 ||
           (release & opriv->do_pollevents.dp_release) != 0)
         {
+          opriv->do_pollpending = true;
+
           /* Yes.. Notify all waiters */
 
           for (i = 0; i < CONFIG_INPUT_DJOYSTICK_NPOLLWAITERS; i++)
@@ -384,6 +375,10 @@ static int djoy_open(FAR struct file *filep)
 
   opriv->do_flink = priv->du_open;
   priv->du_open = opriv;
+
+  /* Enable/disable interrupt handling */
+
+  djoy_enable(priv);
 
   /* Attach the open structure to the file structure */
 
@@ -498,11 +493,13 @@ static ssize_t djoy_read(FAR struct file *filep, FAR char *buffer,
                          size_t len)
 {
   FAR struct inode *inode;
+  FAR struct djoy_open_s *opriv;
   FAR struct djoy_upperhalf_s *priv;
   FAR const struct djoy_lowerhalf_s *lower;
   int ret;
 
   DEBUGASSERT(filep && filep->f_inode);
+  opriv = filep->f_priv;
   inode = filep->f_inode;
   DEBUGASSERT(inode->i_private);
   priv  = (FAR struct djoy_upperhalf_s *)inode->i_private;
@@ -532,6 +529,7 @@ static ssize_t djoy_read(FAR struct file *filep, FAR char *buffer,
   DEBUGASSERT(lower && lower->dl_sample);
   priv->du_sample = lower->dl_sample(lower);
   *(FAR djoy_buttonset_t *)buffer = priv->du_sample;
+  opriv->do_pollpending = false;
   ret = sizeof(djoy_buttonset_t);
 
   djoy_givesem(&priv->du_exclsem);
@@ -713,6 +711,17 @@ static int djoy_poll(FAR struct file *filep, FAR struct pollfd *fds,
 
               opriv->do_fds[i] = fds;
               fds->priv = &opriv->do_fds[i];
+
+              if (opriv->do_pollpending)
+                {
+                  fds->revents |= (fds->events & POLLIN);
+                  if (fds->revents != 0)
+                    {
+                      iinfo("Report events: %02x\n", fds->revents);
+                      nxsem_post(fds->sem);
+                    }
+                }
+
               break;
             }
         }
@@ -765,7 +774,7 @@ errout_with_dusem:
  *
  * Input Parameters:
  *   devname - The name of the discrete joystick device to be registers.
- *     This should be a string of the form "/priv/djoyN" where N is the
+ *     This should be a string of the form "/dev/djoyN" where N is the
  *     minor device number.
  *   lower - An instance of the platform-specific discrete joystick lower
  *     half driver.


### PR DESCRIPTION
## Summary

- input/ajoystick: Fix the event lose between the invocation of poll
- input/djoystick: Fix the event lose between the invocation of poll 
-i nput/buttons: Fix the event lose between the invocation of poll 

## Impact
joystick and buttons driver

## Testing
Test with local device
