### PR TITLE
sched/note: add support of trace section mark

### DIFF
--- a/include/nuttx/sched_note.h
+++ b/include/nuttx/sched_note.h
@@ -188,13 +188,13 @@ struct note_common_s
 #ifdef CONFIG_SMP
   uint8_t nc_cpu;              /* CPU thread/task running on */
 #endif
-  uint8_t nc_pid[2];           /* ID of the thread/task */
+  uint8_t nc_pid[sizeof(pid_t)]; /* ID of the thread/task */
 
 #ifdef CONFIG_SCHED_INSTRUMENTATION_HIRES
-  uint8_t nc_systime_sec[4];   /* Time when note was buffered (sec) */
-  uint8_t nc_systime_nsec[4];  /* Time when note was buffered (nsec) */
+  uint8_t nc_systime_sec[sizeof(time_t)]; /* Time when note was buffered (sec) */
+  uint8_t nc_systime_nsec[sizeof(long)];  /* Time when note was buffered (nsec) */
 #else
-  uint8_t nc_systime[4];       /* Time when note was buffered */
+  uint8_t nc_systime[sizeof(clock_t)]; /* Time when note was buffered */
 #endif
 };
 

--- a/include/nuttx/sched_note.h
+++ b/include/nuttx/sched_note.h
@@ -124,6 +124,10 @@
           sched_note_printf(SCHED_NOTE_IP, fmt, ##args)
 #  define SCHED_NOTE_BPRINTF(event, fmt, args...) \
           sched_note_bprintf(SCHED_NOTE_IP, event, fmt, ##args)
+#  define SCHED_NOTE_BEGIN() \
+          sched_note_begin(SCHED_NOTE_IP, __FUNCTION__)
+#  define SCHED_NOTE_END() \
+          sched_note_end(SCHED_NOTE_IP, __FUNCTION__)
 #else
 #  define SCHED_NOTE_STRING(buf)
 #  define SCHED_NOTE_DUMP(event, buf, len)
@@ -131,6 +135,8 @@
 #  define SCHED_NOTE_VBPRINTF(event, fmt, va)
 #  define SCHED_NOTE_PRINTF(fmt, args...)
 #  define SCHED_NOTE_BPRINTF(event, fmt, args...)
+#  define SCHED_NOTE_BEGIN()
+#  define SCHED_NOTE_END()
 #endif
 
 /****************************************************************************
@@ -538,6 +544,8 @@ void sched_note_printf(uintptr_t ip,
                        FAR const char *fmt, ...) printflike(2, 3);
 void sched_note_bprintf(uintptr_t ip, uint8_t event,
                         FAR const char *fmt, ...) printflike(3, 4);
+void sched_note_begin(uintptr_t ip, FAR const char *buf);
+void sched_note_end(uintptr_t ip, FAR const char *buf);
 #else
 #  define sched_note_string(ip,b)
 #  define sched_note_dump(ip,e,b,l)
@@ -545,6 +553,8 @@ void sched_note_bprintf(uintptr_t ip, uint8_t event,
 #  define sched_note_vbprintf(ip,e,f,v)
 #  define sched_note_printf(ip,f...)
 #  define sched_note_bprintf(ip,e,f...)
+#  define sched_note_begin(ip,f...)
+#  define sched_note_end(ip,f...)
 #endif /* CONFIG_SCHED_INSTRUMENTATION_DUMP */
 
 #if defined(__KERNEL__) || defined(CONFIG_BUILD_FLAT)
@@ -675,6 +685,8 @@ void sched_note_filter_irq(struct note_filter_irq_s *oldf,
 #  define sched_note_vbprintf(ip,e,f,v)
 #  define sched_note_printf(ip,f...)
 #  define sched_note_bprintf(ip,e,f...)
+#  define sched_note_begin(ip,f...)
+#  define sched_note_end(ip,f...)
 
 #endif /* CONFIG_SCHED_INSTRUMENTATION */
 #endif /* __INCLUDE_NUTTX_SCHED_NOTE_H */

--- a/sched/sched/sched_note.c
+++ b/sched/sched/sched_note.c
@@ -1184,6 +1184,16 @@ void sched_note_bprintf(uintptr_t ip, uint8_t event,
   sched_note_vbprintf(ip, event, fmt, va);
   va_end(va);
 }
+
+void sched_note_begin(uintptr_t ip, FAR const char *buf)
+{
+  sched_note_printf(ip, "B|%d|%s", getpid(), buf);
+}
+
+void sched_note_end(uintptr_t ip, FAR const char *buf)
+{
+  sched_note_printf(ip, "E|%d|%s", getpid(), buf);
+}
 #endif /* CONFIG_SCHED_INSTRUMENTATION_DUMP */
 
 #ifdef CONFIG_SCHED_INSTRUMENTATION_FILTER

--- a/sched/sched/sched_note.c
+++ b/sched/sched/sched_note.c
@@ -108,6 +108,40 @@ static unsigned int g_note_disabled_irq_nest[CONFIG_SMP_NCPUS];
  ****************************************************************************/
 
 /****************************************************************************
+ * Name: sched_note_flatten
+ *
+ * Description:
+ *   Copy the data in the little endian layout
+ *
+ ****************************************************************************/
+
+static inline void sched_note_flatten(FAR uint8_t *dst,
+                                      FAR void *src, size_t len)
+{
+  switch (len)
+    {
+#ifdef CONFIG_HAVE_LONG_LONG
+      case 8:
+        dst[7] = (uint8_t)((*(uint64_t *)src >> 56) & 0xff);
+        dst[6] = (uint8_t)((*(uint64_t *)src >> 48) & 0xff);
+        dst[5] = (uint8_t)((*(uint64_t *)src >> 40) & 0xff);
+        dst[4] = (uint8_t)((*(uint64_t *)src >> 32) & 0xff);
+#endif
+      case 4:
+        dst[3] = (uint8_t)((*(uint32_t *)src >> 24) & 0xff);
+        dst[2] = (uint8_t)((*(uint32_t *)src >> 16) & 0xff);
+      case 2:
+        dst[1] = (uint8_t)((*(uint16_t *)src >> 8) & 0xff);
+      case 1:
+        dst[0] = (uint8_t)(*(uint8_t *)src & 0xff);
+        break;
+      default:
+        DEBUGASSERT(FALSE);
+        break;
+    }
+}
+
+/****************************************************************************
  * Name: note_common
  *
  * Description:
@@ -133,36 +167,26 @@ static void note_common(FAR struct tcb_s *tcb,
 
   clock_systime_timespec(&ts);
 #else
-  uint32_t systime    = (uint32_t)clock_systime_ticks();
+  clock_t systime = clock_systime_ticks();
 #endif
 
   /* Save all of the common fields */
 
-  note->nc_length     = length;
-  note->nc_type       = type;
-  note->nc_priority   = tcb->sched_priority;
+  note->nc_length   = length;
+  note->nc_type     = type;
+  note->nc_priority = tcb->sched_priority;
 #ifdef CONFIG_SMP
-  note->nc_cpu        = tcb->cpu;
+  note->nc_cpu      = tcb->cpu;
 #endif
-  note->nc_pid[0]     = (uint8_t)(tcb->pid & 0xff);
-  note->nc_pid[1]     = (uint8_t)((tcb->pid >> 8) & 0xff);
+  sched_note_flatten(note->nc_pid, &tcb->pid, sizeof(tcb->pid));
 
 #ifdef CONFIG_SCHED_INSTRUMENTATION_HIRES
-  note->nc_systime_nsec[0] = (uint8_t)(ts.tv_nsec         & 0xff);
-  note->nc_systime_nsec[1] = (uint8_t)((ts.tv_nsec >> 8)  & 0xff);
-  note->nc_systime_nsec[2] = (uint8_t)((ts.tv_nsec >> 16) & 0xff);
-  note->nc_systime_nsec[3] = (uint8_t)((ts.tv_nsec >> 24) & 0xff);
-  note->nc_systime_sec[0] = (uint8_t)(ts.tv_sec         & 0xff);
-  note->nc_systime_sec[1] = (uint8_t)((ts.tv_sec >> 8)  & 0xff);
-  note->nc_systime_sec[2] = (uint8_t)((ts.tv_sec >> 16) & 0xff);
-  note->nc_systime_sec[3] = (uint8_t)((ts.tv_sec >> 24) & 0xff);
+  sched_note_flatten(note->nc_systime_nsec, &ts.tv_nsec, sizeof(ts.tv_nsec));
+  sched_note_flatten(note->nc_systime_sec, &ts.tv_sec, sizeof(ts.tv_sec));
 #else
   /* Save the LS 32-bits of the system timer in little endian order */
 
-  note->nc_systime[0] = (uint8_t)(systime         & 0xff);
-  note->nc_systime[1] = (uint8_t)((systime >> 8)  & 0xff);
-  note->nc_systime[2] = (uint8_t)((systime >> 16) & 0xff);
-  note->nc_systime[3] = (uint8_t)((systime >> 24) & 0xff);
+  sched_note_flatten(note->nc_systime, &systime, sizeof(systime));
 #endif
 }
 
@@ -419,20 +443,8 @@ static void note_spincommon(FAR struct tcb_s *tcb,
 
   note_common(tcb, &note.nsp_cmn, sizeof(struct note_spinlock_s), type);
 
-  note.nsp_spinlock[0] = (uint8_t)((uintptr_t)spinlock & 0xff);
-  note.nsp_spinlock[1] = (uint8_t)(((uintptr_t)spinlock >> 8)  & 0xff);
-#if UINTPTR_MAX > UINT16_MAX
-  note.nsp_spinlock[2] = (uint8_t)(((uintptr_t)spinlock >> 16) & 0xff);
-  note.nsp_spinlock[3] = (uint8_t)(((uintptr_t)spinlock >> 24) & 0xff);
-#if UINTPTR_MAX > UINT32_MAX
-  note.nsp_spinlock[4] = (uint8_t)(((uintptr_t)spinlock >> 32) & 0xff);
-  note.nsp_spinlock[5] = (uint8_t)(((uintptr_t)spinlock >> 40) & 0xff);
-  note.nsp_spinlock[6] = (uint8_t)(((uintptr_t)spinlock >> 48) & 0xff);
-  note.nsp_spinlock[7] = (uint8_t)(((uintptr_t)spinlock >> 56) & 0xff);
-#endif
-#endif
-
-  note.nsp_value    = (uint8_t)*spinlock;
+  sched_note_flatten(note.nsp_spinlock, &spinlock, sizeof(spilock));
+  note.nsp_value = (uint8_t)*spinlock;
 
   /* Add the note to circular buffer */
 
@@ -691,8 +703,8 @@ void sched_note_premption(FAR struct tcb_s *tcb, bool locked)
 
   note_common(tcb, &note.npr_cmn, sizeof(struct note_preempt_s),
               locked ? NOTE_PREEMPT_LOCK : NOTE_PREEMPT_UNLOCK);
-  note.npr_count[0] = (uint8_t)(tcb->lockcount & 0xff);
-  note.npr_count[1] = (uint8_t)((tcb->lockcount >> 8) & 0xff);
+  sched_note_flatten(note.npr_count,
+                     &tcb->lockcount, sizeof(tcb->lockcount));
 
   /* Add the note to circular buffer */
 
@@ -715,8 +727,7 @@ void sched_note_csection(FAR struct tcb_s *tcb, bool enter)
   note_common(tcb, &note.ncs_cmn, sizeof(struct note_csection_s),
               enter ? NOTE_CSECTION_ENTER : NOTE_CSECTION_LEAVE);
 #ifdef CONFIG_SMP
-  note.ncs_count[0] = (uint8_t)(tcb->irqcount & 0xff);
-  note.ncs_count[1] = (uint8_t)((tcb->irqcount >> 8) & 0xff);
+  sched_note_flatten(note.ncs_count, &tcb->irqcount, sizeof(tcb->irqcount));
 #endif
 
   /* Add the note to circular buffer */
@@ -789,18 +800,8 @@ void sched_note_syscall_enter(int nr, int argc, ...)
   for (i = 0; i < argc; i++)
     {
       arg = (uintptr_t)va_arg(ap, uintptr_t);
-      *args++ = (uint8_t)(arg & 0xff);
-      *args++ = (uint8_t)((arg >> 8)  & 0xff);
-#if UINTPTR_MAX > UINT16_MAX
-      *args++ = (uint8_t)((arg >> 16) & 0xff);
-      *args++ = (uint8_t)((arg >> 24) & 0xff);
-#if UINTPTR_MAX > UINT32_MAX
-      *args++ = (uint8_t)((arg >> 32) & 0xff);
-      *args++ = (uint8_t)((arg >> 40) & 0xff);
-      *args++ = (uint8_t)((arg >> 48) & 0xff);
-      *args++ = (uint8_t)((arg >> 56) & 0xff);
-#endif
-#endif
+      sched_note_flatten(args, &arg, sizeof(arg));
+      args += sizeof(uintptr_t);
     }
 
   va_end(ap);
@@ -825,20 +826,9 @@ void sched_note_syscall_leave(int nr, uintptr_t result)
   note_common(tcb, &note.nsc_cmn, sizeof(struct note_syscall_leave_s),
               NOTE_SYSCALL_LEAVE);
   DEBUGASSERT(nr <= UCHAR_MAX);
-  note.nsc_nr     = nr;
+  note.nsc_nr = nr;
 
-  note.nsc_result[0] = (uint8_t)(result & 0xff);
-  note.nsc_result[1] = (uint8_t)((result >> 8)  & 0xff);
-#if UINTPTR_MAX > UINT16_MAX
-  note.nsc_result[2] = (uint8_t)((result >> 16) & 0xff);
-  note.nsc_result[3] = (uint8_t)((result >> 24) & 0xff);
-#if UINTPTR_MAX > UINT32_MAX
-  note.nsc_result[4] = (uint8_t)((result >> 32) & 0xff);
-  note.nsc_result[5] = (uint8_t)((result >> 40) & 0xff);
-  note.nsc_result[6] = (uint8_t)((result >> 48) & 0xff);
-  note.nsc_result[7] = (uint8_t)((result >> 56) & 0xff);
-#endif
-#endif
+  sched_note_flatten(note.nsc_result, &result, sizeof(result));
 
   /* Add the note to circular buffer */
 
@@ -929,10 +919,7 @@ void sched_note_dump(uint32_t module, uint8_t event,
   note_common(tcb, &note->nbi_cmn, length,
               NOTE_DUMP_BINARY);
 
-  note->nbi_module[0] = (uint8_t)(module         & 0xff);
-  note->nbi_module[1] = (uint8_t)((module >> 8)  & 0xff);
-  note->nbi_module[2] = (uint8_t)((module >> 16) & 0xff);
-  note->nbi_module[3] = (uint8_t)((module >> 24) & 0xff);
+  sched_note_flatten(note->nbi_module, &module, sizeof(module));
   note->nbi_event = event;
   memcpy(note->nbi_data, buf, length - sizeof(struct note_binary_s) + 1);
 
@@ -1168,10 +1155,7 @@ void sched_note_vbprintf(uint32_t module, uint8_t event,
   note_common(tcb, &note->nbi_cmn, length,
               NOTE_DUMP_BINARY);
 
-  note->nbi_module[0] = (uint8_t)(module         & 0xff);
-  note->nbi_module[1] = (uint8_t)((module >> 8)  & 0xff);
-  note->nbi_module[2] = (uint8_t)((module >> 16) & 0xff);
-  note->nbi_module[3] = (uint8_t)((module >> 24) & 0xff);
+  sched_note_flatten(note->nbi_module, &module, sizeof(module));
   note->nbi_event = event;
 
   /* Add the note to circular buffer */


### PR DESCRIPTION
## Summary

sched/note: add support of trace section mark

The implementation of this feature is based on android systrace:

https://source.android.com/devices/tech/debug/ftrace

Application developers are more concerned about the performance of
the specified application section,
added two APIs to implement performance measurement:

```
void sched_note_begin(FAR const char *str);
void sched_note_end(FAR const char *str);
or
SCHED_NOTE_BEGIN();  /* defined to sched_note_begin(__FUNCTION__) */
SCHED_NOTE_END();    /* defined to sched_note_end(__FUNCTION__) */
```

Signed-off-by: chao.an <anchao@xiaomi.com>

## Impact

Depends on: https://github.com/apache/incubator-nuttx-apps/pull/1114

## Testing

https://source.android.com/devices/tech/debug/ftrace
https://github.com/catapult-project/catapult/


test code:

```
void ccc(void)
{
  SCHED_NOTE_BEGIN();
  usleep(10);
  SCHED_NOTE_END();
}

void bbb(void)
{
  SCHED_NOTE_BEGIN();
  ccc();
  SCHED_NOTE_END();
}

void aaa(void)
{
  SCHED_NOTE_BEGIN();
  bbb();
  SCHED_NOTE_END();
}

int main(int argc, FAR char *argv[])
{
  while (1)
    {
      SCHED_NOTE_BEGIN();
      aaa();
      SCHED_NOTE_END();
    }
  return 0;
}

```

![Screenshot from 2022-03-30 22-34-16](https://user-images.githubusercontent.com/758493/160860334-a5006bbe-c506-4d59-b067-74651a863982.png)


## How To Use

https://nuttx.apache.org/docs/latest/guides/tasktraceuser.html

1. enable sched  instrumentation

```
CONFIG_DRIVER_NOTERAM=y
...
CONFIG_SCHED_INSTRUMENTATION=y
CONFIG_SCHED_INSTRUMENTATION_SWITCH=y
CONFIG_SCHED_INSTRUMENTATION_SYSCALL=y
CONFIG_SCHED_INSTRUMENTATION_IRQHANDLER=y
CONFIG_SCHED_INSTRUMENTATION_DUMP=y
```
2. Capture sched note info

```
nsh> trace switch +
nsh> trace syscall +
nsh> trace print +
nsh> trace start
nsh> trace dump
```

3. convert to systrace

https://source.android.com/devices/tech/debug/ftrace

If you captured your systrace with --no-compress, this is in the html file in the section beginning with BEGIN TRACE.
If not, run html2trace from the [Catapult tree](https://github.com/catapult-project/catapult/tree/master/) (tracing/bin/html2trace) to uncompress the trace.

```
$ git clone git@github.com:catapult-project/catapult.git
$ cd catapult/
$ ./tracing/bin/trace2html trace.txt
trace.html
```
[systrace.txt](https://github.com/apache/incubator-nuttx/files/8381565/systrace.txt)


4. open the trace html via web browser:
`$ google-chrome trace.html`