### PR TITLE
libc/pthread_create:need check attr is valid

### DIFF
--- a/sched/pthread/pthread_create.c
+++ b/sched/pthread/pthread_create.c
@@ -240,7 +240,14 @@ int nx_pthread_create(pthread_trampoline_t trampoline, FAR pthread_t *thread,
 
   /* If attributes were not supplied, use the default attributes */
 
-  if (!attr)
+  if (attr)
+    {
+      if (!attr->stacksize)
+        {
+          return EINVAL;
+        }
+    }
+  else
     {
       attr = &g_default_pthread_attr;
     }


### PR DESCRIPTION
https: //man7.org/linux/man-pages/man3/pthread_create.3.html
EINVAL Invalid settings in attr.
Signed-off-by: anjiahao <anjiahao@xiaomi.com>

## Summary
pthread_create,if attr is not a null,but setting is invild need return EINVAL 

