### PR TITLE
Fix warning: 'argnumber' may be used uninitialized in this function

### DIFF
--- a/libs/libc/stdio/lib_libvsprintf.c
+++ b/libs/libc/stdio/lib_libvsprintf.c
@@ -203,7 +203,7 @@ static int vsprintf_internal(FAR struct lib_outstream_s *stream,
   int total_len = 0;
 
 #ifdef CONFIG_LIBC_NUMBERED_ARGS
-  int argnumber;
+  int argnumber = 0;
 #endif
 
   for (; ; )


### PR DESCRIPTION
## Summary

## Impact
Minor fix

## Testing
Pass CI
