### PR TITLE
timerexpiration:fix DEADCODE when RR_INTERVAL or SCHED_SPORADIC not select

### DIFF
--- a/sched/sched/sched_timerexpiration.c
+++ b/sched/sched/sched_timerexpiration.c
@@ -373,7 +373,9 @@ static inline unsigned int nxsched_process_wdtimer(uint32_t ticks,
 static unsigned int nxsched_timer_process(unsigned int ticks,
                                           bool noswitches)
 {
+#if CONFIG_RR_INTERVAL > 0 || defined(CONFIG_SCHED_SPORADIC)
   unsigned int cmptime = UINT_MAX;
+#endif
   unsigned int rettime = 0;
   unsigned int tmp;
 
@@ -388,7 +390,9 @@ static unsigned int nxsched_timer_process(unsigned int ticks,
   tmp = nxsched_process_wdtimer(ticks, noswitches);
   if (tmp > 0)
     {
+#if CONFIG_RR_INTERVAL > 0 || defined(CONFIG_SCHED_SPORADIC)
       cmptime = tmp;
+#endif
       rettime = tmp;
     }
 
@@ -397,10 +401,13 @@ static unsigned int nxsched_timer_process(unsigned int ticks,
    */
 
   tmp = nxsched_process_scheduler(ticks, noswitches);
+
+#if CONFIG_RR_INTERVAL > 0 || defined(CONFIG_SCHED_SPORADIC)
   if (tmp > 0 && tmp < cmptime)
     {
       rettime = tmp;
     }
+#endif
 
   return rettime;
 }


### PR DESCRIPTION
tmp is always true for CONFIG_RR_INTERVAL > 0
and CONFIG_SCHED_SPORADIC not select

Signed-off-by: zhuyanlin <zhuyanlin1@xiaomi.com>

## Summary

## Impact

## Testing

