### PR TITLE
boards/boardctl:common boardctl to read reset cause.

### DIFF
--- a/boards/Kconfig
+++ b/boards/Kconfig
@@ -3499,6 +3499,15 @@ config BOARD_ASSERT_RESET_VALUE
 		implementations to handle the reset differently for the
 		case of a crash.
 
+config BOARDCTL_RESET_CAUSE
+	bool "Return reset cause"
+	default n
+	depends on ARCH_HAVE_RESET
+	---help---
+		Enables support for the BOARDIOC_RESET_CAUSE boardctl() command.
+		Architecture specific logic must provide the board_reset_cause()
+		interface.
+
 config BOARDCTL_UNIQUEID
 	bool "Return board unique ID"
 	default n

--- a/boards/boardctl.c
+++ b/boards/boardctl.c
@@ -777,6 +777,27 @@ int boardctl(unsigned int cmd, uintptr_t arg)
         break;
 #endif
 
+#ifdef CONFIG_BOARDCTL_RESET_CAUSE
+      /* CMD:           BOARDIOC_RESET_CAUSE
+       * DESCRIPTION:   Get the cause of last-time board reset
+       * ARG:           A pointer to an instance of struct
+       *                boardioc_reset_cause_s
+       * CONFIGURATION: CONFIG_BOARDCTL_RESET_CAUSE
+       * DEPENDENCIES:  Board logic must provide the
+       *                board_reset_cause() interface.
+       */
+
+      case BOARDIOC_RESET_CAUSE:
+        {
+          FAR struct boardioc_reset_cause_s *cause =
+            (FAR struct boardioc_reset_cause_s *)arg;
+
+          DEBUGASSERT(cause != NULL);
+          ret = board_reset_cause(cause);
+        }
+        break;
+#endif
+
        default:
          {
 #ifdef CONFIG_BOARDCTL_IOCTL

--- a/include/nuttx/board.h
+++ b/include/nuttx/board.h
@@ -96,6 +96,10 @@
 #  include <nuttx/irq.h>
 #endif
 
+#ifdef CONFIG_BOARDCTL_RESET_CAUSE
+#  include <sys/boardctl.h>
+#endif
+
 /****************************************************************************
  * Public Function Prototypes
  *
@@ -817,6 +821,20 @@ void board_crashdump(uintptr_t currentsp, FAR void *tcb,
 
 #ifdef CONFIG_BOARD_INITRNGSEED
 void board_init_rngseed(void);
+#endif
+
+/****************************************************************************
+ * Name: board_reset_cause
+ *
+ * Description:
+ *   This interface may be used by application specific logic to get the
+ *   cause of last reset. Support for this function is required by
+ *   board-level logic if CONFIG_BOARDCTL_RESET is selected.
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_BOARDCTL_RESET_CAUSE
+int board_reset_cause(FAR struct boardioc_reset_cause_s *cause);
 #endif
 
 #undef EXTERN

--- a/include/sys/boardctl.h
+++ b/include/sys/boardctl.h
@@ -180,6 +180,12 @@
  *                1=locked.
  * CONFIGURATION: CONFIG_BOARDCTL_TESTSET
  * DEPENDENCIES:  Architecture-specific logic provides up_testset()
+ *
+ * CMD:           BOARDIOC_RESET_CAUSE
+ * DESCRIPTION:   Get the cause of last-time board reset
+ * ARG:           A pointer to an instance of struct boardioc_reset_cause_s
+ * CONFIGURATION: CONFIG_BOARDCTL_RESET_CAUSE
+ * DEPENDENCIES:  Board logic must provide the board_reset_cause() interface.
  */
 
 #define BOARDIOC_INIT              _BOARDIOC(0x0001)
@@ -202,6 +208,7 @@
 #define BOARDIOC_UNIQUEKEY         _BOARDIOC(0x0012)
 #define BOARDIOC_SWITCH_BOOT       _BOARDIOC(0x0013)
 #define BOARDIOC_BOOT_IMAGE        _BOARDIOC(0x0014)
+#define BOARDIOC_RESET_CAUSE       _BOARDIOC(0x0015)
 
 /* If CONFIG_BOARDCTL_IOCTL=y, then board-specific commands will be support.
  * In this case, all commands not recognized by boardctl() will be forwarded
@@ -210,7 +217,7 @@
  * User defined board commands may begin with this value:
  */
 
-#define BOARDIOC_USER              _BOARDIOC(0x0015)
+#define BOARDIOC_USER              _BOARDIOC(0x0016)
 
 /****************************************************************************
  * Public Type Definitions
@@ -400,6 +407,39 @@ struct boardioc_boot_info_s
 {
   FAR const char *path;           /* Path to application firmware image */
   uint32_t        header_size;    /* Size of the image header in bytes */
+};
+#endif
+
+#ifdef CONFIG_BOARDCTL_RESET_CAUSE
+/* Describes the reason of last reset */
+
+enum boardioc_reset_cause_e
+{
+  BOARDIOC_RESETCAUSE_NONE = 0,
+  BOARDIOC_RESETCAUSE_SYS_CHIPPOR,      /* chip power on */
+  BOARDIOC_RESETCAUSE_SYS_RWDT,         /* RTC watchdog system reset */
+  BOARDIOC_RESETCAUSE_SYS_BOR,          /* brown-out system reset */
+  BOARDIOC_RESETCAUSE_CORE_SOFT,        /* software core reset */
+  BOARDIOC_RESETCAUSE_CORE_DPSP,        /* deep-sleep core reset */
+  BOARDIOC_RESETCAUSE_CORE_MWDT,        /* main watchdog core reset */
+  BOARDIOC_RESETCAUSE_CORE_RWDT,        /* RTC watchdog core reset */
+  BOARDIOC_RESETCAUSE_CPU_MWDT,         /* main watchdog cpu reset */
+  BOARDIOC_RESETCAUSE_CPU_SOFT,         /* software cpu reset */
+  BOARDIOC_RESETCAUSE_CPU_RWDT          /* RTC watchdog cpu reset */
+};
+
+enum boardioc_softreset_subreason_e
+{
+  BOARDIOC_SOFTRESETCAUSE_USER_REBOOT = 0,
+  BOARDIOC_SOFTRESETCAUSE_PANIC,
+  BOARDIOC_SOFTRESETCAUSE_ASSERT
+};
+
+struct boardioc_reset_cause_s
+{
+  enum boardioc_reset_cause_e cause;  /* The reason of last reset */
+  uint32_t flag;                      /* watchdog number when watchdog reset,
+                                       * or soft-reset subreason */
 };
 #endif
 


### PR DESCRIPTION
Signed-off-by: 田昕 <tianxin7@xiaomi.com>

## Summary
common boardctl to read reset cause.
## Impact
N/A
## Testing
Vela tested.
