### PR TITLE
arch/risc-v: Move group_addrenv to correct place

### DIFF
--- a/arch/risc-v/src/bl602/Make.defs
+++ b/arch/risc-v/src/bl602/Make.defs
@@ -33,7 +33,7 @@ CMN_CSRCS += riscv_interruptcontext.c riscv_modifyreg32.c riscv_puts.c riscv_mde
 CMN_CSRCS += riscv_releasepending.c riscv_reprioritizertr.c
 CMN_CSRCS += riscv_releasestack.c riscv_stackframe.c riscv_schedulesigaction.c
 CMN_CSRCS += riscv_sigdeliver.c riscv_udelay.c riscv_unblocktask.c riscv_usestack.c
-CMN_CSRCS += riscv_idle.c riscv_tcbinfo.c riscv_getnewintctx.c
+CMN_CSRCS += riscv_idle.c riscv_tcbinfo.c riscv_getnewintctx.c riscv_doirq.c
 
 ifeq ($(CONFIG_SCHED_BACKTRACE),y)
 CMN_CSRCS += riscv_backtrace.c

--- a/arch/risc-v/src/bl602/bl602_irq_dispatch.c
+++ b/arch/risc-v/src/bl602/bl602_irq_dispatch.c
@@ -66,52 +66,9 @@ void *riscv_dispatch_irq(uintptr_t vector, uintptr_t *regs)
 
   riscv_ack_irq(irq);
 
-#ifdef CONFIG_SUPPRESS_INTERRUPTS
-  PANIC();
-#else
-  /* Current regs non-zero indicates that we are processing an interrupt;
-   * CURRENT_REGS is also used to manage interrupt level context switches.
-   *
-   * Nested interrupts are not supported
-   */
-
-  DEBUGASSERT(CURRENT_REGS == NULL);
-  CURRENT_REGS = regs;
-
   /* Deliver the IRQ */
 
-  irq_dispatch(irq, regs);
-
-  /* Check for a context switch.  If a context switch occurred, then
-   * CURRENT_REGS will have a different value than it did on entry.  If an
-   * interrupt level context switch has occurred, then restore the floating
-   * point state and the establish the correct address environment before
-   * returning from the interrupt.
-   */
-
-  if (regs != CURRENT_REGS)
-    {
-#ifdef CONFIG_ARCH_ADDRENV
-      /* Make sure that the address environment for the previously
-       * running task is closed down gracefully (data caches dump,
-       * MMU flushed) and set up the address environment for the new
-       * thread at the head of the ready-to-run list.
-       */
-
-      group_addrenv(NULL);
-#endif
-    }
-
-#endif /* CONFIG_SUPPRESS_INTERRUPTS */
-
-  /* If a context switch occurred while processing the interrupt then
-   * CURRENT_REGS may have change value.  If we return any value different
-   * from the input regs, then the lower level will know that a context
-   * switch occurred during interrupt processing.
-   */
-
-  regs = (uintptr_t *)CURRENT_REGS;
-  CURRENT_REGS = NULL;
+  regs = riscv_doirq(irq, regs);
 
   return regs;
 }

--- a/arch/risc-v/src/c906/Make.defs
+++ b/arch/risc-v/src/c906/Make.defs
@@ -33,7 +33,7 @@ CMN_CSRCS += riscv_interruptcontext.c riscv_modifyreg32.c riscv_puts.c
 CMN_CSRCS += riscv_releasepending.c riscv_reprioritizertr.c
 CMN_CSRCS += riscv_releasestack.c riscv_stackframe.c riscv_schedulesigaction.c
 CMN_CSRCS += riscv_sigdeliver.c riscv_unblocktask.c riscv_usestack.c
-CMN_CSRCS += riscv_mdelay.c riscv_idle.c
+CMN_CSRCS += riscv_mdelay.c riscv_idle.c riscv_doirq.c
 CMN_CSRCS += riscv_tcbinfo.c riscv_getnewintctx.c
 
 ifeq ($(CONFIG_SCHED_BACKTRACE),y)

--- a/arch/risc-v/src/c906/c906_irq_dispatch.c
+++ b/arch/risc-v/src/c906/c906_irq_dispatch.c
@@ -83,25 +83,13 @@ void *riscv_dispatch_irq(uintptr_t vector, uintptr_t *regs)
 
   riscv_ack_irq(irq);
 
-#ifdef CONFIG_SUPPRESS_INTERRUPTS
-  PANIC();
-#else
-  /* Current regs non-zero indicates that we are processing an interrupt;
-   * CURRENT_REGS is also used to manage interrupt level context switches.
-   *
-   * Nested interrupts are not supported
-   */
-
-  ASSERT(CURRENT_REGS == NULL);
-  CURRENT_REGS = regs;
-
   /* MEXT means no interrupt */
 
   if (RISCV_IRQ_MEXT != irq)
     {
       /* Deliver the IRQ */
 
-      irq_dispatch(irq, regs);
+      regs = riscv_doirq(irq, regs);
     }
 
   if (C906_IRQ_PERI_START <= irq)
@@ -110,37 +98,6 @@ void *riscv_dispatch_irq(uintptr_t vector, uintptr_t *regs)
 
       putreg32(irq - C906_IRQ_PERI_START, C906_PLIC_MCLAIM);
     }
-
-  /* Check for a context switch.  If a context switch occurred, then
-   * CURRENT_REGS will have a different value than it did on entry.  If an
-   * interrupt level context switch has occurred, then restore the floating
-   * point state and the establish the correct address environment before
-   * returning from the interrupt.
-   */
-
-  if (regs != CURRENT_REGS)
-    {
-#ifdef CONFIG_ARCH_ADDRENV
-      /* Make sure that the address environment for the previously
-       * running task is closed down gracefully (data caches dump,
-       * MMU flushed) and set up the address environment for the new
-       * thread at the head of the ready-to-run list.
-       */
-
-      group_addrenv(NULL);
-#endif
-    }
-
-#endif /* CONFIG_SUPPRESS_INTERRUPTS */
-
-  /* If a context switch occurred while processing the interrupt then
-   * CURRENT_REGS may have change value.  If we return any value different
-   * from the input regs, then the lower level will know that a context
-   * switch occurred during interrupt processing.
-   */
-
-  regs = (uintptr_t *)CURRENT_REGS;
-  CURRENT_REGS = NULL;
 
   return regs;
 }

--- a/arch/risc-v/src/common/riscv_blocktask.c
+++ b/arch/risc-v/src/common/riscv_blocktask.c
@@ -136,15 +136,6 @@ void up_block_task(struct tcb_s *tcb, tstate_t task_state)
 
           struct tcb_s *nexttcb = this_task();
 
-#ifdef CONFIG_ARCH_ADDRENV
-          /* Make sure that the address environment for the previously
-           * running task is closed down gracefully (data caches dump,
-           * MMU flushed) and set up the address environment for the new
-           * thread at the head of the ready-to-run list.
-           */
-
-          (void)group_addrenv(nexttcb);
-#endif
           /* Reset scheduler parameters */
 
           nxsched_resume_scheduler(nexttcb);

--- a/arch/risc-v/src/common/riscv_doirq.c
+++ b/arch/risc-v/src/common/riscv_doirq.c
@@ -70,12 +70,6 @@ uintptr_t *riscv_doirq(int irq, uintptr_t *regs)
   DEBUGASSERT(CURRENT_REGS == NULL);
   CURRENT_REGS = regs;
 
-  /* Disable further occurrences of this interrupt (until the interrupt
-   * sources have been clear by the driver).
-   */
-
-  up_disable_irq(irq);
-
   /* Deliver the IRQ */
 
   irq_dispatch(irq, regs);
@@ -114,9 +108,6 @@ uintptr_t *riscv_doirq(int irq, uintptr_t *regs)
 
   CURRENT_REGS = NULL;
 
-  /* Unmask the last interrupt (global interrupts are still disabled) */
-
-  up_enable_irq(irq);
 #endif
   board_autoled_off(LED_INIRQ);
   return regs;

--- a/arch/risc-v/src/common/riscv_doirq.c
+++ b/arch/risc-v/src/common/riscv_doirq.c
@@ -55,7 +55,7 @@
  * Public Functions
  ****************************************************************************/
 
-uintptr_t *up_doirq(int irq, uintptr_t *regs)
+uintptr_t *riscv_doirq(int irq, uintptr_t *regs)
 {
   board_autoled_on(LED_INIRQ);
 #ifdef CONFIG_SUPPRESS_INTERRUPTS

--- a/arch/risc-v/src/common/riscv_doirq.c
+++ b/arch/risc-v/src/common/riscv_doirq.c
@@ -80,7 +80,6 @@ uintptr_t *riscv_doirq(int irq, uintptr_t *regs)
 
   irq_dispatch(irq, regs);
 
-#if defined(CONFIG_ARCH_FPU) || defined(CONFIG_ARCH_ADDRENV)
   /* Check for a context switch.  If a context switch occurred, then
    * CURRENT_REGS will have a different value than it did on entry.  If an
    * interrupt level context switch has occurred, then restore the floating
@@ -88,15 +87,9 @@ uintptr_t *riscv_doirq(int irq, uintptr_t *regs)
    * returning from the interrupt.
    */
 
+#ifdef CONFIG_ARCH_ADDRENV
   if (regs != CURRENT_REGS)
     {
-#ifdef CONFIG_ARCH_FPU
-      /* Restore floating point registers */
-
-      riscv_restorefpu((uintptr_t *)CURRENT_REGS);
-#endif
-
-#ifdef CONFIG_ARCH_ADDRENV
       /* Make sure that the address environment for the previously
        * running task is closed down gracefully (data caches dump,
        * MMU flushed) and set up the address environment for the new
@@ -104,7 +97,6 @@ uintptr_t *riscv_doirq(int irq, uintptr_t *regs)
        */
 
       group_addrenv(NULL);
-#endif
     }
 #endif
 

--- a/arch/risc-v/src/common/riscv_exit.c
+++ b/arch/risc-v/src/common/riscv_exit.c
@@ -137,16 +137,6 @@ void up_exit(int status)
 
   nxsched_resume_scheduler(tcb);
 
-#ifdef CONFIG_ARCH_ADDRENV
-  /* Make sure that the address environment for the previously running
-   * task is closed down gracefully (data caches dump, MMU flushed) and
-   * set up the address environment for the new thread at the head of
-   * the ready-to-run list.
-   */
-
-  group_addrenv(tcb);
-#endif
-
   /* Then switch contexts */
 
   riscv_fullcontextrestore(tcb->xcp.regs);

--- a/arch/risc-v/src/common/riscv_internal.h
+++ b/arch/risc-v/src/common/riscv_internal.h
@@ -253,6 +253,7 @@ void riscv_netinitialize(void);
 
 /* Exception Handler ********************************************************/
 
+uintptr_t *riscv_doirq(int irq, uintptr_t *regs);
 void riscv_fault(int irq, uintptr_t *regs);
 void riscv_exception(uintptr_t mcause, uintptr_t *regs);
 

--- a/arch/risc-v/src/common/riscv_releasepending.c
+++ b/arch/risc-v/src/common/riscv_releasepending.c
@@ -107,15 +107,6 @@ void up_release_pending(void)
 
           struct tcb_s *nexttcb = this_task();
 
-#ifdef CONFIG_ARCH_ADDRENV
-          /* Make sure that the address environment for the previously
-           * running task is closed down gracefully (data caches dump,
-           * MMU flushed) and set up the address environment for the new
-           * thread at the head of the ready-to-run list.
-           */
-
-          (void)group_addrenv(nexttcb);
-#endif
           /* Update scheduler parameters */
 
           nxsched_resume_scheduler(nexttcb);

--- a/arch/risc-v/src/common/riscv_reprioritizertr.c
+++ b/arch/risc-v/src/common/riscv_reprioritizertr.c
@@ -159,15 +159,6 @@ void up_reprioritize_rtr(struct tcb_s *tcb, uint8_t priority)
 
               struct tcb_s *nexttcb = this_task();
 
-#ifdef CONFIG_ARCH_ADDRENV
-              /* Make sure that the address environment for the previously
-               * running task is closed down gracefully (data caches dump,
-               * MMU flushed) and set up the address environment for the new
-               * thread at the head of the ready-to-run list.
-               */
-
-              (void)group_addrenv(nexttcb);
-#endif
               /* Update scheduler parameters */
 
               nxsched_resume_scheduler(nexttcb);

--- a/arch/risc-v/src/common/riscv_unblocktask.c
+++ b/arch/risc-v/src/common/riscv_unblocktask.c
@@ -122,15 +122,6 @@ void up_unblock_task(struct tcb_s *tcb)
 
           struct tcb_s *nexttcb = this_task();
 
-#ifdef CONFIG_ARCH_ADDRENV
-          /* Make sure that the address environment for the previously
-           * running task is closed down gracefully (data caches dump,
-           * MMU flushed) and set up the address environment for the new
-           * thread at the head of the ready-to-run list.
-           */
-
-          (void)group_addrenv(nexttcb);
-#endif
           /* Update scheduler parameters */
 
           nxsched_resume_scheduler(nexttcb);

--- a/arch/risc-v/src/esp32c3/Make.defs
+++ b/arch/risc-v/src/esp32c3/Make.defs
@@ -36,7 +36,7 @@ CMN_CSRCS += riscv_interruptcontext.c riscv_modifyreg32.c riscv_puts.c riscv_mde
 CMN_CSRCS += riscv_releasepending.c riscv_reprioritizertr.c
 CMN_CSRCS += riscv_releasestack.c riscv_stackframe.c riscv_schedulesigaction.c
 CMN_CSRCS += riscv_sigdeliver.c riscv_udelay.c riscv_unblocktask.c riscv_usestack.c
-CMN_CSRCS += riscv_tcbinfo.c riscv_getnewintctx.c
+CMN_CSRCS += riscv_tcbinfo.c riscv_getnewintctx.c riscv_doirq.c
 
 ifeq ($(CONFIG_SCHED_BACKTRACE),y)
 CMN_CSRCS += riscv_backtrace.c

--- a/arch/risc-v/src/fe310/Make.defs
+++ b/arch/risc-v/src/fe310/Make.defs
@@ -33,7 +33,7 @@ CMN_CSRCS += riscv_interruptcontext.c riscv_modifyreg32.c riscv_puts.c riscv_mde
 CMN_CSRCS += riscv_releasepending.c riscv_reprioritizertr.c
 CMN_CSRCS += riscv_releasestack.c riscv_stackframe.c riscv_schedulesigaction.c
 CMN_CSRCS += riscv_sigdeliver.c riscv_udelay.c riscv_unblocktask.c riscv_usestack.c
-CMN_CSRCS += riscv_idle.c riscv_tcbinfo.c riscv_getnewintctx.c
+CMN_CSRCS += riscv_idle.c riscv_tcbinfo.c riscv_getnewintctx.c riscv_doirq.c
 
 ifeq ($(CONFIG_SCHED_BACKTRACE),y)
 CMN_CSRCS += riscv_backtrace.c

--- a/arch/risc-v/src/fe310/fe310_irq_dispatch.c
+++ b/arch/risc-v/src/fe310/fe310_irq_dispatch.c
@@ -77,21 +77,9 @@ void *riscv_dispatch_irq(uintptr_t vector, uintptr_t *regs)
 
   riscv_ack_irq(irq);
 
-#ifdef CONFIG_SUPPRESS_INTERRUPTS
-  PANIC();
-#else
-  /* Current regs non-zero indicates that we are processing an interrupt;
-   * CURRENT_REGS is also used to manage interrupt level context switches.
-   *
-   * Nested interrupts are not supported
-   */
-
-  DEBUGASSERT(CURRENT_REGS == NULL);
-  CURRENT_REGS = regs;
-
   /* Deliver the IRQ */
 
-  irq_dispatch(irq, regs);
+  regs = riscv_doirq(irq, regs);
 
   if (RISCV_IRQ_MEXT <= irq)
     {
@@ -106,16 +94,6 @@ void *riscv_dispatch_irq(uintptr_t vector, uintptr_t *regs)
 
       putreg32(irq - RISCV_IRQ_MEXT, FE310_PLIC_CLAIM);
     }
-#endif
-
-  /* If a context switch occurred while processing the interrupt then
-   * CURRENT_REGS may have change value.  If we return any value different
-   * from the input regs, then the lower level will know that a context
-   * switch occurred during interrupt processing.
-   */
-
-  regs = (uintptr_t *)CURRENT_REGS;
-  CURRENT_REGS = NULL;
 
   return regs;
 }

--- a/arch/risc-v/src/k210/Make.defs
+++ b/arch/risc-v/src/k210/Make.defs
@@ -33,7 +33,7 @@ CMN_CSRCS += riscv_interruptcontext.c riscv_modifyreg32.c riscv_puts.c
 CMN_CSRCS += riscv_releasepending.c riscv_reprioritizertr.c
 CMN_CSRCS += riscv_releasestack.c riscv_stackframe.c riscv_schedulesigaction.c
 CMN_CSRCS += riscv_sigdeliver.c riscv_unblocktask.c riscv_usestack.c
-CMN_CSRCS += riscv_mdelay.c riscv_idle.c
+CMN_CSRCS += riscv_mdelay.c riscv_idle.c riscv_doirq.c
 CMN_CSRCS += riscv_tcbinfo.c riscv_cpuidlestack.c riscv_getnewintctx.c
 
 ifeq ($(CONFIG_SMP), y)

--- a/arch/risc-v/src/k210/k210_irq_dispatch.c
+++ b/arch/risc-v/src/k210/k210_irq_dispatch.c
@@ -83,25 +83,13 @@ void *riscv_dispatch_irq(uintptr_t vector, uintptr_t *regs)
 
   riscv_ack_irq(irq);
 
-#ifdef CONFIG_SUPPRESS_INTERRUPTS
-  PANIC();
-#else
-  /* Current regs non-zero indicates that we are processing an interrupt;
-   * CURRENT_REGS is also used to manage interrupt level context switches.
-   *
-   * Nested interrupts are not supported
-   */
-
-  ASSERT(CURRENT_REGS == NULL);
-  CURRENT_REGS = regs;
-
   /* MEXT means no interrupt */
 
   if (RISCV_IRQ_MEXT != irq)
     {
       /* Deliver the IRQ */
 
-      irq_dispatch(irq, regs);
+      regs = riscv_doirq(irq, regs);
     }
 
   if (RISCV_IRQ_MEXT <= irq)
@@ -110,16 +98,6 @@ void *riscv_dispatch_irq(uintptr_t vector, uintptr_t *regs)
 
       putreg32(irq - RISCV_IRQ_MEXT, K210_PLIC_CLAIM);
     }
-#endif
-
-  /* If a context switch occurred while processing the interrupt then
-   * CURRENT_REGS may have change value.  If we return any value different
-   * from the input regs, then the lower level will know that a context
-   * switch occurred during interrupt processing.
-   */
-
-  regs = (uintptr_t *)CURRENT_REGS;
-  CURRENT_REGS = NULL;
 
   return regs;
 }

--- a/arch/risc-v/src/litex/Make.defs
+++ b/arch/risc-v/src/litex/Make.defs
@@ -26,7 +26,7 @@ HEAD_ASRC = litex_head.S
 CMN_ASRCS += riscv_vectors.S riscv_testset.S riscv_exception_common.S
 
 # Specify C code within the common directory to be included
-CMN_CSRCS += riscv_initialize.c riscv_swint.c
+CMN_CSRCS += riscv_initialize.c riscv_swint.c riscv_doirq.c
 CMN_CSRCS += riscv_allocateheap.c riscv_createstack.c riscv_exit.c
 CMN_CSRCS += riscv_assert.c riscv_blocktask.c riscv_copystate.c riscv_initialstate.c
 CMN_CSRCS += riscv_interruptcontext.c riscv_modifyreg32.c riscv_puts.c riscv_mdelay.c

--- a/arch/risc-v/src/litex/litex_irq_dispatch.c
+++ b/arch/risc-v/src/litex/litex_irq_dispatch.c
@@ -93,32 +93,9 @@ void *riscv_dispatch_irq(uintptr_t vector, uintptr_t *regs)
 
   riscv_ack_irq(irq);
 
-#ifdef CONFIG_SUPPRESS_INTERRUPTS
-  PANIC();
-#else
-  /* Current regs non-zero indicates that we are processing an interrupt;
-   * CURRENT_REGS is also used to manage interrupt level context switches.
-   *
-   * Nested interrupts are not supported
-   */
-
-  DEBUGASSERT(CURRENT_REGS == NULL);
-  CURRENT_REGS = regs;
-
   /* Deliver the IRQ */
 
-  irq_dispatch(irq, regs);
-
-#endif
-
-  /* If a context switch occurred while processing the interrupt then
-   * CURRENT_REGS may have change value.  If we return any value different
-   * from the input regs, then the lower level will know that a context
-   * switch occurred during interrupt processing.
-   */
-
-  regs = (uintptr_t *)CURRENT_REGS;
-  CURRENT_REGS = NULL;
+  regs = riscv_doirq(irq, regs);
 
   return regs;
 }

--- a/arch/risc-v/src/mpfs/Make.defs
+++ b/arch/risc-v/src/mpfs/Make.defs
@@ -32,7 +32,7 @@ CMN_CSRCS += riscv_releasestack.c riscv_stackframe.c riscv_schedulesigaction.c
 CMN_CSRCS += riscv_sigdeliver.c riscv_unblocktask.c riscv_usestack.c
 CMN_CSRCS += riscv_mdelay.c riscv_udelay.c
 CMN_CSRCS += riscv_idle.c riscv_tcbinfo.c riscv_getnewintctx.c
-CMN_CSRCS += riscv_cpuindex.c
+CMN_CSRCS += riscv_cpuindex.c riscv_doirq.c
 
 ifeq ($(CONFIG_SCHED_BACKTRACE),y)
 CMN_CSRCS += riscv_backtrace.c

--- a/arch/risc-v/src/mpfs/mpfs_irq_dispatch.c
+++ b/arch/risc-v/src/mpfs/mpfs_irq_dispatch.c
@@ -53,8 +53,6 @@ void *riscv_dispatch_irq(uintptr_t vector, uintptr_t *regs)
   int irq = (vector & 0x3f);
   uintptr_t *mepc = regs;
 
-  board_autoled_on(LED_INIRQ);
-
   /* Check if fault happened  */
 
   if (vector < RISCV_IRQ_ECALLU ||
@@ -95,25 +93,13 @@ void *riscv_dispatch_irq(uintptr_t vector, uintptr_t *regs)
 
   riscv_ack_irq(irq);
 
-#ifdef CONFIG_SUPPRESS_INTERRUPTS
-  PANIC();
-#else
-  /* Current regs non-zero indicates that we are processing an interrupt;
-   * CURRENT_REGS is also used to manage interrupt level context switches.
-   *
-   * Nested interrupts are not supported
-   */
-
-  ASSERT(CURRENT_REGS == NULL);
-  CURRENT_REGS = regs;
-
   /* MEXT means no interrupt */
 
   if (irq != RISCV_IRQ_MEXT && irq != MPFS_IRQ_INVALID)
     {
       /* Deliver the IRQ */
 
-      irq_dispatch(irq, regs);
+      regs = riscv_doirq(irq, regs);
     }
 
   if (irq > MPFS_IRQ_EXT_START)
@@ -122,38 +108,6 @@ void *riscv_dispatch_irq(uintptr_t vector, uintptr_t *regs)
 
       putreg32(irq - MPFS_IRQ_EXT_START, claim_address);
     }
-
-  /* Check for a context switch.  If a context switch occurred, then
-   * CURRENT_REGS will have a different value than it did on entry.  If an
-   * interrupt level context switch has occurred, then restore the floating
-   * point state and the establish the correct address environment before
-   * returning from the interrupt.
-   */
-
-  if (regs != CURRENT_REGS)
-    {
-#ifdef CONFIG_ARCH_ADDRENV
-      /* Make sure that the address environment for the previously
-       * running task is closed down gracefully (data caches dump,
-       * MMU flushed) and set up the address environment for the new
-       * thread at the head of the ready-to-run list.
-       */
-
-      group_addrenv(NULL);
-#endif
-    }
-#endif
-
-  /* If a context switch occurred while processing the interrupt then
-   * CURRENT_REGS may have change value.  If we return any value different
-   * from the input regs, then the lower level will know that a context
-   * switch occurred during interrupt processing.
-   */
-
-  regs = (uintptr_t *)CURRENT_REGS;
-  CURRENT_REGS = NULL;
-
-  board_autoled_off(LED_INIRQ);
 
   return regs;
 }

--- a/arch/risc-v/src/qemu-rv/Make.defs
+++ b/arch/risc-v/src/qemu-rv/Make.defs
@@ -34,7 +34,7 @@ CMN_CSRCS += riscv_releasepending.c riscv_reprioritizertr.c
 CMN_CSRCS += riscv_releasestack.c riscv_stackframe.c riscv_schedulesigaction.c
 CMN_CSRCS += riscv_sigdeliver.c riscv_unblocktask.c riscv_usestack.c
 CMN_CSRCS += riscv_idle.c riscv_tcbinfo.c riscv_cpuidlestack.c
-CMN_CSRCS += riscv_fault.c riscv_getnewintctx.c
+CMN_CSRCS += riscv_fault.c riscv_getnewintctx.c riscv_doirq.c
 
 ifeq ($(CONFIG_SMP), y)
 CMN_CSRCS += riscv_cpuindex.c riscv_cpupause.c riscv_cpustart.c

--- a/arch/risc-v/src/qemu-rv/qemu_rv_irq_dispatch.c
+++ b/arch/risc-v/src/qemu-rv/qemu_rv_irq_dispatch.c
@@ -82,25 +82,13 @@ void *riscv_dispatch_irq(uintptr_t vector, uintptr_t *regs)
       *mepc += 4;
     }
 
-#ifdef CONFIG_SUPPRESS_INTERRUPTS
-  PANIC();
-#else
-  /* Current regs non-zero indicates that we are processing an interrupt;
-   * CURRENT_REGS is also used to manage interrupt level context switches.
-   *
-   * Nested interrupts are not supported
-   */
-
-  DEBUGASSERT(CURRENT_REGS == NULL);
-  CURRENT_REGS = regs;
-
   /* MEXT means no interrupt */
 
   if (RISCV_IRQ_MEXT != irq)
     {
       /* Deliver the IRQ */
 
-      irq_dispatch(irq, regs);
+      regs = riscv_doirq(irq, regs);
     }
 
   if (RISCV_IRQ_MEXT <= irq)
@@ -109,36 +97,6 @@ void *riscv_dispatch_irq(uintptr_t vector, uintptr_t *regs)
 
       putreg32(irq - RISCV_IRQ_MEXT, QEMU_RV_PLIC_CLAIM);
     }
-#endif
-
-  /* Check for a context switch.  If a context switch occurred, then
-   * CURRENT_REGS will have a different value than it did on entry.  If an
-   * interrupt level context switch has occurred, then restore the floating
-   * point state and the establish the correct address environment before
-   * returning from the interrupt.
-   */
-
-  if (regs != CURRENT_REGS)
-    {
-#ifdef CONFIG_ARCH_ADDRENV
-      /* Make sure that the address environment for the previously
-       * running task is closed down gracefully (data caches dump,
-       * MMU flushed) and set up the address environment for the new
-       * thread at the head of the ready-to-run list.
-       */
-
-      group_addrenv(NULL);
-#endif
-    }
-
-  /* If a context switch occurred while processing the interrupt then
-   * CURRENT_REGS may have change value.  If we return any value different
-   * from the input regs, then the lower level will know that a context
-   * switch occurred during interrupt processing.
-   */
-
-  regs = (uintptr_t *)CURRENT_REGS;
-  CURRENT_REGS = NULL;
 
   return regs;
 }

--- a/arch/risc-v/src/rv32m1/Make.defs
+++ b/arch/risc-v/src/rv32m1/Make.defs
@@ -26,7 +26,7 @@ HEAD_ASRC = rv32m1_head.S
 CMN_ASRCS = riscv_vectors.S
 
 # Specify C code within the common directory to be included
-CMN_CSRCS += riscv_initialize.c riscv_swint.c
+CMN_CSRCS += riscv_initialize.c riscv_swint.c riscv_doirq.c
 CMN_CSRCS += riscv_allocateheap.c riscv_createstack.c riscv_exit.c
 CMN_CSRCS += riscv_assert.c riscv_blocktask.c riscv_copystate.c riscv_initialstate.c
 CMN_CSRCS += riscv_interruptcontext.c riscv_modifyreg32.c riscv_puts.c


### PR DESCRIPTION
## Summary
We can't change the address enviroment before restore context
or switch context since the syscall will trigger a exception,
and we will save the current context in exception_common, but if the
address enviroment changed, the context of old thread would be saved
in wrong place.

## Impact
RISC-V works in kernel mode
## Testing
CI, may MPFS.
