### PR TITLE
tools/jlink: Change the type of pid from uint16_t to uint32_t

### DIFF
--- a/tools/jlink-nuttx.c
+++ b/tools/jlink-nuttx.c
@@ -207,11 +207,11 @@ static inline uint32_t decode_hex(const char *line)
 }
 
 static int get_pid(struct plugin_priv_s *priv, uint32_t idx,
-                   uint16_t *pid)
+                   uint32_t *pid)
 {
   int ret;
 
-  ret = READU16(priv->pidhash[idx] + priv->tcbinfo->pid_off, pid);
+  ret = READU32(priv->pidhash[idx] + priv->tcbinfo->pid_off, pid);
   if (ret != 0)
     {
       PERROR("read %d pid error return %d\n", idx, ret);
@@ -228,7 +228,7 @@ static int get_idx_from_pid(struct plugin_priv_s *priv,
 
   for (idx = 0; idx < priv->ntcb; idx++)
     {
-      uint16_t tmppid;
+      uint32_t tmppid;
 
       if (get_pid(priv, idx, &tmppid))
         {
@@ -466,7 +466,7 @@ uint32_t RTOS_GetThreadId(uint32_t n)
 {
   if (n < g_plugin_priv.ntcb)
     {
-      uint16_t pid;
+      uint32_t pid;
 
       if (get_pid(&g_plugin_priv, n, &pid) == 0)
         {


### PR DESCRIPTION
## Summary
Report here: https://github.com/apache/incubator-nuttx/pull/5807
follow up the bellow chnage:
```
commit 0f2f48f8bae0e13f7927ed70c3711d03fe6d5f27
Author: Xiang Xiao <xiaoxiang@xiaomi.com>
Date:   Sun Mar 20 18:12:26 2022 +0800

    sys/type.h: Change pid_t from int16_t to int

    to fix the following warning:
    include/unistd.h:302:9: error: incompatible redeclaration of library function 'vfork' [-Werror,-Wincompatible-library-redeclaration]
    pid_t   vfork(void);
            ^
    include/unistd.h:302:9: note: 'vfork' is a builtin with type 'int (void)'

    and change 32768 to INT_MAX to match the type change
```

## Impact
jlink

## Testing

