### PR TITLE
include/nuttx: remove double definitions of UNUSED macro

### DIFF
--- a/include/nuttx/compiler.h
+++ b/include/nuttx/compiler.h
@@ -47,10 +47,6 @@
 #  define CONFIG_HAVE_FUNCTIONNAME 1 /* Has __FUNCTION__ */
 #  define CONFIG_HAVE_FILENAME     1 /* Has __FILE__ */
 
-/* Indicate that a local variable is not used */
-
-#  define UNUSED(a) ((void)(1 || (a)))
-
 /* Built-in functions */
 
 /* The <stddef.h> header shall define the following macros:
@@ -531,10 +527,6 @@
 #  undef  CONFIG_HAVE_DOUBLE
 #  undef  CONFIG_HAVE_LONG_DOUBLE
 
-/* Indicate that a local variable is not used */
-
-#  define UNUSED(a) ((void)(1 || (a)))
-
 #  define offsetof(a, b) ((size_t)(&(((a *)(0))->b)))
 
 /* Zilog-specific definitions ***********************************************/
@@ -660,6 +652,10 @@
 #  undef CONFIG_HAVE_ANONYMOUS_STRUCT
 #  undef  CONFIG_HAVE_ANONYMOUS_UNION
 
+/* Indicate that a local variable is not used */
+
+#  define UNUSED(a) ((void)(1 || (a)))
+
 /* Older Zilog compilers support both types double and long long, but the
  * size is 32-bits (same as long and single precision) so it is safer to say
  * that they are not supported.  Later versions are more ANSII compliant and
@@ -671,23 +667,11 @@
 #  undef  CONFIG_HAVE_DOUBLE
 #  undef  CONFIG_HAVE_LONG_DOUBLE
 
-/* Indicate that a local variable is not used */
-
-#  define UNUSED(a) ((void)(1 || (a)))
-
 #  define offsetof(a, b) ((size_t)(&(((a *)(0))->b)))
 
 /* ICCARM-specific definitions **********************************************/
 
 #elif defined(__ICCARM__)
-
-#  define CONFIG_CPP_HAVE_VARARGS 1 /* Supports variable argument macros */
-#  define CONFIG_HAVE_FILENAME 1    /* Has __FILE__ */
-#  define CONFIG_HAVE_FLOAT 1
-
-/* Indicate that a local variable is not used */
-
-#  define UNUSED(a) ((void)(1 || (a)))
 
 #  define weak_alias(name, aliasname)
 #  define weak_data            __weak
@@ -744,6 +728,14 @@
 #  undef CONFIG_HAVE_ANONYMOUS_STRUCT
 #  undef  CONFIG_HAVE_ANONYMOUS_UNION
 
+/* Indicate that a local variable is not used */
+
+#  define UNUSED(a) ((void)(1 || (a)))
+
+#  define CONFIG_CPP_HAVE_VARARGS 1 /* Supports variable argument macros */
+#  define CONFIG_HAVE_FILENAME 1    /* Has __FILE__ */
+#  define CONFIG_HAVE_FLOAT 1
+
 #  define offsetof(a, b) ((size_t)(&(((a *)(0))->b)))
 
 /* Unknown compiler *********************************************************/
@@ -755,7 +747,7 @@
 #  undef  CONFIG_HAVE_FUNCTIONNAME
 #  undef  CONFIG_HAVE_FILENAME
 #  undef  CONFIG_HAVE_WEAKFUNCTIONS
-#  undef CONFIG_HAVE_CXX14
+#  undef  CONFIG_HAVE_CXX14
 #  define weak_alias(name, aliasname)
 #  define weak_data
 #  define weak_function


### PR DESCRIPTION
## Summary
Remove double definitions of UNUSED macro

## Impact
None

## Testing
Pass CI