### PR TITLE
arch/risc-v: Correct stack coloration in riscv_cpu_boot

### DIFF
--- a/arch/risc-v/src/common/riscv_cpustart.c
+++ b/arch/risc-v/src/common/riscv_cpustart.c
@@ -82,7 +82,7 @@ void riscv_cpu_boot(int cpu)
    * water marks.
    */
 
-  riscv_stack_color(tcb->stack_alloc_ptr, tcb->adj_stack_size);
+  riscv_stack_color(tcb->stack_alloc_ptr, 0);
 #endif
 
   /* TODO: Setup FPU */

--- a/arch/risc-v/src/common/riscv_createstack.c
+++ b/arch/risc-v/src/common/riscv_createstack.c
@@ -213,18 +213,27 @@ int up_create_stack(struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
 #ifdef CONFIG_STACK_COLORATION
 void riscv_stack_color(void *stackbase, size_t nbytes)
 {
-  /* Take extra care that we do not write outsize the stack boundaries */
+  uintptr_t start;
+  uintptr_t end;
+  size_t nwords;
+  uint32_t *ptr;
 
-  uint32_t *stkptr = (uint32_t *)(((uintptr_t)stackbase + 3) & ~3);
-  uintptr_t stkend = nbytes ? (((uintptr_t)stackbase + nbytes) & ~3):
-                     up_getsp(); /* 0: colorize the running stack */
-  size_t    nwords = (stkend - (uintptr_t)stackbase) >> 2;
+  /* Take extra care that we do not write outside the stack boundaries */
+
+  start = STACK_ALIGN_UP((uintptr_t)stackbase);
+  end   = nbytes ? STACK_ALIGN_DOWN((uintptr_t)stackbase + nbytes) :
+          up_getsp(); /* 0: colorize the running stack */
+
+  /* Get the adjusted size based on the top and bottom of the stack */
+
+  nwords = (end - start) >> 2;
+  ptr  = (uint32_t *)start;
 
   /* Set the entire stack to the coloration value */
 
   while (nwords-- > 0)
     {
-      *stkptr++ = STACK_COLOR;
+      *ptr++ = STACK_COLOR;
     }
 }
 #endif


### PR DESCRIPTION
## Summary
In smp system riscv_cpu_boot run in idle task so there is a overlap with the origin coloration range and in used stack.
## Impact
RISC-V SMP
## Testing
maix-bit:smp