### PR TITLE
netinitialize: call xxx_netinitialize unconditionally

### DIFF
--- a/arch/arm/src/common/arm_initialize.c
+++ b/arch/arm/src/common/arm_initialize.c
@@ -122,11 +122,9 @@ void up_initialize(void)
   arm_serialinit();
 #endif
 
-#ifndef CONFIG_NETDEV_LATEINIT
   /* Initialize the network */
 
   arm_netinitialize();
-#endif
 
 #if defined(CONFIG_USBDEV) || defined(CONFIG_USBHOST)
   /* Initialize USB -- device and/or host */

--- a/arch/arm/src/imxrt/imxrt_enet.h
+++ b/arch/arm/src/imxrt/imxrt_enet.h
@@ -55,30 +55,6 @@ extern "C"
 #endif
 
 /****************************************************************************
- * Function: arm_netinitialize
- *
- * Description:
- *   Initialize the first network interface.  If there are more than one
- *   interface in the chip, then board-specific logic will have to provide
- *   this function to determine which, if any, Ethernet controllers should
- *   be initialized.  Also prototyped in arm_internal.h.
- *
- * Input Parameters:
- *   None
- *
- * Returned Value:
- *   OK on success; Negated errno on failure.
- *
- * Assumptions:
- *   Called very early in the initialization sequence.
- *
- ****************************************************************************/
-
-#if !defined(CONFIG_NETDEV_LATEINIT)
-void arm_netinitialize(void);
-#else
-
-/****************************************************************************
  * Function: imxrt_netinitialize
  *
  * Description:
@@ -95,6 +71,7 @@ void arm_netinitialize(void);
  *
  ****************************************************************************/
 
+#ifdef CONFIG_NETDEV_LATEINIT
 int imxrt_netinitialize(int intf);
 #endif
 

--- a/arch/arm/src/imxrt/imxrt_flexcan.h
+++ b/arch/arm/src/imxrt/imxrt_flexcan.h
@@ -70,31 +70,8 @@ extern "C"
  *
  ****************************************************************************/
 
-#if !defined(CONFIG_NETDEV_LATEINIT)
-
-void arm_netinitialize(void);
-
-/****************************************************************************
- * Function: imxrt_caninitialize
- *
- * Description:
- *   Initialize the CAN controller and driver
- *
- * Input Parameters:
- *   intf - In the case where there are multiple CAN devices, this value
- *          identifies which CAN device is to be initialized.
- *
- * Returned Value:
- *   OK on success; Negated errno on failure.
- *
- * Assumptions:
- *
- ****************************************************************************/
-
-#else
-
+#ifdef CONFIG_NETDEV_LATEINIT
 int imxrt_caninitialize(int intf);
-
 #endif
 
 #undef EXTERN

--- a/arch/arm/src/s32k1xx/s32k1xx_enet.h
+++ b/arch/arm/src/s32k1xx/s32k1xx_enet.h
@@ -54,32 +54,6 @@ extern "C"
 #define EXTERN extern
 #endif
 
-#if !defined(CONFIG_NETDEV_LATEINIT)
-
-/****************************************************************************
- * Function: arm_netinitialize
- *
- * Description:
- *   Initialize the first network interface.  If there are more than one
- *   interface in the chip, then board-specific logic will have to provide
- *   this function to determine which, if any, Ethernet controllers should
- *   be initialized.  Also prototyped in arm_internal.h.
- *
- * Input Parameters:
- *   None
- *
- * Returned Value:
- *   OK on success; Negated errno on failure.
- *
- * Assumptions:
- *   Called very early in the initialization sequence.
- *
- ****************************************************************************/
-
-void arm_netinitialize(void);
-
-#else
-
 /****************************************************************************
  * Function: s32k1xx_netinitialize
  *
@@ -97,8 +71,8 @@ void arm_netinitialize(void);
  *
  ****************************************************************************/
 
+#ifdef CONFIG_NETDEV_LATEINIT
 int s32k1xx_netinitialize(int intf);
-
 #endif
 
 /****************************************************************************

--- a/arch/arm/src/s32k1xx/s32k1xx_flexcan.h
+++ b/arch/arm/src/s32k1xx/s32k1xx_flexcan.h
@@ -50,32 +50,6 @@ extern "C"
 #define EXTERN extern
 #endif
 
-#if !defined(CONFIG_NETDEV_LATEINIT)
-
-/****************************************************************************
- * Function: arm_netinitialize
- *
- * Description:
- *   Initialize the enabled CAN device interfaces.  If there are more
- *   different network devices in the chip, then board-specific logic will
- *   have to provide this function to determine which, if any, network
- *   devices should be initialized.
- *
- * Input Parameters:
- *   None
- *
- * Returned Value:
- *   OK on success; Negated errno on failure.
- *
- * Assumptions:
- *   Called very early in the initialization sequence.
- *
- ****************************************************************************/
-
-void arm_netinitialize(void);
-
-#else
-
 /****************************************************************************
  * Function: s32k1xx_caninitialize
  *
@@ -93,8 +67,8 @@ void arm_netinitialize(void);
  *
  ****************************************************************************/
 
+#ifdef CONFIG_NETDEV_LATEINIT
 int s32k1xx_caninitialize(int intf);
-
 #endif
 
 #undef EXTERN

--- a/arch/arm/src/sam34/sam_emac.h
+++ b/arch/arm/src/sam34/sam_emac.h
@@ -56,25 +56,6 @@ extern "C"
 #endif
 
 /****************************************************************************
- * Function: arm_netinitialize
- *
- * Description:
- *   Initialize the EMAC driver.  Also prototyped in arm_internal.h.
- *
- * Input Parameters:
- *   None
- *
- * Returned Value:
- *   OK on success; Negated errno on failure.
- *
- * Assumptions:
- *   Called very early in the initialization sequence.
- *
- ****************************************************************************/
-
-void arm_netinitialize(void);
-
-/****************************************************************************
  * Function: sam_phy_boardinitialize
  *
  * Description:

--- a/arch/avr/src/common/up_initialize.c
+++ b/arch/avr/src/common/up_initialize.c
@@ -151,11 +151,9 @@ void up_initialize(void)
   up_serialinit();
 #endif
 
-#ifndef CONFIG_NETDEV_LATEINIT
   /* Initialize the network */
 
   up_netinitialize();
-#endif
 
   /* Initialize USB */
 

--- a/arch/ceva/src/common/up_initialize.c
+++ b/arch/ceva/src/common/up_initialize.c
@@ -107,11 +107,9 @@ void up_initialize(void)
   up_serialinit();
 #endif
 
-#ifndef CONFIG_NETDEV_LATEINIT
   /* Initialize the network */
 
   up_netinitialize();
-#endif
 
 #if defined(CONFIG_USBDEV) || defined(CONFIG_USBHOST)
   /* Initialize USB -- device and/or host */

--- a/arch/hc/src/common/up_initialize.c
+++ b/arch/hc/src/common/up_initialize.c
@@ -84,11 +84,9 @@ void up_initialize(void)
   up_serialinit();
 #endif
 
-#ifndef CONFIG_NETDEV_LATEINIT
   /* Initialize the network */
 
   up_netinitialize();
-#endif
 
   /* Initialize USB */
 

--- a/arch/mips/src/common/mips_initialize.c
+++ b/arch/mips/src/common/mips_initialize.c
@@ -84,11 +84,9 @@ void up_initialize(void)
   up_serialinit();
 #endif
 
-#ifndef CONFIG_NETDEV_LATEINIT
   /* Initialize the network */
 
   up_netinitialize();
-#endif
 
   /* Initialize USB -- device and/or host */
 

--- a/arch/or1k/src/common/up_initialize.c
+++ b/arch/or1k/src/common/up_initialize.c
@@ -180,11 +180,9 @@ void up_initialize(void)
 
   or1k_print_cpuinfo();
 
-#ifndef CONFIG_NETDEV_LATEINIT
   /* Initialize the network */
 
   up_netinitialize();
-#endif
 
   /* Initialize USB -- device and/or host */
 

--- a/arch/renesas/src/common/up_initialize.c
+++ b/arch/renesas/src/common/up_initialize.c
@@ -67,11 +67,9 @@ void up_initialize(void)
   up_serialinit();
 #endif
 
-#ifndef CONFIG_NETDEV_LATEINIT
   /* Initialize the network */
 
   up_netinitialize();
-#endif
 
   /* Initialize USB */
 

--- a/arch/risc-v/src/common/riscv_initialize.c
+++ b/arch/risc-v/src/common/riscv_initialize.c
@@ -105,11 +105,9 @@ void up_initialize(void)
   riscv_serialinit();
 #endif
 
-#ifdef CONFIG_NET
   /* Initialize the network */
 
   riscv_netinitialize();
-#endif
 
   board_autoled_on(LED_IRQSENABLED);
 }

--- a/arch/risc-v/src/mpfs/mpfs_ethernet.c
+++ b/arch/risc-v/src/mpfs/mpfs_ethernet.c
@@ -52,8 +52,8 @@
 #endif
 
 #include "riscv_internal.h"
-#include "hardware/mpfs_ethernet.h"
 #include "mpfs_memorymap.h"
+#include "mpfs_ethernet.h"
 
 #if defined(CONFIG_NET) && defined(CONFIG_MPFS_ETHMAC)
 

--- a/arch/risc-v/src/mpfs/mpfs_ethernet.h
+++ b/arch/risc-v/src/mpfs/mpfs_ethernet.h
@@ -61,7 +61,9 @@ extern "C"
  *
  ****************************************************************************/
 
+#ifdef CONFIG_NETDEV_LATEINIT
 int mpfs_ethinitialize(int intf);
+#endif
 
 /****************************************************************************
  * Function: mpfs_phy_boardinitialize

--- a/arch/x86/src/common/up_initialize.c
+++ b/arch/x86/src/common/up_initialize.c
@@ -84,11 +84,9 @@ void up_initialize(void)
   up_serialinit();
 #endif
 
-#ifndef CONFIG_NETDEV_LATEINIT
   /* Initialize the network */
 
   up_netinitialize();
-#endif
 
   /* Initialize USB -- device and/or host */
 

--- a/arch/x86_64/src/common/up_initialize.c
+++ b/arch/x86_64/src/common/up_initialize.c
@@ -115,11 +115,9 @@ void up_initialize(void)
   up_serialinit();
 #endif
 
-#ifndef CONFIG_NETDEV_LATEINIT
   /* Initialize the network */
 
   up_netinitialize();
-#endif
 
   /* Initialize USB -- device and/or host */
 

--- a/arch/xtensa/src/common/xtensa_initialize.c
+++ b/arch/xtensa/src/common/xtensa_initialize.c
@@ -125,11 +125,9 @@ void up_initialize(void)
   xtensa_serialinit();
 #endif
 
-#ifndef CONFIG_NETDEV_LATEINIT
   /* Initialize the network */
 
   up_netinitialize();
-#endif
 
   /* Initialize USB -- device and/or host */
 

--- a/arch/z16/src/common/z16_initialize.c
+++ b/arch/z16/src/common/z16_initialize.c
@@ -84,11 +84,9 @@ void up_initialize(void)
   z16_serialinit();
 #endif
 
-#ifndef CONFIG_NETDEV_LATEINIT
   /* Initialize the network */
 
   z16_netinitialize();
-#endif
 
   board_autoled_on(LED_IRQSENABLED);
 }

--- a/arch/z80/src/common/z80_initialize.c
+++ b/arch/z80/src/common/z80_initialize.c
@@ -86,11 +86,9 @@ void up_initialize(void)
   z80_serial_initialize();
 #endif
 
-#ifndef CONFIG_NETDEV_LATEINIT
   /* Initialize the network */
 
   up_netinitialize();
-#endif
 
   board_autoled_on(LED_IRQSENABLED);
 }


### PR DESCRIPTION
## Summary
Call xxx_netinitialize unconditionally.

The xxx_netinitialize is defined to a function only if `CONFIG_NET=y` and `CONFIG_NETDEV_LATEINIT=n`. Otherwise it is defined to an empty macro.

## Impact
None. Refactoring only

## Testing
Pass CI
