### PR TITLE
arch/risc-v/src/mpfs/mpfs_irq.c: Revert "Rework riscv_get_newintctx" …

### DIFF
--- a/arch/risc-v/src/mpfs/mpfs_irq.c
+++ b/arch/risc-v/src/mpfs/mpfs_irq.c
@@ -280,12 +280,10 @@ uintptr_t riscv_get_newintctx(void)
    * user code. Also set machine previous interrupt enable.
    */
 
-  uintptr_t mstatus = READ_CSR(mstatus);
-
 #ifdef CONFIG_ARCH_FPU
-  return (mstatus | MSTATUS_FS_INIT | MSTATUS_MPPM | MSTATUS_MPIE);
+  return (MSTATUS_FS_INIT | MSTATUS_MPPM | MSTATUS_MPIE);
 #else
-  return (mstatus | MSTATUS_MPPM | MSTATUS_MPIE);
+  return (MSTATUS_MPPM | MSTATUS_MPIE);
 #endif
 }
 


### PR DESCRIPTION
…for mpfs target

This is partial revert of
807304f2835e4d70eb2581b15b447582ad009aea arch/risc-v: Rework riscv_get_newintctx

The original patch causes the mpfs stop booting. Using whatever happens to be in
CSR as the initial status is just not right.

Signed-off-by: Jukka Laitinen <jukkax@ssrc.tii.ae>

## Summary

Fix an erroneous intial context

## Impact

This restores MPFS target to work again

## Testing

Tested on Microchip PolarFire SOC FPGA based target
