### PR TITLE
drivers/timers: rename notification parameter oneshot to periodic

### DIFF
--- a/drivers/timers/timer.c
+++ b/drivers/timers/timer.c
@@ -121,7 +121,7 @@ static bool timer_notifier(FAR uint32_t *next_interval_us, FAR void *arg)
 
   nxsig_notification(notify->pid, &notify->event, SI_QUEUE, &upper->work);
 
-  return !notify->oneshot;
+  return notify->periodic;
 }
 
 /****************************************************************************

--- a/include/nuttx/timers/timer.h
+++ b/include/nuttx/timers/timer.h
@@ -116,7 +116,7 @@ struct timer_notify_s
 {
   struct sigevent event;    /* Describe the way a task is to be notified */
   pid_t           pid;      /* The ID of the task/thread to receive the signal */
-  bool            oneshot;  /* Single notification or periodic notifications */
+  bool            periodic; /* True for periodic notifications */
 };
 
 /* This structure provides the "lower-half" driver operations available to


### PR DESCRIPTION
## Summary
Rename notification parameter from `oneshot` to `periodic`.

## Impact
The apps part should be adapted.

## Testing
Tested on SAME70-QMTECH board