### PR TITLE
libc: Change the return type of strerror from "const char *" to "char *"

### DIFF
--- a/include/string.h
+++ b/include/string.h
@@ -53,7 +53,7 @@ extern "C"
 
 FAR char  *strdup(FAR const char *s);
 FAR char  *strndup(FAR const char *s, size_t size);
-FAR const char *strerror(int);
+FAR char  *strerror(int);
 int        strerror_r(int, FAR char *, size_t);
 size_t     strlen(FAR const char *);
 size_t     strnlen(FAR const char *, size_t);

--- a/libs/libc/libc.csv
+++ b/libs/libc/libc.csv
@@ -225,7 +225,7 @@
 "strcpy","string.h","","FAR char *","FAR char *","FAR const char *"
 "strcspn","string.h","","size_t","FAR const char *","FAR const char *"
 "strdup","string.h","","FAR char *","FAR const char *"
-"strerror","string.h","","FAR const char *","int"
+"strerror","string.h","","FAR char *","int"
 "strerror_r","string.h","","int","int","FAR char *","size_t"
 "strftime","time.h","","size_t","FAR char *","size_t","FAR const char *","FAR const struct tm *"
 "strlen","string.h","","size_t","FAR const char *"

--- a/libs/libc/string/lib_strerror.c
+++ b/libs/libc/string/lib_strerror.c
@@ -38,8 +38,8 @@
 
 struct errno_strmap_s
 {
-  uint8_t     errnum;
-  const char *str;
+  uint8_t   errnum;
+  FAR char *str;
 };
 
 /****************************************************************************
@@ -341,7 +341,7 @@ static const struct errno_strmap_s g_errnomap[] =
  * Name: strerror
  ****************************************************************************/
 
-FAR const char *strerror(int errnum)
+FAR char *strerror(int errnum)
 {
 #ifdef CONFIG_LIBC_STRERROR
   int ndxlow = 0;


### PR DESCRIPTION
## Summary
to follow up the spec here:
https://pubs.opengroup.org/onlinepubs/9699919799/functions/strerror.html
report by internal CI:
```
include/string.h:55:17: error: incompatible redeclaration of library function 'strerror' [-Werror,-Wincompatible-library-redeclaration]
FAR const char *strerror(int);
include/string.h:55:17: note: 'strerror' is a builtin with type 'char *(int)'
```

## Impact
strerror prototype

## Testing
Pass CI
