### PR TITLE
sched: group: Fix dataabort when exiting task or pthread if ARCH_ADDR_ENV=y

### DIFF
--- a/sched/group/group_create.c
+++ b/sched/group/group_create.c
@@ -244,13 +244,39 @@ void group_deallocate(FAR struct task_group_s *group)
 {
   if (group)
     {
+#ifdef CONFIG_ARCH_ADDRENV
+      save_addrenv_t oldenv;
+
+      /* NOTE: switch the addrenv before accessing group->tg_info
+       * located in the userland, also save the current addrenv
+       */
+
+      up_addrenv_select(&group->tg_addrenv, &oldenv);
+#endif
+
       if (group->tg_info)
         {
           nxsem_destroy(&group->tg_info->ta_sem);
           group_free(group, group->tg_info);
         }
 
+#ifdef CONFIG_ARCH_ADDRENV
+      /* Destroy the group address environment */
+
+      up_addrenv_destroy(&group->tg_addrenv);
+
+      /* Mark no address environment */
+
+      g_pid_current = INVALID_PROCESS_ID;
+#endif
+
       kmm_free(group);
+
+#ifdef CONFIG_ARCH_ADDRENV
+      /* Restore the previous addrenv */
+
+      up_addrenv_restore(&oldenv);
+#endif
     }
 }
 

--- a/sched/group/group_leave.c
+++ b/sched/group/group_leave.c
@@ -175,11 +175,12 @@ static inline void group_release(FAR struct task_group_s *group)
 #endif
 
 #ifdef CONFIG_ARCH_ADDRENV
-  /* Destroy the group address environment */
-
-  up_addrenv_destroy(&group->tg_addrenv);
-
-  /* Mark no address environment */
+  /* NOTE:
+   * We do not destroy the group address environment here.
+   * It will be done in the group_deallocate().
+   * However, we mark no address environment here,
+   * so that group_addrenv() can work correctly
+   */
 
   g_pid_current = INVALID_PROCESS_ID;
 #endif


### PR DESCRIPTION
## Summary

- I noticed that exiting task or pthread causes dataabort if ARCH_ADDRENV=y
- This commit fixes this issue by switching the addrenv correctly

## Impact

- CONFIG_ARCH_ADDRENV=y only

## Testing

- Tested with sabre-6quad:netknsh (not merged yet)
