### PR TITLE
arch: cxd56xx: Fix critical section in serial transmission

### DIFF
--- a/arch/arm/src/cxd56xx/cxd56_serial.c
+++ b/arch/arm/src/cxd56xx/cxd56_serial.c
@@ -1001,9 +1001,13 @@ static void up_txint(FAR struct uart_dev_s *dev, bool enable)
        * interrupts disabled (note this may recurse).
        */
 
+#  ifdef CONFIG_SMP
       spin_unlock_irqrestore(&priv->lock, flags);
+#  endif
       uart_xmitchars(dev);
+#  ifdef CONFIG_SMP
       flags = spin_lock_irqsave(&priv->lock);
+#  endif
 #endif
     }
   else


### PR DESCRIPTION
## Summary
Fix an issue that the serial transmission buffers are corrupted because
serial transmission are not protected by critical section in non-smp mode.

## Impact
Only for spresense board.

## Testing
spresense:nsh
