### PR TITLE
arch/risc-v: Rework riscv_get_newintctx

### DIFF
--- a/arch/risc-v/src/bl602/bl602_irq.c
+++ b/arch/risc-v/src/bl602/bl602_irq.c
@@ -171,16 +171,18 @@ void up_enable_irq(int irq)
  *
  ****************************************************************************/
 
-uint32_t riscv_get_newintctx(void)
+uintptr_t riscv_get_newintctx(void)
 {
   /* Set machine previous privilege mode to machine mode.
    * Also set machine previous interrupt enable
    */
 
+  uintptr_t mstatus = READ_CSR(mstatus);
+
 #ifdef CONFIG_ARCH_FPU
-  return (MSTATUS_FS_INIT | MSTATUS_MPPM | MSTATUS_MPIE);
+  return (mstatus | MSTATUS_FS_INIT | MSTATUS_MPPM | MSTATUS_MPIE);
 #else
-  return (MSTATUS_MPPM | MSTATUS_MPIE);
+  return (mstatus | MSTATUS_MPPM | MSTATUS_MPIE);
 #endif
 }
 

--- a/arch/risc-v/src/c906/c906_irq.c
+++ b/arch/risc-v/src/c906/c906_irq.c
@@ -202,7 +202,7 @@ void up_enable_irq(int irq)
  *
  ****************************************************************************/
 
-uint32_t riscv_get_newintctx(void)
+uintptr_t riscv_get_newintctx(void)
 {
   /* Set machine previous privilege mode to machine mode. Reegardless of
    * how NuttX is configured and of what kind of thread is being started.
@@ -212,10 +212,12 @@ uint32_t riscv_get_newintctx(void)
    * user code. Also set machine previous interrupt enable.
    */
 
+  uintptr_t mstatus = READ_CSR(mstatus);
+
 #ifdef CONFIG_ARCH_FPU
-  return (MSTATUS_FS_INIT | MSTATUS_MPPM | MSTATUS_MPIE);
+  return (mstatus | MSTATUS_FS_INIT | MSTATUS_MPPM | MSTATUS_MPIE);
 #else
-  return (MSTATUS_MPPM | MSTATUS_MPIE);
+  return (mstatus | MSTATUS_MPPM | MSTATUS_MPIE);
 #endif
 }
 

--- a/arch/risc-v/src/common/riscv_internal.h
+++ b/arch/risc-v/src/common/riscv_internal.h
@@ -197,7 +197,7 @@ void riscv_copyfullstate(uintptr_t *dest, uintptr_t *src);
 
 void riscv_sigdeliver(void);
 int riscv_swint(int irq, void *context, void *arg);
-uint32_t riscv_get_newintctx(void);
+uintptr_t riscv_get_newintctx(void);
 
 #ifdef CONFIG_ARCH_FPU
 void riscv_savefpu(uintptr_t *regs);

--- a/arch/risc-v/src/esp32c3/esp32c3_irq.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_irq.c
@@ -35,6 +35,7 @@
 
 #include <arch/irq.h>
 #include <arch/csr.h>
+#include <stdint.h>
 
 #include "riscv_internal.h"
 #include "hardware/esp32c3_interrupt.h"
@@ -141,13 +142,15 @@ void up_irqinitialize(void)
  *
  ****************************************************************************/
 
-uint32_t riscv_get_newintctx(void)
+uintptr_t riscv_get_newintctx(void)
 {
   /* Set machine previous privilege mode to machine mode.
    * Also set machine previous interrupt enable
    */
 
-  return (MSTATUS_MPPM | MSTATUS_MPIE);
+  uintptr_t mstatus = READ_CSR(mstatus);
+
+  return (mstatus | MSTATUS_MPPM | MSTATUS_MPIE);
 }
 
 /****************************************************************************

--- a/arch/risc-v/src/fe310/fe310_irq.c
+++ b/arch/risc-v/src/fe310/fe310_irq.c
@@ -173,13 +173,15 @@ void up_enable_irq(int irq)
  *
  ****************************************************************************/
 
-uint32_t riscv_get_newintctx(void)
+uintptr_t riscv_get_newintctx(void)
 {
   /* Set machine previous privilege mode to machine mode.
    * Also set machine previous interrupt enable
    */
 
-  return (MSTATUS_MPPM | MSTATUS_MPIE);
+  uintptr_t mstatus = READ_CSR(mstatus);
+
+  return (mstatus | MSTATUS_MPPM | MSTATUS_MPIE);
 }
 
 /****************************************************************************

--- a/arch/risc-v/src/k210/k210_irq.c
+++ b/arch/risc-v/src/k210/k210_irq.c
@@ -218,7 +218,7 @@ void up_enable_irq(int irq)
  *
  ****************************************************************************/
 
-uint32_t riscv_get_newintctx(void)
+uintptr_t riscv_get_newintctx(void)
 {
   /* Set machine previous privilege mode to machine mode. Reegardless of
    * how NuttX is configured and of what kind of thread is being started.
@@ -228,7 +228,9 @@ uint32_t riscv_get_newintctx(void)
    * user code. Also set machine previous interrupt enable.
    */
 
-  return (MSTATUS_MPPM | MSTATUS_MPIE);
+  uintptr_t mstatus = READ_CSR(mstatus);
+
+  return (mstatus | MSTATUS_MPPM | MSTATUS_MPIE);
 }
 
 /****************************************************************************

--- a/arch/risc-v/src/litex/litex_irq.c
+++ b/arch/risc-v/src/litex/litex_irq.c
@@ -179,13 +179,15 @@ void up_enable_irq(int irq)
  *
  ****************************************************************************/
 
-uint32_t riscv_get_newintctx(void)
+uintptr_t riscv_get_newintctx(void)
 {
   /* Set machine previous privilege mode to machine mode.
    * Also set machine previous interrupt enable
    */
 
-  return (MSTATUS_MPPM | MSTATUS_MPIE);
+  uintptr_t mstatus = READ_CSR(mstatus);
+
+  return (mstatus | MSTATUS_MPPM | MSTATUS_MPIE);
 }
 
 /****************************************************************************

--- a/arch/risc-v/src/mpfs/mpfs_irq.c
+++ b/arch/risc-v/src/mpfs/mpfs_irq.c
@@ -270,7 +270,7 @@ void up_enable_irq(int irq)
  *
  ****************************************************************************/
 
-uint32_t riscv_get_newintctx(void)
+uintptr_t riscv_get_newintctx(void)
 {
   /* Set machine previous privilege mode to machine mode. Reegardless of
    * how NuttX is configured and of what kind of thread is being started.
@@ -280,10 +280,12 @@ uint32_t riscv_get_newintctx(void)
    * user code. Also set machine previous interrupt enable.
    */
 
+  uintptr_t mstatus = READ_CSR(mstatus);
+
 #ifdef CONFIG_ARCH_FPU
-  return (MSTATUS_FS_INIT | MSTATUS_MPPM | MSTATUS_MPIE);
+  return (mstatus | MSTATUS_FS_INIT | MSTATUS_MPPM | MSTATUS_MPIE);
 #else
-  return (MSTATUS_MPPM | MSTATUS_MPIE);
+  return (mstatus | MSTATUS_MPPM | MSTATUS_MPIE);
 #endif
 }
 

--- a/arch/risc-v/src/qemu-rv/qemu_rv_irq.c
+++ b/arch/risc-v/src/qemu-rv/qemu_rv_irq.c
@@ -214,12 +214,18 @@ irqstate_t up_irq_enable(void)
  *
  ****************************************************************************/
 
-uint32_t riscv_get_newintctx(void)
+uintptr_t riscv_get_newintctx(void)
 {
   /* Set machine previous privilege mode to machine mode.
    * Also set machine previous interrupt enable
    * Note: In qemu, FPU is always exist even if don't use F|D ISA extension
    */
 
-  return (MSTATUS_MPPM | MSTATUS_MPIE | MSTATUS_FS_INIT);
+  uintptr_t mstatus = READ_CSR(mstatus);
+
+#ifdef CONFIG_ARCH_FPU
+  return (mstatus | MSTATUS_MPPM | MSTATUS_MPIE | MSTATUS_FS_INIT);
+#else
+  return (mstatus | MSTATUS_MPPM | MSTATUS_MPIE);
+#endif
 }

--- a/arch/risc-v/src/rv32m1/rv32m1_irq.c
+++ b/arch/risc-v/src/rv32m1/rv32m1_irq.c
@@ -221,13 +221,15 @@ void up_enable_irq(int irq)
  *
  ****************************************************************************/
 
-uint32_t riscv_get_newintctx(void)
+uintptr_t riscv_get_newintctx(void)
 {
   /* Set machine previous privilege mode to machine mode.
    * Also set machine previous interrupt enable
    */
 
-  return (MSTATUS_MPPM | MSTATUS_MPIE);
+  uintptr_t mstatus = READ_CSR(mstatus);
+
+  return (mstatus | MSTATUS_MPPM | MSTATUS_MPIE);
 }
 
 /****************************************************************************


### PR DESCRIPTION
## Summary
Some fields of mstatus were marked as Reserved Writes Preserve Values, Reads Ignore Values (WPRI),
so we must keep its origin value with addition flags.
## Impact
N/A
## Testing
CI and rv-virt/maix-bit
