### PR TITLE
drviers/syslog: correct the return value of default channel write

### DIFF
--- a/drivers/syslog/syslog_channel.c
+++ b/drivers/syslog/syslog_channel.c
@@ -195,7 +195,7 @@ static ssize_t syslog_default_write(FAR struct syslog_channel_s *channel,
   nxsem_post(&g_syslog_default_sem);
 #endif
 
-  return OK;
+  return buflen;
 }
 #endif
 


### PR DESCRIPTION
## Summary

drviers/syslog: correct the return value of default channel write

## Impact

CONFIG_CONSOLE_SYSLOG=y

## Testing

ostesting with CONFIG_CONSOLE_SYSLOG=y