### PR TITLE
ramlog: support setting threshold value of ramlog for poll waiters

### DIFF
--- a/drivers/syslog/Kconfig
+++ b/drivers/syslog/Kconfig
@@ -61,6 +61,12 @@ config RAMLOG_OVERWRITE
 		Enable overwrite of circular buffer. If RAMLOG buffer overflows,
 		overwrite it from the top of buffer and always keep the latest log.
 
+config RAMLOG_POLLTHRESHOLD
+	int "The threshold value of circular buffer to notify poll waiters"
+	default 1
+	---help---
+		When the length of circular buffer exceeds the threshold value, the poll() will
+		return POLLIN to all poll waiters.
 endif
 
 config SYSLOG_BUFFER


### PR DESCRIPTION


## Summary
ramlog: support setting threshold value of ramlog for poll waiters.


Signed-off-by: Jiuzhu Dong <dongjiuzhu1@xiaomi.com>
## Impact
we can config CONFIG_RAMLOG_POLLTHRESHOLD to control poll ready frequency.
## Testing
Ci test
