### PR TITLE
arch/risc-v: Use riscv_fpuconfig to enable FPU

### DIFF
--- a/arch/risc-v/src/bl602/bl602_head.S
+++ b/arch/risc-v/src/bl602/bl602_head.S
@@ -126,20 +126,6 @@ bl602_entry_zero_wifi_bss_loop:
     bltu a0, a1, bl602_entry_zero_wifi_bss_loop
 bl602_entry_zero_wifi_bss_end:
 
-#ifndef __riscv_float_abi_soft
-
-    /* Enable FPU */
-
-    li t0, MSTATUS_FS
-    csrs mstatus, t0
-    csrr t1, mstatus
-    and t1, t1, t0
-    beqz t1, bl602_entry_enable_fpu_end
-    fssr x0
-
-bl602_entry_enable_fpu_end:
-#endif
-
     auipc ra, 0
     addi sp, sp, -16
     sw ra, 8(sp)

--- a/arch/risc-v/src/bl602/bl602_start.c
+++ b/arch/risc-v/src/bl602/bl602_start.c
@@ -160,6 +160,10 @@ __cyg_profile_func_exit(void *this_fn, void *call_site)
 
 void bfl_main(void)
 {
+  /* Configure FPU */
+
+  riscv_fpuconfig();
+
   /* set interrupt vector */
 
   asm volatile("csrw mtvec, %0" ::"r"((uintptr_t)exception_common + 2));

--- a/arch/risc-v/src/c906/c906_head.S
+++ b/arch/risc-v/src/c906/c906_head.S
@@ -52,13 +52,6 @@ __start:
 
   sfence.vma x0,x0
 
-  /* enable FPU if CFLAGS has 'f' or 'd' in -march */
-
-#ifdef __riscv_flen
-    li      a0, MSTATUS_FS_INIT
-    csrs    mstatus, a0
-#endif
-
   /* enable thead ISA extension:
    * BIT22: enable the THEAD ISA extensions.
    * BIT21: enable extended attributes in PTE.

--- a/arch/risc-v/src/c906/c906_start.c
+++ b/arch/risc-v/src/c906/c906_start.c
@@ -73,6 +73,10 @@ void __c906_start(uint32_t mhartid)
   const uint32_t *src;
   uint32_t *dest;
 
+  /* Configure FPU */
+
+  riscv_fpuconfig();
+
   if (0 != mhartid)
     {
       while (true);

--- a/arch/risc-v/src/common/riscv_fpu.S
+++ b/arch/risc-v/src/common/riscv_fpu.S
@@ -36,7 +36,7 @@
  * Public Symbols
  ************************************************************************************/
 
-    .globl        up_fpuconfig
+    .globl        riscv_fpuconfig
     .globl        riscv_savefpu
     .globl        riscv_restorefpu
 
@@ -72,13 +72,13 @@
  ************************************************************************************/
 
 /************************************************************************************
- * Name: up_fpuconfig
+ * Name: riscv_fpuconfig
  *
  * Description:
  *   init fpu
  *
  * C Function Prototype:
- *   void up_fpuconfig(void);
+ *   void riscv_fpuconfig(void);
  *
  * Input Parameters:
  *   None
@@ -88,9 +88,9 @@
  *
  ************************************************************************************/
 
-    .type        up_fpuconfig, function
+    .type        riscv_fpuconfig, function
 
-up_fpuconfig:
+riscv_fpuconfig:
     li           a0, FS_INITIAL
     csrs         mstatus, a0
     csrwi        fcsr, 0

--- a/arch/risc-v/src/common/riscv_internal.h
+++ b/arch/risc-v/src/common/riscv_internal.h
@@ -204,9 +204,11 @@ int riscv_swint(int irq, void *context, void *arg);
 uintptr_t riscv_get_newintctx(void);
 
 #ifdef CONFIG_ARCH_FPU
+void riscv_fpuconfig(void);
 void riscv_savefpu(uintptr_t *regs);
 void riscv_restorefpu(const uintptr_t *regs);
 #else
+#  define riscv_fpuconfig()
 #  define riscv_savefpu(regs)
 #  define riscv_restorefpu(regs)
 #endif

--- a/arch/risc-v/src/mpfs/mpfs_head.S
+++ b/arch/risc-v/src/mpfs/mpfs_head.S
@@ -116,19 +116,14 @@ __start:
 
   sfence.vma x0, x0
 
-  /* enable FPU and accelerator if present, setting ignored on E51
+  /* Enable accelerator if present, setting ignored on E51
    * 15,16 = MSTATUS_XS, 17,18 = MSTATUS_MPRV
    * not defined on riscv-v/include/csr.h
    */
 
-  /*  li      t0, MSTATUS_FS_DIRTY | (1 << 15) | (1 << 16) | (1 << 17) | (1 << 18) */
-  li t0, 0x00006000 | 0x00018000 /* MSTATUS_FS | MSTATUS_XS */
+  /*  li      t0, (1 << 15) | (1 << 16) | (1 << 17) | (1 << 18) */
+  li t0, 0x00018000 /* MSTATUS_XS */
   csrs    mstatus, t0
-
-  /* Init floating point control register to zero */
-#ifdef __riscv_flen
-    fscsr x0
-#endif
 
 .skip_e51:
 

--- a/arch/risc-v/src/mpfs/mpfs_start.c
+++ b/arch/risc-v/src/mpfs/mpfs_start.c
@@ -116,6 +116,13 @@ void __mpfs_start(uint64_t mhartid)
   const uint32_t *src;
   uint32_t *dest;
 
+  /* Configure FPU (hart 0 don't have an FPU) */
+
+  if (mhartid != 0)
+    {
+      riscv_fpuconfig();
+    }
+
   /* Clear .bss.  We'll do this inline (vs. calling memset) just to be
    * certain that there are no issues with the state of global variables.
    */

--- a/arch/risc-v/src/qemu-rv/qemu_rv_start.c
+++ b/arch/risc-v/src/qemu-rv/qemu_rv_start.c
@@ -63,6 +63,10 @@ void qemu_rv_start(int mhartid)
 {
   uint32_t *dest;
 
+  /* Configure FPU */
+
+  riscv_fpuconfig();
+
   if (mhartid > 0)
     {
       goto cpux;


### PR DESCRIPTION
## Summary
* Rename up_fpuconfig to riscv_fpuconfig

* Use common function instead of chip specified code to enable FPU
## Impact
RISC-V with FPU support
## Testing
QEMU
