### PR TITLE
sched/pthread_create:fix bug,delete data_sem

### DIFF
--- a/sched/pthread/pthread.h
+++ b/sched/pthread/pthread.h
@@ -51,7 +51,6 @@ struct join_s
 {
   FAR struct join_s *next;       /* Implements link list */
   uint8_t        crefs;          /* Reference count */
-  bool           started;        /* true: pthread started. */
   bool           detached;       /* true: pthread_detached'ed */
   bool           terminated;     /* true: detach'ed+exit'ed */
   pthread_t      thread;         /* Includes pid */

--- a/sched/pthread/pthread_create.c
+++ b/sched/pthread/pthread_create.c
@@ -151,21 +151,9 @@ static inline void pthread_addjoininfo(FAR struct task_group_s *group,
 static void pthread_start(void)
 {
   FAR struct pthread_tcb_s *ptcb = (FAR struct pthread_tcb_s *)this_task();
-  FAR struct task_group_s *group = ptcb->cmn.group;
   FAR struct join_s *pjoin = (FAR struct join_s *)ptcb->joininfo;
 
-  DEBUGASSERT(group != NULL && pjoin != NULL);
-
-  /* Successfully spawned, add the pjoin to our data set. */
-
-  pthread_sem_take(&group->tg_joinsem, NULL, false);
-  pthread_addjoininfo(group, pjoin);
-  pthread_sem_give(&group->tg_joinsem);
-
-  /* Report to the spawner that we successfully started. */
-
-  pjoin->started = true;
-  pthread_sem_give(&pjoin->data_sem);
+  DEBUGASSERT(pjoin != NULL);
 
   /* The priority of this thread may have been boosted to avoid priority
    * inversion problems.  If that is the case, then drop to the correct
@@ -529,37 +517,28 @@ int nx_pthread_create(pthread_trampoline_t trampoline, FAR pthread_t *thread,
   pid = ptcb->cmn.pid;
   pjoin->thread = (pthread_t)pid;
 
-  /* Initialize the semaphores in the join structure to zero. */
+  /* Initialize the semaphore in the join structure to zero. */
 
-  ret = nxsem_init(&pjoin->data_sem, 0, 0);
-  if (ret == OK)
-    {
-      ret = nxsem_init(&pjoin->exit_sem, 0, 0);
-    }
+  ret = nxsem_init(&pjoin->exit_sem, 0, 0);
 
   if (ret < 0)
     {
       ret = -ret;
     }
 
-  /* Thse semaphores are used for signaling and, hence, should not have
+  /* Thse semaphore are used for signaling and, hence, should not have
    * priority inheritance enabled.
    */
 
-  if (ret == OK)
-    {
-      ret = nxsem_set_protocol(&pjoin->data_sem, SEM_PRIO_NONE);
+    if (ret == OK)
+      {
+        ret = nxsem_set_protocol(&pjoin->exit_sem, SEM_PRIO_NONE);
+      }
 
-      if (ret == OK)
-        {
-          ret = nxsem_set_protocol(&pjoin->exit_sem, SEM_PRIO_NONE);
-        }
-
-      if (ret < 0)
-        {
-          ret = -ret;
-        }
-    }
+    if (ret < 0)
+      {
+        ret = -ret;
+      }
 
   /* If the priority of the new pthread is lower than the priority of the
    * parent thread, then starting the pthread could result in both the
@@ -590,13 +569,10 @@ int nx_pthread_create(pthread_trampoline_t trampoline, FAR pthread_t *thread,
   sched_lock();
   if (ret == OK)
     {
+      pthread_sem_take(&ptcb->cmn.group->tg_joinsem, NULL, false);
+      pthread_addjoininfo(ptcb->cmn.group, pjoin);
+      pthread_sem_give(&ptcb->cmn.group->tg_joinsem);
       nxtask_activate((FAR struct tcb_s *)ptcb);
-
-      /* Wait for the task to actually get running and to register
-       * its join structure.
-       */
-
-      pthread_sem_take(&pjoin->data_sem, NULL, false);
 
       /* Return the thread information to the caller */
 
@@ -605,19 +581,12 @@ int nx_pthread_create(pthread_trampoline_t trampoline, FAR pthread_t *thread,
           *thread = (pthread_t)pid;
         }
 
-      if (!pjoin->started)
-        {
-          ret = EINVAL;
-        }
-
       sched_unlock();
-      nxsem_destroy(&pjoin->data_sem);
     }
   else
     {
       sched_unlock();
       dq_rem((FAR dq_entry_t *)ptcb, (FAR dq_queue_t *)&g_inactivetasks);
-      nxsem_destroy(&pjoin->data_sem);
       nxsem_destroy(&pjoin->exit_sem);
 
       errcode = EIO;


### PR DESCRIPTION
if a pthread set attr is detach,and when call pthread_create,
new thread exit quikly,new thread's tcb be free,then pthread_create
use new thread's tcb will crash.
Signed-off-by: anjiahao <anjiahao@xiaomi.com>

## Summary

## Impact
will impact thread scheduling method
## Testing
ostest
