### PR TITLE
arch/risc-v: Move fpu [re]store to common place

### DIFF
--- a/arch/risc-v/include/irq.h
+++ b/arch/risc-v/include/irq.h
@@ -492,7 +492,7 @@ struct xcptcontext
   /* These additional register save locations are used to implement the
    * signal delivery trampoline.
    *
-   * REVISIT:  Because there is only one copy of these save areas,
+   * REVISIT:  Because there is only a reference of these save areas,
    * only a single signal handler can be active.  This precludes
    * queuing of signal actions.  As a result, signals received while
    * another signal handler is executing will be ignored!

--- a/arch/risc-v/src/bl602/bl602_irq_dispatch.c
+++ b/arch/risc-v/src/bl602/bl602_irq_dispatch.c
@@ -82,7 +82,6 @@ void *riscv_dispatch_irq(uintptr_t vector, uintptr_t *regs)
 
   irq_dispatch(irq, regs);
 
-#if defined(CONFIG_ARCH_FPU) || defined(CONFIG_ARCH_ADDRENV)
   /* Check for a context switch.  If a context switch occurred, then
    * CURRENT_REGS will have a different value than it did on entry.  If an
    * interrupt level context switch has occurred, then restore the floating
@@ -92,12 +91,6 @@ void *riscv_dispatch_irq(uintptr_t vector, uintptr_t *regs)
 
   if (regs != CURRENT_REGS)
     {
-#ifdef CONFIG_ARCH_FPU
-      /* Restore floating point registers */
-
-      riscv_restorefpu((uintptr_t *)CURRENT_REGS);
-#endif
-
 #ifdef CONFIG_ARCH_ADDRENV
       /* Make sure that the address environment for the previously
        * running task is closed down gracefully (data caches dump,
@@ -108,7 +101,6 @@ void *riscv_dispatch_irq(uintptr_t vector, uintptr_t *regs)
       group_addrenv(NULL);
 #endif
     }
-#endif /* CONFIG_ARCH_FPU || CONFIG_ARCH_ADDRENV */
 
 #endif /* CONFIG_SUPPRESS_INTERRUPTS */
 

--- a/arch/risc-v/src/c906/c906_irq_dispatch.c
+++ b/arch/risc-v/src/c906/c906_irq_dispatch.c
@@ -111,7 +111,6 @@ void *riscv_dispatch_irq(uintptr_t vector, uintptr_t *regs)
       putreg32(irq - C906_IRQ_PERI_START, C906_PLIC_MCLAIM);
     }
 
-#if defined(CONFIG_ARCH_FPU) || defined(CONFIG_ARCH_ADDRENV)
   /* Check for a context switch.  If a context switch occurred, then
    * CURRENT_REGS will have a different value than it did on entry.  If an
    * interrupt level context switch has occurred, then restore the floating
@@ -121,12 +120,6 @@ void *riscv_dispatch_irq(uintptr_t vector, uintptr_t *regs)
 
   if (regs != CURRENT_REGS)
     {
-#ifdef CONFIG_ARCH_FPU
-      /* Restore floating point registers */
-
-      riscv_restorefpu((uintptr_t *)CURRENT_REGS);
-#endif
-
 #ifdef CONFIG_ARCH_ADDRENV
       /* Make sure that the address environment for the previously
        * running task is closed down gracefully (data caches dump,
@@ -137,9 +130,8 @@ void *riscv_dispatch_irq(uintptr_t vector, uintptr_t *regs)
       group_addrenv(NULL);
 #endif
     }
-#endif
 
-#endif
+#endif /* CONFIG_SUPPRESS_INTERRUPTS */
 
   /* If a context switch occurred while processing the interrupt then
    * CURRENT_REGS may have change value.  If we return any value different

--- a/arch/risc-v/src/common/riscv_internal.h
+++ b/arch/risc-v/src/common/riscv_internal.h
@@ -64,8 +64,8 @@
 #  define PRIxREG "016" PRIxPTR
 #endif
 
-/* In the RISC_V model, the state is copied from the stack to the TCB, but
- * only a referenced is passed to get the state from the TCB.
+/* In the RISC-V model, the state is saved in stack,
+ * only a reference stored in TCB.
  */
 
 #ifdef CONFIG_ARCH_FPU

--- a/arch/risc-v/src/common/riscv_internal.h
+++ b/arch/risc-v/src/common/riscv_internal.h
@@ -70,10 +70,11 @@
 
 #ifdef CONFIG_ARCH_FPU
 #define riscv_savestate(regs) (regs = (uintptr_t *)CURRENT_REGS, riscv_savefpu(regs))
+#define riscv_restorestate(regs) (CURRENT_REGS = regs, riscv_restorefpu((uintptr_t *)CURRENT_REGS))
 #else
 #define riscv_savestate(regs) (regs = (uintptr_t *)CURRENT_REGS)
-#endif
 #define riscv_restorestate(regs) (CURRENT_REGS = regs)
+#endif
 
 #define _START_TEXT  &_stext
 #define _END_TEXT    &_etext

--- a/arch/risc-v/src/common/riscv_swint.c
+++ b/arch/risc-v/src/common/riscv_swint.c
@@ -214,8 +214,8 @@ int riscv_swint(int irq, void *context, void *arg)
        *   A1 = restoreregs
        *
        * In this case, we simply need to set CURRENT_REGS to restore register
-       * area referenced in the saved R1. context == CURRENT_REGS is the
-       * normal exception return.  By setting CURRENT_REGS = context[R1], we
+       * area referenced in the saved A1. context == CURRENT_REGS is the
+       * normal exception return.  By setting CURRENT_REGS = context[A1], we
        * force the return to the saved context referenced in $a1.
        */
 
@@ -364,9 +364,9 @@ int riscv_swint(int irq, void *context, void *arg)
        *
        * At this point, the following values are saved in context:
        *
-       *   R0 = SYS_pthread_start
-       *   R1 = entrypt
-       *   R2 = arg
+       *   A0 = SYS_pthread_start
+       *   A1 = entrypt
+       *   A2 = arg
        */
 
 #if !defined(CONFIG_BUILD_FLAT) && !defined(CONFIG_DISABLE_PTHREAD)
@@ -396,11 +396,11 @@ int riscv_swint(int irq, void *context, void *arg)
        *
        * At this point, the following values are saved in context:
        *
-       *   R0 = SYS_signal_handler
-       *   R1 = sighand
-       *   R2 = signo
-       *   R3 = info
-       *   R4 = ucontext
+       *   A0 = SYS_signal_handler
+       *   A1 = sighand
+       *   A2 = signo
+       *   A3 = info
+       *   A4 = ucontext
        */
 
 #ifndef CONFIG_BUILD_FLAT

--- a/arch/risc-v/src/common/riscv_swint.c
+++ b/arch/risc-v/src/common/riscv_swint.c
@@ -223,6 +223,7 @@ int riscv_swint(int irq, void *context, void *arg)
         {
           DEBUGASSERT(regs[REG_A1] != 0);
           CURRENT_REGS = (uintptr_t *)regs[REG_A1];
+          riscv_restorefpu((uintptr_t *)CURRENT_REGS);
         }
         break;
 
@@ -246,9 +247,8 @@ int riscv_swint(int irq, void *context, void *arg)
       case SYS_switch_context:
         {
           DEBUGASSERT(regs[REG_A1] != 0 && regs[REG_A2] != 0);
-#ifdef CONFIG_ARCH_FPU
           riscv_savefpu(regs);
-#endif
+          riscv_restorefpu((uintptr_t *)regs[REG_A2]);
           *(uintptr_t **)regs[REG_A1] = (uintptr_t *)regs;
           CURRENT_REGS = (uintptr_t *)regs[REG_A2];
         }

--- a/arch/risc-v/src/qemu-rv/qemu_rv_irq_dispatch.c
+++ b/arch/risc-v/src/qemu-rv/qemu_rv_irq_dispatch.c
@@ -111,7 +111,6 @@ void *riscv_dispatch_irq(uintptr_t vector, uintptr_t *regs)
     }
 #endif
 
-#if defined(CONFIG_ARCH_FPU) || defined(CONFIG_ARCH_ADDRENV)
   /* Check for a context switch.  If a context switch occurred, then
    * CURRENT_REGS will have a different value than it did on entry.  If an
    * interrupt level context switch has occurred, then restore the floating
@@ -121,12 +120,6 @@ void *riscv_dispatch_irq(uintptr_t vector, uintptr_t *regs)
 
   if (regs != CURRENT_REGS)
     {
-#ifdef CONFIG_ARCH_FPU
-      /* Restore floating point registers */
-
-      riscv_restorefpu((uintptr_t *)CURRENT_REGS);
-#endif
-
 #ifdef CONFIG_ARCH_ADDRENV
       /* Make sure that the address environment for the previously
        * running task is closed down gracefully (data caches dump,
@@ -137,7 +130,6 @@ void *riscv_dispatch_irq(uintptr_t vector, uintptr_t *regs)
       group_addrenv(NULL);
 #endif
     }
-#endif /* CONFIG_ARCH_FPU || CONFIG_ARCH_ADDRENV */
 
   /* If a context switch occurred while processing the interrupt then
    * CURRENT_REGS may have change value.  If we return any value different


### PR DESCRIPTION
## Summary
* Move FPU store/restore from chip specific code to common
* Update some comments 
## Impact
RISC-V with FPU support
## Testing
qemu
