### PR TITLE
fix uinput rpmsg logic error

### DIFF
--- a/drivers/input/uinput.c
+++ b/drivers/input/uinput.c
@@ -272,7 +272,7 @@ static void uinput_rpmsg_notify(FAR struct uinput_context_s *ctx,
 
   list_for_every_entry(&ctx->eptlist, ept, struct uinput_rpmsg_ept_s, node)
     {
-      if (is_rpmsg_ept_ready(&ept->ept) == 0)
+      if (is_rpmsg_ept_ready(&ept->ept))
         {
           if (rpmsg_send(&ept->ept, buffer, buflen) < 0)
             {


### PR DESCRIPTION
## Summary
In uinput last committed changes （#5736,sha: 566b8da5ff474891f1f08efbd7f4aad9ef7a28fa）, some logic errors were made
is_rpmsg_ept_ready successfully returns 1, not 0

## Impact

## Testing
