### PR TITLE
net/netdev: fix switch case missing break

### DIFF
--- a/net/netdev/netdev_ioctl.c
+++ b/net/netdev/netdev_ioctl.c
@@ -1530,6 +1530,7 @@ static int netdev_file_ioctl(FAR struct socket *psock, int cmd,
               ret = -ENOSYS;
             }
         }
+        break;
 
       default:
         ret = -ENOTTY;


### PR DESCRIPTION

## Summary

net/netdev: fix switch case missing break

Signed-off-by: chao.an <anchao@xiaomi.com>

## Impact

N/A

## Testing

CI-check