### PR TITLE
rpmsg_socket: fix kasan report error

### DIFF
--- a/net/rpmsg/rpmsg_sockif.c
+++ b/net/rpmsg/rpmsg_sockif.c
@@ -313,9 +313,9 @@ static int rpmsg_socket_ept_cb(FAR struct rpmsg_endpoint *ept,
           _SO_SETERRNO(conn->psock, OK);
         }
 
-      rpmsg_socket_unlock(&conn->recvlock);
       rpmsg_socket_post(&conn->sendsem);
       rpmsg_socket_pollnotify(conn, POLLOUT);
+      rpmsg_socket_unlock(&conn->recvlock);
     }
   else
     {


### PR DESCRIPTION

## Summary
rpmsg_socket: fix kasan report error

==1598322==ERROR: AddressSanitizer: heap-use-after-free on address 0xf514f8a8 at pc 0x58ac3898 bp 0xd0b4d488 sp 0xd0b4d478
READ of size 4 at 0xf514f8a8 thread T0
    #0 0x58ac3897 in rpmsg_socket_pollnotify rpmsg/rpmsg_sockif.c:211
    #1 0x58ac512f in rpmsg_socket_ept_cb rpmsg/rpmsg_sockif.c:312
    #2 0x5787881c in rpmsg_virtio_rx_callback open-amp/lib/rpmsg/rpmsg_virtio.c:331
    #3 0x57886a67 in virtqueue_notification open-amp/lib/virtio/virtqueue.c:623
    #4 0x5786fb89 in rproc_virtio_notified open-amp/lib/remoteproc/remoteproc_virtio.c:340
    #5 0x5786bde3 in remoteproc_get_notification open-amp/lib/remoteproc/remoteproc.c:985
    #6 0x57755a50 in rptun_worker rptun/rptun.c:303
    #7 0x57755e51 in rptun_thread rptun/rptun.c:352
    #8 0x57730d4a in nxtask_start task/task_start.c:128
    #9 0xdeadbeee  (/memfd:pulseaudio (deleted)+0x15dbeee)

Signed-off-by: ligd <liguiding1@xiaomi.com>


## Impact

rpmsg socket

## Testing

VELA

