### PR TITLE
Revert "sched: Don't duplicate caller file handler when creating kernel thread"

### DIFF
--- a/fs/inode/fs_files.c
+++ b/fs/inode/fs_files.c
@@ -250,8 +250,7 @@ int files_allocate(FAR struct inode *inode, int oflags, off_t pos,
  *
  ****************************************************************************/
 
-int files_duplist(FAR struct filelist *plist,
-                  FAR struct filelist *clist, bool stdio_only)
+int files_duplist(FAR struct filelist *plist, FAR struct filelist *clist)
 {
   int ret;
   int i;
@@ -265,28 +264,25 @@ int files_duplist(FAR struct filelist *plist,
       return ret;
     }
 
-#ifdef CONFIG_FDCLONE_STDIO
-
-  /* Determine how many file descriptors to clone.  If
-   * CONFIG_FDCLONE_DISABLE is set, no file descriptors will be
-   * cloned.  If CONFIG_FDCLONE_STDIO is set, only the first
-   * three descriptors (stdin, stdout, and stderr) will be
-   * cloned.  Otherwise all file descriptors will be cloned.
-   */
-
-  stdio_only = true;
-#endif
-
   for (i = 0; i < plist->fl_rows; i++)
     {
       for (j = 0; j < CONFIG_NFILE_DESCRIPTORS_PER_BLOCK; j++)
         {
           FAR struct file *filep;
+#ifdef CONFIG_FDCLONE_STDIO
 
-          if (stdio_only && i * CONFIG_NFILE_DESCRIPTORS_PER_BLOCK + j >= 3)
+          /* Determine how many file descriptors to clone.  If
+           * CONFIG_FDCLONE_DISABLE is set, no file descriptors will be
+           * cloned.  If CONFIG_FDCLONE_STDIO is set, only the first
+           * three descriptors (stdin, stdout, and stderr) will be
+           * cloned.  Otherwise all file descriptors will be cloned.
+           */
+
+          if (i * CONFIG_NFILE_DESCRIPTORS_PER_BLOCK + j >= 3)
             {
               goto out;
             }
+#endif
 
           filep = &plist->fl_files[i][j];
           if (filep->f_inode == NULL || (filep->f_oflags & O_CLOEXEC) != 0)

--- a/include/nuttx/fs/fs.h
+++ b/include/nuttx/fs/fs.h
@@ -759,8 +759,7 @@ void files_releaselist(FAR struct filelist *list);
  *
  ****************************************************************************/
 
-int files_duplist(FAR struct filelist *plist,
-                  FAR struct filelist *clist, bool stdio_only);
+int files_duplist(FAR struct filelist *plist, FAR struct filelist *clist);
 
 /****************************************************************************
  * Name: file_dup

--- a/sched/group/group_setuptaskfiles.c
+++ b/sched/group/group_setuptaskfiles.c
@@ -57,14 +57,16 @@
 int group_setuptaskfiles(FAR struct task_tcb_s *tcb)
 {
   FAR struct task_group_s *group = tcb->cmn.group;
-  uint8_t ttype = tcb->cmn.flags & TCB_FLAG_TTYPE_MASK;
 #ifndef CONFIG_FDCLONE_DISABLE
   FAR struct tcb_s *rtcb = this_task();
   int ret;
 #endif
 
   DEBUGASSERT(group);
-  DEBUGASSERT(ttype != TCB_FLAG_TTYPE_PTHREAD);
+#ifndef CONFIG_DISABLE_PTHREAD
+  DEBUGASSERT((tcb->cmn.flags & TCB_FLAG_TTYPE_MASK) !=
+              TCB_FLAG_TTYPE_PTHREAD);
+#endif
 
   /* Initialize file descriptors for the TCB */
 
@@ -73,15 +75,9 @@ int group_setuptaskfiles(FAR struct task_tcb_s *tcb)
 #ifndef CONFIG_FDCLONE_DISABLE
   DEBUGASSERT(rtcb->group);
 
-  /* Duplicate the parent task's file descriptors.
-   * If it's a kernel thread, only the first three
-   * descriptors (stdin, stdout, and stderr) will
-   * be cloned.
-   */
+  /* Duplicate the parent task's file descriptors */
 
-  ret = files_duplist(&rtcb->group->tg_filelist,
-                      &group->tg_filelist,
-                      ttype == TCB_FLAG_TTYPE_KERNEL);
+  ret = files_duplist(&rtcb->group->tg_filelist, &group->tg_filelist);
   if (ret < 0)
     {
       return ret;


### PR DESCRIPTION
## Summary
since the temporary kernel spawn proxy need duplicate file handler
from caller, please reference the follow source code for more info:
sched/task/task_posixspawn.c
sched/task/task_spawn.c
and the original patch: https://github.com/apache/incubator-nuttx/pull/5391
This reverts commit 5c5f1dec08390cbb92484a2efbd2cbe5b75b3188.

## Impact
Keep the old behavior until we remove the proxy thread

## Testing
sim:ostest
