### PR TITLE
syscal: Remove .context form .gitignore

### DIFF
--- a/syscall/.gitignore
+++ b/syscall/.gitignore
@@ -1,2 +1,1 @@
-/.context
 /*.ldcmd


### PR DESCRIPTION
## Summary
since it is already added in the top level of .gitignore in https://github.com/apache/incubator-nuttx/pull/5055

## Impact
Minor

## Testing
Pass CI
