### PR TITLE
esp32c3: Simplify irq dispatch logic

### DIFF
--- a/arch/risc-v/include/esp32c3/irq.h
+++ b/arch/risc-v/include/esp32c3/irq.h
@@ -140,9 +140,8 @@
 
 /* ecall is dispatched like normal interrupts.  It occupies an IRQ number. */
 
-#define ESP32C3_IRQ_ECALL_M          0
-#define RISCV_NIRQ_INTERRUPTS        1  /* Number of RISC-V dispatched interrupts. */
-#define ESP32C3_IRQ_FIRSTPERIPH      1  /* First peripheral IRQ number */
+#define RISCV_NIRQ_INTERRUPTS       16  /* Number of RISC-V dispatched interrupts. */
+#define ESP32C3_IRQ_FIRSTPERIPH     16  /* First peripheral IRQ number */
 
 /* Peripheral IRQs */
 


### PR DESCRIPTION
## Summary

ESP32C3 use customized irq encoding for irq dispatch so it's hard to shard further code
with other risc-v based chips, in this patch, we keep the exception
number definition with risc-v spec.

## Impact
ESP32C3 
## Testing
esp32c3:nsh
