### PR TITLE
fs and unistd: increase OPEN_MAX by claiming a Kconfig.

### DIFF
--- a/fs/inode/fs_files.c
+++ b/fs/inode/fs_files.c
@@ -71,7 +71,7 @@ static int files_extend(FAR struct filelist *list, size_t row)
       return 0;
     }
 
-  if (row * CONFIG_NFILE_DESCRIPTORS_PER_BLOCK > _POSIX_OPEN_MAX)
+  if (row * CONFIG_NFILE_DESCRIPTORS_PER_BLOCK > OPEN_MAX)
     {
       return -EMFILE;
     }

--- a/include/limits.h
+++ b/include/limits.h
@@ -203,7 +203,11 @@
 #define NAME_MAX       _POSIX_NAME_MAX
 #define TTY_NAME_MAX   _POSIX_NAME_MAX
 #define NGROUPS_MAX    _POSIX_NGROUPS_MAX
-#define OPEN_MAX       _POSIX_OPEN_MAX
+#if CONFIG_OPEN_MAX < _POSIX_OPEN_MAX
+#  define OPEN_MAX     _POSIX_OPEN_MAX
+#else
+#  define OPEN_MAX     CONFIG_OPEN_MAX
+#endif
 #define PATH_MAX       _POSIX_PATH_MAX
 #define PIPE_BUF       _POSIX_PIPE_BUF
 #define SIZE_MAX       _POSIX_SIZE_MAX

--- a/libs/libc/unistd/Kconfig
+++ b/libs/libc/unistd/Kconfig
@@ -143,3 +143,10 @@ config LIBC_HOSTNAME
 	default ""
 	---help---
 		A unique name to identify device on the network
+
+config OPEN_MAX
+	int "OPEN_MAX for this device"
+	default 255
+	---help---
+		The maximum number of files that a process can have open
+		at any time.  Must not be less than _POSIX_OPEN_MAX.

--- a/libs/libc/unistd/lib_sysconf.c
+++ b/libs/libc/unistd/lib_sysconf.c
@@ -211,7 +211,7 @@ long sysconf(int name)
         return CLOCKS_PER_SEC;
 
       case _SC_OPEN_MAX:
-        return _POSIX_OPEN_MAX;
+        return OPEN_MAX;
 
       case _SC_ATEXIT_MAX:
 #ifdef CONFIG_SCHED_EXIT_MAX


### PR DESCRIPTION
Signed-off-by: 田昕 <tianxin7@xiaomi.com>

## Summary
OPEN_MAX is too smal, we should increase it. 
We can refer to linux(man sysconf, you will see), it is defined as no less than _POSIX_OPEN_MAX.
## Impact
sysconf() and files_extend()
## Testing
Vela tested.
