### PR TITLE
drivers/ioexpander: fix output inversion for ioe_dummy

### DIFF
--- a/drivers/ioexpander/skeleton.c
+++ b/drivers/ioexpander/skeleton.c
@@ -416,7 +416,7 @@ static int skel_getmultibits(FAR struct skel_dev_s *priv, FAR uint8_t *pins,
           return -ENXIO;
         }
 
-      values[i] = ((pinset & (1 << pin)) != 0);
+      values[i] = (((pinset >> pin) & 1) != 0);
     }
 
   return OK;
@@ -474,11 +474,11 @@ static int skel_multiwritepin(FAR struct ioexpander_dev_s *dev,
 
       if (values[i])
         {
-          pinset |= (1 << pin);
+          pinset |= ((ioe_pinset_t)1 << pin);
         }
       else
         {
-          pinset &= ~(1 << pin);
+          pinset &= ~((ioe_pinset_t)1 << pin);
         }
     }
 

--- a/drivers/ioexpander/tca64xx.c
+++ b/drivers/ioexpander/tca64xx.c
@@ -833,11 +833,11 @@ static int tca64_multiwritepin(FAR struct ioexpander_dev_s *dev,
 
       if (values[i])
         {
-          pinset |= (1 << pin);
+          pinset |= ((ioe_pinset_t)1 << pin);
         }
       else
         {
-          pinset &= ~(1 << pin);
+          pinset &= ~((ioe_pinset_t)1 << pin);
         }
     }
 
@@ -927,7 +927,7 @@ static int tca64_multireadpin(FAR struct ioexpander_dev_s *dev,
       pin = pins[i];
       DEBUGASSERT(pin < CONFIG_IOEXPANDER_NPINS);
 
-      values[i] = ((pinset & (1 << pin)) != 0);
+      values[i] = (((pinset >> pin) & 1) != 0);
     }
 
 #ifdef CONFIG_TCA64XX_INT_ENABLE
@@ -1075,7 +1075,7 @@ static void tca64_int_update(FAR struct tca64_dev_s *priv,
               if (((input & 1) == 0 && TCA64_EDGE_FALLING(priv, pin)) ||
                   ((input & 1) != 0 && TCA64_EDGE_RISING(priv, pin)))
                 {
-                  priv->intstat |= 1 << pin;
+                  priv->intstat |= ((ioe_pinset_t)1 << pin);
                 }
             }
         }
@@ -1086,7 +1086,7 @@ static void tca64_int_update(FAR struct tca64_dev_s *priv,
           if (((input & 1) != 0 && TCA64_LEVEL_HIGH(priv, pin)) ||
               ((input & 1) == 0 && TCA64_LEVEL_LOW(priv, pin)))
             {
-              priv->intstat |= 1 << pin;
+              priv->intstat |= ((ioe_pinset_t)1 << pin);
             }
         }
 


### PR DESCRIPTION
## Summary
Inversion of output IO expander pins does not work for ioe_dummy. Fix it and update the rest of IO expander implementations and add type cast to `ioe_pinset_t`.

## Impact
ioe_dummy users

## Testing
Pas CI