### PR TITLE
sched/note: correct flatten format

### DIFF
--- a/include/nuttx/sched_note.h
+++ b/include/nuttx/sched_note.h
@@ -660,6 +660,15 @@ void sched_note_filter_irq(struct note_filter_irq_s *oldf,
 
 #else /* CONFIG_SCHED_INSTRUMENTATION */
 
+#  define SCHED_NOTE_STRING(buf)
+#  define SCHED_NOTE_DUMP(event, buf, len)
+#  define SCHED_NOTE_VPRINTF(fmt, va)
+#  define SCHED_NOTE_VBPRINTF(event, fmt, va)
+#  define SCHED_NOTE_PRINTF(fmt, args...)
+#  define SCHED_NOTE_BPRINTF(event, fmt, args...)
+#  define SCHED_NOTE_BEGIN()
+#  define SCHED_NOTE_END()
+
 #  define sched_note_start(t)
 #  define sched_note_stop(t)
 #  define sched_note_suspend(t)

--- a/sched/sched/sched_note.c
+++ b/sched/sched/sched_note.c
@@ -118,27 +118,15 @@ static unsigned int g_note_disabled_irq_nest[CONFIG_SMP_NCPUS];
 static inline void sched_note_flatten(FAR uint8_t *dst,
                                       FAR void *src, size_t len)
 {
-  switch (len)
+#ifdef CONFIG_ENDIAN_BIG
+  FAR uint8_t *end = (FAR uint8_t *)src + len - 1;
+  while (len-- > 0)
     {
-#ifdef CONFIG_HAVE_LONG_LONG
-      case 8:
-        dst[7] = (uint8_t)((*(uint64_t *)src >> 56) & 0xff);
-        dst[6] = (uint8_t)((*(uint64_t *)src >> 48) & 0xff);
-        dst[5] = (uint8_t)((*(uint64_t *)src >> 40) & 0xff);
-        dst[4] = (uint8_t)((*(uint64_t *)src >> 32) & 0xff);
-#endif
-      case 4:
-        dst[3] = (uint8_t)((*(uint32_t *)src >> 24) & 0xff);
-        dst[2] = (uint8_t)((*(uint32_t *)src >> 16) & 0xff);
-      case 2:
-        dst[1] = (uint8_t)((*(uint16_t *)src >> 8) & 0xff);
-      case 1:
-        dst[0] = (uint8_t)(*(uint8_t *)src & 0xff);
-        break;
-      default:
-        DEBUGASSERT(FALSE);
-        break;
+      *dst++ = *end--;
     }
+#else
+  memcpy(dst, src, len);
+#endif
 }
 
 /****************************************************************************


### PR DESCRIPTION
## Summary

sched/note: correct flatten format

## Impact
Fix endian issue reported by @pkarashchenko :
https://github.com/apache/incubator-nuttx-apps/pull/1114#discussion_r842466352

## Testing

sched note trace test