### PR TITLE
local_socket: default set block mode if accept() a new socket

### DIFF
--- a/net/local/local_accept.c
+++ b/net/local/local_accept.c
@@ -181,8 +181,7 @@ int local_accept(FAR struct socket *psock, FAR struct sockaddr *addr,
                * block.
                */
 
-              ret = local_open_server_tx(
-                      conn, _SS_ISNONBLOCK(server->lc_conn.s_flags));
+              ret = local_open_server_tx(conn, false);
               if (ret < 0)
                 {
                   nerr("ERROR: Failed to open write-only FIFOs for %s: %d\n",
@@ -201,8 +200,7 @@ int local_accept(FAR struct socket *psock, FAR struct sockaddr *addr,
                * for writing.
                */
 
-              ret = local_open_server_rx(
-                      conn, _SS_ISNONBLOCK(server->lc_conn.s_flags));
+              ret = local_open_server_rx(conn, false);
               if (ret < 0)
                 {
                    nerr("ERROR: Failed to open read-only FIFOs for %s: %d\n",

--- a/net/local/local_sockif.c
+++ b/net/local/local_sockif.c
@@ -718,6 +718,17 @@ static int local_ioctl(FAR struct socket *psock, int cmd,
 
   switch (cmd)
     {
+      case FIONBIO:
+        if (conn->lc_infile.f_inode != NULL)
+          {
+            ret = file_ioctl(&conn->lc_infile, cmd, arg);
+          }
+
+        if (ret >= 0 && conn->lc_outfile.f_inode != NULL)
+          {
+            ret = file_ioctl(&conn->lc_outfile, cmd, arg);
+          }
+        break;
       case FIONREAD:
         if (conn->lc_infile.f_inode != NULL)
           {

--- a/net/netdev/netdev_ioctl.c
+++ b/net/netdev/netdev_ioctl.c
@@ -1601,6 +1601,7 @@ ssize_t net_ioctl_arglen(int cmd)
 {
   switch (cmd)
     {
+      case FIONBIO:
       case FIONSPACE:
       case FIONREAD:
         return sizeof(int);


### PR DESCRIPTION
## Summary

    local_socket: default set block mode if accept() a new socket
    
    reference:
    https: //man7.org/linux/man-pages/man2/accept.2.html
    
    1. default set block mode if accept() a new socket
    2. local_socket support FIONBIO
    


## Impact

local socket

## Testing

VELA

