### PR TITLE
risc-v/qemu-rv: Restore FPU context after context switch

### DIFF
--- a/arch/risc-v/src/qemu-rv/qemu_rv_irq_dispatch.c
+++ b/arch/risc-v/src/qemu-rv/qemu_rv_irq_dispatch.c
@@ -117,6 +117,34 @@ void *riscv_dispatch_irq(uintptr_t vector, uintptr_t *regs)
     }
 #endif
 
+#if defined(CONFIG_ARCH_FPU) || defined(CONFIG_ARCH_ADDRENV)
+  /* Check for a context switch.  If a context switch occurred, then
+   * CURRENT_REGS will have a different value than it did on entry.  If an
+   * interrupt level context switch has occurred, then restore the floating
+   * point state and the establish the correct address environment before
+   * returning from the interrupt.
+   */
+
+  if (regs != CURRENT_REGS)
+    {
+#ifdef CONFIG_ARCH_FPU
+      /* Restore floating point registers */
+
+      riscv_restorefpu((uintptr_t *)CURRENT_REGS);
+#endif
+
+#ifdef CONFIG_ARCH_ADDRENV
+      /* Make sure that the address environment for the previously
+       * running task is closed down gracefully (data caches dump,
+       * MMU flushed) and set up the address environment for the new
+       * thread at the head of the ready-to-run list.
+       */
+
+      group_addrenv(NULL);
+#endif
+    }
+#endif /* CONFIG_ARCH_FPU || CONFIG_ARCH_ADDRENV */
+
   /* If a context switch occurred while processing the interrupt then
    * CURRENT_REGS may have change value.  If we return any value different
    * from the input regs, then the lower level will know that a context


### PR DESCRIPTION
## Summary
Add missing FPU register context restore logic.
## Impact
qemu-rv
## Testing
rv-virt:smp/smp64 with QEMU 6.2
