### PR TITLE
xtensa_coporc: Adjust stack frame for C callable coprocessor functions

### DIFF
--- a/arch/xtensa/src/common/xtensa_coproc.S
+++ b/arch/xtensa/src/common/xtensa_coproc.S
@@ -251,7 +251,12 @@ xtensa_coproc_savestate:
    * a13-a15.  So a13-a15 may need to be preserved.
    */
 
-	ENTRY(32 /*16*/)						/* REVISIT: Why 32? */
+	/* Allocate the stack frame.  This function needs to allocate the usual 16
+	 * byte for the base save area + space for one variable.
+	 * NOTE: entry works in multiples of 8 bytes.
+	 */
+
+	ENTRY(24)
 	s32i	a0,  sp, LOCAL_OFFSET(1)		/* Save return address */
 
 	/* Call _xtensa_coproc_savestate() with A2=address of co-processor
@@ -263,7 +268,7 @@ xtensa_coproc_savestate:
 	/* Restore a0 and return */
 
 	l32i	a0,  sp, LOCAL_OFFSET(1)		/* Recover return address */
-	RET(32 /*16*/)							/* REVISIT: Why 32? */
+	RET(24)
 
 #endif
 
@@ -450,7 +455,12 @@ xtensa_coproc_restorestate:
    * a13-a15.  So a13-a15 may need to be preserved.
    */
 
-	ENTRY(32 /*16*/)						/* REVISIT: Why 32? */
+	/* Allocate the stack frame.  This function needs to allocate the usual 16
+	 * byte for the base save area + space for one variable.
+	 * NOTE: entry works in multiples of 8 bytes.
+	 */
+
+	ENTRY(24)
 	s32i	a0,  sp, LOCAL_OFFSET(1)		/* Save return address */
 
 	/* Call _xtensa_coproc_restorestate() with A2=address of co-processor
@@ -462,7 +472,7 @@ xtensa_coproc_restorestate:
 	/* Restore a0 and return */
 
   l32i	a0,  sp, LOCAL_OFFSET(1)		/* Recover return address */
-  RET(32 /*16*/)							/* REVISIT: Why 32? */
+  RET(24)
 
 #endif
 

--- a/arch/xtensa/src/common/xtensa_coproc.S
+++ b/arch/xtensa/src/common/xtensa_coproc.S
@@ -222,11 +222,10 @@ _xtensa_coproc_savestate:
 xtensa_coproc_savestate:
 
 #ifdef __XTENSA_CALL0_ABI__
-
 	/* Need to preserve a8-11.  _xtensa_coproc_savestate modifies a2-a7,
-   * a13-a15. a12-a15 are callee saved registers so a13-a14 must be
-   * preserved.
-   */
+	 * a13-a15. a12-a15 are callee saved registers so a13-a14 must be
+	 * preserved.
+	 */
 
 	ENTRY(16)
 	s32i	a13, sp, LOCAL_OFFSET(1)		/* Save clobbered registers */
@@ -234,8 +233,8 @@ xtensa_coproc_savestate:
 	s32i	a15, sp, LOCAL_OFFSET(3)
 
 	/* Call _xtensa_coproc_savestate() with A2=address of co-processor
-   * save area.
-   */
+	 * save area.
+	 */
 
 	call0 _xtensa_coproc_savestate
 
@@ -247,10 +246,6 @@ xtensa_coproc_savestate:
 	RET(16)
 
 #else
-	/* Need to preserve a8-15.  _xtensa_coproc_savestate modifies a2-a7,
-   * a13-a15.  So a13-a15 may need to be preserved.
-   */
-
 	/* Allocate the stack frame.  This function needs to allocate the usual 16
 	 * byte for the base save area + space for one variable.
 	 * NOTE: entry works in multiples of 8 bytes.
@@ -260,8 +255,8 @@ xtensa_coproc_savestate:
 	s32i	a0,  sp, LOCAL_OFFSET(1)		/* Save return address */
 
 	/* Call _xtensa_coproc_savestate() with A2=address of co-processor
-   * save area.
-   */
+	 * save area.
+	 */
 
 	call0 _xtensa_coproc_savestate
 
@@ -426,11 +421,10 @@ _xtensa_coproc_restorestate:
 xtensa_coproc_restorestate:
 
 #ifdef __XTENSA_CALL0_ABI__
-
 	/* Need to preserve a8-11.  _xtensa_coproc_restorestate modifies a2-a7,
-   * a13-a15. a12-a15 are callee saved registers so a13-a14 must be
-   * preserved.
-   */
+	 * a13-a15. a12-a15 are callee saved registers so a13-a14 must be
+	 * preserved.
+	 */
 
 	ENTRY(16)
 	s32i	a13, sp, LOCAL_OFFSET(1)		/* Save clobbered values */
@@ -438,8 +432,8 @@ xtensa_coproc_restorestate:
 	s32i	a15, sp, LOCAL_OFFSET(3)
 
 	/* Call _xtensa_coproc_restorestate() with A2=address of co-processor
-   * save area.   Registers a0, a2-a7, a13-a15 have been trashed.
-   */
+	 * save area.   Registers a0, a2-a7, a13-a15 have been trashed.
+	 */
 
 	call0 _xtensa_coproc_restorestate
 
@@ -451,10 +445,6 @@ xtensa_coproc_restorestate:
 	RET(16)
 
 #else
-	/* Need to preserve a8-15.  _xtensa_coproc_savestate modifies a2-a7,
-   * a13-a15.  So a13-a15 may need to be preserved.
-   */
-
 	/* Allocate the stack frame.  This function needs to allocate the usual 16
 	 * byte for the base save area + space for one variable.
 	 * NOTE: entry works in multiples of 8 bytes.
@@ -464,15 +454,15 @@ xtensa_coproc_restorestate:
 	s32i	a0,  sp, LOCAL_OFFSET(1)		/* Save return address */
 
 	/* Call _xtensa_coproc_restorestate() with A2=address of co-processor
-   * save area.   Registers a0, a2-a7, a13-a15 have been trashed.
-   */
+	 * save area.   Registers a0, a2-a7, a13-a15 have been trashed.
+	 */
 
-  call0 _xtensa_coproc_restorestate
+	call0 _xtensa_coproc_restorestate
 
 	/* Restore a0 and return */
 
-  l32i	a0,  sp, LOCAL_OFFSET(1)		/* Recover return address */
-  RET(24)
+	l32i	a0,  sp, LOCAL_OFFSET(1)		/* Recover return address */
+	RET(24)
 
 #endif
 


### PR DESCRIPTION
## Summary
These function don't use call8 or call12 and thus need to create just 16
bytes for the base save area, however they do use one variable so we
need a space for that.  The `entry` instruction works in multiples of 8 bytes
so we add whole 8 bytes for one variable.
## Impact
Xtensa chips
## Testing
ESP32, ESP32-S2 and ESP32-S3.
