### PR TITLE
mm_heap: heapsize align with MM_MIN_CHUNK.

### DIFF
--- a/mm/mm_heap/mm.h
+++ b/mm/mm_heap/mm.h
@@ -147,6 +147,10 @@
 
 #define SIZEOF_MM_FREENODE sizeof(struct mm_freenode_s)
 
+/* What is the size of the start/end node? */
+
+#define SIZEOF_MM_STARTENDNODE MM_MIN_CHUNK
+
 /****************************************************************************
  * Public Types
  ****************************************************************************/

--- a/mm/mm_heap/mm_initialize.c
+++ b/mm/mm_heap/mm_initialize.c
@@ -118,15 +118,15 @@ void mm_addregion(FAR struct mm_heap_s *heap, FAR void *heapstart,
   heap->mm_heapstart[IDX]            = (FAR struct mm_allocnode_s *)
                                        heapbase;
   MM_ADD_BACKTRACE(heap, heap->mm_heapstart[IDX]);
-  heap->mm_heapstart[IDX]->size      = SIZEOF_MM_ALLOCNODE;
+  heap->mm_heapstart[IDX]->size      = SIZEOF_MM_STARTENDNODE;
   heap->mm_heapstart[IDX]->preceding = MM_ALLOC_BIT;
   node                               = (FAR struct mm_freenode_s *)
-                                       (heapbase + SIZEOF_MM_ALLOCNODE);
-  node->size                         = heapsize - 2*SIZEOF_MM_ALLOCNODE;
-  node->preceding                    = SIZEOF_MM_ALLOCNODE;
+                                       (heapbase + SIZEOF_MM_STARTENDNODE);
+  node->size                         = heapsize - 2*SIZEOF_MM_STARTENDNODE;
+  node->preceding                    = SIZEOF_MM_STARTENDNODE;
   heap->mm_heapend[IDX]              = (FAR struct mm_allocnode_s *)
-                                       (heapend - SIZEOF_MM_ALLOCNODE);
-  heap->mm_heapend[IDX]->size        = SIZEOF_MM_ALLOCNODE;
+                                       (heapend - SIZEOF_MM_STARTENDNODE);
+  heap->mm_heapend[IDX]->size        = SIZEOF_MM_STARTENDNODE;
   heap->mm_heapend[IDX]->preceding   = node->size | MM_ALLOC_BIT;
   MM_ADD_BACKTRACE(heap, heap->mm_heapend[IDX]);
 

--- a/mm/mm_heap/mm_mallinfo.c
+++ b/mm/mm_heap/mm_mallinfo.c
@@ -121,7 +121,10 @@ int mm_mallinfo(FAR struct mm_heap_s *heap, FAR struct mallinfo *info)
   mm_foreach(heap, mallinfo_handler, info);
 
   info->arena = heap->mm_heapsize;
-  info->uordblks += region * SIZEOF_MM_ALLOCNODE; /* account for the tail node */
+
+  /* Account for the tail node */
+
+  info->uordblks += region * SIZEOF_MM_STARTENDNODE;
 
   DEBUGASSERT(info->uordblks + info->fordblks == heap->mm_heapsize);
 


### PR DESCRIPTION
Make sure the (heapsize - sizeof(heap->mm_heapstart) - sizeof(heap->mm_heapend)) be aligned with MM_MIN_CHUNK to avoid memory assert question when realloc a mem.

Signed-off-by: wangbowen6 <wangbowen6@xiaomi.com>

## Summary

## Impact

## Testing

memtest in nucleo-144