### PR TITLE
sched/dumpstack: Print "backtrace:" only in the first iteration

### DIFF
--- a/libs/libc/sched/sched_dumpstack.c
+++ b/libs/libc/sched/sched_dumpstack.c
@@ -84,7 +84,11 @@ void sched_dumpstack(pid_t tid)
             }
         }
 #else
-      syslog(LOG_EMERG, "backtrace:\n");
+      if (skip == 0)
+        {
+          syslog(LOG_EMERG, "backtrace:\n");
+        }
+
       for (i = 0; i < size; i++)
         {
           syslog(LOG_EMERG, "[%2d] [<%p>] %pS\n",


### PR DESCRIPTION
## Summary
to avoid the same label print multiple time in one dumpstack

## Impact
dumpback

## Testing
Pass local test
