### PR TITLE
arch/riscv: Rename SCRATCH_HARTID_OFFSET to RISCV_HARTID_OFFSET

### DIFF
--- a/arch/risc-v/src/common/riscv_percpu.c
+++ b/arch/risc-v/src/common/riscv_percpu.c
@@ -40,6 +40,9 @@
 
 #define HART_CNT    (CONFIG_ARCH_CPU_COUNT)
 
+static_assert(RISCV_PERCPU_HARTID_OFFSET == offsetof(riscv_percpu_s, hartid),
+              "RISCV_PERCPU_HARTID_OFFSET with a wrong value");
+
 /****************************************************************************
  * Private Data
  ****************************************************************************/
@@ -70,7 +73,7 @@ void riscv_percpu_init(void)
 }
 
 /****************************************************************************
- * Name: riscv_percpu_get_addr
+ * Name: riscv_percpu_add_hart
  *
  * Description:
  *   Get add a hart to the per CPU area

--- a/arch/risc-v/src/common/riscv_percpu.h
+++ b/arch/risc-v/src/common/riscv_percpu.h
@@ -38,10 +38,9 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-#ifdef __ASSEMBLY__
-#define SCRATCH_HARTID_OFFSET   (0 * INT_REG_SIZE)
-#else
-#define SCRATCH_HARTID_OFFSET   offsetof(riscv_percpu_s, hartid)
+#define RISCV_PERCPU_HARTID_OFFSET   (0 * INT_REG_SIZE)
+
+#ifndef __ASSEMBLY__
 
 /****************************************************************************
  * Public Types
@@ -74,7 +73,7 @@ struct riscv_percpu_s
 void riscv_percpu_init(void);
 
 /****************************************************************************
- * Name: riscv_percpu_get_addr
+ * Name: riscv_percpu_add_hart
  *
  * Description:
  *   Get add a hart to the per CPU area


### PR DESCRIPTION
## Summary
and fix the typo error

## Impact
Minor

## Testing
Pass CI
