### PR TITLE
sched/pthread: thread id should updated before start routine

### DIFF
--- a/sched/pthread/pthread_create.c
+++ b/sched/pthread/pthread_create.c
@@ -592,18 +592,18 @@ int nx_pthread_create(pthread_trampoline_t trampoline, FAR pthread_t *thread,
     {
       nxtask_activate((FAR struct tcb_s *)ptcb);
 
-      /* Wait for the task to actually get running and to register
-       * its join structure.
-       */
-
-      pthread_sem_take(&pjoin->data_sem, NULL, false);
-
       /* Return the thread information to the caller */
 
       if (thread)
         {
           *thread = (pthread_t)pid;
         }
+
+      /* Wait for the task to actually get running and to register
+       * its join structure.
+       */
+
+      pthread_sem_take(&pjoin->data_sem, NULL, false);
 
       if (!pjoin->started)
         {


### PR DESCRIPTION
## Summary

sched/pthread: thread id should updated before start routine

if the created thread has a higher priority than the parent process, the pthread id obtained in the thread will be an invalid value

## Impact

pthread_create

## Testing

```
static pthread_t pid = -1;

static void *start_routine(void *arg)
{
  printf("%s: %d, pthread_t: %d\n", __func__, __LINE__, pid);
  return NULL;
}

int main(int argc, FAR char *argv[])
{
  struct sched_param sparam;
  pthread_attr_t pattr;

  pthread_attr_init(&pattr);
  sparam.sched_priority = 101;
  pthread_attr_setschedparam(&pattr, &sparam);

  pthread_create(&pid, &pattr, start_routine, NULL);
  pthread_attr_destroy(&pattr);

  pause();
  return 0;
}
```


before patch:
`nsh> start_routine: 36, pthread_t: -1`

after patch:
`nsh> start_routine: 36, pthread_t: 5`