### PR TITLE
boards/nucleo-f446re: support for SystemView

### DIFF
--- a/arch/arm/src/stm32/Make.defs
+++ b/arch/arm/src/stm32/Make.defs
@@ -29,7 +29,7 @@ CMN_CSRCS += arm_releasestack.c arm_reprioritizertr.c arm_schedulesigaction.c
 CMN_CSRCS += arm_sigdeliver.c arm_stackframe.c arm_svcall.c arm_systemreset.c
 CMN_CSRCS += arm_trigger_irq.c arm_unblocktask.c arm_udelay.c arm_usestack.c
 CMN_CSRCS += arm_doirq.c arm_vfork.c arm_switchcontext.c arm_puts.c
-CMN_CSRCS += arm_tcbinfo.c
+CMN_CSRCS += arm_tcbinfo.c arm_perf.c
 
 ifeq ($(CONFIG_STM32_TICKLESS_SYSTICK),y)
 CMN_CSRCS += arm_systick.c

--- a/boards/arm/stm32/nucleo-f446re/src/stm32_boot.c
+++ b/boards/arm/stm32/nucleo-f446re/src/stm32_boot.c
@@ -52,6 +52,10 @@
 
 void stm32_boardinitialize(void)
 {
+#ifdef CONFIG_SEGGER_SYSVIEW
+  up_perf_init((FAR void *)STM32_SYSCLK_FREQUENCY);
+#endif
+
 #ifdef CONFIG_ARCH_LEDS
   /* Configure on-board LEDs if LED support has been selected. */
 


### PR DESCRIPTION
## Summary

- stm32: add support for up_perf
- boards/nucleo-f446re: initialize up_perf

## Impact

## Testing
SystemView and nucleo-f446re
