### PR TITLE
fs/files_allocate: assert when fd overflow

### DIFF
--- a/fs/inode/fs_files.c
+++ b/fs/inode/fs_files.c
@@ -98,6 +98,12 @@ static int files_extend(FAR struct filelist *list, size_t row)
 
   list->fl_files = tmp;
   list->fl_rows = row;
+
+  /* Note: If assertion occurs, the fl_rows has a overflow.
+   * And there may be file descriptors leak in system.
+   */
+
+  DEBUGASSERT(list->fl_rows == row);
   return 0;
 }
 


### PR DESCRIPTION

## Summary
fs/files_allocate: assert when fd overflow

Signed-off-by: Jiuzhu Dong <dongjiuzhu1@xiaomi.com>
## Impact
N/A
## Testing
Ci test
