### PR TITLE
net: tcp/udp/icmp/icmpv6 add FIONSPACE support

### DIFF
--- a/net/icmp/Make.defs
+++ b/net/icmp/Make.defs
@@ -27,7 +27,7 @@ NET_CSRCS += icmp_input.c icmp_reply.c
 
 ifeq ($(CONFIG_NET_ICMP_SOCKET),y)
 SOCK_CSRCS += icmp_sockif.c icmp_poll.c icmp_conn.c icmp_sendmsg.c
-SOCK_CSRCS += icmp_recvmsg.c icmp_netpoll.c
+SOCK_CSRCS += icmp_recvmsg.c icmp_netpoll.c icmp_ioctl.c
 endif
 
 # Include ICMP build support

--- a/net/icmp/icmp.h
+++ b/net/icmp/icmp.h
@@ -380,6 +380,25 @@ int icmp_pollteardown(FAR struct socket *psock, FAR struct pollfd *fds);
 
 void icmp_reply(FAR struct net_driver_s *dev, int type, int code);
 
+/****************************************************************************
+ * Name: icmp_ioctl
+ *
+ * Description:
+ *   This function performs icmp specific ioctl() operations.
+ *
+ * Parameters:
+ *   conn     The ICMP connection of interest
+ *   cmd      The ioctl command
+ *   arg      The argument of the ioctl cmd
+ *   arglen   The length of 'arg'
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_NET_ICMP_SOCKET
+int icmp_ioctl(FAR struct socket *psock,
+               int cmd, FAR void *arg, size_t arglen);
+#endif
+
 #undef EXTERN
 #ifdef __cplusplus
 }

--- a/net/icmp/icmp_ioctl.c
+++ b/net/icmp/icmp_ioctl.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * net/udp/udp_ioctl.c
+ * net/icmp/icmp_ioctl.c
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -35,30 +35,30 @@
 #include <nuttx/mm/iob.h>
 #include <nuttx/net/net.h>
 
-#include "udp/udp.h"
+#include "icmp/icmp.h"
 
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
 
 /****************************************************************************
- * Name: udp_ioctl
+ * Name: icmp_ioctl
  *
  * Description:
- *   This function performs udp specific ioctl() operations.
+ *   This function performs icmp specific ioctl() operations.
  *
  * Parameters:
- *   conn     The TCP connection of interest
+ *   conn     The ICMP connection of interest
  *   cmd      The ioctl command
  *   arg      The argument of the ioctl cmd
  *   arglen   The length of 'arg'
  *
  ****************************************************************************/
 
-int udp_ioctl(FAR struct udp_conn_s *conn,
-              int cmd, FAR void *arg, size_t arglen)
+int icmp_ioctl(FAR struct socket *psock,
+               int cmd, FAR void *arg, size_t arglen)
 {
-  FAR struct iob_s *iob;
+  FAR struct icmp_conn_s *conn = psock->s_conn;
   int ret = OK;
 
   net_lock();
@@ -66,10 +66,10 @@ int udp_ioctl(FAR struct udp_conn_s *conn,
   switch (cmd)
     {
       case FIONREAD:
-        iob = iob_peek_queue(&conn->readahead);
-        if (iob)
+        if (iob_peek_queue(&conn->readahead) != NULL)
           {
-            *(FAR int *)((uintptr_t)arg) = iob->io_pktlen;
+            *(FAR int *)((uintptr_t)arg) =
+                          iob_peek_queue(&conn->readahead)->io_pktlen;
           }
         else
           {
@@ -77,17 +77,7 @@ int udp_ioctl(FAR struct udp_conn_s *conn,
           }
         break;
       case FIONSPACE:
-#ifdef CONFIG_NET_UDP_WRITE_BUFFERS
-#  if CONFIG_NET_SEND_BUFSIZE == 0
-        *(FAR int *)((uintptr_t)arg) =
-                                iob_navail(true) * CONFIG_IOB_BUFSIZE;
-#  else
-        *(FAR int *)((uintptr_t)arg) =
-                        conn->sndbufs - udp_wrbuffer_inqueue_size(conn);
-#  endif
-#else
         *(FAR int *)((uintptr_t)arg) = MIN_UDP_MSS;
-#endif
         break;
       default:
         ret = -ENOTTY;

--- a/net/icmp/icmp_sockif.c
+++ b/net/icmp/icmp_sockif.c
@@ -81,7 +81,8 @@ const struct sock_intf_s g_icmp_sockif =
   icmp_netpoll,     /* si_poll */
   icmp_sendmsg,     /* si_sendmsg */
   icmp_recvmsg,     /* si_recvmsg */
-  icmp_close        /* si_close */
+  icmp_close,       /* si_close */
+  icmp_ioctl        /* si_ioctl */
 };
 
 /****************************************************************************

--- a/net/icmpv6/Make.defs
+++ b/net/icmpv6/Make.defs
@@ -28,7 +28,7 @@ NET_CSRCS += icmpv6_linkipaddr.c icmpv6_reply.c
 
 ifeq ($(CONFIG_NET_ICMPv6_SOCKET),y)
 SOCK_CSRCS += icmpv6_sockif.c icmpv6_conn.c icmpv6_sendmsg.c
-SOCK_CSRCS += icmpv6_recvmsg.c icmpv6_netpoll.c
+SOCK_CSRCS += icmpv6_recvmsg.c icmpv6_netpoll.c icmpv6_ioctl.c
 endif
 
 ifeq ($(CONFIG_NET_ICMPv6_NEIGHBOR),y)

--- a/net/icmpv6/icmpv6.h
+++ b/net/icmpv6/icmpv6.h
@@ -746,6 +746,25 @@ void icmpv6_linkipaddr(FAR struct net_driver_s *dev, net_ipv6addr_t ipaddr);
 void icmpv6_reply(FAR struct net_driver_s *dev,
                   int type, int code, int data);
 
+/****************************************************************************
+ * Name: icmpv6_ioctl
+ *
+ * Description:
+ *   This function performs icmp specific ioctl() operations.
+ *
+ * Parameters:
+ *   conn     The ICMP connection of interest
+ *   cmd      The ioctl command
+ *   arg      The argument of the ioctl cmd
+ *   arglen   The length of 'arg'
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_NET_ICMPv6_SOCKET
+int icmpv6_ioctl(FAR struct socket *psock,
+                 int cmd, FAR void *arg, size_t arglen);
+#endif
+
 #undef EXTERN
 #ifdef __cplusplus
 }

--- a/net/icmpv6/icmpv6_sockif.c
+++ b/net/icmpv6/icmpv6_sockif.c
@@ -81,7 +81,8 @@ const struct sock_intf_s g_icmpv6_sockif =
   icmpv6_netpoll,     /* si_poll */
   icmpv6_sendmsg,     /* si_sendmsg */
   icmpv6_recvmsg,     /* si_recvmsg */
-  icmpv6_close        /* si_close */
+  icmpv6_close,       /* si_close */
+  icmpv6_ioctl        /* si_ioctl */
 };
 
 /****************************************************************************

--- a/net/tcp/tcp.h
+++ b/net/tcp/tcp.h
@@ -1618,6 +1618,24 @@ void tcp_wrbuffer_release(FAR struct tcp_wrbuffer_s *wrb);
 #endif /* CONFIG_NET_TCP_WRITE_BUFFERS */
 
 /****************************************************************************
+ * Name: tcp_wrbuffer_inqueue_size
+ *
+ * Description:
+ *   Get the in-queued write buffer size from connection
+ *
+ * Input Parameters:
+ *   conn - The TCP connection of interest
+ *
+ * Assumptions:
+ *   Called from user logic with the network locked.
+ *
+ ****************************************************************************/
+
+#if CONFIG_NET_SEND_BUFSIZE > 0
+uint32_t tcp_wrbuffer_inqueue_size(FAR struct tcp_conn_s *conn);
+#endif
+
+/****************************************************************************
  * Name: tcp_wrbuffer_test
  *
  * Description:

--- a/net/tcp/tcp_ioctl.c
+++ b/net/tcp/tcp_ioctl.c
@@ -74,6 +74,19 @@ int tcp_ioctl(FAR struct tcp_conn_s *conn,
             *(FAR int *)((uintptr_t)arg) = 0;
           }
         break;
+      case FIONSPACE:
+#ifdef CONFIG_NET_TCP_WRITE_BUFFERS
+#  if CONFIG_NET_SEND_BUFSIZE == 0
+        *(FAR int *)((uintptr_t)arg) =
+                                iob_navail(true) * CONFIG_IOB_BUFSIZE;
+#  else
+        *(FAR int *)((uintptr_t)arg) =
+                        conn->snd_bufs - tcp_wrbuffer_inqueue_size(conn);
+#  endif
+#else
+        *(FAR int *)((uintptr_t)arg) = MIN_TCP_MSS;
+#endif
+        break;
       default:
         ret = -ENOTTY;
         break;

--- a/net/tcp/tcp_wrbuffer.c
+++ b/net/tcp/tcp_wrbuffer.c
@@ -250,6 +250,46 @@ void tcp_wrbuffer_release(FAR struct tcp_wrbuffer_s *wrb)
 }
 
 /****************************************************************************
+ * Name: tcp_wrbuffer_inqueue_size
+ *
+ * Description:
+ *   Get the in-queued write buffer size from connection
+ *
+ * Input Parameters:
+ *   conn - The TCP connection of interest
+ *
+ * Assumptions:
+ *   Called from user logic with the network locked.
+ *
+ ****************************************************************************/
+
+#if CONFIG_NET_SEND_BUFSIZE > 0
+uint32_t tcp_wrbuffer_inqueue_size(FAR struct tcp_conn_s *conn)
+{
+  FAR struct tcp_wrbuffer_s *wrb;
+  FAR sq_entry_t *entry;
+  uint32_t total = 0;
+
+  if (conn)
+    {
+      for (entry = sq_peek(&conn->unacked_q); entry; entry = sq_next(entry))
+        {
+          wrb = (FAR struct tcp_wrbuffer_s *)entry;
+          total += TCP_WBPKTLEN(wrb);
+        }
+
+      for (entry = sq_peek(&conn->write_q); entry; entry = sq_next(entry))
+        {
+          wrb = (FAR struct tcp_wrbuffer_s *)entry;
+          total += TCP_WBPKTLEN(wrb);
+        }
+    }
+
+  return total;
+}
+#endif /* CONFIG_NET_SEND_BUFSIZE */
+
+/****************************************************************************
  * Name: tcp_wrbuffer_test
  *
  * Description:

--- a/net/udp/udp.h
+++ b/net/udp/udp.h
@@ -511,6 +511,24 @@ void udp_wrbuffer_release(FAR struct udp_wrbuffer_s *wrb);
 #endif /* CONFIG_NET_UDP_WRITE_BUFFERS */
 
 /****************************************************************************
+ * Name: udp_wrbuffer_inqueue_size
+ *
+ * Description:
+ *   Get the in-queued write buffer size from connection
+ *
+ * Input Parameters:
+ *   conn - The UDP connection of interest
+ *
+ * Assumptions:
+ *   Called from user logic with the network locked.
+ *
+ ****************************************************************************/
+
+#if CONFIG_NET_SEND_BUFSIZE > 0
+uint32_t udp_wrbuffer_inqueue_size(FAR struct udp_conn_s *conn);
+#endif /* CONFIG_NET_SEND_BUFSIZE */
+
+/****************************************************************************
  * Name: udp_wrbuffer_test
  *
  * Description:

--- a/net/udp/udp_sendto_buffered.c
+++ b/net/udp/udp_sendto_buffered.c
@@ -105,40 +105,6 @@ static uint16_t sendto_eventhandler(FAR struct net_driver_s *dev,
  ****************************************************************************/
 
 /****************************************************************************
- * Name: udp_inqueue_wrb_size
- *
- * Description:
- *   Get the in-queued write buffer size from connection
- *
- * Input Parameters:
- *   conn - The UDP connection of interest
- *
- * Assumptions:
- *   Called from user logic with the network locked.
- *
- ****************************************************************************/
-
-#if CONFIG_NET_SEND_BUFSIZE > 0
-static uint32_t udp_inqueue_wrb_size(FAR struct udp_conn_s *conn)
-{
-  FAR struct udp_wrbuffer_s *wrb;
-  FAR sq_entry_t *entry;
-  uint32_t total = 0;
-
-  if (conn)
-    {
-      for (entry = sq_peek(&conn->write_q); entry; entry = sq_next(entry))
-        {
-          wrb = (FAR struct udp_wrbuffer_s *)entry;
-          total += wrb->wb_iob->io_pktlen;
-        }
-    }
-
-  return total;
-}
-#endif /* CONFIG_NET_SEND_BUFSIZE */
-
-/****************************************************************************
  * Name: sendto_writebuffer_release
  *
  * Description:
@@ -676,7 +642,7 @@ ssize_t psock_udp_sendto(FAR struct socket *psock, FAR const void *buf,
        * wait for the write buffer to be released
        */
 
-      while (udp_inqueue_wrb_size(conn) + len > conn->sndbufs)
+      while (udp_wrbuffer_inqueue_size(conn) + len > conn->sndbufs)
         {
           if (nonblock)
             {

--- a/net/udp/udp_wrbuffer.c
+++ b/net/udp/udp_wrbuffer.c
@@ -244,6 +244,40 @@ void udp_wrbuffer_release(FAR struct udp_wrbuffer_s *wrb)
 }
 
 /****************************************************************************
+ * Name: udp_wrbuffer_inqueue_size
+ *
+ * Description:
+ *   Get the in-queued write buffer size from connection
+ *
+ * Input Parameters:
+ *   conn - The UDP connection of interest
+ *
+ * Assumptions:
+ *   Called from user logic with the network locked.
+ *
+ ****************************************************************************/
+
+#if CONFIG_NET_SEND_BUFSIZE > 0
+uint32_t udp_wrbuffer_inqueue_size(FAR struct udp_conn_s *conn)
+{
+  FAR struct udp_wrbuffer_s *wrb;
+  FAR sq_entry_t *entry;
+  uint32_t total = 0;
+
+  if (conn)
+    {
+      for (entry = sq_peek(&conn->write_q); entry; entry = sq_next(entry))
+        {
+          wrb = (FAR struct udp_wrbuffer_s *)entry;
+          total += wrb->wb_iob->io_pktlen;
+        }
+    }
+
+  return total;
+}
+#endif /* CONFIG_NET_SEND_BUFSIZE */
+
+/****************************************************************************
  * Name: udp_wrbuffer_test
  *
  * Description:


### PR DESCRIPTION
Signed-off-by: zhanghongyu <zhanghongyu@xiaomi.com>

## Summary
net: tcp/udp/icmp/icmpv6 add FIONSPACE support
## Impact

## Testing

