### PR TITLE
risc-v/esp32c3: Remove deprecated option for disabling atomics support

### DIFF
--- a/arch/risc-v/src/esp32c3/Kconfig
+++ b/arch/risc-v/src/esp32c3/Kconfig
@@ -163,10 +163,6 @@ config ESP32C3_RT_TIMER
 	---help---
 		Real-time Timer is relying upon the Systimer 1.
 
-config ESP32C3_DISABLE_STDC_ATOMIC
-	bool "Disable standard C atomic"
-	default n
-
 config ESP32C3_RTC_HEAP
 	bool "Use the RTC memory as a separate heap"
 	select ARCH_HAVE_EXTRA_HEAPS


### PR DESCRIPTION
## Summary
This PR intends to remove a Kconfig option which has been deprecated since https://github.com/apache/incubator-nuttx/pull/4425.

## Impact
No impact, this Kconfig option has no effect.

## Testing
CI pass.

