### PR TITLE
Fix rpmsgfs/rpmsgfs_client.c:774:3: warning: 'strcpy' writing 1 or more bytes into a region of size 0 overflows the destination

### DIFF
--- a/fs/rpmsgfs/rpmsgfs_client.c
+++ b/fs/rpmsgfs/rpmsgfs_client.c
@@ -726,11 +726,12 @@ int rpmsgfs_client_rename(FAR void *handle, FAR const char *oldpath,
   struct rpmsgfs_rename_s *msg;
   size_t len;
   size_t oldlen;
+  size_t newlen;
   uint32_t space;
 
-  len     = sizeof(*msg);
-  oldlen  = (strlen(oldpath) + 1 + 0x7) & ~0x7;
-  len    += oldlen + strlen(newpath) + 1;
+  oldlen = strlen(oldpath) + 1;
+  newlen = strlen(newpath) + 1;
+  len    = sizeof(*msg) + oldlen + newlen;
 
   msg = rpmsg_get_tx_payload_buffer(&priv->ept, &space, true);
   if (!msg)
@@ -740,8 +741,8 @@ int rpmsgfs_client_rename(FAR void *handle, FAR const char *oldpath,
 
   DEBUGASSERT(len <= space);
 
-  strcpy(msg->pathname, oldpath);
-  strcpy(msg->pathname + oldlen, newpath);
+  memcpy(msg->pathname, oldpath, oldlen);
+  memcpy(msg->pathname + oldlen, newpath, newlen);
 
   return rpmsgfs_send_recv(priv, RPMSGFS_RENAME, false,
           (struct rpmsgfs_header_s *)msg, len, NULL);


### PR DESCRIPTION
## Summary
Found by change https://github.com/apache/incubator-nuttx/pull/5476.

## Impact
Minor, fix warning

## Testing
Pass CI
