### PR TITLE
arch/risc-v: use STACK_FRAME_SIZE for in S-mode syscall asm

### DIFF
--- a/arch/risc-v/include/arch.h
+++ b/arch/risc-v/include/arch.h
@@ -65,6 +65,11 @@
 #  define REGSTORE  __STR(sd)
 #endif
 
+/* RISC-V requires a 16-byte stack alignment. */
+
+#define STACK_ALIGNMENT     16
+#define STACK_FRAME_SIZE    __XSTR(STACK_ALIGNMENT)
+
 /****************************************************************************
  * Inline functions
  ****************************************************************************/

--- a/arch/risc-v/include/syscall.h
+++ b/arch/risc-v/include/syscall.h
@@ -126,11 +126,11 @@
 
 #if defined (CONFIG_ARCH_USE_S_MODE) && defined (__KERNEL__)
 #  define ASM_SYS_CALL \
-     " addi sp, sp, -16\n"                  /* Make room */ \
-     REGSTORE " ra, 0(sp)\n"                /* Save ra */ \
-     " jal  ra, riscv_dispatch_syscall\n"   /* Dispatch (modifies ra) */ \
-     REGLOAD " ra, 0(sp)\n"                 /* Restore ra */ \
-     " addi sp, sp, 16\n"                   /* Restore sp */
+     " addi sp, sp, -" STACK_FRAME_SIZE "\n" /* Make room */ \
+     REGSTORE " ra, 0(sp)\n"                 /* Save ra */ \
+     " jal  ra, riscv_dispatch_syscall\n"    /* Dispatch (modifies ra) */ \
+     REGLOAD " ra, 0(sp)\n"                  /* Restore ra */ \
+     " addi sp, sp, " STACK_FRAME_SIZE "\n"  /* Restore sp */
 #else
 #  define ASM_SYS_CALL \
      "ecall"

--- a/arch/risc-v/src/common/riscv_internal.h
+++ b/arch/risc-v/src/common/riscv_internal.h
@@ -33,6 +33,8 @@
 #  include <sys/types.h>
 #  include <stdint.h>
 #  include <syscall.h>
+#else
+#  include <arch/arch.h>
 #endif
 
 /****************************************************************************
@@ -46,11 +48,6 @@
 #define STACK_COLOR    0xdeadbeef
 #define INTSTACK_COLOR 0xdeadbeef
 #define HEAP_COLOR     'h'
-
-/* RISC-V requires a 16-byte stack alignment. */
-
-#define STACK_ALIGNMENT     16
-#define STACK_FRAME_SIZE    __XSTR(STACK_ALIGNMENT)
 
 /* Stack alignment macros */
 


### PR DESCRIPTION
## Summary
Use STACK_FRAME_SIZE for in S-mode syscall inline assembler

## Impact
Should be none

## Testing
Pass CI
