### PR TITLE
riscv/bl602: Implement SPI Cmd/Data

### DIFF
--- a/arch/risc-v/src/bl602/bl602_spi.c
+++ b/arch/risc-v/src/bl602/bl602_spi.c
@@ -441,6 +441,15 @@ static void bl602_spi_select(struct spi_dev_s *dev, uint32_t devid,
   /* we used hardware CS */
 
   spiinfo("devid: %lu, CS: %s\n", devid, selected ? "select" : "free");
+
+#ifdef CONFIG_SPI_CMDDATA
+  /* revert MISO from GPIO Pin to SPI Pin */
+
+  if (!selected)
+    {
+      bl602_configgpio(BOARD_SPI_MISO);
+    }
+#endif
 }
 
 /****************************************************************************
@@ -681,6 +690,11 @@ static uint8_t bl602_spi_status(struct spi_dev_s *dev, uint32_t devid)
  *   method is required if CONFIG_SPI_CMDDATA is selected in the NuttX
  *   configuration
  *
+ *   This function reconfigures MISO from SPI Pin to GPIO Pin, and sets
+ *   MISO to high (data) or low (command). bl602_spi_select() will revert
+ *   MISO back from GPIO Pin to SPI Pin.  We must revert because the SPI Bus
+ *   may be used by other drivers.
+ *
  * Input Parameters:
  *   dev - Device-specific state data
  *   cmd - TRUE: The following word is a command; FALSE: the following words
@@ -695,10 +709,41 @@ static uint8_t bl602_spi_status(struct spi_dev_s *dev, uint32_t devid)
 static int bl602_spi_cmddata(struct spi_dev_s *dev,
                               uint32_t devid, bool cmd)
 {
+  spiinfo("devid: %" PRIu32 " CMD: %s\n", devid, cmd ? "command" :
+          "data");
+
+#if defined(CONFIG_LCD_ST7735) || defined(CONFIG_LCD_ST7789) || \
+    defined(CONFIG_LCD_GC9A01)
+  if (devid == SPIDEV_DISPLAY(0))
+    {
+      gpio_pinset_t gpio;
+      int ret;
+
+      /* reconfigure MISO from SPI Pin to GPIO Pin */
+
+      gpio = (BOARD_SPI_MISO & GPIO_PIN_MASK)
+             | GPIO_OUTPUT | GPIO_PULLUP | GPIO_FUNC_SWGPIO;
+      ret = bl602_configgpio(gpio);
+      if (ret < 0)
+        {
+          spierr("Failed to configure MISO as GPIO\n");
+          DEBUGPANIC();
+
+          return ret;
+        }
+
+      /* set MISO to high (data) or low (command) */
+
+      bl602_gpiowrite(gpio, !cmd);
+
+      return OK;
+    }
+#endif
+
   spierr("SPI cmddata not supported\n");
   DEBUGPANIC();
 
-  return -1;
+  return -ENODEV;
 }
 #endif
 


### PR DESCRIPTION
## Summary

To control the Data/Command Pin on ST7789 SPI Display, the SPI Driver flips the MISO Pin as though it was a GPIO.

To implement this on BL602, we reconfigure MISO from SPI Pin to GPIO Pin on the fly inside `bl602_spi_cmddata()`.

When the SPI Port is deselected (after the SPI operation), we revert MISO back from GPIO Pin to SPI Pin. We implement this inside `bl602_spi_select()`.

[More Details Here](https://github.com/lupyuen/st7789-nuttx#spi-cmddata)

## Impact

This change impacts 3 LCD drivers that call `SPI_CMDDATA()`: ST7735, ST7789, GC9A01.

Previously the BL602 SPI Driver would fail with "SPI cmddata not supported" when the above drivers are used.

After the change, the above drivers will set the LCD Data/Command Pin correctly.

## Testing

We tested this implementation of SPI Cmd/Data with NuttX ST7789 Driver and a Logic Analyser on PineCone BL602:

-   [Testing with Logic Analyser](https://github.com/lupyuen/st7789-nuttx#spi-cmddata)

We also tested LVGL with ST7789 on PineCone BL602:

-   [Testing with LVGL](https://github.com/lupyuen/st7789-nuttx#run-lvgl-demo)

As for regular SPI Devices that don't require SPI Cmd/Data, we tested `CONFIG_SPI_CMDDATA=y` with Semtech SX1262 SPI Transceiver on PineCone BL602:

-   [Testing Cmd/Data](https://github.com/lupyuen/incubator-nuttx/releases/tag/release-2022-03-29)
