### PR TITLE
arch/risc-v/mpfs: Remove duplicated riscv_restorefpu

### DIFF
--- a/arch/risc-v/src/mpfs/mpfs_irq_dispatch.c
+++ b/arch/risc-v/src/mpfs/mpfs_irq_dispatch.c
@@ -123,7 +123,6 @@ void *riscv_dispatch_irq(uintptr_t vector, uintptr_t *regs)
       putreg32(irq - MPFS_IRQ_EXT_START, claim_address);
     }
 
-#if defined(CONFIG_ARCH_FPU) || defined(CONFIG_ARCH_ADDRENV)
   /* Check for a context switch.  If a context switch occurred, then
    * CURRENT_REGS will have a different value than it did on entry.  If an
    * interrupt level context switch has occurred, then restore the floating
@@ -133,12 +132,6 @@ void *riscv_dispatch_irq(uintptr_t vector, uintptr_t *regs)
 
   if (regs != CURRENT_REGS)
     {
-#ifdef CONFIG_ARCH_FPU
-      /* Restore floating point registers */
-
-      riscv_restorefpu((uintptr_t *)CURRENT_REGS);
-#endif
-
 #ifdef CONFIG_ARCH_ADDRENV
       /* Make sure that the address environment for the previously
        * running task is closed down gracefully (data caches dump,
@@ -149,8 +142,6 @@ void *riscv_dispatch_irq(uintptr_t vector, uintptr_t *regs)
       group_addrenv(NULL);
 #endif
     }
-#endif
-
 #endif
 
   /* If a context switch occurred while processing the interrupt then


### PR DESCRIPTION
## Summary

Follow #5868, forget to remove it from mpfs

## Impact
MPFS
## Testing
CI
