### PR TITLE
arch/risc-v: Merge riscv_getnewintctx into common

### DIFF
--- a/arch/risc-v/include/csr.h
+++ b/arch/risc-v/include/csr.h
@@ -307,6 +307,14 @@
 #define MSTATUS_FS_CLEAN  (0x2 << 13)
 #define MSTATUS_FS_DIRTY  (0x3 << 13)
 
+/* Mask of preserved bits for mstatus */
+
+#ifdef CONFIG_ARCH_RV32
+#define MSTATUS_WPRI      (0xff << 23 | 0x15)
+#else
+#define MSTATUS_WPRI      (UINT64_C(0x1ffffff) << 38 | UINT64_C(0x1ff) << 23 | 0x15)
+#endif
+
 /* In mie (machine interrupt enable) register */
 
 #define MIE_MSIE      (0x1 << 3)  /* Machine Software Interrupt Enable */

--- a/arch/risc-v/src/bl602/Make.defs
+++ b/arch/risc-v/src/bl602/Make.defs
@@ -33,7 +33,7 @@ CMN_CSRCS += riscv_interruptcontext.c riscv_modifyreg32.c riscv_puts.c riscv_mde
 CMN_CSRCS += riscv_releasepending.c riscv_reprioritizertr.c riscv_copyfullstate.c
 CMN_CSRCS += riscv_releasestack.c riscv_stackframe.c riscv_schedulesigaction.c
 CMN_CSRCS += riscv_sigdeliver.c riscv_udelay.c riscv_unblocktask.c riscv_usestack.c
-CMN_CSRCS += riscv_idle.c riscv_tcbinfo.c
+CMN_CSRCS += riscv_idle.c riscv_tcbinfo.c riscv_getnewintctx.c
 
 ifeq ($(CONFIG_SCHED_BACKTRACE),y)
 CMN_CSRCS += riscv_backtrace.c

--- a/arch/risc-v/src/bl602/bl602_irq.c
+++ b/arch/risc-v/src/bl602/bl602_irq.c
@@ -164,29 +164,6 @@ void up_enable_irq(int irq)
 }
 
 /****************************************************************************
- * Name: riscv_get_newintctx
- *
- * Description:
- *   Return initial mstatus when a task is created.
- *
- ****************************************************************************/
-
-uintptr_t riscv_get_newintctx(void)
-{
-  /* Set machine previous privilege mode to machine mode.
-   * Also set machine previous interrupt enable
-   */
-
-  uintptr_t mstatus = READ_CSR(mstatus);
-
-#ifdef CONFIG_ARCH_FPU
-  return (mstatus | MSTATUS_FS_INIT | MSTATUS_MPPM | MSTATUS_MPIE);
-#else
-  return (mstatus | MSTATUS_MPPM | MSTATUS_MPIE);
-#endif
-}
-
-/****************************************************************************
  * Name: riscv_ack_irq
  *
  * Description:

--- a/arch/risc-v/src/c906/Make.defs
+++ b/arch/risc-v/src/c906/Make.defs
@@ -34,7 +34,7 @@ CMN_CSRCS += riscv_releasepending.c riscv_reprioritizertr.c
 CMN_CSRCS += riscv_releasestack.c riscv_stackframe.c riscv_schedulesigaction.c
 CMN_CSRCS += riscv_sigdeliver.c riscv_unblocktask.c riscv_usestack.c
 CMN_CSRCS += riscv_mdelay.c riscv_copyfullstate.c riscv_idle.c
-CMN_CSRCS += riscv_tcbinfo.c
+CMN_CSRCS += riscv_tcbinfo.c riscv_getnewintctx.c
 
 ifeq ($(CONFIG_SCHED_BACKTRACE),y)
 CMN_CSRCS += riscv_backtrace.c

--- a/arch/risc-v/src/c906/c906_irq.c
+++ b/arch/risc-v/src/c906/c906_irq.c
@@ -195,33 +195,6 @@ void up_enable_irq(int irq)
 }
 
 /****************************************************************************
- * Name: riscv_get_newintctx
- *
- * Description:
- *   Return initial mstatus when a task is created.
- *
- ****************************************************************************/
-
-uintptr_t riscv_get_newintctx(void)
-{
-  /* Set machine previous privilege mode to machine mode. Reegardless of
-   * how NuttX is configured and of what kind of thread is being started.
-   * That is because all threads, even user-mode threads will start in
-   * kernel trampoline at nxtask_start() or pthread_start().
-   * The thread's privileges will be dropped before transitioning to
-   * user code. Also set machine previous interrupt enable.
-   */
-
-  uintptr_t mstatus = READ_CSR(mstatus);
-
-#ifdef CONFIG_ARCH_FPU
-  return (mstatus | MSTATUS_FS_INIT | MSTATUS_MPPM | MSTATUS_MPIE);
-#else
-  return (mstatus | MSTATUS_MPPM | MSTATUS_MPIE);
-#endif
-}
-
-/****************************************************************************
  * Name: riscv_ack_irq
  *
  * Description:

--- a/arch/risc-v/src/common/riscv_getnewintctx.c
+++ b/arch/risc-v/src/common/riscv_getnewintctx.c
@@ -1,0 +1,71 @@
+/****************************************************************************
+ * arch/risc-v/src/common/riscv_getnewintctx.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <stdint.h>
+#include <stdio.h>
+#include <assert.h>
+#include <debug.h>
+
+#include <nuttx/arch.h>
+#include <arch/irq.h>
+#include <arch/csr.h>
+
+#include "riscv_internal.h"
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: riscv_get_newintctx
+ *
+ * Description:
+ *   Return initial mstatus when a task is created.
+ *
+ ****************************************************************************/
+
+uintptr_t riscv_get_newintctx(void)
+{
+  /* Set machine previous privilege mode to machine mode. Reegardless of
+   * how NuttX is configured and of what kind of thread is being started.
+   * That is because all threads, even user-mode threads will start in
+   * kernel trampoline at nxtask_start() or pthread_start().
+   * The thread's privileges will be dropped before transitioning to
+   * user code. Also set machine previous interrupt enable.
+   *
+   * Mask the bits which should be preserved (from ISA spec)
+   */
+
+  uintptr_t mstatus = READ_CSR(mstatus);
+
+  mstatus &= MSTATUS_WPRI;
+
+  return (mstatus | MSTATUS_MPPM | MSTATUS_MPIE
+#ifdef CONFIG_ARCH_FPU
+                  | MSTATUS_FS_INIT
+#endif
+  );
+}

--- a/arch/risc-v/src/esp32c3/Make.defs
+++ b/arch/risc-v/src/esp32c3/Make.defs
@@ -36,7 +36,7 @@ CMN_CSRCS += riscv_interruptcontext.c riscv_modifyreg32.c riscv_puts.c riscv_mde
 CMN_CSRCS += riscv_releasepending.c riscv_reprioritizertr.c riscv_copyfullstate.c
 CMN_CSRCS += riscv_releasestack.c riscv_stackframe.c riscv_schedulesigaction.c
 CMN_CSRCS += riscv_sigdeliver.c riscv_udelay.c riscv_unblocktask.c riscv_usestack.c
-CMN_CSRCS += riscv_tcbinfo.c
+CMN_CSRCS += riscv_tcbinfo.c riscv_getnewintctx.c
 
 ifeq ($(CONFIG_SCHED_BACKTRACE),y)
 CMN_CSRCS += riscv_backtrace.c

--- a/arch/risc-v/src/esp32c3/esp32c3_irq.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_irq.c
@@ -135,25 +135,6 @@ void up_irqinitialize(void)
 }
 
 /****************************************************************************
- * Name: riscv_get_newintctx
- *
- * Description:
- *   Return initial mstatus when a task is created.
- *
- ****************************************************************************/
-
-uintptr_t riscv_get_newintctx(void)
-{
-  /* Set machine previous privilege mode to machine mode.
-   * Also set machine previous interrupt enable
-   */
-
-  uintptr_t mstatus = READ_CSR(mstatus);
-
-  return (mstatus | MSTATUS_MPPM | MSTATUS_MPIE);
-}
-
-/****************************************************************************
  * Name: up_enable_irq
  *
  * Description:

--- a/arch/risc-v/src/fe310/Make.defs
+++ b/arch/risc-v/src/fe310/Make.defs
@@ -33,7 +33,7 @@ CMN_CSRCS += riscv_interruptcontext.c riscv_modifyreg32.c riscv_puts.c riscv_mde
 CMN_CSRCS += riscv_releasepending.c riscv_reprioritizertr.c riscv_copyfullstate.c
 CMN_CSRCS += riscv_releasestack.c riscv_stackframe.c riscv_schedulesigaction.c
 CMN_CSRCS += riscv_sigdeliver.c riscv_udelay.c riscv_unblocktask.c riscv_usestack.c
-CMN_CSRCS += riscv_idle.c riscv_tcbinfo.c
+CMN_CSRCS += riscv_idle.c riscv_tcbinfo.c riscv_getnewintctx.c
 
 ifeq ($(CONFIG_SCHED_BACKTRACE),y)
 CMN_CSRCS += riscv_backtrace.c

--- a/arch/risc-v/src/fe310/fe310_irq.c
+++ b/arch/risc-v/src/fe310/fe310_irq.c
@@ -166,25 +166,6 @@ void up_enable_irq(int irq)
 }
 
 /****************************************************************************
- * Name: riscv_get_newintctx
- *
- * Description:
- *   Return initial mstatus when a task is created.
- *
- ****************************************************************************/
-
-uintptr_t riscv_get_newintctx(void)
-{
-  /* Set machine previous privilege mode to machine mode.
-   * Also set machine previous interrupt enable
-   */
-
-  uintptr_t mstatus = READ_CSR(mstatus);
-
-  return (mstatus | MSTATUS_MPPM | MSTATUS_MPIE);
-}
-
-/****************************************************************************
  * Name: riscv_ack_irq
  *
  * Description:

--- a/arch/risc-v/src/k210/Make.defs
+++ b/arch/risc-v/src/k210/Make.defs
@@ -34,7 +34,7 @@ CMN_CSRCS += riscv_releasepending.c riscv_reprioritizertr.c
 CMN_CSRCS += riscv_releasestack.c riscv_stackframe.c riscv_schedulesigaction.c
 CMN_CSRCS += riscv_sigdeliver.c riscv_unblocktask.c riscv_usestack.c
 CMN_CSRCS += riscv_mdelay.c riscv_copyfullstate.c riscv_idle.c
-CMN_CSRCS += riscv_tcbinfo.c riscv_cpuidlestack.c
+CMN_CSRCS += riscv_tcbinfo.c riscv_cpuidlestack.c riscv_getnewintctx.c
 
 ifeq ($(CONFIG_SMP), y)
 CMN_CSRCS += riscv_cpuindex.c riscv_cpupause.c riscv_cpustart.c

--- a/arch/risc-v/src/k210/k210_irq.c
+++ b/arch/risc-v/src/k210/k210_irq.c
@@ -211,29 +211,6 @@ void up_enable_irq(int irq)
 }
 
 /****************************************************************************
- * Name: riscv_get_newintctx
- *
- * Description:
- *   Return initial mstatus when a task is created.
- *
- ****************************************************************************/
-
-uintptr_t riscv_get_newintctx(void)
-{
-  /* Set machine previous privilege mode to machine mode. Reegardless of
-   * how NuttX is configured and of what kind of thread is being started.
-   * That is because all threads, even user-mode threads will start in
-   * kernel trampoline at nxtask_start() or pthread_start().
-   * The thread's privileges will be dropped before transitioning to
-   * user code. Also set machine previous interrupt enable.
-   */
-
-  uintptr_t mstatus = READ_CSR(mstatus);
-
-  return (mstatus | MSTATUS_MPPM | MSTATUS_MPIE);
-}
-
-/****************************************************************************
  * Name: riscv_ack_irq
  *
  * Description:

--- a/arch/risc-v/src/litex/Make.defs
+++ b/arch/risc-v/src/litex/Make.defs
@@ -33,7 +33,7 @@ CMN_CSRCS += riscv_interruptcontext.c riscv_modifyreg32.c riscv_puts.c riscv_mde
 CMN_CSRCS += riscv_releasepending.c riscv_reprioritizertr.c riscv_copyfullstate.c
 CMN_CSRCS += riscv_releasestack.c riscv_stackframe.c riscv_schedulesigaction.c
 CMN_CSRCS += riscv_sigdeliver.c riscv_udelay.c riscv_unblocktask.c riscv_usestack.c
-CMN_CSRCS += riscv_idle.c riscv_tcbinfo.c
+CMN_CSRCS += riscv_idle.c riscv_tcbinfo.c riscv_getnewintctx.c
 
 ifeq ($(CONFIG_SCHED_BACKTRACE),y)
 CMN_CSRCS += riscv_backtrace.c

--- a/arch/risc-v/src/litex/litex_irq.c
+++ b/arch/risc-v/src/litex/litex_irq.c
@@ -172,25 +172,6 @@ void up_enable_irq(int irq)
 }
 
 /****************************************************************************
- * Name: riscv_get_newintctx
- *
- * Description:
- *   Return initial mstatus when a task is created.
- *
- ****************************************************************************/
-
-uintptr_t riscv_get_newintctx(void)
-{
-  /* Set machine previous privilege mode to machine mode.
-   * Also set machine previous interrupt enable
-   */
-
-  uintptr_t mstatus = READ_CSR(mstatus);
-
-  return (mstatus | MSTATUS_MPPM | MSTATUS_MPIE);
-}
-
-/****************************************************************************
  * Name: riscv_ack_irq
  *
  * Description:

--- a/arch/risc-v/src/mpfs/Make.defs
+++ b/arch/risc-v/src/mpfs/Make.defs
@@ -31,7 +31,7 @@ CMN_CSRCS += riscv_releasepending.c riscv_reprioritizertr.c
 CMN_CSRCS += riscv_releasestack.c riscv_stackframe.c riscv_schedulesigaction.c
 CMN_CSRCS += riscv_sigdeliver.c riscv_unblocktask.c riscv_usestack.c
 CMN_CSRCS += riscv_mdelay.c riscv_udelay.c riscv_copyfullstate.c
-CMN_CSRCS += riscv_idle.c riscv_tcbinfo.c
+CMN_CSRCS += riscv_idle.c riscv_tcbinfo.c riscv_getnewintctx.c
 CMN_CSRCS += riscv_cpuindex.c
 
 ifeq ($(CONFIG_SCHED_BACKTRACE),y)

--- a/arch/risc-v/src/mpfs/mpfs_irq.c
+++ b/arch/risc-v/src/mpfs/mpfs_irq.c
@@ -206,33 +206,6 @@ void up_enable_irq(int irq)
 }
 
 /****************************************************************************
- * Name: riscv_get_newintctx
- *
- * Description:
- *   Return initial mstatus when a task is created.
- *
- ****************************************************************************/
-
-uintptr_t riscv_get_newintctx(void)
-{
-  /* Set machine previous privilege mode to machine mode. Reegardless of
-   * how NuttX is configured and of what kind of thread is being started.
-   * That is because all threads, even user-mode threads will start in
-   * kernel trampoline at nxtask_start() or pthread_start().
-   * The thread's privileges will be dropped before transitioning to
-   * user code. Also set machine previous interrupt enable.
-   */
-
-  uintptr_t mstatus = READ_CSR(mstatus);
-
-#ifdef CONFIG_ARCH_FPU
-  return (mstatus | MSTATUS_FS_INIT | MSTATUS_MPPM | MSTATUS_MPIE);
-#else
-  return (mstatus | MSTATUS_MPPM | MSTATUS_MPIE);
-#endif
-}
-
-/****************************************************************************
  * Name: riscv_ack_irq
  *
  * Description:

--- a/arch/risc-v/src/qemu-rv/Make.defs
+++ b/arch/risc-v/src/qemu-rv/Make.defs
@@ -34,7 +34,7 @@ CMN_CSRCS += riscv_releasepending.c riscv_reprioritizertr.c riscv_copyfullstate.
 CMN_CSRCS += riscv_releasestack.c riscv_stackframe.c riscv_schedulesigaction.c
 CMN_CSRCS += riscv_sigdeliver.c riscv_unblocktask.c riscv_usestack.c
 CMN_CSRCS += riscv_idle.c riscv_tcbinfo.c riscv_cpuidlestack.c
-CMN_CSRCS += riscv_fault.c
+CMN_CSRCS += riscv_fault.c riscv_getnewintctx.c
 
 ifeq ($(CONFIG_SMP), y)
 CMN_CSRCS += riscv_cpuindex.c riscv_cpupause.c riscv_cpustart.c

--- a/arch/risc-v/src/qemu-rv/qemu_rv_irq.c
+++ b/arch/risc-v/src/qemu-rv/qemu_rv_irq.c
@@ -205,27 +205,3 @@ irqstate_t up_irq_enable(void)
   oldstat = READ_AND_SET_CSR(mstatus, MSTATUS_MIE);
   return oldstat;
 }
-
-/****************************************************************************
- * Name: riscv_get_newintctx
- *
- * Description:
- *   Return initial mstatus when a task is created.
- *
- ****************************************************************************/
-
-uintptr_t riscv_get_newintctx(void)
-{
-  /* Set machine previous privilege mode to machine mode.
-   * Also set machine previous interrupt enable
-   * Note: In qemu, FPU is always exist even if don't use F|D ISA extension
-   */
-
-  uintptr_t mstatus = READ_CSR(mstatus);
-
-#ifdef CONFIG_ARCH_FPU
-  return (mstatus | MSTATUS_MPPM | MSTATUS_MPIE | MSTATUS_FS_INIT);
-#else
-  return (mstatus | MSTATUS_MPPM | MSTATUS_MPIE);
-#endif
-}

--- a/arch/risc-v/src/rv32m1/Make.defs
+++ b/arch/risc-v/src/rv32m1/Make.defs
@@ -33,7 +33,7 @@ CMN_CSRCS += riscv_interruptcontext.c riscv_modifyreg32.c riscv_puts.c
 CMN_CSRCS += riscv_releasepending.c riscv_reprioritizertr.c riscv_copyfullstate.c
 CMN_CSRCS += riscv_releasestack.c riscv_stackframe.c riscv_schedulesigaction.c
 CMN_CSRCS += riscv_sigdeliver.c riscv_unblocktask.c riscv_usestack.c
-CMN_CSRCS += riscv_idle.c riscv_tcbinfo.c
+CMN_CSRCS += riscv_idle.c riscv_tcbinfo.c riscv_getnewintctx.c
 
 ifeq ($(CONFIG_SCHED_BACKTRACE),y)
 CMN_CSRCS += riscv_backtrace.c

--- a/arch/risc-v/src/rv32m1/rv32m1_irq.c
+++ b/arch/risc-v/src/rv32m1/rv32m1_irq.c
@@ -214,25 +214,6 @@ void up_enable_irq(int irq)
 }
 
 /****************************************************************************
- * Name: riscv_get_newintctx
- *
- * Description:
- *   Return initial mstatus when a task is created.
- *
- ****************************************************************************/
-
-uintptr_t riscv_get_newintctx(void)
-{
-  /* Set machine previous privilege mode to machine mode.
-   * Also set machine previous interrupt enable
-   */
-
-  uintptr_t mstatus = READ_CSR(mstatus);
-
-  return (mstatus | MSTATUS_MPPM | MSTATUS_MPIE);
-}
-
-/****************************************************************************
  * Name: riscv_ack_irq
  *
  * Description:


### PR DESCRIPTION
## Summary
And also fix a issue that MIE should be cleared for a new task/pthread since it was handled by up_irq_enable/up_irq_disable.

## Impact
N/A
## Testing
maix-bit:smp
