### PR TITLE
drivers/ioexpander: Fix invert option value usage

### DIFF
--- a/drivers/ioexpander/ioe_dummy.c
+++ b/drivers/ioexpander/ioe_dummy.c
@@ -244,8 +244,8 @@ static int ioe_dummy_direction(FAR struct ioexpander_dev_s *dev,
  *
  ****************************************************************************/
 
-static int ioe_dummy_option(FAR struct ioexpander_dev_s *dev,
-                            uint8_t pin, int opt, FAR void *value)
+static int ioe_dummy_option(FAR struct ioexpander_dev_s *dev, uint8_t pin,
+                            int opt, FAR void *value)
 {
   FAR struct ioe_dummy_dev_s *priv = (FAR struct ioe_dummy_dev_s *)dev;
   int ret = -ENOSYS;
@@ -264,7 +264,7 @@ static int ioe_dummy_option(FAR struct ioexpander_dev_s *dev,
 
   if (opt == IOEXPANDER_OPTION_INVERT)
     {
-      if ((uintptr_t)value == IOEXPANDER_OPTION_INVERT)
+      if ((uintptr_t)value == IOEXPANDER_VAL_INVERT)
         {
           priv->invert |= (1 << pin);
         }

--- a/drivers/ioexpander/mcp23x17.c
+++ b/drivers/ioexpander/mcp23x17.c
@@ -204,7 +204,7 @@ static inline int mcp23x17_writeread(FAR struct mcp23x17_dev_s *priv,
  ****************************************************************************/
 
 static int mcp23x17_setbit(FAR struct mcp23x17_dev_s *priv, uint8_t addr,
-                           uint8_t pin, int bitval)
+                           uint8_t pin, bool bitval)
 {
   uint8_t buf[2];
   int ret;
@@ -366,15 +366,13 @@ static int mcp23x17_direction(FAR struct ioexpander_dev_s *dev, uint8_t pin,
  ****************************************************************************/
 
 static int mcp23x17_option(FAR struct ioexpander_dev_s *dev, uint8_t pin,
-                           int opt, FAR void *val)
+                           int opt, FAR void *value)
 {
   FAR struct mcp23x17_dev_s *priv = (FAR struct mcp23x17_dev_s *)dev;
   int ret = -EINVAL;
 
   if (opt == IOEXPANDER_OPTION_INVERT)
     {
-      int ival = (int)((intptr_t)val);
-
       /* Get exclusive access to the MCP23X17 */
 
       ret = mcp23x17_lock(priv);
@@ -383,7 +381,8 @@ static int mcp23x17_option(FAR struct ioexpander_dev_s *dev, uint8_t pin,
           return ret;
         }
 
-      ret = mcp23x17_setbit(priv, MCP23X17_IPOLA, pin, ival);
+      ret = mcp23x17_setbit(priv, MCP23X17_IPOLA, pin,
+                            ((uintptr_t)value == IOEXPANDER_VAL_INVERT));
       mcp23x17_unlock(priv);
     }
 

--- a/drivers/ioexpander/pca9538.c
+++ b/drivers/ioexpander/pca9538.c
@@ -197,7 +197,7 @@ static inline int pca9538_writeread(FAR struct pca9538_dev_s *pca,
  ****************************************************************************/
 
 static int pca9538_setbit(FAR struct pca9538_dev_s *pca, uint8_t addr,
-                          uint8_t pin, int bitval)
+                          uint8_t pin, bool bitval)
 {
   uint8_t buf[2];
   int ret;
@@ -349,15 +349,13 @@ static int pca9538_direction(FAR struct ioexpander_dev_s *dev, uint8_t pin,
  ****************************************************************************/
 
 static int pca9538_option(FAR struct ioexpander_dev_s *dev, uint8_t pin,
-                          int opt, FAR void *val)
+                          int opt, FAR void *value)
 {
   FAR struct pca9538_dev_s *pca = (FAR struct pca9538_dev_s *)dev;
   int ret = -EINVAL;
 
   if (opt == IOEXPANDER_OPTION_INVERT)
     {
-      int ival = (int)((intptr_t)val);
-
       /* Get exclusive access to the PCA555 */
 
       ret = pca9538_lock(pca);
@@ -366,7 +364,8 @@ static int pca9538_option(FAR struct ioexpander_dev_s *dev, uint8_t pin,
           return ret;
         }
 
-      ret = pca9538_setbit(pca, PCA9538_REG_POLINV, pin, ival);
+      ret = pca9538_setbit(pca, PCA9538_REG_POLINV, pin,
+                           ((uintptr_t)value == IOEXPANDER_VAL_INVERT));
       pca9538_unlock(pca);
     }
 

--- a/drivers/ioexpander/pca9555.c
+++ b/drivers/ioexpander/pca9555.c
@@ -201,7 +201,7 @@ static inline int pca9555_writeread(FAR struct pca9555_dev_s *pca,
  ****************************************************************************/
 
 static int pca9555_setbit(FAR struct pca9555_dev_s *pca, uint8_t addr,
-                          uint8_t pin, int bitval)
+                          uint8_t pin, bool bitval)
 {
   uint8_t buf[2];
   int ret;
@@ -363,15 +363,13 @@ static int pca9555_direction(FAR struct ioexpander_dev_s *dev, uint8_t pin,
  ****************************************************************************/
 
 static int pca9555_option(FAR struct ioexpander_dev_s *dev, uint8_t pin,
-                          int opt, FAR void *val)
+                          int opt, FAR void *value)
 {
   FAR struct pca9555_dev_s *pca = (FAR struct pca9555_dev_s *)dev;
   int ret = -EINVAL;
 
   if (opt == IOEXPANDER_OPTION_INVERT)
     {
-      int ival = (int)((intptr_t)val);
-
       /* Get exclusive access to the PCA555 */
 
       ret = pca9555_lock(pca);
@@ -380,7 +378,8 @@ static int pca9555_option(FAR struct ioexpander_dev_s *dev, uint8_t pin,
           return ret;
         }
 
-      ret = pca9555_setbit(pca, PCA9555_REG_POLINV, pin, ival);
+      ret = pca9555_setbit(pca, PCA9555_REG_POLINV, pin,
+                           ((uintptr_t)value == IOEXPANDER_VAL_INVERT));
       pca9555_unlock(pca);
     }
 

--- a/drivers/ioexpander/skeleton.c
+++ b/drivers/ioexpander/skeleton.c
@@ -228,7 +228,7 @@ static int skel_direction(FAR struct ioexpander_dev_s *dev, uint8_t pin,
  ****************************************************************************/
 
 static int skel_option(FAR struct ioexpander_dev_s *dev, uint8_t pin,
-                       int opt, FAR void *val)
+                       int opt, FAR void *value)
 {
   FAR struct skel_dev_s *priv = (FAR struct skel_dev_s *)dev;
   int ret = -ENOSYS;

--- a/drivers/ioexpander/tca64xx.c
+++ b/drivers/ioexpander/tca64xx.c
@@ -511,7 +511,6 @@ static int tca64_option(FAR struct ioexpander_dev_s *dev, uint8_t pin,
 
   if (opt == IOEXPANDER_OPTION_INVERT)
     {
-      unsigned int ival = (unsigned int)((uintptr_t)value);
       uint8_t regaddr;
       uint8_t polarity;
 
@@ -537,7 +536,7 @@ static int tca64_option(FAR struct ioexpander_dev_s *dev, uint8_t pin,
 
       /* Set/clear the pin option */
 
-      if (ival == IOEXPANDER_OPTION_INVERT)
+      if ((uintptr_t)value == IOEXPANDER_VAL_INVERT)
         {
           polarity |= (1 << (pin & 7));
         }


### PR DESCRIPTION
## Summary
Wrong macro used for checking invert option value

## Impact
None

## Testing
Pass CI
