### PR TITLE
sched/timer: remove unused variable

### DIFF
--- a/sched/timer/timer.h
+++ b/sched/timer/timer.h
@@ -55,7 +55,6 @@ struct posix_timer_s
   uint8_t          pt_crefs;       /* Reference count */
   pid_t            pt_owner;       /* Creator of timer */
   int              pt_delay;       /* If non-zero, used to reset repetitive timers */
-  int              pt_last;        /* Last value used to set watchdog */
   struct wdog_s    pt_wdog;        /* The watchdog that provides the timing */
   struct sigevent  pt_event;       /* Notification information */
   struct sigwork_s pt_work;

--- a/sched/timer/timer_settime.c
+++ b/sched/timer/timer_settime.c
@@ -98,7 +98,6 @@ static inline void timer_restart(FAR struct posix_timer_s *timer,
 
   if (timer->pt_delay)
     {
-      timer->pt_last = timer->pt_delay;
       wd_start(&timer->pt_wdog, timer->pt_delay, timer_timeout, itimer);
     }
 }
@@ -313,13 +312,7 @@ int timer_settime(timer_t timerid, int flags,
 
   if (delay > 0)
     {
-      /* REVISIT: Should pt_last be sclock_t? Should wd_start delay be
-       *          sclock_t?
-       */
-
-      timer->pt_last = delay;
-      ret = wd_start(&timer->pt_wdog, delay,
-                     timer_timeout, (wdparm_t)timer);
+      ret = wd_start(&timer->pt_wdog, delay, timer_timeout, (wdparm_t)timer);
       if (ret < 0)
         {
           set_errno(-ret);


### PR DESCRIPTION
## Summary
Remove unused variable in POSIX timers implementation

## Impact
None

## Testing
Pass CI