### PR TITLE
Warning fix

### DIFF
--- a/binfmt/libelf/libelf_coredump.c
+++ b/binfmt/libelf/libelf_coredump.c
@@ -227,11 +227,11 @@ static void elf_emit_note_info(FAR struct elf_dumpinfo_s *cinfo)
 
       elf_emit(cinfo, &nhdr, sizeof(nhdr));
 
-      strncpy(name, tcb->name, sizeof(name));
+      strlcpy(name, tcb->name, sizeof(name));
       elf_emit(cinfo, name, sizeof(name));
 
       info.pr_pid   = tcb->pid;
-      strncpy(info.pr_fname, tcb->name, sizeof(info.pr_fname));
+      strlcpy(info.pr_fname, tcb->name, sizeof(info.pr_fname));
       elf_emit(cinfo, &info, sizeof(info));
 
       /* Fill Process status */

--- a/drivers/rptun/rptun.c
+++ b/drivers/rptun/rptun.c
@@ -434,7 +434,7 @@ static void rptun_ns_bind(FAR struct rpmsg_device *rdev,
       FAR struct rptun_cb_s *cb;
 
       bind->dest = dest;
-      strncpy(bind->name, name, RPMSG_NAME_SIZE);
+      strlcpy(bind->name, name, RPMSG_NAME_SIZE);
 
       rptun_lock();
 


### PR DESCRIPTION
## Summary
Continue the work https://github.com/apache/incubator-nuttx/pull/5476:

- Fix libelf/libelf_coredump.c:234:7: warning: 'strncpy' output may be truncated copying 16 bytes from a string of length 31
- Fix rptun/rptun.c:572:7: warning: 'strncpy' specified bound 32 equals destination size

## Impact
Minor

## Testing
Pass CI
