### PR TITLE
Fix imx6

### DIFF
--- a/arch/arm/src/imx6/imx_lowputc.c
+++ b/arch/arm/src/imx6/imx_lowputc.c
@@ -571,7 +571,7 @@ int imx_uart_configure(uint32_t base, FAR const struct uart_config_s *config)
  *
  ****************************************************************************/
 
-#if defined(IMX_HAVE_UART) && defined(CONFIG_DEBUG_FEATURES)
+#ifdef IMX_HAVE_UART
 void imx_lowputc(int ch)
 {
   /* Poll the TX fifo trigger level bit of the UART status register. When the
@@ -585,29 +585,8 @@ void imx_lowputc(int ch)
    * return
    */
 
-  if (ch == '\n')
-    {
-      /* Send the carrage return by writing it into the UART_TXD register. */
-
-      putreg32((uint32_t)'\r', IMX_CONSOLE_VBASE + UART_TXD_OFFSET);
-
-      /* Wait for the tranmsit register to be emptied. When the TXFE bit is
-       * non-zero, the TX Buffer FIFO is empty.
-       */
-
-      while ((getreg32(IMX_CONSOLE_VBASE + UART_USR2_OFFSET) &
-              UART_USR2_TXFE) == 0);
-    }
-
   /* Send the character by writing it into the UART_TXD register. */
 
   putreg32((uint32_t)ch, IMX_CONSOLE_VBASE + UART_TXD_OFFSET);
-
-  /* Wait for the tranmsit register to be emptied. When the TXFE bit is
-   * non-zero, the TX Buffer FIFO is empty.
-   */
-
-  while ((getreg32(IMX_CONSOLE_VBASE + UART_USR2_OFFSET) &
-          UART_USR2_TXFE) == 0);
 }
 #endif

--- a/arch/arm/src/imx6/imx_lowputc.h
+++ b/arch/arm/src/imx6/imx_lowputc.h
@@ -91,10 +91,8 @@ int imx_uart_configure(uint32_t base,
  *
  ****************************************************************************/
 
-#if defined(IMX_HAVE_UART) && defined(CONFIG_DEBUG_FEATURES)
+#ifdef IMX_HAVE_UART
 void imx_lowputc(int ch);
-#else
-#  define imx_lowputc(ch)
 #endif
 
 #endif /* __ARCH_ARM_SRC_IMX6_IMX_LOWPUTC_H */

--- a/arch/arm/src/imx6/imx_serial.c
+++ b/arch/arm/src/imx6/imx_serial.c
@@ -42,7 +42,6 @@
 #include <nuttx/spinlock.h>
 #include <nuttx/init.h>
 #include <nuttx/fs/ioctl.h>
-#include <nuttx/semaphore.h>
 #include <nuttx/serial/serial.h>
 
 #include "chip.h"
@@ -238,10 +237,6 @@ static bool imx_txempty(struct uart_dev_s *dev);
 /****************************************************************************
  * Private Data
  ****************************************************************************/
-
-/* Used to assure mutually exclusive access up_putc() */
-
-static sem_t g_putc_lock = SEM_INITIALIZER(1);
 
 /* Serial driver UART operations */
 
@@ -1123,30 +1118,12 @@ int up_putc(int ch)
 {
   struct imx_uart_s *priv = (struct imx_uart_s *)CONSOLE_DEV.priv;
   uint32_t ier;
-  bool locked;
-  int ret;
-
-  /* Only one thread may enter up_putc at a time. */
-
-  locked = false;
-
-  if (!up_interrupt_context() && g_nx_initstate >= OSINIT_HARDWARE)
-    {
-      ret = nxsem_wait(&g_putc_lock);
-      if (ret < 0)
-        {
-          return ret;
-        }
-
-      locked = true;
-    }
 
   /* Disable UART interrupts and wait until the hardware is ready to send
    * a byte.
    */
 
   imx_disableuartint(priv, &ier);
-  imx_waittxready(priv);
 
   /* Check for LF */
 
@@ -1154,18 +1131,11 @@ int up_putc(int ch)
     {
       /* Add CR */
 
-      imx_serialout(priv, UART_TXD_OFFSET, (uint32_t)'\r');
-      imx_waittxready(priv);
+      imx_lowputc('\r');
     }
 
-  imx_serialout(priv, UART_TXD_OFFSET, (uint32_t)ch);
-  imx_waittxready(priv);
+  imx_lowputc(ch);
   imx_restoreuartint(priv, ier);
-
-  if (locked)
-    {
-      nxsem_post(&g_putc_lock);
-    }
 
   return ch;
 }


### PR DESCRIPTION
## Summary

- This PR contains the following 2 commits
- commit1: arch: imx6: Refactor imx_lowputc()
  - Remove '\n' -> '\r\n' conversion
  - Remove waiting for FIFO empty after sending a character
  - Remove CONFIG_DEBUG_FEATURES
- commit2: Remove sem_t from imx_serial.c
  - I noticed that when exiting getprime, DEBUGASSERT happens in
      nxsem_wait()
  - Finally, I found that up_putc() uses nxsem_wait()
  - This commit fixes this issue by removing the semaphore.
  - Also, up_putc() now calls imx_lowputc()

## Impact

- None

## Testing

- Tested with sabre-6quad:netknsh (not merged yet)

