### PR TITLE
fs/nfs: fix compile warning

### DIFF
--- a/fs/nfs/nfs_vfsops.c
+++ b/fs/nfs/nfs_vfsops.c
@@ -903,7 +903,7 @@ static ssize_t nfs_read(FAR struct file *filep, FAR char *buffer,
   if (buflen > tmp)
     {
       buflen = tmp;
-      finfo("Read size truncated to %d\n", buflen);
+      finfo("Read size truncated to %zu\n", buflen);
     }
 
   /* Now loop until we fill the user buffer (or hit the end of the file) */
@@ -957,7 +957,7 @@ static ssize_t nfs_read(FAR struct file *filep, FAR char *buffer,
 
       /* Perform the read */
 
-      finfo("Reading %d bytes\n", readsize);
+      finfo("Reading %zu bytes\n", readsize);
       nfs_statistics(NFSPROC_READ);
       ret = nfs_request(nmp, NFSPROC_READ,
                         (FAR void *)&nmp->nm_msgbuffer.read, reqlen,
@@ -2006,7 +2006,7 @@ static int nfs_bind(FAR struct inode *blkdriver, FAR const void *data,
   nmp->nm_rsize       = nprmt.rsize;
   nmp->nm_readdirsize = nprmt.readdirsize;
 
-  strncpy(nmp->nm_path, argp->path, 90);
+  strlcpy(nmp->nm_path, argp->path, sizeof(nmp->nm_path));
   memcpy(&nmp->nm_nam, &argp->addr, argp->addrlen);
 
   /* Create an instance of the rpc state structure */

--- a/fs/nfs/rpc_clnt.c
+++ b/fs/nfs/rpc_clnt.c
@@ -588,7 +588,8 @@ int rpcclnt_connect(FAR struct rpcclnt *rpc)
 
   /* Do RPC to mountd. */
 
-  strncpy(request.mountd.mount.rpath, rpc->rc_path, 90);
+  strlcpy(request.mountd.mount.rpath, rpc->rc_path,
+          sizeof(request.mountd.mount.rpath));
   request.mountd.mount.len =
     txdr_unsigned(sizeof(request.mountd.mount.rpath));
 
@@ -716,7 +717,8 @@ void rpcclnt_disconnect(FAR struct rpcclnt *rpc)
 
   /* Do RPC to umountd. */
 
-  strncpy(request.mountd.umount.rpath, rpc->rc_path, 90);
+  strlcpy(request.mountd.umount.rpath, rpc->rc_path,
+          sizeof(request.mountd.umount.rpath));
   request.mountd.umount.len =
     txdr_unsigned(sizeof(request.mountd.umount.rpath));
 


### PR DESCRIPTION
## Summary

fs/nfs: fix compile warning

```
In file included from nfs/nfs_vfsops.c:65:
nfs/nfs_vfsops.c: In function ‘nfs_read’:
nfs/nfs_vfsops.c:906:13: warning: format ‘%d’ expects argument of type ‘int’, but argument 3 has type ‘size_t’ {aka ‘long unsigned int’} [-Wformat=]
  906 |       finfo("Read size truncated to %d\n", buflen);
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~  ~~~~~~
      |                                            |
      |                                            size_t {aka long unsigned int}
nfs/nfs_vfsops.c:906:38: note: format string is defined here
  906 |       finfo("Read size truncated to %d\n", buflen);
      |                                     ~^
      |                                      |
      |                                      int
      |                                     %ld
In file included from nfs/nfs_vfsops.c:65:
nfs/nfs_vfsops.c:960:13: warning: format ‘%d’ expects argument of type ‘int’, but argument 3 has type ‘ssize_t’ {aka ‘long int’} [-Wformat=]
  960 |       finfo("Reading %d bytes\n", readsize);
      |             ^~~~~~~~~~~~~~~~~~~~  ~~~~~~~~
      |                                   |
      |                                   ssize_t {aka long int}
nfs/nfs_vfsops.c:960:23: note: format string is defined here
  960 |       finfo("Reading %d bytes\n", readsize);
      |                      ~^
      |                       |
      |                       int
      |                      %ld


nfs/rpc_clnt.c: In function ‘rpcclnt_connect’:
nfs/rpc_clnt.c:591:3: warning: ‘strncpy’ specified bound 90 equals destination size [-Wstringop-truncation]
  591 |   strncpy(request.mountd.mount.rpath, rpc->rc_path, 90);
      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
make[3]: Entering directory '/home/archer/code/nuttx/n2/apps/platform'
nfs/rpc_clnt.c: In function ‘rpcclnt_disconnect’:
nfs/rpc_clnt.c:719:3: warning: ‘strncpy’ specified bound 90 equals destination size [-Wstringop-truncation]
  719 |   strncpy(request.mountd.umount.rpath, rpc->rc_path, 90);
      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
netdb/lib_getaddrinfo.c: In function ‘alloc_ai’:
netdb/lib_getaddrinfo.c:80:9: warning: ‘strncpy’ specified bound 108 equals destination size [-Wstringop-truncation]
   80 |         strncpy(ai->sa.sun.sun_path, addr, sizeof(ai->sa.sun.sun_path));
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
nfs/nfs_vfsops.c: In function ‘nfs_bind’:
nfs/nfs_vfsops.c:2009:3: warning: ‘strncpy’ specified bound 90 equals destination size [-Wstringop-truncation]
 2009 |   strncpy(nmp->nm_path, argp->path, 90);
      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

```



## Impact

N/A

## Testing

ci-check