### PR TITLE
sim: Fix initialization of static C++ constructors when using glibc >= 2.34

### DIFF
--- a/arch/sim/src/Makefile
+++ b/arch/sim/src/Makefile
@@ -287,10 +287,13 @@ board/libboard$(LIBEXT):
 # So we have to skip the standard facilities and do the construction by ourself.
 # But how to achieve the goal?
 # 1.Command linker generate the default script(-verbose)
-# 2.Replace __init_array_start/__init_array_end with _sinit/_einit
-# 3.Append __init_array_start = .; __init_array_end = .;
-# Step 2 let nxtask_startup find objects need to construct
-# Step 3 cheat the host there is no object to construct
+# 2.Move input sections out of .init_array/.fini_array into new .sinit/.einit
+#   output sections
+# 3.Replace __init_array_start/__init_array_end with _sinit/_einit
+# 4.Append __init_array_start = .; __init_array_end = .;
+# Step 2 cheat the host there is no object to construct (glibc >= 2.34)
+# Step 3 let nxtask_startup find objects need to construct
+# Step 4 cheat the host there is no object to construct (glibc < 2.34)
 # Note: the destructor can be fixed in the same way.
 
 nuttx-names.dat: nuttx-names.in
@@ -318,8 +321,11 @@ nuttx$(EXEEXT): libarch$(LIBEXT) board/libboard$(LIBEXT) $(HEADOBJ) $(LINKOBJS) 
 ifneq ($(CONFIG_HOST_MACOS),y)
 	$(Q) $(OBJCOPY) --redefine-syms=nuttx-names.dat nuttx.rel
 	$(Q) $(CC) $(CFLAGS) -Wl,-verbose 2>&1 | \
-	     sed -e '/====/,/====/!d;//d' -e 's/__executable_start/_stext/g' -e 's/__init_array_start/_sinit/g' \
-	         -e 's/__init_array_end/_einit/g' -e 's/__fini_array_start/_sfini/g' -e 's/__fini_array_end/_efini/g' >nuttx.ld
+	     sed -e '/====/,/====/!d;//d' -e 's/__executable_start/_stext/g' \
+	         -e 's/^\(\s\+\)\(\.init_array\)/\1\2 : { }\n\1.sinit/g' \
+	         -e 's/^\(\s\+\)\(\.fini_array\)/\1\2 : { }\n\1.einit/g' \
+	         -e 's/__init_array_start/_sinit/g' -e 's/__init_array_end/_einit/g' \
+	         -e 's/__fini_array_start/_sfini/g' -e 's/__fini_array_end/_efini/g' >nuttx.ld
 	$(Q) echo "__init_array_start = .; __init_array_end = .; __fini_array_start = .; __fini_array_end = .;" >>nuttx.ld
 endif
 ifneq ($(CONFIG_ALLSYMS),y)


### PR DESCRIPTION
## Summary
This PR intends to fix issue https://github.com/apache/incubator-nuttx/issues/5916.

**glibc 2.34** changed the dynamic linker behavior during the startup process, which makes the previous "__init_array_start" replacement trick non-effective.
Now the dynamic linker parses the constructors/destructors information from the `DYNAMIC` segment of the program.

### References:
- Patchset on glibc: https://patchwork.ozlabs.org/project/glibc/patch/87lfblmsez.fsf@oldenburg.str.redhat.com/
- Detailed explanation about changes introduced on glibc 2.34: https://stackoverflow.com/a/69837439

## Impact
Fix `libc++` usage in NuttX Simulator.
Closes https://github.com/apache/incubator-nuttx/issues/5916.

## Testing
`sim:libcxxtest`

