### PR TITLE
mm_initialize: malloc() return aligend pointer. 

### DIFF
--- a/mm/mm_heap/mm.h
+++ b/mm/mm_heap/mm.h
@@ -146,10 +146,6 @@
 
 #define SIZEOF_MM_FREENODE sizeof(struct mm_freenode_s)
 
-/* What is the size of the start/end node? */
-
-#define SIZEOF_MM_STARTENDNODE MM_MIN_CHUNK
-
 /****************************************************************************
  * Public Types
  ****************************************************************************/

--- a/mm/mm_heap/mm_initialize.c
+++ b/mm/mm_heap/mm_initialize.c
@@ -93,11 +93,15 @@ void mm_addregion(FAR struct mm_heap_s *heap, FAR void *heapstart,
 
   DEBUGVERIFY(mm_takesemaphore(heap));
 
-  /* Adjust the provided heap start and size so that they are both aligned
-   * with the MM_MIN_CHUNK size.
+  /* Adjust the provided heap start and size.
+   *
+   * Note: (uintptr_t)node + SIZEOF_MM_ALLOCNODE is what's actually
+   * returned to the malloc user, which should have natural alignment.
+   * (that is, in this implementation, MM_MIN_CHUNK-alignment.)
    */
 
-  heapbase = MM_ALIGN_UP((uintptr_t)heapstart);
+  heapbase = MM_ALIGN_UP((uintptr_t)heapstart + 2 * SIZEOF_MM_ALLOCNODE) -
+             2 * SIZEOF_MM_ALLOCNODE;
   heapend  = MM_ALIGN_DOWN((uintptr_t)heapstart + (uintptr_t)heapsize);
   heapsize = heapend - heapbase;
 

--- a/mm/mm_heap/mm_initialize.c
+++ b/mm/mm_heap/mm_initialize.c
@@ -118,15 +118,15 @@ void mm_addregion(FAR struct mm_heap_s *heap, FAR void *heapstart,
   heap->mm_heapstart[IDX]            = (FAR struct mm_allocnode_s *)
                                        heapbase;
   MM_ADD_BACKTRACE(heap, heap->mm_heapstart[IDX]);
-  heap->mm_heapstart[IDX]->size      = SIZEOF_MM_STARTENDNODE;
+  heap->mm_heapstart[IDX]->size      = SIZEOF_MM_ALLOCNODE;
   heap->mm_heapstart[IDX]->preceding = MM_ALLOC_BIT;
   node                               = (FAR struct mm_freenode_s *)
-                                       (heapbase + SIZEOF_MM_STARTENDNODE);
-  node->size                         = heapsize - 2*SIZEOF_MM_STARTENDNODE;
-  node->preceding                    = SIZEOF_MM_STARTENDNODE;
+                                       (heapbase + SIZEOF_MM_ALLOCNODE);
+  node->size                         = heapsize - 2*SIZEOF_MM_ALLOCNODE;
+  node->preceding                    = SIZEOF_MM_ALLOCNODE;
   heap->mm_heapend[IDX]              = (FAR struct mm_allocnode_s *)
-                                       (heapend - SIZEOF_MM_STARTENDNODE);
-  heap->mm_heapend[IDX]->size        = SIZEOF_MM_STARTENDNODE;
+                                       (heapend - SIZEOF_MM_ALLOCNODE);
+  heap->mm_heapend[IDX]->size        = SIZEOF_MM_ALLOCNODE;
   heap->mm_heapend[IDX]->preceding   = node->size | MM_ALLOC_BIT;
   MM_ADD_BACKTRACE(heap, heap->mm_heapend[IDX]);
 

--- a/mm/mm_heap/mm_mallinfo.c
+++ b/mm/mm_heap/mm_mallinfo.c
@@ -121,10 +121,7 @@ int mm_mallinfo(FAR struct mm_heap_s *heap, FAR struct mallinfo *info)
   mm_foreach(heap, mallinfo_handler, info);
 
   info->arena = heap->mm_heapsize;
-
-  /* Account for the tail node */
-
-  info->uordblks += region * SIZEOF_MM_STARTENDNODE;
+  info->uordblks += region * SIZEOF_MM_ALLOCNODE; /* account for the tail node */
 
   DEBUGASSERT(info->uordblks + info->fordblks == heap->mm_heapsize);
 


### PR DESCRIPTION
## Summary
malloc() should return aligned (with MM_MIN_CHUNK) pointer, but pr https://github.com/apache/incubator-nuttx/pull/5906 destroy that, this pr find a better method to solve these problems.

## Testing
mm test pass with nucleo-144:f46zg and sim (CONFIG_DEBUG_MM=y/n, CONFIG_MM_SMALL=y/n)

@xiaoxiang781216 
