### PR TITLE
net/udp: clear the connection structure after free

### DIFF
--- a/net/udp/udp_conn.c
+++ b/net/udp/udp_conn.c
@@ -696,6 +696,10 @@ void udp_free(FAR struct udp_conn_s *conn)
 
 #endif
 
+  /* Clear the connection structure */
+
+  memset(conn, 0, sizeof(*conn));
+
   /* Free the connection */
 
   dq_addlast(&conn->sconn.node, &g_free_udp_connections);


### PR DESCRIPTION
## Summary

net/udp: clear the connection structure after free

## Impact

upper layer protocol via UDP (DHCP/DNS/etc)

## Testing

DHCP/DNS service works fine with NONBLOCK flags
ci check