### PR TITLE
riscv/xtensa: corrent dumpstate xcp size

### DIFF
--- a/arch/risc-v/src/common/riscv_assert.c
+++ b/arch/risc-v/src/common/riscv_assert.c
@@ -320,7 +320,7 @@ static void riscv_dumpstate(void)
   if (CURRENT_REGS)
     {
       memcpy(rtcb->xcp.regs,
-             (uintptr_t *)CURRENT_REGS, XCPTCONTEXT_REGS);
+             (uintptr_t *)CURRENT_REGS, XCPTCONTEXT_SIZE);
     }
   else
     {

--- a/arch/xtensa/src/common/xtensa_dumpstate.c
+++ b/arch/xtensa/src/common/xtensa_dumpstate.c
@@ -288,7 +288,7 @@ void xtensa_dumpstate(void)
   if (CURRENT_REGS)
     {
       memcpy(rtcb->xcp.regs,
-             (uintptr_t *)CURRENT_REGS, XCPTCONTEXT_REGS);
+             (uintptr_t *)CURRENT_REGS, XCPTCONTEXT_SIZE);
     }
   else
     {


### PR DESCRIPTION

Signed-off-by: zhuyanlin <zhuyanlin1@xiaomi.com>

## Summary

## Impact

## Testing

