### PR TITLE
sched/init: drivers_initialize() should be late than up_initialize()

### DIFF
--- a/sched/init/nx_start.c
+++ b/sched/init/nx_start.c
@@ -650,10 +650,6 @@ void nx_start(void)
   binfmt_initialize();
 #endif
 
-  /* Initialize common drivers */
-
-  drivers_initialize();
-
   /* Initialize Hardware Facilities *****************************************/
 
   /* The processor specific details of running the operating system
@@ -663,6 +659,10 @@ void nx_start(void)
    */
 
   up_initialize();
+
+  /* Initialize common drivers */
+
+  drivers_initialize();
 
 #ifdef CONFIG_BOARD_EARLY_INITIALIZE
   /* Call the board-specific up_initialize() extension to support


### PR DESCRIPTION
## Summary

sched/init: drivers_initialize() should be late than up_initialize()

```
up_initialize
|
 ->up_serialinit
   |
    ->uart_register  /* ("/dev/console", &CONSOLE_DEV); */

drivers_initialize
|
 ->syslog_console_init
   |
    ->register_driver /* ("/dev/console", &g_consoleops, 0666, NULL); */
```

Signed-off-by: chao.an <anchao@xiaomi.com>


## Impact

up_initialize

Fix https://github.com/apache/incubator-nuttx/pull/5728:
https://github.com/apache/incubator-nuttx/pull/5728#issuecomment-1091139235

## Testing

```
./tools/configure.sh qemu-intel64/nsh
qemu-system-x86_64 -cpu host -enable-kvm -m 2G -cdrom boot.iso -nographic -serial mon:stdio
```