### PR TITLE
arch/arm/arm[-a|-r]: fix typos in comments

### DIFF
--- a/arch/arm/src/arm/arm_vectors.S
+++ b/arch/arm/src/arm/arm_vectors.S
@@ -288,7 +288,7 @@ arm_vectorsvc:
 	cmp	r2, #PSR_MODE_USR		/* User mode? */
 	bne	.Lleavesvcsvc			/* Branch if not user mode */
 
-	mov	r14, sp				/* Get r0=xcp */
+	mov	r14, sp				/* Get r14=xcp */
 	add	sp, sp, #XCPTCONTEXT_SIZE	/* Restore SVC's sp */
 
 	/* ldmia with ^ will return the user mode registers (provided that r15
@@ -423,7 +423,7 @@ arm_vectordata:
 	cmp	r2, #PSR_MODE_USR		/* User mode? */
 	bne	.Ldabtleavesvc			/* Branch if not user mode */
 
-	mov	r14, sp				/* Get r0=xcp */
+	mov	r14, sp				/* Get r14=xcp */
 	add	sp, sp, #XCPTCONTEXT_SIZE	/* Restore SVC's sp */
 
 	/* ldmia with ^ will return the user mode registers (provided that r15
@@ -683,7 +683,7 @@ arm_vectorundefinsn:
 	cmp	r2, #PSR_MODE_USR		/* User mode? */
 	bne	.Lundefleavesvc			/* Branch if not user mode */
 
-	mov	r14, sp				/* Get r0=xcp */
+	mov	r14, sp				/* Get r14=xcp */
 	add	sp, sp, #XCPTCONTEXT_SIZE	/* Restore SVC's sp */
 
 	/* ldmia with ^ will return the user mode registers (provided that r15

--- a/arch/arm/src/armv7-a/arm_vectors.S
+++ b/arch/arm/src/armv7-a/arm_vectors.S
@@ -884,7 +884,7 @@ arm_vectorfiq:
 
 #ifdef CONFIG_BUILD_KERNEL
 	/* Did we enter from user mode?  If so then we need get the values of
-	 * USER mode rr13(sp) and r14(lr).
+	 * USER mode r13(sp) and r14(lr).
 	 */
 
 	and		r1, r4, #PSR_MODE_MASK		/* Interrupted mode */
@@ -934,6 +934,8 @@ arm_vectorfiq:
 	mov		r0, sp				/* Get r0=xcp */
 
 #if CONFIG_ARCH_INTERRUPTSTACK > 7
+	/* Call arm_decodefiq() on the interrupt stack */
+
 	setfiqstack	r1, r4				/* SP = interrupt stack top */
 	str		r0, [sp, #-4]!			/* Save the xcp address at SP-4 then update SP */
 	mov		r4, sp				/* Save the SP in a preserved register */
@@ -941,6 +943,8 @@ arm_vectorfiq:
 	bl		arm_decodefiq			/* Call the handler */
 	ldr		sp, [r4]			/* Restore the user stack pointer */
 #else
+	/* Call arm_decodefiq() on the user stack */
+
 	mov		r4, sp				/* Save the SP in a preserved register */
 	bic		sp, sp, #7			/* Force 8-byte alignment */
 	bl		arm_decodefiq			/* Call the handler */

--- a/arch/arm/src/armv7-r/arm_vectors.S
+++ b/arch/arm/src/armv7-r/arm_vectors.S
@@ -838,7 +838,7 @@ arm_vectorfiq:
 
 #ifdef CONFIG_BUILD_PROTECTED
 	/* Did we enter from user mode?  If so then we need get the values of
-	 * USER mode rr13(sp) and r14(lr).
+	 * USER mode r13(sp) and r14(lr).
 	 */
 
 	and		r1, r4, #PSR_MODE_MASK		/* Interrupted mode */
@@ -888,6 +888,8 @@ arm_vectorfiq:
 	mov		r0, sp				/* Get r0=xcp */
 
 #if CONFIG_ARCH_INTERRUPTSTACK > 7
+	/* Call arm_decodefiq() on the interrupt stack */
+
 	ldr		sp, .Lfiqstacktop		/* SP = interrupt stack top */
 	str		r0, [sp, #-4]!			/* Save the xcp address at SP-4 then update SP */
 	mov		r4, sp				/* Save the SP in a preserved register */
@@ -895,6 +897,8 @@ arm_vectorfiq:
 	bl		arm_decodefiq			/* Call the handler */
 	ldr		sp, [r4]			/* Restore the user stack pointer */
 #else
+	/* Call arm_decodefiq() on the user stack */
+
 	mov		r4, sp				/* Save the SP in a preserved register */
 	bic		sp, sp, #7			/* Force 8-byte alignment */
 	bl		arm_decodefiq			/* Call the handler */

--- a/arch/arm/src/c5471/c5471_vectors.S
+++ b/arch/arm/src/c5471/c5471_vectors.S
@@ -153,7 +153,7 @@ arm_vectorirq:
 	bl	arm_doirq		/* Call the handler */
 #endif
 
-	/* Restore the CPSR, SVC modr registers and return */
+	/* Restore the CPSR, SVC mode registers and return */
 .Lnoirqset:
 	ldr	r0, [sp, #(4*REG_CPSR)]	/* Setup the SVC mode SPSR */
 	msr	spsr_cxsf, r0
@@ -212,7 +212,7 @@ arm_vectorsvc:
 	mov	r0, sp			/* Get r0=xcp */
 	bl	arm_syscall		/* Call the handler */
 
-	/* Restore the CPSR, SVC modr registers and return */
+	/* Restore the CPSR, SVC mode registers and return */
 
 	ldr	r0, [sp, #(4*REG_CPSR)]	/* Setup the SVC mode SPSR */
 	msr	spsr_cxsf, r0
@@ -269,7 +269,7 @@ arm_vectordata:
 	add	r0, sp, #(4*REG_SP)	/* Offset to pc, cpsr storage */
 	stmia	r0, {r1-r4}
 
-	/* Then call the data abort handler with interrupt disabled.
+	/* Then call the data abort handler with interrupts disabled.
 	 * void arm_dataabort(struct xcptcontext *xcp)
 	 */
 
@@ -277,7 +277,7 @@ arm_vectordata:
 	mov	r0, sp			/* Get r0=xcp */
 	bl	arm_dataabort		/* Call the handler */
 
-	/* Restore the CPSR, SVC modr registers and return */
+	/* Restore the CPSR, SVC mode registers and return */
 
 	ldr	r0, [sp, #(4*REG_CPSR)]	/* Setup the SVC mode SPSR */
 	msr	spsr_cxsf, r0
@@ -335,7 +335,7 @@ arm_vectorprefetch:
 	add	r0, sp, #(4*REG_SP)	/* Offset to pc, cpsr storage */
 	stmia	r0, {r1-r4}
 
-	/* Then call the prefetch abort handler with interrupt disabled.
+	/* Then call the prefetch abort handler with interrupts disabled.
 	 * void arm_prefetchabort(struct xcptcontext *xcp)
 	 */
 
@@ -343,7 +343,7 @@ arm_vectorprefetch:
 	mov	r0, sp			/* Get r0=xcp */
 	bl	arm_prefetchabort	/* Call the handler */
 
-	/* Restore the CPSR, SVC modr registers and return */
+	/* Restore the CPSR, SVC mode registers and return */
 
 	ldr	r0, [sp, #(4*REG_CPSR)]	/* Setup the SVC mode SPSR */
 	msr	spsr_cxsf, r0
@@ -401,7 +401,7 @@ arm_vectorundefinsn:
 	add	r0, sp, #(4*REG_SP)	/* Offset to pc, cpsr storage */
 	stmia	r0, {r1-r4}
 
-	/* Then call the undef insn handler with interrupt disabled.
+	/* Then call the undef insn handler with interrupts disabled.
 	 * void arm_undefinedinsn(struct xcptcontext *xcp)
 	 */
 
@@ -409,7 +409,7 @@ arm_vectorundefinsn:
 	mov	r0, sp			/* Get r0=xcp */
 	bl	arm_undefinedinsn	/* Call the handler */
 
-	/* Restore the CPSR, SVC modr registers and return */
+	/* Restore the CPSR, SVC mode registers and return */
 
 	ldr	r0, [sp, #(4*REG_CPSR)]	/* Setup the SVC mode SPSR */
 	msr	spsr_cxsf, r0
@@ -425,10 +425,12 @@ arm_vectorundefinsn:
  *
  * Description:
  *   Shouldn't happen
+ *
  ****************************************************************************/
 
 	.globl	arm_vectorfiq
 	.type	arm_vectorfiq, %function
+
 arm_vectorfiq:
 	subs	pc, lr, #4
 
@@ -460,10 +462,12 @@ arm_vectoraddrexcptn:
 	.global	g_intstacktop
 	.type	g_intstackalloc, object
 	.type	g_intstacktop, object
+
 g_intstackalloc:
 	.skip	(CONFIG_ARCH_INTERRUPTSTACK & ~3)
 g_intstacktop:
 	.size	g_intstacktop, 0
 	.size	g_intstackalloc, (CONFIG_ARCH_INTERRUPTSTACK & ~3)
+
 #endif
 	.end


### PR DESCRIPTION
## Summary
Fix typos in comments in `arm_vectors.S` 

## Impact
None

## Testing
Pass CI
