### PR TITLE
imxrt: userleds: Teensy 4.x board LED is active high

### DIFF
--- a/boards/arm/imxrt/teensy-4.x/src/imxrt_userleds.c
+++ b/boards/arm/imxrt/teensy-4.x/src/imxrt_userleds.c
@@ -65,7 +65,7 @@ uint32_t board_userled_initialize(void)
 
 void board_userled(int led, bool ledon)
 {
-  imxrt_gpio_write(GPIO_LED, !ledon);   /* Low illuminates */
+  imxrt_gpio_write(GPIO_LED, ledon);
 }
 
 /****************************************************************************
@@ -74,9 +74,7 @@ void board_userled(int led, bool ledon)
 
 void board_userled_all(uint32_t ledset)
 {
-  /* Low illuminates */
-
-  imxrt_gpio_write(GPIO_LED, (ledset & BOARD_USERLED_BIT) == 0);
+  imxrt_gpio_write(GPIO_LED, (ledset & BOARD_USERLED_BIT));
 }
 
 #endif                                 /* !CONFIG_ARCH_LEDS */


### PR DESCRIPTION
## Summary

The Teensy 4.0 and 4.1 board LED is active high ([according to schematic](https://www.pjrc.com/teensy/schematic.html)). Fix `board_userled()` and `board_userled_all()` to drive GPIO pin high when LED is set.

## Impact

Only changed `boards/arm/imxrt/teensy-4.x/src/imxrt_userleds.c`.

## Testing

Can set board LED with userleds ioctl and file IO write.
