### PR TITLE
rpmsg_usrsock: Support the wireless ioctl which contain pointer

### DIFF
--- a/include/nuttx/wireless/wireless.h
+++ b/include/nuttx/wireless/wireless.h
@@ -144,6 +144,15 @@
 
 #define SIOCSIWCOUNTRY      _WLIOC(0x0037)  /* Country code extension */
 
+#define WL_IS80211POINTERCMD(cmd) ((cmd) == SIOCGIWSCAN || \
+                                   (cmd) == SIOCSIWSCAN || \
+                                   (cmd) == SIOCSIWCOUNTRY || \
+                                   (cmd) == SIOCGIWRANGE || \
+                                   (cmd) == SIOCSIWENCODEEXT || \
+                                   (cmd) == SIOCGIWENCODEEXT || \
+                                   (cmd) == SIOCGIWESSID || \
+                                   (cmd) == SIOCSIWESSID)
+
 /* Device-specific network IOCTL commands *******************************************/
 
 #define WL_NETFIRST         0x0000          /* First network command */

--- a/net/usrsock/usrsock_dev.c
+++ b/net/usrsock/usrsock_dev.c
@@ -222,7 +222,7 @@ static ssize_t iovec_do(FAR void *srcdst, size_t srcdstlen,
         }
     }
 
-  return total;
+  return total == 0 && iovcnt == 0 ? -1: total;
 }
 
 /****************************************************************************

--- a/net/usrsock/usrsock_dev.c
+++ b/net/usrsock/usrsock_dev.c
@@ -143,7 +143,7 @@ static ssize_t iovec_do(FAR void *srcdst, size_t srcdstlen,
 
   /* Rewind to correct position. */
 
-  while (pos > 0 && iovcnt > 0)
+  while (pos >= 0 && iovcnt > 0)
     {
       if (iov->iov_len <= pos)
         {
@@ -222,7 +222,7 @@ static ssize_t iovec_do(FAR void *srcdst, size_t srcdstlen,
         }
     }
 
-  return total == 0 && iovcnt == 0 ? -1: total;
+  return total;
 }
 
 /****************************************************************************


### PR DESCRIPTION
## Summary
rpmsg_usrsock: Support the wireless ioctl which contain pointer
## Impact

## Testing

