### PR TITLE
arch/sim: Remove the unused SIM_TCNWAITERS from Kconfig

### DIFF
--- a/arch/sim/Kconfig
+++ b/arch/sim/Kconfig
@@ -282,7 +282,7 @@ config SIM_FBWIDTH
 	int "Display width"
 	default 320
 	---help---
-		Simulated width of the display.  Default: 320 or 480
+		Simulated width of the display.  Default: 320
 
 config SIM_FBBPP
 	int "Pixel depth in bits"

--- a/arch/sim/Kconfig
+++ b/arch/sim/Kconfig
@@ -353,14 +353,6 @@ endif # if INPUT
 
 endmenu
 
-config SIM_TCNWAITERS
-	bool "Maximum number poll() waiters"
-	default 4
-	depends on SIM_TOUCHSCREEN
-	---help---
-		The maximum number of threads that can be waiting on poll() for a
-		touchscreen event. Default: 4
-
 config SIM_HCISOCKET
 	bool "Attach Host Bluetooth"
 	default false


### PR DESCRIPTION
## Summary

## Impact
Should not

## Testing
Pass CI
