### PR TITLE
SEGGER_RTT: solve compile error when enable segger rtt in armv7m.

### DIFF
--- a/drivers/segger/Make.defs
+++ b/drivers/segger/Make.defs
@@ -30,6 +30,7 @@ ifeq ($(CONFIG_SEGGER_RTT),y)
   CFLAGS += ${shell $(INCDIR) "$(CC)" segger$(DELIM)RTT$(DELIM)RTT}
 
   ifeq ($(CONFIG_ARCH_ARMV7M),y)
+    AFLAGS += ${shell $(INCDIR) "$(CC)" segger$(DELIM)config}
     ASRCS += segger/RTT/RTT/SEGGER_RTT_ASM_ARMv7M.S
   endif
 

--- a/drivers/segger/config/SEGGER_RTT_Conf.h
+++ b/drivers/segger/config/SEGGER_RTT_Conf.h
@@ -27,7 +27,9 @@
 
 #include <nuttx/config.h>
 
-#include <nuttx/spinlock.h>
+#ifndef __ASSEMBLY__
+#  include <nuttx/spinlock.h>
+#endif
 
 /****************************************************************************
  * Pre-processor Definitions


### PR DESCRIPTION
## Summary
1. SEGGER_RTT_ASM_ARMv7M include SEGGER_RTT.h, and SEGGER_RTT.h
include SEGGER_RTT_Conf.h, so add __ASSEMBLY__ in
SEGGER_RTT_Conf.h;
2. AFLAG add segger/config because SEGGER_RTT_ASM_ARMv7M.S
include SEGGER_RTT_Conf.h;

## Testing
Tested with nucleo-144:f746zg
