### PR TITLE
driver/syslog: Add microseconds after date time

### DIFF
--- a/drivers/syslog/Kconfig
+++ b/drivers/syslog/Kconfig
@@ -137,6 +137,11 @@ config SYSLOG_TIMESTAMP_FORMAT
 		Formatter string for syslog timestamp printing.
 		Uses the standard "strftime" format specifiers.
 
+config SYSLOG_TIMESTAMP_FORMAT_MICROSECOND
+	bool "Append microseconds after seconds"
+	default y
+	depends on SYSLOG_TIMESTAMP_FORMAT = "%e/%m/%y %H:%M:%S"
+
 config SYSLOG_TIMESTAMP_BUFFER
 	int "Formatted timestamp buffer size"
 	default 64

--- a/drivers/syslog/vsyslog.c
+++ b/drivers/syslog/vsyslog.c
@@ -130,11 +130,16 @@ int nx_vsyslog(int priority, FAR const IPTR char *fmt, FAR va_list *ap)
 
   if (ret > 0)
     {
+#if defined(CONFIG_SYSLOG_TIMESTAMP_FORMAT_MICROSECOND)
+      ret = lib_sprintf(&stream.public, "[%s.%06ld] ",
+                        date_buf, ts.tv_nsec / NSEC_PER_USEC);
+#else
       ret = lib_sprintf(&stream.public, "[%s] ", date_buf);
+#endif
     }
 #else
   ret = lib_sprintf(&stream.public, "[%5jd.%06ld] ",
-                    (uintmax_t)ts.tv_sec, ts.tv_nsec / 1000);
+                    (uintmax_t)ts.tv_sec, ts.tv_nsec / NSEC_PER_USEC);
 #endif
 #endif
 


### PR DESCRIPTION


## Summary
driver/syslog: Add microseconds after date time

Signed-off-by: Jiuzhu Dong <dongjiuzhu1@xiaomi.com>
## Impact
Displays more detailed time information
## Testing
local test
