### PR TITLE
Fix the initial idle tasks environment

### DIFF
--- a/include/nuttx/kmalloc.h
+++ b/include/nuttx/kmalloc.h
@@ -123,6 +123,11 @@ extern "C"
 
 FAR void *group_malloc(FAR struct task_group_s *group, size_t nbytes);
 
+/* Functions defined in group/group_realloc.c *******************************/
+
+FAR void *group_realloc(FAR struct task_group_s *group, FAR void *oldmem,
+                        size_t newsize);
+
 /* Functions defined in group/group_zalloc.c ********************************/
 
 FAR void *group_zalloc(FAR struct task_group_s *group, size_t nbytes);
@@ -136,9 +141,10 @@ void group_free(FAR struct task_group_s *group, FAR void *mem);
    * in privileges.
    */
 
-#  define group_malloc(g,n) kumm_malloc(n)
-#  define group_zalloc(g,n) kumm_zalloc(n)
-#  define group_free(g,m)   kumm_free(m)
+#  define group_malloc(g,n)      kumm_malloc(n)
+#  define group_realloc(g,p,s)   kumm_realloc((p),(s))
+#  define group_zalloc(g,n)      kumm_zalloc(n)
+#  define group_free(g,m)        kumm_free(m)
 
 #endif
 

--- a/sched/environ/env_dup.c
+++ b/sched/environ/env_dup.c
@@ -94,7 +94,7 @@ int env_dup(FAR struct task_group_s *group)
         {
           /* There is an environment, duplicate it */
 
-          envp = (FAR char *)kumm_malloc(envlen);
+          envp = (FAR char *)group_malloc(ptcb->group, envlen);
           if (envp == NULL)
             {
               /* The parent's environment can not be inherited due to a

--- a/sched/environ/env_setenv.c
+++ b/sched/environ/env_setenv.c
@@ -145,7 +145,7 @@ int setenv(FAR const char *name, FAR const char *value, int overwrite)
   if (group->tg_envp)
     {
       newsize = group->tg_envsize + varlen;
-      newenvp = (FAR char *)kumm_realloc(group->tg_envp, newsize);
+      newenvp = (FAR char *)group_realloc(group, group->tg_envp, newsize);
       if (!newenvp)
         {
           ret = ENOMEM;
@@ -157,7 +157,7 @@ int setenv(FAR const char *name, FAR const char *value, int overwrite)
   else
     {
       newsize = varlen;
-      newenvp = (FAR char *)kumm_malloc(varlen);
+      newenvp = (FAR char *)group_malloc(group, varlen);
       if (!newenvp)
         {
           ret = ENOMEM;

--- a/sched/environ/env_unsetenv.c
+++ b/sched/environ/env_unsetenv.c
@@ -86,7 +86,7 @@ int unsetenv(FAR const char *name)
 
           if (group->tg_envp != NULL)
             {
-              kumm_free(group->tg_envp);
+              group_free(group, group->tg_envp);
               group->tg_envp = NULL;
             }
 
@@ -96,7 +96,9 @@ int unsetenv(FAR const char *name)
         {
           /* Reallocate the environment to reclaim a little memory */
 
-          newenvp = (FAR char *)kumm_realloc(group->tg_envp, newsize);
+          newenvp = (FAR char *)group_realloc(group, group->tg_envp,
+                                              newsize);
+
           if (newenvp == NULL)
             {
               set_errno(ENOMEM);

--- a/sched/group/Make.defs
+++ b/sched/group/Make.defs
@@ -50,7 +50,7 @@ CSRCS += group_exitinfo.c
 endif
 
 ifneq ($(CONFIG_BUILD_FLAT),y)
-CSRCS += group_malloc.c group_zalloc.c group_free.c
+CSRCS += group_malloc.c group_realloc.c group_zalloc.c group_free.c
 endif
 
 # Include group build support

--- a/sched/init/nx_start.c
+++ b/sched/init/nx_start.c
@@ -558,7 +558,8 @@ void nx_start(void)
        */
 
       group_initialize(&g_idletcb[i]);
-      g_idletcb[i].cmn.group->tg_flags = GROUP_FLAG_NOCLDWAIT;
+      g_idletcb[i].cmn.group->tg_flags = GROUP_FLAG_NOCLDWAIT |
+                                         GROUP_FLAG_PRIVILEGED;
     }
 
   g_lastpid = CONFIG_SMP_NCPUS - 1;


### PR DESCRIPTION
- User mode allocator was used for setting up the environment. This
  works in flat mode and probably in protected mode as well, as there
  is always a a single user allocator present
- This does not work in kernel mode, where each user task has its own
  heap allocator. Also, when the idle tasks environment is being set,
  no allocator is ready and the system crashes at once.

Fix this by using the group allocators instead:
- Idle task is a kernel task, so its group is privileged
- Add group_realloc
- Use the group_malloc/realloc functions instead of kumm_malloc

## Summary
Fixes the initial environment, especially with CONFIG_BUILD_KERNEL

## Impact

## Testing
Tested with boards/risc-v/mpfs/icicle/configs/knsh/defconfig (CONFIG_BUILD_KERNEL=y) / not released yet
