### PR TITLE
arm/chip: add backtrace support for all chips that support thumb instruction set.

### DIFF
--- a/arch/arm/src/efm32/Make.defs
+++ b/arch/arm/src/efm32/Make.defs
@@ -48,6 +48,10 @@ CMN_CSRCS += arm_signal_dispatch.c
 CMN_UASRCS += arm_signal_handler.S
 endif
 
+ifeq ($(CONFIG_SCHED_BACKTRACE),y)
+CMN_CSRCS += arm_backtrace_thumb.c
+endif
+
 ifeq ($(CONFIG_STACK_COLORATION),y)
 CMN_CSRCS += arm_checkstack.c
 endif

--- a/arch/arm/src/eoss3/Make.defs
+++ b/arch/arm/src/eoss3/Make.defs
@@ -48,6 +48,10 @@ CMN_CSRCS += arm_signal_dispatch.c
 CMN_UASRCS += arm_signal_handler.S
 endif
 
+ifeq ($(CONFIG_SCHED_BACKTRACE),y)
+CMN_CSRCS += arm_backtrace_thumb.c
+endif
+
 ifeq ($(CONFIG_STACK_COLORATION),y)
 CMN_CSRCS += arm_checkstack.c
 endif

--- a/arch/arm/src/imxrt/Make.defs
+++ b/arch/arm/src/imxrt/Make.defs
@@ -33,6 +33,10 @@ CMN_CSRCS += arm_unblocktask.c arm_usestack.c arm_doirq.c arm_hardfault.c
 CMN_CSRCS += arm_svcall.c arm_vfork.c arm_trigger_irq.c arm_systemreset.c
 CMN_CSRCS += arm_switchcontext.c arm_puts.c arm_tcbinfo.c
 
+ifeq ($(CONFIG_SCHED_BACKTRACE),y)
+CMN_CSRCS += arm_backtrace_thumb.c
+endif
+
 ifeq ($(CONFIG_ARMV7M_STACKCHECK),y)
 CMN_CSRCS += arm_stackcheck.c
 endif

--- a/arch/arm/src/kinetis/Make.defs
+++ b/arch/arm/src/kinetis/Make.defs
@@ -31,6 +31,10 @@ CMN_CSRCS += arm_doirq.c arm_hardfault.c arm_svcall.c arm_vfork.c
 CMN_CSRCS += arm_systemreset.c arm_trigger_irq.c arm_switchcontext.c arm_puts.c
 CMN_CSRCS += arm_tcbinfo.c
 
+ifeq ($(CONFIG_SCHED_BACKTRACE),y)
+CMN_CSRCS += arm_backtrace_thumb.c
+endif
+
 ifeq ($(CONFIG_ARMV7M_STACKCHECK),y)
 CMN_CSRCS += arm_stackcheck.c
 endif

--- a/arch/arm/src/kl/Make.defs
+++ b/arch/arm/src/kl/Make.defs
@@ -37,6 +37,10 @@ CMN_CSRCS += arm_signal_dispatch.c
 CMN_UASRCS += arm_signal_handler.S
 endif
 
+ifeq ($(CONFIG_SCHED_BACKTRACE),y)
+CMN_CSRCS += arm_backtrace_thumb.c
+endif
+
 ifeq ($(CONFIG_STACK_COLORATION),y)
 CMN_CSRCS += arm_checkstack.c
 endif

--- a/arch/arm/src/lc823450/Make.defs
+++ b/arch/arm/src/lc823450/Make.defs
@@ -37,6 +37,10 @@ CMN_CSRCS += arm_stackframe.c
 CMN_ASRCS += arm_exception.S
 CMN_CSRCS += arm_vectors.c
 
+ifeq ($(CONFIG_SCHED_BACKTRACE),y)
+CMN_CSRCS += arm_backtrace_thumb.c
+endif
+
 ifeq ($(CONFIG_ARCH_RAMVECTORS),y)
 CMN_CSRCS += arm_ramvec_initialize.c arm_ramvec_attach.c
 endif

--- a/arch/arm/src/lpc17xx_40xx/Make.defs
+++ b/arch/arm/src/lpc17xx_40xx/Make.defs
@@ -33,6 +33,10 @@ CMN_CSRCS += arm_unblocktask.c arm_usestack.c arm_doirq.c arm_hardfault.c
 CMN_CSRCS += arm_svcall.c arm_checkstack.c arm_vfork.c arm_switchcontext.c
 CMN_CSRCS += arm_systemreset.c arm_puts.c arm_tcbinfo.c
 
+ifeq ($(CONFIG_SCHED_BACKTRACE),y)
+CMN_CSRCS += arm_backtrace_thumb.c
+endif
+
 ifeq ($(CONFIG_ARMV7M_STACKCHECK),y)
 CMN_CSRCS += arm_stackcheck.c
 endif

--- a/arch/arm/src/lpc43xx/Make.defs
+++ b/arch/arm/src/lpc43xx/Make.defs
@@ -52,6 +52,10 @@ CMN_CSRCS += arm_signal_dispatch.c
 CMN_UASRCS += arm_signal_handler.S
 endif
 
+ifeq ($(CONFIG_SCHED_BACKTRACE),y)
+CMN_CSRCS += arm_backtrace_thumb.c
+endif
+
 ifeq ($(CONFIG_STACK_COLORATION),y)
 CMN_CSRCS += arm_checkstack.c
 endif

--- a/arch/arm/src/lpc54xx/Make.defs
+++ b/arch/arm/src/lpc54xx/Make.defs
@@ -52,6 +52,10 @@ CMN_CSRCS += arm_signal_dispatch.c
 CMN_UASRCS += arm_signal_handler.S
 endif
 
+ifeq ($(CONFIG_SCHED_BACKTRACE),y)
+CMN_CSRCS += arm_backtrace_thumb.c
+endif
+
 ifeq ($(CONFIG_STACK_COLORATION),y)
 CMN_CSRCS += arm_checkstack.c
 endif

--- a/arch/arm/src/max326xx/Make.defs
+++ b/arch/arm/src/max326xx/Make.defs
@@ -50,6 +50,10 @@ CMN_CSRCS += arm_signal_dispatch.c
 CMN_UASRCS += arm_signal_handler.S
 endif
 
+ifeq ($(CONFIG_SCHED_BACKTRACE),y)
+CMN_CSRCS += arm_backtrace_thumb.c
+endif
+
 ifeq ($(CONFIG_STACK_COLORATION),y)
 CMN_CSRCS += arm_checkstack.c
 endif

--- a/arch/arm/src/nrf52/Make.defs
+++ b/arch/arm/src/nrf52/Make.defs
@@ -56,6 +56,10 @@ CMN_CSRCS += arm_signal_dispatch.c
 CMN_UASRCS += arm_signal_handler.S
 endif
 
+ifeq ($(CONFIG_SCHED_BACKTRACE),y)
+CMN_CSRCS += arm_backtrace_thumb.c
+endif
+
 ifeq ($(CONFIG_STACK_COLORATION),y)
 CMN_CSRCS += arm_checkstack.c
 endif

--- a/arch/arm/src/nuc1xx/Make.defs
+++ b/arch/arm/src/nuc1xx/Make.defs
@@ -37,6 +37,10 @@ CMN_CSRCS += arm_signal_dispatch.c
 CMN_UASRCS += arm_signal_handler.S
 endif
 
+ifeq ($(CONFIG_SCHED_BACKTRACE),y)
+CMN_CSRCS += arm_backtrace_thumb.c
+endif
+
 ifeq ($(CONFIG_STACK_COLORATION),y)
 CMN_CSRCS += arm_checkstack.c
 endif

--- a/arch/arm/src/rp2040/Make.defs
+++ b/arch/arm/src/rp2040/Make.defs
@@ -41,6 +41,10 @@ CMN_CSRCS += arm_signal_dispatch.c
 CMN_UASRCS += arm_signal_handler.S
 endif
 
+ifeq ($(CONFIG_SCHED_BACKTRACE),y)
+CMN_CSRCS += arm_backtrace_thumb.c
+endif
+
 ifeq ($(CONFIG_STACK_COLORATION),y)
 CMN_CSRCS += arm_checkstack.c
 endif

--- a/arch/arm/src/rtl8720c/Make.defs
+++ b/arch/arm/src/rtl8720c/Make.defs
@@ -44,6 +44,10 @@ CMN_CSRCS += arm_schedulesigaction.c arm_sigdeliver.c arm_signal_dispatch.c
 CMN_CSRCS += arm_stackcheck.c arm_svcall.c arm_systick.c arm_unblocktask.c
 CMN_CSRCS += arm_switchcontext.c arm_tcbinfo.c
 
+ifeq ($(CONFIG_SCHED_BACKTRACE),y)
+CMN_CSRCS += arm_backtrace_thumb.c
+endif
+
 # arch/arm/src/rtl8720c
 #
 CHIP_CSRCS += ameba_nvic.c ameba_heap.c ameba_idle.c ameba_uart.c ameba_start.c ameba_vectors.c

--- a/arch/arm/src/s32k1xx/Make.defs
+++ b/arch/arm/src/s32k1xx/Make.defs
@@ -26,6 +26,10 @@ CMN_CSRCS += arm_modifyreg32.c arm_puts.c arm_releasestack.c arm_stackframe.c
 CMN_CSRCS += arm_task_start.c arm_udelay.c arm_usestack.c arm_vfork.c
 CMN_CSRCS += arm_tcbinfo.c
 
+ifeq ($(CONFIG_SCHED_BACKTRACE),y)
+CMN_CSRCS += arm_backtrace_thumb.c
+endif
+
 ifeq ($(CONFIG_STACK_COLORATION),y)
 CMN_CSRCS += arm_checkstack.c
 endif

--- a/arch/arm/src/sam34/Make.defs
+++ b/arch/arm/src/sam34/Make.defs
@@ -68,6 +68,10 @@ ifeq ($(CONFIG_ARCH_FPU),y)
 CMN_ASRCS += arm_fpu.S
 endif
 
+ifeq ($(CONFIG_SCHED_BACKTRACE),y)
+CMN_CSRCS += arm_backtrace_thumb.c
+endif
+
 ifeq ($(CONFIG_STACK_COLORATION),y)
 CMN_CSRCS += arm_checkstack.c
 endif

--- a/arch/arm/src/samd2l2/Make.defs
+++ b/arch/arm/src/samd2l2/Make.defs
@@ -37,6 +37,10 @@ CMN_CSRCS += arm_signal_dispatch.c
 CMN_UASRCS += arm_signal_handler.S
 endif
 
+ifeq ($(CONFIG_SCHED_BACKTRACE),y)
+CMN_CSRCS += arm_backtrace_thumb.c
+endif
+
 ifeq ($(CONFIG_STACK_COLORATION),y)
 CMN_CSRCS += arm_checkstack.c
 endif

--- a/arch/arm/src/samd5e5/Make.defs
+++ b/arch/arm/src/samd5e5/Make.defs
@@ -58,6 +58,10 @@ ifeq ($(CONFIG_ARCH_FPU),y)
 CMN_ASRCS += arm_fpu.S
 endif
 
+ifeq ($(CONFIG_SCHED_BACKTRACE),y)
+CMN_CSRCS += arm_backtrace_thumb.c
+endif
+
 ifeq ($(CONFIG_STACK_COLORATION),y)
 CMN_CSRCS += arm_checkstack.c
 endif

--- a/arch/arm/src/samv7/Make.defs
+++ b/arch/arm/src/samv7/Make.defs
@@ -42,6 +42,10 @@ ifneq ($(CONFIG_ARCH_IDLE_CUSTOM),y)
 CMN_CSRCS += arm_idle.c
 endif
 
+ifeq ($(CONFIG_SCHED_BACKTRACE),y)
+CMN_CSRCS += arm_backtrace_thumb.c
+endif
+
 ifeq ($(CONFIG_ARMV7M_STACKCHECK),y)
 CMN_CSRCS += arm_stackcheck.c
 endif

--- a/arch/arm/src/stm32/Make.defs
+++ b/arch/arm/src/stm32/Make.defs
@@ -35,6 +35,10 @@ ifeq ($(CONFIG_STM32_TICKLESS_SYSTICK),y)
 CMN_CSRCS += arm_systick.c
 endif
 
+ifeq ($(CONFIG_SCHED_BACKTRACE),y)
+CMN_CSRCS += arm_backtrace_thumb.c
+endif
+
 ifeq ($(CONFIG_ARMV7M_STACKCHECK),y)
 CMN_CSRCS += arm_stackcheck.c
 endif

--- a/arch/arm/src/stm32f0l0g0/Make.defs
+++ b/arch/arm/src/stm32f0l0g0/Make.defs
@@ -37,6 +37,10 @@ CMN_CSRCS += arm_signal_dispatch.c
 CMN_UASRCS += arm_signal_handler.S
 endif
 
+ifeq ($(CONFIG_SCHED_BACKTRACE),y)
+CMN_CSRCS += arm_backtrace_thumb.c
+endif
+
 ifeq ($(CONFIG_STACK_COLORATION),y)
 CMN_CSRCS += arm_checkstack.c
 endif

--- a/arch/arm/src/stm32f7/Make.defs
+++ b/arch/arm/src/stm32f7/Make.defs
@@ -36,6 +36,10 @@ CMN_CSRCS += arm_svcall.c arm_systemreset.c arm_trigger_irq.c arm_unblocktask.c
 CMN_CSRCS += arm_udelay.c arm_usestack.c arm_vfork.c arm_switchcontext.c arm_puts.c
 CMN_CSRCS += arm_tcbinfo.c
 
+ifeq ($(CONFIG_SCHED_BACKTRACE),y)
+CMN_CSRCS += arm_backtrace_thumb.c
+endif
+
 ifneq ($(CONFIG_ARCH_IDLE_CUSTOM),y)
 CMN_CSRCS += arm_idle.c
 endif

--- a/arch/arm/src/stm32h7/Make.defs
+++ b/arch/arm/src/stm32h7/Make.defs
@@ -42,6 +42,10 @@ endif
 
 # Configuration-dependent common files
 
+ifeq ($(CONFIG_SCHED_BACKTRACE),y)
+CMN_CSRCS += arm_backtrace_thumb.c
+endif
+
 ifeq ($(CONFIG_ARMV7M_STACKCHECK),y)
 CMN_CSRCS += arm_stackcheck.c
 endif

--- a/arch/arm/src/stm32l4/Make.defs
+++ b/arch/arm/src/stm32l4/Make.defs
@@ -38,6 +38,10 @@ CMN_CSRCS += arm_puts.c arm_tcbinfo.c
 
 # Configuration-dependent common files
 
+ifeq ($(CONFIG_SCHED_BACKTRACE),y)
+CMN_CSRCS += arm_backtrace_thumb.c
+endif
+
 ifeq ($(CONFIG_ARMV7M_STACKCHECK),y)
 CMN_CSRCS += arm_stackcheck.c
 endif

--- a/arch/arm/src/stm32l5/Make.defs
+++ b/arch/arm/src/stm32l5/Make.defs
@@ -43,6 +43,10 @@ CMN_CSRCS += arm_puts.c arm_tcbinfo.c
 
 # Configuration-dependent common files
 
+ifeq ($(CONFIG_SCHED_BACKTRACE),y)
+CMN_CSRCS += arm_backtrace_thumb.c
+endif
+
 ifeq ($(CONFIG_ARMV8M_STACKCHECK),y)
 CMN_CSRCS += arm_stackcheck.c
 endif

--- a/arch/arm/src/stm32u5/Make.defs
+++ b/arch/arm/src/stm32u5/Make.defs
@@ -43,6 +43,10 @@ CMN_CSRCS += arm_vfork.c
 
 # Configuration-dependent common files
 
+ifeq ($(CONFIG_SCHED_BACKTRACE),y)
+CMN_CSRCS += arm_backtrace_thumb.c
+endif
+
 ifeq ($(CONFIG_ARMV8M_STACKCHECK),y)
 CMN_CSRCS += arm_stackcheck.c
 endif

--- a/arch/arm/src/tiva/Make.defs
+++ b/arch/arm/src/tiva/Make.defs
@@ -55,6 +55,10 @@ ifeq ($(CONFIG_ARCH_RAMVECTORS),y)
   CMN_CSRCS += arm_ramvec_initialize.c arm_ramvec_attach.c
 endif
 
+ifeq ($(CONFIG_SCHED_BACKTRACE),y)
+CMN_CSRCS += arm_backtrace_thumb.c
+endif
+
 ifeq ($(CONFIG_STACK_COLORATION),y)
   CMN_CSRCS += arm_checkstack.c
 endif

--- a/arch/arm/src/tms570/Make.defs
+++ b/arch/arm/src/tms570/Make.defs
@@ -75,6 +75,10 @@ ifeq ($(CONFIG_ARCH_FPU),y)
 CMN_ASRCS += arm_savefpu.S arm_restorefpu.S
 endif
 
+ifeq ($(CONFIG_SCHED_BACKTRACE),y)
+CMN_CSRCS += arm_backtrace_thumb.c
+endif
+
 ifeq ($(CONFIG_STACK_COLORATION),y)
 CMN_CSRCS += arm_checkstack.c
 endif

--- a/arch/arm/src/xmc4/Make.defs
+++ b/arch/arm/src/xmc4/Make.defs
@@ -30,6 +30,10 @@ CMN_CSRCS += arm_releasepending.c arm_sigdeliver.c arm_stackframe.c arm_svcall.c
 CMN_CSRCS += arm_systemreset.c arm_udelay.c arm_unblocktask.c arm_usestack.c
 CMN_CSRCS += arm_vfork.c arm_switchcontext.c arm_puts.c arm_tcbinfo.c
 
+ifeq ($(CONFIG_SCHED_BACKTRACE),y)
+CMN_CSRCS += arm_backtrace_thumb.c
+endif
+
 ifeq ($(CONFIG_ARMV7M_STACKCHECK),y)
 CMN_CSRCS += arm_stackcheck.c
 endif


### PR DESCRIPTION
## Summary
add backtrace support for all chips that support thumb instruction set.

## Impact

## Testing
nucleo-144 f746zg board, pass ci
