### PR TITLE
arch/risc-v/qemu-rv: Set FS bits in mstatus

### DIFF
--- a/arch/risc-v/src/qemu-rv/qemu_rv_irq.c
+++ b/arch/risc-v/src/qemu-rv/qemu_rv_irq.c
@@ -225,7 +225,8 @@ uint32_t riscv_get_newintctx(void)
 {
   /* Set machine previous privilege mode to machine mode.
    * Also set machine previous interrupt enable
+   * Note: In qemu, FPU is always exist even if don't use F|D ISA extension
    */
 
-  return (MSTATUS_MPPM | MSTATUS_MPIE);
+  return (MSTATUS_MPPM | MSTATUS_MPIE | MSTATUS_FS_INIT);
 }


### PR DESCRIPTION
## Summary
FPU test may fail without correct FS bits.

## Impact
rv-virt
## Testing
QEMU
