### PR TITLE
sim: bt: Add specific bluetooth HCI number id

### DIFF
--- a/arch/sim/Kconfig
+++ b/arch/sim/Kconfig
@@ -378,6 +378,14 @@ config SIM_HCISOCKET
 		control of the device, but is abstracted from the
 		physical interface which is still handled by Linux.
 
+config SIM_HCISOCKET_DEVID
+	int "Bluetooth Device ID"
+	default 0
+	depends on SIM_HCISOCKET
+	---help---
+		Attached the local bluetooth device use specific
+		Bluetooth HCI number id.
+
 config SIM_I2CBUS
 	bool "Simulated I2C Bus"
 	default n

--- a/boards/sim/sim/sim/src/sim_bringup.c
+++ b/boards/sim/sim/sim/src/sim_bringup.c
@@ -361,7 +361,7 @@ int sim_bringup(void)
 #ifdef CONFIG_SIM_HCISOCKET
   /* Register the Host Bluetooth network device via HCI socket */
 
-  ret = bthcisock_register(0);  /* Use HCI0 */
+  ret = bthcisock_register(CONFIG_SIM_HCISOCKET_DEVID);
   if (ret < 0)
     {
       syslog(LOG_ERR, "ERROR: bthcisock_register() failed: %d\n", ret);


### PR DESCRIPTION
Add option for attached the local bluetooth device use
specific bluetooth HCI number id.

Signed-off-by: Lingao Meng <menglingao@xiaomi.com>

## Summary

## Impact

## Testing

