### PR TITLE
ci: Update gcc-arm-none-eabi to 10.3-2021.10

### DIFF
--- a/tools/ci/cibuild.sh
+++ b/tools/ci/cibuild.sh
@@ -164,10 +164,10 @@ function arm-gcc-toolchain {
         ;;
     esac
     cd "${prebuilt}"
-    wget --quiet https://developer.arm.com/-/media/Files/downloads/gnu-rm/9-2019q4/RC2.1/gcc-arm-none-eabi-9-2019-q4-major-${flavor}.tar.bz2
-    tar jxf gcc-arm-none-eabi-9-2019-q4-major-${flavor}.tar.bz2
-    mv gcc-arm-none-eabi-9-2019-q4-major gcc-arm-none-eabi
-    rm gcc-arm-none-eabi-9-2019-q4-major-${flavor}.tar.bz2
+    wget --quiet https://developer.arm.com/-/media/Files/downloads/gnu-rm/10.3-2021.10/gcc-arm-none-eabi-10.3-2021.10-${flavor}.tar.bz2
+    tar jxf gcc-arm-none-eabi-10.3-2021.10-${flavor}.tar.bz2
+    mv gcc-arm-none-eabi-10.3-2021.10 gcc-arm-none-eabi
+    rm gcc-arm-none-eabi-10.3-2021.10-${flavor}.tar.bz2
   fi
   arm-none-eabi-gcc --version
 }

--- a/tools/ci/docker/linux/Dockerfile
+++ b/tools/ci/docker/linux/Dockerfile
@@ -84,7 +84,7 @@ WORKDIR /tools
 FROM nuttx-toolchain-base AS nuttx-toolchain-arm
 # Download the latest ARM GCC toolchain prebuilt by ARM
 RUN mkdir gcc-arm-none-eabi && \
-  curl -s -L  "https://developer.arm.com/-/media/Files/downloads/gnu-rm/9-2019q4/gcc-arm-none-eabi-9-2019-q4-major-x86_64-linux.tar.bz2?revision=108bd959-44bd-4619-9c19-26187abf5225&la=en&hash=E788CE92E5DFD64B2A8C246BBA91A249CB8E2D2D" \
+  curl -s -L  "https://developer.arm.com/-/media/Files/downloads/gnu-rm/10.3-2021.10/gcc-arm-none-eabi-10.3-2021.10-x86_64-linux.tar.bz2" \
   | tar -C gcc-arm-none-eabi --strip-components 1 -xj
 
 ###############################################################################


### PR DESCRIPTION
## Summary
Fix #5637 
There is a bug in arm-none-eabi-gcc 9.2 for cortex a that it don't report libgcc.a correctly for FPU enabled case:
```
gcc-arm-none-eabi-9-2019-q4-major/bin/arm-none-eabi-gcc  -mcpu=cortex-a8 -mfpu=vfpv3-d16 --print-libgcc-file-name
/home/huang/Work/gcc-arm-none-eabi-9-2019-q4-major/bin/../lib/gcc/arm-none-eabi/9.2.1/libgcc.a
```
and
```
 gcc-arm-none-eabi-9-2019-q4-major/bin/arm-none-eabi-gcc  -mcpu=cortex-a8 -mfloat-abi=hard -mfpu=vfpv3-d16 --print-libgcc-file-name
/home/huang/Work/gcc-arm-none-eabi-9-2019-q4-major/bin/../lib/gcc/arm-none-eabi/9.2.1/libgcc.a
```
And in 10.3:
```
arm-none-eabi-gcc --version
arm-none-eabi-gcc (15:10.3-2021.07-4) 10.3.1 20210621 (release)

➜  Work arm-none-eabi-gcc  -mcpu=cortex-a8 -mfpu=vfpv3-d16 --print-libgcc-file-name
/usr/lib/gcc/arm-none-eabi/10.3.1/thumb/v7-a/nofp/libgcc.a

➜  Work arm-none-eabi-gcc  -mcpu=cortex-a8 -mfloat-abi=hard -mfpu=vfpv3-d16 --print-libgcc-file-name
/usr/lib/gcc/arm-none-eabi/10.3.1/thumb/v7-a+fp/hard/libgcc.a
```
## Impact
N/A
## Testing
CI