### PR TITLE
sys/type.h: Change pid_t from int16_t to int

### DIFF
--- a/fs/procfs/fs_procfsproc.c
+++ b/fs/procfs/fs_procfsproc.c
@@ -1445,11 +1445,11 @@ static int proc_open(FAR struct file *filep, FAR const char *relpath,
 
   ptr++;
 
-  /* A valid PID would be in the range of 0-32767 (0 is reserved for the
+  /* A valid PID would be in the range of 0-INT_MAX (0 is reserved for the
    * IDLE thread).
    */
 
-  if (tmp >= 32768)
+  if (tmp > INT_MAX)
     {
       ferr("ERROR: Invalid PID %ld\n", tmp);
       return -ENOENT;
@@ -1701,11 +1701,11 @@ static int proc_opendir(FAR const char *relpath, FAR struct fs_dirent_s *dir)
       return -ENOENT;
     }
 
-  /* A valid PID would be in the range of 0-32767 (0 is reserved for the
+  /* A valid PID would be in the range of 0-INT_MAX (0 is reserved for the
    * IDLE thread).
    */
 
-  if (tmp >= 32768)
+  if (tmp > INT_MAX)
     {
       ferr("ERROR: Invalid PID %ld\n", tmp);
       return -ENOENT;
@@ -1947,11 +1947,11 @@ static int proc_stat(const char *relpath, struct stat *buf)
       return -ENOENT;
     }
 
-  /* A valid PID would be in the range of 0-32767 (0 is reserved for the
+  /* A valid PID would be in the range of 0-INT_MAX (0 is reserved for the
    * IDLE thread).
    */
 
-  if (tmp >= 32768)
+  if (tmp > INT_MAX)
     {
       ferr("ERROR: Invalid PID %ld\n", tmp);
       return -ENOENT;

--- a/include/sys/types.h
+++ b/include/sys/types.h
@@ -145,13 +145,13 @@ typedef uint16_t     nlink_t;
  * because negative PID values are used to represent invalid PIDs.
  */
 
-typedef int16_t      pid_t;
+typedef int          pid_t;
 
 /* id_t is a general identifier that can be used to contain at least a pid_t,
  * uid_t, or gid_t.
  */
 
-typedef int16_t      id_t;
+typedef int          id_t;
 
 /* Unix requires a key of type key_t defined in file sys/types.h for
  * requesting resources such as shared memory segments, message queues and


### PR DESCRIPTION
## Summary
to fix the following warning:
```
include/unistd.h:302:9: error: incompatible redeclaration of library function 'vfork' [-Werror,-Wincompatible-library-redeclaration]
pid_t   vfork(void);
        ^
include/unistd.h:302:9: note: 'vfork' is a builtin with type 'int (void)'
```
and change 32768 to INT_MAX to match the type change.

## Impact
pid_t typedef

## Testing
Pass CI
