### PR TITLE
libc/err: fix unpaired va_end()

### DIFF
--- a/libs/libc/misc/lib_err.c
+++ b/libs/libc/misc/lib_err.c
@@ -97,6 +97,10 @@ void vwarnx(FAR const char *fmt, va_list ap)
 #else
   dprintf(STDERR_FILENO, "%d: %pV\n", getpid(), &vaf);
 #endif
+
+#ifdef va_copy
+  va_end(copy);
+#endif
 }
 
 /****************************************************************************


### PR DESCRIPTION
## Summary

libc/err: fix unpaired va_end()

each invocation of va_start() must be matched by a corresponding invocation of va_end() in the same function

Signed-off-by: chao.an <anchao@xiaomi.com>


## Impact

N/A

## Testing

CI-check