### PR TITLE
riscv/bl602: Enable SPI Master in SPI Poll Send

### DIFF
--- a/arch/risc-v/src/bl602/bl602_spi.c
+++ b/arch/risc-v/src/bl602/bl602_spi.c
@@ -782,6 +782,15 @@ static uint32_t bl602_spi_poll_send(struct bl602_spi_priv_s *priv,
   uint32_t val;
   uint32_t tmp_val = 0;
 
+  /* spi enable master */
+
+  modifyreg32(BL602_SPI_CFG, SPI_CFG_CR_S_EN, SPI_CFG_CR_M_EN);
+
+  /* spi fifo clear  */
+
+  modifyreg32(BL602_SPI_FIFO_CFG_0, SPI_FIFO_CFG_0_RX_CLR
+              | SPI_FIFO_CFG_0_TX_CLR, 0);
+
   /* write data to tx fifo */
 
   putreg32(wd, BL602_SPI_FIFO_WDATA);
@@ -889,15 +898,6 @@ static void bl602_spi_poll_exchange(struct bl602_spi_priv_s *priv,
   int i;
   uint32_t w_wd = 0xffff;
   uint32_t r_wd;
-
-  /* spi enable master */
-
-  modifyreg32(BL602_SPI_CFG, SPI_CFG_CR_S_EN, SPI_CFG_CR_M_EN);
-
-  /* spi fifo clear  */
-
-  modifyreg32(BL602_SPI_FIFO_CFG_0, SPI_FIFO_CFG_0_RX_CLR
-              | SPI_FIFO_CFG_0_TX_CLR, 0);
 
   for (i = 0; i < nwords; i++)
     {


### PR DESCRIPTION
## Summary

SPI Poll Send `bl602_spi_poll_send()` doesn't send any SPI Data because it doesn't enable SPI Master and it doesn't clear the SPI FIFO. Also it hangs because it loops forever waiting for the FIFO.

We fix this problem by moving the code that enables SPI Master and clears the FIFO, from SPI Poll Exchange `bl602_spi_poll_exchange()` to SPI Poll Send. (Note that SPI Poll Exchange calls SPI Poll Send)

[More Details Here](https://github.com/lupyuen/st7789-nuttx#fix-spi-send)

## Impact

This problem affects all NuttX Drivers that call `SPI_SEND()` on BL602, including the ST7789 Display Driver.

Previously `SPI_SEND()` didn't send any SPI Data and never returns, because it loops forever waiting to receive data.

Now `SPI_SEND()` sends data and returns correctly.

[More Details Here](https://github.com/lupyuen/st7789-nuttx#fix-spi-send)

## Testing

We tested the modified SPI Poll Send with NuttX ST7789 Driver and a Logic Analyser on PineCone BL602:

-  [Testing with Logic Analyser](https://github.com/lupyuen/st7789-nuttx#fix-spi-send)

We also tested LVGL with ST7789 on PineCone BL602:

-  [Testing with LVGL](https://github.com/lupyuen/st7789-nuttx#run-lvgl-demo)

As for the modified SPI Poll Exchange, we tested with Semtech SX1262 SPI Transceiver on PineCone BL602:

-  [Testing SPI Poll Exchange](https://github.com/lupyuen/incubator-nuttx/releases/tag/release-2022-03-28)
