### PR TITLE
imx6: fix fpu compile option

### DIFF
--- a/arch/arm/src/imx6/Kconfig
+++ b/arch/arm/src/imx6/Kconfig
@@ -40,6 +40,7 @@ config ARCH_CHIP_IMX6_6DUAL
 config ARCH_CHIP_IMX6_6QUAD
 	bool "i.MX 6Quad"
 	select ARCH_HAVE_MULTICPU
+	select ARM_HAVE_FPU_D32
 	select ARMV7A_HAVE_GICv2
 	select ARMV7A_HAVE_GTM
 	select ARMV7A_HAVE_PTM

--- a/boards/arm/imx6/sabre-6quad/scripts/Make.defs
+++ b/boards/arm/imx6/sabre-6quad/scripts/Make.defs
@@ -34,7 +34,7 @@ ifneq ($(CONFIG_DEBUG_NOOPT),y)
   ARCHOPTIMIZATION += $(MAXOPTIMIZATION) -fno-strict-aliasing
 endif
 
-ARCHCPUFLAGS = -mcpu=cortex-a9 -mfpu=vfpv4-d16 -mthumb
+ARCHCPUFLAGS = -mcpu=cortex-a9 -mfpu=vfpv3 -mthumb
 ARCHCFLAGS = -fno-common -fno-builtin -ffunction-sections -fdata-sections
 ARCHCXXFLAGS = -fno-common -fno-builtin -fno-exceptions -fcheck-new -fno-rtti
 ARCHWARNINGS = -Wall -Wstrict-prototypes -Wshadow -Wundef


### PR DESCRIPTION
## Summary

- imx6 fpu is vfpv3
- imx6 fpu has 32 registers (CONFIG_ARM_HAVE_FPU_D32=y)
- With this fix, "getprime" now succeeds by gcc-10.3.1.

In the following page, there is "VFPv3" in the block diagram.

https://www.nxp.com/products/processors-and-microcontrollers/arm-processors/i-mx-applications-processors/i-mx-6-processors/i-mx-6quad-processors-high-performance-3d-graphics-hd-video-arm-cortex-a9-core:i.MX6Q

The following statements can be found in the data sheet.

> NEON register file with 32x64-bit general-purpose registers

## Impact

- imx6

## Testing

- getprime on sabre-6quad:knsh (QEMU)

```
% arm-none-eabi-gcc -v
gcc version 10.3.1 20210824 (release) (GNU Arm Embedded Toolchain 10.3-2021.10)
% qemu-system-arm -semihosting -M sabrelite -m 1024 -smp 4 -nographic -kernel ./nuttx
ABDGHIJKNOPQ

NuttShell (NSH) NuttX-10.2.0
nsh> /system/bin/hello
Hello, World!!
nsh> /system/bin/getprime
Set thread priority to 10
Set thread policy to SCHED_RR
Start thread #0
thread #0 started, looking for primes < 10000, doing 10 run(s)
thread #0 finished, found 1230 primes, last one was 9973
Done
/system/bin/getprime took 1310 msec
nsh>
```