### PR TITLE
xtensa: small improvements around using the software interrupt. 

### DIFF
--- a/arch/xtensa/include/irq.h
+++ b/arch/xtensa/include/irq.h
@@ -213,7 +213,7 @@ static inline void up_irq_restore(uint32_t ps)
 {
   __asm__ __volatile__
   (
-    "wsr %0, PS \n"
+    "wsr %0, PS\n"
     "rsync \n"
     :
     : "r"(ps)
@@ -276,6 +276,7 @@ static inline void xtensa_disable_all(void)
   (
     "movi a2, 0\n"
     "xsr a2, INTENABLE\n"
+    "rsync\n"
     : : : "a2"
   );
 }
@@ -289,6 +290,7 @@ static inline void xtensa_intclear(uint32_t mask)
   __asm__ __volatile__
   (
     "wsr %0, INTCLEAR\n"
+    "rsync\n"
     :
     : "r"(mask)
     :

--- a/arch/xtensa/include/syscall.h
+++ b/arch/xtensa/include/syscall.h
@@ -176,7 +176,7 @@ static inline uintptr_t sys_call0(unsigned int nbr)
   (
     "movi a3, %1\n"
     "wsr a3, intset\n"
-    "isync\n"
+    "rsync\n"
     : "=r"(reg0)
     : "i"(XCHAL_SWINT_CALL), "r"(reg0)
     : "a3", "memory"
@@ -202,7 +202,7 @@ static inline uintptr_t sys_call1(unsigned int nbr, uintptr_t parm1)
   (
     "movi a4, %1\n"
     "wsr a4, intset\n"
-    "isync\n"
+    "rsync\n"
     : "=r"(reg0)
     : "i"(XCHAL_SWINT_CALL), "r"(reg0), "r"(reg1)
     : "a4", "memory"
@@ -230,7 +230,7 @@ static inline uintptr_t sys_call2(unsigned int nbr, uintptr_t parm1,
   (
     "movi a5, %1\n"
     "wsr a5, intset\n"
-    "isync\n"
+    "rsync\n"
     : "=r"(reg0)
     : "i"(XCHAL_SWINT_CALL), "r"(reg0), "r"(reg1), "r"(reg2)
     : "a5", "memory"
@@ -259,7 +259,7 @@ static inline uintptr_t sys_call3(unsigned int nbr, uintptr_t parm1,
   (
     "movi a6, %1\n"
     "wsr a6, intset\n"
-    "isync\n"
+    "rsync\n"
     : "=r"(reg0)
     : "i"(XCHAL_SWINT_CALL), "r"(reg0), "r"(reg1), "r"(reg2),
       "r"(reg3)
@@ -291,7 +291,7 @@ static inline uintptr_t sys_call4(unsigned int nbr, uintptr_t parm1,
   (
     "movi a7, %1\n"
     "wsr a7, intset\n"
-    "isync\n"
+    "rsync\n"
     : "=r"(reg0)
     : "i"(XCHAL_SWINT_CALL), "r"(reg0), "r"(reg1), "r"(reg2),
       "r"(reg3), "r"(reg4)
@@ -324,7 +324,7 @@ static inline uintptr_t sys_call5(unsigned int nbr, uintptr_t parm1,
   (
     "movi a8, %1\n"
     "wsr a8, intset\n"
-    "isync\n"
+    "rsync\n"
     : "=r"(reg0)
     : "i"(XCHAL_SWINT_CALL), "r"(reg0), "r"(reg1), "r"(reg2),
       "r"(reg3), "r"(reg4), "r"(reg5)
@@ -359,7 +359,7 @@ static inline uintptr_t sys_call6(unsigned int nbr, uintptr_t parm1,
   (
     "movi a9, %1\n"
     "wsr a9, intset\n"
-    "isync\n"
+    "rsync\n"
     : "=r"(reg0)
     : "i"(XCHAL_SWINT_CALL), "r"(reg0), "r"(reg1), "r"(reg2),
       "r"(reg3), "r"(reg4), "r"(reg5)

--- a/arch/xtensa/src/common/xtensa_context.S
+++ b/arch/xtensa/src/common/xtensa_context.S
@@ -277,96 +277,6 @@ xtensa_context_save:
 #ifndef __XTENSA_CALL0_ABI__
 
 /****************************************************************************
- * Name: _xtensa_save_hook:
- *
- * Input State:
- *   True return value has already been saved
- *   a0 = The return value into xtensa_context_save()
- *   a2 = The address of the register state structure
- *
- * Return state:
- *   a0, a3 modified.
- *   Other values as on entry
- *   Returned value is in a3 (non-stanadard)
- *
- ****************************************************************************/
-
-	.type	_xtensa_save_hook, @function
-
-	.align	4
-	.literal_position
-	.align	4
-
-_xtensa_save_hook:
-
-	/* Save the return value of 1 that will be used when returning from a
-	 * context switch.  NOTE that the returned value from this function is
-	 * expected in a3 (not the usual a2). This also frees up a3 for a use
-	 * as a scratch register.
-	 */
-
-	movi	a3,  1							/* Set saved a3 to 1 */
-	s32i	a3,  a2, (4 * REG_A3)
-
-	/* Save the rest of the processor state.
-	 *
-	 * REVISIT: We could save a lot here.  It should not be necessary to
-	 * preserve all of these registers.  The ABI permits volatile, callee-
-	 * saved, registers to be clobbered on function calls.  We save the
-	 * whole tamale here mostly for debug purposes.
-	 *
-	 * NOTE that a3 was saved above.  The true a0 return value was saved
-	 * in xtensa_context_save.  The a0 value saved below is the return into
-	 * xtensa_context_save.
-	 */
-
-	rsr		a3,  PS							/* Save callee's PS */
-	s32i	a3,  a2, (4 * REG_PS)
-	s32i	a0,  a2, (4 * REG_PC)			/* Save Return address as PC */
-
-	s32i	sp,  a2, (4 * REG_A1)			/* Save callee's SP */
-	s32i	a2,  a2, (4 * REG_A2)
-	s32i	a4,  a2, (4 * REG_A4)			/* Save remaining registers */
-	s32i	a5,  a2, (4 * REG_A5)
-	s32i	a6,  a2, (4 * REG_A6)
-	s32i	a7,  a2, (4 * REG_A7)
-	s32i	a8,  a2, (4 * REG_A8)
-	s32i	a9,  a2, (4 * REG_A9)
-	s32i	a10, a2, (4 * REG_A10)
-	s32i	a11, a2, (4 * REG_A11)
-
-	/* Call0 ABI callee-saved regs a12-15 */
-
-	s32i	a12, a2, (4 * REG_A12)
-	s32i	a13, a2, (4 * REG_A13)
-	s32i	a14, a2, (4 * REG_A14)
-	s32i	a15, a2, (4 * REG_A15)
-
-	rsr		a3, SAR
-	s32i	a3, a2, (4 * REG_SAR)
-
-#if XCHAL_HAVE_S32C1I != 0
-	rsr		a3, SCOMPARE1
-	s32i	a3, a2, (4 * REG_SCOMPARE1)
-#endif
-
-#if XCHAL_HAVE_LOOPS != 0
-	rsr		a3, LBEG
-	s32i	a3, a2, (4 * REG_LBEG)
-	rsr		a3, LEND
-	s32i	a3, a2, (4 * REG_LEND)
-	rsr		a3, LCOUNT
-	s32i	a3, a2, (4 * REG_LCOUNT)
-#endif
-
-	/* NOTE that the returned value is through a3 */
-
-	movi	a3, 0							/* Return zero, no context switch */
-	ret
-
-	.size	_xtensa_save_hook, . - _xtensa_save_hook
-
-/****************************************************************************
  * Name: xtensa_context_save:
  *
  * Description:
@@ -396,25 +306,12 @@ _xtensa_save_hook:
 xtensa_context_save:
 	ENTRY(16)
 
-	/* Save the true return address in the register save structure (a0). */
+	mov  a3, a2
+	movi a2, SYS_save_context
+	movi a4, XCHAL_SWINT_CALL
+	wsr  a4, intset
+	rsync
 
-	s32i	a0, a2, (4 * REG_A0)		/* Save true return address (a0) */
-
-	/* Then perform the actual state save in _xtensa_save_hook.  The saved
-	 * EPC will be set to the return from this function then we will do the
-	 * RET(16) window fix-up.
-	 */
-
-	call0	_xtensa_save_hook			/* Save full register state */
-
-	/* a0 and a2 will be automatically restored in the context switch case
-	 * with  a3=1.  In the non-context switch return with a2=0, a2 will still
-	 * be valid, but we have to restore	 a0 ourself.  The following should
-	 * work in either case.
-	 */
-
-	l32i	a0, a2, (4 * REG_A0)		/* Recover the true return address (a0) */
-	mov		a2, a3						/* Move a3 to the correct register for return */
 	RET(16)
 
 	.size	xtensa_context_save, . - xtensa_context_save

--- a/arch/xtensa/src/common/xtensa_context.S
+++ b/arch/xtensa/src/common/xtensa_context.S
@@ -548,7 +548,7 @@ xtensa_context_restore:
 	movi a2, SYS_restore_context
 	movi a4, XCHAL_SWINT_CALL
 	wsr  a4, intset
-	isync
+	rsync
 
 	RET(16)
 

--- a/arch/xtensa/src/common/xtensa_cpuint.S
+++ b/arch/xtensa/src/common/xtensa_cpuint.S
@@ -82,6 +82,7 @@ xtensa_enable_cpuint:
 	s32i	a5, a2, 0			  /* shadow |= mask */
 
 	wsr		a5, INTENABLE		/* Set CPU INTENABLE to shadow */
+	rsync
 	mov		a3, a4			   	/* Return previous shadow content */
 	RET(16)
 
@@ -122,6 +123,7 @@ xtensa_disable_cpuint:
 	s32i	a5, a2, 0			  /* shadow &= ~mask */
 
 	wsr		a5, INTENABLE		/* Set CPU INTENABLE to shadow */
+	rsync
 	mov		a3, a4				  /* Return previous shadow content */
 	RET(16)
 

--- a/arch/xtensa/src/common/xtensa_exit.c
+++ b/arch/xtensa/src/common/xtensa_exit.c
@@ -143,12 +143,6 @@ void up_exit(int status)
 
   nxsched_resume_scheduler(tcb);
 
-#if XCHAL_CP_NUM > 0
-  /* Set up the co-processor state for the newly started thread. */
-
-  xtensa_coproc_restorestate(&tcb->xcp.cpstate);
-#endif
-
 #ifdef CONFIG_ARCH_ADDRENV
   /* Make sure that the address environment for the previously running
    * task is closed down gracefully (data caches dump, MMU flushed) and
@@ -163,7 +157,7 @@ void up_exit(int status)
 
   xtensa_context_restore(tcb->xcp.regs);
 
-  /* xtensa_full_context_restore() should not return but could if the
+  /* xtensa_context_restore() should not return but could if the
    * software interrupts are disabled.
    */
 

--- a/arch/xtensa/src/common/xtensa_swint.c
+++ b/arch/xtensa/src/common/xtensa_swint.c
@@ -131,12 +131,12 @@ int xtensa_swint(int irq, void *context, void *arg)
 
       case SYS_restore_context:
         {
+          DEBUGASSERT(regs[REG_A3] != 0);
+          CURRENT_REGS = (uint32_t *)regs[REG_A3];
 #if XCHAL_CP_NUM > 0
           cpstate = (uintptr_t)regs[REG_A3] + cpstate_off;
           xtensa_coproc_restorestate((struct xtensa_cpstate_s *)cpstate);
 #endif
-          DEBUGASSERT(regs[REG_A3] != 0);
-          CURRENT_REGS = (uint32_t *)regs[REG_A3];
         }
 
         break;


### PR DESCRIPTION
## Summary
 - Use `rsync` when manipulating interrupt registers, this is the recommended instruction by the TRM.
 - Co-processor state was restored two times in `xtensa_exit`.
## Impact
Xtensa chips
## Testing
Tested the defconfigs of all ESP32xx chips.
