### PR TITLE
arch/risc-v: Attach exception handler in common place

### DIFF
--- a/arch/risc-v/src/bl602/Make.defs
+++ b/arch/risc-v/src/bl602/Make.defs
@@ -34,7 +34,7 @@ CMN_CSRCS += riscv_releasepending.c riscv_reprioritizertr.c
 CMN_CSRCS += riscv_releasestack.c riscv_stackframe.c riscv_schedulesigaction.c
 CMN_CSRCS += riscv_sigdeliver.c riscv_udelay.c riscv_unblocktask.c riscv_usestack.c
 CMN_CSRCS += riscv_idle.c riscv_tcbinfo.c riscv_getnewintctx.c riscv_doirq.c
-CMN_CSRCS += riscv_cpuindex.c
+CMN_CSRCS += riscv_cpuindex.c riscv_exception.c
 
 ifeq ($(CONFIG_SCHED_BACKTRACE),y)
 CMN_CSRCS += riscv_backtrace.c

--- a/arch/risc-v/src/bl602/bl602_irq.c
+++ b/arch/risc-v/src/bl602/bl602_irq.c
@@ -92,9 +92,9 @@ void up_irqinitialize(void)
 
   CURRENT_REGS = NULL;
 
-  /* Attach the ecall interrupt handler */
+  /* Attach the common interrupt handler */
 
-  irq_attach(RISCV_IRQ_ECALLM, riscv_swint, NULL);
+  riscv_exception_attach();
 
 #ifndef CONFIG_SUPPRESS_INTERRUPTS
 

--- a/arch/risc-v/src/bl602/bl602_irq_dispatch.c
+++ b/arch/risc-v/src/bl602/bl602_irq_dispatch.c
@@ -44,20 +44,12 @@
 void *riscv_dispatch_irq(uintptr_t vector, uintptr_t *regs)
 {
   int irq  = vector & 0x3ff; /* E24 [9:0] */
-  uintptr_t *mepc = regs;
 
   /* If current is interrupt */
 
   if ((vector & RISCV_IRQ_BIT) != 0)
     {
       irq += RISCV_IRQ_ASYNC;
-    }
-
-  /* NOTE: In case of ecall, we need to adjust mepc in the context */
-
-  if (RISCV_IRQ_ECALLM == irq)
-    {
-      *mepc += 4;
     }
 
   /* Acknowledge the interrupt */

--- a/arch/risc-v/src/c906/c906_irq.c
+++ b/arch/risc-v/src/c906/c906_irq.c
@@ -93,13 +93,9 @@ void up_irqinitialize(void)
 
   CURRENT_REGS = NULL;
 
-  /* Attach the ecall interrupt handler */
+  /* Attach the common interrupt handler */
 
-  irq_attach(RISCV_IRQ_ECALLM, riscv_swint, NULL);
-
-#ifdef CONFIG_BUILD_PROTECTED
-  irq_attach(RISCV_IRQ_ECALLU, riscv_swint, NULL);
-#endif
+  riscv_exception_attach();
 
 #ifndef CONFIG_SUPPRESS_INTERRUPTS
 

--- a/arch/risc-v/src/c906/c906_irq_dispatch.c
+++ b/arch/risc-v/src/c906/c906_irq_dispatch.c
@@ -58,7 +58,7 @@ void *riscv_dispatch_irq(uintptr_t vector, uintptr_t *regs)
 
   if (vector < RISCV_IRQ_ECALLU)
     {
-      riscv_exception(irq, regs);
+      riscv_exception(irq, regs, NULL);
     }
 
   /* Firstly, check if the irq is machine external interrupt */

--- a/arch/risc-v/src/c906/c906_irq_dispatch.c
+++ b/arch/risc-v/src/c906/c906_irq_dispatch.c
@@ -52,7 +52,6 @@
 void *riscv_dispatch_irq(uintptr_t vector, uintptr_t *regs)
 {
   int irq = (vector >> RV_IRQ_MASK) | (vector & 0xf);
-  uintptr_t *mepc = regs;
 
   /* Firstly, check if the irq is machine external interrupt */
 
@@ -63,13 +62,6 @@ void *riscv_dispatch_irq(uintptr_t vector, uintptr_t *regs)
       /* Add the value to nuttx irq which is offset to the mext */
 
       irq = val + C906_IRQ_PERI_START;
-    }
-
-  /* NOTE: In case of ecall, we need to adjust mepc in the context */
-
-  if (RISCV_IRQ_ECALLM == irq || RISCV_IRQ_ECALLU == irq)
-    {
-      *mepc += 4;
     }
 
   /* Acknowledge the interrupt */

--- a/arch/risc-v/src/c906/c906_irq_dispatch.c
+++ b/arch/risc-v/src/c906/c906_irq_dispatch.c
@@ -54,13 +54,6 @@ void *riscv_dispatch_irq(uintptr_t vector, uintptr_t *regs)
   int irq = (vector >> RV_IRQ_MASK) | (vector & 0xf);
   uintptr_t *mepc = regs;
 
-  /* Check if fault happened */
-
-  if (vector < RISCV_IRQ_ECALLU)
-    {
-      riscv_exception(irq, regs, NULL);
-    }
-
   /* Firstly, check if the irq is machine external interrupt */
 
   if (RISCV_IRQ_MEXT == irq)

--- a/arch/risc-v/src/common/riscv_doirq.c
+++ b/arch/risc-v/src/common/riscv_doirq.c
@@ -61,6 +61,14 @@ uintptr_t *riscv_doirq(int irq, uintptr_t *regs)
 #ifdef CONFIG_SUPPRESS_INTERRUPTS
   PANIC();
 #else
+
+  /* NOTE: In case of ecall, we need to adjust mepc in the context */
+
+  if (irq >= RISCV_IRQ_ECALLU && irq <= RISCV_IRQ_ECALLM)
+    {
+      regs[REG_EPC] += 4;
+    }
+
   /* Current regs non-zero indicates that we are processing an interrupt;
    * CURRENT_REGS is also used to manage interrupt level context switches.
    *

--- a/arch/risc-v/src/common/riscv_exception.c
+++ b/arch/risc-v/src/common/riscv_exception.c
@@ -69,7 +69,7 @@ static const char *g_reasons_str[RISCV_MAX_EXCEPTION + 1] =
  *
  ****************************************************************************/
 
-void riscv_exception(uintptr_t mcause, uintptr_t *regs)
+int riscv_exception(int mcause, void *regs, void *args)
 {
   uintptr_t cause = mcause & RISCV_IRQ_MASK;
 
@@ -87,5 +87,6 @@ void riscv_exception(uintptr_t mcause, uintptr_t *regs)
   up_irq_save();
   CURRENT_REGS = regs;
   PANIC();
-}
 
+  return 0;
+}

--- a/arch/risc-v/src/common/riscv_exception.c
+++ b/arch/risc-v/src/common/riscv_exception.c
@@ -90,3 +90,51 @@ int riscv_exception(int mcause, void *regs, void *args)
 
   return 0;
 }
+
+/****************************************************************************
+ * Name: riscv_exception_attach
+ *
+ * Description:
+ *   Attach standard exception with suitable handler
+ *
+ ****************************************************************************/
+
+void riscv_exception_attach(void)
+{
+  irq_attach(RISCV_IRQ_IAMISALIGNED, riscv_exception, NULL);
+  irq_attach(RISCV_IRQ_IAFAULT, riscv_exception, NULL);
+  irq_attach(RISCV_IRQ_IINSTRUCTION, riscv_exception, NULL);
+  irq_attach(RISCV_IRQ_BPOINT, riscv_exception, NULL);
+  irq_attach(RISCV_IRQ_LAMISALIGNED, riscv_exception, NULL);
+  irq_attach(RISCV_IRQ_LAFAULT, riscv_exception, NULL);
+  irq_attach(RISCV_IRQ_SAMISALIGNED, riscv_exception, NULL);
+  irq_attach(RISCV_IRQ_SAFAULT, riscv_exception, NULL);
+
+  /* Attach the ecall interrupt handler */
+
+#ifndef CONFIG_BUILD_FLAT
+  irq_attach(RISCV_IRQ_ECALLU, riscv_swint, NULL);
+#else
+  irq_attach(RISCV_IRQ_ECALLU, riscv_exception, NULL);
+#endif
+
+  irq_attach(RISCV_IRQ_ECALLS, riscv_exception, NULL);
+  irq_attach(RISCV_IRQ_ECALLH, riscv_exception, NULL);
+
+#ifndef CONFIG_ARCH_USE_S_MODE
+  irq_attach(RISCV_IRQ_ECALLM, riscv_swint, NULL);
+#else
+  irq_attach(RISCV_IRQ_ECALLM, riscv_exception, NULL);
+#endif
+
+  irq_attach(RISCV_IRQ_INSTRUCTIONPF, riscv_exception, NULL);
+  irq_attach(RISCV_IRQ_LOADPF, riscv_exception, NULL);
+  irq_attach(RISCV_IRQ_RESERVED, riscv_exception, NULL);
+  irq_attach(RISCV_IRQ_STOREPF, riscv_exception, NULL);
+
+#ifdef CONFIG_SMP
+  irq_attach(RISCV_IRQ_MSOFT, riscv_pause_handler, NULL);
+#else
+  irq_attach(RISCV_IRQ_MSOFT, riscv_exception, NULL);
+#endif
+}

--- a/arch/risc-v/src/common/riscv_internal.h
+++ b/arch/risc-v/src/common/riscv_internal.h
@@ -286,7 +286,7 @@ void riscv_netinitialize(void);
 /* Exception Handler ********************************************************/
 
 uintptr_t *riscv_doirq(int irq, uintptr_t *regs);
-void riscv_exception(uintptr_t mcause, uintptr_t *regs);
+int riscv_exception(int mcause, void *regs, void *args);
 int riscv_misaligned(int irq, void *context, void *arg);
 
 /* Debug ********************************************************************/

--- a/arch/risc-v/src/common/riscv_internal.h
+++ b/arch/risc-v/src/common/riscv_internal.h
@@ -229,6 +229,7 @@ void riscv_copystate(uintptr_t *dest, uintptr_t *src);
 void riscv_sigdeliver(void);
 int riscv_swint(int irq, void *context, void *arg);
 uintptr_t riscv_get_newintctx(void);
+void riscv_exception_attach(void);
 
 #ifdef CONFIG_ARCH_FPU
 void riscv_fpuconfig(void);

--- a/arch/risc-v/src/esp32c3/esp32c3_irq.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_irq.c
@@ -112,9 +112,9 @@ void up_irqinitialize(void)
 
   putreg32(ESP32C3_DEFAULT_INT_THRESHOLD, INTERRUPT_CPU_INT_THRESH_REG);
 
-  /* Attach the ECALL interrupt. */
+  /* Attach the common interrupt handler */
 
-  irq_attach(RISCV_IRQ_ECALLM, riscv_swint, NULL);
+  riscv_exception_attach();
 
 #ifdef CONFIG_ESP32C3_GPIO_IRQ
   /* Initialize GPIO interrupt support */

--- a/arch/risc-v/src/esp32c3/esp32c3_irq.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_irq.c
@@ -391,11 +391,6 @@ IRAM_ATTR uintptr_t *esp32c3_dispatch_irq(uintptr_t mcause, uintptr_t *regs)
       irq = mcause;
     }
 
-  if (mcause == RISCV_IRQ_ECALLM)
-    {
-      regs[REG_EPC] += 4;
-    }
-
   regs = riscv_doirq(irq, regs);
 
   /* Toggle the bit back to zero. */

--- a/arch/risc-v/src/fe310/Make.defs
+++ b/arch/risc-v/src/fe310/Make.defs
@@ -26,7 +26,7 @@ HEAD_ASRC = fe310_head.S
 CMN_ASRCS += riscv_vectors.S riscv_testset.S riscv_exception_common.S
 
 # Specify C code within the common directory to be included
-CMN_CSRCS += riscv_initialize.c riscv_swint.c
+CMN_CSRCS += riscv_initialize.c riscv_swint.c riscv_exception.c
 CMN_CSRCS += riscv_allocateheap.c riscv_createstack.c riscv_exit.c
 CMN_CSRCS += riscv_assert.c riscv_blocktask.c riscv_copystate.c riscv_initialstate.c
 CMN_CSRCS += riscv_interruptcontext.c riscv_modifyreg32.c riscv_puts.c riscv_mdelay.c

--- a/arch/risc-v/src/fe310/fe310_irq.c
+++ b/arch/risc-v/src/fe310/fe310_irq.c
@@ -86,9 +86,9 @@ void up_irqinitialize(void)
 
   CURRENT_REGS = NULL;
 
-  /* Attach the ecall interrupt handler */
+  /* Attach the common interrupt handler */
 
-  irq_attach(RISCV_IRQ_ECALLM, riscv_swint, NULL);
+  riscv_exception_attach();
 
 #ifndef CONFIG_SUPPRESS_INTERRUPTS
 

--- a/arch/risc-v/src/fe310/fe310_irq_dispatch.c
+++ b/arch/risc-v/src/fe310/fe310_irq_dispatch.c
@@ -51,7 +51,6 @@
 void *riscv_dispatch_irq(uintptr_t vector, uintptr_t *regs)
 {
   int irq = (vector >> RV_IRQ_MASK) | (vector & 0xf);
-  uintptr_t *mepc = regs;
 
   /* Firstly, check if the irq is machine external interrupt */
 
@@ -62,13 +61,6 @@ void *riscv_dispatch_irq(uintptr_t vector, uintptr_t *regs)
       /* Add the value to nuttx irq which is offset to the mext */
 
       irq += val;
-    }
-
-  /* NOTE: In case of ecall, we need to adjust mepc in the context */
-
-  if (RISCV_IRQ_ECALLM == irq)
-    {
-      *mepc += 4;
     }
 
   /* Acknowledge the interrupt */

--- a/arch/risc-v/src/k210/k210_irq.c
+++ b/arch/risc-v/src/k210/k210_irq.c
@@ -90,22 +90,15 @@ void up_irqinitialize(void)
 
   CURRENT_REGS = NULL;
 
-  /* Attach the ecall interrupt handler */
+  /* Attach the common interrupt handler */
 
-  irq_attach(RISCV_IRQ_ECALLM, riscv_swint, NULL);
-
-#ifdef CONFIG_BUILD_PROTECTED
-  irq_attach(RISCV_IRQ_ECALLU, riscv_swint, NULL);
-#endif
+  riscv_exception_attach();
 
 #ifdef CONFIG_SMP
   /* Clear MSOFT for CPU0 */
 
   putreg32(0, K210_CLINT_MSIP);
 
-  /* Setup MSOFT for CPU0 with pause handler */
-
-  irq_attach(RISCV_IRQ_MSOFT, riscv_pause_handler, NULL);
   up_enable_irq(RISCV_IRQ_MSOFT);
 #endif
 

--- a/arch/risc-v/src/k210/k210_irq_dispatch.c
+++ b/arch/risc-v/src/k210/k210_irq_dispatch.c
@@ -53,7 +53,6 @@
 void *riscv_dispatch_irq(uintptr_t vector, uintptr_t *regs)
 {
   int irq = (vector >> RV_IRQ_MASK) | (vector & 0xf);
-  uintptr_t *mepc = regs;
 
   /* Firstly, check if the irq is machine external interrupt */
 
@@ -64,13 +63,6 @@ void *riscv_dispatch_irq(uintptr_t vector, uintptr_t *regs)
       /* Add the value to nuttx irq which is offset to the mext */
 
       irq += val;
-    }
-
-  /* NOTE: In case of ecall, we need to adjust mepc in the context */
-
-  if (RISCV_IRQ_ECALLM == irq || RISCV_IRQ_ECALLU == irq)
-    {
-      *mepc += 4;
     }
 
   /* Acknowledge the interrupt */

--- a/arch/risc-v/src/k210/k210_irq_dispatch.c
+++ b/arch/risc-v/src/k210/k210_irq_dispatch.c
@@ -29,6 +29,7 @@
 
 #include <nuttx/irq.h>
 #include <nuttx/arch.h>
+#include <sys/types.h>
 
 #include "riscv_internal.h"
 #include "group/group.h"
@@ -58,7 +59,7 @@ void *riscv_dispatch_irq(uintptr_t vector, uintptr_t *regs)
 
   if (vector < RISCV_IRQ_ECALLU)
     {
-      riscv_exception(irq, regs);
+      riscv_exception(irq, regs, NULL);
     }
 
   /* Firstly, check if the irq is machine external interrupt */

--- a/arch/risc-v/src/k210/k210_irq_dispatch.c
+++ b/arch/risc-v/src/k210/k210_irq_dispatch.c
@@ -55,13 +55,6 @@ void *riscv_dispatch_irq(uintptr_t vector, uintptr_t *regs)
   int irq = (vector >> RV_IRQ_MASK) | (vector & 0xf);
   uintptr_t *mepc = regs;
 
-  /* Check if fault happened */
-
-  if (vector < RISCV_IRQ_ECALLU)
-    {
-      riscv_exception(irq, regs, NULL);
-    }
-
   /* Firstly, check if the irq is machine external interrupt */
 
   if (RISCV_IRQ_MEXT == irq)

--- a/arch/risc-v/src/litex/Make.defs
+++ b/arch/risc-v/src/litex/Make.defs
@@ -26,7 +26,7 @@ HEAD_ASRC = litex_head.S
 CMN_ASRCS += riscv_vectors.S riscv_testset.S riscv_exception_common.S
 
 # Specify C code within the common directory to be included
-CMN_CSRCS += riscv_initialize.c riscv_swint.c riscv_doirq.c
+CMN_CSRCS += riscv_initialize.c riscv_swint.c riscv_doirq.c riscv_exception.c
 CMN_CSRCS += riscv_allocateheap.c riscv_createstack.c riscv_exit.c
 CMN_CSRCS += riscv_assert.c riscv_blocktask.c riscv_copystate.c riscv_initialstate.c
 CMN_CSRCS += riscv_interruptcontext.c riscv_modifyreg32.c riscv_puts.c riscv_mdelay.c

--- a/arch/risc-v/src/litex/litex_irq.c
+++ b/arch/risc-v/src/litex/litex_irq.c
@@ -72,9 +72,9 @@ void up_irqinitialize(void)
 
   CURRENT_REGS = NULL;
 
-  /* Attach the ecall interrupt handler */
+  /* Attach the common interrupt handler */
 
-  irq_attach(RISCV_IRQ_ECALLM, riscv_swint, NULL);
+  riscv_exception_attach();
 
 #ifndef CONFIG_SUPPRESS_INTERRUPTS
 

--- a/arch/risc-v/src/litex/litex_irq_dispatch.c
+++ b/arch/risc-v/src/litex/litex_irq_dispatch.c
@@ -50,7 +50,6 @@
 void *riscv_dispatch_irq(uintptr_t vector, uintptr_t *regs)
 {
   int irq = (vector >> RV_IRQ_MASK) | (vector & 0xf);
-  uintptr_t *mepc = regs;
   int i;
 
   /* Firstly, check if the irq is machine external interrupt */
@@ -78,13 +77,6 @@ void *riscv_dispatch_irq(uintptr_t vector, uintptr_t *regs)
       /* Add the value to nuttx irq which is offset to the mext */
 
       irq += val;
-    }
-
-  /* NOTE: In case of ecall, we need to adjust mepc in the context */
-
-  if (RISCV_IRQ_ECALLM == irq)
-    {
-      *mepc += 4;
     }
 
   /* Acknowledge the interrupt */

--- a/arch/risc-v/src/mpfs/mpfs_irq_dispatch.c
+++ b/arch/risc-v/src/mpfs/mpfs_irq_dispatch.c
@@ -52,17 +52,6 @@ void *riscv_dispatch_irq(uintptr_t vector, uintptr_t *regs)
   int irq = (vector & 0x3f);
   uintptr_t *epc = regs;
 
-  /* Check if fault happened  */
-
-  if (vector < RISCV_IRQ_ECALLU ||
-      vector == RISCV_IRQ_INSTRUCTIONPF ||
-      vector == RISCV_IRQ_LOADPF ||
-      vector == RISCV_IRQ_STOREPF ||
-      vector == RISCV_IRQ_RESERVED)
-    {
-      riscv_exception(irq, regs, NULL);
-    }
-
   if ((vector & RISCV_IRQ_BIT) != 0)
     {
        irq += MPFS_IRQ_ASYNC;

--- a/arch/risc-v/src/mpfs/mpfs_irq_dispatch.c
+++ b/arch/risc-v/src/mpfs/mpfs_irq_dispatch.c
@@ -29,6 +29,7 @@
 
 #include <nuttx/irq.h>
 #include <nuttx/arch.h>
+#include <sys/types.h>
 
 #include "riscv_internal.h"
 
@@ -59,7 +60,7 @@ void *riscv_dispatch_irq(uintptr_t vector, uintptr_t *regs)
       vector == RISCV_IRQ_STOREPF ||
       vector == RISCV_IRQ_RESERVED)
     {
-      riscv_exception(irq, regs);
+      riscv_exception(irq, regs, NULL);
     }
 
   if ((vector & RISCV_IRQ_BIT) != 0)

--- a/arch/risc-v/src/mpfs/mpfs_irq_dispatch.c
+++ b/arch/risc-v/src/mpfs/mpfs_irq_dispatch.c
@@ -50,7 +50,6 @@
 void *riscv_dispatch_irq(uintptr_t vector, uintptr_t *regs)
 {
   int irq = (vector & 0x3f);
-  uintptr_t *epc = regs;
 
   if ((vector & RISCV_IRQ_BIT) != 0)
     {
@@ -68,13 +67,6 @@ void *riscv_dispatch_irq(uintptr_t vector, uintptr_t *regs)
       /* Add the value to nuttx irq which is offset to the ext */
 
       irq = MPFS_IRQ_EXT_START + ext;
-    }
-
-  /* NOTE: In case of ecall, we need to adjust epc in the context */
-
-  if (irq == RISCV_IRQ_ECALLM || irq == RISCV_IRQ_ECALLU)
-    {
-      *epc += 4;
     }
 
   /* Acknowledge the interrupt */

--- a/arch/risc-v/src/qemu-rv/qemu_rv_irq.c
+++ b/arch/risc-v/src/qemu-rv/qemu_rv_irq.c
@@ -84,9 +84,9 @@ void up_irqinitialize(void)
 
   CURRENT_REGS = NULL;
 
-  /* Attach the ecall interrupt handler */
+  /* Attach the common interrupt handler */
 
-  irq_attach(RISCV_IRQ_ECALLM, riscv_swint, NULL);
+  riscv_exception_attach();
 
 #ifdef CONFIG_SMP
   /* Clear MSOFT for CPU0 */

--- a/arch/risc-v/src/qemu-rv/qemu_rv_irq_dispatch.c
+++ b/arch/risc-v/src/qemu-rv/qemu_rv_irq_dispatch.c
@@ -56,7 +56,6 @@
 void *riscv_dispatch_irq(uintptr_t vector, uintptr_t *regs)
 {
   int irq = (vector >> RV_IRQ_MASK) | (vector & 0xf);
-  uintptr_t *mepc = regs;
 
   /* Firstly, check if the irq is machine external interrupt */
 
@@ -67,13 +66,6 @@ void *riscv_dispatch_irq(uintptr_t vector, uintptr_t *regs)
       /* Add the value to nuttx irq which is offset to the mext */
 
       irq += val;
-    }
-
-  /* NOTE: In case of ecall, we need to adjust mepc in the context */
-
-  if (RISCV_IRQ_ECALLM == irq)
-    {
-      *mepc += 4;
     }
 
   /* MEXT means no interrupt */

--- a/arch/risc-v/src/qemu-rv/qemu_rv_irq_dispatch.c
+++ b/arch/risc-v/src/qemu-rv/qemu_rv_irq_dispatch.c
@@ -58,11 +58,6 @@ void *riscv_dispatch_irq(uintptr_t vector, uintptr_t *regs)
   int irq = (vector >> RV_IRQ_MASK) | (vector & 0xf);
   uintptr_t *mepc = regs;
 
-  if (vector < RISCV_IRQ_ECALLM)
-    {
-      riscv_exception(irq, regs, NULL);
-    }
-
   /* Firstly, check if the irq is machine external interrupt */
 
   if (RISCV_IRQ_MEXT == irq)

--- a/arch/risc-v/src/qemu-rv/qemu_rv_irq_dispatch.c
+++ b/arch/risc-v/src/qemu-rv/qemu_rv_irq_dispatch.c
@@ -29,6 +29,7 @@
 
 #include <nuttx/irq.h>
 #include <nuttx/arch.h>
+#include <sys/types.h>
 
 #include "riscv_internal.h"
 #include "hardware/qemu_rv_memorymap.h"
@@ -59,7 +60,7 @@ void *riscv_dispatch_irq(uintptr_t vector, uintptr_t *regs)
 
   if (vector < RISCV_IRQ_ECALLM)
     {
-      riscv_exception(irq, regs);
+      riscv_exception(irq, regs, NULL);
     }
 
   /* Firstly, check if the irq is machine external interrupt */

--- a/arch/risc-v/src/rv32m1/Make.defs
+++ b/arch/risc-v/src/rv32m1/Make.defs
@@ -26,7 +26,7 @@ HEAD_ASRC = rv32m1_head.S
 CMN_ASRCS = riscv_vectors.S
 
 # Specify C code within the common directory to be included
-CMN_CSRCS += riscv_initialize.c riscv_swint.c riscv_doirq.c
+CMN_CSRCS += riscv_initialize.c riscv_swint.c riscv_doirq.c riscv_exception.c
 CMN_CSRCS += riscv_allocateheap.c riscv_createstack.c riscv_exit.c
 CMN_CSRCS += riscv_assert.c riscv_blocktask.c riscv_copystate.c riscv_initialstate.c
 CMN_CSRCS += riscv_interruptcontext.c riscv_modifyreg32.c riscv_puts.c

--- a/arch/risc-v/src/rv32m1/rv32m1_irq.c
+++ b/arch/risc-v/src/rv32m1/rv32m1_irq.c
@@ -119,9 +119,9 @@ void up_irqinitialize(void)
 
   CURRENT_REGS = NULL;
 
-  /* Attach the ecall interrupt handler */
+  /* Attach the common interrupt handler */
 
-  irq_attach(RISCV_IRQ_ECALLM, riscv_swint, NULL);
+  riscv_exception_attach();
 
 #ifndef CONFIG_SUPPRESS_INTERRUPTS
 

--- a/arch/risc-v/src/rv32m1/rv32m1_irq_dispatch.c
+++ b/arch/risc-v/src/rv32m1/rv32m1_irq_dispatch.c
@@ -53,15 +53,7 @@ void *rv32m1_dispatch_irq(uintptr_t vector, uintptr_t *regs)
 {
   uint32_t vec = vector & 0x1f;
   int irq = (vector >> RV_IRQ_MASK) + vec;
-  uintptr_t *mepc = regs;
   int irqofs = 0;
-
-  /* NOTE: In case of ecall, we need to adjust mepc in the context */
-
-  if (RISCV_IRQ_ECALLM == irq)
-    {
-      *mepc += 4;
-    }
 
   if (RV32M1_IRQ_INTMUX0 <= irq)
     {


### PR DESCRIPTION
## Summary
* Align prototype of riscv_exception with xcpt_t 
* Add a common exception handler initializer to attach common exception
* Move epc adjustment to riscv_doirq
## Impact
Refactor only
## Testing
CI
