### PR TITLE
arch/arm: set the SP to stack top

### DIFF
--- a/arch/arm/src/arm/arm_initialstate.c
+++ b/arch/arm/src/arm/arm_initialstate.c
@@ -82,10 +82,9 @@ void up_initial_state(struct tcb_s *tcb)
 
   /* Initialize the context registers to stack top */
 
-  xcp->regs = (FAR void *)STACK_ALIGN_DOWN(
-                          (uint32_t)tcb->stack_base_ptr +
-                                    tcb->adj_stack_size -
-                                    XCPTCONTEXT_SIZE);
+  xcp->regs = (FAR void *)((uint32_t)tcb->stack_base_ptr +
+                                     tcb->adj_stack_size -
+                                     XCPTCONTEXT_SIZE);
 
   /* Initialize the xcp registers */
 
@@ -93,7 +92,8 @@ void up_initial_state(struct tcb_s *tcb)
 
   /* Save the initial stack pointer */
 
-  xcp->regs[REG_SP] = (uint32_t)xcp->regs;
+  xcp->regs[REG_SP] = (uint32_t)tcb->stack_base_ptr +
+                                tcb->adj_stack_size;
 
   /* Save the task entry point */
 

--- a/arch/arm/src/armv6-m/arm_initialstate.c
+++ b/arch/arm/src/armv6-m/arm_initialstate.c
@@ -83,10 +83,9 @@ void up_initial_state(struct tcb_s *tcb)
 
   /* Initialize the context registers to stack top */
 
-  xcp->regs = (FAR void *)STACK_ALIGN_DOWN(
-                          (uint32_t)tcb->stack_base_ptr +
-                                    tcb->adj_stack_size -
-                                    XCPTCONTEXT_SIZE);
+  xcp->regs = (FAR void *)((uint32_t)tcb->stack_base_ptr +
+                                     tcb->adj_stack_size -
+                                     XCPTCONTEXT_SIZE);
 
   /* Initialize the xcp registers */
 
@@ -94,7 +93,8 @@ void up_initial_state(struct tcb_s *tcb)
 
   /* Save the initial stack pointer */
 
-  xcp->regs[REG_SP]      = (uint32_t)xcp->regs;
+  xcp->regs[REG_SP]      = (uint32_t)tcb->stack_base_ptr +
+                                     tcb->adj_stack_size;
 
   /* Save the task entry point (stripping off the thumb bit) */
 

--- a/arch/arm/src/armv7-a/arm_initialstate.c
+++ b/arch/arm/src/armv7-a/arm_initialstate.c
@@ -82,10 +82,9 @@ void up_initial_state(struct tcb_s *tcb)
 
   /* Initialize the context registers to stack top */
 
-  xcp->regs = (FAR void *)STACK_ALIGN_DOWN(
-                          (uint32_t)tcb->stack_base_ptr +
-                                    tcb->adj_stack_size -
-                                    XCPTCONTEXT_SIZE);
+  xcp->regs = (FAR void *)((uint32_t)tcb->stack_base_ptr +
+                                     tcb->adj_stack_size -
+                                     XCPTCONTEXT_SIZE);
 
   /* Initialize the xcp registers */
 
@@ -93,7 +92,8 @@ void up_initial_state(struct tcb_s *tcb)
 
   /* Save the initial stack pointer */
 
-  xcp->regs[REG_SP] = (uint32_t)xcp->regs;
+  xcp->regs[REG_SP] = (uint32_t)tcb->stack_base_ptr +
+                                tcb->adj_stack_size;
 
   /* Save the task entry point */
 

--- a/arch/arm/src/armv7-m/arm_initialstate.c
+++ b/arch/arm/src/armv7-m/arm_initialstate.c
@@ -84,10 +84,9 @@ void up_initial_state(struct tcb_s *tcb)
 
   /* Initialize the context registers to stack top */
 
-  xcp->regs = (FAR void *)STACK_ALIGN_DOWN(
-                          (uint32_t)tcb->stack_base_ptr +
-                                    tcb->adj_stack_size -
-                                    XCPTCONTEXT_SIZE);
+  xcp->regs = (FAR void *)((uint32_t)tcb->stack_base_ptr +
+                                     tcb->adj_stack_size -
+                                     XCPTCONTEXT_SIZE);
 
   /* Initialize the xcp registers */
 
@@ -95,7 +94,8 @@ void up_initial_state(struct tcb_s *tcb)
 
   /* Save the initial stack pointer */
 
-  xcp->regs[REG_SP]      = (uint32_t)xcp->regs;
+  xcp->regs[REG_SP]      = (uint32_t)tcb->stack_base_ptr +
+                                     tcb->adj_stack_size;
 
 #ifdef CONFIG_ARMV7M_STACKCHECK
   /* Set the stack limit value */

--- a/arch/arm/src/armv7-r/arm_initialstate.c
+++ b/arch/arm/src/armv7-r/arm_initialstate.c
@@ -82,10 +82,9 @@ void up_initial_state(struct tcb_s *tcb)
 
   /* Initialize the context registers to stack top */
 
-  xcp->regs = (FAR void *)STACK_ALIGN_DOWN(
-                          (uint32_t)tcb->stack_base_ptr +
-                                    tcb->adj_stack_size -
-                                    XCPTCONTEXT_SIZE);
+  xcp->regs = (FAR void *)((uint32_t)tcb->stack_base_ptr +
+                                     tcb->adj_stack_size -
+                                     XCPTCONTEXT_SIZE);
 
   /* Initialize the xcp registers */
 
@@ -93,7 +92,8 @@ void up_initial_state(struct tcb_s *tcb)
 
   /* Save the initial stack pointer */
 
-  xcp->regs[REG_SP] = (uint32_t)xcp->regs;
+  xcp->regs[REG_SP] = (uint32_t)tcb->stack_base_ptr +
+                                tcb->adj_stack_size;
 
   /* Save the task entry point */
 

--- a/arch/arm/src/armv8-m/arm_initialstate.c
+++ b/arch/arm/src/armv8-m/arm_initialstate.c
@@ -84,10 +84,9 @@ void up_initial_state(struct tcb_s *tcb)
 
   /* Initialize the context registers to stack top */
 
-  xcp->regs = (FAR void *)STACK_ALIGN_DOWN(
-                          (uint32_t)tcb->stack_base_ptr +
-                                    tcb->adj_stack_size -
-                                    XCPTCONTEXT_SIZE);
+  xcp->regs = (FAR void *)((uint32_t)tcb->stack_base_ptr +
+                                     tcb->adj_stack_size -
+                                     XCPTCONTEXT_SIZE);
 
   /* Initialize the xcp registers */
 
@@ -95,7 +94,8 @@ void up_initial_state(struct tcb_s *tcb)
 
   /* Save the initial stack pointer */
 
-  xcp->regs[REG_SP]      = (uint32_t)xcp->regs;
+  xcp->regs[REG_SP]      = (uint32_t)tcb->stack_base_ptr +
+                                     tcb->adj_stack_size;
 
 #ifdef CONFIG_ARMV8M_STACKCHECK
   /* Set the stack limit value */


### PR DESCRIPTION
## Summary

arch/arm: set the SP to stack top

fix the stack imbalance

reported by:
https://github.com/apache/incubator-nuttx/pull/5645#issuecomment-1070388334

Signed-off-by: chao.an <anchao@xiaomi.com>

## Impact

stack usage

## Testing

sabre-6quad/netknsh (/mnt/nfs/bin/getprime) (CONFIG_ARCH_INTERRUPTSTACK 0 / 2048)
sabre-6quad:smp (ostest) (CONFIG_ARCH_INTERRUPTSTACK 0 / 2048)
lm3s6965-ek:qemu-kostest (ostest) (CONFIG_ARCH_INTERRUPTSTACK 0 / 2048)

sabre-6quad:smp :
Before:
```
nsh> ps
  PID GROUP CPU PRI POLICY   TYPE    NPX STATE    EVENT     SIGMASK   STACK   USED  FILLED COMMAND
    0     0   0   0 FIFO     Kthread N-- Assigned           00000000 001000 000440  44.0%  CPU0 IDLE
    1     1   1   0 FIFO     Kthread N-- Running            00000000 001000 000408  40.8%  CPU1 IDLE
    2     2   2   0 FIFO     Kthread N-- Running            00000000 001000 000408  40.8%  CPU2 IDLE
    3     3   3   0 FIFO     Kthread N-- Running            00000000 001000 000408  40.8%  CPU3 IDLE
    4     4 --- 192 RR       Kthread --- Waiting  Semaphore 00000000 002016 000468  23.2%  hpwork 0x1082188c
    5     5   0 100 RR       Task    --- Running            00000000 002024 001324  65.4%  nsh_main
```

after:
```
nsh> ps
  PID GROUP CPU PRI POLICY   TYPE    NPX STATE    EVENT     SIGMASK   STACK   USED  FILLED COMMAND
    0     0   0   0 FIFO     Kthread N-- Assigned           00000000 001000 000440  44.0%  CPU0 IDLE
    1     1   1   0 FIFO     Kthread N-- Running            00000000 001000 000408  40.8%  CPU1 IDLE
    2     2   2   0 FIFO     Kthread N-- Running            00000000 001000 000408  40.8%  CPU2 IDLE
    3     3   3   0 FIFO     Kthread N-- Running            00000000 001000 000408  40.8%  CPU3 IDLE
    4     4 --- 192 RR       Kthread --- Waiting  Semaphore 00000000 002016 000268  13.2%  hpwork 0x1082188c
    5     5   0 100 RR       Task    --- Running            00000000 002024 001136  56.1%  nsh_main
```
