### PR TITLE
arch/risc-v: Remove the unnecessary inclusion of board header files

### DIFF
--- a/arch/risc-v/src/bl602/bl602_irq.c
+++ b/arch/risc-v/src/bl602/bl602_irq.c
@@ -30,9 +30,7 @@
 #include <debug.h>
 
 #include <nuttx/arch.h>
-#include <nuttx/board.h>
 #include <nuttx/irq.h>
-#include <arch/board/board.h>
 
 #include "riscv_internal.h"
 #include "hardware/bl602_clic.h"

--- a/arch/risc-v/src/bl602/bl602_irq_dispatch.c
+++ b/arch/risc-v/src/bl602/bl602_irq_dispatch.c
@@ -29,8 +29,6 @@
 
 #include <nuttx/irq.h>
 #include <nuttx/arch.h>
-#include <nuttx/board.h>
-#include <arch/board/board.h>
 
 #include "riscv_internal.h"
 #include "chip.h"

--- a/arch/risc-v/src/c906/c906_allocateheap.c
+++ b/arch/risc-v/src/c906/c906_allocateheap.c
@@ -28,8 +28,6 @@
 #include <nuttx/userspace.h>
 
 #include <nuttx/arch.h>
-#include <nuttx/board.h>
-#include <arch/board/board.h>
 
 #include "c906.h"
 

--- a/arch/risc-v/src/c906/c906_irq_dispatch.c
+++ b/arch/risc-v/src/c906/c906_irq_dispatch.c
@@ -29,11 +29,11 @@
 
 #include <nuttx/irq.h>
 #include <nuttx/arch.h>
-#include <nuttx/board.h>
-#include <arch/board/board.h>
 
 #include "riscv_internal.h"
 #include "group/group.h"
+
+#include "c906_memorymap.h"
 
 /****************************************************************************
  * Pre-processor Definitions

--- a/arch/risc-v/src/common/riscv_checkstack.c
+++ b/arch/risc-v/src/common/riscv_checkstack.c
@@ -31,7 +31,6 @@
 #include <debug.h>
 
 #include <nuttx/arch.h>
-#include <nuttx/board.h>
 
 #include "sched/sched.h"
 #include "riscv_internal.h"

--- a/arch/risc-v/src/common/riscv_exception.c
+++ b/arch/risc-v/src/common/riscv_exception.c
@@ -31,8 +31,6 @@
 
 #include <nuttx/irq.h>
 #include <nuttx/arch.h>
-#include <nuttx/board.h>
-#include <nuttx/syslog/syslog.h>
 
 #include "riscv_internal.h"
 

--- a/arch/risc-v/src/esp32c3/esp32c3_irq.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_irq.c
@@ -31,8 +31,6 @@
 
 #include <nuttx/irq.h>
 #include <nuttx/arch.h>
-#include <nuttx/board.h>
-#include <arch/board/board.h>
 
 #include "riscv_internal.h"
 #include "hardware/esp32c3_interrupt.h"

--- a/arch/risc-v/src/esp32c3/esp32c3_resetcause.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_resetcause.c
@@ -27,7 +27,6 @@
 #include <stdint.h>
 
 #include <nuttx/arch.h>
-#include <nuttx/board.h>
 
 #include "hardware/esp32c3_rtccntl.h"
 

--- a/arch/risc-v/src/esp32c3/esp32c3_systemreset.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_systemreset.c
@@ -27,7 +27,6 @@
 #include <stdint.h>
 
 #include <nuttx/arch.h>
-#include <nuttx/board.h>
 
 #include "hardware/esp32c3_rtccntl.h"
 #include "esp32c3.h"

--- a/arch/risc-v/src/esp32c3/esp32c3_uid.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_uid.c
@@ -26,9 +26,6 @@
 
 #include <stdint.h>
 
-#include <nuttx/arch.h>
-#include <nuttx/board.h>
-
 #include "hardware/esp32c3_efuse.h"
 #include "esp32c3.h"
 

--- a/arch/risc-v/src/fe310/fe310_irq_dispatch.c
+++ b/arch/risc-v/src/fe310/fe310_irq_dispatch.c
@@ -29,8 +29,6 @@
 
 #include <nuttx/irq.h>
 #include <nuttx/arch.h>
-#include <nuttx/board.h>
-#include <arch/board/board.h>
 
 #include "riscv_internal.h"
 #include "fe310_gpio.h"

--- a/arch/risc-v/src/k210/k210_irq_dispatch.c
+++ b/arch/risc-v/src/k210/k210_irq_dispatch.c
@@ -29,11 +29,11 @@
 
 #include <nuttx/irq.h>
 #include <nuttx/arch.h>
-#include <nuttx/board.h>
-#include <arch/board/board.h>
 
 #include "riscv_internal.h"
 #include "group/group.h"
+
+#include "k210_memorymap.h"
 
 /****************************************************************************
  * Pre-processor Definitions

--- a/arch/risc-v/src/litex/litex_irq.c
+++ b/arch/risc-v/src/litex/litex_irq.c
@@ -30,9 +30,7 @@
 #include <debug.h>
 
 #include <nuttx/arch.h>
-#include <nuttx/board.h>
 #include <nuttx/irq.h>
-#include <arch/board/board.h>
 
 #include "riscv_internal.h"
 #include "litex.h"

--- a/arch/risc-v/src/litex/litex_irq_dispatch.c
+++ b/arch/risc-v/src/litex/litex_irq_dispatch.c
@@ -29,8 +29,6 @@
 
 #include <nuttx/irq.h>
 #include <nuttx/arch.h>
-#include <nuttx/board.h>
-#include <arch/board/board.h>
 
 #include "riscv_internal.h"
 #include "litex.h"

--- a/arch/risc-v/src/mpfs/mpfs_allocateheap.c
+++ b/arch/risc-v/src/mpfs/mpfs_allocateheap.c
@@ -28,8 +28,6 @@
 #include <nuttx/userspace.h>
 
 #include <nuttx/arch.h>
-#include <nuttx/board.h>
-#include <arch/board/board.h>
 
 #ifdef CONFIG_MM_KERNEL_HEAP
 #include <arch/board/board_memorymap.h>

--- a/arch/risc-v/src/mpfs/mpfs_irq_dispatch.c
+++ b/arch/risc-v/src/mpfs/mpfs_irq_dispatch.c
@@ -29,8 +29,6 @@
 
 #include <nuttx/irq.h>
 #include <nuttx/arch.h>
-#include <nuttx/board.h>
-#include <arch/board/board.h>
 
 #include "riscv_internal.h"
 

--- a/arch/risc-v/src/mpfs/mpfs_systemreset.c
+++ b/arch/risc-v/src/mpfs/mpfs_systemreset.c
@@ -27,7 +27,6 @@
 #include <stdint.h>
 
 #include <nuttx/arch.h>
-#include <nuttx/board.h>
 
 #include "riscv_internal.h"
 #include "hardware/mpfs_memorymap.h"

--- a/arch/risc-v/src/qemu-rv/qemu_rv_irq.c
+++ b/arch/risc-v/src/qemu-rv/qemu_rv_irq.c
@@ -30,9 +30,7 @@
 #include <debug.h>
 
 #include <nuttx/arch.h>
-#include <nuttx/board.h>
 #include <nuttx/irq.h>
-#include <arch/board/board.h>
 
 #include "riscv_internal.h"
 #include "chip.h"

--- a/arch/risc-v/src/qemu-rv/qemu_rv_irq_dispatch.c
+++ b/arch/risc-v/src/qemu-rv/qemu_rv_irq_dispatch.c
@@ -29,8 +29,6 @@
 
 #include <nuttx/irq.h>
 #include <nuttx/arch.h>
-#include <nuttx/board.h>
-#include <arch/board/board.h>
 
 #include "riscv_internal.h"
 #include "hardware/qemu_rv_memorymap.h"

--- a/arch/risc-v/src/rv32m1/rv32m1_irq_dispatch.c
+++ b/arch/risc-v/src/rv32m1/rv32m1_irq_dispatch.c
@@ -29,8 +29,6 @@
 
 #include <nuttx/irq.h>
 #include <nuttx/arch.h>
-#include <nuttx/board.h>
-#include <arch/board/board.h>
 
 #include "riscv_internal.h"
 #include "rv32m1.h"


### PR DESCRIPTION
## Summary

## Impact
Minor

## Testing
Pass CI
