### PR TITLE
arch/risc-v: get wider visibility for arch instruction macros

### DIFF
--- a/arch/risc-v/include/arch.h
+++ b/arch/risc-v/include/arch.h
@@ -39,9 +39,37 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
+#ifdef __ASSEMBLY__
+#  define __STR(s)  s
+#else
+#  define __STR(s)  #s
+#endif
+#define __XSTR(s)   __STR(s)
+
+#if defined(CONFIG_ARCH_QPFPU)
+#  define FLOAD     __STR(flq)
+#  define FSTORE    __STR(fsq)
+#elif defined(CONFIG_ARCH_DPFPU)
+#  define FLOAD     __STR(fld)
+#  define FSTORE    __STR(fsd)
+#else
+#  define FLOAD     __STR(flw)
+#  define FSTORE    __STR(fsw)
+#endif
+
+#ifdef CONFIG_ARCH_RV32
+#  define REGLOAD   __STR(lw)
+#  define REGSTORE  __STR(sw)
+#else
+#  define REGLOAD   __STR(ld)
+#  define REGSTORE  __STR(sd)
+#endif
+
 /****************************************************************************
  * Inline functions
  ****************************************************************************/
+
+#ifndef __ASSEMBLY__
 
 /****************************************************************************
  * Name: up_getsp
@@ -57,6 +85,8 @@ static inline uintptr_t up_getsp(void)
   );
   return sp;
 }
+
+#endif
 
 /****************************************************************************
  * Public Types

--- a/arch/risc-v/include/irq.h
+++ b/arch/risc-v/include/irq.h
@@ -35,7 +35,6 @@
 
 #include <arch/types.h>
 
-#include <nuttx/irq.h>
 #include <arch/csr.h>
 #include <arch/chip/irq.h>
 

--- a/arch/risc-v/src/common/riscv_exception_common.S
+++ b/arch/risc-v/src/common/riscv_exception_common.S
@@ -23,9 +23,9 @@
  ****************************************************************************/
 
 #include <nuttx/config.h>
-#include <arch/irq.h>
 
-#include "riscv_internal.h"
+#include <arch/arch.h>
+#include <arch/irq.h>
 
 /****************************************************************************
  * Public Symbols

--- a/arch/risc-v/src/common/riscv_fpu.S
+++ b/arch/risc-v/src/common/riscv_fpu.S
@@ -24,9 +24,8 @@
 
 #include <nuttx/config.h>
 
+#include <arch/arch.h>
 #include <arch/irq.h>
-
-#include "riscv_internal.h"
 
 #ifdef CONFIG_ARCH_FPU
 

--- a/arch/risc-v/src/common/riscv_internal.h
+++ b/arch/risc-v/src/common/riscv_internal.h
@@ -38,32 +38,6 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-#ifdef __ASSEMBLY__
-#  define __STR(s)  s
-#else
-#  define __STR(s)  #s
-#endif
-#define __XSTR(s)   __STR(s)
-
-#if defined(CONFIG_ARCH_QPFPU)
-#  define FLOAD     __STR(flq)
-#  define FSTORE    __STR(fsq)
-#elif defined(CONFIG_ARCH_DPFPU)
-#  define FLOAD     __STR(fld)
-#  define FSTORE    __STR(fsd)
-#else
-#  define FLOAD     __STR(flw)
-#  define FSTORE    __STR(fsw)
-#endif
-
-#ifdef CONFIG_ARCH_RV32
-#  define REGLOAD   __STR(lw)
-#  define REGSTORE  __STR(sw)
-#else
-#  define REGLOAD   __STR(ld)
-#  define REGSTORE  __STR(sd)
-#endif
-
 /* This is the value used to mark the stack for subsequent stack monitoring
  * logic.
  */

--- a/arch/risc-v/src/common/riscv_signal_handler.S
+++ b/arch/risc-v/src/common/riscv_signal_handler.S
@@ -24,6 +24,7 @@
 
 #include <nuttx/config.h>
 
+#include <arch/arch.h>
 #include <arch/syscall.h>
 
 #include "riscv_internal.h"

--- a/arch/risc-v/src/qemu-rv/qemu_rv_head.S
+++ b/arch/risc-v/src/qemu-rv/qemu_rv_head.S
@@ -23,6 +23,8 @@
  ****************************************************************************/
 
 #include <nuttx/config.h>
+
+#include <arch/arch.h>
 #include <arch/irq.h>
 
 #include "chip.h"


### PR DESCRIPTION
## Summary
Get wider visibility for arch instruction macros

## Impact
Should be none

## Testing
Pass Ci