### PR TITLE
arch/arm: Move ARCHCPUFLAGS to Toolchain.defs

### DIFF
--- a/arch/arm/src/armv7-a/Toolchain.defs
+++ b/arch/arm/src/armv7-a/Toolchain.defs
@@ -59,18 +59,27 @@ ifeq ($(CONFIG_ARM_THUMB),y)
 ARCHCPUFLAGS += -mthumb
 endif
 
-ifeq ($(CONFIG_ARCH_FPU),y)
-ARCHCPUFLAGS += -mfloat-abi=hard
+ifeq ($(CONFIG_ARCH_CORTEXA5),y)
+  ARCHCPUFLAGS += -mcpu=cortex-a5
+else ifeq ($(CONFIG_ARCH_CORTEXA7),y)
+  ARCHCPUFLAGS += -mcpu=cortex-a7
+else ifeq ($(CONFIG_ARCH_CORTEXA8),y)
+  ARCHCPUFLAGS += -mcpu=cortex-a8
+else ifeq ($(CONFIG_ARCH_CORTEXA9),y)
+  ARCHCPUFLAGS += -mcpu=cortex-a9
 endif
 
-ifeq ($(CONFIG_ARCH_CORTEXA5),y)
-ARCHCPUFLAGS += -mcpu=cortex-a5
-else ifeq ($(CONFIG_ARCH_CORTEXA7),y)
-ARCHCPUFLAGS += -mcpu=cortex-a7
-else ifeq ($(CONFIG_ARCH_CORTEXA8),y)
-ARCHCPUFLAGS += -mcpu=cortex-a8
-else ifeq ($(CONFIG_ARCH_CORTEXA9),y)
-ARCHCPUFLAGS += -mcpu=cortex-a9
+ifeq ($(CONFIG_ARCH_FPU),y)
+  ARCHCPUFLAGS += -mfloat-abi=hard
+  ifeq ($(CONFIG_ARCH_CORTEXA8),y)
+    ARCHCPUFLAGS += -mfpu=vfpv3-d16
+  else ifeq ($(CONFIG_ARCH_CORTEXA9),y)
+    ARCHCPUFLAGS += -mfpu=vfpv3-d16
+  else
+    ARCHCPUFLAGS += -mfpu=vfpv4-d16
+  endif
+else
+  ARCHCPUFLAGS += -mfloat-abi=soft
 endif
 
 ifeq ($(CONFIG_DEBUG_CUSTOMOPT),y)

--- a/arch/arm/src/armv7-r/Toolchain.defs
+++ b/arch/arm/src/armv7-r/Toolchain.defs
@@ -67,6 +67,32 @@ else
   MAXOPTIMIZATION += -fomit-frame-pointer
 endif
 
+ARCHCPUFLAGS = -march=armv7-r
+
+ifeq ($(CONFIG_ARCH_FPU),y)
+  ARCHCPUFLAGS += -mfloat-abi=hard -mfpu=vfpv3-d16
+else
+  ARCHCPUFLAGS += -mfloat-abi=soft
+endif
+
+endif
+
+ifeq ($(CONFIG_ENDIAN_BIG),y)
+  ARCHCPUFLAGS += -mbig-endian
+endif
+
+ifeq ($(CONFIG_ARCH_CORTEXR4),y)
+  ifeq ($(CONFIG_ARCH_FPU),y)
+    ARCHCPUFLAGS += -mcpu=cortex-r4f
+  else
+    ARCHCPUFLAGS += -mcpu=cortex-r4
+  endif
+else ifeq ($(CONFIG_ARCH_CORTEXR5),y)
+  ARCHCPUFLAGS += -mcpu=cortex-r5
+else ifeq ($(CONFIG_ARCH_CORTEXR7),y)
+  ARCHCPUFLAGS += -mcpu=cortex-r7
+endif
+
 ifeq ($(CONFIG_ENDIAN_BIG),y)
   TARGET_ARCH := armeb
 else

--- a/boards/arm/a1x/pcduino-a10/scripts/Make.defs
+++ b/boards/arm/a1x/pcduino-a10/scripts/Make.defs
@@ -34,7 +34,6 @@ ifneq ($(CONFIG_DEBUG_NOOPT),y)
   ARCHOPTIMIZATION += $(MAXOPTIMIZATION) -fno-strict-aliasing
 endif
 
-ARCHCPUFLAGS = -mcpu=cortex-a8 -mfpu=vfpv4-d16
 ARCHCFLAGS = -fno-common -fno-builtin
 ARCHCXXFLAGS = -fno-common -fno-builtin -fno-exceptions -fcheck-new -fno-rtti
 ARCHWARNINGS = -Wall -Wstrict-prototypes -Wshadow -Wundef

--- a/boards/arm/am335x/beaglebone-black/scripts/Make.defs
+++ b/boards/arm/am335x/beaglebone-black/scripts/Make.defs
@@ -28,29 +28,12 @@ LDSCRIPT = sdram.ld
 
 ARCHSCRIPT += $(BOARD_DIR)$(DELIM)scripts$(DELIM)$(LDSCRIPT)
 
-ARCHCCVERSION = ${shell $(CC) -v 2>&1 | sed -n '/^gcc version/p' | sed -e 's/^gcc version \([0-9\.]\)/\1/g' -e 's/[-\ ].*//g' -e '1q'}
-ARCHCCMAJOR = ${shell echo $(ARCHCCVERSION) | cut -d'.' -f1}
-
-ifeq ($(ARCHCCMAJOR),2)
-  OLDGCC = y
-else ifeq ($(ARCHCCMAJOR),3)
-  OLDGCC = y
-else
-  OLDGCC = n
-endif
-
 ifeq ($(CONFIG_DEBUG_SYMBOLS),y)
   ARCHOPTIMIZATION = -g
 endif
 
 ifneq ($(CONFIG_DEBUG_NOOPT),y)
   ARCHOPTIMIZATION += $(MAXOPTIMIZATION) -fno-strict-aliasing
-endif
-
-ifeq ($(OLDGCC),n)
-  ARCHCPUFLAGS = -mcpu=cortex-a8 -mfpu=neon -mfloat-abi=softfp -ftree-vectorize
-else
-  ARCHCPUFLAGS = -mapcs-32 -march=arm7-a -msoft-float
 endif
 
 ARCHCFLAGS = -fno-common -fno-builtin

--- a/boards/arm/imx6/sabre-6quad/scripts/Make.defs
+++ b/boards/arm/imx6/sabre-6quad/scripts/Make.defs
@@ -34,7 +34,6 @@ ifneq ($(CONFIG_DEBUG_NOOPT),y)
   ARCHOPTIMIZATION += $(MAXOPTIMIZATION) -fno-strict-aliasing
 endif
 
-ARCHCPUFLAGS = -mcpu=cortex-a9 -mfpu=vfpv4-d16 -mthumb
 ARCHCFLAGS = -fno-common -fno-builtin -ffunction-sections -fdata-sections
 ARCHCXXFLAGS = -fno-common -fno-builtin -fno-exceptions -fcheck-new -fno-rtti
 ARCHWARNINGS = -Wall -Wstrict-prototypes -Wshadow -Wundef

--- a/boards/arm/lpc43xx/bambino-200e/README.txt
+++ b/boards/arm/lpc43xx/bambino-200e/README.txt
@@ -111,18 +111,6 @@ ports.
      CONFIG_ARCH_FPU=y
      CONFIG_ARMV7M_LAZYFPU=y
 
-CFLAGS
-------
-
-Only the recent toolchains have built-in support for the Cortex-M4 FPU.  You will see
-the following lines in each Make.defs file:
-
-  ifeq ($(CONFIG_ARCH_FPU),y)
-    ARCHCPUFLAGS = -mcpu=cortex-m4 -mthumb -march=armv7e-m -mfpu=fpv4-sp-d16 -mfloat-abi=hard
-  else
-    ARCHCPUFLAGS = -mcpu=cortex-m3 -mthumb -mfloat-abi=soft
-  endif
-
 Bambino-200e Configuration Options
 ==================================
 

--- a/boards/arm/lpc43xx/lpc4330-xplorer/README.txt
+++ b/boards/arm/lpc43xx/lpc4330-xplorer/README.txt
@@ -363,18 +363,6 @@ ports.
      CONFIG_ARCH_FPU=y
      CONFIG_ARMV7M_LAZYFPU=y
 
-CFLAGS
-------
-
-Only the recent toolchains have built-in support for the Cortex-M4 FPU.  You will see
-the following lines in each Make.defs file:
-
-  ifeq ($(CONFIG_ARCH_FPU),y)
-    ARCHCPUFLAGS = -mcpu=cortex-m4 -mthumb -march=armv7e-m -mfpu=fpv4-sp-d16 -mfloat-abi=hard
-  else
-    ARCHCPUFLAGS = -mcpu=cortex-m3 -mthumb -mfloat-abi=soft
-  endif
-
 LPC4330-Xplorer Configuration Options
 =====================================
 

--- a/boards/arm/lpc43xx/lpc4337-ws/README.txt
+++ b/boards/arm/lpc43xx/lpc4337-ws/README.txt
@@ -402,18 +402,6 @@ ports.
      CONFIG_ARCH_FPU=y
      CONFIG_ARMV7M_LAZYFPU=y
 
-CFLAGS
-------
-
-Only the recent toolchains have built-in support for the Cortex-M4 FPU.  You will see
-the following lines in each Make.defs file:
-
-  ifeq ($(CONFIG_ARCH_FPU),y)
-    ARCHCPUFLAGS = -mcpu=cortex-m4 -mthumb -march=armv7e-m -mfpu=fpv4-sp-d16 -mfloat-abi=hard
-  else
-    ARCHCPUFLAGS = -mcpu=cortex-m3 -mthumb -mfloat-abi=soft
-  endif
-
 LPC4337-ws Configuration Options
 =====================================
 

--- a/boards/arm/lpc43xx/lpc4357-evb/README.txt
+++ b/boards/arm/lpc43xx/lpc4357-evb/README.txt
@@ -399,18 +399,6 @@ ports.
      CONFIG_ARCH_FPU=y
      CONFIG_ARMV7M_LAZYFPU=y
 
-CFLAGS
-------
-
-Only the recent toolchains have built-in support for the Cortex-M4 FPU.  You will see
-the following lines in each Make.defs file:
-
-  ifeq ($(CONFIG_ARCH_FPU),y)
-    ARCHCPUFLAGS = -mcpu=cortex-m4 -mthumb -march=armv7e-m -mfpu=fpv4-sp-d16 -mfloat-abi=hard
-  else
-    ARCHCPUFLAGS = -mcpu=cortex-m3 -mthumb -mfloat-abi=soft
-  endif
-
 LPC4357-EVB Configuration Options
 =====================================
 

--- a/boards/arm/lpc43xx/lpc4370-link2/README.txt
+++ b/boards/arm/lpc43xx/lpc4370-link2/README.txt
@@ -402,18 +402,6 @@ ports.
      CONFIG_ARCH_FPU=y
      CONFIG_ARMV7M_LAZYFPU=y
 
-CFLAGS
-------
-
-Only the recent toolchains have built-in support for the Cortex-M4 FPU.  You will see
-the following lines in each Make.defs file:
-
-  ifeq ($(CONFIG_ARCH_FPU),y)
-    ARCHCPUFLAGS = -mcpu=cortex-m4 -mthumb -march=armv7e-m -mfpu=fpv4-sp-d16 -mfloat-abi=hard
-  else
-    ARCHCPUFLAGS = -mcpu=cortex-m3 -mthumb -mfloat-abi=soft
-  endif
-
 LPC4370-Link2 Configuration Options
 =====================================
 

--- a/boards/arm/sama5/giant-board/scripts/Make.defs
+++ b/boards/arm/sama5/giant-board/scripts/Make.defs
@@ -44,7 +44,6 @@ ifneq ($(CONFIG_DEBUG_NOOPT),y)
   ARCHOPTIMIZATION += $(MAXOPTIMIZATION) -fno-strict-aliasing
 endif
 
-ARCHCPUFLAGS = -mcpu=cortex-a5 -mfpu=vfpv4-d16
 ARCHCFLAGS = -fno-common -fno-builtin
 ARCHCXXFLAGS = -fno-common -fno-builtin -fno-exceptions -fcheck-new -fno-rtti
 ARCHWARNINGS = -Wall -Wstrict-prototypes -Wshadow -Wundef

--- a/boards/arm/sama5/sama5d2-xult/scripts/Make.defs
+++ b/boards/arm/sama5/sama5d2-xult/scripts/Make.defs
@@ -44,7 +44,6 @@ ifneq ($(CONFIG_DEBUG_NOOPT),y)
   ARCHOPTIMIZATION += $(MAXOPTIMIZATION) -fno-strict-aliasing
 endif
 
-ARCHCPUFLAGS = -mcpu=cortex-a5 -mfpu=vfpv4-d16
 ARCHCFLAGS = -fno-common -fno-builtin
 ARCHCXXFLAGS = -fno-common -fno-builtin -fno-exceptions -fcheck-new -fno-rtti
 ARCHWARNINGS = -Wall -Wstrict-prototypes -Wshadow -Wundef

--- a/boards/arm/sama5/sama5d3-xplained/scripts/Make.defs
+++ b/boards/arm/sama5/sama5d3-xplained/scripts/Make.defs
@@ -40,7 +40,6 @@ ifneq ($(CONFIG_DEBUG_NOOPT),y)
   ARCHOPTIMIZATION += $(MAXOPTIMIZATION) -fno-strict-aliasing
 endif
 
-ARCHCPUFLAGS = -mcpu=cortex-a5 -mfpu=vfpv4-d16
 ARCHCFLAGS = -fno-common -fno-builtin
 ARCHCXXFLAGS = -fno-common -fno-builtin -fno-exceptions -fcheck-new -fno-rtti
 ARCHWARNINGS = -Wall -Wstrict-prototypes -Wshadow -Wundef

--- a/boards/arm/sama5/sama5d3x-ek/scripts/Make.defs
+++ b/boards/arm/sama5/sama5d3x-ek/scripts/Make.defs
@@ -60,7 +60,6 @@ ifneq ($(CONFIG_DEBUG_NOOPT),y)
   ARCHOPTIMIZATION += $(MAXOPTIMIZATION) -fno-strict-aliasing
 endif
 
-ARCHCPUFLAGS = -mcpu=cortex-a5 -mfpu=vfpv4-d16
 ARCHCFLAGS = -fno-common -fno-builtin
 ARCHCXXFLAGS = -fno-common -fno-builtin -fno-exceptions -fcheck-new -fno-rtti
 ARCHWARNINGS = -Wall -Wstrict-prototypes -Wshadow -Wundef

--- a/boards/arm/sama5/sama5d4-ek/configs/knsh/Make.defs
+++ b/boards/arm/sama5/sama5d4-ek/configs/knsh/Make.defs
@@ -44,7 +44,6 @@ ifneq ($(CONFIG_DEBUG_NOOPT),y)
   ARCHOPTIMIZATION += $(MAXOPTIMIZATION) -fno-strict-aliasing
 endif
 
-ARCHCPUFLAGS = -mcpu=cortex-a5 -mfpu=vfpv4-d16
 ARCHCFLAGS = -fno-common -fno-builtin
 ARCHCXXFLAGS = -fno-common -fno-builtin -fno-exceptions -fcheck-new -fno-rtti
 ARCHWARNINGS = -Wall -Wstrict-prototypes -Wshadow -Wundef

--- a/boards/arm/sama5/sama5d4-ek/scripts/Make.defs
+++ b/boards/arm/sama5/sama5d4-ek/scripts/Make.defs
@@ -44,7 +44,6 @@ ifneq ($(CONFIG_DEBUG_NOOPT),y)
   ARCHOPTIMIZATION += $(MAXOPTIMIZATION) -fno-strict-aliasing
 endif
 
-ARCHCPUFLAGS = -mcpu=cortex-a5 -mfpu=vfpv4-d16
 ARCHCFLAGS = -fno-common -fno-builtin
 ARCHCXXFLAGS = -fno-common -fno-builtin -fno-exceptions -fcheck-new -fno-rtti
 ARCHWARNINGS = -Wall -Wstrict-prototypes -Wshadow -Wundef

--- a/boards/arm/stm32/mikroe-stm32f4/README.txt
+++ b/boards/arm/stm32/mikroe-stm32f4/README.txt
@@ -168,18 +168,6 @@ all of these configurations is the MIO283QT-2.  But MIO283QT-9A is also
 supported and you can switch from the MIO283QT-2 to the MIO283QT-9A by simply
 modifying the NuttX configuration
 
-CFLAGS
-------
-
-Only recent GCC toolchains have built-in support for the Cortex-M4 FPU.  You will see
-the following lines in each Make.defs file:
-
-  ifeq ($(CONFIG_ARCH_FPU),y)
-    ARCHCPUFLAGS = -mcpu=cortex-m4 -mthumb -march=armv7e-m -mfpu=fpv4-sp-d16 -mfloat-abi=hard
-  else
-    ARCHCPUFLAGS = -mcpu=cortex-m3 -mthumb -mfloat-abi=soft
-  endif
-
 Mikroe-STM32F4-specific Configuration Options
 ===============================================
 

--- a/boards/arm/stm32/stm3240g-eval/README.txt
+++ b/boards/arm/stm32/stm3240g-eval/README.txt
@@ -178,18 +178,6 @@ There are two version of the FPU support built into the STM32 port.
      CONFIG_ARCH_FPU=y
      CONFIG_ARMV7M_LAZYFPU=y
 
-CFLAGS
-------
-
-Only recent GCC toolchains have built-in support for the Cortex-M4 FPU.  You will see
-the following lines in each Make.defs file:
-
-  ifeq ($(CONFIG_ARCH_FPU),y)
-    ARCHCPUFLAGS = -mcpu=cortex-m4 -mthumb -march=armv7e-m -mfpu=fpv4-sp-d16 -mfloat-abi=hard
-  else
-    ARCHCPUFLAGS = -mcpu=cortex-m3 -mthumb -mfloat-abi=soft
-  endif
-
 FSMC SRAM
 =========
 

--- a/boards/arm/stm32/stm32f3discovery/README.txt
+++ b/boards/arm/stm32/stm32f3discovery/README.txt
@@ -112,18 +112,6 @@ There are two version of the FPU support built into the STM32 port.
      CONFIG_ARCH_FPU=y
      CONFIG_ARMV7M_LAZYFPU=y
 
-CFLAGS
-------
-
-Only recent GCC toolchains have built-in support for the Cortex-M4 FPU.  You will see
-the following lines in each Make.defs file:
-
-  ifeq ($(CONFIG_ARCH_FPU),y)
-    ARCHCPUFLAGS = -mcpu=cortex-m4 -mthumb -march=armv7e-m -mfpu=fpv4-sp-d16 -mfloat-abi=hard
-  else
-    ARCHCPUFLAGS = -mcpu=cortex-m3 -mthumb -mfloat-abi=soft
-  endif
-
 Debugging
 =========
 

--- a/boards/arm/stm32/stm32f429i-disco/README.txt
+++ b/boards/arm/stm32/stm32f429i-disco/README.txt
@@ -283,18 +283,6 @@ There are two version of the FPU support built into the STM32 port.
      CONFIG_ARCH_FPU=y
      CONFIG_ARMV7M_LAZYFPU=y
 
-CFLAGS
-------
-
-Only recent GCC toolchains have built-in support for the Cortex-M4 FPU.  You will see
-the following lines in each Make.defs file:
-
-  ifeq ($(CONFIG_ARCH_FPU),y)
-    ARCHCPUFLAGS = -mcpu=cortex-m4 -mthumb -march=armv7e-m -mfpu=fpv4-sp-d16 -mfloat-abi=hard
-  else
-    ARCHCPUFLAGS = -mcpu=cortex-m3 -mthumb -mfloat-abi=soft
-  endif
-
 FMC SDRAM
 =========
 

--- a/boards/arm/stm32/stm32f4discovery/README.txt
+++ b/boards/arm/stm32/stm32f4discovery/README.txt
@@ -336,18 +336,6 @@ There are two version of the FPU support built into the STM32 port.
      CONFIG_ARCH_FPU=y
      CONFIG_ARMV7M_LAZYFPU=y
 
-CFLAGS
-------
-
-Only recent GCC toolchains have built-in support for the Cortex-M4 FPU.  You will see
-the following lines in each Make.defs file:
-
-  ifeq ($(CONFIG_ARCH_FPU),y)
-    ARCHCPUFLAGS = -mcpu=cortex-m4 -mthumb -march=armv7e-m -mfpu=fpv4-sp-d16 -mfloat-abi=hard
-  else
-    ARCHCPUFLAGS = -mcpu=cortex-m3 -mthumb -mfloat-abi=soft
-  endif
-
 STM32F4DIS-BB
 =============
 

--- a/boards/arm/tms570/tms570ls31x-usb-kit/scripts/Make.defs
+++ b/boards/arm/tms570/tms570ls31x-usb-kit/scripts/Make.defs
@@ -34,7 +34,6 @@ ifneq ($(CONFIG_DEBUG_NOOPT),y)
   ARCHOPTIMIZATION += $(MAXOPTIMIZATION) -fno-strict-aliasing
 endif
 
-ARCHCPUFLAGS = -mcpu=cortex-r4f -march=armv7-r -mbig-endian -mfpu=vfpv3-d16 -mfloat-abi=hard
 ARCHCFLAGS = -fno-common -fno-builtin
 ARCHCXXFLAGS = -fno-common -fno-builtin -fno-exceptions -fcheck-new -fno-rtti
 ARCHWARNINGS = -Wall -Wstrict-prototypes -Wshadow -Wundef


### PR DESCRIPTION
## Summary
Move ARCHCPUFLAGS to Toolchain.defs since they are common setting for all cortex-a based socs.
## Impact
Cortex A based socs.
## Testing
sabre-6quad:ostest
