### PR TITLE
arch/armv7-a: Fix a typo in Toolchain.defs

### DIFF
--- a/arch/arm/src/armv7-a/Toolchain.defs
+++ b/arch/arm/src/armv7-a/Toolchain.defs
@@ -99,7 +99,7 @@ ifeq ($(CONFIG_ARCH_FPU),y)
   ARCHCPUFLAGS += -mfpu=$(ARCHNEON)$(ARCHFPU)$(ARCHFPUD16)
 
 else
-  ARCHFPUFLAGS += -mfloat-abi=soft
+  ARCHCPUFLAGS += -mfloat-abi=soft
 endif
 
 ifeq ($(CONFIG_MM_KASAN),y)


### PR DESCRIPTION
## Summary

## Impact

## Testing
CI
