### PR TITLE
RISC-V: Move mhartid to own assembly macro+function

### DIFF
--- a/arch/risc-v/src/common/riscv_macros.S
+++ b/arch/risc-v/src/common/riscv_macros.S
@@ -152,3 +152,23 @@
 .endm
 #endif /* !defined(CONFIG_SMP) && !defined(CONFIG_ARCH_USE_S_MODE) */
 #endif /* CONFIG_ARCH_INTERRUPTSTACK > 15 */
+
+/****************************************************************************
+ * Name: riscv_mhartid
+ *
+ * Description:
+ *   Context aware way to query hart id
+ *
+ * Returned Value:
+ *   Hart id
+ *
+ ****************************************************************************/
+
+.macro  riscv_mhartid out
+#ifdef CONFIG_ARCH_USE_S_MODE
+  csrr    \out, CSR_SCRATCH
+  REGLOAD \out, RISCV_PERCPU_HARTID(\out)
+#else
+  csrr    \out, mhartid
+#endif
+.endm

--- a/arch/risc-v/src/common/riscv_mhartid.S
+++ b/arch/risc-v/src/common/riscv_mhartid.S
@@ -1,5 +1,5 @@
 /****************************************************************************
- * arch/risc-v/src/common/riscv_cpuindex.c
+ * arch/risc-v/src/common/riscv_mhartid.S
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -18,42 +18,36 @@
  *
  ****************************************************************************/
 
+.file "riscv_mhartid.S"
+
 /****************************************************************************
  * Included Files
  ****************************************************************************/
 
 #include <nuttx/config.h>
 
-#include <stdint.h>
-
-#include <nuttx/arch.h>
-#include <nuttx/irq.h>
-
-#include "riscv_internal.h"
+#include "riscv_macros.S"
 
 /****************************************************************************
- * Public Functions
+ * Public Symbols
  ****************************************************************************/
 
+    .globl  riscv_mhartid
+
 /****************************************************************************
- * Name: up_cpu_index
+ * Name: riscv_mhartid
  *
  * Description:
- *   Return an index in the range of 0 through (CONFIG_SMP_NCPUS-1) that
- *   corresponds to the currently executing CPU.
- *
- * Input Parameters:
- *   None
+ *   Context aware way to query hart id
  *
  * Returned Value:
- *   An integer index in the range of 0 through (CONFIG_SMP_NCPUS-1) that
- *   corresponds to the currently executing CPU.
+ *   Hart id
  *
  ****************************************************************************/
 
-#ifdef CONFIG_SMP
-int up_cpu_index(void)
-{
-  return (int)riscv_mhartid();
-}
-#endif
+.type riscv_mhartid, function
+
+riscv_mhartid:
+
+  riscv_mhartid a0
+  ret

--- a/arch/risc-v/src/k210/Make.defs
+++ b/arch/risc-v/src/k210/Make.defs
@@ -39,6 +39,7 @@ CMN_CSRCS += riscv_misaligned.c
 
 ifeq ($(CONFIG_SMP), y)
 CMN_CSRCS += riscv_cpuindex.c riscv_cpupause.c riscv_cpustart.c
+CMN_ASRCS += riscv_mhartid.S
 endif
 
 ifeq ($(CONFIG_SCHED_BACKTRACE),y)

--- a/arch/risc-v/src/mpfs/Make.defs
+++ b/arch/risc-v/src/mpfs/Make.defs
@@ -32,7 +32,10 @@ CMN_CSRCS += riscv_releasestack.c riscv_stackframe.c riscv_schedulesigaction.c
 CMN_CSRCS += riscv_sigdeliver.c riscv_unblocktask.c riscv_usestack.c
 CMN_CSRCS += riscv_mdelay.c riscv_udelay.c
 CMN_CSRCS += riscv_idle.c riscv_tcbinfo.c riscv_getnewintctx.c
-CMN_CSRCS += riscv_cpuindex.c riscv_doirq.c riscv_mtimer.c
+CMN_CSRCS += riscv_doirq.c riscv_mtimer.c
+
+# Specify ASM code within the common directory to be included
+CMN_ASRCS += riscv_mhartid.S
 
 ifeq ($(CONFIG_SCHED_BACKTRACE),y)
 CMN_CSRCS += riscv_backtrace.c

--- a/arch/risc-v/src/qemu-rv/Make.defs
+++ b/arch/risc-v/src/qemu-rv/Make.defs
@@ -38,6 +38,7 @@ CMN_CSRCS += riscv_exception.c riscv_getnewintctx.c riscv_doirq.c
 
 ifeq ($(CONFIG_SMP), y)
 CMN_CSRCS += riscv_cpuindex.c riscv_cpupause.c riscv_cpustart.c
+CMN_ASRCS += riscv_mhartid.S
 endif
 
 ifeq ($(CONFIG_SCHED_BACKTRACE),y)


### PR DESCRIPTION
Hartid and cpuindex are not the same thing. Hartid is needed regardless
of SMP, for external interrupt handling etc.

SMP needs cpuindex which might not be index == hartid, so both are
needed. IMO it is clearer to provide separate API for both.

Currently the implementation of up_cpu_index is done a bit lazily,
because it assumes hartid == cpu index, but this is not 100% accurate,
so it is still missing some logic.

## Summary
Separates SMP cpuindex and mhartid
## Impact
De-couples two unrelated things from each other
## Testing
MPFS icicle:knsh
