### PR TITLE
fs/romfs: fix string overflow

### DIFF
--- a/fs/romfs/fs_romfs.c
+++ b/fs/romfs/fs_romfs.c
@@ -870,7 +870,8 @@ static int romfs_readdir(FAR struct inode *mountpt,
 
 #ifdef CONFIG_FS_ROMFS_CACHE_NODE
       next = (*dir->u.romfs.fr_currnode)->rn_next;
-      strcpy(dir->fd_dir.d_name, (*dir->u.romfs.fr_currnode)->rn_name);
+      strlcpy(dir->fd_dir.d_name, (*dir->u.romfs.fr_currnode)->rn_name,
+              sizeof(dir->fd_dir.d_name));
       dir->u.romfs.fr_currnode++;
 #else
       /* Parse the directory entry */


### PR DESCRIPTION

## Summary
fs/romfs: fix string overflow when the length of rn_name exceeds NAME_MAX + 1

Signed-off-by: Jiuzhu Dong <dongjiuzhu1@xiaomi.com>
## Impact
N/A
## Testing
local test
