### PR TITLE
nuttx/include: fix list.h type error

### DIFF
--- a/include/nuttx/list.h
+++ b/include/nuttx/list.h
@@ -60,7 +60,7 @@
 #define list_remove_tail_type(list, type, element) (\
 {\
   FAR struct list_node *__nod = list_remove_tail(list);\
-  FAR ype *__t;\
+  FAR type *__t;\
 \
   if(__nod)\
     {\


### PR DESCRIPTION
## Summary
fix list.h type error
## Impact

## Testing

