### PR TITLE
arch/riscv: Jump instead call riscv_dispatch_syscall

### DIFF
--- a/arch/risc-v/include/arch.h
+++ b/arch/risc-v/include/arch.h
@@ -66,11 +66,6 @@
 #  define REGSTORE  __STR(sd)
 #endif
 
-/* RISC-V requires a 16-byte stack alignment. */
-
-#define STACK_ALIGNMENT     16
-#define STACK_FRAME_SIZE    __XSTR(STACK_ALIGNMENT)
-
 /* Provide the maximum amount of page table levels per MMU type */
 
 #ifdef CONFIG_ARCH_MMU_TYPE_SV39

--- a/arch/risc-v/include/syscall.h
+++ b/arch/risc-v/include/syscall.h
@@ -124,18 +124,6 @@
 #define SYS_signal_handler_return (7)
 #endif /* !CONFIG_BUILD_FLAT */
 
-#if defined (CONFIG_ARCH_USE_S_MODE) && defined (__KERNEL__)
-#  define ASM_SYS_CALL \
-     " addi sp, sp, -16\n"                  /* Make room */ \
-     REGSTORE " ra, 0(sp)\n"                /* Save ra */ \
-     " jal  ra, riscv_dispatch_syscall\n"   /* Dispatch (modifies ra) */ \
-     REGLOAD " ra, 0(sp)\n"                 /* Restore ra */ \
-     " addi sp, sp, 16\n"                   /* Restore sp */
-#else
-#  define ASM_SYS_CALL \
-     "ecall"
-#endif
-
 /****************************************************************************
  * Public Types
  ****************************************************************************/
@@ -162,6 +150,20 @@ extern "C"
 #define EXTERN extern
 #endif
 
+#if defined(CONFIG_ARCH_USE_S_MODE) && defined(__KERNEL__)
+uintptr_t sys_call0(unsigned int nbr);
+uintptr_t sys_call1(unsigned int nbr, uintptr_t parm1);
+uintptr_t sys_call2(unsigned int nbr, uintptr_t parm1, uintptr_t parm2);
+uintptr_t sys_call3(unsigned int nbr, uintptr_t parm1, uintptr_t parm2,
+                    uintptr_t parm3);
+uintptr_t sys_call4(unsigned int nbr, uintptr_t parm1, uintptr_t parm2,
+                    uintptr_t parm3, uintptr_t parm4);
+uintptr_t sys_call5(unsigned int nbr, uintptr_t parm1, uintptr_t parm2,
+                    uintptr_t parm3, uintptr_t parm4, uintptr_t parm5);
+uintptr_t sys_call6(unsigned int nbr, uintptr_t parm1, uintptr_t parm2,
+                    uintptr_t parm3, uintptr_t parm4, uintptr_t parm5,
+                    uintptr_t parm6);
+#else
 /****************************************************************************
  * Name: sys_call0
  *
@@ -176,7 +178,7 @@ static inline uintptr_t sys_call0(unsigned int nbr)
 
   asm volatile
     (
-     ASM_SYS_CALL
+     "ecall"
      :: "r"(r0)
      : "memory"
      );
@@ -201,7 +203,7 @@ static inline uintptr_t sys_call1(unsigned int nbr, uintptr_t parm1)
 
   asm volatile
     (
-     ASM_SYS_CALL
+     "ecall"
      :: "r"(r0), "r"(r1)
      : "memory"
      );
@@ -228,7 +230,7 @@ static inline uintptr_t sys_call2(unsigned int nbr, uintptr_t parm1,
 
   asm volatile
     (
-     ASM_SYS_CALL
+     "ecall"
      :: "r"(r0), "r"(r1), "r"(r2)
      : "memory"
      );
@@ -256,7 +258,7 @@ static inline uintptr_t sys_call3(unsigned int nbr, uintptr_t parm1,
 
   asm volatile
     (
-     ASM_SYS_CALL
+     "ecall"
      :: "r"(r0), "r"(r1), "r"(r2), "r"(r3)
      : "memory"
      );
@@ -286,7 +288,7 @@ static inline uintptr_t sys_call4(unsigned int nbr, uintptr_t parm1,
 
   asm volatile
     (
-     ASM_SYS_CALL
+     "ecall"
      :: "r"(r0), "r"(r1), "r"(r2), "r"(r3), "r"(r4)
      : "memory"
      );
@@ -317,7 +319,7 @@ static inline uintptr_t sys_call5(unsigned int nbr, uintptr_t parm1,
 
   asm volatile
     (
-     ASM_SYS_CALL
+     "ecall"
      :: "r"(r0), "r"(r1), "r"(r2), "r"(r3), "r"(r4), "r"(r5)
      : "memory"
      );
@@ -350,7 +352,7 @@ static inline uintptr_t sys_call6(unsigned int nbr, uintptr_t parm1,
 
   asm volatile
     (
-     ASM_SYS_CALL
+     "ecall"
      :: "r"(r0), "r"(r1), "r"(r2), "r"(r3), "r"(r4), "r"(r5), "r"(r6)
      : "memory"
      );
@@ -359,6 +361,7 @@ static inline uintptr_t sys_call6(unsigned int nbr, uintptr_t parm1,
 
   return r0;
 }
+#endif
 
 #undef EXTERN
 #ifdef __cplusplus

--- a/arch/risc-v/include/syscall.h
+++ b/arch/risc-v/include/syscall.h
@@ -126,11 +126,11 @@
 
 #if defined (CONFIG_ARCH_USE_S_MODE) && defined (__KERNEL__)
 #  define ASM_SYS_CALL \
-     " addi sp, sp, -" STACK_FRAME_SIZE "\n" /* Make room */ \
-     REGSTORE " ra, 0(sp)\n"                 /* Save ra */ \
-     " jal  ra, riscv_dispatch_syscall\n"    /* Dispatch (modifies ra) */ \
-     REGLOAD " ra, 0(sp)\n"                  /* Restore ra */ \
-     " addi sp, sp, " STACK_FRAME_SIZE "\n"  /* Restore sp */
+     " addi sp, sp, -16\n"                  /* Make room */ \
+     REGSTORE " ra, 0(sp)\n"                /* Save ra */ \
+     " jal  ra, riscv_dispatch_syscall\n"   /* Dispatch (modifies ra) */ \
+     REGLOAD " ra, 0(sp)\n"                 /* Restore ra */ \
+     " addi sp, sp, 16\n"                   /* Restore sp */
 #else
 #  define ASM_SYS_CALL \
      "ecall"

--- a/arch/risc-v/src/common/riscv_internal.h
+++ b/arch/risc-v/src/common/riscv_internal.h
@@ -323,7 +323,6 @@ uintptr_t riscv_mhartid(void);
 /* If kernel runs in Supervisor mode, a system call trampoline is needed */
 
 #ifdef CONFIG_ARCH_USE_S_MODE
-void riscv_dispatch_syscall(void) noreturn_function;
 void *riscv_perform_syscall(uintptr_t *regs);
 #endif
 

--- a/arch/risc-v/src/common/riscv_internal.h
+++ b/arch/risc-v/src/common/riscv_internal.h
@@ -33,8 +33,6 @@
 #  include <sys/types.h>
 #  include <stdint.h>
 #  include <syscall.h>
-#else
-#  include <arch/arch.h>
 #endif
 
 /****************************************************************************
@@ -48,6 +46,11 @@
 #define STACK_COLOR    0xdeadbeef
 #define INTSTACK_COLOR 0xdeadbeef
 #define HEAP_COLOR     'h'
+
+/* RISC-V requires a 16-byte stack alignment. */
+
+#define STACK_ALIGNMENT     16
+#define STACK_FRAME_SIZE    __XSTR(STACK_ALIGNMENT)
 
 /* Stack alignment macros */
 

--- a/arch/risc-v/src/common/riscv_swint.c
+++ b/arch/risc-v/src/common/riscv_swint.c
@@ -130,9 +130,9 @@ static void dispatch_syscall(void)
      "mv   a2, a0\n"                        /* a2=Save return value in a0 */
      "li   a0, 3\n"                         /* a0=SYS_syscall_return (3) */
 #ifdef CONFIG_ARCH_USE_S_MODE
-     "j    riscv_dispatch_syscall"          /* Return from the syscall */
+     "j    sys_call2"                       /* Return from the syscall */
 #else
-     " ecall"                               /* Return from the syscall */
+     "ecall"                                /* Return from the syscall */
 #endif
   );
 }

--- a/arch/risc-v/src/common/supervisor/Make.defs
+++ b/arch/risc-v/src/common/supervisor/Make.defs
@@ -20,7 +20,7 @@
 
 # If the NuttX kernel runs in S-mode
 
-CMN_ASRCS += riscv_dispatch_syscall.S
+CMN_ASRCS += riscv_syscall.S
 CMN_CSRCS += riscv_perform_syscall.c
 CMN_CSRCS += riscv_percpu.c riscv_sbi.c
 

--- a/arch/risc-v/src/common/supervisor/riscv_syscall.S
+++ b/arch/risc-v/src/common/supervisor/riscv_syscall.S
@@ -1,5 +1,5 @@
 /****************************************************************************
- * arch/risc-v/src/common/supervisor/riscv_dispatch_syscall.S
+ * arch/risc-v/src/common/supervisor/riscv_syscall.S
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -18,7 +18,7 @@
  *
  ****************************************************************************/
 
-.file "riscv_dispatch_syscall.S"
+.file "riscv_syscall.S"
 
 /****************************************************************************
  * Included Files
@@ -39,16 +39,22 @@
  * Public Symbols
  ****************************************************************************/
 
-    .globl  riscv_dispatch_syscall
+    .globl  sys_call0
+    .globl  sys_call1
+    .globl  sys_call2
+    .globl  sys_call3
+    .globl  sys_call4
+    .globl  sys_call5
+    .globl  sys_call6
 
 /****************************************************************************
- * Name: riscv_dispatch_syscall
+ * Name: sys_callx
  *
  * Description:
  *   Dispatch syscall from kernel
  *
  * C Function Prototype:
- *   void riscv_dispatch_syscall(void);
+ *   uintptr_t sys_callx(unsigned int nbr, ...);
  *
  * Input Parameters:
  *   Assumes the context to return is already set up
@@ -61,9 +67,21 @@
  *
  ****************************************************************************/
 
-.type riscv_dispatch_syscall, function
+.type sys_call0, function
+.type sys_call1, function
+.type sys_call2, function
+.type sys_call3, function
+.type sys_call4, function
+.type sys_call5, function
+.type sys_call6, function
 
-riscv_dispatch_syscall:
+sys_call0:
+sys_call1:
+sys_call2:
+sys_call3:
+sys_call4:
+sys_call5:
+sys_call6:
 
   addi       sp, sp, -XCPTCONTEXT_SIZE /* make room */
   save_ctx   sp                        /* save current context */
@@ -135,3 +153,13 @@ riscv_dispatch_syscall:
   /* return from exception, which updates the status register */
 
   ERET
+
+  .size sys_call0, .-sys_call0
+  .size sys_call1, .-sys_call1
+  .size sys_call2, .-sys_call2
+  .size sys_call3, .-sys_call3
+  .size sys_call4, .-sys_call4
+  .size sys_call5, .-sys_call5
+  .size sys_call6, .-sys_call6
+
+  .end


### PR DESCRIPTION
## Summary
adn revert "arch/risc-v: use STACK_FRAME_SIZE for in S-mode syscall asm"

## Impact
RISCV kernel mode

## Testing

