### PR TITLE
imxrt: fix userled config in appinit

### DIFF
--- a/boards/arm/imxrt/imxrt1060-evk/src/imxrt_appinit.c
+++ b/boards/arm/imxrt/imxrt1060-evk/src/imxrt_appinit.c
@@ -27,12 +27,9 @@
 #include <sys/types.h>
 
 #include <nuttx/board.h>
+#include <nuttx/leds/userled.h>
 
 #include "imxrt1060-evk.h"
-
-#if !defined(CONFIG_ARCH_LEDS) && defined(CONFIG_USERLED_LOWER)
-#  define HAVE_LEDS 0
-#endif
 
 #ifdef CONFIG_BOARDCTL
 
@@ -67,7 +64,7 @@
 
 int board_app_initialize(uintptr_t arg)
 {
-#ifdef HAVE_LEDS
+#if !defined(CONFIG_ARCH_LEDS) && defined(CONFIG_USERLED_LOWER)
   /* Register the LED driver */
 
   int ret;

--- a/boards/arm/imxrt/imxrt1064-evk/src/imxrt_appinit.c
+++ b/boards/arm/imxrt/imxrt1064-evk/src/imxrt_appinit.c
@@ -27,12 +27,9 @@
 #include <sys/types.h>
 
 #include <nuttx/board.h>
+#include <nuttx/leds/userled.h>
 
 #include "imxrt1064-evk.h"
-
-#if !defined(CONFIG_ARCH_LEDS) && defined(CONFIG_USERLED_LOWER)
-#  define HAVE_LEDS 0
-#endif
 
 #ifdef CONFIG_BOARDCTL
 
@@ -67,7 +64,7 @@
 
 int board_app_initialize(uintptr_t arg)
 {
-#ifdef HAVE_LEDS
+#if !defined(CONFIG_ARCH_LEDS) && defined(CONFIG_USERLED_LOWER)
   /* Register the LED driver */
 
   int ret;

--- a/boards/arm/imxrt/teensy-4.x/src/imxrt_appinit.c
+++ b/boards/arm/imxrt/teensy-4.x/src/imxrt_appinit.c
@@ -28,12 +28,9 @@
 #include <syslog.h>
 
 #include <nuttx/board.h>
+#include <nuttx/leds/userled.h>
 
 #include "teensy-4.h"
-
-#if !defined(CONFIG_ARCH_LEDS) && defined(CONFIG_USERLED_LOWER)
-#  define HAVE_LEDS 0
-#endif
 
 #ifdef CONFIG_BOARDCTL
 
@@ -69,7 +66,7 @@
 int board_app_initialize(uintptr_t arg)
 {
   int ret;
-  #ifdef HAVE_LEDS
+#if !defined(CONFIG_ARCH_LEDS) && defined(CONFIG_USERLED_LOWER)
   /* Register the LED driver */
 
   ret = userled_lower_initialize(LED_DRIVER_PATH);


### PR DESCRIPTION
## Summary

The imxrt1060, imxrt1064, and teensy-4.x board configs would fail to
build when `CONFIG_USERLED_LOWER` was enabled, due to a missing header in
imxrt_appinit.c and an unset local define.

## Impact

No modifications outside of `boards/arm/imxrt/*/src/imxrt_appinit.c`. `CONFIG_ARCH_LEDS`
works as before. `CONFIG_USERLED_LOWER` now works with upper half userled driver.

## Testing

Verified a build succeds for the specified boards with the following
defconfig modifications:

    # CONFIG_ARCH_LEDS is not set
    CONFIG_USERLED=y
    CONFIG_USERLED_LOWER=y

Tested the `leds` Led driver example on a Teensy 4.1.
