### PR TITLE
arch/risc-v: Implement SYS_save_context in swint

### DIFF
--- a/arch/risc-v/src/common/riscv_copystate.c
+++ b/arch/risc-v/src/common/riscv_copystate.c
@@ -55,10 +55,6 @@ void riscv_copystate(uintptr_t *dest, uintptr_t *src)
 {
   int i;
 
-#ifdef CONFIG_ARCH_FPU
-  uintptr_t *regs = dest;
-#endif
-
   /* In the RISC-V model, the state is copied from the stack to the TCB,
    * but only a reference is passed to get the state from the TCB.  So the
    * following check avoids copying the TCB save area onto itself:
@@ -79,7 +75,7 @@ void riscv_copystate(uintptr_t *dest, uintptr_t *src)
        */
 
 #ifdef CONFIG_ARCH_FPU
-      riscv_savefpu(regs);
+      riscv_savefpu(dest);
 #endif
     }
 }

--- a/arch/risc-v/src/common/riscv_swint.c
+++ b/arch/risc-v/src/common/riscv_swint.c
@@ -182,6 +182,26 @@ int riscv_swint(int irq, void *context, void *arg)
 
   switch (regs[REG_A0])
     {
+      /* A0=SYS_save_context:  This is a save context command:
+       *
+       *   int riscv_saveusercontext(uintptr saveregs);
+       *
+       * At this point, the following values are saved in context:
+       *
+       *   A0 = SYS_save_context
+       *   A1 = saveregs
+       *
+       * In this case, we simply need to copy the current registers to the
+       * save register space references in the saved A1 and return.
+       */
+
+      case SYS_save_context:
+        {
+          DEBUGASSERT(regs[REG_A1] != 0);
+          riscv_copystate((uintptr_t *)regs[REG_A1], regs);
+        }
+        break;
+
       /* A0=SYS_restore_context: This a restore context command:
        *
        * void


### PR DESCRIPTION
## Summary
* Correct FPU register save area in riscv_copystate
* Implement SYS_save_context to support riscv_saveusercontext (which used by FPU test in ostest with syscall enabled)
## Impact
New syscall
## Testing
rv-virt:ostest with syscall enabled.
