### PR TITLE
MPFS: Add board_memorymap.h

### DIFF
--- a/arch/risc-v/src/common/riscv_mmu.h
+++ b/arch/risc-v/src/common/riscv_mmu.h
@@ -70,6 +70,15 @@
 #define MMU_UTEXT_FLAGS         (PTE_R | PTE_X | PTE_U)
 #define MMU_UDATA_FLAGS         (PTE_R | PTE_W | PTE_U)
 
+/* I/O region flags */
+
+#define MMU_IO_FLAGS            (PTE_R | PTE_W | PTE_G)
+
+/* Kernel FLASH and RAM are mapped globally */
+
+#define MMU_KTEXT_FLAGS         (PTE_R | PTE_X | PTE_G)
+#define MMU_KDATA_FLAGS         (PTE_R | PTE_W | PTE_G)
+
 /* SvX definitions, only Sv39 is currently supported, but it should be
  * trivial to extend the driver to support other SvX implementations
  *

--- a/arch/risc-v/src/mpfs/mpfs_allocateheap.c
+++ b/arch/risc-v/src/mpfs/mpfs_allocateheap.c
@@ -31,6 +31,10 @@
 #include <nuttx/board.h>
 #include <arch/board/board.h>
 
+#ifdef CONFIG_MM_KERNEL_HEAP
+#include <arch/board/board_memorymap.h>
+#endif
+
 #include "mpfs.h"
 
 /****************************************************************************
@@ -38,7 +42,7 @@
  ****************************************************************************/
 
 #ifdef CONFIG_MM_KERNEL_HEAP
-#define KRAM_END    ((uintptr_t)&__ksram_end)
+#define KRAM_END    KSRAM_END
 #else
 #define KRAM_END    CONFIG_RAM_END
 #endif
@@ -46,10 +50,6 @@
 /****************************************************************************
  * Public Data
  ****************************************************************************/
-
-#ifdef CONFIG_MM_KERNEL_HEAP
-extern uintptr_t    __ksram_end;
-#endif
 
 /****************************************************************************
  * Public Functions

--- a/arch/risc-v/src/mpfs/mpfs_userspace.c
+++ b/arch/risc-v/src/mpfs/mpfs_userspace.c
@@ -29,6 +29,8 @@
 
 #include <nuttx/userspace.h>
 
+#include <arch/board/board_memorymap.h>
+
 #include "mpfs_userspace.h"
 #include "riscv_internal.h"
 #include "riscv_mmu.h"
@@ -42,11 +44,6 @@
 #define PMP_UFLASH_FLAGS    (PMPCFG_A_NAPOT | PMPCFG_X | PMPCFG_R)
 #define PMP_USRAM_FLAGS     (PMPCFG_A_NAPOT | PMPCFG_W | PMPCFG_R)
 
-#define UFLASH_START        (uintptr_t)&__uflash_start
-#define UFLASH_SIZE         (uintptr_t)&__uflash_size
-#define USRAM_START         (uintptr_t)&__usram_start
-#define USRAM_SIZE          (uintptr_t)&__usram_size
-
 /* Physical and virtual addresses to page tables (vaddr = paddr mapping) */
 
 #define PGT_L1_PBASE        (uint64_t)&m_l1_pgtable
@@ -55,16 +52,6 @@
 #define PGT_L1_VBASE        PGT_L1_PBASE
 #define PGT_L2_VBASE        PGT_L2_PBASE
 #define PGT_L3_VBASE        PGT_L3_PBASE
-
-/* Flags for user FLASH (RX) and user RAM (RW) */
-
-#define MMU_UFLASH_FLAGS    (PTE_R | PTE_X | PTE_U | PTE_G)
-#define MMU_USRAM_FLAGS     (PTE_R | PTE_W | PTE_U | PTE_G)
-
-/* Kernel RAM needs to be opened (the page tables) */
-
-#define KSRAM_START         (uintptr_t)&__ksram_start
-#define KSRAM_SIZE          (uintptr_t)&__ksram_size
 
 /****************************************************************************
  * Private Functions
@@ -108,20 +95,6 @@ static void configure_mmu(void);
 static uint64_t             m_l1_pgtable[512] locate_data(".pgtables");
 static uint64_t             m_l2_pgtable[512] locate_data(".pgtables");
 static uint64_t             m_l3_pgtable[512] locate_data(".pgtables");
-
-/****************************************************************************
- * Public Data
- ****************************************************************************/
-
-extern uintptr_t            __uflash_start;
-extern uintptr_t            __uflash_size;
-extern uintptr_t            __usram_start;
-extern uintptr_t            __usram_size;
-
-/* Needed to allow access to the page tables, which reside in kernel RAM */
-
-extern uintptr_t            __ksram_start;
-extern uintptr_t            __ksram_size;
 
 /****************************************************************************
  * Public Functions
@@ -269,12 +242,12 @@ static void configure_mmu(void)
   /* Setup the L3 references for executable memory */
 
   mmu_ln_map_region(3, PGT_L3_VBASE, UFLASH_START, UFLASH_START,
-                    UFLASH_SIZE, MMU_UFLASH_FLAGS);
+                    UFLASH_SIZE, MMU_UTEXT_FLAGS);
 
   /* Setup the L3 references for data memory */
 
   mmu_ln_map_region(3, PGT_L3_VBASE, USRAM_START, USRAM_START,
-                    USRAM_SIZE, MMU_USRAM_FLAGS);
+                    USRAM_SIZE, MMU_UDATA_FLAGS);
 
   /* Setup the L2 and L1 references */
 

--- a/boards/risc-v/mpfs/icicle/include/board_memorymap.h
+++ b/boards/risc-v/mpfs/icicle/include/board_memorymap.h
@@ -1,0 +1,93 @@
+/****************************************************************************
+ * boards/risc-v/mpfs/icicle/include/board_memorymap.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __BOARDS_RISCV_MPFS_ICICLE_INCLUDE_BOARD_MEMORYMAP_H
+#define __BOARDS_RISCV_MPFS_ICICLE_INCLUDE_BOARD_MEMORYMAP_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <stdint.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/* Kernel code memory (RX) */
+
+#define KFLASH_START    (uintptr_t)&__kflash_start
+#define KFLASH_SIZE     (uintptr_t)&__kflash_size
+#define KSRAM_START     (uintptr_t)&__ksram_start
+#define KSRAM_SIZE      (uintptr_t)&__ksram_size
+#define KSRAM_END       (uintptr_t)&__ksram_end
+
+/* Kernel RAM (RW) */
+
+#define PGPOOL_START    (uintptr_t)&__pgheap_start
+#define PGPOOL_SIZE     (uintptr_t)&__pgheap_size
+
+/* Page pool (RWX) */
+
+#define PGPOOL_START    (uintptr_t)&__pgheap_start
+#define PGPOOL_SIZE     (uintptr_t)&__pgheap_size
+#define PGPOOL_END      (PGPOOL_START + PGPOOL_SIZE)
+
+/* User flash */
+
+#define UFLASH_START    (uintptr_t)&__uflash_start
+#define UFLASH_SIZE     (uintptr_t)&__uflash_size
+
+/* User RAM */
+
+#define USRAM_START     (uintptr_t)&__usram_start
+#define USRAM_SIZE      (uintptr_t)&__usram_size
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+/* Kernel code memory (RX)  */
+
+extern uintptr_t        __kflash_start;
+extern uintptr_t        __kflash_size;
+
+/* Kernel RAM (RW) */
+
+extern uintptr_t        __ksram_start;
+extern uintptr_t        __ksram_size;
+extern uintptr_t        __ksram_end;
+
+/* Page pool (RWX) */
+
+extern uintptr_t        __pgheap_start;
+extern uintptr_t        __pgheap_size;
+
+/* User code memory (RX) */
+
+extern uintptr_t        __uflash_start;
+extern uintptr_t        __uflash_size;
+
+/* User RAM (RW) */
+
+extern uintptr_t        __usram_start;
+extern uintptr_t        __usram_size;
+
+#endif /* __BOARDS_RISC_V_MPFS_ICICLE_INCLUDE_BOARD_MEMORYMAP_H */


### PR DESCRIPTION
Move the target specific memory map to a separate file so there is no
need to copy&paste the __xxram_start etc linker symbols to each file
that needs them.

Also add MMU flags for I/O and kernel areas, they will be needed
when the kernel runs with virtual addresses also.

## Summary
Adds a header file that can be used to access the linker defined memory boundary symbols
## Impact

## Testing
Icicle board knsh
