### PR TITLE
boards/arm/samv7: fix typos left after file renaming

### DIFF
--- a/boards/arm/samv7/same70-qmtech/src/Make.defs
+++ b/boards/arm/samv7/same70-qmtech/src/Make.defs
@@ -1,5 +1,5 @@
 ############################################################################
-# boards/arm/samv7/same70-qmtech/src/Makefile
+# boards/arm/samv7/same70-qmtech/src/Make.defs
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with

--- a/boards/arm/samv7/same70-xplained/src/Make.defs
+++ b/boards/arm/samv7/same70-xplained/src/Make.defs
@@ -1,5 +1,5 @@
 ############################################################################
-# boards/arm/samv7/same70-xplained/src/Makefile
+# boards/arm/samv7/same70-xplained/src/Make.defs
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with

--- a/boards/arm/samv7/samv71-xult/src/Make.defs
+++ b/boards/arm/samv7/samv71-xult/src/Make.defs
@@ -1,5 +1,5 @@
 ############################################################################
-# boards/arm/samv7/samv71-xult/src/Makefile
+# boards/arm/samv7/samv71-xult/src/Make.defs
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with


### PR DESCRIPTION
## Summary
Fix typos left after file renaming

## Impact
None

## Testing
Pass CI