### PR TITLE
Add vm map

### DIFF
--- a/fs/mmap/fs_mmap.c
+++ b/fs/mmap/fs_mmap.c
@@ -52,6 +52,10 @@ static int file_mmap_(FAR struct file *filep, FAR void *start,
   FAR void *addr;
   int ret;
 
+#ifdef CONFIG_MM_VM_MAP
+  union vm_map_id_u map_id;
+#endif
+
   /* Since only a tiny subset of mmap() functionality, we have to verify many
    * things.
    */
@@ -121,6 +125,11 @@ static int file_mmap_(FAR struct file *filep, FAR void *start,
           return -ENOMEM;
         }
 
+#ifdef CONFIG_MM_VM_MAP
+      map_id.val = 0;
+      vm_map_add(VM_MAP_ANONYMOUS, map_id, *mapped, length);
+#endif
+
       return OK;
     }
 
@@ -163,6 +172,12 @@ static int file_mmap_(FAR struct file *filep, FAR void *start,
   /* Return the offset address */
 
   *mapped = (FAR void *)(((FAR uint8_t *)addr) + offset);
+
+#ifdef CONFIG_MM_VM_MAP
+      map_id.inode = filep->f_inode;
+      vm_map_add(VM_MAP_FILE, map_id, *mapped, length);
+#endif
+
   return OK;
 }
 

--- a/include/nuttx/fs/ioctl.h
+++ b/include/nuttx/fs/ioctl.h
@@ -185,6 +185,9 @@
 #define FIOC_TRUNCATE   _FIOC(0x0010)     /* IN:  Length of the file after truncate
                                            * OUT: None
                                            */
+#define FIOC_MUNMAP     _FIOC(0x0011)     /* IN:  Pointer to struct vm_map_entry
+                                           * OUT: None
+                                           */
 
 /* NuttX file system ioctl definitions **************************************/
 

--- a/include/nuttx/mm/shm.h
+++ b/include/nuttx/mm/shm.h
@@ -78,13 +78,6 @@ struct group_shm_s
    */
 
   GRAN_HANDLE gs_handle;
-
-  /* This array is used to do a reverse lookup:  Give the virtual address
-   * of a shared memory region, find the region index that performs that
-   * mapping.
-   */
-
-  uintptr_t gs_vaddr[CONFIG_ARCH_SHM_MAXREGIONS];
 };
 
 /****************************************************************************

--- a/include/nuttx/mm/shm.h
+++ b/include/nuttx/mm/shm.h
@@ -64,23 +64,6 @@
 #endif
 
 /****************************************************************************
- * Public Types
- ****************************************************************************/
-
-/* This structure describes the virtual page allocator that is use to manage
- * the mapping of shared memory into the group/process address space.
- */
-
-struct group_shm_s
-{
-  /* Handle returned by gran_initialize() when the virtual page allocator
-   * was created.
-   */
-
-  GRAN_HANDLE gs_handle;
-};
-
-/****************************************************************************
  * Public Data
  ****************************************************************************/
 

--- a/include/nuttx/mm/vm_map.h
+++ b/include/nuttx/mm/vm_map.h
@@ -66,12 +66,24 @@ struct vm_map_entry_s
   size_t length;
 };
 
+/* Type of memory allocators */
+
+enum vm_allocator_type
+{
+#ifdef CONFIG_MM_SHM
+  VM_ALLOCATOR_SHM,
+#endif
+
+  VM_ALLOCATOR_END /* Last allocater, size of the table */
+};
+
 /* A structure for the task group */
 
 struct vm_map_s
 {
   sq_queue_t vm_map_sq;
   sem_t vm_map_sem;
+  FAR const void *allocator_handle[VM_ALLOCATOR_END];
 };
 
 /****************************************************************************
@@ -171,6 +183,58 @@ FAR const struct vm_map_entry_s *vm_map_find(FAR const void *vaddr);
  ****************************************************************************/
 
 int vm_map_rm(FAR const void *vaddr);
+
+/****************************************************************************
+ * Name: vm_allocator_add
+ *
+ * Description:
+ *   Stores a memory allocator handle
+ *
+ * Input Parameters:
+ *   id:               Type of the allocator
+ *   allocator_handle: Handle to the allocator
+ *
+ * Returned Value:
+ *   OK:               Added successfully
+ *   -ENOENT:          Invalid allocator type
+ *
+ ****************************************************************************/
+
+int vm_allocator_add(enum vm_allocator_type id,
+                     FAR const void *allocator_handle);
+
+/****************************************************************************
+ * Name: vm_allocator_get
+ *
+ * Description:
+ *   Returns a memory allocator handle
+ *
+ * Input Parameters:
+ *   id   - Id of a stored allocator
+ *
+ * Returned Value:
+ *   Handle to the stored allocator, NULL on error
+ *
+ ****************************************************************************/
+
+FAR const void *vm_allocator_get(enum vm_allocator_type id);
+
+/****************************************************************************
+ * Name: vm_allocator_rm
+ *
+ * Description:
+ *   Removes a stored memory allocator handle
+ *
+ * Input Parameters:
+ *   id:       Type of the allocator
+ *
+ * Returned Value:
+ *   OK:       Added successfully
+ *   -ENOENT:  Invalid allocator type
+ *
+ ****************************************************************************/
+
+int vm_allocator_rm(enum vm_allocator_type id);
 
 #endif /* defined(CONFIG_BUILD_FLAT) || defined(__KERNEL__) */
 

--- a/include/nuttx/mm/vm_map.h
+++ b/include/nuttx/mm/vm_map.h
@@ -1,0 +1,179 @@
+/****************************************************************************
+ * include/nuttx/mm/vm_map.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __INCLUDE_NUTTX_MM_VM_MAP_H
+#define __INCLUDE_NUTTX_MM_VM_MAP_H
+
+#ifdef CONFIG_MM_VM_MAP
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+#include <nuttx/fs/fs.h>
+#include <queue.h>
+
+/****************************************************************************
+ * Public Types
+ ****************************************************************************/
+
+/* Type of the mapping */
+
+enum vm_map_type
+{
+  VM_MAP_ANONYMOUS,
+  VM_MAP_NAMED,
+  VM_MAP_FILE,
+  VM_MAP_SHM
+};
+
+/* Id of the mapping */
+
+union vm_map_id_u
+{
+  FAR const char *name;
+  FAR struct inode *inode;
+  int shmid;
+  uintptr_t val;
+};
+
+/* A vm mapping list item */
+
+struct vm_map_entry_s
+{
+  FAR struct vm_map_entry *flink;  /* this is used as sq_entry_t */
+  enum vm_map_type type;
+  union vm_map_id_u id;
+  FAR const void *vaddr;
+  size_t length;
+};
+
+/* A structure for the task group */
+
+struct vm_map_s
+{
+  sq_queue_t vm_map_sq;
+  sem_t vm_map_sem;
+};
+
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
+
+/* These may only be called within kernel context */
+
+#if defined(CONFIG_BUILD_FLAT) || defined(__KERNEL__)
+
+/****************************************************************************
+ * Name: vm_map_initialize
+ *
+ * Description:
+ *   Initialization function, called only by group_initialize
+ *
+ * Input Parameters:
+ *   mm - Pointer to the vm_map structure to be initialized
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+void vm_map_initialize(FAR struct vm_map_s *mm);
+
+/****************************************************************************
+ * Name: vm_map_destroy
+ *
+ * Description:
+ *   Uninitialization function, called only by group_release
+ *
+ * Input Parameters:
+ *   mm - Pointer to the vm_map structure to be initialized
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+void vm_map_destroy(FAR struct vm_map_s *mm);
+
+/****************************************************************************
+ * Name: vm_map_add
+ *
+ * Description:
+ *   Adds a virtual memory area into the list of mappings
+ *
+ * Input Parameters:
+ *   type   - Type of the mapping, defined by enum vm_map_type
+ *   id     - Id of the type. E.g. name or file pointer
+ *   vaddr  - Start address of the vm region
+ *   length - Size of the vm region
+ *
+ * Returned Value:
+ *   OK        Added succesfully
+ *   -EINVAL:  Invalid attempt to get the semaphore
+ *   -EINTR:   The wait was interrupted by the receipt of a signal.
+ *   -ENOMEM:  Out of memory
+ *
+ ****************************************************************************/
+
+int vm_map_add(enum vm_map_type type, union vm_map_id_u id,
+               FAR const void *vaddr, size_t length);
+
+/****************************************************************************
+ * Name: vm_map_find
+ *
+ * Description:
+ *   Find the first mapping containing an address from the task group's list
+ *
+ * Input Parameters:
+ *   vaddr   - Address within the mapped aread
+ *
+ * Returned Value:
+ *   Pointer to the mapping, NULL if not found
+ *
+ ****************************************************************************/
+
+FAR const struct vm_map_entry_s *vm_map_find(FAR const void *vaddr);
+
+/****************************************************************************
+ * Name: vm_map_rm
+ *
+ * Description:
+ *   Removes a virtual memory area from the list of mappings
+ *
+ * Input Parameters:
+ *   vaddr   - Address within the mapped aread
+ *
+ * Returned Value:
+ *   OK:       Removed succesfully
+ *   -EINVAL:  Invalid attempt to get the semaphore
+ *   -EINTR:   The wait was interrupted by the receipt of a signal.
+ *   -ENOENT:  Memory area not found
+ *
+ ****************************************************************************/
+
+int vm_map_rm(FAR const void *vaddr);
+
+#endif /* defined(CONFIG_BUILD_FLAT) || defined(__KERNEL__) */
+
+#endif /* CONFIG_MM_VM_MAP */
+
+#endif /* __INCLUDE_NUTTX_MM_VM_MAP_H */

--- a/include/nuttx/sched.h
+++ b/include/nuttx/sched.h
@@ -520,12 +520,6 @@ struct task_group_s
   group_addrenv_t tg_addrenv;       /* Task group address environment       */
 #endif
 
-#ifdef CONFIG_MM_SHM
-  /* Shared Memory **********************************************************/
-
-  struct group_shm_s tg_shm;        /* Task shared memory logic             */
-#endif
-
   /* Virtual memory mapping info ********************************************/
 
 #ifdef CONFIG_MM_VM_MAP

--- a/include/nuttx/sched.h
+++ b/include/nuttx/sched.h
@@ -42,6 +42,7 @@
 #include <nuttx/mm/shm.h>
 #include <nuttx/fs/fs.h>
 #include <nuttx/net/net.h>
+#include <nuttx/mm/vm_map.h>
 
 #include <arch/arch.h>
 
@@ -523,6 +524,12 @@ struct task_group_s
   /* Shared Memory **********************************************************/
 
   struct group_shm_s tg_shm;        /* Task shared memory logic             */
+#endif
+
+  /* Virtual memory mapping info ********************************************/
+
+#ifdef CONFIG_MM_VM_MAP
+  FAR struct vm_map_s tg_vm_map;    /* Task mmappings */
 #endif
 };
 

--- a/include/sys/syscall_lookup.h
+++ b/include/sys/syscall_lookup.h
@@ -255,7 +255,7 @@ SYSCALL_LOOKUP(utimens,                    2)
 SYSCALL_LOOKUP(lutimens,                   2)
 SYSCALL_LOOKUP(futimens,                   2)
 
-#if defined(CONFIG_FS_RAMMAP)
+#if defined(CONFIG_FS_RAMMAP) || defined(CONFIG_MM_VM_MAP)
   SYSCALL_LOOKUP(munmap,                   2)
 #endif
 

--- a/mm/Kconfig
+++ b/mm/Kconfig
@@ -161,6 +161,7 @@ config MM_SHM
 	bool "Shared memory support"
 	default n
 	depends on MM_PGALLOC && BUILD_KERNEL && EXPERIMENTAL
+	select MM_VM_MAP
 	---help---
 		Build in support for the shared memory interfaces shmget(), shmat(),
 		shmctl(), and shmdt().

--- a/mm/Kconfig
+++ b/mm/Kconfig
@@ -206,4 +206,8 @@ config MM_PANIC_ON_FAILURE
 	default n
 	depends on DEBUG_MM
 
+config MM_VM_MAP
+       bool
+       default n
+
 source "mm/iob/Kconfig"

--- a/mm/Makefile
+++ b/mm/Makefile
@@ -30,6 +30,7 @@ include shm/Make.defs
 include iob/Make.defs
 include circbuf/Make.defs
 include kasan/Make.defs
+include vm_map/Make.defs
 
 BINDIR ?= bin
 

--- a/mm/shm/shmat.c
+++ b/mm/shm/shmat.c
@@ -31,6 +31,7 @@
 #include <nuttx/sched.h>
 #include <nuttx/arch.h>
 #include <nuttx/pgalloc.h>
+#include <nuttx/mm/vm_map.h>
 
 #include "shm/shm.h"
 
@@ -102,6 +103,7 @@ FAR void *shmat(int shmid, FAR const void *shmaddr, int shmflg)
   uintptr_t vaddr;
   unsigned int npages;
   int ret;
+  union vm_map_id_u map_id;
 
   /* Get the region associated with the shmid */
 
@@ -113,9 +115,8 @@ FAR void *shmat(int shmid, FAR const void *shmaddr, int shmflg)
 
   tcb = nxsched_self();
   DEBUGASSERT(tcb && tcb->group);
-  group = tcb->group;
-  DEBUGASSERT(group->tg_shm.gs_handle != NULL &&
-              group->tg_shm.gs_vaddr[shmid] == 0);
+
+  DEBUGASSERT(group->tg_shm.gs_handle != NULL);
 
   /* Get exclusive access to the region data structure */
 
@@ -155,7 +156,14 @@ FAR void *shmat(int shmid, FAR const void *shmaddr, int shmflg)
    * detach, we need to get the region table index.
    */
 
-  group->tg_shm.gs_vaddr[shmid] = vaddr;
+  map_id.shmid = shmid;
+  ret = vm_map_add(VM_MAP_SHM, map_id,
+                   vaddr, region->sr_ds.shm_segsz);
+  if (ret < 0)
+    {
+      shmerr("ERROR: vm_map_add() failed\n");
+      goto errout_with_vaddr;
+    }
 
   /* Increment the count of processes attached to this region */
 

--- a/mm/shm/shmdt.c
+++ b/mm/shm/shmdt.c
@@ -69,19 +69,13 @@
 int shmdt(FAR const void *shmaddr)
 {
   FAR struct shm_region_s *region;
-  FAR struct task_group_s *group;
-  FAR struct tcb_s *tcb;
   FAR const struct vm_map_entry_s *map;
   unsigned int npages;
   int shmid;
   int ret;
+  GRAN_HANDLE gran = vm_allocator_get(VM_ALLOCATOR_SHM);
 
-  /* Get the TCB and group containing our virtual memory allocator */
-
-  tcb = nxsched_self();
-  DEBUGASSERT(tcb && tcb->group);
-  group = tcb->group;
-  DEBUGASSERT(group->tg_shm.gs_handle != NULL);
+  DEBUGASSERT(gran);
 
   /* Perform the reverse lookup to get the shmid corresponding to this
    * shmaddr.
@@ -115,7 +109,7 @@ int shmdt(FAR const void *shmaddr)
 
   /* Free the virtual address space */
 
-  gran_free(group->tg_shm.gs_handle, (FAR void *)shmaddr,
+  gran_free(gran, (FAR void *)shmaddr,
             region->sr_ds.shm_segsz);
 
   /* Convert the region size to pages */
@@ -166,7 +160,7 @@ int shmdt(FAR const void *shmaddr)
 
   /* Save the process ID of the last operation */
 
-  region->sr_ds.shm_lpid = tcb->pid;
+  region->sr_ds.shm_lpid = getpid();
 
   /* Save the time of the last shmdt() */
 

--- a/mm/vm_map/Make.defs
+++ b/mm/vm_map/Make.defs
@@ -1,0 +1,30 @@
+############################################################################
+# mm/vm_map/Make.defs
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+# Virtual memory map list support
+
+ifeq ($(CONFIG_MM_VM_MAP),y)
+CSRCS += vm_map.c
+
+# Add the shared memory directory to the build
+
+DEPPATH += --dep-path vm_map
+VPATH += :vm_map
+endif

--- a/mm/vm_map/vm_map.c
+++ b/mm/vm_map/vm_map.c
@@ -1,0 +1,231 @@
+/****************************************************************************
+ * mm/vm_map/vm_map.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <queue.h>
+#include <nuttx/sched.h>
+#include <nuttx/semaphore.h>
+#include <nuttx/mm/vm_map.h>
+#include <nuttx/kmalloc.h>
+#include <sys/mman.h>
+#include <assert.h>
+
+#if defined(CONFIG_BUILD_FLAT) || defined(__KERNEL__)
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+static bool vaddr_in_area(FAR const void *addr, FAR const void *start,
+                          size_t length)
+{
+  uintptr_t u_addr = (uintptr_t)addr;
+  uintptr_t u_start = (uintptr_t)start;
+  return (u_addr >= u_start) && (u_addr < u_start + length);
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: vm_map_initialize
+ *
+ * Description:
+ *   Allocates a task group specific vm_map stucture. Called when the group
+ *   is initialized
+ *
+ ****************************************************************************/
+
+void vm_map_initialize(FAR struct vm_map_s *mm)
+{
+  memset(mm, 0, sizeof(struct vm_map_s));
+  sq_init(&mm->vm_map_sq);
+  nxsem_init(&mm->vm_map_sem, 0, 1);
+}
+
+/****************************************************************************
+ * Name: vm_map_destroy
+ *
+ * Description:
+ *   De-allocates a task group specific vm_map stucture and the vm_map_sem
+ *
+ ****************************************************************************/
+
+void vm_map_destroy(FAR struct vm_map_s *mm)
+{
+  FAR struct vm_map_entry_s *map =
+    (struct vm_map_entry_s *)sq_peek(&mm->vm_map_sq);
+  FAR struct vm_map_entry_s *next;
+  while (map)
+    {
+      next = (struct vm_map_entry_s *)sq_next(((sq_entry_t *)map));
+      munmap((void *)map->vaddr, map->length);
+
+      /* file_unmap should have successfully destroyed the first mapping
+       * but just in case it fails continue on the next one
+       */
+
+      DEBUGASSERT(next == (struct vm_map_entry_s *)sq_peek(&mm->vm_map_sq));
+      map = next;
+    }
+
+  nxsem_destroy(&mm->vm_map_sem);
+}
+
+/****************************************************************************
+ * Name: vm_map_add
+ *
+ * Description:
+ *   Add a mapping to task group's vm_map list
+ *
+ ****************************************************************************/
+
+int vm_map_add(enum vm_map_type type, union vm_map_id_u id,
+               FAR const void *vaddr, size_t length)
+{
+  FAR struct tcb_s *tcb = nxsched_self();
+  FAR struct task_group_s *group = tcb->group;
+  FAR struct vm_map_s *mm = &group->tg_vm_map;
+  FAR struct vm_map_entry_s *map = kmm_zalloc(sizeof(struct vm_map_entry_s));
+  int ret;
+
+  if (!map)
+    {
+      return -ENOMEM;
+    }
+
+  map->type = type;
+  map->id = id;
+  map->vaddr = vaddr;
+  map->length = length;
+
+  ret = nxsem_wait(&mm->vm_map_sem);
+  if (ret < 0)
+    {
+      kmm_free(map);
+      return ret;
+    }
+
+  sq_addfirst((sq_entry_t *)map, &mm->vm_map_sq);
+
+  nxsem_post(&mm->vm_map_sem);
+
+  return OK;
+}
+
+/****************************************************************************
+ * Name: vm_map_find
+ *
+ * Description:
+ *   Find the first mapping containing an address from the task group's list
+ *
+ ****************************************************************************/
+
+FAR const struct vm_map_entry_s *vm_map_find(FAR const void *vaddr)
+{
+  FAR struct tcb_s *tcb = nxsched_self();
+  FAR struct task_group_s *group = tcb->group;
+  FAR struct vm_map_s *mm = &group->tg_vm_map;
+  FAR struct vm_map_entry_s *map = NULL;
+
+  if (nxsem_wait(&mm->vm_map_sem) == OK)
+    {
+      map = (struct vm_map_entry_s *)sq_peek(&mm->vm_map_sq);
+
+      while (map && !vaddr_in_area(vaddr, map->vaddr, map->length))
+        {
+          map = (struct vm_map_entry_s *)sq_next(((sq_entry_t *)map));
+        }
+
+      nxsem_post(&mm->vm_map_sem);
+    }
+
+  return map;
+}
+
+/****************************************************************************
+ * Name: vm_map_rm
+ *
+ * Description:
+ *   Completely remove first mapping containing an address from the task
+ *   group's list
+ *
+ ****************************************************************************/
+
+int vm_map_rm(FAR const void *vaddr)
+{
+  FAR struct tcb_s *tcb = nxsched_self();
+  FAR struct task_group_s *group = tcb->group;
+  FAR struct vm_map_s *mm = &group->tg_vm_map;
+  FAR struct vm_map_entry_s *prev;
+  FAR struct vm_map_entry_s *r = NULL;
+
+  int ret = nxsem_wait(&mm->vm_map_sem);
+  if (ret < 0)
+    {
+      return ret;
+    }
+
+  prev = (struct vm_map_entry_s *)sq_peek(&mm->vm_map_sq);
+
+  if (!prev)
+    {
+      nxsem_post(&mm->vm_map_sem);
+      return -ENOENT;
+    }
+
+  if (vaddr_in_area(vaddr, prev->vaddr, prev->length))
+    {
+      sq_remfirst(&mm->vm_map_sq);
+      r = prev;
+    }
+  else
+    {
+      while ((r = (struct vm_map_entry_s *)sq_next(((sq_entry_t *)prev))))
+        {
+          if (vaddr_in_area(vaddr, r->vaddr, r->length))
+            {
+              sq_remafter((sq_entry_t *)prev, &mm->vm_map_sq);
+              break;
+            }
+
+          prev = r;
+        }
+    }
+
+  nxsem_post(&mm->vm_map_sem);
+
+  if (r)
+    {
+      kmm_free(r);
+      return OK;
+    }
+
+  return -ENOENT;
+}
+
+#endif /* defined(CONFIG_BUILD_FLAT) || defined(__KERNEL__) */

--- a/mm/vm_map/vm_map.c
+++ b/mm/vm_map/vm_map.c
@@ -228,4 +228,75 @@ int vm_map_rm(FAR const void *vaddr)
   return -ENOENT;
 }
 
+/****************************************************************************
+ * Name: vm_allocator_add
+ *
+ * Description:
+ *   Adds a memory allocator handle
+ *
+ ****************************************************************************/
+
+int vm_allocator_add(enum vm_allocator_type id,
+                     FAR const void *allocator_handle)
+{
+  FAR struct tcb_s *tcb = nxsched_self();
+  FAR struct task_group_s *group = tcb->group;
+  FAR struct vm_map_s *mm = &group->tg_vm_map;
+
+  if (id >= VM_ALLOCATOR_END)
+    {
+      return -ENOENT;
+    }
+
+  mm->allocator_handle[id] = allocator_handle;
+
+  return OK;
+}
+
+/****************************************************************************
+ * Name: vm_allocator_get
+ *
+ * Description:
+ *   Returns a memory allocator handle
+ *
+ ****************************************************************************/
+
+FAR const void *vm_allocator_get(int id)
+{
+  FAR struct tcb_s *tcb = nxsched_self();
+  FAR struct task_group_s *group = tcb->group;
+  FAR struct vm_map_s *mm = &group->tg_vm_map;
+
+  if (id >= VM_ALLOCATOR_END)
+    {
+      return NULL;
+    }
+
+  return mm->allocator_handle[id];
+}
+
+/****************************************************************************
+ * Name: vm_allocator_rm
+ *
+ * Description:
+ *   Removes a memory allocator handle
+ *
+ ****************************************************************************/
+
+int vm_allocator_rm(int id)
+{
+  FAR struct tcb_s *tcb = nxsched_self();
+  FAR struct task_group_s *group = tcb->group;
+  FAR struct vm_map_s *mm = &group->tg_vm_map;
+
+  if (id >= VM_ALLOCATOR_END)
+    {
+      return -ENOENT;
+    }
+
+  mm->allocator_handle[id] = NULL;
+
+  return OK;
+}
+
 #endif /* defined(CONFIG_BUILD_FLAT) || defined(__KERNEL__) */

--- a/sched/group/group_create.c
+++ b/sched/group/group_create.c
@@ -36,6 +36,7 @@
 #include <nuttx/semaphore.h>
 #include <nuttx/sched.h>
 #include <nuttx/tls.h>
+#include <nuttx/mm/vm_map.h>
 
 #include "sched/sched.h"
 #include "group/group.h"
@@ -281,6 +282,12 @@ void group_initialize(FAR struct task_tcb_s *tcb)
   /* Assign the PID of this new task as a member of the group. */
 
   group->tg_members[0] = tcb->cmn.pid;
+#endif
+
+#ifdef CONFIG_MM_VM_MAP
+  /* Allocate vm_map list if required */
+
+  vm_map_initialize(&group->tg_vm_map);
 #endif
 
   /* Save the ID of the main task within the group of threads.  This needed

--- a/sched/group/group_leave.c
+++ b/sched/group/group_leave.c
@@ -34,6 +34,7 @@
 #include <nuttx/net/net.h>
 #include <nuttx/lib/lib.h>
 #include <nuttx/tls.h>
+#include <nuttx/mm/vm_map.h>
 
 #ifdef CONFIG_BINFMT_LOADABLE
 #  include <nuttx/binfmt/binfmt.h>
@@ -196,6 +197,12 @@ static inline void group_release(FAR struct task_group_s *group)
       kmm_free(group->tg_members);
       group->tg_members = NULL;
     }
+#endif
+
+#ifdef CONFIG_MM_VM_MAP
+  /* Destroy the vm_map list */
+
+  vm_map_destroy(&group->tg_vm_map);
 #endif
 
 #if defined(CONFIG_FILE_STREAM) && defined(CONFIG_MM_KERNEL_HEAP)

--- a/syscall/syscall.csv
+++ b/syscall/syscall.csv
@@ -69,7 +69,7 @@
 "mq_timedreceive","mqueue.h","!defined(CONFIG_DISABLE_MQUEUE)","ssize_t","mqd_t","FAR char *","size_t","FAR unsigned int *","FAR const struct timespec *"
 "mq_timedsend","mqueue.h","!defined(CONFIG_DISABLE_MQUEUE)","int","mqd_t","FAR const char *","size_t","unsigned int","FAR const struct timespec *"
 "mq_unlink","mqueue.h","!defined(CONFIG_DISABLE_MQUEUE)","int","FAR const char *"
-"munmap","sys/mman.h","defined(CONFIG_FS_RAMMAP)","int","FAR void *","size_t"
+"munmap","sys/mman.h","defined(CONFIG_MM_VM_MAP) || defined(CONFIG_FS_RAMMAP)","int","FAR void *","size_t"
 "nx_mkfifo","nuttx/fs/fs.h","defined(CONFIG_PIPES) && CONFIG_DEV_FIFO_SIZE > 0","int","FAR const char *","mode_t","size_t"
 "nx_pipe","nuttx/fs/fs.h","defined(CONFIG_PIPES) && CONFIG_DEV_PIPE_SIZE > 0","int","int [2]|FAR int *","size_t","int"
 "nx_pthread_create","nuttx/pthread.h","!defined(CONFIG_DISABLE_PTHREAD)","int","pthread_trampoline_t","FAR pthread_t *","FAR const pthread_attr_t *","pthread_startroutine_t","pthread_addr_t"


### PR DESCRIPTION
## Summary

This adds
1) A task group specific virtual memory structure, and inside it a list of virtual memory mappings. This information is needed at least to make munmap (find info about the vm mapping based on a process specific virtual address).
2) Hooks for calling mmap and munmap ioctl for drivers which can implement virtual memory mapping for files
3) An ioctl for MUNMAP, which didn't exist even though MMAP is there.
4) Add a config flag CONFIG_MM_VM_MAP, which can be selected by other features requiring this

## Impact

This is a pre-requisite for implementing posix shm support, which needs mmap, munmap and ftruncate.

## Testing

Has been tested with a posix shm interface, which is still under some cleanup work, can proceed on publishing that later on
