### PR TITLE
regulator/rpmsg: list delete should use safe version in loop

### DIFF
--- a/drivers/power/regulator_rpmsg.c
+++ b/drivers/power/regulator_rpmsg.c
@@ -327,9 +327,10 @@ static void regulator_rpmsg_server_unbind(FAR struct rpmsg_endpoint *ept)
 {
   FAR struct regulator_rpmsg_server_s *priv = ept->priv;
   FAR struct regulator_rpmsg_s *reg;
+  FAR struct regulator_rpmsg_s *tmp;
 
-  list_for_every_entry(&priv->regulator_list, reg,
-                       struct regulator_rpmsg_s, node)
+  list_for_every_entry_safe(&priv->regulator_list, reg, tmp,
+                            struct regulator_rpmsg_s, node)
     {
       while (regulator_is_enabled(reg->regulator))
         {


### PR DESCRIPTION
## Summary

regulator/rpmsg: list delete should use safe version in loop

## Impact

N/A

## Testing

CI-check