### PR TITLE
riscv/esp32c3: Remove check for LCD driver

### DIFF
--- a/boards/risc-v/esp32c3/esp32c3-devkit/src/esp32c3_board_spi.c
+++ b/boards/risc-v/esp32c3/esp32c3-devkit/src/esp32c3_board_spi.c
@@ -63,8 +63,6 @@ uint8_t esp32c3_spi2_status(FAR struct spi_dev_s *dev, uint32_t devid)
 
 int esp32c3_spi2_cmddata(FAR struct spi_dev_s *dev, uint32_t devid, bool cmd)
 {
-#if defined(CONFIG_LCD_ST7735) || defined(CONFIG_LCD_ST7789) || \
-    defined(CONFIG_LCD_GC9A01)
   if (devid == SPIDEV_DISPLAY(0))
     {
       /*  This is the Data/Command control pad which determines whether the
@@ -76,7 +74,6 @@ int esp32c3_spi2_cmddata(FAR struct spi_dev_s *dev, uint32_t devid, bool cmd)
       return OK;
     }
 
-#endif
   spiinfo("devid: %" PRIu32 " CMD: %s\n", devid, cmd ? "command" :
           "data");
 


### PR DESCRIPTION
## Summary

`esp32c3_spi2_cmddata()` implements SPI Cmd/Data `SPI_CMDDATA()` for only 3 LCD drivers: ST7735, ST7789 and GC9A01.

This patch removes the check for LCD drivers, so that SPI Cmd/Data will work for all LCD drivers.

More details: https://github.com/apache/incubator-nuttx/pull/5898

## Impact

This change impacts LCD drivers that call `SPI_CMDDATA()`.

Previously `SPI_CMDDATA()` would fail with `ENODEV` for LCD drivers other than ST7735, ST7789 and GC9A01.

After patching, `SPI_CMDDATA()` will work correctly with all LCD drivers.

## Testing

This is a minor patch so no testing is needed.
