### PR TITLE
arch/Kconfig: Don't depend on Xtensa for the SUPPRESS_CLOCK_CONFIG option

### DIFF
--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -906,7 +906,6 @@ menu "Bring-Up Options"
 config SUPPRESS_CLOCK_CONFIG
 	bool "Suppress clock configuration"
 	default n
-	depends on ARCH_XTENSA
 	---help---
 		Do not configure clocking.  Instead relies on the reset clock
 		configuration (or clock configuration provided by a bootloader).


### PR DESCRIPTION
## Summary
This config was probably added in the early bring up of the
ESP32 chip. At that point the clock config was suppressed and we relied
on the bootloader.  Now we can configure the clock from NuttX.

The option itself is still useful though, and can be used for any other
architecture or chip.

## Impact
No impact as no code is using this option now.
## Testing
N/A
