### PR TITLE
Include nuttx/compiler.h from string.h

### DIFF
--- a/include/string.h
+++ b/include/string.h
@@ -26,6 +26,7 @@
  ****************************************************************************/
 
 #include <nuttx/config.h>
+#include <nuttx/compiler.h>
 
 #include <stddef.h>
 


### PR DESCRIPTION
NuttX' string.h is using the FAR preprocessor definition, which is
defined in nuttx/compiler.h.  Thus, it should include it.

Signed-off-by: Michael Jung <mijung@gmx.net>
