### PR TITLE
fs/vfs/fs_truncate.c: Use ioctl to truncate on non-mountpoint inode

### DIFF
--- a/fs/vfs/fs_truncate.c
+++ b/fs/vfs/fs_truncate.c
@@ -31,6 +31,7 @@
 #include <debug.h>
 
 #include <nuttx/fs/fs.h>
+#include <nuttx/fs/ioctl.h>
 
 #include "inode/inode.h"
 
@@ -68,7 +69,19 @@ int file_truncate(FAR struct file *filep, off_t length)
    */
 
   inode = filep->f_inode;
-  if (inode == NULL || !INODE_IS_MOUNTPT(inode) || inode->u.i_mops == NULL)
+  if (inode == NULL)
+    {
+      return -EINVAL;
+    }
+
+  /* If inode is not mountpoint try ioctl first */
+
+  if (!INODE_IS_MOUNTPT(inode))
+    {
+      return file_ioctl(filep, FIOC_TRUNCATE, length);
+    }
+
+  if (inode->u.i_mops == NULL)
     {
       fwarn("WARNING:  Not a (regular) file on a mounted file system.\n");
       return -EINVAL;

--- a/include/nuttx/fs/ioctl.h
+++ b/include/nuttx/fs/ioctl.h
@@ -182,6 +182,9 @@
                                            *      configuration
                                            * OUT: None
                                            */
+#define FIOC_TRUNCATE   _FIOC(0x0010)     /* IN:  Length of the file after truncate
+                                           * OUT: None
+                                           */
 
 /* NuttX file system ioctl definitions **************************************/
 


### PR DESCRIPTION
Signed-off-by: Jukka Laitinen <jukkax@ssrc.tii.ae>

## Summary

This adds support to call ftruncate on an inode in non-mountable filesystem, e.g. a driver or shm

## Impact

Enables calling ftruncate on a driver node

## Testing

Tested on stm32f7 with a custom posix shm driver
