### PR TITLE
MPFS: Fix error in flat build linker script

### DIFF
--- a/boards/risc-v/mpfs/icicle/scripts/ld.script
+++ b/boards/risc-v/mpfs/icicle/scripts/ld.script
@@ -28,7 +28,7 @@ OUTPUT_ARCH("riscv")
 
 __ksram_start = ORIGIN(sram);
 __ksram_size = LENGTH(sram);
-__ksram_end = ORIGIN(ksram) + LENGTH(ksram);
+__ksram_end = ORIGIN(sram) + LENGTH(sram);
 
 ENTRY(_stext)
 EXTERN(_vectors)


### PR DESCRIPTION
Use sram instead of ksram (copy&paste error)

## Summary
Fixes warning given by linker of missing ksram region
## Impact

## Testing

