### PR TITLE
irq_csection: fix assert warning in clang build

### DIFF
--- a/sched/irq/irq_csection.c
+++ b/sched/irq/irq_csection.c
@@ -414,7 +414,7 @@ irqstate_t enter_critical_section(void)
        * call to enter_critical_section.
        */
 
-      DEBUGASSERT(rtcb->irqcount >= 0 && rtcb->irqcount < UINT16_MAX);
+      DEBUGASSERT(rtcb->irqcount >= 0 && rtcb->irqcount < INT16_MAX);
       if (++rtcb->irqcount == 1)
         {
           /* Note that we have entered the critical section */


### PR DESCRIPTION
constant 65535 with expression of type 'int16_t' (aka 'short')
is always true

Signed-off-by: zhuyanlin <zhuyanlin1@xiaomi.com>

## Summary

## Impact

## Testing

