### PR TITLE
arch/Kconfig: Add IRQ stack dependency to address environments

### DIFF
--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -445,6 +445,7 @@ menuconfig ARCH_ADDRENV
 	bool "Address environments"
 	default n
 	depends on ARCH_HAVE_ADDRENV
+	depends on ARCH_KERNEL_STACK || ARCH_INTERRUPTSTACK != 0
 	---help---
 		Support per-task address environments using the MMU... i.e., support
 		"processes"


### PR DESCRIPTION
When process a is switched to process b, the address environment
is swapped with a call to group_addrenv(). The stack upon entry
will be a's, and upon exit b's. This will fail, so a neutral stack
is required, either a kernel stack or an IRQ stack.

To me IRQ stack == kernel stack, so make the dependency like this.

## Summary
Sanity check
## Impact
None, unless someone uses ARCH_ADDRENV=y without an IRQ stack (which does not work as mentioned above)
## Testing
MPFS/icicle:knsh
