### PR TITLE
lib_lib_vsprintf/backtrace: fix the type issue

### DIFF
--- a/libs/libc/stdio/lib_libvsprintf.c
+++ b/libs/libc/stdio/lib_libvsprintf.c
@@ -1160,7 +1160,7 @@ static int vsprintf_internal(FAR struct lib_outstream_s *stream,
 
                           if (c == 'S')
                             {
-                              sprintf_internal(stream, "+%#jx/%#zx",
+                              sprintf_internal(stream, "+%#tx/%#zx",
                                                addr - symbol->sym_value,
                                                symbolsize);
                             }


### PR DESCRIPTION

## Summary
lib_lib_vsprintf/backtrace: fix the type issue

using 't': For integer types, causes printf to expect a ptrdiff_t-sized integer argument.

Signed-off-by: Jiuzhu Dong <dongjiuzhu1@xiaomi.com>

## Impact
N/A
## Testing
Ci
