### PR TITLE
arch/xtensa: Don't always reset the APP CPU on startup

### DIFF
--- a/arch/xtensa/src/esp32/esp32_cpustart.c
+++ b/arch/xtensa/src/esp32/esp32_cpustart.c
@@ -124,7 +124,7 @@ static inline void xtensa_attach_fromcpu0_interrupt(void)
  *
  ****************************************************************************/
 
-void xtensa_appcpu_start(void)
+void IRAM_ATTR xtensa_appcpu_start(void)
 {
   struct tcb_s *tcb = this_task();
   register uint32_t sp;
@@ -296,25 +296,33 @@ int up_cpu_start(int cpu)
       regval &= ~RTC_CNTL_SW_STALL_APPCPU_C0_M;
       putreg32(regval, RTC_CNTL_OPTIONS0_REG);
 
-      /* Enable clock gating for the APP CPU */
+      /* OpenOCD might have already enabled clock gating and taken APP CPU
+       * out of reset.  Don't reset the APP CPU if that's the case as this
+       * will clear the breakpoints that may have already been set.
+       */
 
-      regval  = getreg32(DPORT_APPCPU_CTRL_B_REG);
-      regval |= DPORT_APPCPU_CLKGATE_EN;
-      putreg32(regval, DPORT_APPCPU_CTRL_B_REG);
+      regval = getreg32(DPORT_APPCPU_CTRL_B_REG);
+      if ((regval & DPORT_APPCPU_CLKGATE_EN_M) == 0)
+        {
+          /* Enable clock gating for the APP CPU */
 
-      regval  = getreg32(DPORT_APPCPU_CTRL_C_REG);
-      regval &= ~DPORT_APPCPU_RUNSTALL;
-      putreg32(regval, DPORT_APPCPU_CTRL_C_REG);
+          regval |= DPORT_APPCPU_CLKGATE_EN;
+          putreg32(regval, DPORT_APPCPU_CTRL_B_REG);
 
-      /* Reset the APP CPU */
+          regval  = getreg32(DPORT_APPCPU_CTRL_C_REG);
+          regval &= ~DPORT_APPCPU_RUNSTALL;
+          putreg32(regval, DPORT_APPCPU_CTRL_C_REG);
 
-      regval  = getreg32(DPORT_APPCPU_CTRL_A_REG);
-      regval |= DPORT_APPCPU_RESETTING;
-      putreg32(regval, DPORT_APPCPU_CTRL_A_REG);
+          /* Reset the APP CPU */
 
-      regval  = getreg32(DPORT_APPCPU_CTRL_A_REG);
-      regval &= ~DPORT_APPCPU_RESETTING;
-      putreg32(regval, DPORT_APPCPU_CTRL_A_REG);
+          regval  = getreg32(DPORT_APPCPU_CTRL_A_REG);
+          regval |= DPORT_APPCPU_RESETTING;
+          putreg32(regval, DPORT_APPCPU_CTRL_A_REG);
+
+          regval  = getreg32(DPORT_APPCPU_CTRL_A_REG);
+          regval &= ~DPORT_APPCPU_RESETTING;
+          putreg32(regval, DPORT_APPCPU_CTRL_A_REG);
+        }
 
       /* Set the CPU1 start address */
 

--- a/arch/xtensa/src/esp32/esp32_start.c
+++ b/arch/xtensa/src/esp32/esp32_start.c
@@ -137,7 +137,6 @@ uint32_t g_idlestack[IDLETHREAD_STACKWORDS]
 
 static noreturn_function void __esp32_start(void)
 {
-  uint32_t regval;
   uint32_t sp;
 
   /* Make sure that normal interrupts are disabled.  This is really only an
@@ -169,11 +168,15 @@ static noreturn_function void __esp32_start(void)
 
   memset(&_sbss, 0, (&_ebss - &_sbss) * sizeof(_sbss));
 
+#ifndef CONFIG_SMP
+  uint32_t regval;
+
   /* Make sure that the APP_CPU is disabled for now */
 
   regval  = getreg32(DPORT_APPCPU_CTRL_B_REG);
   regval &= ~DPORT_APPCPU_CLKGATE_EN;
   putreg32(regval, DPORT_APPCPU_CTRL_B_REG);
+#endif
 
   /* The 2nd stage bootloader enables RTC WDT to check on startup sequence
    * related issues in application. Hence disable that as we are about to

--- a/arch/xtensa/src/esp32s3/esp32s3_cpustart.c
+++ b/arch/xtensa/src/esp32s3/esp32s3_cpustart.c
@@ -241,35 +241,42 @@ int up_cpu_start(int cpu)
 
       spin_initialize(&g_appcpu_interlock, SP_LOCKED);
 
-      /* Unstall the APP CPU */
+      /* OpenOCD might have already enabled clock gating and taken APP CPU
+       * out of reset.  Don't reset the APP CPU if that's the case as this
+       * will clear the breakpoints that may have already been set.
+       */
 
-      regval  = getreg32(RTC_CNTL_RTC_SW_CPU_STALL_REG);
-      regval &= ~RTC_CNTL_SW_STALL_APPCPU_C1_M;
-      putreg32(regval, RTC_CNTL_RTC_SW_CPU_STALL_REG);
+      regval = getreg32(SYSTEM_CORE_1_CONTROL_0_REG);
+      if ((regval & SYSTEM_CONTROL_CORE_1_CLKGATE_EN) == 0)
+        {
+          regval  = getreg32(RTC_CNTL_RTC_SW_CPU_STALL_REG);
+          regval &= ~RTC_CNTL_SW_STALL_APPCPU_C1_M;
+          putreg32(regval, RTC_CNTL_RTC_SW_CPU_STALL_REG);
 
-      regval  = getreg32(RTC_CNTL_RTC_OPTIONS0_REG);
-      regval &= ~RTC_CNTL_SW_STALL_APPCPU_C0_M;
-      putreg32(regval, RTC_CNTL_RTC_OPTIONS0_REG);
+          regval  = getreg32(RTC_CNTL_RTC_OPTIONS0_REG);
+          regval &= ~RTC_CNTL_SW_STALL_APPCPU_C0_M;
+          putreg32(regval, RTC_CNTL_RTC_OPTIONS0_REG);
 
-      /* Enable clock gating for the APP CPU */
+          /* Enable clock gating for the APP CPU */
 
-      regval  = getreg32(SYSTEM_CORE_1_CONTROL_0_REG);
-      regval |= SYSTEM_CONTROL_CORE_1_CLKGATE_EN;
-      putreg32(regval, SYSTEM_CORE_1_CONTROL_0_REG);
+          regval  = getreg32(SYSTEM_CORE_1_CONTROL_0_REG);
+          regval |= SYSTEM_CONTROL_CORE_1_CLKGATE_EN;
+          putreg32(regval, SYSTEM_CORE_1_CONTROL_0_REG);
 
-      regval  = getreg32(SYSTEM_CORE_1_CONTROL_0_REG);
-      regval &= ~SYSTEM_CONTROL_CORE_1_RUNSTALL;
-      putreg32(regval, SYSTEM_CORE_1_CONTROL_0_REG);
+          regval  = getreg32(SYSTEM_CORE_1_CONTROL_0_REG);
+          regval &= ~SYSTEM_CONTROL_CORE_1_RUNSTALL;
+          putreg32(regval, SYSTEM_CORE_1_CONTROL_0_REG);
 
-      /* Reset the APP CPU */
+          /* Reset the APP CPU */
 
-      regval  = getreg32(SYSTEM_CORE_1_CONTROL_0_REG);
-      regval |= SYSTEM_CONTROL_CORE_1_RESETING;
-      putreg32(regval, SYSTEM_CORE_1_CONTROL_0_REG);
+          regval  = getreg32(SYSTEM_CORE_1_CONTROL_0_REG);
+          regval |= SYSTEM_CONTROL_CORE_1_RESETING;
+          putreg32(regval, SYSTEM_CORE_1_CONTROL_0_REG);
 
-      regval  = getreg32(SYSTEM_CORE_1_CONTROL_0_REG);
-      regval &= ~SYSTEM_CONTROL_CORE_1_RESETING;
-      putreg32(regval, SYSTEM_CORE_1_CONTROL_0_REG);
+          regval  = getreg32(SYSTEM_CORE_1_CONTROL_0_REG);
+          regval &= ~SYSTEM_CONTROL_CORE_1_RESETING;
+          putreg32(regval, SYSTEM_CORE_1_CONTROL_0_REG);
+        }
 
       /* Set the CPU1 start address */
 

--- a/arch/xtensa/src/esp32s3/esp32s3_start.c
+++ b/arch/xtensa/src/esp32s3/esp32s3_start.c
@@ -183,6 +183,7 @@ static void IRAM_ATTR configure_cpu_caches(void)
  *
  ****************************************************************************/
 
+#ifndef CONFIG_SMP
 static void IRAM_ATTR disable_app_cpu(void)
 {
   uint32_t regval;
@@ -204,6 +205,7 @@ static void IRAM_ATTR disable_app_cpu(void)
   regval &= ~SYSTEM_CONTROL_CORE_1_RESETING;
   putreg32(regval, SYSTEM_CORE_1_CONTROL_0_REG);
 }
+#endif
 
 /****************************************************************************
  * Name: __esp32s3_start
@@ -257,9 +259,11 @@ void noreturn_function IRAM_ATTR __esp32s3_start(void)
       *dest = 0;
     }
 
+#ifndef CONFIG_SMP
   /* Make sure that the APP_CPU is disabled for now */
 
   disable_app_cpu();
+#endif
 
   /* The 2nd stage bootloader enables RTC WDT to check on startup sequence
    * related issues in application. Hence disable that as we are about to


### PR DESCRIPTION
## Summary
If we reset and reconfigure the APP CPU at startup we will clear OpenOCD's configurations and thus breakpoints will have no effect on the APP CPU.
## Impact
ESP32 & ESP32-S3
## Testing
ESP32 & ESP32-S3
