### PR TITLE
libc/netdb: Support the recursive lock 

### DIFF
--- a/libs/libc/netdb/lib_dnsaddserver.c
+++ b/libs/libc/netdb/lib_dnsaddserver.c
@@ -81,6 +81,8 @@ int dns_add_nameserver(FAR const struct sockaddr *addr, socklen_t addrlen)
       return ret;
     }
 
+  dns_semtake();
+
 #ifdef CONFIG_NET_IPv4
   /* Check for an IPv4 address */
 
@@ -183,11 +185,17 @@ int dns_add_nameserver(FAR const struct sockaddr *addr, socklen_t addrlen)
       goto errout;
     }
 
-  dns_notify_nameserver(addr, addrlen);
   ret = OK;
 
 errout:
+  dns_semgive();
   fclose(stream);
+
+  if (ret == OK)
+    {
+      dns_notify_nameserver(addr, addrlen);
+    }
+
   return ret;
 }
 

--- a/libs/libc/netdb/lib_dnsforeach.c
+++ b/libs/libc/netdb/lib_dnsforeach.c
@@ -96,6 +96,8 @@ int dns_foreach_nameserver(dns_callback_t callback, FAR void *arg)
       return ret;
     }
 
+  dns_semtake();
+
   keylen = strlen(NETDB_DNS_KEYWORD);
   while (fgets(line, DNS_MAX_LINE, stream) != NULL)
     {
@@ -218,14 +220,14 @@ int dns_foreach_nameserver(dns_callback_t callback, FAR void *arg)
 
           if (ret != OK)
             {
-              fclose(stream);
-              return ret;
+              break;
             }
         }
     }
 
+  dns_semgive();
   fclose(stream);
-  return OK;
+  return ret;
 }
 
 #else /* CONFIG_NETDB_RESOLVCONF */

--- a/libs/libc/netdb/lib_dnsforeach.c
+++ b/libs/libc/netdb/lib_dnsforeach.c
@@ -253,9 +253,7 @@ int dns_foreach_nameserver(dns_callback_t callback, FAR void *arg)
 
           /* Perform the callback */
 
-          dns_semgive();
           ret = callback(arg, addr, sizeof(struct sockaddr_in));
-          dns_semtake();
         }
       else
 #endif
@@ -274,9 +272,7 @@ int dns_foreach_nameserver(dns_callback_t callback, FAR void *arg)
 
           /* Perform the callback */
 
-          dns_semgive();
           ret = callback(arg, addr, sizeof(struct sockaddr_in6));
-          dns_semtake();
         }
       else
 #endif


### PR DESCRIPTION
## Summary

- libc/netdb: Support the recursive lock 
- libc/netdb: Remove the temporary unlock in dns_foreach_nameserver
- libc/netdb: Hold dns lock when operating with resolv.conf 

## Impact
netdb

## Testing
local test
