### PR TITLE
RISC-V: Combine 3 variables that depend on CPU amount into one

### DIFF
--- a/arch/risc-v/Kconfig
+++ b/arch/risc-v/Kconfig
@@ -234,10 +234,6 @@ config ARCH_MPU_HAS_NAPOT
 	bool "PMP supports NAPOT"
 	default y	if !PMP_HAS_LIMITED_FEATURES
 
-config ARCH_CPU_COUNT
-    int "Amount of CPUs in SoC"
-    default 5 if ARCH_CHIP_MPFS
-
 source "arch/risc-v/src/opensbi/Kconfig"
 source "arch/risc-v/src/common/Kconfig"
 

--- a/arch/risc-v/include/irq.h
+++ b/arch/risc-v/include/irq.h
@@ -98,16 +98,6 @@
 #  define CONFIG_SYS_NNEST  2
 #endif
 
-/* Amount of interrupt stacks (amount of harts) */
-
-#ifdef CONFIG_IRQ_NSTACKS
-#  define IRQ_NSTACKS       CONFIG_IRQ_NSTACKS
-#elif defined CONFIG_SMP
-#  define IRQ_NSTACKS       CONFIG_SMP_NCPUS
-#else
-#  define IRQ_NSTACKS       1
-#endif
-
 /* Processor PC */
 
 #define REG_EPC_NDX         0

--- a/arch/risc-v/src/bl602/Make.defs
+++ b/arch/risc-v/src/bl602/Make.defs
@@ -34,7 +34,7 @@ CMN_CSRCS += riscv_releasepending.c riscv_reprioritizertr.c
 CMN_CSRCS += riscv_releasestack.c riscv_stackframe.c riscv_schedulesigaction.c
 CMN_CSRCS += riscv_sigdeliver.c riscv_udelay.c riscv_unblocktask.c riscv_usestack.c
 CMN_CSRCS += riscv_idle.c riscv_tcbinfo.c riscv_getnewintctx.c riscv_doirq.c
-CMN_CSRCS += riscv_cpuindex.c riscv_exception.c
+CMN_CSRCS += riscv_exception.c
 
 ifeq ($(CONFIG_SCHED_BACKTRACE),y)
 CMN_CSRCS += riscv_backtrace.c

--- a/arch/risc-v/src/c906/Make.defs
+++ b/arch/risc-v/src/c906/Make.defs
@@ -34,7 +34,7 @@ CMN_CSRCS += riscv_releasepending.c riscv_reprioritizertr.c
 CMN_CSRCS += riscv_releasestack.c riscv_stackframe.c riscv_schedulesigaction.c
 CMN_CSRCS += riscv_sigdeliver.c riscv_unblocktask.c riscv_usestack.c
 CMN_CSRCS += riscv_mdelay.c riscv_idle.c riscv_doirq.c
-CMN_CSRCS += riscv_tcbinfo.c riscv_getnewintctx.c riscv_cpuindex.c
+CMN_CSRCS += riscv_tcbinfo.c riscv_getnewintctx.c
 
 ifeq ($(CONFIG_SCHED_BACKTRACE),y)
 CMN_CSRCS += riscv_backtrace.c

--- a/arch/risc-v/src/common/riscv_exception_common.S
+++ b/arch/risc-v/src/common/riscv_exception_common.S
@@ -28,8 +28,13 @@
 #include <arch/irq.h>
 #include <arch/mode.h>
 
+#include <sys/types.h>
+
 #include "chip.h"
+
 #include "riscv_macros.S"
+
+#include "riscv_internal.h"
 
 /****************************************************************************
  * Pre-processor Definitions
@@ -99,27 +104,9 @@ exception_common:
 
 #if CONFIG_ARCH_INTERRUPTSTACK > 15
 
-  /* Offset to hartid */
-
-  mv         s0, a0               /* save cause */
-#ifdef CONFIG_SMP
-  jal        x1, riscv_mhartid    /* get hartid */
-#else
-  li         a0, 0
-#endif
-
   /* Switch to interrupt stack */
 
-#if IRQ_NSTACKS > 1
-  li         t0, (CONFIG_ARCH_INTERRUPTSTACK & ~15)
-  mul        t0, a0, t0
-  la         a0, g_intstacktop
-  sub        sp, a0, t0
-#else
-  la         sp, g_intstacktop
-#endif
-
-  mv         a0, s0               /* restore cause */
+  setintstack t0, t1
 
   /* Call interrupt handler in C */
 
@@ -165,6 +152,10 @@ exception_common:
  *  Name: g_intstackalloc and g_intstacktop
  ****************************************************************************/
 
+/* Total required interrupt stack size */
+
+#define STACK_ALLOC_SIZE (CONFIG_ARCH_INTERRUPTSTACK * CONFIG_SMP_NCPUS)
+
 #if CONFIG_ARCH_INTERRUPTSTACK > 15
   .bss
   .balign 16
@@ -173,8 +164,8 @@ exception_common:
   .type   g_intstackalloc, object
   .type   g_intstacktop, object
 g_intstackalloc:
-  .skip  (((CONFIG_ARCH_INTERRUPTSTACK * IRQ_NSTACKS) + 8) & ~15)
+  .skip  STACK_ALIGN_UP(STACK_ALLOC_SIZE)
 g_intstacktop:
   .size  g_intstacktop, 0
-  .size  g_intstackalloc, ((CONFIG_ARCH_INTERRUPTSTACK * IRQ_NSTACKS) & ~15)
+  .size  g_intstackalloc, STACK_ALIGN_DOWN(STACK_ALLOC_SIZE)
 #endif

--- a/arch/risc-v/src/common/riscv_macros.S
+++ b/arch/risc-v/src/common/riscv_macros.S
@@ -29,6 +29,11 @@
 #include <arch/arch.h>
 #include <arch/irq.h>
 
+#include <sys/types.h>
+
+#include "riscv_internal.h"
+#include "riscv_percpu.h"
+
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
@@ -128,3 +133,22 @@
   REGLOAD    x31, REG_X31(\out)  /* t6 */
 
 .endm
+
+/****************************************************************************
+ * Name: setintstack
+ *
+ * Description:
+ *   Set the current stack pointer to the "top" the interrupt stack. Works
+ *   for single CPU case in flat mode.
+ *   Must be provided by MCU-specific logic in the SMP case, or the kernel
+ *   runs in supervisor mode (S-mode).
+ *
+ ****************************************************************************/
+
+#if CONFIG_ARCH_INTERRUPTSTACK > 15
+#if !defined(CONFIG_SMP) && !defined(CONFIG_ARCH_USE_S_MODE)
+.macro  setintstack tmp0, tmp1
+  la    sp, g_intstacktop
+.endm
+#endif /* !defined(CONFIG_SMP) && !defined(CONFIG_ARCH_USE_S_MODE) */
+#endif /* CONFIG_ARCH_INTERRUPTSTACK > 15 */

--- a/arch/risc-v/src/common/riscv_percpu.c
+++ b/arch/risc-v/src/common/riscv_percpu.c
@@ -24,12 +24,15 @@
 
 #include <nuttx/config.h>
 #include <nuttx/irq.h>
+#include <nuttx/spinlock.h>
 
 #include <arch/barriers.h>
 #include <arch/mode.h>
 
 #include <assert.h>
 #include <stdint.h>
+
+#include <queue.h>
 
 #include "riscv_internal.h"
 #include "riscv_percpu.h"
@@ -38,40 +41,74 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-#define HART_CNT    (CONFIG_ARCH_CPU_COUNT)
+#define HART_CNT    (CONFIG_SMP_NCPUS)
+#define STACK_SIZE  (STACK_ALIGN_DOWN(CONFIG_ARCH_INTERRUPTSTACK))
 
-static_assert(RISCV_PERCPU_HARTID_OFFSET ==
-              offsetof(struct riscv_percpu_s, hartid),
-              "RISCV_PERCPU_HARTID_OFFSET with a wrong value");
+static_assert(RISCV_PERCPU_HARTID == offsetof(riscv_percpu_t, hartid),
+              "RISCV_PERCPU_HARTID offset is wrong");
+static_assert(RISCV_PERCPU_IRQSTACK == offsetof(riscv_percpu_t, irq_stack),
+              "RISCV_PERCPU_IRQSTACK offset is wrong");
 
 /****************************************************************************
  * Private Data
  ****************************************************************************/
 
-static struct riscv_percpu_s g_percpu[HART_CNT];
+static riscv_percpu_t   g_percpu[HART_CNT];
+static sq_queue_t       g_freelist;
+static uintptr_t        g_initialized;
 
 /****************************************************************************
- * Public Functions
+ * Private Functions
  ****************************************************************************/
 
 /****************************************************************************
  * Name: riscv_percpu_init
  *
  * Description:
- *   Initialize the per CPU structures, should only be done on the boot
- *   hart.
+ *   Initialize the per CPU structures, the first to get here does the init.
  *
  ****************************************************************************/
 
-void riscv_percpu_init(void)
+static void riscv_percpu_init(void)
 {
-  uintptr_t i;
+  uintptr_t  i;
+  uintptr_t  initialized;
+  irqstate_t flags;
+
+  /* Need to lock access during configuration */
+
+  flags = spin_lock_irqsave(NULL);
+
+  /* Initialize if not done so already */
+
+  initialized = g_initialized;
+  g_initialized = 1;
+
+  if (initialized == 1)
+    {
+      goto out_with_lock;
+    }
+
+  sq_init(&g_freelist);
 
   for (i = 0; i < HART_CNT; i++)
     {
-      g_percpu[i].hartid = i;
+      /* Set interrupt stack (if any) */
+
+#if CONFIG_ARCH_INTERRUPTSTACK > 15
+      g_percpu[i].irq_stack = (uintptr_t)&g_intstacktop - i * STACK_SIZE;
+#endif
+
+      sq_addlast((struct sq_entry_s *) &g_percpu[i], &g_freelist);
     }
+
+out_with_lock:
+  spin_unlock_irqrestore(NULL, flags);
 }
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
 
 /****************************************************************************
  * Name: riscv_percpu_add_hart
@@ -86,13 +123,27 @@ void riscv_percpu_init(void)
 
 void riscv_percpu_add_hart(uintptr_t hartid)
 {
-  /* Hart IDs go from 0...4 */
+  riscv_percpu_t *percpu;
+  irqstate_t      flags;
 
-  DEBUGASSERT(hartid < HART_CNT);
+  /* Make sure we are initialized */
+
+  riscv_percpu_init();
+
+  /* Get free entry for this hart, this must not fail */
+
+  flags = spin_lock_irqsave(NULL);
+  percpu = (riscv_percpu_t *)sq_remfirst(&g_freelist);
+  spin_unlock_irqrestore(NULL, flags);
+  DEBUGASSERT(percpu);
+
+  /* Assign hartid, stack has already been assigned */
+
+  percpu->hartid = hartid;
 
   /* Set the scratch register value to point to the scratch area */
 
-  WRITE_CSR(CSR_SCRATCH, &g_percpu[hartid]);
+  WRITE_CSR(CSR_SCRATCH, percpu);
 
   /* Make sure it sticks */
 
@@ -118,5 +169,26 @@ uintptr_t riscv_percpu_get_hartid(void)
   DEBUGASSERT(scratch >= (uintptr_t) &g_percpu &&
               scratch <  (uintptr_t) &g_percpu + sizeof(g_percpu));
 
-  return ((struct riscv_percpu_s *)scratch)->hartid;
+  return ((riscv_percpu_t *)scratch)->hartid;
+}
+
+/****************************************************************************
+ * Name: riscv_percpu_get_irqstack
+ *
+ * Description:
+ *   Get harts own IRQ stack by reading it from the per CPU area.
+ *
+ * Returned Value:
+ *   IRQ stack, or 0 if no IRQ stack is assigned
+ *
+ ****************************************************************************/
+
+uintptr_t riscv_percpu_get_irqstack(void)
+{
+  uintptr_t scratch = READ_CSR(CSR_SCRATCH);
+
+  DEBUGASSERT(scratch >= (uintptr_t) &g_percpu &&
+              scratch <  (uintptr_t) &g_percpu + sizeof(g_percpu));
+
+  return ((riscv_percpu_t *)scratch)->irq_stack;
 }

--- a/arch/risc-v/src/common/supervisor/riscv_dispatch_syscall.S
+++ b/arch/risc-v/src/common/supervisor/riscv_dispatch_syscall.S
@@ -27,6 +27,8 @@
 #include <nuttx/config.h>
 #include <arch/mode.h>
 
+#include "chip.h"
+
 #include "riscv_macros.S"
 
 /****************************************************************************
@@ -96,18 +98,10 @@ riscv_dispatch_syscall:
 
   mv         a0, sp                    /* a0 = context */
 
+#if CONFIG_ARCH_INTERRUPTSTACK > 15
   /* Switch to interrupt stack */
 
-#if CONFIG_ARCH_INTERRUPTSTACK > 15
-#if IRQ_NSTACKS > 1
-  jal        x1, riscv_mhartid    /* get hartid */
-  li         t0, (CONFIG_ARCH_INTERRUPTSTACK & ~15)
-  mul        t0, a0, t0
-  la         a0, g_intstacktop
-  sub        sp, a0, t0
-#else
-  la         sp, g_intstacktop
-#endif
+  setintstack t0, t1
 #endif
 
   /* Run the handler */

--- a/arch/risc-v/src/esp32c3/Make.defs
+++ b/arch/risc-v/src/esp32c3/Make.defs
@@ -41,7 +41,6 @@ CMN_CSRCS += riscv_releasepending.c riscv_reprioritizertr.c
 CMN_CSRCS += riscv_releasestack.c riscv_stackframe.c riscv_schedulesigaction.c
 CMN_CSRCS += riscv_sigdeliver.c riscv_udelay.c riscv_unblocktask.c riscv_usestack.c
 CMN_CSRCS += riscv_tcbinfo.c riscv_getnewintctx.c riscv_doirq.c
-CMN_CSRCS += riscv_cpuindex.c
 
 ifeq ($(CONFIG_SCHED_BACKTRACE),y)
 CMN_CSRCS += riscv_backtrace.c

--- a/arch/risc-v/src/fe310/Make.defs
+++ b/arch/risc-v/src/fe310/Make.defs
@@ -34,7 +34,6 @@ CMN_CSRCS += riscv_releasepending.c riscv_reprioritizertr.c
 CMN_CSRCS += riscv_releasestack.c riscv_stackframe.c riscv_schedulesigaction.c
 CMN_CSRCS += riscv_sigdeliver.c riscv_udelay.c riscv_unblocktask.c riscv_usestack.c
 CMN_CSRCS += riscv_idle.c riscv_tcbinfo.c riscv_getnewintctx.c riscv_doirq.c
-CMN_CSRCS += riscv_cpuindex.c
 
 ifeq ($(CONFIG_SCHED_BACKTRACE),y)
 CMN_CSRCS += riscv_backtrace.c

--- a/arch/risc-v/src/k210/Make.defs
+++ b/arch/risc-v/src/k210/Make.defs
@@ -35,7 +35,6 @@ CMN_CSRCS += riscv_releasestack.c riscv_stackframe.c riscv_schedulesigaction.c
 CMN_CSRCS += riscv_sigdeliver.c riscv_unblocktask.c riscv_usestack.c
 CMN_CSRCS += riscv_mdelay.c riscv_idle.c riscv_doirq.c
 CMN_CSRCS += riscv_tcbinfo.c riscv_cpuidlestack.c riscv_getnewintctx.c
-CMN_CSRCS += riscv_cpuindex.c
 
 ifeq ($(CONFIG_SMP), y)
 CMN_CSRCS += riscv_cpuindex.c riscv_cpupause.c riscv_cpustart.c

--- a/arch/risc-v/src/k210/chip.h
+++ b/arch/risc-v/src/k210/chip.h
@@ -29,4 +29,32 @@
 
 #include "k210_memorymap.h"
 
+#include "riscv_internal.h"
+
+/****************************************************************************
+ * Macro Definitions
+ ****************************************************************************/
+
+#ifdef __ASSEMBLY__
+
+/****************************************************************************
+ * Name: setintstack
+ *
+ * Description:
+ *   Set the current stack pointer to the  "top" the correct interrupt stack
+ *   for the current CPU.
+ *
+ ****************************************************************************/
+
+#if defined(CONFIG_SMP) && CONFIG_ARCH_INTERRUPTSTACK > 15
+.macro  setintstack tmp0, tmp1
+  csrr  \tmp0, mhartid
+  li    \tmp1, STACK_ALIGN_DOWN(CONFIG_ARCH_INTERRUPTSTACK)
+  mul   \tmp1, \tmp0, \tmp1
+  la    \tmp0, g_intstacktop
+  sub   sp, \tmp0, \tmp1
+.endm
+#endif /* CONFIG_SMP && CONFIG_ARCH_INTERRUPTSTACK > 15 */
+
+#endif /* __ASSEMBLY__  */
 #endif /* __ARCH_RISCV_SRC_K210_CHIP_H */

--- a/arch/risc-v/src/litex/Make.defs
+++ b/arch/risc-v/src/litex/Make.defs
@@ -34,7 +34,6 @@ CMN_CSRCS += riscv_releasepending.c riscv_reprioritizertr.c
 CMN_CSRCS += riscv_releasestack.c riscv_stackframe.c riscv_schedulesigaction.c
 CMN_CSRCS += riscv_sigdeliver.c riscv_udelay.c riscv_unblocktask.c riscv_usestack.c
 CMN_CSRCS += riscv_idle.c riscv_tcbinfo.c riscv_getnewintctx.c
-CMN_CSRCS += riscv_cpuindex.c
 
 ifeq ($(CONFIG_SCHED_BACKTRACE),y)
 CMN_CSRCS += riscv_backtrace.c

--- a/arch/risc-v/src/mpfs/Kconfig
+++ b/arch/risc-v/src/mpfs/Kconfig
@@ -46,17 +46,12 @@ config MPFS_BOOTLOADER
 	---help---
 		This NuttX image is used as a bootloader, which will boot only on one hart, putting the others in WFI
 
-config IRQ_NSTACKS
-	int
-	depends on MPFS_BOOTLOADER
-	default 5
-
 config MPFS_OPENSBI
-        bool "Use OpenSBI"
-        depends on MPFS_BOOTLOADER && OPENSBI
-        default n
-        ---help---
-                This uses a ld-envm-opensbi.script linker script and the mpfs_opensbi.c code to use external OpenSBI.
+	bool "Use OpenSBI"
+	depends on MPFS_BOOTLOADER && OPENSBI
+	default n
+	---help---
+		This uses a ld-envm-opensbi.script linker script and the mpfs_opensbi.c code to use external OpenSBI.
 
 config MPFS_HART0_SBI
 	bool "HART0 boots via SBI"

--- a/arch/risc-v/src/mpfs/chip.h
+++ b/arch/risc-v/src/mpfs/chip.h
@@ -29,4 +29,31 @@
 
 #include "mpfs_memorymap.h"
 
+#include "riscv_percpu.h"
+
+/****************************************************************************
+ * Macro Definitions
+ ****************************************************************************/
+
+#ifdef __ASSEMBLY__
+
+/****************************************************************************
+ * Name: setintstack
+ *
+ * Description:
+ *   Set the current stack pointer to the  "top" the correct interrupt stack
+ *   for the current CPU.
+ *
+ ****************************************************************************/
+
+#if CONFIG_ARCH_INTERRUPTSTACK > 15
+#if defined(CONFIG_SMP) || defined(CONFIG_ARCH_USE_S_MODE)
+.macro  setintstack tmp0, tmp1
+  csrr    \tmp0, CSR_SCRATCH
+  REGLOAD sp, RISCV_PERCPU_IRQSTACK(\tmp0)
+.endm
+#endif /* defined(CONFIG_SMP) || defined(CONFIG_ARCH_USE_S_MODE) */
+#endif /* CONFIG_ARCH_INTERRUPTSTACK > 15 */
+
+#endif /* __ASSEMBLY__  */
 #endif /* __ARCH_RISCV_SRC_MPFS_CHIP_H */

--- a/arch/risc-v/src/qemu-rv/Make.defs
+++ b/arch/risc-v/src/qemu-rv/Make.defs
@@ -35,7 +35,6 @@ CMN_CSRCS += riscv_releasestack.c riscv_stackframe.c riscv_schedulesigaction.c
 CMN_CSRCS += riscv_sigdeliver.c riscv_unblocktask.c riscv_usestack.c
 CMN_CSRCS += riscv_idle.c riscv_tcbinfo.c riscv_cpuidlestack.c
 CMN_CSRCS += riscv_exception.c riscv_getnewintctx.c riscv_doirq.c
-CMN_CSRCS += riscv_cpuindex.c
 
 ifeq ($(CONFIG_SMP), y)
 CMN_CSRCS += riscv_cpuindex.c riscv_cpupause.c riscv_cpustart.c

--- a/arch/risc-v/src/qemu-rv/chip.h
+++ b/arch/risc-v/src/qemu-rv/chip.h
@@ -38,7 +38,7 @@
 extern void up_earlyserialinit(void);
 extern void up_serialinit(void);
 
-#endif
+#endif /* __ASSEMBLY__  */
 
 #include "qemu_rv_memorymap.h"
 
@@ -46,4 +46,32 @@ extern void up_serialinit(void);
 #include "hardware/qemu_rv_memorymap.h"
 #include "hardware/qemu_rv_plic.h"
 
+#include "riscv_internal.h"
+
+/****************************************************************************
+ * Macro Definitions
+ ****************************************************************************/
+
+#ifdef __ASSEMBLY__
+
+/****************************************************************************
+ * Name: setintstack
+ *
+ * Description:
+ *   Set the current stack pointer to the  "top" the correct interrupt stack
+ *   for the current CPU.
+ *
+ ****************************************************************************/
+
+#if defined(CONFIG_SMP) && CONFIG_ARCH_INTERRUPTSTACK > 15
+.macro  setintstack tmp0, tmp1
+  csrr  \tmp0, mhartid
+  li    \tmp1, STACK_ALIGN_DOWN(CONFIG_ARCH_INTERRUPTSTACK)
+  mul   \tmp1, \tmp0, \tmp1
+  la    \tmp0, g_intstacktop
+  sub   sp, \tmp0, \tmp1
+.endm
+#endif /* CONFIG_SMP && CONFIG_ARCH_INTERRUPTSTACK > 15 */
+
+#endif /* __ASSEMBLY__  */
 #endif /* __ARCH_RISCV_SRC_QEMU_RV_CHIP_H */

--- a/arch/risc-v/src/rv32m1/Make.defs
+++ b/arch/risc-v/src/rv32m1/Make.defs
@@ -34,7 +34,6 @@ CMN_CSRCS += riscv_releasepending.c riscv_reprioritizertr.c
 CMN_CSRCS += riscv_releasestack.c riscv_stackframe.c riscv_schedulesigaction.c
 CMN_CSRCS += riscv_sigdeliver.c riscv_unblocktask.c riscv_usestack.c
 CMN_CSRCS += riscv_idle.c riscv_tcbinfo.c riscv_getnewintctx.c
-CMN_CSRCS += riscv_cpuindex.c
 
 ifeq ($(CONFIG_SCHED_BACKTRACE),y)
 CMN_CSRCS += riscv_backtrace.c


### PR DESCRIPTION
IRQ_NSTACKS, ARCH_CPU_COUNT, CONFIG_SMP_NCPUS all relate to each
other. However, a bit of clean up can be done and everything can
be merged into SMP_NCPUS.

The MPFS bootloader case works also as it requires only 1 IRQ stack
for the hart that executes as bootloader.

## Summary
Merges three related Kconfig parameters into one
## Impact
Reduces configuration complexity by reducing related parameters
## Testing
MPFS icicle:knsh + CI passed
