### PR TITLE
fix up_tls_info define for BUILD_KERNEL

### DIFF
--- a/include/nuttx/arch.h
+++ b/include/nuttx/arch.h
@@ -1780,7 +1780,7 @@ int up_timer_start(FAR const struct timespec *ts);
  */
 
 #ifndef up_tls_info
-#  ifdef CONFIG_TLS_ALIGNED
+#  if defined(CONFIG_TLS_ALIGNED) && !defined(__KERNEL__)
 #    define up_tls_info() TLS_INFO((uintptr_t)up_getsp())
 #  else
 #    define up_tls_info() tls_get_info()

--- a/include/nuttx/tls.h
+++ b/include/nuttx/tls.h
@@ -378,7 +378,7 @@ uintptr_t task_tls_get_value(int tlsindex);
  *
  ****************************************************************************/
 
-#ifndef CONFIG_TLS_ALIGNED
+#if !defined(CONFIG_TLS_ALIGNED) || defined(__KERNEL__)
 FAR struct tls_info_s *tls_get_info(void);
 #endif
 

--- a/libs/libc/tls/Make.defs
+++ b/libs/libc/tls/Make.defs
@@ -18,15 +18,11 @@
 #
 ############################################################################
 
-CSRCS += task_getinfo.c
+CSRCS += task_getinfo.c tls_getinfo.c
 
 ifneq ($(CONFIG_TLS_NELEM),0)
 CSRCS += tls_alloc.c tls_free.c
 CSRCS += tls_setvalue.c tls_getvalue.c tls_destruct.c
-endif
-
-ifneq ($(CONFIG_TLS_ALIGNED),y)
-CSRCS += tls_getinfo.c
 endif
 
 # Include tls build support

--- a/libs/libc/tls/tls_getinfo.c
+++ b/libs/libc/tls/tls_getinfo.c
@@ -30,7 +30,7 @@
 #include <nuttx/arch.h>
 #include <nuttx/tls.h>
 
-#ifndef CONFIG_TLS_ALIGNED
+#if !defined(CONFIG_TLS_ALIGNED) || defined(__KERNEL__)
 
 /****************************************************************************
  * Public Functions
@@ -42,7 +42,7 @@
  * Description:
  *   Return a reference to the tls_info_s structure.  This is used as part
  *   of the internal implementation of tls_get/set_elem() and ONLY for the
- *   where CONFIG_TLS_ALIGNED is *not* defined
+ *   where CONFIG_TLS_ALIGNED is *not* defined or __KERNEL__ is defined.
  *
  * Input Parameters:
  *   None
@@ -72,4 +72,4 @@ FAR struct tls_info_s *tls_get_info(void)
   return info;
 }
 
-#endif /* !CONFIG_TLS_ALIGNED */
+#endif /* !CONFIG_TLS_ALIGNED || __KERNEL__ */


### PR DESCRIPTION
## Summary

- In the case of BUILD_KERNEL, NuttX uses USR mode sp and SVC mode sp.
- The kernel runs on SVC mode sp.
- While the kernel is running, up_getsp() cannot get the TLS address.
- The kernel requires tls_get_info() function.
- For the user land, up_getsp() can be used.

## Impact

BUILD_KERNEL

## Testing

test program on custom Cortex-A9 board (BUILD_KERNEL)
ostest on sabre-6quad:smp (QEMU, BUILD_FLAT)
