### PR TITLE
arch/risc-v: Apply misaligned access handler for k210/bl602

### DIFF
--- a/arch/risc-v/Kconfig
+++ b/arch/risc-v/Kconfig
@@ -30,6 +30,7 @@ config ARCH_CHIP_K210
 	select ARCH_HAVE_MPU
 	select ARCH_HAVE_TESTSET
 	select ARCH_HAVE_MULTICPU
+	select ARCH_HAVE_MISALIGN_EXCEPTION
 	select ONESHOT
 	select ALARM_ARCH
 	---help---
@@ -52,6 +53,7 @@ config ARCH_CHIP_BL602
 	select ARCH_RV_ISA_C
 	select ARCH_HAVE_FPU
 	select ARCH_HAVE_RESET
+	select ARCH_HAVE_MISALIGN_EXCEPTION
 	select ONESHOT
 	select ALARM_ARCH
 	---help---
@@ -205,6 +207,17 @@ config ARCH_MMU_TYPE_SV39
 config ARCH_HAVE_S_MODE
 	bool
 	default n
+
+config ARCH_HAVE_MISALIGN_EXCEPTION
+	bool
+	default n
+	---help---
+		The chip will raise a exception while misaligned memory access.
+
+config RISCV_MISALIGNED_HANDLER
+	bool "Software misaligned memory access handler"
+	depends on ARCH_HAVE_MISALIGN_EXCEPTION
+	default y
 
 # Option to run NuttX in supervisor mode. This is obviously not usable in
 # flat mode, is questionable in protected mode, but is mandatory in kernel

--- a/arch/risc-v/src/bl602/Make.defs
+++ b/arch/risc-v/src/bl602/Make.defs
@@ -34,7 +34,7 @@ CMN_CSRCS += riscv_releasepending.c riscv_reprioritizertr.c
 CMN_CSRCS += riscv_releasestack.c riscv_stackframe.c riscv_schedulesigaction.c
 CMN_CSRCS += riscv_sigdeliver.c riscv_udelay.c riscv_unblocktask.c riscv_usestack.c
 CMN_CSRCS += riscv_idle.c riscv_tcbinfo.c riscv_getnewintctx.c riscv_doirq.c
-CMN_CSRCS += riscv_exception.c riscv_mtimer.c
+CMN_CSRCS += riscv_exception.c riscv_mtimer.c riscv_misaligned.c
 
 ifeq ($(CONFIG_SCHED_BACKTRACE),y)
 CMN_CSRCS += riscv_backtrace.c

--- a/arch/risc-v/src/common/riscv_exception.c
+++ b/arch/risc-v/src/common/riscv_exception.c
@@ -105,10 +105,16 @@ void riscv_exception_attach(void)
   irq_attach(RISCV_IRQ_IAFAULT, riscv_exception, NULL);
   irq_attach(RISCV_IRQ_IINSTRUCTION, riscv_exception, NULL);
   irq_attach(RISCV_IRQ_BPOINT, riscv_exception, NULL);
-  irq_attach(RISCV_IRQ_LAMISALIGNED, riscv_exception, NULL);
   irq_attach(RISCV_IRQ_LAFAULT, riscv_exception, NULL);
-  irq_attach(RISCV_IRQ_SAMISALIGNED, riscv_exception, NULL);
   irq_attach(RISCV_IRQ_SAFAULT, riscv_exception, NULL);
+
+#ifdef CONFIG_RISCV_MISALIGNED_HANDLER
+  irq_attach(RISCV_IRQ_LAMISALIGNED, riscv_misaligned, NULL);
+  irq_attach(RISCV_IRQ_SAMISALIGNED, riscv_misaligned, NULL);
+#else
+  irq_attach(RISCV_IRQ_LAMISALIGNED, riscv_exception, NULL);
+  irq_attach(RISCV_IRQ_SAMISALIGNED, riscv_exception, NULL);
+#endif
 
   /* Attach the ecall interrupt handler */
 

--- a/arch/risc-v/src/k210/Make.defs
+++ b/arch/risc-v/src/k210/Make.defs
@@ -35,6 +35,7 @@ CMN_CSRCS += riscv_releasestack.c riscv_stackframe.c riscv_schedulesigaction.c
 CMN_CSRCS += riscv_sigdeliver.c riscv_unblocktask.c riscv_usestack.c
 CMN_CSRCS += riscv_mdelay.c riscv_idle.c riscv_doirq.c
 CMN_CSRCS += riscv_tcbinfo.c riscv_cpuidlestack.c riscv_getnewintctx.c
+CMN_CSRCS += riscv_misaligned.c
 
 ifeq ($(CONFIG_SMP), y)
 CMN_CSRCS += riscv_cpuindex.c riscv_cpupause.c riscv_cpustart.c


### PR DESCRIPTION
## Summary
Add a new option to use misaligned memory access for K210/BL602
## Impact
New function for K210/BL602
## Testing
Custom board
