### PR TITLE
Optimize network subsystem initialization

### DIFF
--- a/net/bluetooth/bluetooth_conn.c
+++ b/net/bluetooth/bluetooth_conn.c
@@ -90,14 +90,7 @@ void bluetooth_conn_initialize(void)
 {
 #ifndef CONFIG_NET_ALLOC_CONNS
   int i;
-#endif
 
-  /* Initialize the queues */
-
-  dq_init(&g_free_bluetooth_connections);
-  dq_init(&g_active_bluetooth_connections);
-
-#ifndef CONFIG_NET_ALLOC_CONNS
   for (i = 0; i < CONFIG_NET_BLUETOOTH_NCONNS; i++)
     {
       /* Link each pre-allocated connection structure into the free list. */

--- a/net/can/can_conn.c
+++ b/net/can/can_conn.c
@@ -56,7 +56,7 @@ static struct can_conn_s g_can_connections[CONFIG_CAN_CONNS];
 /* A list of all free NetLink connections */
 
 static dq_queue_t g_free_can_connections;
-static sem_t g_free_sem;
+static sem_t g_free_sem = SEM_INITIALIZER(1);
 
 /* A list of all allocated NetLink connections */
 
@@ -101,15 +101,7 @@ void can_initialize(void)
 {
 #ifndef CONFIG_NET_ALLOC_CONNS
   int i;
-#endif
 
-  /* Initialize the queues */
-
-  dq_init(&g_free_can_connections);
-  dq_init(&g_active_can_connections);
-  nxsem_init(&g_free_sem, 0, 1);
-
-#ifndef CONFIG_NET_ALLOC_CONNS
   for (i = 0; i < CONFIG_CAN_CONNS; i++)
     {
       /* Mark the connection closed and move it to the free list */

--- a/net/icmp/icmp_conn.c
+++ b/net/icmp/icmp_conn.c
@@ -55,7 +55,7 @@ static struct icmp_conn_s g_icmp_connections[CONFIG_NET_ICMP_NCONNS];
 /* A list of all free IPPROTO_ICMP socket connections */
 
 static dq_queue_t g_free_icmp_connections;
-static sem_t g_free_sem;
+static sem_t g_free_sem = SEM_INITIALIZER(1);
 
 /* A list of all allocated IPPROTO_ICMP socket connections */
 
@@ -78,15 +78,7 @@ void icmp_sock_initialize(void)
 {
 #ifndef CONFIG_NET_ALLOC_CONNS
   int i;
-#endif
 
-  /* Initialize the queues */
-
-  dq_init(&g_free_icmp_connections);
-  dq_init(&g_active_icmp_connections);
-  nxsem_init(&g_free_sem, 0, 1);
-
-#ifndef CONFIG_NET_ALLOC_CONNS
   for (i = 0; i < CONFIG_NET_ICMP_NCONNS; i++)
     {
       /* Move the connection structure to the free list */

--- a/net/icmpv6/icmpv6_conn.c
+++ b/net/icmpv6/icmpv6_conn.c
@@ -55,7 +55,7 @@ static struct icmpv6_conn_s g_icmpv6_connections[CONFIG_NET_ICMPv6_NCONNS];
 /* A list of all free IPPROTO_ICMP socket connections */
 
 static dq_queue_t g_free_icmpv6_connections;
-static sem_t g_free_sem;
+static sem_t g_free_sem = SEM_INITIALIZER(1);
 
 /* A list of all allocated IPPROTO_ICMP socket connections */
 
@@ -78,15 +78,7 @@ void icmpv6_sock_initialize(void)
 {
 #ifndef CONFIG_NET_ALLOC_CONNS
   int i;
-#endif
 
-  /* Initialize the queues */
-
-  dq_init(&g_free_icmpv6_connections);
-  dq_init(&g_active_icmpv6_connections);
-  nxsem_init(&g_free_sem, 0, 1);
-
-#ifndef CONFIG_NET_ALLOC_CONNS
   for (i = 0; i < CONFIG_NET_ICMPv6_NCONNS; i++)
     {
       /* Move the connection structure to the free list */

--- a/net/ieee802154/ieee802154_conn.c
+++ b/net/ieee802154/ieee802154_conn.c
@@ -84,14 +84,7 @@ void ieee802154_conn_initialize(void)
 {
 #ifndef CONFIG_NET_ALLOC_CONNS
   int i;
-#endif
 
-  /* Initialize the queues */
-
-  dq_init(&g_free_ieee802154_connections);
-  dq_init(&g_active_ieee802154_connections);
-
-#ifndef CONFIG_NET_ALLOC_CONNS
   for (i = 0; i < CONFIG_NET_IEEE802154_NCONNS; i++)
     {
       /* Link each pre-allocated connection structure into the free list. */

--- a/net/igmp/igmp.h
+++ b/net/igmp/igmp.h
@@ -131,8 +131,8 @@ extern "C"
 #  define EXTERN extern
 #endif
 
-EXTERN in_addr_t g_ipv4_allsystems;
-EXTERN in_addr_t g_ipv4_allrouters;
+EXTERN const in_addr_t g_ipv4_allsystems;
+EXTERN const in_addr_t g_ipv4_allrouters;
 
 /****************************************************************************
  * Public Function Prototypes
@@ -272,7 +272,7 @@ void igmp_poll(FAR struct net_driver_s *dev);
  ****************************************************************************/
 
 void igmp_send(FAR struct net_driver_s *dev, FAR struct igmp_group_s *group,
-               FAR in_addr_t *destipaddr, uint8_t msgid);
+               FAR const in_addr_t *destipaddr, uint8_t msgid);
 
 /****************************************************************************
  * Name:  igmp_joingroup
@@ -359,7 +359,7 @@ bool igmp_cmptimer(FAR struct igmp_group_s *group, int maxticks);
  *
  ****************************************************************************/
 
-void igmp_addmcastmac(FAR struct net_driver_s *dev, FAR in_addr_t *ip);
+void igmp_addmcastmac(FAR struct net_driver_s *dev, FAR const in_addr_t *ip);
 
 /****************************************************************************
  * Name:  igmp_removemcastmac
@@ -369,7 +369,8 @@ void igmp_addmcastmac(FAR struct net_driver_s *dev, FAR in_addr_t *ip);
  *
  ****************************************************************************/
 
-void igmp_removemcastmac(FAR struct net_driver_s *dev, FAR in_addr_t *ip);
+void igmp_removemcastmac(FAR struct net_driver_s *dev,
+                         FAR const in_addr_t *ip);
 
 #undef EXTERN
 #ifdef __cplusplus

--- a/net/igmp/igmp_initialize.c
+++ b/net/igmp/igmp_initialize.c
@@ -59,28 +59,12 @@
  * Public Data
  ****************************************************************************/
 
-in_addr_t g_ipv4_allsystems;
-in_addr_t g_ipv4_allrouters;
+const in_addr_t g_ipv4_allsystems = HTONL(0xe0000001);
+const in_addr_t g_ipv4_allrouters = HTONL(0xe0000002);
 
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
-
-/****************************************************************************
- * Name:  igmp_initialize
- *
- * Description:
- *   Perform one-time IGMP initialization.
- *
- ****************************************************************************/
-
-void igmp_initialize(void)
-{
-  ninfo("IGMP initializing\n");
-
-  net_ipaddr(g_ipv4_allrouters, 224, 0, 0, 2);
-  net_ipaddr(g_ipv4_allsystems, 224, 0, 0, 1);
-}
 
 /****************************************************************************
  * Name:  igmp_devinit

--- a/net/igmp/igmp_mcastmac.c
+++ b/net/igmp/igmp_mcastmac.c
@@ -70,7 +70,7 @@
  *
  ****************************************************************************/
 
-static void igmp_mcastmac(in_addr_t *ip, FAR uint8_t *mac)
+static void igmp_mcastmac(FAR const in_addr_t *ip, FAR uint8_t *mac)
 {
   /* This mapping is from the IETF IN RFC 1700 */
 
@@ -97,7 +97,7 @@ static void igmp_mcastmac(in_addr_t *ip, FAR uint8_t *mac)
  *
  ****************************************************************************/
 
-void igmp_addmcastmac(FAR struct net_driver_s *dev, FAR in_addr_t *ip)
+void igmp_addmcastmac(FAR struct net_driver_s *dev, FAR const in_addr_t *ip)
 {
   uint8_t mcastmac[6];
 
@@ -117,7 +117,8 @@ void igmp_addmcastmac(FAR struct net_driver_s *dev, FAR in_addr_t *ip)
  *
  ****************************************************************************/
 
-void igmp_removemcastmac(FAR struct net_driver_s *dev, FAR in_addr_t *ip)
+void igmp_removemcastmac(FAR struct net_driver_s *dev,
+                         FAR const in_addr_t *ip)
 {
   uint8_t mcastmac[6];
 

--- a/net/igmp/igmp_poll.c
+++ b/net/igmp/igmp_poll.c
@@ -90,7 +90,7 @@
 static inline void igmp_sched_send(FAR struct net_driver_s *dev,
                                    FAR struct igmp_group_s *group)
 {
-  in_addr_t *dest;
+  FAR const in_addr_t *dest;
 
   /* REVISIT:  This should be deferred to a work queue */
 

--- a/net/igmp/igmp_send.c
+++ b/net/igmp/igmp_send.c
@@ -102,7 +102,7 @@ static uint16_t igmp_chksum(FAR uint8_t *buffer, int buflen)
  ****************************************************************************/
 
 void igmp_send(FAR struct net_driver_s *dev, FAR struct igmp_group_s *group,
-               FAR in_addr_t *destipaddr, uint8_t msgid)
+               FAR const in_addr_t *destipaddr, uint8_t msgid)
 {
   FAR struct igmp_iphdr_s *ipv4 = IPv4BUF;
   FAR struct igmp_hdr_s *igmp;

--- a/net/local/local.h
+++ b/net/local/local.h
@@ -204,17 +204,6 @@ struct sockaddr; /* Forward reference */
 struct socket;   /* Forward reference */
 
 /****************************************************************************
- * Name: local_initialize
- *
- * Description:
- *   Initialize the local, Unix domain connection structures.  Called once
- *   and only from the common network initialization logic.
- *
- ****************************************************************************/
-
-void local_initialize(void);
-
-/****************************************************************************
  * Name: local_alloc
  *
  * Description:

--- a/net/local/local_conn.c
+++ b/net/local/local_conn.c
@@ -48,20 +48,6 @@ static dq_queue_t g_local_connections;
  ****************************************************************************/
 
 /****************************************************************************
- * Name: local_initialize
- *
- * Description:
- *   Initialize the local, Unix domain connection structures.  Called once
- *   and only from the common network initialization logic.
- *
- ****************************************************************************/
-
-void local_initialize(void)
-{
-  dq_init(&g_local_connections);
-}
-
-/****************************************************************************
  * Name: local_nextconn
  *
  * Description:

--- a/net/net_initialize.c
+++ b/net/net_initialize.c
@@ -43,7 +43,6 @@
 #include "ieee802154/ieee802154.h"
 #include "can/can.h"
 #include "netlink/netlink.h"
-#include "igmp/igmp.h"
 #include "route/route.h"
 #include "usrsock/usrsock.h"
 
@@ -156,12 +155,6 @@ void net_initialize(void)
 #ifdef CONFIG_NET_UDP_WRITE_BUFFERS
   udp_wrbuffer_initialize();
 #endif
-#endif
-
-#ifdef CONFIG_NET_IGMP
-  /* Initialize IGMP support */
-
-  igmp_initialize();
 #endif
 
 #ifdef CONFIG_NET_ROUTE

--- a/net/net_initialize.c
+++ b/net/net_initialize.c
@@ -137,10 +137,6 @@ void net_initialize(void)
 #endif
 
 #ifdef NET_TCP_HAVE_STACK
-  /* Initialize the listening port structures */
-
-  tcp_listen_initialize();
-
   /* Initialize the TCP/IP connection structures */
 
   tcp_initialize();

--- a/net/net_initialize.c
+++ b/net/net_initialize.c
@@ -47,7 +47,6 @@
 #include "igmp/igmp.h"
 #include "route/route.h"
 #include "usrsock/usrsock.h"
-#include "utils/utils.h"
 
 /****************************************************************************
  * Public Functions
@@ -78,10 +77,6 @@
 
 void net_initialize(void)
 {
-  /* Initialize the locking facility */
-
-  net_lockinitialize();
-
 #ifdef CONFIG_NET_IPv6
 #ifdef CONFIG_NET_6LOWPAN
   /* Initialize 6LoWPAN data structures */

--- a/net/net_initialize.c
+++ b/net/net_initialize.c
@@ -41,7 +41,6 @@
 #include "pkt/pkt.h"
 #include "bluetooth/bluetooth.h"
 #include "ieee802154/ieee802154.h"
-#include "local/local.h"
 #include "can/can.h"
 #include "netlink/netlink.h"
 #include "igmp/igmp.h"
@@ -123,12 +122,6 @@ void net_initialize(void)
   /* Initialize IEEE 802.15.4  socket support */
 
   ieee802154_initialize();
-#endif
-
-#ifdef CONFIG_NET_LOCAL
-  /* Initialize the local, "Unix domain" socket support */
-
-  local_initialize();
 #endif
 
 #ifdef CONFIG_NET_CAN

--- a/net/net_initialize.c
+++ b/net/net_initialize.c
@@ -75,6 +75,46 @@
 
 void net_initialize(void)
 {
+  /* Initialize the device interface layer */
+
+  devif_initialize();
+
+#ifdef CONFIG_NET_BLUETOOTH
+  /* Initialize Bluetooth  socket support */
+
+  bluetooth_initialize();
+#endif
+
+#ifdef CONFIG_NET_CAN
+  /* Initialize SocketCAN support */
+
+  can_initialize();
+#endif
+
+#ifdef CONFIG_NET_IEEE802154
+  /* Initialize IEEE 802.15.4  socket support */
+
+  ieee802154_initialize();
+#endif
+
+#ifdef CONFIG_NET_NETLINK
+  /* Initialize the Netlink IPC support */
+
+  netlink_initialize();
+#endif
+
+#ifdef CONFIG_NET_PKT
+  /* Initialize packet socket support */
+
+  pkt_initialize();
+#endif
+
+#ifdef CONFIG_NET_ROUTE
+  /* Initialize the routing table */
+
+  net_init_route();
+#endif
+
 #ifdef CONFIG_NET_IPv6
 #ifdef CONFIG_NET_6LOWPAN
   /* Initialize 6LoWPAN data structures */
@@ -83,20 +123,10 @@ void net_initialize(void)
 #endif
 #endif /* CONFIG_NET_IPv6 */
 
-  /* Initialize the device interface layer */
-
-  devif_initialize();
-
 #ifdef HAVE_FWDALLOC
   /* Initialize IP forwarding support */
 
   ipfwd_initialize();
-#endif
-
-#ifdef CONFIG_NET_PKT
-  /* Initialize packet socket support */
-
-  pkt_initialize();
 #endif
 
 #ifdef CONFIG_NET_ICMP_SOCKET
@@ -109,30 +139,6 @@ void net_initialize(void)
   /* Initialize IPPPROTO_ICMP6 socket support */
 
   icmpv6_sock_initialize();
-#endif
-
-#ifdef CONFIG_NET_BLUETOOTH
-  /* Initialize Bluetooth  socket support */
-
-  bluetooth_initialize();
-#endif
-
-#ifdef CONFIG_NET_IEEE802154
-  /* Initialize IEEE 802.15.4  socket support */
-
-  ieee802154_initialize();
-#endif
-
-#ifdef CONFIG_NET_CAN
-  /* Initialize SocketCAN support */
-
-  can_initialize();
-#endif
-
-#ifdef CONFIG_NET_NETLINK
-  /* Initialize the Netlink IPC support */
-
-  netlink_initialize();
 #endif
 
 #ifdef NET_TCP_HAVE_STACK
@@ -155,12 +161,6 @@ void net_initialize(void)
 #ifdef CONFIG_NET_UDP_WRITE_BUFFERS
   udp_wrbuffer_initialize();
 #endif
-#endif
-
-#ifdef CONFIG_NET_ROUTE
-  /* Initialize the routing table */
-
-  net_init_route();
 #endif
 
 #ifdef CONFIG_NET_USRSOCK

--- a/net/netlink/netlink_conn.c
+++ b/net/netlink/netlink_conn.c
@@ -57,7 +57,7 @@ static struct netlink_conn_s g_netlink_connections[CONFIG_NETLINK_CONNS];
 /* A list of all free NetLink connections */
 
 static dq_queue_t g_free_netlink_connections;
-static sem_t g_free_sem;
+static sem_t g_free_sem = SEM_INITIALIZER(1);
 
 /* A list of all allocated NetLink connections */
 
@@ -125,15 +125,7 @@ void netlink_initialize(void)
 {
 #ifndef CONFIG_NET_ALLOC_CONNS
   int i;
-#endif
 
-  /* Initialize the queues */
-
-  dq_init(&g_free_netlink_connections);
-  dq_init(&g_active_netlink_connections);
-  nxsem_init(&g_free_sem, 0, 1);
-
-#ifndef CONFIG_NET_ALLOC_CONNS
   for (i = 0; i < CONFIG_NETLINK_CONNS; i++)
     {
       /* Mark the connection closed and move it to the free list */

--- a/net/pkt/pkt_conn.c
+++ b/net/pkt/pkt_conn.c
@@ -63,7 +63,7 @@ static struct pkt_conn_s g_pkt_connections[CONFIG_NET_PKT_CONNS];
 /* A list of all free packet socket connections */
 
 static dq_queue_t g_free_pkt_connections;
-static sem_t g_free_sem;
+static sem_t g_free_sem = SEM_INITIALIZER(1);
 
 /* A list of all allocated packet socket connections */
 
@@ -105,15 +105,7 @@ void pkt_initialize(void)
 {
 #ifndef CONFIG_NET_ALLOC_CONNS
   int i;
-#endif
 
-  /* Initialize the queues */
-
-  dq_init(&g_free_pkt_connections);
-  dq_init(&g_active_pkt_connections);
-  nxsem_init(&g_free_sem, 0, 1);
-
-#ifndef CONFIG_NET_ALLOC_CONNS
   for (i = 0; i < CONFIG_NET_PKT_CONNS; i++)
     {
       dq_addlast(&g_pkt_connections[i].sconn.node, &g_free_pkt_connections);

--- a/net/route/fileroute.h
+++ b/net/route/fileroute.h
@@ -47,25 +47,6 @@
 struct file; /* Forward reference */
 
 /****************************************************************************
- * Name: net_init_fileroute
- *
- * Description:
- *   Initialize the in-memory, RAM routing table
- *
- * Input Parameters:
- *   None
- *
- * Returned Value:
- *   None
- *
- * Assumptions:
- *   Called early in initialization so that no special protection is needed.
- *
- ****************************************************************************/
-
-void net_init_fileroute(void);
-
-/****************************************************************************
  * Name: net_openroute_ipv4/net_openroute_ipv6
  *
  * Description:

--- a/net/route/net_cacheroute.c
+++ b/net/route/net_cacheroute.c
@@ -122,7 +122,7 @@ static struct net_cache_ipv4_entry_s
 
 /* Serializes access to the routing table cache */
 
-static sem_t g_ipv4_cachelock;
+static sem_t g_ipv4_cachelock = SEM_INITIALIZER(1);
 #endif
 
 #if defined(CONFIG_ROUTE_IPv6_CACHEROUTE)
@@ -141,7 +141,7 @@ static struct net_cache_ipv6_entry_s
 
 /* Serializes access to the routing table cache */
 
-static sem_t g_ipv6_cachelock;
+static sem_t g_ipv6_cachelock = SEM_INITIALIZER(1);
 #endif
 
 /****************************************************************************
@@ -481,12 +481,10 @@ void net_init_cacheroute(void)
   /* Initialize the routing table cash and the free list */
 
 #ifdef CONFIG_ROUTE_IPv4_CACHEROUTE
-  nxsem_init(&g_ipv4_cachelock, 0, 1);
   net_reset_ipv4_cache();
 #endif
 
 #ifdef CONFIG_ROUTE_IPv6_CACHEROUTE
-  nxsem_init(&g_ipv6_cachelock, 0, 1);
   net_reset_ipv6_cache();
 #endif
 }

--- a/net/route/net_fileroute.c
+++ b/net/route/net_fileroute.c
@@ -56,7 +56,7 @@
 #ifdef CONFIG_ROUTE_IPv4_FILEROUTE
 /* Semaphore used to lock a routing table for exclusive write-only access */
 
-static sem_t g_ipv4_exclsem;
+static sem_t g_ipv4_exclsem = SEM_INITIALIZER(1);
 static pid_t g_ipv4_holder = NO_HOLDER;
 static int g_ipv4_count;
 #endif
@@ -64,7 +64,7 @@ static int g_ipv4_count;
 #ifdef CONFIG_ROUTE_IPv6_FILEROUTE
 /* Semaphore used to lock a routing table for exclusive write-only access */
 
-static sem_t g_ipv6_exclsem;
+static sem_t g_ipv6_exclsem = SEM_INITIALIZER(1);
 static pid_t g_ipv6_holder = NO_HOLDER;
 static int g_ipv6_count;
 #endif
@@ -179,36 +179,6 @@ int net_routesize(FAR const char *path, size_t entrysize)
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
-
-/****************************************************************************
- * Name: net_init_fileroute
- *
- * Description:
- *   Initialize the in-memory, RAM routing table
- *
- * Input Parameters:
- *   None
- *
- * Returned Value:
- *   None
- *
- * Assumptions:
- *   Called early in initialization so that no special protection is needed.
- *
- ****************************************************************************/
-
-void net_init_fileroute(void)
-{
-  /* Initialize semaphores */
-
-#ifdef CONFIG_ROUTE_IPv4_FILEROUTE
-  nxsem_init(&g_ipv4_exclsem, 0, 1);
-#endif
-
-#ifdef CONFIG_ROUTE_IPv6_FILEROUTE
-  nxsem_init(&g_ipv6_exclsem, 0, 1);
-#endif
-}
 
 /****************************************************************************
  * Name: net_openroute_ipv4/net_openroute_ipv6

--- a/net/route/net_initroute.c
+++ b/net/route/net_initroute.c
@@ -25,7 +25,6 @@
 #include <nuttx/config.h>
 
 #include "route/ramroute.h"
-#include "route/fileroute.h"
 #include "route/cacheroute.h"
 #include "route/route.h"
 
@@ -53,10 +52,6 @@ void net_init_route(void)
 {
 #if defined(CONFIG_ROUTE_IPv4_RAMROUTE) || defined(CONFIG_ROUTE_IPv6_RAMROUTE)
   net_init_ramroute();
-#endif
-
-#if defined(CONFIG_ROUTE_IPv4_FILEROUTE) || defined(CONFIG_ROUTE_IPv6_FILEROUTE)
-  net_init_fileroute();
 #endif
 
 #if defined(CONFIG_ROUTE_IPv4_CACHEROUTE) || defined(CONFIG_ROUTE_IPv6_CACHEROUTE)

--- a/net/tcp/tcp.h
+++ b/net/tcp/tcp.h
@@ -831,20 +831,6 @@ void tcp_timer(FAR struct net_driver_s *dev, FAR struct tcp_conn_s *conn,
                int hsec);
 
 /****************************************************************************
- * Name: tcp_listen_initialize
- *
- * Description:
- *   Setup the listening data structures
- *
- * Assumptions:
- *   Called early in the initialization phase while the system is still
- *   single-threaded.
- *
- ****************************************************************************/
-
-void tcp_listen_initialize(void);
-
-/****************************************************************************
  * Name: tcp_findlistener
  *
  * Description:

--- a/net/tcp/tcp_conn.c
+++ b/net/tcp/tcp_conn.c
@@ -580,16 +580,7 @@ void tcp_initialize(void)
 {
 #ifndef CONFIG_NET_ALLOC_CONNS
   int i;
-#endif
 
-  /* Initialize the queues */
-
-  dq_init(&g_free_tcp_connections);
-  dq_init(&g_active_tcp_connections);
-
-  /* Now initialize each connection structure */
-
-#ifndef CONFIG_NET_ALLOC_CONNS
   for (i = 0; i < CONFIG_NET_TCP_CONNS; i++)
     {
       /* Mark the connection closed and move it to the free list */

--- a/net/tcp/tcp_listen.c
+++ b/net/tcp/tcp_listen.c
@@ -146,27 +146,6 @@ FAR struct tcp_conn_s *tcp_findlistener(FAR union ip_binding_u *uaddr,
  ****************************************************************************/
 
 /****************************************************************************
- * Name: tcp_listen_initialize
- *
- * Description:
- *   Setup the listening data structures
- *
- * Assumptions:
- *   Called early in the initialization phase while the system is still
- *   single-threaded.
- *
- ****************************************************************************/
-
-void tcp_listen_initialize(void)
-{
-  int ndx;
-  for (ndx = 0; ndx < CONFIG_NET_MAX_LISTENPORTS; ndx++)
-    {
-      tcp_listenports[ndx] = NULL;
-    }
-}
-
-/****************************************************************************
  * Name: tcp_unlisten
  *
  * Description:

--- a/net/tcp/tcp_wrbuffer.c
+++ b/net/tcp/tcp_wrbuffer.c
@@ -94,8 +94,6 @@ void tcp_wrbuffer_initialize(void)
 {
   int i;
 
-  sq_init(&g_wrbuffer.freebuffers);
-
   for (i = 0; i < CONFIG_NET_TCP_NWRBCHAINS; i++)
     {
       sq_addfirst(&g_wrbuffer.buffers[i].wb_node, &g_wrbuffer.freebuffers);

--- a/net/udp/udp_conn.c
+++ b/net/udp/udp_conn.c
@@ -88,7 +88,7 @@ struct udp_conn_s g_udp_connections[CONFIG_NET_UDP_CONNS];
 /* A list of all free UDP connections */
 
 static dq_queue_t g_free_udp_connections;
-static sem_t g_free_sem;
+static sem_t g_free_sem = SEM_INITIALIZER(1);
 
 /* A list of all allocated UDP connections */
 
@@ -580,15 +580,7 @@ void udp_initialize(void)
 {
 #ifndef CONFIG_NET_ALLOC_CONNS
   int i;
-#endif
 
-  /* Initialize the queues */
-
-  dq_init(&g_free_udp_connections);
-  dq_init(&g_active_udp_connections);
-  nxsem_init(&g_free_sem, 0, 1);
-
-#ifndef CONFIG_NET_ALLOC_CONNS
   for (i = 0; i < CONFIG_NET_UDP_CONNS; i++)
     {
       /* Mark the connection closed and move it to the free list */

--- a/net/usrsock/usrsock_conn.c
+++ b/net/usrsock/usrsock_conn.c
@@ -53,7 +53,7 @@ static struct usrsock_conn_s g_usrsock_connections[CONFIG_NET_USRSOCK_CONNS];
 /* A list of all free usrsock connections */
 
 static dq_queue_t g_free_usrsock_connections;
-static sem_t g_free_sem;
+static sem_t g_free_sem = SEM_INITIALIZER(1);
 
 /* A list of all allocated usrsock connections */
 
@@ -333,15 +333,7 @@ void usrsock_initialize(void)
 #ifndef CONFIG_NET_ALLOC_CONNS
   FAR struct usrsock_conn_s *conn;
   int i;
-#endif
 
-  /* Initialize the queues */
-
-  dq_init(&g_free_usrsock_connections);
-  dq_init(&g_active_usrsock_connections);
-  nxsem_init(&g_free_sem, 0, 1);
-
-#ifndef CONFIG_NET_ALLOC_CONNS
   for (i = 0; i < CONFIG_NET_USRSOCK_CONNS; i++)
     {
       conn = &g_usrsock_connections[i];

--- a/net/utils/net_lock.c
+++ b/net/utils/net_lock.c
@@ -49,9 +49,9 @@
  * Private Data
  ****************************************************************************/
 
-static sem_t        g_netlock;
-static pid_t        g_holder = NO_HOLDER;
-static unsigned int g_count  = 0;
+static sem_t        g_netlock = SEM_INITIALIZER(1);
+static pid_t        g_holder  = NO_HOLDER;
+static unsigned int g_count;
 
 /****************************************************************************
  * Private Functions
@@ -148,19 +148,6 @@ _net_timedwait(sem_t *sem, bool interruptible, unsigned int timeout)
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
-
-/****************************************************************************
- * Name: net_lockinitialize
- *
- * Description:
- *   Initialize the locking facility
- *
- ****************************************************************************/
-
-void net_lockinitialize(void)
-{
-  nxsem_init(&g_netlock, 0, 1);
-}
 
 /****************************************************************************
  * Name: net_lock

--- a/net/utils/utils.h
+++ b/net/utils/utils.h
@@ -62,16 +62,6 @@ struct net_driver_s;      /* Forward reference */
 struct timeval;           /* Forward reference */
 
 /****************************************************************************
- * Name: net_lockinitialize
- *
- * Description:
- *   Initialize the locking facility
- *
- ****************************************************************************/
-
-void net_lockinitialize(void);
-
-/****************************************************************************
  * Name: net_breaklock
  *
  * Description:


### PR DESCRIPTION
## Summary

- net: Remove net_lockinitialize
- net/local: Remove local_initialize 
- net/tcp: Remove tcp_listen_initialize
- net/route: Remove net_init_fileroute
- net/igmp: Remove igmp_initialize 
- net: Remove the unnecessary initialization code
- net: Reoder the initialize sequence(mac->ip->tcp/udp) 

## Impact
Minor, code refactor

## Testing
Pass CI
