### PR TITLE
ioe_rpmsg: use rptun_wait/post to resolve deadlock with usrsock

### DIFF
--- a/drivers/ioexpander/ioe_rpmsg.c
+++ b/drivers/ioexpander/ioe_rpmsg.c
@@ -237,13 +237,13 @@ static int ioe_rpmsg_wait_ready(FAR struct rpmsg_endpoint *ept)
       FAR struct ioe_rpmsg_client_s *priv =
         container_of(ept, struct ioe_rpmsg_client_s, ept);
 
-      ret = nxsem_wait_uninterruptible(&priv->sem);
+      ret = rpmsg_wait(ept, &priv->sem);
       if (ret < 0)
         {
           return ret;
         }
 
-      nxsem_post(&priv->sem);
+      rpmsg_post(ept, &priv->sem);
     }
 
   return ret;
@@ -281,7 +281,7 @@ static int ioe_rpmsg_sendrecv(FAR struct rpmsg_endpoint *ept,
       return ret;
     }
 
-  ret = nxsem_wait_uninterruptible(&cookie.sem);
+  ret = rpmsg_wait(ept, &cookie.sem);
   if (ret < 0)
     {
       return ret;
@@ -550,7 +550,7 @@ static int ioe_rpmsg_ept_cb(FAR struct rpmsg_endpoint *ept, FAR void *data,
   if (msg->response && cookie)
     {
       cookie->result = msg->result;
-      nxsem_post(&cookie->sem);
+      rpmsg_post(ept, &cookie->sem);
       ret = 0;
     }
   else if (cmd < ARRAY_SIZE(g_ioe_rpmsg_handler)
@@ -577,7 +577,7 @@ static void ioe_rpmsg_client_created(FAR struct rpmsg_device *rdev,
       rpmsg_create_ept(&priv->ept, rdev, eptname, RPMSG_ADDR_ANY,
                        RPMSG_ADDR_ANY, ioe_rpmsg_ept_cb, NULL);
 
-      nxsem_post(&priv->sem);
+      rpmsg_post(&priv->ept, &priv->sem);
     }
 }
 
@@ -588,7 +588,7 @@ static void ioe_rpmsg_client_destroy(FAR struct rpmsg_device *rdev,
 
   if (!strcmp(priv->cpuname, rpmsg_get_cpuname(rdev)))
     {
-      nxsem_wait(&priv->sem);
+      rpmsg_wait(&priv->ept, &priv->sem);
       rpmsg_destroy_ept(&priv->ept);
     }
 }


### PR DESCRIPTION


## Summary

ioe_rpmsg: use rptun_wait/post to resolve deadlock with usrsock

This depends on:
https://github.com/apache/incubator-nuttx/pull/5847/

## Impact

ioe_rpmsg

## Testing

VELA
