### PR TITLE
env_dup: Allocate memory from the correct memory pool

### DIFF
--- a/sched/environ/env_dup.c
+++ b/sched/environ/env_dup.c
@@ -94,7 +94,7 @@ int env_dup(FAR struct task_group_s *group)
         {
           /* There is an environment, duplicate it */
 
-          envp = (FAR char *)group_malloc(ptcb->group, envlen);
+          envp = (FAR char *)group_malloc(group, envlen);
           if (envp == NULL)
             {
               /* The parent's environment can not be inherited due to a


### PR DESCRIPTION
When the initial proxy task is duplicated into the first user task,
the environment exists in kernel memory and this must be copied to user
memory.

The memory allocated for the new task was allocated with the parent's
priority which is incorrect. Use the new task's priority instead.

Follow-up for: #5753

## Summary
Fix bug in environment duplication
## Impact

## Testing
Tested with icicle:knsh (CONFIG_BUILD_KERNEL=y), e.g. ls fails because the working directory name resides in kernel memory.
