### PR TITLE
ARCH_ADDRENV: Add guard against mis-configuration

### DIFF
--- a/arch/risc-v/src/common/riscv_exception_common.S
+++ b/arch/risc-v/src/common/riscv_exception_common.S
@@ -28,6 +28,25 @@
 #include "riscv_internal.h"
 
 /****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/* Using address environments currently require that a common interrupt stack
+ * is in place. This is needed because during context switch the procedure
+ * that swaps the active address environment is dependent on a stack, which
+ * must be a 'neutral' stack.
+ *
+ * Another option would be to use a per-process kernel stack, but full
+ * support for this is not yet in place, so use the common IRQ stack instead.
+ */
+
+#ifdef CONFIG_ARCH_ADDRENV
+#  if CONFIG_ARCH_INTERRUPTSTACK == 0 && !defined(CONFIG_ARCH_KERNEL_STACK)
+#    error "IRQ or kernel stack is needed for swapping address environments"
+#  endif
+#endif
+
+/****************************************************************************
  * Public Symbols
  ****************************************************************************/
 


### PR DESCRIPTION
When process a is switched to process b, the address environment is
swapped with a call to group_addrenv(). The stack upon entry will be
a's, and upon exit b's. This will fail, so a neutral stack is required,
either a kernel stack or an IRQ stack.

Infrastructure for an IRQ stack is already in place, so give a hint
that an interrupt stack should be provided if address environments
are enabled.

## Summary
Sanity check
## Impact
None, unless someone uses ARCH_ADDRENV=y without an IRQ stack (which does not work as mentioned above)
## Testing
MPFS/icicle:knsh
