### PR TITLE
mm/memdump: dynamic turn on backtrace in heap when enable DEBUG_MM

### DIFF
--- a/fs/procfs/fs_procfsmeminfo.c
+++ b/fs/procfs/fs_procfsmeminfo.c
@@ -417,7 +417,8 @@ static ssize_t memdump_read(FAR struct file *filep, FAR char *buffer,
 
 #ifdef CONFIG_DEBUG_MM
   linesize  = procfs_snprintf(procfile->line, MEMINFO_LINELEN,
-                              "usage: <pid/used/free>\n"
+                              "usage: <pid/used/free/on/off>\n"
+                              "on/off backtrace\n"
                               "pid: dump pid allocated node\n");
 #else
   linesize  = procfs_snprintf(procfile->line, MEMINFO_LINELEN,
@@ -448,7 +449,7 @@ static ssize_t memdump_read(FAR struct file *filep, FAR char *buffer,
 static ssize_t memdump_write(FAR struct file *filep, FAR const char *buffer,
                              size_t buflen)
 {
-  FAR const struct procfs_meminfo_entry_s *entry;
+  FAR struct procfs_meminfo_entry_s *entry;
   FAR struct meminfo_file_s *procfile;
   pid_t pid = INVALID_PROCESS_ID;
 
@@ -458,6 +459,27 @@ static ssize_t memdump_write(FAR struct file *filep, FAR const char *buffer,
 
   procfile = filep->f_priv;
   DEBUGASSERT(procfile);
+
+#ifdef CONFIG_DEBUG_MM
+  if (strcmp(buffer, "on") == 0)
+    {
+      for (entry = g_procfs_meminfo; entry != NULL; entry = entry->next)
+        {
+          entry->backtrace = true;
+        }
+
+      return buflen;
+    }
+  else if (strcmp(buffer, "off") == 0)
+    {
+      for (entry = g_procfs_meminfo; entry != NULL; entry = entry->next)
+        {
+          entry->backtrace = false;
+        }
+
+      return buflen;
+    }
+#endif
 
   switch (buffer[0])
     {

--- a/include/nuttx/fs/procfs.h
+++ b/include/nuttx/fs/procfs.h
@@ -133,6 +133,14 @@ struct procfs_meminfo_entry_s
   FAR const char *name;
   FAR struct mm_heap_s *heap;
   struct procfs_meminfo_entry_s *next;
+#if defined(CONFIG_DEBUG_MM)
+
+  /* This is dynamic control flag whether to turn on backtrace in the heap,
+   * you can set it by /proc/memdump.
+   */
+
+  bool backtrace;
+#endif
 };
 
 /****************************************************************************

--- a/mm/Kconfig
+++ b/mm/Kconfig
@@ -186,4 +186,9 @@ config MM_KASAN
 		bugs in native code. After turn on this option, Please
 		add -fsanitize=kernel-address to CFLAGS/CXXFLAGS too.
 
+config MM_BACKTRACE_DEFAULT
+	bool "Enable the backtrace record by default"
+	default n
+	depends on DEBUG_MM
+
 source "mm/iob/Kconfig"

--- a/mm/mm_heap/mm.h
+++ b/mm/mm_heap/mm.h
@@ -93,17 +93,24 @@
 #ifdef CONFIG_DEBUG_MM
 #  define MM_MIN_SHIFT       (MM_MIN_SHIFT_ + 2)
 #  define MM_BACKTRACE_DEPTH 8
-#  define MM_ADD_BACKTRACE(ptr) \
+#  define MM_ADD_BACKTRACE(heap, ptr) \
      do \
        { \
          FAR struct mm_allocnode_s *tmp = (FAR struct mm_allocnode_s *)(ptr); \
          tmp->pid = getpid(); \
-         memset(tmp->backtrace, 0, sizeof(tmp->backtrace)); \
-         backtrace(tmp->backtrace, MM_BACKTRACE_DEPTH); \
+         if ((heap)->mm_procfs.backtrace) \
+           { \
+             memset(tmp->backtrace, 0, sizeof(tmp->backtrace)); \
+             backtrace(tmp->backtrace, MM_BACKTRACE_DEPTH); \
+           } \
+         else \
+           { \
+             tmp->backtrace[0] = 0; \
+           } \
        } \
      while (0)
 #else
-#  define MM_ADD_BACKTRACE(ptr)
+#  define MM_ADD_BACKTRACE(heap, ptr)
 #  define MM_MIN_SHIFT MM_MIN_SHIFT_
 #endif
 

--- a/mm/mm_heap/mm_initialize.c
+++ b/mm/mm_heap/mm_initialize.c
@@ -117,7 +117,7 @@ void mm_addregion(FAR struct mm_heap_s *heap, FAR void *heapstart,
 
   heap->mm_heapstart[IDX]            = (FAR struct mm_allocnode_s *)
                                        heapbase;
-  MM_ADD_BACKTRACE(heap->mm_heapstart[IDX]);
+  MM_ADD_BACKTRACE(heap, heap->mm_heapstart[IDX]);
   heap->mm_heapstart[IDX]->size      = SIZEOF_MM_ALLOCNODE;
   heap->mm_heapstart[IDX]->preceding = MM_ALLOC_BIT;
   node                               = (FAR struct mm_freenode_s *)
@@ -128,7 +128,7 @@ void mm_addregion(FAR struct mm_heap_s *heap, FAR void *heapstart,
                                        (heapend - SIZEOF_MM_ALLOCNODE);
   heap->mm_heapend[IDX]->size        = SIZEOF_MM_ALLOCNODE;
   heap->mm_heapend[IDX]->preceding   = node->size | MM_ALLOC_BIT;
-  MM_ADD_BACKTRACE(heap->mm_heapend[IDX]);
+  MM_ADD_BACKTRACE(heap, heap->mm_heapend[IDX]);
 
 #undef IDX
 

--- a/mm/mm_heap/mm_initialize.c
+++ b/mm/mm_heap/mm_initialize.c
@@ -213,6 +213,9 @@ FAR struct mm_heap_s *mm_initialize(FAR const char *name,
 #if defined(CONFIG_BUILD_FLAT) || defined(__KERNEL__)
   heap->mm_procfs.name = name;
   heap->mm_procfs.heap = heap;
+#if defined (CONFIG_DEBUG_MM) && defined(CONFIG_MM_BACKTRACE_DEFAULT)
+  heap->mm_procfs.backtrace = true;
+#endif
   procfs_register_meminfo(&heap->mm_procfs);
 #endif
 #endif

--- a/mm/mm_heap/mm_malloc.c
+++ b/mm/mm_heap/mm_malloc.c
@@ -223,7 +223,7 @@ FAR void *mm_malloc(FAR struct mm_heap_s *heap, size_t size)
       /* Handle the case of an exact size match */
 
       node->preceding |= MM_ALLOC_BIT;
-      MM_ADD_BACKTRACE(node);
+      MM_ADD_BACKTRACE(heap, node);
       ret = (FAR void *)((FAR char *)node + SIZEOF_MM_ALLOCNODE);
     }
 

--- a/mm/mm_heap/mm_malloc.c
+++ b/mm/mm_heap/mm_malloc.c
@@ -27,6 +27,7 @@
 #include <assert.h>
 #include <debug.h>
 #include <string.h>
+#include <malloc.h>
 
 #include <nuttx/arch.h>
 #include <nuttx/mm/mm.h>
@@ -243,7 +244,13 @@ FAR void *mm_malloc(FAR struct mm_heap_s *heap, size_t size)
 #ifdef CONFIG_DEBUG_MM
   else
     {
+      struct mallinfo minfo;
+
       mwarn("WARNING: Allocation failed, size %zu\n", alignsize);
+      mm_mallinfo(heap, &minfo);
+      mwarn("Total:%d, used:%d, free:%d, largest:%d, nused:%d, nfree:%d\n",
+            minfo.arena, minfo.uordblks, minfo.fordblks,
+            minfo.mxordblk, minfo.aordblks, minfo.ordblks);
       mm_memdump(heap, -1);
       DEBUGASSERT(false);
     }

--- a/mm/mm_heap/mm_memalign.c
+++ b/mm/mm_heap/mm_memalign.c
@@ -178,7 +178,7 @@ FAR void *mm_memalign(FAR struct mm_heap_s *heap, size_t alignment,
 
       newnode->size = (size_t)next - (size_t)newnode;
       newnode->preceding = precedingsize | MM_ALLOC_BIT;
-      MM_ADD_BACKTRACE(newnode);
+      MM_ADD_BACKTRACE(heap, newnode);
 
       /* Reduce the size of the original chunk and mark it not allocated, */
 

--- a/mm/mm_heap/mm_realloc.c
+++ b/mm/mm_heap/mm_realloc.c
@@ -128,7 +128,7 @@ FAR void *mm_realloc(FAR struct mm_heap_s *heap, FAR void *oldmem,
                        oldsize - oldnode->size);
         }
 
-      MM_ADD_BACKTRACE(oldnode);
+      MM_ADD_BACKTRACE(heap, oldnode);
 
       /* Then return the original address */
 
@@ -334,7 +334,7 @@ FAR void *mm_realloc(FAR struct mm_heap_s *heap, FAR void *oldmem,
             }
         }
 
-      MM_ADD_BACKTRACE((FAR char *)newmem - SIZEOF_MM_ALLOCNODE);
+      MM_ADD_BACKTRACE(heap, (FAR char *)newmem - SIZEOF_MM_ALLOCNODE);
 
       mm_givesemaphore(heap);
 


### PR DESCRIPTION
## Summary
When enable DEBUG_MM, we can use command:memdump to dump memory info of task with specified pid, however, backtrace record is slow, so if you don't need to record backtrace, you can dynamically control it to improve malloc speed by command "memdump off", and "memdump on" will enable backtrace record in heap.

Backtrace is not recored at startup by default, but you can configure MM_BACKTRACE_DEFAULT to be turned on by default.

## Impact
Improving malloc speed when enable CONFIG_DEBUG_MM
## Testing
daily test
