### PR TITLE
signal: Don't do schedule_sigaction when there is no action

### DIFF
--- a/sched/signal/sig_dispatch.c
+++ b/sched/signal/sig_dispatch.c
@@ -105,6 +105,13 @@ static int nxsig_queue_action(FAR struct tcb_s *stcb, siginfo_t *info)
 
           flags = enter_critical_section();
           sq_addlast((FAR sq_entry_t *)sigq, &(stcb->sigpendactionq));
+
+          /* Then schedule execution of the signal handling action on the
+           * recipient's thread. SMP related handling will be done in
+           * up_schedule_sigaction()
+           */
+
+          up_schedule_sigaction(stcb, nxsig_deliver);
           leave_critical_section(flags);
         }
     }
@@ -382,13 +389,6 @@ int nxsig_tcbdispatch(FAR struct tcb_s *stcb, siginfo_t *info)
       /* Deliver of the signal must be performed in a critical section */
 
       flags = enter_critical_section();
-
-      /* Then schedule execution of the signal handling action on the
-       * recipient's thread. SMP related handling will be done in
-       * up_schedule_sigaction()
-       */
-
-      up_schedule_sigaction(stcb, nxsig_deliver);
 
       /* Check if the task is waiting for an unmasked signal. If so, then
        * unblock it. This must be performed in a critical section because

--- a/sched/task/task_start.c
+++ b/sched/task/task_start.c
@@ -82,9 +82,12 @@ void nxtask_start(void)
               TCB_FLAG_TTYPE_PTHREAD);
 
 #ifdef CONFIG_SIG_DEFAULT
-  /* Set up default signal actions */
+  if ((tcb->cmn.flags & TCB_FLAG_TTYPE_MASK) != TCB_FLAG_TTYPE_KERNEL)
+    {
+      /* Set up default signal actions for NON-kernel thread */
 
-  nxsig_default_initialize(&tcb->cmn);
+      nxsig_default_initialize(&tcb->cmn);
+    }
 #endif
 
   /* Execute the start hook if one has been registered */


### PR DESCRIPTION
## Summary

signal: Don't do schedule_sigaction when there is no action
task: don't set default signal in kernal thread

We think, the kernel thread should set default signal action, like SIGINT SIGSTOP...

## Impact

signal on kernel thread

## Testing

VELA
