### PR TITLE
sched: Fix typo in references to SIGEV_THREAD

### DIFF
--- a/sched/Kconfig
+++ b/sched/Kconfig
@@ -1363,7 +1363,7 @@ config SIG_PREALLOC_IRQ_ACTIONS
 		The number of pre-allocated irq action structures.
 
 config SIG_EVTHREAD
-	bool "Support SIGEV_THHREAD"
+	bool "Support SIGEV_THREAD"
 	default n
 	depends on !BUILD_KERNEL && SCHED_WORKQUEUE
 	select LIBC_USRWORK if BUILD_PROTECTED
@@ -1380,7 +1380,7 @@ config SIG_EVTHREAD_HPWORK
 	default n
 	depends on SIG_EVTHREAD && SCHED_HPWORK
 	---help---
-		if selected, SIGEV_THHREAD will use the high priority work queue.
+		if selected, SIGEV_THREAD will use the high priority work queue.
 		If not, it will use the low priority work queue (if available).
 
 		REVISIT:  This solution is non-optimal.  Some notifications should


### PR DESCRIPTION
## Summary
This PR intends to fix some typos in references to the Kconfig option `SIGEV_THREAD`.

## Impact
No impact, just typos in Kconfig strings.

## Testing
Not applicable.

