### PR TITLE
arch/xtensa: Small improvements around xtensa_context

### DIFF
--- a/arch/xtensa/include/irq.h
+++ b/arch/xtensa/include/irq.h
@@ -106,13 +106,10 @@
 #endif
 
 #ifndef __XTENSA_CALL0_ABI__
-  /* Temporary space for saving stuff during window spill.
-   * REVISIT: I don't think that we need so many temporaries.
-   */
+  /* Temporary space for saving stuff during window spill. */
 
 #  define REG_TMP0          (_REG_WINDOW_TMPS + 0)
-#  define REG_TMP1          (_REG_WINDOW_TMPS + 1)
-#  define _REG_OVLY_START   (_REG_WINDOW_TMPS + 2)
+#  define _REG_OVLY_START   (_REG_WINDOW_TMPS + 1)
 #else
 #  define _REG_OVLY_START   _REG_WINDOW_TMPS
 #endif

--- a/arch/xtensa/src/common/xtensa_asm_utils.h
+++ b/arch/xtensa/src/common/xtensa_asm_utils.h
@@ -1,0 +1,76 @@
+/****************************************************************************
+ * arch/xtensa/src/common/xtensa_asm_utils.h
+ *
+ * Copyright (c) 2017, Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ ****************************************************************************/
+
+#ifndef __ARCH_XTENSA_SRC_COMMON_XTENSA_ASM_UTILS_H
+#define __ARCH_XTENSA_SRC_COMMON_XTENSA_ASM_UTILS_H
+
+/****************************************************************************
+ * Assembly Language Macros
+ ****************************************************************************/
+
+/****************************************************************************
+ *
+ * Name: SPILL_ALL_WINDOWS
+ *
+ * Spills all windowed registers (i.e. registers not visible as
+ * A0-A15) to their ABI-defined spill regions on the stack.
+ *
+ * Unlike the Xtensa HAL implementation, this code requires that the
+ * EXCM and WOE bit be enabled in PS, and relies on repeated hardware
+ * exception handling to do the register spills.  The trick is to do a
+ * noop write to the high registers, which the hardware will trap
+ * (into an overflow exception) in the case where those registers are
+ * already used by an existing call frame.  Then it rotates the window
+ * and repeats until all but the A0-A3 registers of the original frame
+ * are guaranteed to be spilled, eventually rotating back around into
+ * the original frame.  Advantages:
+ *
+ * - Vastly smaller code size
+ *
+ * - More easily maintained if changes are needed to window over/underflow
+ *   exception handling.
+ *
+ * - Requires no scratch registers to do its work, so can be used safely in
+ *   any context.
+ *
+ * - If the WOE bit is not enabled (for example, in code written for
+ *   the CALL0 ABI), this becomes a silent noop and operates compatbily.
+ *
+ * - Hilariously it's ACTUALLY FASTER than the HAL routine.  And not
+ *   just a little bit, it's MUCH faster.  With a mostly full register
+ *   file on an LX6 core (ESP-32) I'm measuring 145 cycles to spill
+ *   registers with this vs. 279 (!) to do it with
+ *   xthal_spill_windows().
+ ****************************************************************************/
+
+.macro SPILL_ALL_WINDOWS
+#if XCHAL_NUM_AREGS == 64
+  and a12, a12, a12
+  rotw 3
+  and a12, a12, a12
+  rotw 3
+  and a12, a12, a12
+  rotw 3
+  and a12, a12, a12
+  rotw 3
+  and a12, a12, a12
+  rotw 4
+#elif XCHAL_NUM_AREGS == 32
+  and a12, a12, a12
+  rotw 3
+  and a12, a12, a12
+  rotw 3
+  and a4, a4, a4
+  rotw 2
+#else
+#error Unrecognized XCHAL_NUM_AREGS
+#endif
+.endm
+
+#endif /* __ARCH_XTENSA_SRC_COMMON_XTENSA_ASM_UTILS_H */

--- a/arch/xtensa/src/common/xtensa_context.S
+++ b/arch/xtensa/src/common/xtensa_context.S
@@ -115,6 +115,7 @@
 
 _xtensa_context_save:
 
+	s32i	a3,  sp, (4 * REG_A3)
 	s32i	a4,  sp, (4 * REG_A4)
 	s32i	a5,  sp, (4 * REG_A5)
 	s32i	a6,  sp, (4 * REG_A6)
@@ -307,6 +308,7 @@ _xtensa_context_restore:
 
 	l32i	a3, a2, (4 * REG_SAR)
 	wsr		a3, SAR
+
 	l32i	a3, a2, (4 * REG_A3)
 	l32i	a4, a2, (4 * REG_A4)
 	l32i	a5, a2, (4 * REG_A5)

--- a/arch/xtensa/src/common/xtensa_context.S
+++ b/arch/xtensa/src/common/xtensa_context.S
@@ -114,34 +114,34 @@
 
 _xtensa_context_save:
 
-	s32i	a4,  a2, (4 * REG_A4)
-	s32i	a5,  a2, (4 * REG_A5)
-	s32i	a6,  a2, (4 * REG_A6)
-	s32i	a7,  a2, (4 * REG_A7)
-	s32i	a8,  a2, (4 * REG_A8)
-	s32i	a9,  a2, (4 * REG_A9)
-	s32i	a10, a2, (4 * REG_A10)
-	s32i	a11, a2, (4 * REG_A11)
+	s32i	a4,  sp, (4 * REG_A4)
+	s32i	a5,  sp, (4 * REG_A5)
+	s32i	a6,  sp, (4 * REG_A6)
+	s32i	a7,  sp, (4 * REG_A7)
+	s32i	a8,  sp, (4 * REG_A8)
+	s32i	a9,  sp, (4 * REG_A9)
+	s32i	a10, sp, (4 * REG_A10)
+	s32i	a11, sp, (4 * REG_A11)
 
 	/* Call0 ABI callee-saved regs a12-15 do not need to be saved here */
 
 #ifndef __XTENSA_CALL0_ABI__
-	s32i	a12, a2, (4 * REG_A12)
-	s32i	a13, a2, (4 * REG_A13)
-	s32i	a14, a2, (4 * REG_A14)
-	s32i	a15, a2, (4 * REG_A15)
+	s32i	a12, sp, (4 * REG_A12)
+	s32i	a13, sp, (4 * REG_A13)
+	s32i	a14, sp, (4 * REG_A14)
+	s32i	a15, sp, (4 * REG_A15)
 #endif
 
 	rsr		a3, SAR
-	s32i	a3, a2, (4 * REG_SAR)
+	s32i	a3, sp, (4 * REG_SAR)
 
 #if XCHAL_HAVE_LOOPS != 0
 	rsr		a3, LBEG
-	s32i	a3, a2, (4 * REG_LBEG)
+	s32i	a3, sp, (4 * REG_LBEG)
 	rsr		a3, LEND
-	s32i	a3, a2, (4 * REG_LEND)
+	s32i	a3, sp, (4 * REG_LEND)
 	rsr		a3, LCOUNT
-	s32i	a3, a2, (4 * REG_LCOUNT)
+	s32i	a3, sp, (4 * REG_LCOUNT)
 #endif
 
 #ifndef __XTENSA_CALL0_ABI__
@@ -160,16 +160,16 @@ _xtensa_context_save:
 #error Overlay support is not implemented
 #endif
 
-	s32i	a0, a2, (4 * REG_TMP0)			/* Save return address */
-	s32i	sp, a2, (4 * REG_TMP1)			/* Save current stack pointer */
-	wsr		a2, EXCSAVE_1					/* Preserve register save area */
+	s32i	a0, sp, (4 * REG_TMP0)			/* Save return address */
+	s32i	sp, sp, (4 * REG_TMP1)			/* Save current stack pointer */
+	wsr		sp, EXCSAVE_1					/* Preserve register save area */
 
-	l32i	sp, a2, (4 * REG_A1)			/* Restore the interruptee's SP */
+	l32i	sp, sp, (4 * REG_A1)			/* Restore the interruptee's SP */
 	call0	_xtensa_window_spill			/* Preserves only a4-a5, a8-a9, a12-a13 */
 
-	rsr		a2, EXCSAVE_1					/* Save interruptee's a0 */
-	l32i	a0, a2, (4 * REG_TMP0)			/* Save return address */
-	l32i	sp, a2, (4 * REG_TMP1)			/* Save current stack pointer */
+	rsr		sp, EXCSAVE_1					/* Save interruptee's a0 */
+	l32i	a0, sp, (4 * REG_TMP0)			/* Save return address */
+	l32i	sp, sp, (4 * REG_TMP1)			/* Save current stack pointer */
 #endif
 
 	ret

--- a/arch/xtensa/src/common/xtensa_context.S
+++ b/arch/xtensa/src/common/xtensa_context.S
@@ -244,7 +244,7 @@ xtensa_context_save:
  ****************************************************************************/
 
 	.global _xtensa_context_restore
-	.type	xtensa_context_restore,@function
+	.type	_xtensa_context_restore,@function
 
 	.align  4
 	.literal_position

--- a/arch/xtensa/src/common/xtensa_context.S
+++ b/arch/xtensa/src/common/xtensa_context.S
@@ -279,7 +279,6 @@ _xtensa_context_restore:
 
 	l32i	a3, a2, (4 * REG_SAR)
 	wsr		a3, SAR
-	l32i	sp, a2, (4 * REG_A1)
 	l32i	a3, a2, (4 * REG_A3)
 	l32i	a4, a2, (4 * REG_A4)
 	l32i	a5, a2, (4 * REG_A5)

--- a/arch/xtensa/src/common/xtensa_context.S
+++ b/arch/xtensa/src/common/xtensa_context.S
@@ -68,6 +68,7 @@
 
 #include "syscall.h"
 #include "xtensa_swi.h"
+#include "xtensa_asm_utils.h"
 
 /****************************************************************************
  * Public Functions
@@ -160,16 +161,43 @@ _xtensa_context_save:
 #error Overlay support is not implemented
 #endif
 
-	s32i	a0, sp, (4 * REG_TMP0)			/* Save return address */
-	s32i	sp, sp, (4 * REG_TMP1)			/* Save current stack pointer */
-	wsr		sp, EXCSAVE_1					/* Preserve register save area */
+	/* SPILL_ALL_WINDOWS macro requires window overflow exceptions to be enabled,
+	 * i.e. PS.EXCM cleared and PS.WOE set.
+	 * Since we are going to clear PS.EXCM, we also need to increase INTLEVEL
+	 * at least to XCHAL_EXCM_LEVEL. This matches that value of effective INTLEVEL
+	 * at entry (CINTLEVEL=max(PS.INTLEVEL, XCHAL_EXCM_LEVEL) when PS.EXCM is set.
+	 * Since WindowOverflow exceptions will trigger inside SPILL_ALL_WINDOWS,
+	 * we need to save/restore EPC1 as well.
+	 * NOTE: Even though a4-a15 are saved into the exception frame, we should not
+	 * clobber them until after SPILL_ALL_WINDOWS. This is because these registers
+	 * may contain live windows belonging to previous frames in the call stack.
+	 * These frames will be spilled by SPILL_ALL_WINDOWS, and if the register was
+	 * used as a temporary by this code, the temporary value would get stored
+	 * onto the stack, instead of the real value.
+	 */
 
-	l32i	sp, sp, (4 * REG_A1)			/* Restore the interruptee's SP */
-	call0	_xtensa_window_spill			/* Preserves only a4-a5, a8-a9, a12-a13 */
+	s32i    a0, sp, (4 * REG_TMP0)     /* Save return address */
+	rsr     a2, PS                     /* To be restored after SPILL_ALL_WINDOWS */
+	movi    a0, PS_INTLEVEL_MASK
+	and     a3, a2, a0                 /* Get the current INTLEVEL */
+	bgeui   a3, XCHAL_EXCM_LEVEL, 1f   /* Calculate max(INTLEVEL, XCHAL_EXCM_LEVEL) */
+	movi    a3, XCHAL_EXCM_LEVEL
+1:
+	movi    a0, PS_UM | PS_WOE         /* Clear EXCM, enable window overflow, set new INTLEVEL */
+	or      a3, a3, a0
+	wsr     a3, ps
+	rsync
+	rsr     a0, EPC1                   /* To be restored after SPILL_ALL_WINDOWS */
 
-	rsr		sp, EXCSAVE_1					/* Save interruptee's a0 */
-	l32i	a0, sp, (4 * REG_TMP0)			/* Save return address */
-	l32i	sp, sp, (4 * REG_TMP1)			/* Save current stack pointer */
+	addi    sp,  sp, XCPTCONTEXT_SIZE  /* Go back to spill register region */
+	SPILL_ALL_WINDOWS                  /* Place the live register windows there */
+	addi    sp,  sp, -XCPTCONTEXT_SIZE /* Return the current stack pointer and proceed with context save*/
+
+	wsr     a2, PS                     /* Restore PS to the value at entry */
+	wsr     a0, EPC1                   /* Restore EPC1 to the value at entry */
+	rsync
+	l32i  a0, sp, (4 * REG_TMP0)       /* Restore return address */
+
 #endif
 
 	ret

--- a/arch/xtensa/src/common/xtensa_context.S
+++ b/arch/xtensa/src/common/xtensa_context.S
@@ -82,21 +82,17 @@
  *
  *   NOTE: MUST BE CALLED ONLY BY 'CALL0' INSTRUCTION!
  *
- *   This function saves Xtensa processor state:  xtensa_context_save
- *   saves all registers except PC, PS, A0, A1 (SP), and A2
- *
- *   This function is called directly by interrupt handling logic and from
- *   xtensa_context_save() below with interrupts disabled.  In either calling
- *   context, caller saves PC, PS, A0, A1 (SP), and A2.  This
- *   logic also executes indirectly from xtensa_context_save() by falling
- *   through from above.
+ *   This function saves Xtensa processor state.
+ *   It is called directly by interrupt handling logic with interrupts
+ *   disabled.  Registers PC, PS, A0, A1 (SP), A2 and A3 are saved before
+ *   calling this function. 
  *
  *   The counterpart to this function is _xtensa_context_restore().
  *
  * Entry Conditions:
  *   - A0  = Return address to caller.
  *   - A2  = Pointer to the processor state save area
- *   - Other processor state except PC, PS, A0, A1 (SP), and A2 are as at
+ *   - Other processor state except PC, PS, A0, A1 (SP), A2 and A3 are as at
  *     the point of interruption.
  *
  * Exit conditions:
@@ -185,106 +181,11 @@ _xtensa_context_save:
  *
  * Description:
  *
- *   This functions implements the moral equivalent of setjmp().  It is
+ *   This function implements the moral equivalent of setjmp().  It is
  *   called from user code (with interrupts disabled) to save the current
  *   state of the running thread.  This function always returns zero.
- *   However, it sets the saved value of the return address (A2) to 1.
- *   If the thread is s via _xtensa_context_restore or
- *   xtensa_context_restore, it will appear as a second return from
- *   xtensa_context_save but with the returned value of 1 to distinguish
- *   the two cases.
  *
  *   The counterpart to this function is xtensa_context_restore().
- *
- * Entry Conditions:
- *   - A0  = Return address to caller.
- *   - A2  = Pointer to the processor state save area
- *
- * Exit conditions:
- *   - A0  = Return address in caller.
- *   - A2  = 0
- *
- * Assumptions:
- *   - Interrupts are disabled.
- *
- ****************************************************************************/
-
-#ifdef __XTENSA_CALL0_ABI__
-
-/****************************************************************************
- * Name: xtensa_context_save:
- *
- * Description:
- *   This implementation of xtensa_context_save for the case of the CALL0 ABI
- *
- * Input State:
- *   a0 = The return value to the caller.
- *   a2 = The address of the register state structure
- *
- * Return state:
- *   a0 = The return value to the caller.
- *   a2, a12-a15 preserved as at entry
- *
- ****************************************************************************/
-
-	.global	xtensa_context_save
-	.type	xtensa_context_save, @function
-
-	.align	4
-	.literal_position
-	.align	4
-
-xtensa_context_save:
-	ENTRY(16)
-
-	/* Set up for (potential) call to _xtensa_context_save() */
-
-	s32i	a3,  a2, (4 * REG_A3)			/* Get  scratch register */
-	rsr		a3, PS							/* Save callee's PS */
-	s32i	a3, a2, (4 * REG_PS)
-	s32i	a0, a2, (4 * REG_PC)			/* Save Return address as PC */
-
-	s32i	a0, a2, (4 * REG_A0)			/* Save callee's a0 */
-	s32i	sp, a2, (4 * REG_A1)			/* Save callee's SP */
-	movi	a3, 1							/* Set saved A2 to 1 */
-	s32i	a3, a2, (4 * REG_A2)
-
-	/* Save the rest of the processor state.  For the CALL0 ABI, we can use
-	 * _xtensa_context_save(),  Otherwise we duplicate the context save here
-	 * to avoid the window spill.
-	 */
-
-	l32i	a3, a2, (4 * REG_A3)			/* Recover original a3 */
-	call0	_xtensa_context_save			/* Save full register state */
-
-	/* Recover the return address and return zero */
-
-	l32i	a0, a2, (4 * REG_A0)			/* Recover return address */
-	movi	a2, 0							/* Return zero */
-	RET(16)
-
-	.size	xtensa_context_save, . - xtensa_context_save
-#endif
-
-/****************************************************************************
- * This implementation of xtensa_context_save for the case of the window ABI.
- * This case is more complex.  For the Window ABI, there is a "hook" that
- * performs the low level state.  xtensa_context_save() is simply a
- * trampoline function that performs the window operations in that
- * configuration.
- ****************************************************************************/
-
-#ifndef __XTENSA_CALL0_ABI__
-
-/****************************************************************************
- * Name: xtensa_context_save:
- *
- * Description:
- *   This is the implementation of xtensa_context_save for the case of the
- *   window ABI.  In the window ABI configuration, xtensa_context_save is a
- *   thin  "trampoline" layer.  It performs the ENTRY window operations on
- *   entry and the exit.  A call0 is used to force the return from the context
- *   switch to the window return within this trampoline.
  *
  * Input State:
  *   a0 = The true return value to the caller.
@@ -315,7 +216,6 @@ xtensa_context_save:
 	RET(16)
 
 	.size	xtensa_context_save, . - xtensa_context_save
-#endif
 
 /****************************************************************************
  * Name: _xtensa_context_restore
@@ -324,9 +224,9 @@ xtensa_context_save:
  *
  *   NOTE: MUST BE CALLED ONLY BY 'CALL0' INSTRUCTION!
  *
- *   These functions restores Xtensa processor state and differ in which
- *   registers are saved: _xtensa_context_restore() restores all registers
- *   except PC, PS, A0, and A2
+ *   This function restores Xtensa processor state.
+ *   It is called directly by interrupt handling logic with interrupts
+ *   disabled.  It restores all registers except PC, PS, A0, and A2
  *
  *   The caller is responsible for restoring PC, PS, A0, and A2.
  *

--- a/arch/xtensa/src/common/xtensa_dumpstate.c
+++ b/arch/xtensa/src/common/xtensa_dumpstate.c
@@ -256,10 +256,6 @@ static inline void xtensa_registerdump(uintptr_t *regs)
          (unsigned long)regs[REG_LBEG], (unsigned long)regs[REG_LEND],
          (unsigned long)regs[REG_LCOUNT]);
 #endif
-#ifndef __XTENSA_CALL0_ABI__
-  _alert(" TMP0: %08lx  TMP1: %08lx\n",
-         (unsigned long)regs[REG_TMP0], (unsigned long)regs[REG_TMP1]);
-#endif
 }
 
 /****************************************************************************

--- a/arch/xtensa/src/common/xtensa_int_handlers.S
+++ b/arch/xtensa/src/common/xtensa_int_handlers.S
@@ -352,7 +352,7 @@ _xtensa_level1_handler:
 	l32i	a0, a2, (4 * REG_PC)			/* Retrieve interruptee's PC */
 	wsr		a0, EPC_1
 	l32i	a0, a2, (4 * REG_A0)			/* Retrieve interruptee's A0 */
-  l32i  sp, a2, (4 * REG_A1)      /* Retrieve interrupt stack frame */
+	l32i  sp, a2, (4 * REG_A1)      /* Retrieve interrupt stack frame */
 	l32i	a2, a2, (4 * REG_A2)			/* Retrieve interruptee's A2 */
 	rsync								          	/* Ensure PS and EPC written */
 

--- a/arch/xtensa/src/common/xtensa_int_handlers.S
+++ b/arch/xtensa/src/common/xtensa_int_handlers.S
@@ -756,13 +756,13 @@ _xtensa_level6_handler:
 
 	/* Restore only level-specific regs (the rest were already restored) */
 
-	l32i	a0, a2, (4 * REG_PS)      /* Retrieve interruptee's PS */
+	l32i	a0, a2, (4 * REG_PS)			/* Retrieve interruptee's PS */
 	wsr		a0, EPS_6
-	l32i	a0, a2, (4 * REG_PC)      /* Retrieve interruptee's PC */
+	l32i	a0, a2, (4 * REG_PC)			/* Retrieve interruptee's PC */
 	wsr		a0, EPC_6
-	l32i	a0, a2, (4 * REG_A0)      /* Retrieve interruptee's A0 */
-	l32i	sp, a2, (4 * REG_A1)      /* Retrieve interrupt stack frame */
-	l32i	a2, a2, (4 * REG_A2)      /* Retrieve interruptee's A2 */
+	l32i	a0, a2, (4 * REG_A0)			/* Retrieve interruptee's A0 */
+	l32i	sp, a2, (4 * REG_A1)			/* Retrieve interrupt stack frame */
+	l32i	a2, a2, (4 * REG_A2)			/* Retrieve interruptee's A2 */
 	rsync									/* Ensure EPS and EPC written */
 
 	/* Return from interrupt.  RFI  restores the PS from EPS_6 and jumps to

--- a/arch/xtensa/src/common/xtensa_int_handlers.S
+++ b/arch/xtensa/src/common/xtensa_int_handlers.S
@@ -353,7 +353,7 @@ _xtensa_level1_handler:
 	l32i	a0, a2, (4 * REG_PC)			/* Retrieve interruptee's PC */
 	wsr		a0, EPC_1
 	l32i	a0, a2, (4 * REG_A0)			/* Retrieve interruptee's A0 */
-  l32i  sp, a2, (4 * REG_A1)      /* Remove interrupt stack frame */
+  l32i  sp, a2, (4 * REG_A1)      /* Retrieve interrupt stack frame */
 	l32i	a2, a2, (4 * REG_A2)			/* Retrieve interruptee's A2 */
 	rsync								          	/* Ensure PS and EPC written */
 

--- a/arch/xtensa/src/common/xtensa_int_handlers.S
+++ b/arch/xtensa/src/common/xtensa_int_handlers.S
@@ -311,7 +311,6 @@ _xtensa_level1_handler:
 	/* Save rest of interrupt context. */
 
 	s32i	a2, sp, (4 * REG_A2)
-	mov		a2, sp							      /* Address of state save on stack */
 	s32i	a3, sp, (4 * REG_A3)
 	call0	_xtensa_context_save			/* Save full register state */
 
@@ -415,7 +414,6 @@ _xtensa_level2_handler:
 	/* Save rest of interrupt context. */
 
 	s32i	a2, sp, (4 * REG_A2)
-	mov		a2, sp							/* Address of state save on stack */
 	s32i	a3, sp, (4 * REG_A3)
 	call0	_xtensa_context_save			/* Save full register state */
 
@@ -494,7 +492,6 @@ _xtensa_level3_handler:
 	/* Save rest of interrupt context. */
 
 	s32i	a2, sp, (4 * REG_A2)
-	mov		a2, sp							/* Address of state save on stack */
 	s32i	a3, sp, (4 * REG_A3)
 	call0	_xtensa_context_save			/* Save full register state */
 
@@ -573,7 +570,6 @@ _xtensa_level4_handler:
 	/* Save rest of interrupt context. */
 
 	s32i	a2, sp, (4 * REG_A2)
-	mov		a2, sp							/* Address of state save on stack */
 	s32i	a3, sp, (4 * REG_A3)
 	call0	_xtensa_context_save			/* Save full register state */
 
@@ -652,7 +648,6 @@ _xtensa_level5_handler:
 	/* Save rest of interrupt context. */
 
 	s32i	a2, sp, (4 * REG_A2)
-	mov		a2, sp							/* Address of state save on stack */
 	s32i	a3, sp, (4 * REG_A3)
 	call0	_xtensa_context_save			/* Save full register state */
 
@@ -731,7 +726,6 @@ _xtensa_level6_handler:
 	/* Save rest of interrupt context. */
 
 	s32i	a2, sp, (4 * REG_A2)
-	mov		a2, sp							/* Address of state save on stack */
 	s32i	a3, sp, (4 * REG_A3)
 	call0	_xtensa_context_save			/* Save full register state */
 

--- a/arch/xtensa/src/common/xtensa_int_handlers.S
+++ b/arch/xtensa/src/common/xtensa_int_handlers.S
@@ -303,6 +303,7 @@ _xtensa_level1_handler:
 	s32i	a0, sp, (4 * REG_PC)
 	rsr		a0, EXCSAVE_1					            /* Save interruptee's a0 */
 	s32i	a0, sp, (4 * REG_A0)
+	s32i	a2, sp, (4 * REG_A2)
 
 #ifdef CONFIG_XTENSA_INTBACKTRACE
   wsr sp, EXCSAVE_1
@@ -310,9 +311,7 @@ _xtensa_level1_handler:
 
 	/* Save rest of interrupt context. */
 
-	s32i	a2, sp, (4 * REG_A2)
-	s32i	a3, sp, (4 * REG_A3)
-	call0	_xtensa_context_save			/* Save full register state */
+	call0	_xtensa_context_save
 
   /* Save current SP before (possibly) overwriting it, it's the register save
    * area. This value will be used later by dispatch_c_isr to retrieve the
@@ -347,13 +346,13 @@ _xtensa_level1_handler:
 
 	/* Restore only level-specific regs (the rest were already restored) */
 
-	l32i	a0, a2, (4 * REG_PS)			/* Retrieve interruptee's PS */
+	l32i	a0, a2, (4 * REG_PS)      /* Retrieve interruptee's PS */
 	wsr		a0, PS
-	l32i	a0, a2, (4 * REG_PC)			/* Retrieve interruptee's PC */
+	l32i	a0, a2, (4 * REG_PC)      /* Retrieve interruptee's PC */
 	wsr		a0, EPC_1
-	l32i	a0, a2, (4 * REG_A0)			/* Retrieve interruptee's A0 */
-	l32i  sp, a2, (4 * REG_A1)      /* Retrieve interrupt stack frame */
-	l32i	a2, a2, (4 * REG_A2)			/* Retrieve interruptee's A2 */
+	l32i	a0, a2, (4 * REG_A0)      /* Retrieve interruptee's A0 */
+	l32i	sp, a2, (4 * REG_A1)      /* Retrieve interrupt stack frame */
+	l32i	a2, a2, (4 * REG_A2)      /* Retrieve interruptee's A2 */
 	rsync								          	/* Ensure PS and EPC written */
 
 	/* Return from exception. RFE returns from either the UserExceptionVector
@@ -406,6 +405,7 @@ _xtensa_level2_handler:
 	s32i	a0, sp, (4 * REG_PC)
 	rsr		a0, EXCSAVE_2					/* Save interruptee's a0 */
 	s32i	a0, sp, (4 * REG_A0)
+	s32i	a2, sp, (4 * REG_A2)
 
 #ifdef CONFIG_XTENSA_INTBACKTRACE
   wsr sp, EXCSAVE_2
@@ -413,9 +413,7 @@ _xtensa_level2_handler:
 
 	/* Save rest of interrupt context. */
 
-	s32i	a2, sp, (4 * REG_A2)
-	s32i	a3, sp, (4 * REG_A3)
-	call0	_xtensa_context_save			/* Save full register state */
+	call0	_xtensa_context_save
 
 	/* Save current SP before (possibly) overwriting it, it's the register save
 	 * area. This value will be used later by dispatch_c_isr to retrieve the
@@ -450,13 +448,13 @@ _xtensa_level2_handler:
 
 	/* Restore only level-specific regs (the rest were already restored) */
 
-	l32i	a0, a2, (4 * REG_PS)			/* Retrieve interruptee's PS */
+	l32i	a0, a2, (4 * REG_PS)      /* Retrieve interruptee's PS */
 	wsr		a0, EPS_2
-	l32i	a0, a2, (4 * REG_PC)			/* Retrieve interruptee's PC */
+	l32i	a0, a2, (4 * REG_PC)      /* Retrieve interruptee's PC */
 	wsr		a0, EPC_2
-	l32i	a0, a2, (4 * REG_A0)			/* Retrieve interruptee's A0 */
-	l32i	sp, a2, (4 * REG_A1)			/* Remove interrupt stack frame */
-	l32i	a2, a2, (4 * REG_A2)			/* Retrieve interruptee's A2 */
+	l32i	a0, a2, (4 * REG_A0)      /* Retrieve interruptee's A0 */
+	l32i	sp, a2, (4 * REG_A1)      /* Retrieve interrupt stack frame */
+	l32i	a2, a2, (4 * REG_A2)      /* Retrieve interruptee's A2 */
 	rsync									/* Ensure EPS and EPC written */
 
 	/* Return from interrupt.  RFI  restores the PS from EPS_2 and jumps to
@@ -484,6 +482,7 @@ _xtensa_level3_handler:
 	s32i	a0, sp, (4 * REG_PC)
 	rsr		a0, EXCSAVE_3					/* Save interruptee's a0 */
 	s32i	a0, sp, (4 * REG_A0)
+	s32i	a2, sp, (4 * REG_A2)
 
 #ifdef CONFIG_XTENSA_INTBACKTRACE
   wsr sp, EXCSAVE_3
@@ -491,9 +490,7 @@ _xtensa_level3_handler:
 
 	/* Save rest of interrupt context. */
 
-	s32i	a2, sp, (4 * REG_A2)
-	s32i	a3, sp, (4 * REG_A3)
-	call0	_xtensa_context_save			/* Save full register state */
+	call0	_xtensa_context_save
 
 	/* Save current SP before (possibly) overwriting it, it's the register save
 	 * area. This value will be used later by dispatch_c_isr to retrieve the
@@ -528,13 +525,13 @@ _xtensa_level3_handler:
 
 	/* Restore only level-specific regs (the rest were already restored) */
 
-	l32i	a0, a2, (4 * REG_PS)			/* Retrieve interruptee's PS */
+	l32i	a0, a2, (4 * REG_PS)      /* Retrieve interruptee's PS */
 	wsr		a0, EPS_3
-	l32i	a0, a2, (4 * REG_PC)			/* Retrieve interruptee's PC */
+	l32i	a0, a2, (4 * REG_PC)      /* Retrieve interruptee's PC */
 	wsr		a0, EPC_3
-	l32i	a0, a2, (4 * REG_A0)			/* Retrieve interruptee's A0 */
-	l32i	sp, a2, (4 * REG_A1)			/* Remove interrupt stack frame */
-	l32i	a2, a2, (4 * REG_A2)			/* Retrieve interruptee's A2 */
+	l32i	a0, a2, (4 * REG_A0)      /* Retrieve interruptee's A0 */
+	l32i	sp, a2, (4 * REG_A1)      /* Retrieve interrupt stack frame */
+	l32i	a2, a2, (4 * REG_A2)      /* Retrieve interruptee's A2 */
 	rsync									/* Ensure EPS and EPC written */
 
 	/* Return from interrupt.  RFI  restores the PS from EPS_3 and jumps to
@@ -562,6 +559,7 @@ _xtensa_level4_handler:
 	s32i	a0, sp, (4 * REG_PC)
 	rsr		a0, EXCSAVE_4					/* Save interruptee's a0 */
 	s32i	a0, sp, (4 * REG_A0)
+	s32i	a2, sp, (4 * REG_A2)
 
 #ifdef CONFIG_XTENSA_INTBACKTRACE
   wsr sp, EXCSAVE_4
@@ -569,9 +567,7 @@ _xtensa_level4_handler:
 
 	/* Save rest of interrupt context. */
 
-	s32i	a2, sp, (4 * REG_A2)
-	s32i	a3, sp, (4 * REG_A3)
-	call0	_xtensa_context_save			/* Save full register state */
+	call0	_xtensa_context_save
 
 	/* Save current SP before (possibly) overwriting it, it's the register save
 	 * area. This value will be used later by dispatch_c_isr to retrieve the
@@ -606,13 +602,13 @@ _xtensa_level4_handler:
 
 	/* Restore only level-specific regs (the rest were already restored) */
 
-	l32i	a0, a2, (4 * REG_PS)			/* Retrieve interruptee's PS */
+	l32i	a0, a2, (4 * REG_PS)      /* Retrieve interruptee's PS */
 	wsr		a0, EPS_4
-	l32i	a0, a2, (4 * REG_PC)			/* Retrieve interruptee's PC */
+	l32i	a0, a2, (4 * REG_PC)      /* Retrieve interruptee's PC */
 	wsr		a0, EPC_4
-	l32i	a0, a2, (4 * REG_A0)			/* Retrieve interruptee's A0 */
-	l32i	sp, a2, (4 * REG_A1)			/* Remove interrupt stack frame */
-	l32i	a2, a2, (4 * REG_A2)			/* Retrieve interruptee's A2 */
+	l32i	a0, a2, (4 * REG_A0)      /* Retrieve interruptee's A0 */
+	l32i	sp, a2, (4 * REG_A1)      /* Retrieve interrupt stack frame */
+	l32i	a2, a2, (4 * REG_A2)      /* Retrieve interruptee's A2 */
 	rsync									/* Ensure EPS and EPC written */
 
 	/* Return from interrupt.  RFI  restores the PS from EPS_4 and jumps to
@@ -640,6 +636,7 @@ _xtensa_level5_handler:
 	s32i	a0, sp, (4 * REG_PC)
 	rsr		a0, EXCSAVE_5					/* Save interruptee's a0 */
 	s32i	a0, sp, (4 * REG_A0)
+	s32i	a2, sp, (4 * REG_A2)
 
 #ifdef CONFIG_XTENSA_INTBACKTRACE
   wsr sp, EXCSAVE_5
@@ -647,9 +644,7 @@ _xtensa_level5_handler:
 
 	/* Save rest of interrupt context. */
 
-	s32i	a2, sp, (4 * REG_A2)
-	s32i	a3, sp, (4 * REG_A3)
-	call0	_xtensa_context_save			/* Save full register state */
+	call0	_xtensa_context_save
 
 	/* Save current SP before (possibly) overwriting it, it's the register save
 	 * area. This value will be used later by dispatch_c_isr to retrieve the
@@ -684,13 +679,13 @@ _xtensa_level5_handler:
 
 	/* Restore only level-specific regs (the rest were already restored) */
 
-	l32i	a0, a2, (4 * REG_PS)			/* Retrieve interruptee's PS */
+	l32i	a0, a2, (4 * REG_PS)      /* Retrieve interruptee's PS */
 	wsr		a0, EPS_5
-	l32i	a0, a2, (4 * REG_PC)			/* Retrieve interruptee's PC */
+	l32i	a0, a2, (4 * REG_PC)      /* Retrieve interruptee's PC */
 	wsr		a0, EPC_5
-	l32i	a0, a2, (4 * REG_A0)			/* Retrieve interruptee's A0 */
-	l32i	sp, a2, (4 * REG_A1)			/* Remove interrupt stack frame */
-	l32i	a2, a2, (4 * REG_A2)			/* Retrieve interruptee's A2 */
+	l32i	a0, a2, (4 * REG_A0)      /* Retrieve interruptee's A0 */
+	l32i	sp, a2, (4 * REG_A1)      /* Retrieve interrupt stack frame */
+	l32i	a2, a2, (4 * REG_A2)      /* Retrieve interruptee's A2 */
 	rsync									/* Ensure EPS and EPC written */
 
 	/* Return from interrupt.  RFI  restores the PS from EPS_5 and jumps to
@@ -718,6 +713,7 @@ _xtensa_level6_handler:
 	s32i	a0, sp, (4 * REG_PC)
 	rsr		a0, EXCSAVE_6					/* Save interruptee's a0 */
 	s32i	a0, sp, (4 * REG_A0)
+	s32i	a2, sp, (4 * REG_A2)
 
 #ifdef CONFIG_XTENSA_INTBACKTRACE
   wsr sp, EXCSAVE_6
@@ -725,8 +721,6 @@ _xtensa_level6_handler:
 
 	/* Save rest of interrupt context. */
 
-	s32i	a2, sp, (4 * REG_A2)
-	s32i	a3, sp, (4 * REG_A3)
 	call0	_xtensa_context_save			/* Save full register state */
 
 	/* Save current SP before (possibly) overwriting it, it's the register save
@@ -762,13 +756,13 @@ _xtensa_level6_handler:
 
 	/* Restore only level-specific regs (the rest were already restored) */
 
-	l32i	a0, a2, (4 * REG_PS)			/* Retrieve interruptee's PS */
+	l32i	a0, a2, (4 * REG_PS)      /* Retrieve interruptee's PS */
 	wsr		a0, EPS_6
-	l32i	a0, a2, (4 * REG_PC)			/* Retrieve interruptee's PC */
+	l32i	a0, a2, (4 * REG_PC)      /* Retrieve interruptee's PC */
 	wsr		a0, EPC_6
-	l32i	a0, a2, (4 * REG_A0)			/* Retrieve interruptee's A0 */
-	l32i	sp, a2, (4 * REG_A1)			/* Remove interrupt stack frame */
-	l32i	a2, a2, (4 * REG_A2)			/* Retrieve interruptee's A2 */
+	l32i	a0, a2, (4 * REG_A0)      /* Retrieve interruptee's A0 */
+	l32i	sp, a2, (4 * REG_A1)      /* Retrieve interrupt stack frame */
+	l32i	a2, a2, (4 * REG_A2)      /* Retrieve interruptee's A2 */
 	rsync									/* Ensure EPS and EPC written */
 
 	/* Return from interrupt.  RFI  restores the PS from EPS_6 and jumps to

--- a/arch/xtensa/src/common/xtensa_panic.S
+++ b/arch/xtensa/src/common/xtensa_panic.S
@@ -126,7 +126,7 @@ _xtensa_panic:
 	 * stack.
 	 */
 
-	mov		a2, sp							/* Address of state save on stack */
+	s32i	a2, sp, (4 * REG_A2)
 	s32i	a3, sp, (4 * REG_A3)
 	call0	_xtensa_context_save			/* Save full register state */
 

--- a/arch/xtensa/src/common/xtensa_panic.S
+++ b/arch/xtensa/src/common/xtensa_panic.S
@@ -127,7 +127,6 @@ _xtensa_panic:
 	 */
 
 	s32i	a2, sp, (4 * REG_A2)
-	s32i	a3, sp, (4 * REG_A3)
 	call0	_xtensa_context_save			/* Save full register state */
 
 	/* Dispatch the sycall as with other interrupts. */

--- a/arch/xtensa/src/common/xtensa_user_handler.S
+++ b/arch/xtensa/src/common/xtensa_user_handler.S
@@ -338,16 +338,16 @@ _xtensa_syscall_handler:
 	rsr		a0, EXCSAVE_1					/* Save interruptee's a0 */
 	s32i	a0, sp, (4 * REG_A0)
 
-	/* Save EPC */
-
-#if XCHAL_HAVE_LOOPS != 0
-	/* Save A2 and A3 now to give us some registers to work with.  A0, A2
-	 * and A3 are now available.
-	 */
-
 	s32i	a2, sp, (4 * REG_A2)			/* Save interruptee's A2 */
 	s32i	a3, sp, (4 * REG_A3)			/* Save interruptee's A3 */
 
+	/* Save rest of interrupt context. */
+
+	call0	_xtensa_context_save
+
+	/* Save EPC */
+
+#if XCHAL_HAVE_LOOPS != 0
 	/* Get the interruptee's PC and skip over the 'syscall' instruction.
 	 * If it's at the end of a zero-overhead loop and it's not on the last
 	 * iteration, decrement loop counter and skip to beginning of loop.
@@ -378,14 +378,7 @@ _xtensa_syscall_handler:
 
 	wsr		a0, EPC_1						/* Update PC */
 	s32i	a0, sp, (4 * REG_PC)
-
-	s32i	a2, sp, (4 * REG_A2)			/* Save interruptee's A2 */
-	s32i	a3, sp, (4 * REG_A3)			/* Save interruptee's A3 */
 #endif
-
-	/* Save rest of interrupt context. */
-
-	call0	_xtensa_context_save			/* Save full register state */
 
 	/* Dispatch the sycall as with other interrupts. */
 

--- a/arch/xtensa/src/common/xtensa_user_handler.S
+++ b/arch/xtensa/src/common/xtensa_user_handler.S
@@ -218,6 +218,7 @@ _xtensa_user_handler:
 	s32i	a0, sp, (4 * REG_PC)
 	rsr		a0, EXCSAVE_1					/* Save interruptee's a0 */
 	s32i	a0, sp, (4 * REG_A0)
+	s32i	a2, sp, (4 * REG_A2)
 
 	/* Save EXCCAUSE and EXCVADDR into the user frame */
 
@@ -228,8 +229,6 @@ _xtensa_user_handler:
 
 	/* Save rest of interrupt context. */
 
-	s32i	a2, sp, (4 * REG_A2)
-	s32i	a3, sp, (4 * REG_A3)
 	call0	_xtensa_context_save			/* Save full register state */
 
 	/* Save current SP before (possibly) overwriting it,
@@ -298,8 +297,8 @@ _xtensa_user_handler:
 	l32i	a0, a2, (4 * REG_PC)			/* Retrieve interruptee's PC */
 	wsr		a0, EPC_1
 	l32i	a0, a2, (4 * REG_A0)			/* Retrieve interruptee's A0 */
-	l32i	sp, a2, (4 * REG_A1)			/* Remove interrupt stack frame */
-	l32i	a2, a2, (4 * REG_A2)			/* Retrieve interruptee's A2 */
+	l32i	sp, a2, (4 * REG_A1)			/* Retrieve interrupt stack frame */
+	l32i  a2, a2, (4 * REG_A2)		  /* Retrieve interruptee's A2 */
 	rsync									/* Ensure PS and EPC written */
 
 	/* Return from exception. RFE returns from either the UserExceptionVector
@@ -337,9 +336,7 @@ _xtensa_syscall_handler:
 	s32i	a0, sp, (4 * REG_PS)
 	rsr		a0, EXCSAVE_1					/* Save interruptee's a0 */
 	s32i	a0, sp, (4 * REG_A0)
-
-	s32i	a2, sp, (4 * REG_A2)			/* Save interruptee's A2 */
-	s32i	a3, sp, (4 * REG_A3)			/* Save interruptee's A3 */
+	s32i	a2, sp, (4 * REG_A2)
 
 	/* Save rest of interrupt context. */
 
@@ -430,8 +427,8 @@ _xtensa_syscall_handler:
 	l32i	a0, a2, (4 * REG_PC)			/* Retrieve interruptee's PC */
 	wsr		a0, EPC_1
 	l32i	a0, a2, (4 * REG_A0)			/* Retrieve interruptee's A0 */
-	l32i	sp, a2, (4 * REG_A1)			/* Remove interrupt stack frame */
-	l32i	a2, a2, (4 * REG_A2)			/* Retrieve interruptee's A2 */
+	l32i	sp, a2, (4 * REG_A1)			/* Retrieve interrupt stack frame */
+	l32i  a2, a2, (4 * REG_A2)		  /* Retrieve interruptee's A2 */
 	rsync									/* Ensure PS and EPC written */
 
 	/* Return from exception. RFE returns from either the UserExceptionVector
@@ -502,11 +499,10 @@ _xtensa_coproc_handler:
 	s32i	a0, sp, (4 * REG_PC)
 	rsr		a0, EXCSAVE_1					/* Save interruptee's a0 */
 	s32i	a0, sp, (4 * REG_A0)
+	s32i	a2, sp, (4 * REG_A2)
 
 	/* Save rest of interrupt context. */
 
-	s32i	a2, sp, (4 * REG_A2)
-	s32i	a3, sp, (4 * REG_A3)
 	call0	_xtensa_context_save			/* Save full register state */
 
 	/* Switch to an interrupt stack if we have one */

--- a/arch/xtensa/src/common/xtensa_user_handler.S
+++ b/arch/xtensa/src/common/xtensa_user_handler.S
@@ -229,7 +229,6 @@ _xtensa_user_handler:
 	/* Save rest of interrupt context. */
 
 	s32i	a2, sp, (4 * REG_A2)
-	mov		a2, sp							/* Address of state save on stack */
 	s32i	a3, sp, (4 * REG_A3)
 	call0	_xtensa_context_save			/* Save full register state */
 
@@ -343,8 +342,7 @@ _xtensa_syscall_handler:
 
 #if XCHAL_HAVE_LOOPS != 0
 	/* Save A2 and A3 now to give us some registers to work with.  A0, A2
-	 * and A3 are now available.  NOTE that A3 will get saved again in
-	 * _xtensa_context_save().
+	 * and A3 are now available.
 	 */
 
 	s32i	a2, sp, (4 * REG_A2)			/* Save interruptee's A2 */
@@ -381,14 +379,12 @@ _xtensa_syscall_handler:
 	wsr		a0, EPC_1						/* Update PC */
 	s32i	a0, sp, (4 * REG_PC)
 
-	/* Save a2 which will hold the argument to _xtensa_context_save*/
-
 	s32i	a2, sp, (4 * REG_A2)			/* Save interruptee's A2 */
+	s32i	a3, sp, (4 * REG_A3)			/* Save interruptee's A3 */
 #endif
 
 	/* Save rest of interrupt context. */
 
-	mov		a2, sp							/* Address of state save on stack */
 	call0	_xtensa_context_save			/* Save full register state */
 
 	/* Dispatch the sycall as with other interrupts. */
@@ -517,7 +513,6 @@ _xtensa_coproc_handler:
 	/* Save rest of interrupt context. */
 
 	s32i	a2, sp, (4 * REG_A2)
-	mov		a2, sp							/* Address of state save on stack */
 	s32i	a3, sp, (4 * REG_A3)
 	call0	_xtensa_context_save			/* Save full register state */
 

--- a/arch/xtensa/src/common/xtensa_user_handler.S
+++ b/arch/xtensa/src/common/xtensa_user_handler.S
@@ -298,7 +298,7 @@ _xtensa_user_handler:
 	wsr		a0, EPC_1
 	l32i	a0, a2, (4 * REG_A0)			/* Retrieve interruptee's A0 */
 	l32i	sp, a2, (4 * REG_A1)			/* Retrieve interrupt stack frame */
-	l32i  a2, a2, (4 * REG_A2)		  /* Retrieve interruptee's A2 */
+	l32i	a2, a2, (4 * REG_A2)			/* Retrieve interruptee's A2 */
 	rsync									/* Ensure PS and EPC written */
 
 	/* Return from exception. RFE returns from either the UserExceptionVector
@@ -428,7 +428,7 @@ _xtensa_syscall_handler:
 	wsr		a0, EPC_1
 	l32i	a0, a2, (4 * REG_A0)			/* Retrieve interruptee's A0 */
 	l32i	sp, a2, (4 * REG_A1)			/* Retrieve interrupt stack frame */
-	l32i  a2, a2, (4 * REG_A2)		  /* Retrieve interruptee's A2 */
+	l32i	a2, a2, (4 * REG_A2)			/* Retrieve interruptee's A2 */
 	rsync									/* Ensure PS and EPC written */
 
 	/* Return from exception. RFE returns from either the UserExceptionVector


### PR DESCRIPTION
## Summary
 - `xtensa_context_save` can use A1 directly no need to pass the saving area in A2.  This will free A2 to use as a scratch register.
 - A1 register was being restored twice.
 - Use Zephyr's small version of window spill.
 - Save A3 with the rest of the context in `_xtensa_context_save`.
 - Closes #574
## Impact
Xtensa chips.
## Testing
ESP32xx defconfigs all build and run successfully.
