### PR TITLE
ESP32-S3: Stall Timer ISR when core 1 is temporarily stalled

### DIFF
--- a/arch/xtensa/src/esp32s3/esp32s3_tickless.c
+++ b/arch/xtensa/src/esp32s3/esp32s3_tickless.c
@@ -479,6 +479,9 @@ void up_timer_initialize(void)
   /* Stall systimer 0 when CPU stalls, e.g., when using JTAG to debug */
 
   modifyreg32(SYSTIMER_CONF_REG, 0, SYSTIMER_TIMER_UNIT0_CORE0_STALL_EN);
+#ifdef CONFIG_SMP
+  modifyreg32(SYSTIMER_CONF_REG, 0, SYSTIMER_TIMER_UNIT0_CORE1_STALL_EN);
+#endif
 }
 
 #endif /* CONFIG_SCHED_TICKLESS */

--- a/arch/xtensa/src/esp32s3/esp32s3_timerisr.c
+++ b/arch/xtensa/src/esp32s3/esp32s3_timerisr.c
@@ -130,6 +130,9 @@ void up_timer_initialize(void)
   /* Stall systimer 0 when CPU stalls, e.g., when using JTAG to debug */
 
   modifyreg32(SYSTIMER_CONF_REG, 0, SYSTIMER_TIMER_UNIT0_CORE0_STALL_EN);
+#ifdef CONFIG_SMP
+  modifyreg32(SYSTIMER_CONF_REG, 0, SYSTIMER_TIMER_UNIT0_CORE1_STALL_EN);
+#endif
 
   /* Enable interrupt */
 

--- a/arch/xtensa/src/esp32s3/esp32s3_timerisr.c
+++ b/arch/xtensa/src/esp32s3/esp32s3_timerisr.c
@@ -119,7 +119,7 @@ void up_timer_initialize(void)
   modifyreg32(SYSTEM_PERIP_RST_EN0_REG, SYSTEM_SYSTIMER_RST, 0);
   modifyreg32(SYSTIMER_CONF_REG, 0, SYSTIMER_CLK_EN);
 
-  /* Configure alarm0 (Comparator 0) */
+  /* Configure alarm 0 (Comparator 0) */
 
   regval = SYSTIMER_TARGET0_PERIOD_MODE |
            ((ESP32S3_SYSTIMER_TICKS_PER_SEC / CLOCKS_PER_SEC) <<
@@ -138,9 +138,9 @@ void up_timer_initialize(void)
 
   modifyreg32(SYSTIMER_INT_CLR_REG, 0, SYSTIMER_TARGET0_INT_CLR);
   modifyreg32(SYSTIMER_INT_ENA_REG, 0, SYSTIMER_TARGET0_INT_ENA);
+
+  /* Start alarm 0 and counter 0 */
+
   modifyreg32(SYSTIMER_CONF_REG, 0, SYSTIMER_TARGET0_WORK_EN);
-
-  /* Start alarm0 counter0 */
-
   modifyreg32(SYSTIMER_CONF_REG, 0, SYSTIMER_TIMER_UNIT0_WORK_EN);
 }


### PR DESCRIPTION
## Summary
This PR intends to add a preventive fix for the behavior of Systimer during debugging with `CONFIG_SMP` enabled, where it could keep running while the debugger temporarily stalls core 1.

## Impact
In practice, this is currently not an issue due to `openocd-esp32` always stopping both CPUs around the same time.
Should have no immediate impact.

## Testing
Validated with `esp32s3-devkit:nsh` and `esp32s3-devkit:tickless`, with `CONFIG_SMP` enabled and disabled.
