### PR TITLE
arch/sim: support simulator keyboard devices

### DIFF
--- a/arch/sim/Kconfig
+++ b/arch/sim/Kconfig
@@ -349,6 +349,21 @@ config SIM_NOINPUT
 	bool "No input device"
 
 endchoice # Input Device
+
+config SIM_KEYBOARD
+	bool "X11 keyboard"
+	select INPUT_KEYBOARD
+	depends on SIM_X11FB
+	---help---
+		Support an X11 mouse-based keyboard emulation.  Also needs INPUT=y
+
+config SIM_KEYBOARD_BUFFSIZE
+	int "sim keyboard buffer size"
+	default 64
+	depends on SIM_KEYBOARD
+	---help---
+		Emulator keyboard buffer size
+
 endif # if INPUT
 
 endmenu

--- a/arch/sim/src/Makefile
+++ b/arch/sim/src/Makefile
@@ -144,6 +144,10 @@ else ifeq ($(CONFIG_SIM_AJOYSTICK),y)
 else ifeq ($(CONFIG_SIM_BUTTONS),y)
   HOSTSRCS += up_x11eventloop.c
 endif
+
+ifeq ($(CONFIG_SIM_KEYBOARD),y)
+  CSRCS += up_keyboard.c
+endif
 endif
 
 ifeq ($(CONFIG_FS_FAT),y)

--- a/arch/sim/src/sim/up_internal.h
+++ b/arch/sim/src/sim/up_internal.h
@@ -231,10 +231,17 @@ int sim_tsc_initialize(int minor);
 int sim_tsc_uninitialize(void);
 #endif
 
+/* up_keyboard.c ************************************************************/
+
+#ifdef CONFIG_SIM_KEYBOARD
+int sim_kbd_initialize(void);
+void up_kbdevent(uint32_t key, bool is_press);
+#endif
+
 /* up_eventloop.c ***********************************************************/
 
 #if defined(CONFIG_SIM_TOUCHSCREEN) || defined(CONFIG_SIM_AJOYSTICK) || \
-    defined(CONFIG_ARCH_BUTTONS)
+    defined(CONFIG_ARCH_BUTTONS) || defined(CONFING_SIM_KEYBOARD)
 void up_x11events(void);
 void up_buttonevent(int x, int y, int buttons);
 #endif

--- a/arch/sim/src/sim/up_keyboard.c
+++ b/arch/sim/src/sim/up_keyboard.c
@@ -1,0 +1,115 @@
+/****************************************************************************
+ * arch/sim/src/sim/up_keyboard.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+#include <sys/types.h>
+
+#include <assert.h>
+#include <debug.h>
+#include <string.h>
+
+#include <nuttx/input/keyboard.h>
+
+#include "up_internal.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define DEVNAME "/dev/kbd"
+
+/****************************************************************************
+ * Private Types
+ ****************************************************************************/
+
+struct up_dev_s
+{
+  int eventloop;
+  struct keyboard_lowerhalf_s lower;
+};
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+/* Only one simulated keyboard is supported so the driver state
+ * structure may as well be pre-allocated.
+ */
+
+static struct up_dev_s g_simkeyboard;
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: sim_kbd_initialize
+ ****************************************************************************/
+
+int sim_kbd_initialize(void)
+{
+  int                  ret;
+  FAR struct up_dev_s *priv = &g_simkeyboard;
+
+  memset(priv, 0, sizeof(*priv));
+
+  /* Register the device as an input device */
+
+  ret = keyboard_register(&priv->lower, DEVNAME,
+                          CONFIG_SIM_KEYBOARD_BUFFSIZE);
+  if (ret < 0)
+    {
+      ierr("ERROR: keyboard_register() failed: %d\n", ret);
+      return ret;
+    }
+
+  /* Enable X11 event processing from the IDLE loop */
+
+  priv->eventloop = 1;
+  return OK;
+}
+
+/****************************************************************************
+ * Name: up_kbdevent
+ ****************************************************************************/
+
+void up_kbdevent(uint32_t key, bool is_press)
+{
+  FAR struct up_dev_s *priv = (FAR struct up_dev_s *) &g_simkeyboard;
+  uint32_t types[2] =
+    {
+      KEYBOARD_RELEASE, KEYBOARD_PRESS
+    };
+
+  if (priv->eventloop == 0)
+    {
+      return;
+    }
+
+  iinfo("key=%04x\n", key);
+
+  /* Report data changes */
+
+  keyboard_event(&priv->lower, key, types[is_press]);
+}

--- a/arch/sim/src/sim/up_x11eventloop.c
+++ b/arch/sim/src/sim/up_x11eventloop.c
@@ -24,6 +24,7 @@
 
 #include <stdio.h>
 #include <X11/Xlib.h>
+#include <X11/keysym.h>
 
 #include "up_internal.h"
 
@@ -116,6 +117,15 @@ void up_x11events(void)
 
       switch (event.type)
         {
+          #ifdef CONFIG_SIM_KEYBOARD
+          case KeyPress:
+            up_kbdevent(XLookupKeysym(&event.xkey, 0), true);
+            break;
+          case KeyRelease:
+            up_kbdevent(XLookupKeysym(&event.xkey, 0), false);
+            break;
+          #endif
+
           case MotionNotify : /* Enabled by ButtonMotionMask */
             {
               up_buttonevent(event.xmotion.x, event.xmotion.y,

--- a/arch/sim/src/sim/up_x11framebuffer.c
+++ b/arch/sim/src/sim/up_x11framebuffer.c
@@ -115,7 +115,7 @@ static inline int up_x11createframe(void)
 #else
   XSelectInput(g_display, g_window,
                ButtonPressMask | ButtonReleaseMask | PointerMotionMask |
-               KeyPressMask);
+               KeyPressMask | KeyReleaseMask);
 #endif
 
   /* Release queued events on the display */

--- a/boards/sim/sim/sim/src/sim_bringup.c
+++ b/boards/sim/sim/sim/src/sim_bringup.c
@@ -318,6 +318,16 @@ int sim_bringup(void)
     }
 #endif
 
+#ifdef CONFIG_SIM_KEYBOARD
+  /* Initialize the keyboard */
+
+  ret = sim_kbd_initialize();
+  if (ret < 0)
+    {
+      syslog(LOG_ERR, "ERROR: sim_kbd_initialize failed: %d\n", ret);
+    }
+#endif
+
 #ifdef CONFIG_IEEE802154_LOOPBACK
   /* Initialize and register the IEEE802.15.4 MAC network loop device */
 


### PR DESCRIPTION
## Summary
Read the keyboard data of the computer on the emulator, this needs to depend on X11
## Impact

## Testing
./tools/configure.sh -l sim:minibasic

enable the following configuration:
CONFIG_DRIVERS_VIDEO=y
CONFIG_INPUT=y
CONFIG_VIDEO=y
CONFIG_VIDEO_FB=y
CONFIG_SIM_KEYBOARD=y
CONFIG_SIM_TOUCHSCREEN=y
CONFIG_SIM_X11FB=y

monitor device data changes:
cat /dev/kbd &
you will see the value of the key pressed is printed twice, one for press and one for release