### PR TITLE
xtensa/esp32(s2)_user.c: Use macros defined in xtens_corebits.h

### DIFF
--- a/arch/xtensa/src/esp32/esp32_user.c
+++ b/arch/xtensa/src/esp32/esp32_user.c
@@ -26,7 +26,7 @@
 #include <nuttx/arch.h>
 
 #include <arch/loadstore.h>
-#include <arch/xtensa/core.h>
+#include <arch/xtensa/xtensa_corebits.h>
 
 #include <sys/types.h>
 #include <assert.h>
@@ -337,7 +337,7 @@ uint32_t *xtensa_user(int exccause, uint32_t *regs)
    * (thus binfo() is used below)
    */
 
-  if (exccause == XCHAL_EXCCAUSE_LOAD_STORE_ERROR &&
+  if (exccause == EXCCAUSE_LOAD_STORE_ERROR &&
       (uintptr_t)&_siramheap <= regs[REG_EXCVADDR] &&
       (uintptr_t)&_eiramheap > regs[REG_EXCVADDR])
     {
@@ -346,7 +346,7 @@ uint32_t *xtensa_user(int exccause, uint32_t *regs)
       uint8_t s;
       uint8_t t;
 
-      binfo("XCHAL_EXCCAUSE_LOAD_STORE_ERROR at %p, pc=%p\n",
+      binfo("EXCCAUSE_LOAD_STORE_ERROR at %p, pc=%p\n",
             (void *)regs[REG_EXCVADDR],
             pc);
 

--- a/arch/xtensa/src/esp32s2/esp32s2_user.c
+++ b/arch/xtensa/src/esp32s2/esp32s2_user.c
@@ -26,7 +26,7 @@
 #include <nuttx/arch.h>
 
 #include <arch/loadstore.h>
-#include <arch/xtensa/core.h>
+#include <arch/xtensa/xtensa_corebits.h>
 
 #include <sys/types.h>
 #include <assert.h>
@@ -307,7 +307,7 @@ uint32_t *xtensa_user(int exccause, uint32_t *regs)
    * (thus binfo() is used below)
    */
 
-  if (exccause == XCHAL_EXCCAUSE_LOAD_STORE_ERROR &&
+  if (exccause == EXCCAUSE_LOAD_STORE_ERROR &&
       (uintptr_t)&_stextheap <= regs[REG_EXCVADDR] &&
       (uintptr_t)&_etextheap > regs[REG_EXCVADDR])
     {
@@ -316,7 +316,7 @@ uint32_t *xtensa_user(int exccause, uint32_t *regs)
       uint8_t s;
       uint8_t t;
 
-      binfo("XCHAL_EXCCAUSE_LOAD_STORE_ERROR at %p, pc=%p\n",
+      binfo("EXCCAUSE_LOAD_STORE_ERROR at %p, pc=%p\n",
             (void *)regs[REG_EXCVADDR],
             pc);
 


### PR DESCRIPTION

## Summary
For EXCCAUSE values, use macros defined in xtensa_corebits.h instead of those defined in core.h as they are deprecated.
## Impact
N/A
## Testing
ESP32 & ESP32-S2
