### PR TITLE
docs/risc-v: Fix ESP32-C3 toolchain download link

### DIFF
--- a/Documentation/platforms/risc-v/esp32c3/index.rst
+++ b/Documentation/platforms/risc-v/esp32c3/index.rst
@@ -27,7 +27,7 @@ ESP32-C3 Toolchain
 ==================
 
 A generic RISC-V toolchain can be used to build ESP32-C3 projects.
-SiFive's toolchain can be downloaded from: https://static.dev.sifive.com/dev-tools/riscv64-unknown-elf-gcc-8.3.0-2019.08.0-x86_64-linux-ubuntu14.tar.gz
+SiFive's toolchain can be downloaded from: https://github.com/sifive/freedom-tools/releases
 
 Second stage bootloader and partition table
 ===========================================


### PR DESCRIPTION
## Summary
Fix ESP32-C3 toolchain download link
## Impact
Only Documentation
## Testing
N/A
