### PR TITLE
sim: Enable garbage collection of unused input sections 

### DIFF
--- a/boards/sim/sim/sim/scripts/Make.defs
+++ b/boards/sim/sim/sim/scripts/Make.defs
@@ -210,6 +210,12 @@ endif
 LDELFFLAGS = -r -e main --gc-sections
 LDELFFLAGS += -T $(call CONVERT_PATH,$(BOARD_DIR)$(DELIM)scripts$(DELIM)gnu-elf.ld)
 
+ifeq ($(CONFIG_HOST_MACOS),y)
+  LDFLAGS += -Wl,-dead_strip
+else
+  LDFLAGS += -Wl,--gc-sections
+endif
+
 ifeq ($(CONFIG_SIM_M32),y)
   LDLINKFLAGS += -melf_i386
   LDFLAGS += -m32


### PR DESCRIPTION
## Summary

sim: Enable garbage collection of unused input sections

LDFLAGS += -Wl,--gc-sections

GC should be enabled on arch/sim/src/Makefile:

```
326   $(if $(CONFIG_HAVE_CXX),\
327   $(Q) "$(CXX)" $(CFLAGS) $(LDFLAGS) -o $(TOPDIR)/$@ $(HEADOBJ) nuttx.rel $(HOSTOBJS) $(STDLIBS),\
328   $(Q) "$(CC)" $(CFLAGS) $(LDFLAGS) -o $(TOPDIR)/$@ $(HEADOBJ) nuttx.rel $(HOSTOBJS) $(STDLIBS))
```

## Impact

N/A

## Testing

CI-CHECK