### PR TITLE
joystick:  Remove [a|d]joy_enable from [a|d]joy_sample

### DIFF
--- a/drivers/input/ajoystick.c
+++ b/drivers/input/ajoystick.c
@@ -63,7 +63,6 @@ struct ajoy_upperhalf_s
 
   FAR const struct ajoy_lowerhalf_s *au_lower;
 
-  ajoy_buttonset_t au_enabled; /* Set of currently enabled button interrupts */
   ajoy_buttonset_t au_sample;  /* Last sampled button states */
   sem_t au_exclsem;            /* Supports exclusive access to the device */
 

--- a/drivers/input/ajoystick.c
+++ b/drivers/input/ajoystick.c
@@ -331,10 +331,6 @@ static void ajoy_sample(FAR struct ajoy_upperhalf_s *priv)
         }
     }
 
-  /* Enable/disable interrupt handling */
-
-  ajoy_enable(priv);
-
   priv->au_sample = sample;
   leave_critical_section(flags);
 }

--- a/drivers/input/button_upper.c
+++ b/drivers/input/button_upper.c
@@ -324,10 +324,6 @@ static void btn_sample(FAR struct btn_upperhalf_s *priv)
         }
     }
 
-  /* Enable/disable interrupt handling */
-
-  btn_enable(priv);
-
   priv->bu_sample = sample;
   leave_critical_section(flags);
 }

--- a/drivers/input/button_upper.c
+++ b/drivers/input/button_upper.c
@@ -59,7 +59,6 @@ struct btn_upperhalf_s
 
   FAR const struct btn_lowerhalf_s *bu_lower;
 
-  btn_buttonset_t bu_enabled; /* Set of currently enabled button interrupts */
   btn_buttonset_t bu_sample;  /* Last sampled button states */
   sem_t bu_exclsem;           /* Supports exclusive access to the device */
 

--- a/drivers/input/djoystick.c
+++ b/drivers/input/djoystick.c
@@ -331,10 +331,6 @@ static void djoy_sample(FAR struct djoy_upperhalf_s *priv)
         }
     }
 
-  /* Enable/disable interrupt handling */
-
-  djoy_enable(priv);
-
   priv->du_sample = sample;
   leave_critical_section(flags);
 }

--- a/drivers/input/djoystick.c
+++ b/drivers/input/djoystick.c
@@ -63,7 +63,6 @@ struct djoy_upperhalf_s
 
   FAR const struct djoy_lowerhalf_s *du_lower;
 
-  djoy_buttonset_t du_enabled; /* Set of currently enabled button interrupts */
   djoy_buttonset_t du_sample;  /* Last sampled button states */
   sem_t du_exclsem;            /* Supports exclusive access to the device */
 

--- a/include/nuttx/input/djoystick.h
+++ b/include/nuttx/input/djoystick.h
@@ -220,12 +220,6 @@ struct djoy_lowerhalf_s
   CODE void (*dl_enable)(FAR const struct djoy_lowerhalf_s *lower,
                          djoy_buttonset_t press, djoy_buttonset_t release,
                          djoy_interrupt_t handler, FAR void *arg);
-
-  /* Allow for storing implementation specific data to support cases where
-   * their may be more than one joystick
-   */
-
-  FAR void *config;
 };
 
 /****************************************************************************


### PR DESCRIPTION
## Summary
Since the enable status keep stable in [a|d]joy_sample.
- input/buttons: Remove btn_enable from btn_sample
- input/ajoystck: Remove ajoy_enable from ajoy_sample
- input/djoystck: Remove djoy_enable from djoy_sample 
and other minor fix.

## Impact
No

## Testing
Pass CI
