### PR TITLE
netdb/getaddrinfo: fix NULL pointer reference

### DIFF
--- a/libs/libc/netdb/lib_getaddrinfo.c
+++ b/libs/libc/netdb/lib_getaddrinfo.c
@@ -290,11 +290,10 @@ int getaddrinfo(FAR const char *hostname, FAR const char *servname,
       if (ai != NULL)
         {
           *res = (FAR struct addrinfo *)ai;
-        }
-
-      if (flags & AI_CANONNAME)
-        {
-          ai->ai.ai_canonname = (FAR char *)hostname;
+          if (flags & AI_CANONNAME)
+            {
+              ai->ai.ai_canonname = (FAR char *)hostname;
+            }
         }
 
       return (*res != NULL) ? OK : EAI_MEMORY;


### PR DESCRIPTION


## Summary

netdb/getaddrinfo: fix NULL pointer reference

Signed-off-by: chao.an <anchao@xiaomi.com>

## Impact

N/A

## Testing

ci-check