### PR TITLE
fs/romfs: fix read file mismatch when the length of file name is 16

### DIFF
--- a/fs/romfs/fs_romfsutil.c
+++ b/fs/romfs/fs_romfsutil.c
@@ -1173,7 +1173,7 @@ int romfs_datastart(FAR struct romfs_mountpt_s *rm,
 {
 #ifdef CONFIG_FS_ROMFS_CACHE_NODE
   *start = ROMFS_ALIGNUP(nodeinfo->rn_offset +
-                         ROMFS_FHDR_NAME + nodeinfo->rn_namesize);
+                         ROMFS_FHDR_NAME + nodeinfo->rn_namesize + 1);
   return OK;
 #else
   uint32_t offset = nodeinfo->rn_offset;


### PR DESCRIPTION


## Summary
fs/romfs: fix read file mismatch when the length of file name is 16

romfs rules: file name must end with '\0'

Signed-off-by: Jiuzhu Dong <dongjiuzhu1@xiaomi.com>
## Impact
Access  correctly file with the len of name is 16
## Testing
daily test
