### PR TITLE
fs/vfs: fix st_mode mask check

### DIFF
--- a/fs/vfs/fs_chstat.c
+++ b/fs/vfs/fs_chstat.c
@@ -118,7 +118,7 @@ static int chstat(FAR const char *path,
 
   /* Adjust and check buf and flags */
 
-  if ((flags & CH_STAT_MODE) && (buf->st_mode & ~07777))
+  if ((flags & CH_STAT_MODE) && (buf->st_mode & ~0177777))
     {
       goto errout;
     }

--- a/fs/vfs/fs_fchstat.c
+++ b/fs/vfs/fs_fchstat.c
@@ -112,7 +112,7 @@ int file_fchstat(FAR struct file *filep, FAR struct stat *buf, int flags)
 
   /* Adjust and check buf and flags */
 
-  if ((flags & CH_STAT_MODE) && (buf->st_mode & ~07777))
+  if ((flags & CH_STAT_MODE) && (buf->st_mode & ~0177777))
     {
       return -EINVAL;
     }


### PR DESCRIPTION
## Summary
The full mask for st_mode is 0177777
Now modify any file permissions in hostfs and all will fail

## Impact

## Testing
found the problem when using libuv uv_fs_copyfile