### PR TITLE
[docs] eliminate potential misunderstandings

### DIFF
--- a/Documentation/quickstart/compiling.rst
+++ b/Documentation/quickstart/compiling.rst
@@ -41,7 +41,7 @@ configuration system with:
 
 .. code-block:: console
 
-   $ cd nuttx/
+   $ cd nuttx
    $ make menuconfig
 
 Modifying the configuration is covered in :doc:`configuring`.
@@ -53,7 +53,7 @@ We can now build NuttX. To do so, you can simply run:
 
   .. code-block:: console
 
-     $ cd nuttx/
+     $ cd nuttx
      $ make
 
 The build will complete by generating the binary outputs

--- a/Documentation/quickstart/install.rst
+++ b/Documentation/quickstart/install.rst
@@ -152,8 +152,8 @@ Apache NuttX is actively developed on GitHub. There are two main repositories, `
   
     .. code-block:: console
 
-       $ mkdir nuttx
-       $ cd nuttx
+       $ mkdir nuttxspace
+       $ cd nuttxspace
        $ git clone https://github.com/apache/incubator-nuttx.git nuttx
        $ git clone https://github.com/apache/incubator-nuttx-apps apps
 
@@ -161,8 +161,8 @@ Apache NuttX is actively developed on GitHub. There are two main repositories, `
 
     .. code-block:: console
 
-       $ mkdir nuttx
-       $ cd nuttx
+       $ mkdir nuttxspace
+       $ cd nuttxspace
        $ curl -L https://github.com/apache/incubator-nuttx/tarball/master -o nuttx.tar.gz 
        $ curl -L https://github.com/apache/incubator-nuttx-apps/tarball/master -o apps.tar.gz
        $ tar zxf nuttx.tar.gz --one-top-level=nuttx --strip-components 1
@@ -178,8 +178,8 @@ Apache NuttX is actively developed on GitHub. There are two main repositories, `
 
     .. code-block:: console
     
-       $ mkdir nuttx
-       $ cd nuttx
+       $ mkdir nuttxspace
+       $ cd nuttxspace
        $ curl -L https://www.apache.org/dyn/closer.lua/incubator/nuttx/10.1.0/apache-nuttx-10.1.0-incubating.tar.gz?action=download -o nuttx.tar.gz 
        $ curl -L https://www.apache.org/dyn/closer.lua/incubator/nuttx/10.1.0/apache-nuttx-apps-10.1.0-incubating.tar.gz?action=download -o apps.tar.gz
        $ tar zxf nuttx.tar.gz


### PR DESCRIPTION
## Summary

There are two folders called "nuttx", which makes people confusion  a little bit.

change from `nuttx/nuttx` to `nuttxspace/nuttx`

## Impact

## Testing

