### PR TITLE
fs/poll: change format for type pollevent_t

### DIFF
--- a/drivers/rc/lirc_dev.c
+++ b/drivers/rc/lirc_dev.c
@@ -124,7 +124,7 @@ static void lirc_pollnotify(FAR struct lirc_fh_s *fh,
 
       if (fh->fd->revents != 0)
         {
-          rcinfo("Report events: %02x\n", fh->fd->revents);
+          rcinfo("Report events: %08" PRIx32 "\n", fh->fd->revents);
 
           nxsem_get_value(fh->fd->sem, &semcount);
           if (semcount < 1)

--- a/drivers/sensors/sensor.c
+++ b/drivers/sensors/sensor.c
@@ -167,7 +167,7 @@ static void sensor_pollnotify(FAR struct sensor_upperhalf_s *upper,
 
           if (fd->revents != 0)
             {
-              sninfo("Report events: %02x\n", fd->revents);
+              sninfo("Report events: %08" PRIx32 "\n", fd->revents);
 
               nxsem_get_value(fd->sem, &semcount);
               if (semcount < 1)


### PR DESCRIPTION
## Summary

[fs/poll: change format for type pollevent_t](https://github.com/apache/incubator-nuttx/commit/acd5a378245ee214becdbe79b1cb3360d0379acc)

complete the following commits:

```
commit d87cf8d4ca5fe69c71c131015a7b64b68c917593
Author: Jiuzhu Dong <dongjiuzhu1@xiaomi.com>
Date:   Fri Apr 1 20:59:55 2022 +0800

    fs/poll: change format for type pollevent_t

    Signed-off-by: Jiuzhu Dong <dongjiuzhu1@xiaomi.com>

commit d535943a69f03033b077cb95cce162bb28b40b56
Author: Jiuzhu Dong <dongjiuzhu1@xiaomi.com>
Date:   Fri Apr 1 17:49:10 2022 +0800

    fs/epoll: change type of eventset from uint8_t to uint32_t

    to support EPOLLONESHOT and so on.

    Signed-off-by: Jiuzhu Dong <dongjiuzhu1@xiaomi.com>

Signed-off-by: chao.an <anchao@xiaomi.com>
```


## Impact
```

In file included from sensors/sensor.c:33:
sensors/sensor.c: In function 'sensor_pollnotify':
Error: sensors/sensor.c:170:22: error: format '%x' expects argument of type 'unsigned int', but argument 3 has type 'pollevent_t' {aka 'long unsigned int'} [-Werror=format=]
  170 |               sninfo("Report events: %02x\n", fd->revents);
      |                      ^~~~~~~~~~~~~~~~~~~~~~~  ~~~~~~~~~~~
      |                                                 |
      |                                                 pollevent_t {aka long unsigned int}
sensors/sensor.c:170:41: note: format string is defined here
  170 |               sninfo("Report events: %02x\n", fd->revents);
      |                                      ~~~^
      |                                         |
      |                                         unsigned int
      |                                      %02lx
```

## Testing

ci check