### PR TITLE
fs/epoll: change type of eventset from uint8_t to uint32_t

### DIFF
--- a/arch/arm/src/cxd56xx/cxd56_geofence.c
+++ b/arch/arm/src/cxd56xx/cxd56_geofence.c
@@ -450,7 +450,7 @@ static void cxd56_geofence_sighandler(uint32_t data, FAR void *userdata)
       if (fds)
         {
           fds->revents |= POLLIN;
-          gnssinfo("Report events: %02x\n", fds->revents);
+          gnssinfo("Report events: %08" PRIx32 "\n", fds->revents);
           nxsem_post(fds->sem);
         }
     }

--- a/arch/arm/src/cxd56xx/cxd56_gnss.c
+++ b/arch/arm/src/cxd56xx/cxd56_gnss.c
@@ -2402,7 +2402,7 @@ static void cxd56_gnss_default_sighandler(uint32_t data, FAR void *userdata)
       if (fds)
         {
           fds->revents |= POLLIN;
-          gnssinfo("Report events: %02x\n", fds->revents);
+          gnssinfo("Report events: %08" PRIx32 "\n", fds->revents);
           nxsem_post(fds->sem);
         }
     }

--- a/arch/arm/src/sama5/sam_tsd.c
+++ b/arch/arm/src/sama5/sam_tsd.c
@@ -271,7 +271,7 @@ static void sam_tsd_notify(struct sam_tsd_s *priv)
       if (fds)
         {
           fds->revents |= POLLIN;
-          iinfo("Report events: %02x\n", fds->revents);
+          iinfo("Report events: %08" PRIx32 "\n", fds->revents);
           nxsem_post(fds->sem);
         }
     }

--- a/boards/arm/stm32/mikroe-stm32f4/src/stm32_touchscreen.c
+++ b/boards/arm/stm32/mikroe-stm32f4/src/stm32_touchscreen.c
@@ -601,7 +601,7 @@ static void tc_notify(FAR struct tc_dev_s *priv)
       if (fds)
         {
           fds->revents |= POLLIN;
-          iinfo("Report events: %02x\n", fds->revents);
+          iinfo("Report events: %08" PRIx32 "\n", fds->revents);
           nxsem_post(fds->sem);
         }
     }
@@ -1385,7 +1385,8 @@ static int tc_poll(FAR struct file *filep, FAR struct pollfd *fds,
 
       if ((fds->events & POLLIN) == 0)
         {
-          ierr("ERROR: Missing POLLIN: revents: %08x\n", fds->revents);
+          ierr("ERROR: Missing POLLIN: revents: %08" PRIx32 "\n",
+               fds->revents);
           ret = -EDEADLK;
           goto errout;
         }

--- a/boards/mips/pic32mx/pic32mx7mmb/src/pic32_touchscreen.c
+++ b/boards/mips/pic32mx/pic32mx7mmb/src/pic32_touchscreen.c
@@ -490,7 +490,7 @@ static void tc_notify(FAR struct tc_dev_s *priv)
       if (fds)
         {
           fds->revents |= POLLIN;
-          iinfo("Report events: %02x\n", fds->revents);
+          iinfo("Report events: %08" PRIx32 "\n", fds->revents);
           nxsem_post(fds->sem);
         }
     }
@@ -1262,7 +1262,8 @@ static int tc_poll(FAR struct file *filep, FAR struct pollfd *fds,
 
       if ((fds->events & POLLIN) == 0)
         {
-          ierr("ERROR: Missing POLLIN: revents: %08x\n", fds->revents);
+          ierr("ERROR: Missing POLLIN: revents: %08" PRIx32 "\n",
+               fds->revents);
           ret = -EDEADLK;
           goto errout;
         }

--- a/drivers/analog/comp.c
+++ b/drivers/analog/comp.c
@@ -115,7 +115,7 @@ static void comp_pollnotify(FAR struct comp_dev_s *dev,
 
           if (fds->revents != 0)
             {
-              ainfo("Report events: %02x\n", fds->revents);
+              ainfo("Report events: %08" PRIx32 "\n", fds->revents);
               nxsem_post(fds->sem);
             }
         }

--- a/drivers/can/can.c
+++ b/drivers/can/can.c
@@ -186,7 +186,7 @@ static void can_pollnotify(FAR struct can_dev_s *dev, pollevent_t eventset)
           fds->revents |= fds->events & eventset;
           if (fds->revents != 0)
             {
-              caninfo("Report events: %02x\n", fds->revents);
+              caninfo("Report events: %08" PRIx32 "\n", fds->revents);
               nxsem_post(fds->sem);
             }
         }

--- a/drivers/input/ads7843e.c
+++ b/drivers/input/ads7843e.c
@@ -293,7 +293,7 @@ static void ads7843e_notify(FAR struct ads7843e_dev_s *priv)
       if (fds)
         {
           fds->revents |= POLLIN;
-          iinfo("Report events: %02x\n", fds->revents);
+          iinfo("Report events: %08" PRIx32 "\n", fds->revents);
           nxsem_post(fds->sem);
         }
     }

--- a/drivers/input/ajoystick.c
+++ b/drivers/input/ajoystick.c
@@ -273,7 +273,7 @@ static void ajoy_sample(FAR struct ajoy_upperhalf_s *priv)
                   fds->revents |= (fds->events & POLLIN);
                   if (fds->revents != 0)
                     {
-                      iinfo("Report events: %02x\n", fds->revents);
+                      iinfo("Report events: %08" PRIx32 "\n", fds->revents);
                       nxsem_post(fds->sem);
                     }
                 }
@@ -638,7 +638,7 @@ static int ajoy_poll(FAR struct file *filep, FAR struct pollfd *fds,
                   fds->revents |= (fds->events & POLLIN);
                   if (fds->revents != 0)
                     {
-                      iinfo("Report events: %02x\n", fds->revents);
+                      iinfo("Report events: %08" PRIx32 "\n", fds->revents);
                       nxsem_post(fds->sem);
                     }
                 }

--- a/drivers/input/button_upper.c
+++ b/drivers/input/button_upper.c
@@ -275,7 +275,7 @@ static void btn_sample(FAR struct btn_upperhalf_s *priv)
                   fds->revents |= (fds->events & POLLIN);
                   if (fds->revents != 0)
                     {
-                      iinfo("Report events: %02x\n", fds->revents);
+                      iinfo("Report events: %08" PRIx32 "\n", fds->revents);
                       nxsem_post(fds->sem);
                     }
                 }
@@ -690,7 +690,7 @@ static int btn_poll(FAR struct file *filep, FAR struct pollfd *fds,
                   fds->revents |= (fds->events & POLLIN);
                   if (fds->revents != 0)
                     {
-                      iinfo("Report events: %02x\n", fds->revents);
+                      iinfo("Report events: %08" PRIx32 "\n", fds->revents);
                       nxsem_post(fds->sem);
                     }
                 }

--- a/drivers/input/cypress_mbr3108.c
+++ b/drivers/input/cypress_mbr3108.c
@@ -992,7 +992,7 @@ static void mbr3108_poll_notify(FAR struct mbr3108_dev_s *priv)
       struct pollfd *fds = priv->fds[i];
       if (fds)
         {
-          mbr3108_dbg("Report events: %02x\n", fds->revents);
+          mbr3108_dbg("Report events: %08" PRIx32 "\n", fds->revents);
 
           fds->revents |= POLLIN;
           nxsem_post(fds->sem);

--- a/drivers/input/djoystick.c
+++ b/drivers/input/djoystick.c
@@ -273,7 +273,7 @@ static void djoy_sample(FAR struct djoy_upperhalf_s *priv)
                   fds->revents |= (fds->events & POLLIN);
                   if (fds->revents != 0)
                     {
-                      iinfo("Report events: %02x\n", fds->revents);
+                      iinfo("Report events: %08" PRIx32 "\n", fds->revents);
                       nxsem_post(fds->sem);
                     }
                 }
@@ -632,7 +632,7 @@ static int djoy_poll(FAR struct file *filep, FAR struct pollfd *fds,
                   fds->revents |= (fds->events & POLLIN);
                   if (fds->revents != 0)
                     {
-                      iinfo("Report events: %02x\n", fds->revents);
+                      iinfo("Report events: %08" PRIx32 "\n", fds->revents);
                       nxsem_post(fds->sem);
                     }
                 }

--- a/drivers/input/ft5x06.c
+++ b/drivers/input/ft5x06.c
@@ -215,7 +215,7 @@ static void ft5x06_notify(FAR struct ft5x06_dev_s *priv)
       if (fds)
         {
           fds->revents |= POLLIN;
-          iinfo("Report events: %02x\n", fds->revents);
+          iinfo("Report events: %08" PRIx32 "\n", fds->revents);
           nxsem_post(fds->sem);
         }
     }
@@ -1024,7 +1024,8 @@ static int ft5x06_poll(FAR struct file *filep, FAR struct pollfd *fds,
 
       if ((fds->events & POLLIN) == 0)
         {
-          ierr("ERROR: Missing POLLIN: revents: %08x\n", fds->revents);
+          ierr("ERROR: Missing POLLIN: revents: %08" PRIx32 "\n",
+               fds->revents);
           ret = -EDEADLK;
           goto errout;
         }

--- a/drivers/input/max11802.c
+++ b/drivers/input/max11802.c
@@ -250,7 +250,7 @@ static void max11802_notify(FAR struct max11802_dev_s *priv)
       if (fds)
         {
           fds->revents |= POLLIN;
-          iinfo("Report events: %02x\n", fds->revents);
+          iinfo("Report events: %08" PRIx32 "\n", fds->revents);
           nxsem_post(fds->sem);
         }
     }

--- a/drivers/input/mxt.c
+++ b/drivers/input/mxt.c
@@ -598,7 +598,7 @@ static void mxt_notify(FAR struct mxt_dev_s *priv)
       if (fds)
         {
           fds->revents |= POLLIN;
-          iinfo("Report events: %02x\n", fds->revents);
+          iinfo("Report events: %08" PRIx32 "\n", fds->revents);
           nxsem_post(fds->sem);
         }
     }
@@ -1569,7 +1569,8 @@ static int mxt_poll(FAR struct file *filep, FAR struct pollfd *fds,
 
       if ((fds->events & POLLIN) == 0)
         {
-          ierr("ERROR: Missing POLLIN: revents: %08x\n", fds->revents);
+          ierr("ERROR: Missing POLLIN: revents: %08" PRIx32 "\n",
+               fds->revents);
           ret = -EDEADLK;
           goto errout;
         }

--- a/drivers/input/spq10kbd.c
+++ b/drivers/input/spq10kbd.c
@@ -456,7 +456,7 @@ static void spq10kbd_pollnotify(FAR struct spq10kbd_dev_s *priv)
           fds->revents |= (fds->events & POLLIN);
           if (fds->revents != 0)
             {
-              uinfo("Report events: %02x\n", fds->revents);
+              uinfo("Report events: %08" PRIx32 "\n", fds->revents);
               nxsem_post(fds->sem);
             }
         }

--- a/drivers/input/stmpe811_tsc.c
+++ b/drivers/input/stmpe811_tsc.c
@@ -159,7 +159,7 @@ static void stmpe811_notify(FAR struct stmpe811_dev_s *priv)
       if (fds)
         {
           fds->revents |= POLLIN;
-          iinfo("Report events: %02x\n", fds->revents);
+          iinfo("Report events: %08" PRIx32 "\n", fds->revents);
           nxsem_post(fds->sem);
         }
     }
@@ -634,7 +634,8 @@ static int stmpe811_poll(FAR struct file *filep, FAR struct pollfd *fds,
 
       if ((fds->events & POLLIN) == 0)
         {
-          ierr("ERROR: Missing POLLIN: revents: %08x\n", fds->revents);
+          ierr("ERROR: Missing POLLIN: revents: %08" PRIx32 "\n",
+               fds->revents);
           ret = -EDEADLK;
           goto errout;
         }

--- a/drivers/input/tsc2007.c
+++ b/drivers/input/tsc2007.c
@@ -251,7 +251,7 @@ static void tsc2007_notify(FAR struct tsc2007_dev_s *priv)
       if (fds)
         {
           fds->revents |= POLLIN;
-          iinfo("Report events: %02x\n", fds->revents);
+          iinfo("Report events: %08" PRIx32 "\n", fds->revents);
           nxsem_post(fds->sem);
         }
     }
@@ -1112,7 +1112,8 @@ static int tsc2007_poll(FAR struct file *filep, FAR struct pollfd *fds,
 
       if ((fds->events & POLLIN) == 0)
         {
-          ierr("ERROR: Missing POLLIN: revents: %08x\n", fds->revents);
+          ierr("ERROR: Missing POLLIN: revents: %08" PRIx32 "\n",
+               fds->revents);
           ret = -EDEADLK;
           goto errout;
         }

--- a/drivers/pipes/pipe_common.c
+++ b/drivers/pipes/pipe_common.c
@@ -104,7 +104,7 @@ static void pipecommon_pollnotify(FAR struct pipe_dev_s *dev,
 
           if (fds->revents != 0)
             {
-              finfo("Report events: %02x\n", fds->revents);
+              finfo("Report events: %08" PRIx32 "\n", fds->revents);
               nxsem_post(fds->sem);
             }
         }

--- a/drivers/sensors/hc_sr04.c
+++ b/drivers/sensors/hc_sr04.c
@@ -289,7 +289,7 @@ static void hcsr04_notify(FAR struct hcsr04_dev_s *priv)
       if (fds)
         {
           fds->revents |= POLLIN;
-          hcsr04_dbg("Report events: %02x\n", fds->revents);
+          hcsr04_dbg("Report events: %08" PRIx32 "\n", fds->revents);
           nxsem_post(fds->sem);
         }
     }

--- a/drivers/sensors/hts221.c
+++ b/drivers/sensors/hts221.c
@@ -1072,7 +1072,7 @@ static void hts221_notify(FAR struct hts221_dev_s *priv)
       if (fds)
         {
           fds->revents |= POLLIN;
-          hts221_dbg("Report events: %02x\n", fds->revents);
+          hts221_dbg("Report events: %08" PRIx32 "\n", fds->revents);
           nxsem_post(fds->sem);
         }
     }

--- a/drivers/sensors/lis2dh.c
+++ b/drivers/sensors/lis2dh.c
@@ -754,7 +754,7 @@ static void lis2dh_notify(FAR struct lis2dh_dev_s *priv)
       if (fds)
         {
           fds->revents |= POLLIN;
-          lis2dh_dbg("lis2dh: Report events: %02x\n", fds->revents);
+          lis2dh_dbg("lis2dh: Report events: %08" PRIx32 "\n", fds->revents);
           nxsem_post(fds->sem);
         }
     }

--- a/drivers/sensors/max44009.c
+++ b/drivers/sensors/max44009.c
@@ -770,7 +770,7 @@ static void max44009_notify(FAR struct max44009_dev_s *priv)
       if (fds)
         {
           fds->revents |= POLLIN;
-          max44009_dbg("Report events: %02x\n", fds->revents);
+          max44009_dbg("Report events: %08" PRIx32 "\n", fds->revents);
           nxsem_post(fds->sem);
           priv->int_pending = false;
         }

--- a/drivers/serial/serial.c
+++ b/drivers/serial/serial.c
@@ -187,7 +187,7 @@ static void uart_pollnotify(FAR uart_dev_t *dev, pollevent_t eventset)
             {
               int semcount;
 
-              finfo("Report events: %02x\n", fds->revents);
+              finfo("Report events: %08" PRIx32 "\n", fds->revents);
 
               nxsem_get_value(fds->sem, &semcount);
               if (semcount < 1)

--- a/drivers/usbhost/usbhost_cdcmbim.c
+++ b/drivers/usbhost/usbhost_cdcmbim.c
@@ -418,7 +418,7 @@ static void usbhost_pollnotify(FAR struct usbhost_cdcmbim_s *priv)
           fds->revents |= (fds->events & POLLIN);
           if (fds->revents != 0)
             {
-              uinfo("Report events: %02x\n", fds->revents);
+              uinfo("Report events: %08" PRIx32 "\n", fds->revents);
               nxsem_post(fds->sem);
             }
         }

--- a/drivers/usbhost/usbhost_hidkbd.c
+++ b/drivers/usbhost/usbhost_hidkbd.c
@@ -696,7 +696,7 @@ static void usbhost_pollnotify(FAR struct usbhost_state_s *priv)
           fds->revents |= (fds->events & POLLIN);
           if (fds->revents != 0)
             {
-              uinfo("Report events: %02x\n", fds->revents);
+              uinfo("Report events: %08" PRIx32 "\n", fds->revents);
               nxsem_post(fds->sem);
             }
         }

--- a/drivers/usbhost/usbhost_hidmouse.c
+++ b/drivers/usbhost/usbhost_hidmouse.c
@@ -483,7 +483,7 @@ static void usbhost_pollnotify(FAR struct usbhost_state_s *priv)
           fds->revents |= (fds->events & POLLIN);
           if (fds->revents != 0)
             {
-              uinfo("Report events: %02x\n", fds->revents);
+              uinfo("Report events: %08" PRIx32 "\n", fds->revents);
               nxsem_post(fds->sem);
             }
         }
@@ -700,7 +700,7 @@ static void usbhost_notify(FAR struct usbhost_state_s *priv)
       if (fds)
         {
           fds->revents |= POLLIN;
-          iinfo("Report events: %02x\n", fds->revents);
+          iinfo("Report events: %08" PRIx32 "\n", fds->revents);
           nxsem_post(fds->sem);
         }
     }

--- a/drivers/usbhost/usbhost_xboxcontroller.c
+++ b/drivers/usbhost/usbhost_xboxcontroller.c
@@ -584,7 +584,7 @@ static void usbhost_pollnotify(FAR struct usbhost_state_s *priv)
       if (fds)
         {
           fds->revents |= POLLIN;
-          iinfo("Report events: %02x\n", fds->revents);
+          iinfo("Report events: %08" PRIx32 "\n", fds->revents);
           nxsem_post(fds->sem);
         }
     }

--- a/drivers/usbmisc/fusb301.c
+++ b/drivers/usbmisc/fusb301.c
@@ -755,7 +755,7 @@ static void fusb301_notify(FAR struct fusb301_dev_s *priv)
       if (fds)
         {
           fds->revents |= POLLIN;
-          fusb301_info("Report events: %02x\n", fds->revents);
+          fusb301_info("Report events: %08" PRIx32 "\n", fds->revents);
           nxsem_post(fds->sem);
         }
     }

--- a/drivers/usbmisc/fusb303.c
+++ b/drivers/usbmisc/fusb303.c
@@ -943,7 +943,7 @@ static void fusb303_notify(FAR struct fusb303_dev_s *priv)
       if (fds)
         {
           fds->revents |= POLLIN;
-          fusb303_info("Report events: %02x\n", fds->revents);
+          fusb303_info("Report events: %08" PRIx32 "\n", fds->revents);
           nxsem_post(fds->sem);
         }
     }

--- a/include/sys/poll.h
+++ b/include/sys/poll.h
@@ -91,11 +91,11 @@
 typedef unsigned int nfds_t;
 
 /* In the standard poll() definition, the size of the event set is 'short'.
- * Here we pick the smallest storage element that will contain all of the
- * poll events.
+ * Here we pick the uint32_t type to be consistent with the linux to support
+ * EPOLLRDHUP, EPOLLWAKEUP, EPOLLONESHOT...
  */
 
-typedef uint8_t pollevent_t;
+typedef uint32_t pollevent_t;
 
 /* This is the NuttX variant of the standard pollfd structure.  The poll()
  * interfaces receive a variable length array of such structures.

--- a/net/local/local_netpoll.c
+++ b/net/local/local_netpoll.c
@@ -135,7 +135,7 @@ void local_event_pollnotify(FAR struct local_conn_s *conn,
           fds->revents |= (fds->events & eventset);
           if (fds->revents != 0)
             {
-              ninfo("Report events: %02x\n", fds->revents);
+              ninfo("Report events: %08" PRIx32 "\n", fds->revents);
               nxsem_post(fds->sem);
             }
         }

--- a/net/usrsock/usrsock_dev.c
+++ b/net/usrsock/usrsock_dev.c
@@ -295,7 +295,7 @@ static void usrsockdev_pollnotify(FAR struct usrsockdev_s *dev,
           fds->revents |= (fds->events & eventset);
           if (fds->revents != 0)
             {
-              ninfo("Report events: %02x\n", fds->revents);
+              ninfo("Report events: %08" PRIx32 "\n", fds->revents);
               nxsem_post(fds->sem);
             }
         }


### PR DESCRIPTION

## Summary
fs/epoll: change type of eventset from uint8_t to uint32_t to support EPOLLONESHOT and so on.

Signed-off-by: Jiuzhu Dong <dongjiuzhu1@xiaomi.com>
## Impact
support EPOLLHUP,EPOLLRDHUP,EPOLLONESHOT...
## Testing
local test
