### PR TITLE
boards/sparc: Remove HOSTCC related flags from Make.defs

### DIFF
--- a/boards/sparc/bm3803/xx3803/scripts/Make.defs
+++ b/boards/sparc/bm3803/xx3803/scripts/Make.defs
@@ -86,11 +86,3 @@ endif
 ifeq ($(CONFIG_DEBUG_SYMBOLS),y)
   LDFLAGS += -g
 endif
-
-# Host tools
-
-HOSTCC = gcc
-HOSTINCLUDES = -I.
-HOSTCFLAGS = -Wall -Wstrict-prototypes -Wshadow -Wundef -g -pipe
-HOSTLDFLAGS =
-

--- a/boards/sparc/bm3823/xx3823/scripts/Make.defs
+++ b/boards/sparc/bm3823/xx3823/scripts/Make.defs
@@ -64,9 +64,3 @@ ASMEXT = .S
 OBJEXT = .o
 LIBEXT = .a
 EXEEXT = .elf
-
-HOSTCC = gcc
-HOSTINCLUDES = -I.
-HOSTCFLAGS = -Wall -Wstrict-prototypes -Wshadow -Wundef -g -pipe
-HOSTLDFLAGS =
-


### PR DESCRIPTION
## Summary
since these variables are defined in Config.mk now

## Impact
Code refactor only

## Testing
Pass CI
