### PR TITLE
boards: Remove -nostartfiles -nodefaultlibs from phy62xx

### DIFF
--- a/boards/arm/phy62xx/phy6222/scripts/Make.defs
+++ b/boards/arm/phy62xx/phy6222/scripts/Make.defs
@@ -53,9 +53,6 @@ NXFLATLDFLAGS1 = -r -Wl,-d -Wl,-warn-common
 NXFLATLDFLAGS2 = $(NXFLATLDFLAGS1) -T$(TOPDIR)/binfmt/libnxflat/gnu-nxflat-pcrel.ld -Wl,-no-check-sections
 LDNXFLATFLAGS = -e main -s 2048
 
-ifneq ($(CROSSDEV),arm-nuttx-elf-)
-  LDFLAGS += -nostartfiles -nodefaultlibs
-endif
 ifeq ($(CONFIG_DEBUG_SYMBOLS),y)
   LDFLAGS += -g
 endif


### PR DESCRIPTION
## Summary
-nostartfiles -nodefaultlibs can't be recognized by gcc 10.3, and already removed from other socs.
## Impact
phy62xx
## Testing
CI
