### PR TITLE
modlib_bind.c: Restore "Relocation address out of range" checks

### DIFF
--- a/libs/libc/modlib/modlib_bind.c
+++ b/libs/libc/modlib/modlib_bind.c
@@ -297,8 +297,7 @@ static int modlib_relocate(FAR struct module_s *modp,
 
       /* Calculate the relocation address. */
 
-      if (rel->r_offset ||
-          rel->r_offset + sizeof(uint32_t) > dstsec->sh_size)
+      if (rel->r_offset + sizeof(uint32_t) > dstsec->sh_size)
         {
           berr("ERROR: Section %d reloc %d: "
                "Relocation address out of range, "
@@ -485,8 +484,7 @@ static int modlib_relocateadd(FAR struct module_s *modp,
 
       /* Calculate the relocation address. */
 
-      if (rela->r_offset ||
-          rela->r_offset + sizeof(uint32_t) > dstsec->sh_size)
+      if (rela->r_offset + sizeof(uint32_t) > dstsec->sh_size)
         {
           berr("ERROR: Section %d reloc %d: "
                "Relocation address out of range, "


### PR DESCRIPTION
Restore the checks which got completely broken by the following change.
```
commit 15142a8b106bee8db6ac744b963969feba5c8289
Author: anjiahao <anjiahao@xiaomi.com>
Date:   Fri Apr 1 16:20:03 2022 +0800

    modlib/modlib_bind:fix unsigned_compare with zero

    Signed-off-by: anjiahao <anjiahao@xiaomi.com>
```

## Summary

## Impact

## Testing
tested with my app using dlopen etc on sim/linux
