### PR TITLE
netdb/getaddrinfo: fix the compile warning

### DIFF
--- a/drivers/mtd/mtd_partition.c
+++ b/drivers/mtd/mtd_partition.c
@@ -906,7 +906,7 @@ int mtd_setpartitionname(FAR struct mtd_dev_s *mtd, FAR const char *name)
 
   /* Allocate space for the name */
 
-  strncpy(priv->name, name, sizeof(priv->name));
+  strlcpy(priv->name, name, sizeof(priv->name));
   return OK;
 }
 #endif

--- a/libs/libc/netdb/lib_getaddrinfo.c
+++ b/libs/libc/netdb/lib_getaddrinfo.c
@@ -77,7 +77,7 @@ FAR static struct ai_s *alloc_ai(int family, int socktype, int protocol,
       case AF_LOCAL:
         ai->ai.ai_addrlen       = sizeof(struct sockaddr_un);
         ai->sa.sun.sun_family   = AF_LOCAL;
-        strncpy(ai->sa.sun.sun_path, addr, sizeof(ai->sa.sun.sun_path));
+        strlcpy(ai->sa.sun.sun_path, addr, sizeof(ai->sa.sun.sun_path));
         break;
 #endif
 #ifdef CONFIG_NET_IPv4
@@ -100,7 +100,7 @@ FAR static struct ai_s *alloc_ai(int family, int socktype, int protocol,
       case AF_RPMSG:
         ai->ai.ai_addrlen       = sizeof(struct sockaddr_rpmsg);
         ai->sa.srp.rp_family    = AF_RPMSG;
-        strncpy(ai->sa.srp.rp_cpu, addr, sizeof(ai->sa.srp.rp_cpu));
+        strlcpy(ai->sa.srp.rp_cpu, addr, sizeof(ai->sa.srp.rp_cpu));
         snprintf(ai->sa.srp.rp_name, sizeof(ai->sa.srp.rp_name), "%d", port);
         break;
 #endif


### PR DESCRIPTION
## Summary

netdb/getaddrinfo: fix the compile warning

```
netdb/lib_getaddrinfo.c: In function ‘alloc_ai’:
netdb/lib_getaddrinfo.c:80:9: warning: ‘strncpy’ specified bound 108 equals destination size [-Wstringop-truncation]
   80 |         strncpy(ai->sa.sun.sun_path, addr, sizeof(ai->sa.sun.sun_path));
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

```
Signed-off-by: chao.an <anchao@xiaomi.com>

## Impact

N/A

## Testing

CI-check