### PR TITLE
Increase audio_comp driver flexibility

### DIFF
--- a/audio/audio_comp.c
+++ b/audio/audio_comp.c
@@ -969,10 +969,13 @@ FAR struct audio_lowerhalf_s *audio_comp_initialize(FAR const char *name,
     }
 
   va_end(ap);
-  ret = audio_register(name, &priv->export);
-  if (ret < 0)
+  if (name != NULL)
     {
-      goto free_lower;
+      ret = audio_register(name, &priv->export);
+      if (ret < 0)
+        {
+          goto free_lower;
+        }
     }
 
   return &priv->export;

--- a/audio/audio_comp.c
+++ b/audio/audio_comp.c
@@ -919,14 +919,15 @@ static void audio_comp_callback(FAR void *arg, uint16_t reason,
  *   ...  - The list of the lower half audio driver.
  *
  * Returned Value:
- *   Zero on success; a negated errno value on failure.
+ *   struct audio_lowerhalf_s* on success; NULL on failure.
  *
  * Note
  *   The variable argument list must be NULL terminated.
  *
  ****************************************************************************/
 
-int audio_comp_initialize(FAR const char *name, ...)
+FAR struct audio_lowerhalf_s *audio_comp_initialize(FAR const char *name,
+                                                    ...)
 {
   FAR struct audio_comp_priv_s *priv;
   va_list ap;
@@ -936,7 +937,7 @@ int audio_comp_initialize(FAR const char *name, ...)
   priv = kmm_zalloc(sizeof(struct audio_comp_priv_s));
   if (priv == NULL)
     {
-      return ret;
+      return NULL;
     }
 
   priv->export.ops = &g_audio_comp_ops;
@@ -974,11 +975,11 @@ int audio_comp_initialize(FAR const char *name, ...)
       goto free_lower;
     }
 
-  return OK;
+  return &priv->export;
 
 free_lower:
   kmm_free(priv->lower);
 free_priv:
   kmm_free(priv);
-  return ret;
+  return NULL;
 }

--- a/include/nuttx/audio/audio_comp.h
+++ b/include/nuttx/audio/audio_comp.h
@@ -65,14 +65,15 @@ extern "C"
  *   ...  - The list of the lower half audio driver.
  *
  * Returned Value:
- *   Zero on success; a negated errno value on failure.
+ *   struct audio_lowerhalf_s* on success; NULL on failure.
  *
  * Note
  *   The variable argument list must be NULL terminated.
  *
  ****************************************************************************/
 
-int audio_comp_initialize(FAR const char *name, ...);
+FAR struct audio_lowerhalf_s *audio_comp_initialize(FAR const char *name,
+                                                    ...);
 
 #undef EXTERN
 #ifdef __cplusplus


### PR DESCRIPTION
## Summary

- audio: Return audio_lowerhalf_s pointer instead error code in audio_comp_initialize
- audio: Don't register audio device if name isn't given in audio_comp_initialize

## Impact
audio_comp

## Testing
Pass CI
