### PR TITLE
arm/armv7-a/r: unified syscall registers dump

### DIFF
--- a/arch/arm/src/armv7-a/arm_syscall.c
+++ b/arch/arm/src/armv7-a/arm_syscall.c
@@ -45,6 +45,32 @@
  ****************************************************************************/
 
 /****************************************************************************
+ * Name: dump_syscall
+ *
+ * Description:
+ *   Dump the syscall registers
+ *
+ ****************************************************************************/
+
+static void dump_syscall(const char *tag, uint32_t cmd, const uint32_t *regs)
+{
+  /* The SVCall software interrupt is called with R0 = system call command
+   * and R1..R7 =  variable number of arguments depending on the system call.
+   */
+
+  svcinfo("SYSCALL %s: regs: %p cmd: %" PRId32 "\n", tag, regs, cmd);
+  svcinfo("  R0: %08" PRIx32 " %08" PRIx32 " %08" PRIx32 " %08" PRIx32
+          " %08" PRIx32 " %08" PRIx32 " %08" PRIx32 " %08" PRIx32 "\n",
+          regs[REG_R0],  regs[REG_R1],  regs[REG_R2],  regs[REG_R3],
+          regs[REG_R4],  regs[REG_R5],  regs[REG_R6],  regs[REG_R7]);
+  svcinfo("  R8: %08" PRIx32 " %08" PRIx32 " %08" PRIx32 " %08" PRIx32
+          " %08" PRIx32 " %08" PRIx32 " %08" PRIx32 " %08" PRIx32 "\n",
+          regs[REG_R8],  regs[REG_R9],  regs[REG_R10], regs[REG_R11],
+          regs[REG_R12], regs[REG_R13], regs[REG_R14], regs[REG_R15]);
+  svcinfo("CPSR: %08" PRIx32 "\n", regs[REG_CPSR]);
+}
+
+/****************************************************************************
  * Name: dispatch_syscall
  *
  * Description:
@@ -104,10 +130,6 @@ static void dispatch_syscall(void)
 #endif
 
 /****************************************************************************
- * Private Functions
- ****************************************************************************/
-
-/****************************************************************************
  * Public Functions
  ****************************************************************************/
 
@@ -142,16 +164,7 @@ uint32_t *arm_syscall(uint32_t *regs)
    * and R1..R7 =  variable number of arguments depending on the system call.
    */
 
-  svcinfo("SYSCALL Entry: regs: %p cmd: %" PRId32 "\n", regs, cmd);
-  svcinfo("  R0: %08" PRIx32 " %08" PRIx32 " %08" PRIx32 " %08" PRIx32
-          " %08" PRIx32 " %08" PRIx32 " %08" PRIx32 " %08" PRIx32 "\n",
-          regs[REG_R0],  regs[REG_R1],  regs[REG_R2],  regs[REG_R3],
-          regs[REG_R4],  regs[REG_R5],  regs[REG_R6],  regs[REG_R7]);
-  svcinfo("  R8: %08" PRIx32 " %08" PRIx32 " %08" PRIx32 " %08" PRIx32
-          " %08" PRIx32 " %08" PRIx32 " %08" PRIx32 " %08" PRIx32 "\n",
-          regs[REG_R8],  regs[REG_R9],  regs[REG_R10], regs[REG_R11],
-          regs[REG_R12], regs[REG_R13], regs[REG_R14], regs[REG_R15]);
-  svcinfo("CPSR: %08" PRIx32 "\n", regs[REG_CPSR]);
+  dump_syscall("Entry", cmd, regs);
 
   /* Handle the SVCall according to the command in R0 */
 
@@ -512,16 +525,7 @@ uint32_t *arm_syscall(uint32_t *regs)
 
   /* Report what happened */
 
-  svcinfo("SYSCALL Exit: regs: %p\n", regs);
-  svcinfo("  R0: %" PRIx32 " %" PRIx32 " %" PRIx32 " %" PRIx32
-          " %" PRIx32 " %" PRIx32 " %" PRIx32 " %" PRIx32 "\n",
-          regs[REG_R0],  regs[REG_R1],  regs[REG_R2],  regs[REG_R3],
-          regs[REG_R4],  regs[REG_R5],  regs[REG_R6],  regs[REG_R7]);
-  svcinfo("  R8: %" PRIx32 " %" PRIx32 " %" PRIx32 " %" PRIx32
-          " %" PRIx32 " %" PRIx32 " %" PRIx32 " %" PRIx32 "\n",
-          regs[REG_R8],  regs[REG_R9],  regs[REG_R10], regs[REG_R11],
-          regs[REG_R12], regs[REG_R13], regs[REG_R14], regs[REG_R15]);
-  svcinfo("CPSR: %08" PRIx32 "\n", regs[REG_CPSR]);
+  dump_syscall("Exit", cmd, regs);
 
   /* Return the last value of curent_regs.  This supports context switches
    * on return from the exception.  That capability is only used with the

--- a/arch/arm/src/armv7-a/arm_syscall.c
+++ b/arch/arm/src/armv7-a/arm_syscall.c
@@ -58,7 +58,18 @@ static void dump_syscall(const char *tag, uint32_t cmd, const uint32_t *regs)
    * and R1..R7 =  variable number of arguments depending on the system call.
    */
 
-  svcinfo("SYSCALL %s: regs: %p cmd: %" PRId32 "\n", tag, regs, cmd);
+#ifdef CONFIG_LIB_SYSCALL
+  if (cmd >= CONFIG_SYS_RESERVED)
+    {
+      svcinfo("SYSCALL %s: regs: %p cmd: %" PRId32 " name: %s\n", tag,
+              regs, cmd, g_funcnames[cmd - CONFIG_SYS_RESERVED]);
+    }
+  else
+#endif
+    {
+      svcinfo("SYSCALL %s: regs: %p cmd: %" PRId32 "\n", tag, regs, cmd);
+    }
+
   svcinfo("  R0: %08" PRIx32 " %08" PRIx32 " %08" PRIx32 " %08" PRIx32
           " %08" PRIx32 " %08" PRIx32 " %08" PRIx32 " %08" PRIx32 "\n",
           regs[REG_R0],  regs[REG_R1],  regs[REG_R2],  regs[REG_R3],

--- a/arch/arm/src/armv7-r/arm_syscall.c
+++ b/arch/arm/src/armv7-r/arm_syscall.c
@@ -42,6 +42,32 @@
  ****************************************************************************/
 
 /****************************************************************************
+ * Name: dump_syscall
+ *
+ * Description:
+ *   Dump the syscall registers
+ *
+ ****************************************************************************/
+
+static void dump_syscall(const char *tag, uint32_t cmd, const uint32_t *regs)
+{
+  /* The SVCall software interrupt is called with R0 = system call command
+   * and R1..R7 =  variable number of arguments depending on the system call.
+   */
+
+  svcinfo("SYSCALL %s: regs: %p cmd: %" PRId32 "\n", tag, regs, cmd);
+  svcinfo("  R0: %08" PRIx32 " %08" PRIx32 " %08" PRIx32 " %08" PRIx32
+          " %08" PRIx32 " %08" PRIx32 " %08" PRIx32 " %08" PRIx32 "\n",
+          regs[REG_R0],  regs[REG_R1],  regs[REG_R2],  regs[REG_R3],
+          regs[REG_R4],  regs[REG_R5],  regs[REG_R6],  regs[REG_R7]);
+  svcinfo("  R8: %08" PRIx32 " %08" PRIx32 " %08" PRIx32 " %08" PRIx32
+          " %08" PRIx32 " %08" PRIx32 " %08" PRIx32 " %08" PRIx32 "\n",
+          regs[REG_R8],  regs[REG_R9],  regs[REG_R10], regs[REG_R11],
+          regs[REG_R12], regs[REG_R13], regs[REG_R14], regs[REG_R15]);
+  svcinfo("CPSR: %08" PRIx32 "\n", regs[REG_CPSR]);
+}
+
+/****************************************************************************
  * Name: dispatch_syscall
  *
  * Description:
@@ -101,10 +127,6 @@ static void dispatch_syscall(void)
 #endif
 
 /****************************************************************************
- * Private Functions
- ****************************************************************************/
-
-/****************************************************************************
  * Public Functions
  ****************************************************************************/
 
@@ -139,14 +161,7 @@ uint32_t *arm_syscall(uint32_t *regs)
    * and R1..R7 =  variable number of arguments depending on the system call.
    */
 
-  svcinfo("SYSCALL Entry: regs: %p cmd: %d\n", regs, cmd);
-  svcinfo("  R0: %08x %08x %08x %08x %08x %08x %08x %08x\n",
-          regs[REG_R0],  regs[REG_R1],  regs[REG_R2],  regs[REG_R3],
-          regs[REG_R4],  regs[REG_R5],  regs[REG_R6],  regs[REG_R7]);
-  svcinfo("  R8: %08x %08x %08x %08x %08x %08x %08x %08x\n",
-          regs[REG_R8],  regs[REG_R9],  regs[REG_R10], regs[REG_R11],
-          regs[REG_R12], regs[REG_R13], regs[REG_R14], regs[REG_R15]);
-  svcinfo("CPSR: %08x\n", regs[REG_CPSR]);
+  dump_syscall("Entry", cmd, regs);
 
   /* Handle the SVCall according to the command in R0 */
 
@@ -507,14 +522,7 @@ uint32_t *arm_syscall(uint32_t *regs)
 
   /* Report what happened */
 
-  svcinfo("SYSCALL Exit: regs: %p\n", regs);
-  svcinfo("  R0: %08x %08x %08x %08x %08x %08x %08x %08x\n",
-          regs[REG_R0],  regs[REG_R1],  regs[REG_R2],  regs[REG_R3],
-          regs[REG_R4],  regs[REG_R5],  regs[REG_R6],  regs[REG_R7]);
-  svcinfo("  R8: %08x %08x %08x %08x %08x %08x %08x %08x\n",
-          regs[REG_R8],  regs[REG_R9],  regs[REG_R10], regs[REG_R11],
-          regs[REG_R12], regs[REG_R13], regs[REG_R14], regs[REG_R15]);
-  svcinfo("CPSR: %08x\n", regs[REG_CPSR]);
+  dump_syscall("Exit", cmd, regs);
 
   /* Return the last value of curent_regs.  This supports context switches
    * on return from the exception.  That capability is only used with the

--- a/arch/arm/src/armv7-r/arm_syscall.c
+++ b/arch/arm/src/armv7-r/arm_syscall.c
@@ -55,7 +55,18 @@ static void dump_syscall(const char *tag, uint32_t cmd, const uint32_t *regs)
    * and R1..R7 =  variable number of arguments depending on the system call.
    */
 
-  svcinfo("SYSCALL %s: regs: %p cmd: %" PRId32 "\n", tag, regs, cmd);
+#ifdef CONFIG_LIB_SYSCALL
+  if (cmd >= CONFIG_SYS_RESERVED)
+    {
+      svcinfo("SYSCALL %s: regs: %p cmd: %" PRId32 " name: %s\n", tag,
+              regs, cmd, g_funcnames[cmd - CONFIG_SYS_RESERVED]);
+    }
+  else
+#endif
+    {
+      svcinfo("SYSCALL %s: regs: %p cmd: %" PRId32 "\n", tag, regs, cmd);
+    }
+
   svcinfo("  R0: %08" PRIx32 " %08" PRIx32 " %08" PRIx32 " %08" PRIx32
           " %08" PRIx32 " %08" PRIx32 " %08" PRIx32 " %08" PRIx32 "\n",
           regs[REG_R0],  regs[REG_R1],  regs[REG_R2],  regs[REG_R3],

--- a/include/sys/syscall.h
+++ b/include/sys/syscall.h
@@ -89,15 +89,11 @@ EXTERN const uintptr_t g_stublookup[SYS_nsyscalls];
 
 #endif
 
-#ifdef CONFIG_SCHED_INSTRUMENTATION_SYSCALL
-
 /* Given the system call number, the corresponding entry in this table
  * provides the name of the function.
  */
 
 EXTERN const char *g_funcnames[SYS_nsyscalls];
-
-#endif
 
 /****************************************************************************
  * Public Function Prototypes

--- a/syscall/Makefile
+++ b/syscall/Makefile
@@ -27,6 +27,8 @@ include wraps/Make.defs
 MKSYSCALL = "$(TOPDIR)$(DELIM)tools$(DELIM)mksyscall$(HOSTEXEEXT)"
 CSVFILE = "$(TOPDIR)$(DELIM)syscall$(DELIM)syscall.csv"
 
+STUB_SRCS += syscall_names.c
+
 ifeq ($(CONFIG_SCHED_INSTRUMENTATION_SYSCALL),y)
 ifeq ($(CONFIG_LIB_SYSCALL),y)
 PROXY_SRCS += syscall_names.c


### PR DESCRIPTION
## Summary

arm/armv7-a/r: unified syscall registers dump
syscall/names: export the syscall name in STUB module

```
[   18.550000] [ 4] [ ALERT] SYSCALL Entry: regs: 0x10845358 cmd: 30 name: sem_wait
[   18.550000] [ 4] [ ALERT]   R0: 0000001e 802001e4 00000004 802001e4 8020055c 80200174 00000000 802026c0
[   18.550000] [ 4] [ ALERT]   R8: 00000000 00000000 00000000 00000000 10807469 802026c0 8001799f 80017982
[   18.550000] [ 4] [ ALERT] CPSR: 00000070
[   18.550000] [ 4] [ ALERT] SYSCALL Exit: regs: 0x10845358 cmd: 30 name: sem_wait
[   18.550000] [ 4] [ ALERT]   R0: 00000016 802001e4 00000004 802001e4 8020055c 80200174 00000000 802026c0
[   18.550000] [ 4] [ ALERT]   R8: 00000000 00000000 00000000 00000000 10807469 10845420 8001799f 10801535
[   18.550000] [ 4] [ ALERT] CPSR: 00000073
```


## Impact

N/A

## Testing

ci-check