### PR TITLE
lseek: use type:off_t for return value

### DIFF
--- a/drivers/bch/bchdev_driver.c
+++ b/drivers/bch/bchdev_driver.c
@@ -223,7 +223,7 @@ static off_t bch_seek(FAR struct file *filep, off_t offset, int whence)
   FAR struct inode *inode = filep->f_inode;
   FAR struct bchlib_s *bch;
   off_t newpos;
-  int ret;
+  off_t ret;
 
   DEBUGASSERT(inode && inode->i_private);
 
@@ -231,7 +231,7 @@ static off_t bch_seek(FAR struct file *filep, off_t offset, int whence)
   ret = bchlib_semtake(bch);
   if (ret < 0)
     {
-      return (off_t)ret;
+      return ret;
     }
 
   /* Determine the new, requested file position */

--- a/fs/vfs/fs_lseek.c
+++ b/fs/vfs/fs_lseek.c
@@ -57,7 +57,7 @@
 off_t file_seek(FAR struct file *filep, off_t offset, int whence)
 {
   FAR struct inode *inode;
-  int ret;
+  off_t ret;
 
   DEBUGASSERT(filep);
   inode =  filep->f_inode;
@@ -66,7 +66,7 @@ off_t file_seek(FAR struct file *filep, off_t offset, int whence)
 
   if (inode && inode->u.i_ops && inode->u.i_ops->seek)
     {
-      ret = (int)inode->u.i_ops->seek(filep, offset, whence);
+      ret = inode->u.i_ops->seek(filep, offset, whence);
       if (ret < 0)
         {
           return ret;
@@ -123,7 +123,7 @@ off_t file_seek(FAR struct file *filep, off_t offset, int whence)
 off_t nx_seek(int fd, off_t offset, int whence)
 {
   FAR struct file *filep;
-  int ret;
+  off_t ret;
 
   /* Get the file structure corresponding to the file descriptor. */
 


### PR DESCRIPTION


## Summary
lseek: use type:off_t for return value

Signed-off-by: Jiuzhu Dong <dongjiuzhu1@xiaomi.com>
## Impact
N/A
## Testing
daily test
