### PR TITLE
openamp: Change the dependence from OPENAMP to RPTUN

### DIFF
--- a/drivers/clk/Kconfig
+++ b/drivers/clk/Kconfig
@@ -10,7 +10,7 @@ if CLK
 config CLK_RPMSG
 	bool "rpmsg clk driver"
 	default n
-	depends on OPENAMP
+	depends on RPTUN
 	---help---
 		Rpmsg clk are proxy/master pairs clock that operate clks between client and
 		server processor.

--- a/drivers/ioexpander/Kconfig
+++ b/drivers/ioexpander/Kconfig
@@ -16,6 +16,7 @@ if IOEXPANDER
 
 config IOEXPANDER_RPMSG
 	bool "IO expander rpmsg server and client"
+	depends on RPTUN
 	default n
 	select IOEXPANDER_INT_ENABLE
 	---help---

--- a/drivers/net/Kconfig
+++ b/drivers/net/Kconfig
@@ -25,7 +25,7 @@ comment "General Ethernet MAC Driver Options"
 
 config NET_RPMSG_DRV
 	bool "RPMSG net driver"
-	depends on NET && OPENAMP
+	depends on RPTUN
 	select ARCH_HAVE_NETDEV_STATISTICS
 	---help---
 		Use the rpmsg as net device, transfer packet between remoteproc.

--- a/drivers/power/Kconfig
+++ b/drivers/power/Kconfig
@@ -337,7 +337,7 @@ config REGULATOR
 
 config REGULATOR_RPMSG
 	bool "Regulator rpmsg driver support"
-	depends on OPENAMP
+	depends on RPTUN
 	default n
 	---help---
 		The rpmsg regulator driver implements the common regulator APIs, inside which

--- a/drivers/serial/Kconfig
+++ b/drivers/serial/Kconfig
@@ -66,7 +66,7 @@ config MCU_SERIAL
 config RPMSG_UART
 	bool "UART rpmsg support"
 	default n
-	depends on OPENAMP
+	depends on RPTUN
 	select ARCH_HAVE_SERIAL_TERMIOS
 	select SERIAL_RXDMA
 	select SERIAL_TXDMA

--- a/drivers/syslog/Kconfig
+++ b/drivers/syslog/Kconfig
@@ -208,7 +208,7 @@ config RAMLOG_SYSLOG
 
 config SYSLOG_RPMSG
 	bool "Log to RPMSG"
-	depends on OPENAMP
+	depends on RPTUN
 	depends on SCHED_WORKQUEUE
 	default n
 	---help---
@@ -292,7 +292,7 @@ endif # SYSLOG_RPMSG
 config SYSLOG_RPMSG_SERVER
 	bool "Enable RPMSG server for SYSLOG"
 	default n
-	depends on OPENAMP
+	depends on RPTUN
 	---help---
 		Use rpmsg to receive message from remote proc.
 

--- a/drivers/timers/Kconfig
+++ b/drivers/timers/Kconfig
@@ -312,12 +312,12 @@ endif # RTC_RX8010SJ
 config RTC_RPMSG
 	bool "Rpmsg RTC Driver"
 	default n
-	depends on OPENAMP
+	depends on RPTUN
 	select ARCH_HAVE_RTC_SUBSECONDS
 
 config RTC_RPMSG_SERVER
 	bool "The RTC Rpmsg Role"
-	depends on OPENAMP
+	depends on RPTUN
 
 config RTC_RPMSG_SERVER_NAME
 	string "The name of RTC Rpmsg Server"

--- a/fs/rpmsgfs/Kconfig
+++ b/fs/rpmsgfs/Kconfig
@@ -6,7 +6,7 @@
 config FS_RPMSGFS
 	bool "RPMSG File System"
 	default n
-	depends on OPENAMP
+	depends on RPTUN
 	---help---
 		Use rpmsg file system to mount remote directories to local.
 		This the method for user to use remote file like own core.

--- a/net/rpmsg/Kconfig
+++ b/net/rpmsg/Kconfig
@@ -8,6 +8,7 @@ menu "Rpmsg Socket Support"
 
 config NET_RPMSG
 	bool "Rpmsg domain (remote) sockets"
+	depends on RPTUN
 	select MM_CIRCBUF
 	default n
 	---help---


### PR DESCRIPTION
## Summary
since all rpmsg driver need the extension api exposed by rptun driver

## Impact
Minor

## Testing
Pass CI
