### PR TITLE
riscv/bl602: Remove check for LCD driver

### DIFF
--- a/arch/risc-v/src/bl602/bl602_spi.c
+++ b/arch/risc-v/src/bl602/bl602_spi.c
@@ -712,8 +712,6 @@ static int bl602_spi_cmddata(struct spi_dev_s *dev,
   spiinfo("devid: %" PRIu32 " CMD: %s\n", devid, cmd ? "command" :
           "data");
 
-#if defined(CONFIG_LCD_ST7735) || defined(CONFIG_LCD_ST7789) || \
-    defined(CONFIG_LCD_GC9A01)
   if (devid == SPIDEV_DISPLAY(0))
     {
       gpio_pinset_t gpio;
@@ -738,7 +736,6 @@ static int bl602_spi_cmddata(struct spi_dev_s *dev,
 
       return OK;
     }
-#endif
 
   spierr("SPI cmddata not supported\n");
   DEBUGPANIC();


### PR DESCRIPTION
## Summary

`bl602_spi_cmddata()` implements SPI Cmd/Data `SPI_CMDDATA()` for only 3 LCD drivers: ST7735, ST7789 and GC9A01.

This patch removes the check for LCD drivers, so that SPI Cmd/Data will work for all LCD drivers.

More details: https://github.com/apache/incubator-nuttx/pull/5898

## Impact

This change impacts LCD drivers that call `SPI_CMDDATA()`.

Previously `SPI_CMDDATA()` would fail with `ENODEV` for LCD drivers other than ST7735, ST7789 and GC9A01.

After patching, `SPI_CMDDATA()` will work correctly with all LCD drivers.

## Testing

We tested with LVGL and ST7789 on PineCone BL602:

-   [Testing with LVGL](https://github.com/lupyuen/st7789-nuttx#run-lvgl-demo)

As for regular SPI Devices that don't require SPI Cmd/Data, we tested `CONFIG_SPI_CMDDATA=y` with Semtech SX1262 SPI Transceiver on PineCone BL602:

-   [Testing Cmd/Data](https://github.com/lupyuen/incubator-nuttx/releases/tag/release-2022-03-30)
