### PR TITLE
rpmsgfs/rename: fix bug about pathname align with 8bytes

### DIFF
--- a/fs/rpmsgfs/rpmsgfs_client.c
+++ b/fs/rpmsgfs/rpmsgfs_client.c
@@ -727,11 +727,13 @@ int rpmsgfs_client_rename(FAR void *handle, FAR const char *oldpath,
   size_t len;
   size_t oldlen;
   size_t newlen;
+  size_t alignlen;
   uint32_t space;
 
-  oldlen = strlen(oldpath) + 1;
-  newlen = strlen(newpath) + 1;
-  len    = sizeof(*msg) + oldlen + newlen;
+  oldlen   = strlen(oldpath) + 1;
+  alignlen = (oldlen + 0x7) & ~0x7;
+  newlen   = strlen(newpath) + 1;
+  len      = sizeof(*msg) + alignlen + newlen;
 
   msg = rpmsg_get_tx_payload_buffer(&priv->ept, &space, true);
   if (!msg)
@@ -742,7 +744,7 @@ int rpmsgfs_client_rename(FAR void *handle, FAR const char *oldpath,
   DEBUGASSERT(len <= space);
 
   memcpy(msg->pathname, oldpath, oldlen);
-  memcpy(msg->pathname + oldlen, newpath, newlen);
+  memcpy(msg->pathname + alignlen, newpath, newlen);
 
   return rpmsgfs_send_recv(priv, RPMSGFS_RENAME, false,
           (struct rpmsgfs_header_s *)msg, len, NULL);


### PR DESCRIPTION


## Summary
rpmsgfs/rename: fix bug about pathname align with 8bytes

Signed-off-by: Jiuzhu Dong <dongjiuzhu1@xiaomi.com>
## Impact
Fix bug about rmpsg rename
## Testing
Daily test
