### PR TITLE
netdev_file_ioctl: Fix fcntl F_SETFL O_NONBLOCK regression

### DIFF
--- a/net/netdev/netdev_ioctl.c
+++ b/net/netdev/netdev_ioctl.c
@@ -1522,7 +1522,7 @@ static int netdev_file_ioctl(FAR struct socket *psock, int cmd,
                    conn->s_flags &= ~_SF_NONBLOCK;
                  }
 
-               ret = OK;
+               ret = -ENOTTY; /* let file_vioctl update f_oflags */
             }
           else
             {


### PR DESCRIPTION
## Summary

This fixes a regression caused by the following commit,
which prevents the file flag from being updated.

```
commit 28860b5242dd5efd86b5da8a089e5d898cd8a9a1
Author: chao.an <anchao@xiaomi.com>
Date:   Sat Mar 19 14:47:37 2022 +0800

    net/netdev: fix switch case missing break

    Signed-off-by: chao.an <anchao@xiaomi.com>
```

Note: some applications like mbedtls uses F_GETFL to confirm
the nonblock-ness of the socket. This is critical for such
applications.

## Impact

## Testing

tested with my app using mbedtls on sim/linux.
