### PR TITLE
nxstyle: ignore mixed-case identifiers for Lua types

### DIFF
--- a/tools/nxstyle.c
+++ b/tools/nxstyle.c
@@ -203,6 +203,8 @@ static const char *g_white_prefix[] =
   "ub32",    /* Ref:  include/fixedmath.h */
   "ASCII_",  /* Ref:  include/nuttx/ascii.h */
   "XK_",     /* Ref:  include/input/X11_keysymdef.h */
+  "lua_",    /* Ref:  apps/interpreters/lua/lua-5.x.x/src/lua.h */
+  "luaL_",   /* Ref:  apps/interpreters/lua/lua-5.x.x/src/lauxlib.h */
 
   NULL
 };


### PR DESCRIPTION
## Summary

Silence `nxstyle` mixed-case identifier warnings for Lua types. Notably, Lua C modules that use the `lua_State` and `luaL_Reg` types.

Related to https://github.com/apache/incubator-nuttx-apps/pull/1075

## Impact

Should not affect non-Lua C module style lints. The prefixes `lua_` and `luaL_` do not exist anywhere else in the NuttX codebase.

## Testing

Ran `nxstyle` on `luamod_hello.c` from `apps/examples/lua_module/`. No mixed-case identifier warnings.

