### PR TITLE
nuttx: unify FAR attribute usage across the code

### DIFF
--- a/arch/arm/src/efm32/efm32_usbhost.c
+++ b/arch/arm/src/efm32/efm32_usbhost.c
@@ -341,8 +341,8 @@ static int efm32_ctrlep_alloc(FAR struct efm32_usbhost_s *priv,
                               FAR const struct usbhost_epdesc_s *epdesc,
                               FAR usbhost_ep_t *ep);
 static int efm32_xfrep_alloc(FAR struct efm32_usbhost_s *priv,
-                              FAR const struct usbhost_epdesc_s *epdesc,
-                              FAR usbhost_ep_t *ep);
+                             FAR const struct usbhost_epdesc_s *epdesc,
+                             FAR usbhost_ep_t *ep);
 
 /* Control/data transfer logic **********************************************/
 
@@ -434,7 +434,7 @@ static int efm32_ep0configure(FAR struct usbhost_driver_s *drvr,
                               usbhost_ep_t ep0, uint8_t funcaddr,
                               uint8_t speed, uint16_t maxpacketsize);
 static int efm32_epalloc(FAR struct usbhost_driver_s *drvr,
-                         FAR const FAR struct usbhost_epdesc_s *epdesc,
+                         FAR const struct usbhost_epdesc_s *epdesc,
                          FAR usbhost_ep_t *ep);
 static int efm32_epfree(FAR struct usbhost_driver_s *drvr, usbhost_ep_t ep);
 static int efm32_alloc(FAR struct usbhost_driver_s *drvr,
@@ -1444,8 +1444,8 @@ static int efm32_ctrlep_alloc(FAR struct efm32_usbhost_s *priv,
  ****************************************************************************/
 
 static int efm32_xfrep_alloc(FAR struct efm32_usbhost_s *priv,
-                              FAR const struct usbhost_epdesc_s *epdesc,
-                              FAR usbhost_ep_t *ep)
+                             FAR const struct usbhost_epdesc_s *epdesc,
+                             FAR usbhost_ep_t *ep)
 {
   struct usbhost_hubport_s *hport;
   FAR struct efm32_chan_s *chan;

--- a/arch/arm/src/imxrt/imxrt_ehci.c
+++ b/arch/arm/src/imxrt/imxrt_ehci.c
@@ -515,41 +515,46 @@ static int imxrt_ehci_interrupt(int irq, FAR void *context, FAR void *arg);
 /* USB Host Controller Operations *******************************************/
 
 static int imxrt_wait(FAR struct usbhost_connection_s *conn,
-         FAR struct usbhost_hubport_s **hport);
+                      FAR struct usbhost_hubport_s **hport);
 static int imxrt_rh_enumerate(FAR struct usbhost_connection_s *conn,
-         FAR struct usbhost_hubport_s *hport);
+                              FAR struct usbhost_hubport_s *hport);
 static int imxrt_enumerate(FAR struct usbhost_connection_s *conn,
-         FAR struct usbhost_hubport_s *hport);
+                           FAR struct usbhost_hubport_s *hport);
 
 static int imxrt_ep0configure(FAR struct usbhost_driver_s *drvr,
-         usbhost_ep_t ep0, uint8_t funcaddr, uint8_t speed,
-         uint16_t maxpacketsize);
+                              usbhost_ep_t ep0, uint8_t funcaddr,
+                              uint8_t speed, uint16_t maxpacketsize);
 static int imxrt_epalloc(FAR struct usbhost_driver_s *drvr,
-         const FAR struct usbhost_epdesc_s *epdesc, usbhost_ep_t *ep);
+                         FAR const struct usbhost_epdesc_s *epdesc,
+                         FAR usbhost_ep_t *ep);
 static int imxrt_epfree(FAR struct usbhost_driver_s *drvr, usbhost_ep_t ep);
 static int imxrt_alloc(FAR struct usbhost_driver_s *drvr,
-         FAR uint8_t **buffer, FAR size_t *maxlen);
+                       FAR uint8_t **buffer, FAR size_t *maxlen);
 static int imxrt_free(FAR struct usbhost_driver_s *drvr,
-         FAR uint8_t *buffer);
+                      FAR uint8_t *buffer);
 static int imxrt_ioalloc(FAR struct usbhost_driver_s *drvr,
-         FAR uint8_t **buffer, size_t buflen);
+                         FAR uint8_t **buffer, size_t buflen);
 static int imxrt_iofree(FAR struct usbhost_driver_s *drvr,
-         FAR uint8_t *buffer);
+                        FAR uint8_t *buffer);
 static int imxrt_ctrlin(FAR struct usbhost_driver_s *drvr, usbhost_ep_t ep0,
-         FAR const struct usb_ctrlreq_s *req, FAR uint8_t *buffer);
+                        FAR const struct usb_ctrlreq_s *req,
+                        FAR uint8_t *buffer);
 static int imxrt_ctrlout(FAR struct usbhost_driver_s *drvr, usbhost_ep_t ep0,
-         FAR const struct usb_ctrlreq_s *req, FAR const uint8_t *buffer);
+                         FAR const struct usb_ctrlreq_s *req,
+                         FAR const uint8_t *buffer);
 static ssize_t imxrt_transfer(FAR struct usbhost_driver_s *drvr,
-         usbhost_ep_t ep, FAR uint8_t *buffer, size_t buflen);
+                              usbhost_ep_t ep, FAR uint8_t *buffer,
+                              size_t buflen);
 #ifdef CONFIG_USBHOST_ASYNCH
 static int imxrt_asynch(FAR struct usbhost_driver_s *drvr, usbhost_ep_t ep,
-         FAR uint8_t *buffer, size_t buflen, usbhost_asynch_t callback,
-         FAR void *arg);
+                        FAR uint8_t *buffer, size_t buflen,
+                        usbhost_asynch_t callback, FAR void *arg);
 #endif
 static int imxrt_cancel(FAR struct usbhost_driver_s *drvr, usbhost_ep_t ep);
 #ifdef CONFIG_USBHOST_HUB
 static int imxrt_connect(FAR struct usbhost_driver_s *drvr,
-         FAR struct usbhost_hubport_s *hport, bool connected);
+                         FAR struct usbhost_hubport_s *hport,
+                         bool connected);
 #endif
 static void imxrt_disconnect(FAR struct usbhost_driver_s *drvr,
                              FAR struct usbhost_hubport_s *hport);
@@ -3968,8 +3973,8 @@ static int imxrt_ep0configure(FAR struct usbhost_driver_s *drvr,
  ****************************************************************************/
 
 static int imxrt_epalloc(FAR struct usbhost_driver_s *drvr,
-                         const FAR struct usbhost_epdesc_s *epdesc,
-                         usbhost_ep_t *ep)
+                         FAR const struct usbhost_epdesc_s *epdesc,
+                         FAR usbhost_ep_t *ep)
 {
   struct imxrt_epinfo_s *epinfo;
   struct usbhost_hubport_s *hport;

--- a/arch/arm/src/kinetis/kinetis_usbhshost.c
+++ b/arch/arm/src/kinetis/kinetis_usbhshost.c
@@ -533,27 +533,27 @@ static int kinetis_ehci_interrupt(int irq,
 /* USB Host Controller Operations *******************************************/
 
 static int kinetis_wait(FAR struct usbhost_connection_s *conn,
-         FAR struct usbhost_hubport_s **hport);
+                        FAR struct usbhost_hubport_s **hport);
 static int kinetis_rh_enumerate(FAR struct usbhost_connection_s *conn,
-         FAR struct usbhost_hubport_s *hport);
+                                FAR struct usbhost_hubport_s *hport);
 static int kinetis_enumerate(FAR struct usbhost_connection_s *conn,
-         FAR struct usbhost_hubport_s *hport);
-
+                             FAR struct usbhost_hubport_s *hport);
 static int kinetis_ep0configure(FAR struct usbhost_driver_s *drvr,
-         usbhost_ep_t ep0, uint8_t funcaddr, uint8_t speed,
-         uint16_t maxpacketsize);
+                                usbhost_ep_t ep0, uint8_t funcaddr,
+                                uint8_t speed, uint16_t maxpacketsize);
 static int kinetis_epalloc(FAR struct usbhost_driver_s *drvr,
-         const FAR struct usbhost_epdesc_s *epdesc, usbhost_ep_t *ep);
+                           FAR const struct usbhost_epdesc_s *epdesc,
+                           FAR usbhost_ep_t *ep);
 static int kinetis_epfree(FAR struct usbhost_driver_s *drvr,
                           usbhost_ep_t ep);
 static int kinetis_alloc(FAR struct usbhost_driver_s *drvr,
-         FAR uint8_t **buffer, FAR size_t *maxlen);
+                         FAR uint8_t **buffer, FAR size_t *maxlen);
 static int kinetis_free(FAR struct usbhost_driver_s *drvr,
-         FAR uint8_t *buffer);
+                        FAR uint8_t *buffer);
 static int kinetis_ioalloc(FAR struct usbhost_driver_s *drvr,
-         FAR uint8_t **buffer, size_t buflen);
+                           FAR uint8_t **buffer, size_t buflen);
 static int kinetis_iofree(FAR struct usbhost_driver_s *drvr,
-         FAR uint8_t *buffer);
+                          FAR uint8_t *buffer);
 static int kinetis_ctrlin(FAR struct usbhost_driver_s *drvr,
                           usbhost_ep_t ep0,
                           FAR const struct usb_ctrlreq_s *req,
@@ -563,23 +563,22 @@ static int kinetis_ctrlout(FAR struct usbhost_driver_s *drvr,
                            FAR const struct usb_ctrlreq_s *req,
                            FAR const uint8_t *buffer);
 static ssize_t kinetis_transfer(FAR struct usbhost_driver_s *drvr,
-         usbhost_ep_t ep, FAR uint8_t *buffer, size_t buflen);
+                                usbhost_ep_t ep, FAR uint8_t *buffer,
+                                size_t buflen);
 #ifdef CONFIG_USBHOST_ASYNCH
-static int kinetis_asynch(FAR struct usbhost_driver_s *drvr,
-                          usbhost_ep_t ep,
-                          FAR uint8_t *buffer,
-                          size_t buflen,
-                          usbhost_asynch_t callback,
-                          FAR void *arg);
+static int kinetis_asynch(FAR struct usbhost_driver_s *drvr, usbhost_ep_t ep,
+                          FAR uint8_t *buffer, size_t buflen,
+                          usbhost_asynch_t callback, FAR void *arg);
 #endif
 static int kinetis_cancel(FAR struct usbhost_driver_s *drvr,
                           usbhost_ep_t ep);
 #ifdef CONFIG_USBHOST_HUB
 static int kinetis_connect(FAR struct usbhost_driver_s *drvr,
-         FAR struct usbhost_hubport_s *hport, bool connected);
+                           FAR struct usbhost_hubport_s *hport,
+                           bool connected);
 #endif
 static void kinetis_disconnect(FAR struct usbhost_driver_s *drvr,
-                             FAR struct usbhost_hubport_s *hport);
+                               FAR struct usbhost_hubport_s *hport);
 
 /* Initialization ***********************************************************/
 
@@ -4043,8 +4042,8 @@ static int kinetis_ep0configure(FAR struct usbhost_driver_s *drvr,
  ****************************************************************************/
 
 static int kinetis_epalloc(FAR struct usbhost_driver_s *drvr,
-                         const FAR struct usbhost_epdesc_s *epdesc,
-                         usbhost_ep_t *ep)
+                           FAR const struct usbhost_epdesc_s *epdesc,
+                           FAR usbhost_ep_t *ep)
 {
   struct kinetis_epinfo_s *epinfo;
   struct usbhost_hubport_s *hport;

--- a/arch/arm/src/lpc31xx/lpc31_ehci.c
+++ b/arch/arm/src/lpc31xx/lpc31_ehci.c
@@ -528,7 +528,8 @@ static int lpc31_ep0configure(FAR struct usbhost_driver_s *drvr,
          usbhost_ep_t ep0, uint8_t funcaddr, uint8_t speed,
          uint16_t maxpacketsize);
 static int lpc31_epalloc(FAR struct usbhost_driver_s *drvr,
-         const FAR struct usbhost_epdesc_s *epdesc, usbhost_ep_t *ep);
+                         FAR const struct usbhost_epdesc_s *epdesc,
+                         FAR usbhost_ep_t *ep);
 static int lpc31_epfree(FAR struct usbhost_driver_s *drvr, usbhost_ep_t ep);
 static int lpc31_alloc(FAR struct usbhost_driver_s *drvr,
          FAR uint8_t **buffer, FAR size_t *maxlen);
@@ -3992,8 +3993,8 @@ static int lpc31_ep0configure(FAR struct usbhost_driver_s *drvr,
  ****************************************************************************/
 
 static int lpc31_epalloc(FAR struct usbhost_driver_s *drvr,
-                         const FAR struct usbhost_epdesc_s *epdesc,
-                         usbhost_ep_t *ep)
+                         FAR const struct usbhost_epdesc_s *epdesc,
+                         FAR usbhost_ep_t *ep)
 {
   struct lpc31_epinfo_s *epinfo;
   struct usbhost_hubport_s *hport;

--- a/arch/arm/src/lpc43xx/lpc43_ehci.c
+++ b/arch/arm/src/lpc43xx/lpc43_ehci.c
@@ -517,7 +517,8 @@ static int lpc43_ep0configure(FAR struct usbhost_driver_s *drvr,
          usbhost_ep_t ep0, uint8_t funcaddr, uint8_t speed,
          uint16_t maxpacketsize);
 static int lpc43_epalloc(FAR struct usbhost_driver_s *drvr,
-         const FAR struct usbhost_epdesc_s *epdesc, usbhost_ep_t *ep);
+                         FAR const struct usbhost_epdesc_s *epdesc,
+                         FAR usbhost_ep_t *ep);
 static int lpc43_epfree(FAR struct usbhost_driver_s *drvr, usbhost_ep_t ep);
 static int lpc43_alloc(FAR struct usbhost_driver_s *drvr,
          FAR uint8_t **buffer, FAR size_t *maxlen);
@@ -3829,8 +3830,8 @@ static int lpc43_ep0configure(FAR struct usbhost_driver_s *drvr,
  ****************************************************************************/
 
 static int lpc43_epalloc(FAR struct usbhost_driver_s *drvr,
-                         const FAR struct usbhost_epdesc_s *epdesc,
-                         usbhost_ep_t *ep)
+                         FAR const struct usbhost_epdesc_s *epdesc,
+                         FAR usbhost_ep_t *ep)
 {
   struct lpc43_epinfo_s *epinfo;
   struct usbhost_hubport_s *hport;

--- a/arch/arm/src/sama5/sam_ehci.c
+++ b/arch/arm/src/sama5/sam_ehci.c
@@ -398,7 +398,8 @@ static int sam_ep0configure(FAR struct usbhost_driver_s *drvr,
          usbhost_ep_t ep0, uint8_t funcaddr, uint8_t speed,
          uint16_t maxpacketsize);
 static int sam_epalloc(FAR struct usbhost_driver_s *drvr,
-         const FAR struct usbhost_epdesc_s *epdesc, usbhost_ep_t *ep);
+                       FAR const struct usbhost_epdesc_s *epdesc,
+                       FAR usbhost_ep_t *ep);
 static int sam_epfree(FAR struct usbhost_driver_s *drvr, usbhost_ep_t ep);
 static int sam_alloc(FAR struct usbhost_driver_s *drvr,
          FAR uint8_t **buffer, FAR size_t *maxlen);
@@ -3751,8 +3752,8 @@ static int sam_ep0configure(FAR struct usbhost_driver_s *drvr,
  ****************************************************************************/
 
 static int sam_epalloc(FAR struct usbhost_driver_s *drvr,
-                       const FAR struct usbhost_epdesc_s *epdesc,
-                       usbhost_ep_t *ep)
+                       FAR const struct usbhost_epdesc_s *epdesc,
+                       FAR usbhost_ep_t *ep)
 {
   struct sam_epinfo_s *epinfo;
   struct usbhost_hubport_s *hport;

--- a/arch/arm/src/samd5e5/sam_usb.c
+++ b/arch/arm/src/samd5e5/sam_usb.c
@@ -957,7 +957,7 @@ static int sam_ep0configure(FAR struct usbhost_driver_s *drvr,
                             uint8_t speed,
                             uint16_t maxpacketsize);
 static int sam_epalloc(FAR struct usbhost_driver_s *drvr,
-                       FAR const FAR struct usbhost_epdesc_s *epdesc,
+                       FAR const struct usbhost_epdesc_s *epdesc,
                        FAR usbhost_ep_t *ep);
 static int sam_epfree(FAR struct usbhost_driver_s *drvr, usbhost_ep_t ep);
 static int sam_alloc(FAR struct usbhost_driver_s *drvr,

--- a/arch/arm/src/stm32/stm32_otgfshost.c
+++ b/arch/arm/src/stm32/stm32_otgfshost.c
@@ -425,7 +425,7 @@ static int stm32_ep0configure(FAR struct usbhost_driver_s *drvr,
                               usbhost_ep_t ep0, uint8_t funcaddr,
                               uint8_t speed, uint16_t maxpacketsize);
 static int stm32_epalloc(FAR struct usbhost_driver_s *drvr,
-                         FAR const FAR struct usbhost_epdesc_s *epdesc,
+                         FAR const struct usbhost_epdesc_s *epdesc,
                          FAR usbhost_ep_t *ep);
 static int stm32_epfree(FAR struct usbhost_driver_s *drvr, usbhost_ep_t ep);
 static int stm32_alloc(FAR struct usbhost_driver_s *drvr,

--- a/arch/arm/src/stm32/stm32_otghshost.c
+++ b/arch/arm/src/stm32/stm32_otghshost.c
@@ -430,7 +430,7 @@ static int stm32_ep0configure(FAR struct usbhost_driver_s *drvr,
                               usbhost_ep_t ep0, uint8_t funcaddr,
                               uint8_t speed, uint16_t maxpacketsize);
 static int stm32_epalloc(FAR struct usbhost_driver_s *drvr,
-                         FAR const FAR struct usbhost_epdesc_s *epdesc,
+                         FAR const struct usbhost_epdesc_s *epdesc,
                          FAR usbhost_ep_t *ep);
 static int stm32_epfree(FAR struct usbhost_driver_s *drvr, usbhost_ep_t ep);
 static int stm32_alloc(FAR struct usbhost_driver_s *drvr,

--- a/arch/arm/src/stm32f7/stm32_otghost.c
+++ b/arch/arm/src/stm32f7/stm32_otghost.c
@@ -423,7 +423,7 @@ static int stm32_ep0configure(FAR struct usbhost_driver_s *drvr,
                               usbhost_ep_t ep0, uint8_t funcaddr,
                               uint8_t speed, uint16_t maxpacketsize);
 static int stm32_epalloc(FAR struct usbhost_driver_s *drvr,
-                         FAR const FAR struct usbhost_epdesc_s *epdesc,
+                         FAR const struct usbhost_epdesc_s *epdesc,
                          FAR usbhost_ep_t *ep);
 static int stm32_epfree(FAR struct usbhost_driver_s *drvr, usbhost_ep_t ep);
 static int stm32_alloc(FAR struct usbhost_driver_s *drvr,

--- a/arch/arm/src/stm32h7/stm32_otghost.c
+++ b/arch/arm/src/stm32h7/stm32_otghost.c
@@ -426,7 +426,7 @@ static int stm32_ep0configure(FAR struct usbhost_driver_s *drvr,
                               usbhost_ep_t ep0, uint8_t funcaddr,
                               uint8_t speed, uint16_t maxpacketsize);
 static int stm32_epalloc(FAR struct usbhost_driver_s *drvr,
-                         FAR const FAR struct usbhost_epdesc_s *epdesc,
+                         FAR const struct usbhost_epdesc_s *epdesc,
                          FAR usbhost_ep_t *ep);
 static int stm32_epfree(FAR struct usbhost_driver_s *drvr, usbhost_ep_t ep);
 static int stm32_alloc(FAR struct usbhost_driver_s *drvr,

--- a/arch/arm/src/stm32l4/stm32l4_otgfshost.c
+++ b/arch/arm/src/stm32l4/stm32l4_otgfshost.c
@@ -429,7 +429,7 @@ static int stm32l4_ep0configure(FAR struct usbhost_driver_s *drvr,
                                 usbhost_ep_t ep0, uint8_t funcaddr,
                                 uint8_t speed, uint16_t maxpacketsize);
 static int stm32l4_epalloc(FAR struct usbhost_driver_s *drvr,
-                           FAR const FAR struct usbhost_epdesc_s *epdesc,
+                           FAR const struct usbhost_epdesc_s *epdesc,
                            FAR usbhost_ep_t *ep);
 static int stm32l4_epfree(FAR struct usbhost_driver_s *drvr,
                           usbhost_ep_t ep);

--- a/drivers/audio/cs43l22.h
+++ b/drivers/audio/cs43l22.h
@@ -321,7 +321,7 @@ struct cs43l22_dev_s
 
   /* Our specific driver data goes here */
 
-  const FAR struct cs43l22_lower_s *lower;  /* Pointer to the board lower functions */
+  FAR const struct cs43l22_lower_s *lower;  /* Pointer to the board lower functions */
   FAR struct i2c_master_s *i2c;             /* I2C driver to use */
   FAR struct i2s_dev_s   *i2s;              /* I2S driver to use */
   struct dq_queue_s       pendq;            /* Queue of pending buffers to be sent */

--- a/drivers/audio/cxd56.h
+++ b/drivers/audio/cxd56.h
@@ -263,7 +263,7 @@ struct cxd56_dev_s
 
   /* Our specific driver data goes here */
 
-  const FAR struct cxd56_lower_s *lower;    /* Pointer to the board lower functions */
+  FAR const struct cxd56_lower_s *lower;    /* Pointer to the board lower functions */
   enum cxd56_devstate_e   state;            /* Driver state */
   enum cxd56_dmahandle_e  dma_handle;       /* DMA handle */
   struct file             mq;               /* Message queue for receiving messages */

--- a/drivers/audio/vs1053.c
+++ b/drivers/audio/vs1053.c
@@ -97,7 +97,7 @@ struct vs1053_struct_s
 
   /* Our specific driver data goes here */
 
-  const FAR struct vs1053_lower_s *hw_lower; /* Pointer to the hardware lower functions */
+  FAR const struct vs1053_lower_s *hw_lower; /* Pointer to the hardware lower functions */
   FAR struct spi_dev_s    *spi;              /* Pointer to the SPI bus */
   FAR struct ap_buffer_s  *apb;              /* Pointer to the buffer we are processing */
   struct dq_queue_s       apbq;              /* Our queue for enqueued buffers */

--- a/drivers/audio/wm8776.h
+++ b/drivers/audio/wm8776.h
@@ -76,7 +76,7 @@ struct wm8776_dev_s
 
   struct audio_lowerhalf_s dev;             /* WM8776 audio lower half (this device) */
 
-  const FAR struct wm8776_lower_s *lower;   /* Pointer to the board lower functions */
+  FAR const struct wm8776_lower_s *lower;   /* Pointer to the board lower functions */
   FAR struct i2c_master_s *i2c;             /* I2C driver to use */
   FAR struct i2s_dev_s   *i2s;              /* I2S driver to use */
   struct dq_queue_s       pendq;            /* Queue of pending buffers to be sent */

--- a/drivers/audio/wm8904.h
+++ b/drivers/audio/wm8904.h
@@ -1082,7 +1082,7 @@ struct wm8904_dev_s
 
   /* Our specific driver data goes here */
 
-  const FAR struct wm8904_lower_s *lower;   /* Pointer to the board lower functions */
+  FAR const struct wm8904_lower_s *lower;   /* Pointer to the board lower functions */
   FAR struct i2c_master_s *i2c;             /* I2C driver to use */
   FAR struct i2s_dev_s   *i2s;              /* I2S driver to use */
   struct dq_queue_s       pendq;            /* Queue of pending buffers to be sent */

--- a/drivers/audio/wm8994.h
+++ b/drivers/audio/wm8994.h
@@ -1568,7 +1568,7 @@ struct wm8994_dev_s
 
   /* Our specific driver data goes here */
 
-  const FAR struct wm8994_lower_s *lower;   /* Pointer to the board lower functions */
+  FAR const struct wm8994_lower_s *lower;   /* Pointer to the board lower functions */
   FAR struct i2c_master_s *i2c;             /* I2C driver to use */
   FAR struct i2s_dev_s   *i2s;              /* I2S driver to use */
   struct dq_queue_s       pendq;            /* Queue of pending buffers to be sent */

--- a/drivers/lcd/lcd_dev.c
+++ b/drivers/lcd/lcd_dev.c
@@ -132,8 +132,8 @@ static int lcddev_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
       break;
     case LCDDEVIO_PUTRUN:
       {
-        const FAR struct lcddev_run_s *lcd_run =
-            (const FAR struct lcddev_run_s *)arg;
+        FAR const struct lcddev_run_s *lcd_run =
+            (FAR const struct lcddev_run_s *)arg;
 
         ret = priv->planeinfo.putrun(lcd_run->row, lcd_run->col,
                                      lcd_run->data, lcd_run->npixels);
@@ -176,8 +176,8 @@ static int lcddev_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
       break;
     case LCDDEVIO_PUTAREA:
       {
-        const FAR struct lcddev_area_s *lcd_area =
-            (const FAR struct lcddev_area_s *)arg;
+        FAR const struct lcddev_area_s *lcd_area =
+            (FAR const struct lcddev_area_s *)arg;
 
         if (priv->planeinfo.putarea)
           {

--- a/drivers/power/regulator.c
+++ b/drivers/power/regulator.c
@@ -724,9 +724,9 @@ int regulator_get_voltage(FAR struct regulator_s *regulator)
  ****************************************************************************/
 
 FAR struct regulator_dev_s *
-regulator_register(const FAR struct regulator_desc_s *regulator_desc,
-                   const struct regulator_ops_s *regulator_ops,
-                   void *priv)
+regulator_register(FAR const struct regulator_desc_s *regulator_desc,
+                   FAR const struct regulator_ops_s *regulator_ops,
+                   FAR void *priv)
 {
   FAR struct regulator_dev_s *rdev;
 

--- a/drivers/timers/arch_timer.c
+++ b/drivers/timers/arch_timer.c
@@ -77,7 +77,7 @@ static inline void timespec_from_usec(FAR struct timespec *ts,
 }
 
 #ifdef CONFIG_SCHED_TICKLESS
-static inline uint64_t timespec_to_usec(const FAR struct timespec *ts)
+static inline uint64_t timespec_to_usec(FAR const struct timespec *ts)
 {
   return (uint64_t)ts->tv_sec * USEC_PER_SEC + ts->tv_nsec / NSEC_PER_USEC;
 }

--- a/drivers/usbdev/pl2303.c
+++ b/drivers/usbdev/pl2303.c
@@ -904,7 +904,7 @@ static int usbclass_mkstrdesc(uint8_t id, FAR struct usb_strdesc_s *strdesc)
 
 #ifdef CONFIG_USBDEV_DUALSPEED
 static inline void usbclass_mkepbulkdesc(
-                             const FAR struct usb_epdesc_s *indesc,
+                             FAR const struct usb_epdesc_s *indesc,
                              uint16_t mxpacket,
                              FAR struct usb_epdesc_s *outdesc)
 {

--- a/drivers/usbhost/usbhost_max3421e.c
+++ b/drivers/usbhost/usbhost_max3421e.c
@@ -545,7 +545,7 @@ static int  max3421e_ep0configure(FAR struct usbhost_driver_s *drvr,
               usbhost_ep_t ep0, uint8_t funcaddr, uint8_t speed,
               uint16_t maxpacketsize);
 static int  max3421e_epalloc(FAR struct usbhost_driver_s *drvr,
-              FAR const FAR struct usbhost_epdesc_s *epdesc,
+              FAR const struct usbhost_epdesc_s *epdesc,
               FAR usbhost_ep_t *ep);
 static int  max3421e_epfree(FAR struct usbhost_driver_s *drvr,
               usbhost_ep_t ep);

--- a/drivers/video/video.c
+++ b/drivers/video/video.c
@@ -2985,12 +2985,12 @@ int video_uninitialize(void)
   return OK;
 }
 
-void imgsensor_register(const FAR struct imgsensor_ops_s *ops)
+void imgsensor_register(FAR const struct imgsensor_ops_s *ops)
 {
   g_video_sensor_ops = ops;
 }
 
-void imgdata_register(const FAR struct imgdata_ops_s *ops)
+void imgdata_register(FAR const struct imgdata_ops_s *ops)
 {
   g_video_data_ops = ops;
 }

--- a/fs/fat/fs_fat32dirent.c
+++ b/fs/fat/fs_fat32dirent.c
@@ -339,7 +339,7 @@ static inline int fat_parsesfname(FAR const char **path,
   enum fat_case_e extcase  = FATCASE_UNKNOWN;
 #endif
 #endif
-  const FAR char *node = *path;
+  FAR const char *node = *path;
   int endndx;
   uint8_t ch;
   int ndx = 0;

--- a/fs/rpmsgfs/rpmsgfs_client.c
+++ b/fs/rpmsgfs/rpmsgfs_client.c
@@ -871,7 +871,7 @@ int rpmsgfs_client_fchstat(FAR void *handle, int fd,
 }
 
 int rpmsgfs_client_chstat(FAR void *handle, FAR const char *path,
-                          const FAR struct stat *buf, int flags)
+                          FAR const struct stat *buf, int flags)
 {
   FAR struct rpmsgfs_s *priv = handle;
   FAR struct rpmsgfs_chstat_s *msg;

--- a/graphics/nxglib/cursor/nxglib_cursor_backup.c
+++ b/graphics/nxglib/cursor/nxglib_cursor_backup.c
@@ -68,7 +68,7 @@ void NXGL_FUNCNAME(nxglib_cursor_backup, NXGLIB_SUFFIX)
   FAR uint8_t *fbmem;
   FAR const uint8_t *sline;
   FAR uint8_t *dline;
-  FAR const FAR NXGL_PIXEL_T *src;
+  FAR const NXGL_PIXEL_T *src;
   FAR FAR NXGL_PIXEL_T *dest;
   nxgl_coord_t width;
   nxgl_coord_t height;

--- a/include/nuttx/clk/clk.h
+++ b/include/nuttx/clk/clk.h
@@ -74,7 +74,7 @@ int      clk_set_phase(FAR struct clk_s *clk, int degrees);
 int      clk_get_phase(FAR struct clk_s *clk);
 
 void clk_disable_unused(void);
-FAR const char *clk_get_name(const FAR struct clk_s *clk);
+FAR const char *clk_get_name(FAR const struct clk_s *clk);
 
 #undef EXTERN
 #ifdef __cplusplus

--- a/include/nuttx/video/imgdata.h
+++ b/include/nuttx/video/imgdata.h
@@ -98,7 +98,7 @@ extern "C"
 
 /* Register image data operations. */
 
-void imgdata_register(const FAR struct imgdata_ops_s *ops);
+void imgdata_register(FAR const struct imgdata_ops_s *ops);
 
 #undef EXTERN
 #ifdef __cplusplus

--- a/include/nuttx/video/imgsensor.h
+++ b/include/nuttx/video/imgsensor.h
@@ -340,7 +340,7 @@ extern "C"
 
 /* Register image sensor operations. */
 
-void imgsensor_register(const FAR struct imgsensor_ops_s *ops);
+void imgsensor_register(FAR const struct imgsensor_ops_s *ops);
 
 #undef EXTERN
 #ifdef __cplusplus

--- a/libs/libc/netdb/lib_netdb.c
+++ b/libs/libc/netdb/lib_netdb.c
@@ -48,7 +48,7 @@ int h_errno;
  * Public Functions
  ****************************************************************************/
 
-bool convert_hostent(const FAR struct hostent_s *in,
+bool convert_hostent(FAR const struct hostent_s *in,
                      int type, FAR struct hostent *out)
 {
   int i;

--- a/libs/libc/netdb/lib_netdb.h
+++ b/libs/libc/netdb/lib_netdb.h
@@ -105,7 +105,7 @@ EXTERN const struct services_db_s g_services_db[];
  * Public Function Prototypes
  ****************************************************************************/
 
-bool convert_hostent(const FAR struct hostent_s *in,
+bool convert_hostent(FAR const struct hostent_s *in,
                      int type, FAR struct hostent *out);
 
 ssize_t parse_hostfile(FAR FILE *stream, FAR struct hostent_s *host,


### PR DESCRIPTION
## Summary
Unify `FAR` attribute usage across the code

## Impact
Should be none

## Testing
Pass CI