### PR TITLE
RISC-V: Add kernel stack

### DIFF
--- a/arch/risc-v/include/irq.h
+++ b/arch/risc-v/include/irq.h
@@ -519,6 +519,22 @@ struct xcptcontext
 
 #endif
 
+#ifdef CONFIG_ARCH_ADDRENV
+#ifdef CONFIG_ARCH_KERNEL_STACK
+  /* In this configuration, all syscalls execute from an internal kernel
+   * stack.  Why?  Because when we instantiate and initialize the address
+   * environment of the new user process, we will temporarily lose the
+   * address environment of the old user process, including its stack
+   * contents.  The kernel C logic will crash immediately with no valid
+   * stack in place.
+   */
+
+  uintptr_t *ustkptr;  /* Saved user stack pointer */
+  uintptr_t *kstack;   /* Allocate base of the (aligned) kernel stack */
+  uintptr_t *kstkptr;  /* Saved kernel stack pointer */
+#endif
+#endif
+
   /* Register save area */
 
   uintptr_t regs[XCPTCONTEXT_REGS];

--- a/arch/risc-v/src/common/addrenv.h
+++ b/arch/risc-v/src/common/addrenv.h
@@ -1,0 +1,52 @@
+/****************************************************************************
+ * arch/risc-v/src/common/addrenv.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __ARCH_RISC_V_SRC_COMMON_ADDRENV_H
+#define __ARCH_RISC_V_SRC_COMMON_ADDRENV_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <sys/types.h>
+#include <stdint.h>
+
+#include "riscv_internal.h"
+
+#ifdef CONFIG_ARCH_ADDRENV
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/* Aligned size of the kernel stack */
+
+#ifdef CONFIG_ARCH_KERNEL_STACK
+#  define ARCH_KERNEL_STACKSIZE STACK_ALIGN_UP(CONFIG_ARCH_KERNEL_STACKSIZE)
+#endif
+
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
+
+#endif /* CONFIG_ARCH_ADDRENV */
+#endif /* __ARCH_RISC_V_SRC_COMMON_ADDRENV_H */

--- a/arch/risc-v/src/common/riscv_addrenv_kstack.c
+++ b/arch/risc-v/src/common/riscv_addrenv_kstack.c
@@ -1,0 +1,111 @@
+/****************************************************************************
+ * arch/risc-v/src/common/riscv_addrenv_kstack.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <errno.h>
+#include <assert.h>
+#include <debug.h>
+
+#include <nuttx/sched.h>
+#include <nuttx/kmalloc.h>
+#include <nuttx/addrenv.h>
+#include <nuttx/arch.h>
+
+#include "addrenv.h"
+#include "riscv_internal.h"
+
+#if defined(CONFIG_ARCH_ADDRENV) && defined(CONFIG_ARCH_KERNEL_STACK)
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: up_addrenv_kstackalloc
+ *
+ * Description:
+ *   This function is called when a new thread is created to allocate
+ *   the new thread's kernel stack.   This function may be called for certain
+ *   terminating threads which have no kernel stack.  It must be tolerant of
+ *   that case.
+ *
+ * Input Parameters:
+ *   tcb - The TCB of the thread that requires the kernel stack.
+ *
+ * Returned Value:
+ *   Zero (OK) on success; a negated errno value on failure.
+ *
+ ****************************************************************************/
+
+int up_addrenv_kstackalloc(FAR struct tcb_s *tcb)
+{
+  DEBUGASSERT(tcb && tcb->xcp.kstack == NULL);
+
+  /* Allocate the kernel stack */
+
+  tcb->xcp.kstack = (uintptr_t *)kmm_memalign(STACK_ALIGNMENT,
+                                              ARCH_KERNEL_STACKSIZE);
+  if (!tcb->xcp.kstack)
+    {
+      berr("ERROR: Failed to allocate the kernel stack\n");
+      return -ENOMEM;
+    }
+
+  return OK;
+}
+
+/****************************************************************************
+ * Name: up_addrenv_kstackfree
+ *
+ * Description:
+ *   This function is called when any thread exits.  This function frees
+ *   the kernel stack.
+ *
+ * Input Parameters:
+ *   tcb - The TCB of the thread that no longer requires the kernel stack.
+ *
+ * Returned Value:
+ *   Zero (OK) on success; a negated errno value on failure.
+ *
+ ****************************************************************************/
+
+int up_addrenv_kstackfree(FAR struct tcb_s *tcb)
+{
+  DEBUGASSERT(tcb);
+
+  /* Does the exiting thread have a kernel stack? */
+
+  if (tcb->xcp.kstack)
+    {
+      /* Yes.. Free the kernel stack */
+
+      kmm_free(tcb->xcp.kstack);
+      tcb->xcp.kstack = NULL;
+    }
+
+  return OK;
+}
+
+#endif /* CONFIG_ARCH_ADDRENV && CONFIG_ARCH_KERNEL_STACK */

--- a/arch/risc-v/src/common/riscv_assert.c
+++ b/arch/risc-v/src/common/riscv_assert.c
@@ -306,6 +306,9 @@ static void riscv_dumpstate(void)
   uintptr_t istackbase;
   uintptr_t istacksize;
 #endif
+#ifdef CONFIG_ARCH_KERNEL_STACK
+  uintptr_t kstackbase = 0;
+#endif
 
   /* Show back trace */
 
@@ -383,18 +386,46 @@ static void riscv_dumpstate(void)
   _alert("stack size: %" PRIxREG "\n", ustacksize);
 #endif
 
+#ifdef CONFIG_ARCH_KERNEL_STACK
+  /* Does this thread have a kernel stack allocated? */
+
+  if (rtcb->xcp.kstack)
+    {
+      kstackbase = (uintptr_t)rtcb->xcp.kstack;
+
+      _alert("Kernel stack:\n");
+      _alert("  base: %" PRIxREG "\n", kstackbase);
+      _alert("  size: %" PRIxREG "\n", CONFIG_ARCH_KERNEL_STACKSIZE);
+    }
+#endif
+
   /* Dump the user stack if the stack pointer lies within the allocated user
    * stack memory.
    */
 
   if (sp >= ustackbase && sp < ustackbase + ustacksize)
     {
-      _alert("ERROR: Stack pointer is not within allocated stack\n");
-      riscv_stackdump(ustackbase, ustackbase + ustacksize);
+      _alert("User Stack\n");
+      riscv_stackdump(sp, ustackbase + ustacksize);
     }
+
+#ifdef CONFIG_ARCH_KERNEL_STACK
+  /* Dump the kernel stack if the stack pointer lies within the allocated
+   * kernel stack memory.
+   */
+
+  else if (kstackbase != 0 &&
+           sp >= kstackbase &&
+           sp < kstackbase + CONFIG_ARCH_KERNEL_STACKSIZE)
+    {
+      _alert("Kernel Stack\n");
+      riscv_stackdump(sp, kstackbase + CONFIG_ARCH_KERNEL_STACKSIZE);
+    }
+#endif
   else
     {
-      riscv_stackdump(sp, ustackbase + ustacksize);
+      _alert("ERROR: Stack pointer is not within allocated stack\n");
+      riscv_stackdump(ustackbase, ustackbase + ustacksize);
     }
 }
 #else

--- a/arch/risc-v/src/mpfs/Make.defs
+++ b/arch/risc-v/src/mpfs/Make.defs
@@ -81,6 +81,10 @@ ifeq ($(CONFIG_ARCH_USE_MMU),y)
 CMN_CSRCS += riscv_mmu.c
 endif
 
+ifeq ($(CONFIG_ARCH_KERNEL_STACK),y)
+CMN_CSRCS += riscv_addrenv_kstack.c
+endif
+
 ifeq ($(CONFIG_SPI),y)
 CHIP_CSRCS += mpfs_spi.c
 endif


### PR DESCRIPTION
## Summary
Adds support for a separate kernel stack, needed by CONFIG_BUILD_KERNEL=y
## Impact
No impact to existing code
## Testing
Tested with icicle:knsh (CONFIG_BUILD_KERNEL=y) / not released yet

This includes more missing pieces to get CONFIG_BUILD_KERNEL=y for RISC-V. Code is basically copy&pasted from the ARMv7 implementation.