### PR TITLE
MPFS: Fix issue with external interrupt detection

### DIFF
--- a/arch/risc-v/include/irq.h
+++ b/arch/risc-v/include/irq.h
@@ -82,9 +82,9 @@
 /* IRQ bit and IRQ mask */
 
 #ifdef CONFIG_ARCH_RV32
-#  define RISCV_IRQ_BIT           (1 << 31)
+#  define RISCV_IRQ_BIT           (UINT32_C(1) << 31)
 #else
-#  define RISCV_IRQ_BIT           (1 << 63)
+#  define RISCV_IRQ_BIT           (UINT64_C(1) << 63)
 #endif
 
 #define RISCV_IRQ_MASK            (~RISCV_IRQ_BIT)


### PR DESCRIPTION
The bitmask overflow'd. Failing test is at mpfs_irq_dispatch / line 69

## Summary
Fixes external interrupts for mpfs (and any other 64-bit RISC-V target).
## Impact

## Testing
MPFS / icicle:nsh
