### PR TITLE
Remove the unnecessary code from nx_start

### DIFF
--- a/fs/inode/fs_inode.c
+++ b/fs/inode/fs_inode.c
@@ -62,7 +62,10 @@ struct inode_sem_s
  * Private Data
  ****************************************************************************/
 
-static struct inode_sem_s g_inode_sem;
+static struct inode_sem_s g_inode_sem =
+{
+  SEM_INITIALIZER(1), NO_HOLDER, 0
+};
 
 /****************************************************************************
  * Public Functions
@@ -79,14 +82,6 @@ static struct inode_sem_s g_inode_sem;
 
 void inode_initialize(void)
 {
-  /* Initialize the semaphore to one (to support one-at-a-time access to the
-   * inode tree).
-   */
-
-  nxsem_init(&g_inode_sem.sem, 0, 1);
-  g_inode_sem.holder = NO_HOLDER;
-  g_inode_sem.count  = 0;
-
   /* Reserve the root node */
 
   inode_root_reserve();

--- a/include/nuttx/mm/shm.h
+++ b/include/nuttx/mm/shm.h
@@ -96,22 +96,6 @@ struct group_shm_s
  ****************************************************************************/
 
 /****************************************************************************
- * Name: shm_initialize
- *
- * Description:
- *   Perform one time, start-up initialization of the shared memory logic.
- *
- * Input Parameters:
- *   None
- *
- * Returned Value:
- *   None
- *
- ****************************************************************************/
-
-void shm_initialize(void);
-
-/****************************************************************************
  * Name: shm_group_initialize
  *
  * Description:

--- a/mm/shm/shm_initialize.c
+++ b/mm/shm/shm_initialize.c
@@ -43,32 +43,14 @@
 
 /* State of the all shared memory */
 
-struct shm_info_s g_shminfo;
+struct shm_info_s g_shminfo =
+{
+  SEM_INITIALIZER(1)
+};
 
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
-
-/****************************************************************************
- * Name: shm_initialize
- *
- * Description:
- *   Perform one time, start-up initialization of the shared memory logic.
- *
- * Input Parameters:
- *   None
- *
- * Returned Value:
- *   None
- *
- ****************************************************************************/
-
-void shm_initialize(void)
-{
-  /* Initialize the shared memory region list */
-
-  nxsem_init(&g_shminfo.si_sem, 0, 1);
-}
 
 /****************************************************************************
  * Name: shm_group_initialize

--- a/net/bluetooth/bluetooth_conn.c
+++ b/net/bluetooth/bluetooth_conn.c
@@ -90,14 +90,7 @@ void bluetooth_conn_initialize(void)
 {
 #ifndef CONFIG_NET_ALLOC_CONNS
   int i;
-#endif
 
-  /* Initialize the queues */
-
-  dq_init(&g_free_bluetooth_connections);
-  dq_init(&g_active_bluetooth_connections);
-
-#ifndef CONFIG_NET_ALLOC_CONNS
   for (i = 0; i < CONFIG_NET_BLUETOOTH_NCONNS; i++)
     {
       /* Link each pre-allocated connection structure into the free list. */

--- a/net/can/can_conn.c
+++ b/net/can/can_conn.c
@@ -56,7 +56,7 @@ static struct can_conn_s g_can_connections[CONFIG_CAN_CONNS];
 /* A list of all free NetLink connections */
 
 static dq_queue_t g_free_can_connections;
-static sem_t g_free_sem;
+static sem_t g_free_sem = SEM_INITIALIZER(1);
 
 /* A list of all allocated NetLink connections */
 
@@ -101,15 +101,7 @@ void can_initialize(void)
 {
 #ifndef CONFIG_NET_ALLOC_CONNS
   int i;
-#endif
 
-  /* Initialize the queues */
-
-  dq_init(&g_free_can_connections);
-  dq_init(&g_active_can_connections);
-  nxsem_init(&g_free_sem, 0, 1);
-
-#ifndef CONFIG_NET_ALLOC_CONNS
   for (i = 0; i < CONFIG_CAN_CONNS; i++)
     {
       /* Mark the connection closed and move it to the free list */

--- a/net/icmp/icmp_conn.c
+++ b/net/icmp/icmp_conn.c
@@ -55,7 +55,7 @@ static struct icmp_conn_s g_icmp_connections[CONFIG_NET_ICMP_NCONNS];
 /* A list of all free IPPROTO_ICMP socket connections */
 
 static dq_queue_t g_free_icmp_connections;
-static sem_t g_free_sem;
+static sem_t g_free_sem = SEM_INITIALIZER(1);
 
 /* A list of all allocated IPPROTO_ICMP socket connections */
 
@@ -78,15 +78,7 @@ void icmp_sock_initialize(void)
 {
 #ifndef CONFIG_NET_ALLOC_CONNS
   int i;
-#endif
 
-  /* Initialize the queues */
-
-  dq_init(&g_free_icmp_connections);
-  dq_init(&g_active_icmp_connections);
-  nxsem_init(&g_free_sem, 0, 1);
-
-#ifndef CONFIG_NET_ALLOC_CONNS
   for (i = 0; i < CONFIG_NET_ICMP_NCONNS; i++)
     {
       /* Move the connection structure to the free list */

--- a/net/icmpv6/icmpv6_conn.c
+++ b/net/icmpv6/icmpv6_conn.c
@@ -55,7 +55,7 @@ static struct icmpv6_conn_s g_icmpv6_connections[CONFIG_NET_ICMPv6_NCONNS];
 /* A list of all free IPPROTO_ICMP socket connections */
 
 static dq_queue_t g_free_icmpv6_connections;
-static sem_t g_free_sem;
+static sem_t g_free_sem = SEM_INITIALIZER(1);
 
 /* A list of all allocated IPPROTO_ICMP socket connections */
 
@@ -78,15 +78,7 @@ void icmpv6_sock_initialize(void)
 {
 #ifndef CONFIG_NET_ALLOC_CONNS
   int i;
-#endif
 
-  /* Initialize the queues */
-
-  dq_init(&g_free_icmpv6_connections);
-  dq_init(&g_active_icmpv6_connections);
-  nxsem_init(&g_free_sem, 0, 1);
-
-#ifndef CONFIG_NET_ALLOC_CONNS
   for (i = 0; i < CONFIG_NET_ICMPv6_NCONNS; i++)
     {
       /* Move the connection structure to the free list */

--- a/net/ieee802154/ieee802154_conn.c
+++ b/net/ieee802154/ieee802154_conn.c
@@ -84,14 +84,7 @@ void ieee802154_conn_initialize(void)
 {
 #ifndef CONFIG_NET_ALLOC_CONNS
   int i;
-#endif
 
-  /* Initialize the queues */
-
-  dq_init(&g_free_ieee802154_connections);
-  dq_init(&g_active_ieee802154_connections);
-
-#ifndef CONFIG_NET_ALLOC_CONNS
   for (i = 0; i < CONFIG_NET_IEEE802154_NCONNS; i++)
     {
       /* Link each pre-allocated connection structure into the free list. */

--- a/net/netlink/netlink_conn.c
+++ b/net/netlink/netlink_conn.c
@@ -57,7 +57,7 @@ static struct netlink_conn_s g_netlink_connections[CONFIG_NETLINK_CONNS];
 /* A list of all free NetLink connections */
 
 static dq_queue_t g_free_netlink_connections;
-static sem_t g_free_sem;
+static sem_t g_free_sem = SEM_INITIALIZER(1);
 
 /* A list of all allocated NetLink connections */
 
@@ -125,15 +125,7 @@ void netlink_initialize(void)
 {
 #ifndef CONFIG_NET_ALLOC_CONNS
   int i;
-#endif
 
-  /* Initialize the queues */
-
-  dq_init(&g_free_netlink_connections);
-  dq_init(&g_active_netlink_connections);
-  nxsem_init(&g_free_sem, 0, 1);
-
-#ifndef CONFIG_NET_ALLOC_CONNS
   for (i = 0; i < CONFIG_NETLINK_CONNS; i++)
     {
       /* Mark the connection closed and move it to the free list */

--- a/net/pkt/pkt_conn.c
+++ b/net/pkt/pkt_conn.c
@@ -63,7 +63,7 @@ static struct pkt_conn_s g_pkt_connections[CONFIG_NET_PKT_CONNS];
 /* A list of all free packet socket connections */
 
 static dq_queue_t g_free_pkt_connections;
-static sem_t g_free_sem;
+static sem_t g_free_sem = SEM_INITIALIZER(1);
 
 /* A list of all allocated packet socket connections */
 
@@ -105,15 +105,7 @@ void pkt_initialize(void)
 {
 #ifndef CONFIG_NET_ALLOC_CONNS
   int i;
-#endif
 
-  /* Initialize the queues */
-
-  dq_init(&g_free_pkt_connections);
-  dq_init(&g_active_pkt_connections);
-  nxsem_init(&g_free_sem, 0, 1);
-
-#ifndef CONFIG_NET_ALLOC_CONNS
   for (i = 0; i < CONFIG_NET_PKT_CONNS; i++)
     {
       dq_addlast(&g_pkt_connections[i].sconn.node, &g_free_pkt_connections);

--- a/net/route/net_cacheroute.c
+++ b/net/route/net_cacheroute.c
@@ -122,7 +122,7 @@ static struct net_cache_ipv4_entry_s
 
 /* Serializes access to the routing table cache */
 
-static sem_t g_ipv4_cachelock;
+static sem_t g_ipv4_cachelock = SEM_INITIALIZER(1);
 #endif
 
 #if defined(CONFIG_ROUTE_IPv6_CACHEROUTE)
@@ -141,7 +141,7 @@ static struct net_cache_ipv6_entry_s
 
 /* Serializes access to the routing table cache */
 
-static sem_t g_ipv6_cachelock;
+static sem_t g_ipv6_cachelock = SEM_INITIALIZER(1);
 #endif
 
 /****************************************************************************
@@ -481,12 +481,10 @@ void net_init_cacheroute(void)
   /* Initialize the routing table cash and the free list */
 
 #ifdef CONFIG_ROUTE_IPv4_CACHEROUTE
-  nxsem_init(&g_ipv4_cachelock, 0, 1);
   net_reset_ipv4_cache();
 #endif
 
 #ifdef CONFIG_ROUTE_IPv6_CACHEROUTE
-  nxsem_init(&g_ipv6_cachelock, 0, 1);
   net_reset_ipv6_cache();
 #endif
 }

--- a/net/tcp/tcp_conn.c
+++ b/net/tcp/tcp_conn.c
@@ -580,16 +580,7 @@ void tcp_initialize(void)
 {
 #ifndef CONFIG_NET_ALLOC_CONNS
   int i;
-#endif
 
-  /* Initialize the queues */
-
-  dq_init(&g_free_tcp_connections);
-  dq_init(&g_active_tcp_connections);
-
-  /* Now initialize each connection structure */
-
-#ifndef CONFIG_NET_ALLOC_CONNS
   for (i = 0; i < CONFIG_NET_TCP_CONNS; i++)
     {
       /* Mark the connection closed and move it to the free list */

--- a/net/tcp/tcp_wrbuffer.c
+++ b/net/tcp/tcp_wrbuffer.c
@@ -94,8 +94,6 @@ void tcp_wrbuffer_initialize(void)
 {
   int i;
 
-  sq_init(&g_wrbuffer.freebuffers);
-
   for (i = 0; i < CONFIG_NET_TCP_NWRBCHAINS; i++)
     {
       sq_addfirst(&g_wrbuffer.buffers[i].wb_node, &g_wrbuffer.freebuffers);

--- a/net/udp/udp_conn.c
+++ b/net/udp/udp_conn.c
@@ -88,7 +88,7 @@ struct udp_conn_s g_udp_connections[CONFIG_NET_UDP_CONNS];
 /* A list of all free UDP connections */
 
 static dq_queue_t g_free_udp_connections;
-static sem_t g_free_sem;
+static sem_t g_free_sem = SEM_INITIALIZER(1);
 
 /* A list of all allocated UDP connections */
 
@@ -580,15 +580,7 @@ void udp_initialize(void)
 {
 #ifndef CONFIG_NET_ALLOC_CONNS
   int i;
-#endif
 
-  /* Initialize the queues */
-
-  dq_init(&g_free_udp_connections);
-  dq_init(&g_active_udp_connections);
-  nxsem_init(&g_free_sem, 0, 1);
-
-#ifndef CONFIG_NET_ALLOC_CONNS
   for (i = 0; i < CONFIG_NET_UDP_CONNS; i++)
     {
       /* Mark the connection closed and move it to the free list */

--- a/net/usrsock/usrsock_conn.c
+++ b/net/usrsock/usrsock_conn.c
@@ -53,7 +53,7 @@ static struct usrsock_conn_s g_usrsock_connections[CONFIG_NET_USRSOCK_CONNS];
 /* A list of all free usrsock connections */
 
 static dq_queue_t g_free_usrsock_connections;
-static sem_t g_free_sem;
+static sem_t g_free_sem = SEM_INITIALIZER(1);
 
 /* A list of all allocated usrsock connections */
 
@@ -333,15 +333,7 @@ void usrsock_initialize(void)
 #ifndef CONFIG_NET_ALLOC_CONNS
   FAR struct usrsock_conn_s *conn;
   int i;
-#endif
 
-  /* Initialize the queues */
-
-  dq_init(&g_free_usrsock_connections);
-  dq_init(&g_active_usrsock_connections);
-  nxsem_init(&g_free_sem, 0, 1);
-
-#ifndef CONFIG_NET_ALLOC_CONNS
   for (i = 0; i < CONFIG_NET_USRSOCK_CONNS; i++)
     {
       conn = &g_usrsock_connections[i];

--- a/sched/init/nx_start.c
+++ b/sched/init/nx_start.c
@@ -668,6 +668,12 @@ void nx_start(void)
   net_initialize();
 #endif
 
+#ifndef CONFIG_BINFMT_DISABLE
+  /* Initialize the binfmt system */
+
+  binfmt_initialize();
+#endif
+
   /* Initialize Hardware Facilities *****************************************/
 
   /* The processor specific details of running the operating system
@@ -692,12 +698,6 @@ void nx_start(void)
   g_nx_initstate = OSINIT_HARDWARE;
 
   /* Setup for Multi-Tasking ************************************************/
-
-#ifndef CONFIG_BINFMT_DISABLE
-  /* Initialize the binfmt system */
-
-  binfmt_initialize();
-#endif
 
   /* Announce that the CPU0 IDLE task has started */
 

--- a/sched/init/nx_start.c
+++ b/sched/init/nx_start.c
@@ -37,7 +37,6 @@
 #include <nuttx/net/net.h>
 #include <nuttx/mm/iob.h>
 #include <nuttx/mm/mm.h>
-#include <nuttx/mm/shm.h>
 #include <nuttx/kmalloc.h>
 #include <nuttx/sched_note.h>
 #include <nuttx/syslog/syslog.h>
@@ -705,12 +704,6 @@ void nx_start(void)
   g_nx_initstate = OSINIT_HARDWARE;
 
   /* Setup for Multi-Tasking ************************************************/
-
-#ifdef CONFIG_MM_SHM
-  /* Initialize shared memory support */
-
-  shm_initialize();
-#endif
 
 #ifndef CONFIG_BINFMT_DISABLE
   /* Initialize the binfmt system */

--- a/sched/init/nx_start.c
+++ b/sched/init/nx_start.c
@@ -46,11 +46,8 @@
 
 #include "sched/sched.h"
 #include "signal/signal.h"
-#include "wdog/wdog.h"
 #include "semaphore/semaphore.h"
-#ifndef CONFIG_DISABLE_MQUEUE
-#  include "mqueue/mqueue.h"
-#endif
+#include "mqueue/mqueue.h"
 #include "clock/clock.h"
 #include "timer/timer.h"
 #include "irq/irq.h"
@@ -625,15 +622,6 @@ void nx_start(void)
 #endif
     {
       irq_initialize();
-    }
-
-  /* Initialize the watchdog facility (if included in the link) */
-
-#ifdef CONFIG_HAVE_WEAKFUNCTIONS
-  if (wd_initialize != NULL)
-#endif
-    {
-      wd_initialize();
     }
 
   /* Initialize the POSIX timer facility (if included in the link) */

--- a/sched/init/nx_start.c
+++ b/sched/init/nx_start.c
@@ -340,31 +340,6 @@ void nx_start(void)
 
   /* Initialize RTOS Data ***************************************************/
 
-  /* Initialize all task lists */
-
-  dq_init(&g_readytorun);
-  dq_init(&g_pendingtasks);
-  dq_init(&g_waitingforsemaphore);
-  dq_init(&g_waitingforsignal);
-#ifndef CONFIG_DISABLE_MQUEUE
-  dq_init(&g_waitingformqnotfull);
-  dq_init(&g_waitingformqnotempty);
-#endif
-#ifdef CONFIG_PAGING
-  dq_init(&g_waitingforfill);
-#endif
-#ifdef CONFIG_SIG_SIGSTOP_ACTION
-  dq_init(&g_stoppedtasks);
-#endif
-  dq_init(&g_inactivetasks);
-
-#ifdef CONFIG_SMP
-  for (i = 0; i < CONFIG_SMP_NCPUS; i++)
-    {
-      dq_init(&g_assignedtasks[i]);
-    }
-#endif
-
   /* Initialize the IDLE task TCB *******************************************/
 
   for (i = 0; i < CONFIG_SMP_NCPUS; i++)
@@ -443,11 +418,10 @@ void nx_start(void)
        * stack and there is no support that yet.
        */
 
-      g_idleargv[i][0]  = g_idletcb[i].cmn.name;
+      g_idleargv[i][0] = g_idletcb[i].cmn.name;
 #else
-      g_idleargv[i][0]  = (FAR char *)g_idlename;
+      g_idleargv[i][0] = (FAR char *)g_idlename;
 #endif /* CONFIG_TASK_NAME_SIZE */
-      g_idleargv[i][1]  = NULL;
 
       /* Then add the idle task's TCB to the head of the current ready to
        * run list.

--- a/sched/irq/irq_initialize.c
+++ b/sched/irq/irq_initialize.c
@@ -73,17 +73,6 @@ void irq_initialize(void)
   for (i = 0; i < TAB_SIZE; i++)
     {
       g_irqvector[i].handler = irq_unexpected_isr;
-      g_irqvector[i].arg     = NULL;
-#ifdef CONFIG_SCHED_IRQMONITOR
-      g_irqvector[i].start   = 0;
-#ifdef CONFIG_HAVE_LONG_LONG
-      g_irqvector[i].count   = 0;
-#else
-      g_irqvector[i].mscount = 0;
-      g_irqvector[i].lscount = 0;
-#endif
-      g_irqvector[i].time    = 0;
-#endif
     }
 
 #ifdef CONFIG_IRQCHAIN

--- a/sched/wdog/wd_initialize.c
+++ b/sched/wdog/wd_initialize.c
@@ -50,29 +50,3 @@ clock_t g_wdtickbase;
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
-
-/****************************************************************************
- * Name: wd_initialize
- *
- * Description:
- * This function initializes the watchdog data structures
- *
- * Input Parameters:
- *   None
- *
- * Returned Value:
- *   None
- *
- * Assumptions:
- *   This function must be called early in the initialization sequence
- *   before the timer interrupt is attached and before any watchdog
- *   services are used.
- *
- ****************************************************************************/
-
-void wd_initialize(void)
-{
-  /* Initialize watchdog lists */
-
-  sq_init(&g_wdactivelist);
-}

--- a/sched/wdog/wdog.h
+++ b/sched/wdog/wdog.h
@@ -87,27 +87,6 @@ extern clock_t g_wdtickbase;
  ****************************************************************************/
 
 /****************************************************************************
- * Name: wd_initialize
- *
- * Description:
- * This function initializes the watchdog data structures
- *
- * Input Parameters:
- *   None
- *
- * Returned Value:
- *   None
- *
- * Assumptions:
- *   This function must be called early in the initialization sequence
- *   before the timer interrupt is attached and before any watchdog
- *   services are used.
- *
- ****************************************************************************/
-
-void weak_function wd_initialize(void);
-
-/****************************************************************************
  * Name: wd_timer
  *
  * Description:


### PR DESCRIPTION
## Summary

- fs: Initialize g_inode_sem at the definition place
- mm/shm: Initialize shm_info_s at the definition place 
- sched/wdog: Remove wd_initialize which isn't really used anymore
- mm/iob: Remove initialized static variable inside iob_initialize 
- sched/irq: Remove the code which zero out g_irqvector fields
- sched/init: Move binfmt_initialize before hardware initialization 

## Impact
Minor, code refactor

## Testing
Pass CI and local test

