### PR TITLE
driver/uinput: add cross core control function 

### DIFF
--- a/boards/sim/sim/sim/src/sim_bringup.c
+++ b/boards/sim/sim/sim/src/sim_bringup.c
@@ -319,15 +319,21 @@ int sim_bringup(void)
     }
 #endif
 
-#ifdef CONFIG_INPUT_UINPUT
-  /* Initialize the touchscreen uinput */
-
+#ifdef CONFIG_UINPUT_TOUCHSCREEN
   ret = uinput_touch_initialize("utouch", 1, 4);
   if (ret < 0)
     {
       syslog(LOG_ERR, "ERROR: uinput_touch_initialize failed: %d\n", ret);
     }
-#endif
+#endif /* CONFIG_UINPUT_TOUCHSCREEN */
+
+#ifdef CONFIG_UINPUT_BUTTONS
+  ret = uinput_button_initialize("ubutton");
+  if (ret < 0)
+    {
+      syslog(LOG_ERR, "ERROR: uinput_button_initialize failed: %d\n", ret);
+    }
+#endif /* CONFIG_UINPUT_BUTTONS */
 
 #ifdef CONFIG_IEEE802154_LOOPBACK
   /* Initialize and register the IEEE802.15.4 MAC network loop device */

--- a/drivers/input/Kconfig
+++ b/drivers/input/Kconfig
@@ -35,6 +35,21 @@ config INPUT_TOUCHSCREEN
 	select MM_CIRCBUF
 	default n
 
+config INPUT_KEYBOARD
+	bool
+	select MM_CIRCBUF
+	default n
+
+if INPUT_KEYBOARD
+
+config INPUT_KEYBOARD_BUFFSIZE
+	int "Number keyboard data buffer"
+	default 64
+	---help---
+		Maximum number of keyboard data buffer
+
+endif # INPUT_KEYBOARD
+
 config INPUT_UINPUT
 	bool
 	default n

--- a/drivers/input/Kconfig
+++ b/drivers/input/Kconfig
@@ -35,16 +35,6 @@ config INPUT_TOUCHSCREEN
 	select MM_CIRCBUF
 	default n
 
-if INPUT_TOUCHSCREEN
-
-config INPUT_TOUCHSCREEN_NPOLLWAITERS
-	int "Number touchscreen poll waiters"
-	default 4
-	---help---
-		Maximum number of threads that can be waiting on poll()
-
-endif # INPUT_TOUCHSCREEN
-
 config INPUT_UINPUT
 	bool "Enable uinput"
 	select INPUT_TOUCHSCREEN

--- a/drivers/input/Kconfig
+++ b/drivers/input/Kconfig
@@ -36,11 +36,26 @@ config INPUT_TOUCHSCREEN
 	default n
 
 config INPUT_UINPUT
-	bool "Enable uinput"
-	select INPUT_TOUCHSCREEN
+	bool
 	default n
 	---help---
 		Enable support virtual input device driver
+
+config UINPUT_TOUCHSCREEN
+	bool "Enable uinput touchscreen"
+	select INPUT_TOUCHSCREEN
+	select INPUT_UINPUT
+	default n
+	---help---
+		Enable support virtual input touchscreen device driver
+
+config UINPUT_BUTTONS
+	bool "Enable uinput buttons"
+	select INPUT_BUTTONS
+	select INPUT_UINPUT
+	default n
+	---help---
+		Enable support virtual input button device driver
 
 config INPUT_MAX11802
 	bool "MAX11802 touchscreen controller"

--- a/drivers/input/Kconfig
+++ b/drivers/input/Kconfig
@@ -41,6 +41,14 @@ config INPUT_UINPUT
 	---help---
 		Enable support virtual input device driver
 
+config UINPUT_RPMSG
+	bool "Enable uinput rpmsg"
+	depends on INPUT_UINPUT
+	depends on RPTUN
+	default n
+	---help---
+		Enable support uinput cross core communication
+
 config UINPUT_TOUCHSCREEN
 	bool "Enable uinput touchscreen"
 	select INPUT_TOUCHSCREEN

--- a/drivers/input/Kconfig
+++ b/drivers/input/Kconfig
@@ -80,6 +80,14 @@ config UINPUT_BUTTONS
 	---help---
 		Enable support virtual input button device driver
 
+config UINPUT_KEYBOARD
+	bool "Enable uinput keyboard"
+	select INPUT_KEYBOARD
+	select INPUT_UINPUT
+	default n
+	---help---
+		Enable support virtual input keyboard device driver
+
 config INPUT_MAX11802
 	bool "MAX11802 touchscreen controller"
 	default n

--- a/drivers/input/Make.defs
+++ b/drivers/input/Make.defs
@@ -80,6 +80,10 @@ endif
 
 endif
 
+ifeq ($(CONFIG_INPUT_KEYBOARD),y)
+  CSRCS += keyboard_upper.c
+endif
+
 ifeq ($(CONFIG_INPUT_DJOYSTICK),y)
   CSRCS += djoystick.c
 endif

--- a/drivers/input/keyboard_upper.c
+++ b/drivers/input/keyboard_upper.c
@@ -1,0 +1,444 @@
+/****************************************************************************
+ * drivers/input/keyboard_upper.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <assert.h>
+#include <debug.h>
+#include <fcntl.h>
+#include <poll.h>
+
+#include <nuttx/input/keyboard.h>
+#include <nuttx/kmalloc.h>
+#include <nuttx/list.h>
+#include <nuttx/mm/circbuf.h>
+#include <nuttx/semaphore.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Types
+ ****************************************************************************/
+
+struct keyboard_opriv_s
+{
+  sem_t              waitsem;
+  sem_t              locksem;
+  struct circbuf_s   circ;
+  struct list_node   node;
+  FAR struct pollfd *fds;
+};
+
+/* This structure is for keyboard upper half driver */
+
+struct keyboard_upperhalf_s
+{
+  sem_t            exclsem; /* Manages exclusive access to this structure */
+  struct list_node head;    /* Head of list */
+  FAR struct keyboard_lowerhalf_s
+                  *lower;   /* A pointer of lower half instance */
+};
+
+/****************************************************************************
+ * Private Function Prototypes
+ ****************************************************************************/
+
+static int     keyboard_open(FAR struct file *filep);
+static int     keyboard_close(FAR struct file *filep);
+static ssize_t keyboard_read(FAR struct file *filep, FAR char *buffer,
+                             size_t len);
+static ssize_t keyboard_write(FAR struct file *filep, FAR const char *buffer,
+                              size_t len);
+static int     keyboard_poll(FAR struct file *filep, FAR struct pollfd *fds,
+                             bool setup);
+static void    keyboard_notify(FAR struct keyboard_opriv_s *buffer);
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+static const struct file_operations g_keyboard_fops =
+{
+  keyboard_open,  /* open */
+  keyboard_close, /* close */
+  keyboard_read,  /* read */
+  keyboard_write, /* write */
+  NULL,           /* seek */
+  NULL,           /* ioctl */
+  keyboard_poll   /* poll */
+#ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
+  , NULL          /* unlink */
+#endif
+};
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: keyboard_notify
+ ****************************************************************************/
+
+static void keyboard_notify(FAR struct keyboard_opriv_s *opriv)
+{
+  FAR struct pollfd *fds = opriv->fds;
+  if (fds != NULL)
+    {
+      fds->revents |= (fds->events & POLLIN);
+      if (fds->revents != 0)
+        {
+          /* report event log */
+
+          int semcount;
+          nxsem_get_value(fds->sem, &semcount);
+          if (semcount < 1)
+            {
+              nxsem_post(fds->sem);
+            }
+        }
+    }
+}
+
+/****************************************************************************
+ * Name: keyboard_open
+ ****************************************************************************/
+
+static int keyboard_open(FAR struct file *filep)
+{
+  FAR struct keyboard_opriv_s     *opriv = NULL;
+  FAR struct inode                *inode = filep->f_inode;
+  FAR struct keyboard_upperhalf_s *upper = inode->i_private;
+  int ret;
+
+  ret = nxsem_wait(&upper->exclsem);
+  if (ret < 0)
+    {
+      return ret;
+    }
+
+  opriv = kmm_zalloc(sizeof(FAR struct keyboard_opriv_s));
+  if (opriv == NULL)
+    {
+      nxsem_post(&upper->exclsem);
+      return -ENOMEM;
+    }
+
+  /* Initializes the buffer for each open file */
+
+  ret = circbuf_init(&opriv->circ, NULL, CONFIG_INPUT_KEYBOARD_BUFFSIZE);
+  if (ret < 0)
+    {
+      kmm_free(opriv);
+      nxsem_post(&upper->exclsem);
+      return ret;
+    }
+
+  /* Perform the operations required by the lower level */
+
+  if (upper->lower->open)
+    {
+      ret = upper->lower->open(upper->lower);
+      if (ret < 0)
+        {
+          kmm_free(opriv);
+          nxsem_post(&upper->exclsem);
+          return ret;
+        }
+    }
+
+  nxsem_init(&opriv->waitsem, 0, 0);
+  nxsem_init(&opriv->locksem, 0, 1);
+  nxsem_set_protocol(&opriv->waitsem, SEM_PRIO_NONE);
+  list_add_tail(&upper->head, &opriv->node);
+  filep->f_priv = opriv;
+
+  nxsem_post(&upper->exclsem);
+  return ret;
+}
+
+/****************************************************************************
+ * Name: keyboard_close
+ ****************************************************************************/
+
+static int keyboard_close(FAR struct file *filep)
+{
+  FAR struct keyboard_opriv_s     *opriv = filep->f_priv;
+  FAR struct inode                *inode = filep->f_inode;
+  FAR struct keyboard_upperhalf_s *upper = inode->i_private;
+  int ret;
+
+  ret = nxsem_wait(&upper->exclsem);
+  if (ret < 0)
+    {
+      return ret;
+    }
+
+  /* Perform the operations required by the lower level */
+
+  if (upper->lower->close)
+    {
+      ret = upper->lower->close(upper->lower);
+      if (ret < 0)
+        {
+          goto out;
+        }
+    }
+
+  list_delete(&opriv->node);
+  circbuf_uninit(&opriv->circ);
+  nxsem_destroy(&opriv->waitsem);
+  nxsem_destroy(&opriv->locksem);
+  kmm_free(opriv);
+
+out:
+  nxsem_post(&upper->exclsem);
+  return ret;
+}
+
+/****************************************************************************
+ * Name: keyboard_read
+ ****************************************************************************/
+
+static ssize_t keyboard_read(FAR struct file *filep,
+                             FAR char *buff, size_t len)
+{
+  FAR struct keyboard_opriv_s *opriv = filep->f_priv;
+  int ret;
+
+  /* Make sure that we have exclusive access to the private data structure */
+
+  ret = nxsem_wait(&opriv->locksem);
+  if (ret < 0)
+    {
+      return ret;
+    }
+
+  /* Is there keyboard data now? */
+
+  while (circbuf_is_empty(&opriv->circ))
+    {
+      if ((filep->f_oflags & O_NONBLOCK) != 0)
+        {
+          ret = -EAGAIN;
+          goto out;
+        }
+      else
+        {
+          nxsem_post(&opriv->locksem);
+          ret = nxsem_wait_uninterruptible(&opriv->waitsem);
+          if (ret < 0)
+            {
+              return ret;
+            }
+
+          ret = nxsem_wait(&opriv->locksem);
+          if (ret < 0)
+            {
+              return ret;
+            }
+        }
+    }
+
+  ret = circbuf_read(&opriv->circ, buff, len);
+
+out:
+  nxsem_post(&opriv->locksem);
+  return ret;
+}
+
+/****************************************************************************
+ * Name: keyboard_poll
+ ****************************************************************************/
+
+static int keyboard_poll(FAR struct file *filep,
+                         FAR struct pollfd *fds, bool setup)
+{
+  FAR struct keyboard_opriv_s *opriv = filep->f_priv;
+  int ret;
+
+  ret = nxsem_wait(&opriv->locksem);
+  if (ret < 0)
+    {
+      return ret;
+    }
+
+  if (setup)
+    {
+      if (opriv->fds == NULL)
+        {
+          opriv->fds = fds;
+          fds->priv  = &opriv->fds;
+        }
+      else
+        {
+          ret = -EBUSY;
+          goto errout;
+        }
+
+      if (!circbuf_is_empty(&opriv->circ))
+        {
+          keyboard_notify(opriv);
+        }
+    }
+  else
+    {
+      opriv->fds = NULL;
+      fds->priv  = NULL;
+    }
+
+errout:
+  nxsem_post(&opriv->locksem);
+  return ret;
+}
+
+/****************************************************************************
+ * Name: keyboard_write
+ ****************************************************************************/
+
+static ssize_t keyboard_write(FAR struct file *filep,
+                              FAR const char *buffer, size_t buflen)
+{
+  FAR struct inode                *inode = filep->f_inode;
+  FAR struct keyboard_upperhalf_s *upper = inode->i_private;
+  FAR struct keyboard_lowerhalf_s *lower = upper->lower;
+
+  if (lower->write != NULL)
+    {
+      return lower->write(lower, buffer, buflen);
+    }
+
+  return -ENOSYS;
+}
+
+/****************************************************************************
+ * Public Function
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: keyboard_register
+ ****************************************************************************/
+
+int keyboard_register(FAR struct keyboard_lowerhalf_s *lower,
+                      FAR const char *path)
+{
+  FAR struct keyboard_upperhalf_s *upper;
+  int ret;
+
+  iinfo("Registering %s\n", path);
+  if (lower == NULL)
+    {
+      ierr("ERROR: invalid touchscreen device\n");
+      return -EINVAL;
+    }
+
+  upper = kmm_zalloc(sizeof(struct keyboard_upperhalf_s));
+  if (upper == NULL)
+    {
+      ierr("ERROR: Failed to mem alloc!\n");
+      return -ENOMEM;
+    }
+
+  upper->lower = lower;
+  lower->priv  = upper;
+  list_initialize(&upper->head);
+  nxsem_init(&upper->exclsem, 0, 1);
+
+  ret = register_driver(path, &g_keyboard_fops, 0666, upper);
+  if (ret < 0)
+    {
+      nxsem_destroy(&upper->exclsem);
+      kmm_free(upper);
+      return ret;
+    }
+
+  return ret;
+}
+
+/****************************************************************************
+ * Name: keyboard_unregister
+ ****************************************************************************/
+
+int keyboard_unregister(FAR struct keyboard_lowerhalf_s *lower,
+                        FAR const char *path)
+{
+  FAR struct keyboard_upperhalf_s *upper;
+  int ret;
+
+  DEBUGASSERT(lower != NULL);
+  DEBUGASSERT(lower->priv != NULL);
+
+  upper = lower->priv;
+
+  iinfo("UnRegistering %s\n", path);
+  ret = unregister_driver(path);
+  if (ret < 0)
+    {
+      return ret;
+    }
+
+  nxsem_destroy(&upper->exclsem);
+  kmm_free(upper);
+  return 0;
+}
+
+/****************************************************************************
+ * keyboard_event
+ ****************************************************************************/
+
+void keyboard_event(FAR struct keyboard_lowerhalf_s *lower, uint32_t keycode,
+                    uint32_t type)
+{
+  FAR struct keyboard_upperhalf_s *upper = lower->priv;
+  FAR struct keyboard_opriv_s     *opriv;
+  struct keyboard_event_s          key;
+  int semcount;
+
+  if (nxsem_wait(&upper->exclsem) < 0)
+    {
+      return;
+    }
+
+  key.code = keycode;
+  key.type = type;
+  list_for_every_entry(&upper->head, opriv, struct keyboard_opriv_s, node)
+    {
+      if (nxsem_wait(&opriv->locksem) == 0)
+        {
+          circbuf_overwrite(&opriv->circ, &key,
+                            sizeof(struct keyboard_event_s));
+          nxsem_get_value(&opriv->waitsem, &semcount);
+          if (semcount < 1)
+            {
+              nxsem_post(&opriv->waitsem);
+            }
+
+          keyboard_notify(opriv);
+          nxsem_post(&opriv->locksem);
+        }
+    }
+
+  nxsem_post(&upper->exclsem);
+}

--- a/drivers/input/touchscreen_upper.c
+++ b/drivers/input/touchscreen_upper.c
@@ -23,60 +23,56 @@
  ****************************************************************************/
 
 #include <nuttx/config.h>
-
 #include <sys/types.h>
+
+#include <assert.h>
+#include <debug.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <poll.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include <string.h>
-#include <assert.h>
-#include <errno.h>
-#include <debug.h>
 
-#include <poll.h>
-#include <fcntl.h>
-#include <nuttx/kmalloc.h>
-#include <nuttx/mm/circbuf.h>
 #include <nuttx/input/touchscreen.h>
-
-/****************************************************************************
- * Pre-processor Definitions
- ****************************************************************************/
+#include <nuttx/kmalloc.h>
+#include <nuttx/list.h>
+#include <nuttx/mm/circbuf.h>
 
 /****************************************************************************
  * Private Types
  ****************************************************************************/
 
+struct touch_openpriv_s
+{
+  struct circbuf_s   circbuf; /* Store touch point data in circle buffer */
+  struct list_node   node;    /* Opened file buffer linked list node */
+  FAR struct pollfd *fds;     /* Polling structure of waiting thread */
+  sem_t              waitsem; /* Used to wait for the availability of data */
+  sem_t              locksem; /* Manages exclusive access to this structure */
+};
+
 /* This structure is for touchscreen upper half driver */
 
 struct touch_upperhalf_s
 {
-  uint8_t                      open_count;   /* Number of times the device has been opened */
-  uint32_t                     buff_nums;    /* Number of touch point structure */
-  uint8_t                      nwaiters;     /* Number of threads waiting for touch point data */
-  sem_t                        exclsem;      /* Manages exclusive access to this structure */
-  sem_t                        buffersem;    /* Used to wait for the availability of data */
-  struct circbuf_s             buffer;       /* Store touch point data in circle buffer */
-
-  /* The following is a list if poll structures of threads waiting for
-   * driver events. The 'struct pollfd' reference for each open is also
-   * retained in the f_priv field of the 'struct file'.
-   */
-
-  FAR struct pollfd            *fds[CONFIG_INPUT_TOUCHSCREEN_NPOLLWAITERS];
-  FAR struct touch_lowerhalf_s *lower;       /* A pointer of lower half instance */
+  uint32_t         nums;               /* Number of touch point structure */
+  sem_t            exclsem;            /* Manages exclusive access to this structure */
+  struct list_node head;               /* Opened file buffer chain header node */
+  FAR struct touch_lowerhalf_s *lower; /* A pointer of lower half instance */
 };
 
 /****************************************************************************
  * Private Function Prototypes
  ****************************************************************************/
 
-static void    touch_notify(FAR struct touch_upperhalf_s *upper,
+static void    touch_notify(FAR struct touch_openpriv_s *openpriv,
                             pollevent_t eventset);
 static int     touch_open(FAR struct file *filep);
 static int     touch_close(FAR struct file *filep);
 static ssize_t touch_read(FAR struct file *filep, FAR char *buffer,
                           size_t buflen);
-static ssize_t touch_write(FAR struct file *filep, FAR const char *buffer,
+static ssize_t touch_write(FAR struct file *filep, FAR const char *openpriv,
                            size_t buflen);
 static int     touch_ioctl(FAR struct file *filep, int cmd,
                            unsigned long arg);
@@ -105,28 +101,24 @@ static const struct file_operations g_touch_fops =
  * Private Functions
  ****************************************************************************/
 
-static void touch_notify(FAR struct touch_upperhalf_s *upper,
+static void touch_notify(FAR struct touch_openpriv_s *openpriv,
                          pollevent_t eventset)
 {
-  FAR struct pollfd *fd;
-  int i;
+  FAR struct pollfd *fd = openpriv->fds;
 
-  for (i = 0; i < CONFIG_INPUT_TOUCHSCREEN_NPOLLWAITERS; i++)
+  fd = openpriv->fds;
+  if (fd)
     {
-      fd = upper->fds[i];
-      if (fd)
+      fd->revents |= (fd->events & eventset);
+      if (fd->revents != 0)
         {
-          fd->revents |= (fd->events & eventset);
-          if (fd->revents != 0)
-            {
-              /* report event log */
+          /* report event log */
 
-              int semcount;
-              nxsem_get_value(fd->sem, &semcount);
-              if (semcount < 1)
-                {
-                   nxsem_post(fd->sem);
-                }
+          int semcount;
+          nxsem_get_value(fd->sem, &semcount);
+          if (semcount < 1)
+            {
+              nxsem_post(fd->sem);
             }
         }
     }
@@ -138,37 +130,44 @@ static void touch_notify(FAR struct touch_upperhalf_s *upper,
 
 static int touch_open(FAR struct file *filep)
 {
-  FAR struct inode *inode = filep->f_inode;
+  FAR struct touch_openpriv_s  *openpriv;
+  FAR struct inode             *inode = filep->f_inode;
   FAR struct touch_upperhalf_s *upper = inode->i_private;
   FAR struct touch_lowerhalf_s *lower = upper->lower;
   int ret;
-  int tmp;
+
+  openpriv = kmm_zalloc(sizeof(struct touch_openpriv_s));
+  if (openpriv == NULL)
+    {
+      return -ENOMEM;
+    }
+
+  ret = circbuf_init(&openpriv->circbuf, NULL,
+                     upper->nums * SIZEOF_TOUCH_SAMPLE_S(lower->maxpoint));
+  if (ret < 0)
+    {
+      kmm_free(openpriv);
+      return ret;
+    }
 
   ret = nxsem_wait(&upper->exclsem);
   if (ret < 0)
     {
+      circbuf_uninit(&openpriv->circbuf);
+      kmm_free(openpriv);
       return ret;
     }
 
-  tmp = upper->open_count + 1;
-  if (tmp == 0)
-    {
-      ret = -EMFILE;
-      goto err_out;
-    }
-  else if (tmp == 1)
-    {
-      ret = circbuf_init(&upper->buffer, NULL, upper->buff_nums *
-                         SIZEOF_TOUCH_SAMPLE_S(lower->maxpoint));
-      if (ret < 0)
-        {
-          goto err_out;
-        }
-    }
+  nxsem_init(&openpriv->waitsem, 0, 0);
+  nxsem_init(&openpriv->locksem, 0, 1);
+  nxsem_set_protocol(&openpriv->waitsem, SEM_PRIO_NONE);
+  list_add_tail(&upper->head, &openpriv->node);
 
-  upper->open_count = tmp;
+  /* Save the buffer node pointer so that it can be used directly
+   * in the read operation.
+   */
 
-err_out:
+  filep->f_priv = openpriv;
   nxsem_post(&upper->exclsem);
   return ret;
 }
@@ -179,8 +178,9 @@ err_out:
 
 static int touch_close(FAR struct file *filep)
 {
-  FAR struct inode *inode = filep->f_inode;
-  FAR struct touch_upperhalf_s *upper = inode->i_private;
+  FAR struct touch_openpriv_s  *openpriv = filep->f_priv;
+  FAR struct inode             *inode    = filep->f_inode;
+  FAR struct touch_upperhalf_s *upper    = inode->i_private;
   int ret;
 
   ret = nxsem_wait(&upper->exclsem);
@@ -189,11 +189,11 @@ static int touch_close(FAR struct file *filep)
       return ret;
     }
 
-  if (upper->open_count == 1)
-    {
-      upper->open_count--;
-      circbuf_uninit(&upper->buffer);
-    }
+  list_delete(&openpriv->node);
+  circbuf_uninit(&openpriv->circbuf);
+  nxsem_destroy(&openpriv->waitsem);
+  nxsem_destroy(&openpriv->locksem);
+  kmm_free(openpriv);
 
   nxsem_post(&upper->exclsem);
   return ret;
@@ -222,11 +222,10 @@ static ssize_t touch_write(FAR struct file *filep, FAR const char *buffer,
  * Name: touch_read
  ****************************************************************************/
 
-static ssize_t touch_read(FAR struct file *filep, FAR char *buffer,
-                          size_t len)
+static ssize_t
+touch_read(FAR struct file *filep, FAR char *buffer, size_t len)
 {
-  FAR struct inode *inode = filep->f_inode;
-  FAR struct touch_upperhalf_s *upper = inode->i_private;
+  FAR struct touch_openpriv_s *openpriv = filep->f_priv;
   int ret;
 
   if (!buffer || !len)
@@ -234,13 +233,13 @@ static ssize_t touch_read(FAR struct file *filep, FAR char *buffer,
       return -EINVAL;
     }
 
-  ret = nxsem_wait(&upper->exclsem);
+  ret = nxsem_wait(&openpriv->locksem);
   if (ret < 0)
     {
       return ret;
     }
 
-  while (circbuf_is_empty(&upper->buffer))
+  while (circbuf_is_empty(&openpriv->circbuf))
     {
       if (filep->f_oflags & O_NONBLOCK)
         {
@@ -249,14 +248,14 @@ static ssize_t touch_read(FAR struct file *filep, FAR char *buffer,
         }
       else
         {
-          nxsem_post(&upper->exclsem);
-          ret = nxsem_wait_uninterruptible(&upper->buffersem);
+          nxsem_post(&openpriv->locksem);
+          ret = nxsem_wait_uninterruptible(&openpriv->waitsem);
           if (ret < 0)
             {
               return ret;
             }
 
-          ret = nxsem_wait(&upper->exclsem);
+          ret = nxsem_wait(&openpriv->locksem);
           if (ret < 0)
             {
               return ret;
@@ -264,16 +263,16 @@ static ssize_t touch_read(FAR struct file *filep, FAR char *buffer,
         }
     }
 
-  ret = circbuf_read(&upper->buffer, buffer, len);
+  ret = circbuf_read(&openpriv->circbuf, buffer, len);
 
 out:
-  nxsem_post(&upper->exclsem);
+  nxsem_post(&openpriv->locksem);
   return ret;
 }
 
 static int touch_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
 {
-  FAR struct inode *inode = filep->f_inode;
+  FAR struct inode             *inode = filep->f_inode;
   FAR struct touch_upperhalf_s *upper = inode->i_private;
   FAR struct touch_lowerhalf_s *lower = upper->lower;
   int ret;
@@ -297,16 +296,13 @@ static int touch_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
   return ret;
 }
 
-static int touch_poll(FAR struct file *filep,
-                      struct pollfd *fds, bool setup)
+static int touch_poll(FAR struct file *filep, struct pollfd *fds, bool setup)
 {
-  FAR struct inode *inode = filep->f_inode;
-  FAR struct touch_upperhalf_s *upper = inode->i_private;
+  FAR struct touch_openpriv_s *openpriv = filep->f_priv;
   pollevent_t eventset = 0;
   int ret;
-  int i;
 
-  ret = nxsem_wait(&upper->exclsem);
+  ret = nxsem_wait(&openpriv->locksem);
   if (ret < 0)
     {
       return ret;
@@ -314,48 +310,35 @@ static int touch_poll(FAR struct file *filep,
 
   if (setup)
     {
-      for (i = 0; i < CONFIG_INPUT_TOUCHSCREEN_NPOLLWAITERS; i++)
+      if (openpriv->fds == NULL)
         {
-          if (NULL == upper->fds[i])
-            {
-              upper->fds[i] = fds;
-              fds->priv = &upper->fds[i];
-              break;
-            }
+          openpriv->fds = fds;
+          fds->priv     = &openpriv->fds;
         }
-
-      if (i >= CONFIG_INPUT_TOUCHSCREEN_NPOLLWAITERS)
+      else
         {
-          fds->priv = NULL;
-          ret       = -EBUSY;
+          ret = -EBUSY;
           goto errout;
         }
 
-      if (!circbuf_is_empty(&upper->buffer))
+      if (!circbuf_is_empty(&openpriv->circbuf))
         {
           eventset |= (fds->events & POLLIN);
         }
 
       if (eventset)
         {
-          touch_notify(upper, eventset);
+          touch_notify(openpriv, POLLIN);
         }
     }
   else if (fds->priv)
     {
-      for (i = 0; i < CONFIG_INPUT_TOUCHSCREEN_NPOLLWAITERS; i++)
-        {
-          if (fds == upper->fds[i])
-            {
-              upper->fds[i] = NULL;
-              fds->priv = NULL;
-              break;
-            }
-        }
+      openpriv->fds = NULL;
+      fds->priv   = NULL;
     }
 
 errout:
-  nxsem_post(&upper->exclsem);
+  nxsem_post(&openpriv->locksem);
   return ret;
 }
 
@@ -366,6 +349,7 @@ errout:
 void touch_event(FAR void *priv, FAR const struct touch_sample_s *sample)
 {
   FAR struct touch_upperhalf_s *upper = priv;
+  FAR struct touch_openpriv_s  *openpriv;
   int semcount;
 
   if (nxsem_wait(&upper->exclsem) < 0)
@@ -373,27 +357,32 @@ void touch_event(FAR void *priv, FAR const struct touch_sample_s *sample)
       return;
     }
 
-  circbuf_overwrite(&upper->buffer, sample,
-                    SIZEOF_TOUCH_SAMPLE_S(sample->npoints));
-  touch_notify(upper, POLLIN);
-  nxsem_get_value(&upper->buffersem, &semcount);
-  if (semcount < 1)
+  list_for_every_entry(&upper->head, openpriv, struct touch_openpriv_s, node)
     {
-      nxsem_post(&upper->buffersem);
+      circbuf_overwrite(&openpriv->circbuf, sample,
+                        SIZEOF_TOUCH_SAMPLE_S(sample->npoints));
+
+      nxsem_get_value(&openpriv->waitsem, &semcount);
+      if (semcount < 1)
+        {
+          nxsem_post(&openpriv->waitsem);
+        }
+
+      touch_notify(openpriv, POLLIN);
     }
 
   nxsem_post(&upper->exclsem);
 }
 
 int touch_register(FAR struct touch_lowerhalf_s *lower,
-                   FAR const char *path, uint8_t buff_nums)
+                   FAR const char *path, uint8_t nums)
 {
   FAR struct touch_upperhalf_s *upper;
   int ret;
 
   iinfo("Registering %s\n", path);
 
-  if (lower == NULL || !buff_nums)
+  if (lower == NULL || nums == 0)
     {
       ierr("ERROR: invalid touchscreen device\n");
       return -EINVAL;
@@ -406,27 +395,20 @@ int touch_register(FAR struct touch_lowerhalf_s *lower,
       return -ENOMEM;
     }
 
-  upper->lower     = lower;
-  upper->buff_nums = buff_nums;
-
+  lower->priv  = upper;
+  upper->lower = lower;
+  upper->nums  = nums;
+  list_initialize(&upper->head);
   nxsem_init(&upper->exclsem, 0, 1);
-  nxsem_init(&upper->buffersem, 0, 0);
-
-  nxsem_set_protocol(&upper->buffersem, SEM_PRIO_NONE);
-
-  lower->priv = upper;
 
   ret = register_driver(path, &g_touch_fops, 0666, upper);
   if (ret < 0)
     {
-      goto err_out;
+      nxsem_destroy(&upper->exclsem);
+      kmm_free(upper);
+      return ret;
     }
 
-  return ret;
-err_out:
-  nxsem_destroy(&upper->exclsem);
-  nxsem_destroy(&upper->buffersem);
-  kmm_free(upper);
   return ret;
 }
 
@@ -439,12 +421,9 @@ void touch_unregister(FAR struct touch_lowerhalf_s *lower,
   DEBUGASSERT(lower->priv != NULL);
 
   upper = lower->priv;
-
   iinfo("UnRegistering %s\n", path);
   unregister_driver(path);
 
   nxsem_destroy(&upper->exclsem);
-  nxsem_destroy(&upper->buffersem);
-
   kmm_free(upper);
 }

--- a/drivers/input/uinput.c
+++ b/drivers/input/uinput.c
@@ -21,6 +21,8 @@
 #include <nuttx/config.h>
 #include <sys/types.h>
 
+#include <assert.h>
+#include <debug.h>
 #include <errno.h>
 #include <stdio.h>
 
@@ -28,19 +30,58 @@
 #include <nuttx/input/touchscreen.h>
 #include <nuttx/input/uinput.h>
 #include <nuttx/kmalloc.h>
+#include <nuttx/list.h>
+
+#ifdef CONFIG_UINPUT_RPMSG
+#  include <nuttx/rptun/openamp.h>
+#endif
 
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
 
-#define UINPUT_NAME_SIZE 32
+#define UINPUT_NAME_SIZE  16
+#define RPMSG_UINPUT_NAME "rpmsg-uinput-%s"
 
 /****************************************************************************
  * Private Types
  ****************************************************************************/
 
+#ifdef CONFIG_UINPUT_RPMSG
+
+struct uinput_rpmsg_ept_s
+{
+  struct rpmsg_endpoint ept;
+  struct rpmsg_device  *rdev;
+  struct list_node      node;
+};
+
+struct uinput_context_s
+{
+  char name[UINPUT_NAME_SIZE];
+  struct list_node eptlist;
+  ssize_t (*notify)(FAR void *uinput_lower,
+                    FAR const char *buffer,
+                    size_t buflen);
+};
+
+#endif /* CONFIG_UINPUT_RPMSG */
+
+struct uinput_touch_lowerhalf_s
+{
+#ifdef CONFIG_UINPUT_RPMSG
+  struct uinput_context_s ctx;
+#endif
+
+  struct touch_lowerhalf_s lower;
+};
+
 struct uinput_button_lowerhalf_s
 {
+#ifdef CONFIG_UINPUT_RPMSG
+  struct uinput_context_s ctx;
+#endif
+
   struct btn_lowerhalf_s lower;
   btn_buttonset_t        buttons;
   btn_handler_t          handler;
@@ -51,7 +92,30 @@ struct uinput_button_lowerhalf_s
  * Private Function Prototypes
  ****************************************************************************/
 
+#ifdef CONFIG_UINPUT_RPMSG
+
+static int uinput_rpmsg_ept_cb(FAR struct rpmsg_endpoint *ept,
+                               FAR void *data, size_t len,
+                               uint32_t src, FAR void *priv);
+
+static void uinput_rpmsg_device_created(FAR struct rpmsg_device *rdev,
+                                        FAR void *priv);
+
+static void uinput_rpmsg_device_destroy(FAR struct rpmsg_device *rdev,
+                                        FAR void *priv);
+
+static int uinput_rpmsg_initialize(FAR struct uinput_context_s *ctx,
+                                   FAR const char *name);
+
+static void uinput_rpmsg_notify(FAR struct uinput_context_s *ctx,
+                                FAR const char *buffer, size_t buflen);
+
+#endif /* CONFIG_UINPUT_RPMSG */
+
 #ifdef CONFIG_UINPUT_TOUCHSCREEN
+
+static ssize_t uinput_touch_notify(FAR void *uinput_lower,
+                                   FAR const char *buffer, size_t buflen);
 
 static ssize_t uinput_touch_write(FAR struct touch_lowerhalf_s *lower,
                                   FAR const char *buffer, size_t buflen);
@@ -59,6 +123,9 @@ static ssize_t uinput_touch_write(FAR struct touch_lowerhalf_s *lower,
 #endif /* CONFIG_UINPUT_TOUCHSCREEN */
 
 #ifdef CONFIG_UINPUT_BUTTONS
+
+static ssize_t uinput_button_notify(FAR void *uinput_lower,
+                                    FAR const char *buffer, size_t buflen);
 
 static ssize_t uinput_button_write(FAR const struct btn_lowerhalf_s *lower,
                                    FAR const char *buffer, size_t buflen);
@@ -81,7 +148,136 @@ static void uinput_button_enable(FAR const struct btn_lowerhalf_s *lower,
  * Private Functions
  ****************************************************************************/
 
+#ifdef CONFIG_UINPUT_RPMSG
+
+/****************************************************************************
+ * uinput_rpmsg_ept_cb
+ ****************************************************************************/
+
+static int uinput_rpmsg_ept_cb(FAR struct rpmsg_endpoint *ept,
+                               FAR void *data, size_t len,
+                               uint32_t src, FAR void *priv)
+{
+  FAR struct uinput_context_s *ctx = priv;
+
+  ctx->notify(ctx, data, len);
+  return 0;
+}
+
+/****************************************************************************
+ * uinput_rpmsg_device_created
+ ****************************************************************************/
+
+static void uinput_rpmsg_device_created(FAR struct rpmsg_device *rdev,
+                                        FAR void *priv)
+{
+  int  ret;
+  char rpmsg_ept_name[RPMSG_NAME_SIZE];
+  FAR struct uinput_rpmsg_ept_s *ept;
+  FAR struct uinput_context_s   *ctx  = (FAR struct uinput_context_s *)priv;
+  FAR struct list_node          *list = &ctx->eptlist;
+
+  ept = kmm_zalloc(sizeof(struct uinput_rpmsg_ept_s));
+  if (ept == NULL)
+    {
+      ierr("Failed to alloc memory\n");
+      return;
+    }
+
+  ept->ept.priv = ctx;
+  snprintf(rpmsg_ept_name, sizeof(rpmsg_ept_name),
+           RPMSG_UINPUT_NAME, ctx->name);
+  ret = rpmsg_create_ept(&ept->ept, rdev, rpmsg_ept_name,
+                         RPMSG_ADDR_ANY, RPMSG_ADDR_ANY,
+                         uinput_rpmsg_ept_cb, NULL);
+  if (ret < 0)
+    {
+      ierr("uinput rpmsg create failure, %s\n", rpmsg_get_cpuname(rdev));
+      kmm_free(ept);
+      return;
+    }
+
+  ept->rdev = rdev;
+  list_add_tail(list, &ept->node);
+}
+
+/****************************************************************************
+ * uinput_rpmsg_device_destroy
+ ****************************************************************************/
+
+static void uinput_rpmsg_device_destroy(FAR struct rpmsg_device *rdev,
+                                        FAR void *priv)
+{
+  FAR struct uinput_context_s   *ctx  = (FAR struct uinput_context_s *)priv;
+  FAR struct list_node          *list = &ctx->eptlist;
+  FAR struct uinput_rpmsg_ept_s *ept;
+
+  list_for_every_entry(list, ept, struct uinput_rpmsg_ept_s, node)
+    {
+      if (ept->rdev == rdev)
+        {
+          list_delete(&ept->node);
+          rpmsg_destroy_ept(priv);
+          kmm_free(ept);
+          return;
+        }
+    }
+}
+
+/****************************************************************************
+ * Name: uinput_rpmsg_initialize
+ ****************************************************************************/
+
+static int uinput_rpmsg_initialize(FAR struct uinput_context_s *ctx,
+                                   FAR const char *name)
+{
+  list_initialize(&ctx->eptlist);
+  strlcpy(ctx->name, name, UINPUT_NAME_SIZE);
+  return rpmsg_register_callback(ctx, uinput_rpmsg_device_created,
+                                 uinput_rpmsg_device_destroy, NULL);
+}
+
+/****************************************************************************
+ * Name: uinput_rpmsg_notify
+ ****************************************************************************/
+
+static void uinput_rpmsg_notify(FAR struct uinput_context_s *ctx,
+                                FAR const char *buffer, size_t buflen)
+{
+  FAR struct uinput_rpmsg_ept_s *ept;
+
+  list_for_every_entry(&ctx->eptlist, ept, struct uinput_rpmsg_ept_s, node)
+    {
+      if (is_rpmsg_ept_ready(&ept->ept) == 0)
+        {
+          if (rpmsg_send(&ept->ept, buffer, buflen) < 0)
+            {
+              ierr("uinput rpmsg send failed, cpu : %s\n",
+                   rpmsg_get_cpuname(ept->rdev));
+            }
+        }
+    }
+}
+
+#endif /* CONFIG_UINPUT_RPMSG */
+
 #ifdef CONFIG_UINPUT_TOUCHSCREEN
+
+/****************************************************************************
+ * Name: uinput_touch_notify
+ ****************************************************************************/
+
+static ssize_t uinput_touch_notify(FAR void *uinput_lower,
+                                   FAR const char *buffer, size_t buflen)
+{
+  FAR struct uinput_touch_lowerhalf_s *utcs_lower =
+    (FAR struct uinput_touch_lowerhalf_s *)uinput_lower;
+  FAR const struct touch_sample_s *sample =
+    (FAR const struct touch_sample_s *)buffer;
+
+  touch_event(utcs_lower->lower.priv, sample);
+  return buflen;
+}
 
 /****************************************************************************
  * Name: uinput_touch_write
@@ -90,21 +286,43 @@ static void uinput_button_enable(FAR const struct btn_lowerhalf_s *lower,
 static ssize_t uinput_touch_write(FAR struct touch_lowerhalf_s *lower,
                                   FAR const char *buffer, size_t buflen)
 {
-  FAR const struct touch_sample_s *sample;
+  FAR struct uinput_touch_lowerhalf_s *utcs_lower =
+    container_of(lower, struct uinput_touch_lowerhalf_s, lower);
 
-  sample = (FAR const struct touch_sample_s *)buffer;
-  if (sample == NULL)
-    {
-      return -EINVAL;
-    }
+#ifdef CONFIG_UINPUT_RPMSG
+  uinput_rpmsg_notify(&utcs_lower->ctx, buffer, buflen);
+#endif
 
-  touch_event(lower->priv, sample);
-  return buflen;
+  return uinput_touch_notify(utcs_lower, buffer, buflen);
 }
 
 #endif /* CONFIG_UINPUT_TOUCHSCREEN */
 
 #ifdef CONFIG_UINPUT_BUTTONS
+
+/****************************************************************************
+ * Name: uinput_button_notify
+ ****************************************************************************/
+
+static ssize_t uinput_button_notify(FAR void *uinput_lower,
+                                    FAR const char *buffer, size_t buflen)
+{
+  FAR struct uinput_button_lowerhalf_s *ubtn_lower =
+    (FAR struct uinput_button_lowerhalf_s *)uinput_lower;
+
+  if (buflen != sizeof(btn_buttonset_t))
+    {
+      return -EINVAL;
+    }
+
+  ubtn_lower->buttons = *(btn_buttonset_t *)buffer;
+  if (ubtn_lower->handler != NULL)
+    {
+      ubtn_lower->handler(&ubtn_lower->lower, ubtn_lower->arg);
+    }
+
+  return buflen;
+}
 
 /****************************************************************************
  * Name: uinput_button_write
@@ -114,25 +332,21 @@ static ssize_t uinput_button_write(FAR const struct btn_lowerhalf_s *lower,
                                    FAR const char *buffer, size_t buflen)
 {
   FAR struct uinput_button_lowerhalf_s *ubtn_lower =
-             (FAR struct uinput_button_lowerhalf_s *)lower;
+    container_of(lower, struct uinput_button_lowerhalf_s, lower);
 
-  if (buflen != sizeof(btn_buttonset_t))
-    {
-      return -EINVAL;
-    }
+#ifdef CONFIG_UINPUT_RPMSG
+  uinput_rpmsg_notify(&ubtn_lower->ctx, buffer, buflen);
+#endif
 
-  ubtn_lower->buttons = *(btn_buttonset_t *)buffer;
-  ubtn_lower->handler(&ubtn_lower->lower, ubtn_lower->arg);
-
-  return buflen;
+  return uinput_button_notify(ubtn_lower, buffer, buflen);
 }
 
 /****************************************************************************
  * Name: uinput_button_supported
  ****************************************************************************/
 
-static btn_buttonset_t uinput_button_supported(FAR const struct
-                                               btn_lowerhalf_s *lower)
+static btn_buttonset_t
+uinput_button_supported(FAR const struct btn_lowerhalf_s *lower)
 {
   return ~0u;
 }
@@ -145,8 +359,7 @@ static btn_buttonset_t
 uinput_button_buttons(FAR const struct btn_lowerhalf_s *lower)
 {
   FAR struct uinput_button_lowerhalf_s *ubtn_lower =
-             (FAR struct uinput_button_lowerhalf_s *)lower;
-
+    container_of(lower, struct uinput_button_lowerhalf_s, lower);
   return ubtn_lower->buttons;
 }
 
@@ -160,8 +373,7 @@ static void uinput_button_enable(FAR const struct btn_lowerhalf_s *lower,
                                  btn_handler_t handler, FAR void *arg)
 {
   FAR struct uinput_button_lowerhalf_s *ubtn_lower =
-    (FAR struct uinput_button_lowerhalf_s *)lower;
-
+    container_of(lower, struct uinput_button_lowerhalf_s, lower);
   ubtn_lower->arg     = arg;
   ubtn_lower->handler = handler;
 }
@@ -194,28 +406,36 @@ static void uinput_button_enable(FAR const struct btn_lowerhalf_s *lower,
 int uinput_touch_initialize(FAR const char *name, int maxpoint, int buffnums)
 {
   char devname[UINPUT_NAME_SIZE];
-  FAR struct touch_lowerhalf_s *lower;
+  FAR struct uinput_touch_lowerhalf_s *utcs_lower;
   int ret;
 
-  lower = kmm_zalloc(sizeof(struct touch_lowerhalf_s));
-  if (!lower)
+  utcs_lower = kmm_zalloc(sizeof(struct uinput_touch_lowerhalf_s));
+  if (utcs_lower == NULL)
     {
       return -ENOMEM;
     }
 
+  utcs_lower->lower.write    = uinput_touch_write;
+  utcs_lower->lower.maxpoint = maxpoint;
+#ifdef CONFIG_UINPUT_RPMSG
+  utcs_lower->ctx.notify     = uinput_touch_notify;
+#endif
+
   /* Regiest Touchscreen device */
 
-  lower->write    = uinput_touch_write;
-  lower->maxpoint = maxpoint;
-
-  snprintf(devname, UINPUT_NAME_SIZE, "/dev/%s", name);
-  ret = touch_register(lower, devname, buffnums);
+  snprintf(devname, sizeof(devname), "/dev/%s", name);
+  ret = touch_register(&utcs_lower->lower, devname, buffnums);
   if (ret < 0)
     {
-      kmm_free(lower);
+      kmm_free(utcs_lower);
+      return ret;
     }
 
-  return ret;
+#ifdef CONFIG_UINPUT_RPMSG
+  uinput_rpmsg_initialize(&utcs_lower->ctx, name);
+#endif
+
+  return 0;
 }
 
 #endif /* CONFIG_UINPUT_TOUCHSCREEN */
@@ -248,15 +468,24 @@ int uinput_button_initialize(FAR const char *name)
   ubtn_lower->lower.bl_enable    = uinput_button_enable;
   ubtn_lower->lower.bl_supported = uinput_button_supported;
   ubtn_lower->lower.bl_write     = uinput_button_write;
+#ifdef CONFIG_UINPUT_RPMSG
+  ubtn_lower->ctx.notify         = uinput_button_notify;
+#endif
 
-  snprintf(devname, UINPUT_NAME_SIZE, "/dev/%s", name);
+  snprintf(devname, sizeof(devname), "/dev/%s", name);
   ret = btn_register(devname, &ubtn_lower->lower);
   if (ret < 0)
     {
       kmm_free(ubtn_lower);
+      ierr("ERROR: uinput button initialize failed\n");
+      return ret;
     }
 
-  return ret;
+#ifdef CONFIG_UINPUT_RPMSG
+  uinput_rpmsg_initialize(&ubtn_lower->ctx, name);
+#endif
+
+  return 0;
 }
 
 #endif /* CONFIG_UINPUT_BUTTONS */

--- a/drivers/input/uinput.c
+++ b/drivers/input/uinput.c
@@ -51,12 +51,15 @@ struct uinput_button_lowerhalf_s
  * Private Function Prototypes
  ****************************************************************************/
 
-#ifdef CONFIG_INPUT_TOUCHSCREEN
+#ifdef CONFIG_UINPUT_TOUCHSCREEN
+
 static ssize_t uinput_touch_write(FAR struct touch_lowerhalf_s *lower,
                                   FAR const char *buffer, size_t buflen);
-#endif
 
-#ifdef CONFIG_INPUT_BUTTONS
+#endif /* CONFIG_UINPUT_TOUCHSCREEN */
+
+#ifdef CONFIG_UINPUT_BUTTONS
+
 static ssize_t uinput_button_write(FAR const struct btn_lowerhalf_s *lower,
                                    FAR const char *buffer, size_t buflen);
 
@@ -71,13 +74,14 @@ static void uinput_button_enable(FAR const struct btn_lowerhalf_s *lower,
                                  btn_buttonset_t release,
                                  btn_handler_t handler,
                                  FAR void *arg);
-#endif
+
+#endif /* CONFIG_UINPUT_BUTTONS */
 
 /****************************************************************************
  * Private Functions
  ****************************************************************************/
 
-#ifdef CONFIG_INPUT_TOUCHSCREEN
+#ifdef CONFIG_UINPUT_TOUCHSCREEN
 
 /****************************************************************************
  * Name: uinput_touch_write
@@ -97,13 +101,10 @@ static ssize_t uinput_touch_write(FAR struct touch_lowerhalf_s *lower,
   touch_event(lower->priv, sample);
   return buflen;
 }
-#endif /* CONFIG_INPUT_TOUCHSCREEN */
 
-#ifdef CONFIG_INPUT_BUTTONS
+#endif /* CONFIG_UINPUT_TOUCHSCREEN */
 
-/****************************************************************************
- * Name: uinput_button_write
- ****************************************************************************/
+#ifdef CONFIG_UINPUT_BUTTONS
 
 /****************************************************************************
  * Name: uinput_button_write
@@ -165,7 +166,7 @@ static void uinput_button_enable(FAR const struct btn_lowerhalf_s *lower,
   ubtn_lower->handler = handler;
 }
 
-#endif /* CONFIG_INPUT_BUTTONS */
+#endif /* CONFIG_UINPUT_BUTTONS */
 
 /****************************************************************************
  * Public Functions
@@ -188,7 +189,8 @@ static void uinput_button_enable(FAR const struct btn_lowerhalf_s *lower,
  *
  ****************************************************************************/
 
-#ifdef CONFIG_INPUT_TOUCHSCREEN
+#ifdef CONFIG_UINPUT_TOUCHSCREEN
+
 int uinput_touch_initialize(FAR const char *name, int maxpoint, int buffnums)
 {
   char devname[UINPUT_NAME_SIZE];
@@ -215,7 +217,8 @@ int uinput_touch_initialize(FAR const char *name, int maxpoint, int buffnums)
 
   return ret;
 }
-#endif
+
+#endif /* CONFIG_UINPUT_TOUCHSCREEN */
 
 /****************************************************************************
  * Name: uinput_button_initialize
@@ -232,7 +235,8 @@ int uinput_touch_initialize(FAR const char *name, int maxpoint, int buffnums)
  *
  ****************************************************************************/
 
-#ifdef CONFIG_INPUT_BUTTONS
+#ifdef CONFIG_UINPUT_BUTTONS
+
 int uinput_button_initialize(FAR const char *name)
 {
   char devname[UINPUT_NAME_SIZE];
@@ -254,4 +258,5 @@ int uinput_button_initialize(FAR const char *name)
 
   return ret;
 }
-#endif /* CONFIG_INPUT_BUTTONS */
+
+#endif /* CONFIG_UINPUT_BUTTONS */

--- a/include/nuttx/input/kbd_codec.h
+++ b/include/nuttx/input/kbd_codec.h
@@ -29,8 +29,6 @@
 #include <nuttx/config.h>
 #include <nuttx/streams.h>
 
-#ifdef CONFIG_LIBC_KBDCODEC
-
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
@@ -195,6 +193,8 @@ struct kbd_getstate_s
 /****************************************************************************
  * Public Function Prototypes
  ****************************************************************************/
+
+#ifdef CONFIG_LIBC_KBDCODEC
 
 #ifdef __cplusplus
 extern "C"

--- a/include/nuttx/input/keyboard.h
+++ b/include/nuttx/input/keyboard.h
@@ -1,0 +1,97 @@
+/****************************************************************************
+ * include/nuttx/input/keyboard.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __INCLUDE_NUTTX_INPUT_KEYBOARD_H
+#define __INCLUDE_NUTTX_INPUT_KEYBOARD_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <nuttx/input/x11_keysym.h>
+#include <nuttx/input/x11_xf86keysym.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define KEYBOARD_PRESS   0 /* Key press event */
+#define KEYBOARD_RELEASE 1 /* Key release event */
+
+/****************************************************************************
+ * Public Types
+ ****************************************************************************/
+
+struct keyboard_event_s
+{
+  uint32_t type;
+  uint32_t code;
+};
+
+struct keyboard_lowerhalf_s
+{
+  FAR void *priv;
+  CODE int (*open)(FAR struct keyboard_lowerhalf_s *lower);
+  CODE int (*close)(FAR struct keyboard_lowerhalf_s *lower);
+  CODE ssize_t (*write)(FAR struct keyboard_lowerhalf_s *lower,
+                        FAR const char *buffer, size_t buflen);
+};
+
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
+
+#ifdef __cplusplus
+#define EXTERN extern "C"
+extern "C"
+{
+#else
+#define EXTERN extern
+#endif
+
+/****************************************************************************
+ * Name: keyboard_event
+ ****************************************************************************/
+
+void keyboard_event(FAR struct keyboard_lowerhalf_s *lower, uint32_t keycode,
+                    uint32_t type);
+
+/****************************************************************************
+ * Name: keyboard_register
+ ****************************************************************************/
+
+int keyboard_register(FAR struct keyboard_lowerhalf_s *lower,
+                      FAR const char *path);
+
+/****************************************************************************
+ * Name: keyboard_register
+ ****************************************************************************/
+
+int keyboard_unregister(FAR struct keyboard_lowerhalf_s *lower,
+                        FAR const char *path);
+
+#undef EXTERN
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __INCLUDE_NUTTX_INPUT_KEYBOARD_H */

--- a/include/nuttx/input/touchscreen.h
+++ b/include/nuttx/input/touchscreen.h
@@ -236,7 +236,7 @@ void touch_event(FAR void *priv, FAR const struct touch_sample_s *sample);
  * Arguments:
  *   lower     - A pointer of lower half instance.
  *   path      - The path of touchscreen device. such as "/dev/input0"
- *   buff_nums - Number of the touch points structure.
+ *   nums      - Number of the touch points structure.
  *
  * Return:
  *   OK if the driver was successfully registered; A negated errno value is
@@ -245,7 +245,7 @@ void touch_event(FAR void *priv, FAR const struct touch_sample_s *sample);
  ****************************************************************************/
 
 int touch_register(FAR struct touch_lowerhalf_s *lower,
-                   FAR const char *path, uint8_t buff_nums);
+                   FAR const char *path, uint8_t nums);
 
 /****************************************************************************
  * Name: touch_unregister

--- a/include/nuttx/input/uinput.h
+++ b/include/nuttx/input/uinput.h
@@ -52,6 +52,25 @@ int uinput_touch_initialize(FAR const char *name, int maxpoint,
 #endif
 
 /****************************************************************************
+ * Name: uinput_keyboard_initialize
+ *
+ * Description:
+ *   Initialized the uinput keyboard device
+ *
+ * Input Parameters:
+ *   name:      keyboard devices name
+ *
+ * Returned Value:
+ *   Zero is returned on success. Otherwise, a negated errno value is
+ *   returned to indicate the nature of the failure.
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_UINPUT_KEYBOARD
+int uinput_keyboard_initialize(FAR const char *name);
+#endif
+
+/****************************************************************************
  * Name: uinput_button_initialize
  *
  * Description:

--- a/include/nuttx/input/uinput.h
+++ b/include/nuttx/input/uinput.h
@@ -46,8 +46,10 @@
  *
  ****************************************************************************/
 
+#ifdef CONFIG_UINPUT_TOUCHSCREEN
 int uinput_touch_initialize(FAR const char *name, int maxpoint,
                             int buffnums);
+#endif
 
 /****************************************************************************
  * Name: uinput_button_initialize
@@ -64,6 +66,8 @@ int uinput_touch_initialize(FAR const char *name, int maxpoint,
  *
  ****************************************************************************/
 
+#ifdef CONFIG_UINPUT_BUTTONS
 int uinput_button_initialize(FAR const char *name);
+#endif
 
 #endif /* __INCLUDE_NUTTX_INPUT_UINPUT_H */


### PR DESCRIPTION
## Summary
In the case of multi-core, the uinput data of one CPU can notify the uinput data of another CPU.
add uinput keyboard device support

## Impact

## Testing

