### PR TITLE
arch/arm/src/sam34/sam_dmac.c:  Fix compilation error

### DIFF
--- a/arch/arm/src/sam34/sam_dmac.c
+++ b/arch/arm/src/sam34/sam_dmac.c
@@ -196,12 +196,12 @@ static struct sam_dma_s g_dma[SAM34_NDMACHAN] =
     .chan     = 3,
     .flags    = DMACH_FLAG_FIFO_32BYTES,
     .base     = SAM_DMACHAN3_BASE,
-  }
+  },
   {
     .chan     = 4,
     .flags    = DMACH_FLAG_FIFO_8BYTES,
     .base     = SAM_DMACHAN4_BASE,
-  }
+  },
   {
     .chan     = 5,
     .flags    = DMACH_FLAG_FIFO_32BYTES,


### PR DESCRIPTION
## Summary
Fix missing commas in array DMA state array initialiser 

## Impact
SAM3/4 DMA users

## Testing
Compilation on the Arduino-Due target:
-> defines `ARCH_CHIP_ATSAM3X8E`
--> defines `ARCH_CHIP_SAM3X`
---> which exposes this issue.
