### PR TITLE
net/local: correct the socket flags from server socket

### DIFF
--- a/net/local/local_accept.c
+++ b/net/local/local_accept.c
@@ -182,7 +182,7 @@ int local_accept(FAR struct socket *psock, FAR struct sockaddr *addr,
                */
 
               ret = local_open_server_tx(
-                      conn, _SS_ISNONBLOCK(conn->lc_conn.s_flags));
+                      conn, _SS_ISNONBLOCK(server->lc_conn.s_flags));
               if (ret < 0)
                 {
                   nerr("ERROR: Failed to open write-only FIFOs for %s: %d\n",
@@ -202,7 +202,7 @@ int local_accept(FAR struct socket *psock, FAR struct sockaddr *addr,
                */
 
               ret = local_open_server_rx(
-                      conn, _SS_ISNONBLOCK(conn->lc_conn.s_flags));
+                      conn, _SS_ISNONBLOCK(server->lc_conn.s_flags));
               if (ret < 0)
                 {
                    nerr("ERROR: Failed to open read-only FIFOs for %s: %d\n",


### PR DESCRIPTION


## Summary

net/local: correct the socket flags from server socket

newsock = accept(server, &addr, &addrlen);

replace the socket flags from newsock to server to ensure that
the nonblock flags is handled correctly

Signed-off-by: chao.an <anchao@xiaomi.com>

## Impact

local socket

## Testing

local socket nonblock send/recv