### PR TITLE
sched/pthread:need check pthread is DETACHED

### DIFF
--- a/sched/pthread/pthread_detach.c
+++ b/sched/pthread/pthread_detach.c
@@ -65,7 +65,7 @@ int pthread_detach(pthread_t thread)
   FAR struct tcb_s *rtcb = this_task();
   FAR struct task_group_s *group = rtcb->group;
   FAR struct join_s *pjoin;
-  int ret;
+  int ret = OK;
 
   sinfo("Thread=%d group=%p\n", thread, group);
   DEBUGASSERT(group);
@@ -96,12 +96,15 @@ int pthread_detach(pthread_t thread)
            * thread exits
            */
 
-          pjoin->detached = true;
+          if (pjoin->detached)
+            {
+              ret = EINVAL;
+            }
+          else
+            {
+              pjoin->detached = true;
+            }
         }
-
-      /* Either case is successful */
-
-      ret = OK;
     }
 
   pthread_sem_give(&group->tg_joinsem);

--- a/sched/pthread/pthread_join.c
+++ b/sched/pthread/pthread_join.c
@@ -138,6 +138,13 @@ int pthread_join(pthread_t thread, FAR pthread_addr_t *pexit_value)
     }
   else
     {
+      if (pjoin->detached)
+        {
+          pthread_sem_give(&group->tg_joinsem);
+          leave_cancellation_point();
+          return EINVAL;
+        }
+
       /* NOTE: sched_lock() is not enough for SMP
        * because another CPU would continue the pthread and exit
        * sequences so need to protect it with a critical section


### PR DESCRIPTION
pthread_join need check thread is DETACHED,
Whether to wait according to the result.And,
if a thread is DETACHED,it will not set a new
attr.
Signed-off-by: anjiahao <anjiahao@xiaomi.com>

## Summary
Change thread behavior
## Impact
maybe will impact thread is DETACHED

