### PR TITLE
esp32/Make.defs: Organise common arch files and chip files appropriately.

### DIFF
--- a/arch/xtensa/src/esp32/Make.defs
+++ b/arch/xtensa/src/esp32/Make.defs
@@ -39,14 +39,9 @@ CMN_CSRCS += xtensa_modifyreg8.c xtensa_modifyreg16.c xtensa_modifyreg32.c
 CMN_CSRCS += xtensa_puts.c xtensa_releasepending.c xtensa_releasestack.c
 CMN_CSRCS += xtensa_reprioritizertr.c xtensa_schedsigaction.c
 CMN_CSRCS += xtensa_sigdeliver.c xtensa_stackframe.c xtensa_udelay.c
-CMN_CSRCS += xtensa_unblocktask.c xtensa_usestack.c xtensa_swint.c
-CMN_CSRCS += esp32_systemreset.c esp32_resetcause.c xtensa_switchcontext.c
+CMN_CSRCS += xtensa_unblocktask.c xtensa_usestack.c xtensa_swint.c xtensa_switchcontext.c
 
 # Configuration-dependent common XTENSA files
-
-ifneq ($(CONFIG_ARCH_IDLE_CUSTOM),y)
-  CMN_CSRCS += esp32_idle.c
-endif
 
 ifeq ($(CONFIG_DEBUG_ALERT),y)
   CMN_CSRCS += xtensa_dumpstate.c
@@ -72,9 +67,14 @@ endif
 # Required ESP32 files (arch/xtensa/src/lx6)
 
 CHIP_CSRCS  = esp32_allocateheap.c esp32_clockconfig.c esp32_gpio.c
+CHIP_CSRCS += esp32_systemreset.c esp32_resetcause.c
 CHIP_CSRCS += esp32_irq.c esp32_region.c
 CHIP_CSRCS += esp32_user.c
 CHIP_CSRCS += esp32_dma.c
+
+ifneq ($(CONFIG_ARCH_IDLE_CUSTOM),y)
+CHIP_CSRCS += esp32_idle.c
+endif
 
 ifeq ($(CONFIG_SCHED_TICKLESS),y)
 CHIP_CSRCS += esp32_tickless.c
@@ -105,9 +105,9 @@ endif
 
 ifeq ($(CONFIG_ESP32_SPI),y)
 CHIP_CSRCS += esp32_spi.c
-  ifeq ($(CONFIG_SPI_SLAVE),y)
-    CHIP_CSRCS += esp32_spi_slave.c
-  endif
+ifeq ($(CONFIG_SPI_SLAVE),y)
+CHIP_CSRCS += esp32_spi_slave.c
+endif
 endif
 
 # SPIFLASH and SPIRAM need spicache.c
@@ -142,15 +142,15 @@ endif
 
 ifeq ($(CONFIG_SMP),y)
 CHIP_ASRCS  = esp32_cpuindex.S
-CMN_CSRCS  += esp32_cpuidlestack.c esp32_cpustart.c esp32_intercpu_interrupt.c
+CHIP_CSRCS += esp32_cpuidlestack.c esp32_cpustart.c esp32_intercpu_interrupt.c
 endif
 
 ifeq ($(CONFIG_ESP32_UART),y)
-CMN_CSRCS += esp32_serial.c
+CHIP_CSRCS += esp32_serial.c
 endif
 
 ifeq ($(CONFIG_ESP32_RNG),y)
-CMN_CSRCS += esp32_rng.c
+CHIP_CSRCS += esp32_rng.c
 endif
 
 ifeq ($(CONFIG_ESP32_TIMER),y)
@@ -193,7 +193,7 @@ endif
 
 ifeq ($(CONFIG_ARCH_USE_TEXT_HEAP),y)
 CHIP_CSRCS += esp32_textheap.c
-CMN_ASRCS += xtensa_loadstore.S
+CMN_ASRCS  += xtensa_loadstore.S
 endif
 
 ifeq ($(CONFIG_ESP32_RT_TIMER),y)


### PR DESCRIPTION
## Summary
Some chip files where grouped with the common files variable.
## Impact
ESP32.
## Testing
All configs still build error free.
