### PR TITLE
drivers: remove unimplemented open/close/ioctl interfaces

### DIFF
--- a/arch/arm/src/cxd56xx/cxd56_charger.c
+++ b/arch/arm/src/cxd56xx/cxd56_charger.c
@@ -77,8 +77,6 @@ static int charger_online(FAR bool *online);
 static int charger_get_temptable(FAR struct battery_temp_table_s *table);
 static int charger_set_temptable(FAR struct battery_temp_table_s *table);
 
-static int charger_open(FAR struct file *filep);
-static int charger_close(FAR struct file *filep);
 static ssize_t charger_read(FAR struct file *filep, FAR char *buffer,
                             size_t buflen);
 static ssize_t charger_write(FAR struct file *filep,
@@ -92,8 +90,8 @@ static int charger_ioctl(FAR struct file *filep, int cmd,
 
 static const struct file_operations g_chargerops =
 {
-  charger_open,   /* open */
-  charger_close,  /* close */
+  NULL,           /* open */
+  NULL,           /* close */
   charger_read,   /* read */
   charger_write,  /* write */
   NULL,           /* seek */
@@ -417,32 +415,6 @@ static int charger_set_temptable(FAR struct battery_temp_table_s *table)
   buf.T00 = table->T00;
 
   return cxd56_pmic_settemptable(&buf);
-}
-
-/****************************************************************************
- * Name: charger_open
- *
- * Description:
- *   This function is called whenever the battery device is opened.
- *
- ****************************************************************************/
-
-static int charger_open(FAR struct file *filep)
-{
-  return OK;
-}
-
-/****************************************************************************
- * Name: charger_close
- *
- * Description:
- *   This routine is called when the battery device is closed.
- *
- ****************************************************************************/
-
-static int charger_close(FAR struct file *filep)
-{
-  return OK;
 }
 
 /****************************************************************************

--- a/arch/arm/src/cxd56xx/cxd56_gauge.c
+++ b/arch/arm/src/cxd56xx/cxd56_gauge.c
@@ -62,14 +62,12 @@ struct bat_gauge_dev_s
  * Private Function Prototypes
  ****************************************************************************/
 
-static int gauge_open(FAR struct file *filep);
-static int gauge_close(FAR struct file *filep);
 static ssize_t gauge_read(FAR struct file *filep, FAR char *buffer,
                             size_t buflen);
 static ssize_t gauge_write(FAR struct file *filep,
                              FAR const char *buffer, size_t buflen);
 static int gauge_ioctl(FAR struct file *filep, int cmd,
-                         unsigned long arg);
+                       unsigned long arg);
 
 /****************************************************************************
  * Private Data
@@ -77,8 +75,8 @@ static int gauge_ioctl(FAR struct file *filep, int cmd,
 
 static const struct file_operations g_gaugeops =
 {
-  gauge_open,   /* open */
-  gauge_close,  /* close */
+  NULL,         /* open */
+  NULL,         /* close */
   gauge_read,   /* read */
   gauge_write,  /* write */
   NULL,         /* seek */
@@ -244,32 +242,6 @@ static int gauge_online(FAR bool *online)
     }
 
   *online = true;
-  return OK;
-}
-
-/****************************************************************************
- * Name: gauge_open
- *
- * Description:
- *   This function is called whenever the battery device is opened.
- *
- ****************************************************************************/
-
-static int gauge_open(FAR struct file *filep)
-{
-  return OK;
-}
-
-/****************************************************************************
- * Name: gauge_close
- *
- * Description:
- *   This routine is called when the battery device is closed.
- *
- ****************************************************************************/
-
-static int gauge_close(FAR struct file *filep)
-{
   return OK;
 }
 

--- a/arch/arm/src/cxd56xx/cxd56_ge2d.c
+++ b/arch/arm/src/cxd56xx/cxd56_ge2d.c
@@ -46,8 +46,6 @@
  * Private Function Prototypes
  ****************************************************************************/
 
-static int ge2d_open(FAR struct file *filep);
-static int ge2d_close(FAR struct file *filep);
 static ssize_t ge2d_read(FAR struct file *filep, FAR char *buffer,
                          size_t len);
 static ssize_t ge2d_write(FAR struct file *filep, FAR const char *buffer,
@@ -63,12 +61,9 @@ static int ge2d_irqhandler(int irq, FAR void *context, FAR void *arg);
 
 static const struct file_operations g_ge2dfops =
 {
-  .open  = ge2d_open,
-  .close = ge2d_close,
   .read  = ge2d_read,
   .write = ge2d_write,
-  .seek  = NULL,
-  .ioctl = ge2d_ioctl,
+  .ioctl = ge2d_ioctl
 };
 
 static sem_t g_wait;
@@ -97,24 +92,6 @@ static void ge2d_semgive(sem_t *id)
 }
 
 /****************************************************************************
- * Name: ge2d_open
- ****************************************************************************/
-
-static int ge2d_open(FAR struct file *filep)
-{
-  return 0;
-}
-
-/****************************************************************************
- * Name: ge2d_close
- ****************************************************************************/
-
-static int ge2d_close(FAR struct file *filep)
-{
-  return 0;
-}
-
-/****************************************************************************
  * Name: ge2d_read
  ****************************************************************************/
 
@@ -129,8 +106,7 @@ static ssize_t ge2d_read(FAR struct file *filep,
  * Name: ge2d_write
  ****************************************************************************/
 
-static ssize_t ge2d_write(FAR struct file *filep,
-                          FAR const char *buffer,
+static ssize_t ge2d_write(FAR struct file *filep, FAR const char *buffer,
                           size_t len)
 {
   uint32_t bits;

--- a/arch/arm/src/cxd56xx/cxd56_geofence.c
+++ b/arch/arm/src/cxd56xx/cxd56_geofence.c
@@ -68,8 +68,6 @@ struct cxd56_geofence_dev_s
 
 /* file operation functions */
 
-static int cxd56_geofence_open(FAR struct file *filep);
-static int cxd56_geofence_close(FAR struct file *filep);
 static ssize_t cxd56_geofence_read(FAR struct file *filep,
                                    FAR char *buffer,
                                    size_t len);
@@ -101,8 +99,8 @@ static int cxd56_geofence_set_mode(unsigned long arg);
 
 static const struct file_operations g_geofencefops =
 {
-  cxd56_geofence_open,  /* open */
-  cxd56_geofence_close, /* close */
+  NULL,                 /* open */
+  NULL,                 /* close */
   cxd56_geofence_read,  /* read */
   NULL,                 /* write */
   NULL,                 /* seek */
@@ -472,48 +470,6 @@ static void cxd56_geofence_sighandler(uint32_t data, FAR void *userdata)
  ****************************************************************************/
 
 static int cxd56_geofence_initialize(FAR struct cxd56_geofence_dev_s *dev)
-{
-  int32_t ret = 0;
-
-  return ret;
-}
-
-/****************************************************************************
- * Name: cxd56_geofence_open
- *
- * Description:
- *   Standard character driver open method.
- *
- * Input Parameters:
- *   filep - File structure pointer
- *
- * Returned Value:
- *   Zero (OK) on success; a negated errno value on failure.
- *
- ****************************************************************************/
-
-static int cxd56_geofence_open(FAR struct file *filep)
-{
-  int32_t ret = 0;
-
-  return ret;
-}
-
-/****************************************************************************
- * Name: cxd56_geofence_close
- *
- * Description:
- *   Standard character driver close method.
- *
- * Input Parameters:
- *   filep - File structure pointer
- *
- * Returned Value:
- *   Zero (OK) on success; a negated errno value on failure.
- *
- ****************************************************************************/
-
-static int cxd56_geofence_close(FAR struct file *filep)
 {
   int32_t ret = 0;
 

--- a/arch/arm/src/cxd56xx/cxd56_gnss.c
+++ b/arch/arm/src/cxd56xx/cxd56_gnss.c
@@ -2438,8 +2438,6 @@ static void cxd56_gnss_cpufifoapi_signalhandler(uint32_t data,
 
   priv->apiret = CXD56_CPU1_GET_DATA((int)data);
   nxsem_post(&priv->apiwait);
-
-  return;
 }
 
 /****************************************************************************

--- a/arch/arm/src/cxd56xx/cxd56_hostif.c
+++ b/arch/arm/src/cxd56xx/cxd56_hostif.c
@@ -141,8 +141,10 @@ static const struct file_operations g_hif_fops =
   hif_write,   /* write */
   hif_seek,    /* seek */
   hif_ioctl,   /* ioctl */
-  hif_poll,    /* poll */
-  hif_unlink   /* unlink */
+  hif_poll     /* poll */
+#ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
+  , hif_unlink /* unlink */
+#endif
 };
 
 /****************************************************************************
@@ -343,10 +345,12 @@ static int hif_poll(FAR struct file *filep,
   return OK;
 }
 
+#ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
 static int hif_unlink(FAR struct inode *inode)
 {
   return OK;
 }
+#endif
 
 static int hif_rxhandler(int cpuid, int protoid,
                          uint32_t pdata, uint32_t data,

--- a/arch/arm/src/cxd56xx/cxd56_sph.c
+++ b/arch/arm/src/cxd56xx/cxd56_sph.c
@@ -92,11 +92,7 @@ static int cxd56_sphirqhandler(int irq, FAR void *context, FAR void *arg);
 static const struct file_operations sph_fops =
 {
   .open  = sph_open,
-  .close = NULL,
-  .read  = NULL,
-  .write = NULL,
-  .seek  = NULL,
-  .ioctl = sph_ioctl,
+  .ioctl = sph_ioctl
 };
 
 static struct sph_dev_s g_sphdev[NR_HSEMS];

--- a/arch/arm/src/cxd56xx/cxd56_sysctl.c
+++ b/arch/arm/src/cxd56xx/cxd56_sysctl.c
@@ -73,7 +73,7 @@ static int g_errcode = 0;
 
 static const struct file_operations g_sysctlfops =
 {
-  .ioctl = sysctl_ioctl,
+  .ioctl = sysctl_ioctl
 };
 
 /****************************************************************************

--- a/arch/arm/src/cxd56xx/cxd56_uart0.c
+++ b/arch/arm/src/cxd56xx/cxd56_uart0.c
@@ -72,7 +72,6 @@ static ssize_t uart0_read(FAR struct file *filep,
                           FAR char *buffer, size_t len);
 static ssize_t uart0_write(FAR struct file *filep,
                            FAR const char *buffer, size_t len);
-static int uart0_ioctl(FAR struct file *filep, int cmd, unsigned long arg);
 static int uart0_semtake(sem_t *id);
 static void uart0_semgive(sem_t *id);
 
@@ -98,9 +97,7 @@ static const struct file_operations g_uart0fops =
   .open  = uart0_open,
   .close = uart0_close,
   .read  = uart0_read,
-  .write = uart0_write,
-  .seek  = NULL,
-  .ioctl = uart0_ioctl,
+  .write = uart0_write
 };
 
 static sem_t g_lock;
@@ -249,15 +246,6 @@ static ssize_t uart0_write(FAR struct file *filep,
   uart0_semgive(&g_lock);
 
   return (ssize_t)ret;
-}
-
-/****************************************************************************
- * Name: uart0_ioctl
- ****************************************************************************/
-
-static int uart0_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
-{
-  return -ENOTTY;
 }
 
 /****************************************************************************

--- a/arch/arm/src/phy62xx/phyplus_stub.c
+++ b/arch/arm/src/phy62xx/phyplus_stub.c
@@ -52,8 +52,6 @@
  * Private Function Prototypes
  ****************************************************************************/
 
-static int     phyplus_stub_open(FAR struct file *filep);
-static int     phyplus_stub_close(FAR struct file *filep);
 static ssize_t phyplus_stub_read(
                 FAR struct file *filep, FAR char *buffer, size_t buflen);
 static ssize_t phyplus_stub_write(
@@ -70,15 +68,15 @@ static int     phyplus_stub_ioctl(
 
 static const struct file_operations g_stub_drvrops =
 {
-  phyplus_stub_open,   /* open */
-  phyplus_stub_close,  /* close */
+  NULL,                /* open */
+  NULL,                /* close */
   phyplus_stub_read,   /* read */
   phyplus_stub_write,  /* write */
   phyplus_stub_seek,   /* seek */
   phyplus_stub_ioctl,  /* ioctl */
   NULL                 /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
-  , NULL       /* unlink */
+  , NULL               /* unlink */
 #endif
 };
 
@@ -567,33 +565,6 @@ static int phyplus_parse_params_and_action(char *buff)
 }
 
 /****************************************************************************
- * Name: phyplus_stub_open
- *
- * Description:
- *   Standard character driver open method.
- *
- ****************************************************************************/
-
-static int phyplus_stub_open(FAR struct file *filep)
-{
-  filep->f_pos = 0;
-  return OK;
-}
-
-/****************************************************************************
- * Name: phyplus_stub_close
- *
- * Description:
- *   Standard character driver close method.
- *
- ****************************************************************************/
-
-static int phyplus_stub_close(FAR struct file *filep)
-{
-  return OK;
-}
-
-/****************************************************************************
  * Name: phyplus_gpio_read
  *
  * Description:
@@ -633,7 +604,7 @@ static ssize_t phyplus_stub_read(
 static char phyplus_cmd[CMD_LEN];
 
 static ssize_t phyplus_stub_write(FAR struct file *filep,
-              FAR const char *buffer, size_t buflen)
+                                  FAR const char *buffer, size_t buflen)
 {
   FAR struct inode *inode;
 
@@ -686,8 +657,8 @@ static ssize_t phyplus_stub_write(FAR struct file *filep,
  *
  ****************************************************************************/
 
-static off_t phyplus_stub_seek(FAR struct file *filep,
-               off_t offset, int whence)
+static off_t phyplus_stub_seek(FAR struct file *filep, off_t offset,
+                               int whence)
 {
   /* Only SEEK_SET is supported, return ENOSYS for other valid options */
 
@@ -717,8 +688,8 @@ static off_t phyplus_stub_seek(FAR struct file *filep,
  *
  ****************************************************************************/
 
-static int phyplus_stub_ioctl(FAR struct file *filep,
-             int cmd, unsigned long arg)
+static int phyplus_stub_ioctl(FAR struct file *filep, int cmd,
+                              unsigned long arg)
 {
     FAR struct inode *inode;
     int ret = 0;

--- a/arch/arm/src/rtl8720c/ameba_hci.c
+++ b/arch/arm/src/rtl8720c/ameba_hci.c
@@ -26,7 +26,7 @@
 #include <fcntl.h>
 #include <nuttx/serial/serial.h>
 #include <nuttx/net/netdev.h>
-#include <../../../../net/netdev/netdev.h>
+#include <nuttx/net/netdev/netdev.h>
 #include "amebaz_hci_board.h"
 
 /****************************************************************************

--- a/arch/arm/src/sama5/sam_tsd.c
+++ b/arch/arm/src/sama5/sam_tsd.c
@@ -1675,7 +1675,7 @@ int sam_tsd_register(struct sam_adc_s *adc, int minor)
 
   /* Register the device as an input device */
 
-  snprintf(devname, DEV_NAMELEN, DEV_FORMAT, minor);
+  snprintf(devname, sizeof(devname), DEV_FORMAT, minor);
   iinfo("Registering %s\n", devname);
 
   ret = register_driver(devname, &g_tsdops, 0666, priv);

--- a/arch/arm/src/stm32/stm32_bbsram.c
+++ b/arch/arm/src/stm32/stm32_bbsram.c
@@ -140,7 +140,7 @@ static const struct file_operations stm32_bbsram_fops =
   .ioctl  = stm32_bbsram_ioctl,
   .poll   = stm32_bbsram_poll,
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
-  .unlink = stm32_bbsram_unlink,
+  .unlink = stm32_bbsram_unlink
 #endif
 };
 

--- a/arch/arm/src/stm32f7/stm32_bbsram.c
+++ b/arch/arm/src/stm32f7/stm32_bbsram.c
@@ -140,7 +140,7 @@ static const struct file_operations stm32_bbsram_fops =
   .ioctl  = stm32_bbsram_ioctl,
   .poll   = stm32_bbsram_poll,
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
-  .unlink = stm32_bbsram_unlink,
+  .unlink = stm32_bbsram_unlink
 #endif
 };
 

--- a/arch/arm/src/stm32h7/stm32_bbsram.c
+++ b/arch/arm/src/stm32h7/stm32_bbsram.c
@@ -161,7 +161,7 @@ static const struct file_operations stm32_bbsram_fops =
   .ioctl  = stm32_bbsram_ioctl,
   .poll   = stm32_bbsram_poll,
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
-  .unlink = stm32_bbsram_unlink,
+  .unlink = stm32_bbsram_unlink
 #endif
 };
 

--- a/arch/renesas/src/rx65n/rx65n_sbram.c
+++ b/arch/renesas/src/rx65n/rx65n_sbram.c
@@ -135,7 +135,7 @@ static const struct file_operations rx65n_sbram_fops =
   .ioctl  = rx65n_sbram_ioctl,
   .poll   = rx65n_sbram_poll,
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
-  .unlink = rx65n_sbram_unlink,
+  .unlink = rx65n_sbram_unlink
 #endif
 };
 

--- a/arch/sim/src/sim/up_touchscreen.c
+++ b/arch/sim/src/sim/up_touchscreen.c
@@ -115,7 +115,7 @@ int sim_tsc_initialize(int minor)
 
   /* Register the device as an input device */
 
-  snprintf(devname, DEV_NAMELEN, DEV_FORMAT, minor);
+  snprintf(devname, sizeof(devname), DEV_FORMAT, minor);
   iinfo("Registering %s\n", devname);
 
   ret = touch_register(&priv->lower, devname, 1);
@@ -162,7 +162,7 @@ int sim_tsc_uninitialize(void)
 
   /* Un-register the device */
 
-  snprintf(devname, DEV_NAMELEN, DEV_FORMAT, priv->minor);
+  snprintf(devname, sizeof(devname), DEV_FORMAT, priv->minor);
   iinfo("Un-registering %s\n", devname);
 
   touch_unregister(&priv->lower, devname);

--- a/arch/x86/src/qemu/qemu_keypad.c
+++ b/arch/x86/src/qemu/qemu_keypad.c
@@ -203,8 +203,6 @@ typedef enum
  * Private Function Prototypes
  ****************************************************************************/
 
-static int keypad_open(struct file *filep);
-static int keypad_close(struct file *filep);
 static ssize_t keypad_read(struct file *filep, FAR char *buf, size_t buflen);
 
 /****************************************************************************
@@ -253,31 +251,21 @@ static const unsigned char g_kdbus[128] =
 
 static const struct file_operations g_keypadops =
 {
-  keypad_open,                  /* open */
-  keypad_close,                 /* close */
-  keypad_read,                  /* read */
-  NULL,                         /* write */
-  NULL,                         /* seek */
-  NULL,                         /* ioctl */
-  NULL                          /* poll */
+  NULL,         /* open */
+  NULL,         /* close */
+  keypad_read,  /* read */
+  NULL,         /* write */
+  NULL,         /* seek */
+  NULL,         /* ioctl */
+  NULL          /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
-  , NULL                        /* unlink */
+  , NULL        /* unlink */
 #endif
 };
 
 /****************************************************************************
  * Private Functions
  ****************************************************************************/
-
-static int keypad_open(struct file *filep)
-{
-  return OK;
-}
-
-static int keypad_close(struct file *filep)
-{
-  return OK;
-}
 
 static ssize_t keypad_read(struct file *filep, FAR char *buf, size_t buflen)
 {

--- a/arch/x86/src/qemu/qemu_vga.c
+++ b/arch/x86/src/qemu/qemu_vga.c
@@ -109,11 +109,9 @@ static int vga_getpower(struct lcd_dev_s *dev);
 static int vga_setpower(struct lcd_dev_s *dev, int power);
 static int vga_getcontrast(struct lcd_dev_s *dev);
 static int vga_setcontrast(struct lcd_dev_s *dev, unsigned int contrast);
-static int vga_open(struct file *filep);
-static int vga_close(struct file *filep);
 static ssize_t vga_read(struct file *filep, FAR char *buf, size_t buflen);
-static ssize_t vga_write(struct file *filep,
-                         FAR const char *buf, size_t buflen);
+static ssize_t vga_write(struct file *filep, FAR const char *buf,
+                         size_t buflen);
 static off_t vga_seek(FAR struct file *filp, off_t offset, int whence);
 
 /****************************************************************************
@@ -233,15 +231,15 @@ static struct lcd_dev_s g_lcddev =
 
 static const struct file_operations g_vgaops =
 {
-  vga_open,                  /* open */
-  vga_close,                 /* close */
-  vga_read,                  /* read */
-  vga_write,                 /* write */
-  vga_seek,                  /* seek */
-  NULL,                      /* ioctl */
-  NULL                       /* poll */
+  NULL,         /* open */
+  NULL,         /* close */
+  vga_read,     /* read */
+  vga_write,    /* write */
+  vga_seek,     /* seek */
+  NULL,         /* ioctl */
+  NULL          /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
-  , NULL                     /* unlink */
+  , NULL        /* unlink */
 #endif
 };
 
@@ -472,16 +470,6 @@ static int vga_setcontrast(struct lcd_dev_s *dev, unsigned int contrast)
   return -ENOSYS;
 }
 
-static int vga_open(struct file * filep)
-{
-  return OK;
-}
-
-static int vga_close(struct file * filep)
-{
-  return OK;
-}
-
 static ssize_t vga_read(struct file *filep, FAR char *buf, size_t buflen)
 {
   if (buf == NULL || buflen < 1)
@@ -494,8 +482,8 @@ static ssize_t vga_read(struct file *filep, FAR char *buf, size_t buflen)
   return buflen;
 }
 
-static ssize_t vga_write(struct file *filep,
-                         FAR const char *buf, size_t buflen)
+static ssize_t vga_write(struct file *filep, FAR const char *buf,
+                         size_t buflen)
 {
   int i;
   int j;

--- a/arch/xtensa/src/esp32/esp32_himem.c
+++ b/arch/xtensa/src/esp32/esp32_himem.c
@@ -103,8 +103,6 @@
 
 /* Character driver methods */
 
-static int     himem_open(struct file *filep);
-static int     himem_close(struct file *filep);
 static ssize_t himem_read(struct file *filep, char *buffer,
                           size_t buflen);
 static ssize_t himem_write(struct file *filep, const char *buffer,
@@ -151,8 +149,8 @@ irqstate_t spinlock_flags;
 
 static const struct file_operations g_himemfops =
 {
-  himem_open,       /* open   */
-  himem_close,      /* close */
+  NULL,             /* open   */
+  NULL,             /* close */
   himem_read,       /* read */
   himem_write,      /* write */
   NULL,             /* seek */
@@ -648,32 +646,6 @@ int esp_himem_unmap(esp_himem_rangehandle_t range, void *ptr,
 }
 
 /****************************************************************************
- * Name: himem_open
- *
- * Description:
- *   This function is called whenever the LM-75 device is opened.
- *
- ****************************************************************************/
-
-static int himem_open(struct file *filep)
-{
-  return OK;
-}
-
-/****************************************************************************
- * Name: himem_close
- *
- * Description:
- *   This routine is called when the LM-75 device is closed.
- *
- ****************************************************************************/
-
-static int himem_close(struct file *filep)
-{
-  return OK;
-}
-
-/****************************************************************************
  * Name: himem_read
  ****************************************************************************/
 
@@ -699,7 +671,7 @@ static ssize_t himem_write(struct file *filep, const char *buffer,
 
 static int himem_ioctl(struct file *filep, int cmd, unsigned long arg)
 {
-  int ret   = OK;
+  int ret = OK;
 
   switch (cmd)
     {

--- a/boards/arm/cxd56xx/drivers/sensors/bmp280_scu.c
+++ b/boards/arm/cxd56xx/drivers/sensors/bmp280_scu.c
@@ -175,9 +175,11 @@ static const struct file_operations g_bmp280pressfops =
   bmp280_close_press,           /* close */
   bmp280_read_press,            /* read */
   bmp280_write,                 /* write */
-  0,                            /* seek */
-  bmp280_ioctl_press,           /* ioctl */
-  0                             /* unlink */
+  NULL,                         /* seek */
+  bmp280_ioctl_press            /* ioctl */
+#ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
+  , NULL                        /* unlink */
+#endif
 };
 
 static const struct file_operations g_bmp280tempfops =
@@ -186,9 +188,11 @@ static const struct file_operations g_bmp280tempfops =
   bmp280_close_temp,            /* close */
   bmp280_read_temp,             /* read */
   bmp280_write,                 /* write */
-  0,                            /* seek */
-  bmp280_ioctl_temp,            /* ioctl */
-  0                             /* unlink */
+  NULL,                         /* seek */
+  bmp280_ioctl_temp             /* ioctl */
+#ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
+  , NULL                        /* unlink */
+#endif
 };
 
 /* SCU instructions for pick pressure sensing data. */

--- a/boards/arm/stm32/mikroe-stm32f4/src/stm32_touchscreen.c
+++ b/boards/arm/stm32/mikroe-stm32f4/src/stm32_touchscreen.c
@@ -1517,7 +1517,7 @@ int stm32_tsc_setup(int minor)
 
   /* Register the device as an input device */
 
-  snprintf(devname, DEV_NAMELEN, DEV_FORMAT, minor);
+  snprintf(devname, sizeof(devname), DEV_FORMAT, minor);
   iinfo("Registering %s\n", devname);
 
   ret = register_driver(devname, &tc_fops, 0666, priv);

--- a/boards/mips/pic32mx/pic32mx7mmb/src/pic32_touchscreen.c
+++ b/boards/mips/pic32mx/pic32mx7mmb/src/pic32_touchscreen.c
@@ -1381,7 +1381,7 @@ int pic32mx_tsc_setup(int minor)
 
   /* Register the device as an input device */
 
-  snprintf(devname, DEV_NAMELEN, DEV_FORMAT, minor);
+  snprintf(devname, sizeof(devname), DEV_FORMAT, minor);
   iinfo("Registering %s\n", devname);
 
   ret = register_driver(devname, &tc_fops, 0666, priv);

--- a/drivers/analog/dac.c
+++ b/drivers/analog/dac.c
@@ -54,7 +54,7 @@
 static int     dac_open(FAR struct file *filep);
 static int     dac_close(FAR struct file *filep);
 static ssize_t dac_write(FAR struct file *filep, FAR const char *buffer,
-                 size_t buflen);
+                         size_t buflen);
 static int     dac_ioctl(FAR struct file *filep, int cmd, unsigned long arg);
 
 /****************************************************************************

--- a/drivers/efuse/efuse.c
+++ b/drivers/efuse/efuse.c
@@ -65,8 +65,6 @@ struct efuse_upperhalf_s
  * Private Function Prototypes
  ****************************************************************************/
 
-static int     efuse_open(FAR struct file *filep);
-static int     efuse_close(FAR struct file *filep);
 static ssize_t efuse_read(FAR struct file *filep, FAR char *buffer,
                           size_t buflen);
 static ssize_t efuse_write(FAR struct file *filep, FAR const char *buffer,
@@ -80,8 +78,8 @@ static int     efuse_ioctl(FAR struct file *filep, int cmd,
 
 static const struct file_operations g_efuseops =
 {
-  efuse_open,  /* open */
-  efuse_close, /* close */
+  NULL,        /* open */
+  NULL,        /* close */
   efuse_read,  /* read */
   efuse_write, /* write */
   NULL,        /* seek */
@@ -95,32 +93,6 @@ static const struct file_operations g_efuseops =
 /****************************************************************************
  * Private Functions
  ****************************************************************************/
-
-/****************************************************************************
- * Name: efuse_open
- *
- * Description:
- *   This function is called whenever the efuse timer device is opened.
- *
- ****************************************************************************/
-
-static int efuse_open(FAR struct file *filep)
-{
-  return OK;
-}
-
-/****************************************************************************
- * Name: efuse_close
- *
- * Description:
- *   This function is called when the efuse timer device is closed.
- *
- ****************************************************************************/
-
-static int efuse_close(FAR struct file *filep)
-{
-  return OK;
-}
 
 /****************************************************************************
  * Name: efuse_read

--- a/drivers/input/ads7843e.c
+++ b/drivers/input/ads7843e.c
@@ -85,15 +85,15 @@ static void ads7843e_lock(FAR struct spi_dev_s *spi);
 static void ads7843e_unlock(FAR struct spi_dev_s *spi);
 
 static uint16_t ads7843e_sendcmd(FAR struct ads7843e_dev_s *priv,
-              uint8_t cmd);
+                                 uint8_t cmd);
 
 /* Interrupts and data sampling */
 
 static void ads7843e_notify(FAR struct ads7843e_dev_s *priv);
 static int  ads7843e_sample(FAR struct ads7843e_dev_s *priv,
-                           FAR struct ads7843e_sample_s *sample);
+                            FAR struct ads7843e_sample_s *sample);
 static int  ads7843e_waitsample(FAR struct ads7843e_dev_s *priv,
-                               FAR struct ads7843e_sample_s *sample);
+                                FAR struct ads7843e_sample_s *sample);
 static void ads7843e_worker(FAR void *arg);
 static int  ads7843e_interrupt(int irq, FAR void *context, FAR void *arg);
 
@@ -102,11 +102,11 @@ static int  ads7843e_interrupt(int irq, FAR void *context, FAR void *arg);
 static int  ads7843e_open(FAR struct file *filep);
 static int  ads7843e_close(FAR struct file *filep);
 static ssize_t ads7843e_read(FAR struct file *filep, FAR char *buffer,
-              size_t len);
+                             size_t len);
 static int  ads7843e_ioctl(FAR struct file *filep, int cmd,
-              unsigned long arg);
+                           unsigned long arg);
 static int  ads7843e_poll(FAR struct file *filep, struct pollfd *fds,
-              bool setup);
+                          bool setup);
 
 /****************************************************************************
  * Private Data
@@ -317,7 +317,7 @@ static void ads7843e_notify(FAR struct ads7843e_dev_s *priv)
  ****************************************************************************/
 
 static int ads7843e_sample(FAR struct ads7843e_dev_s *priv,
-                          FAR struct ads7843e_sample_s *sample)
+                           FAR struct ads7843e_sample_s *sample)
 {
   irqstate_t flags;
   int ret = -EAGAIN;
@@ -1018,7 +1018,7 @@ static int ads7843e_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
  ****************************************************************************/
 
 static int ads7843e_poll(FAR struct file *filep, FAR struct pollfd *fds,
-                        bool setup)
+                         bool setup)
 {
   FAR struct inode *inode;
   FAR struct ads7843e_dev_s *priv;
@@ -1203,7 +1203,7 @@ int ads7843e_register(FAR struct spi_dev_s *spi,
 
   /* Register the device as an input device */
 
-  snprintf(devname, DEV_NAMELEN, DEV_FORMAT, minor);
+  snprintf(devname, sizeof(devname), DEV_FORMAT, minor);
   iinfo("Registering %s\n", devname);
 
   ret = register_driver(devname, &ads7843e_fops, 0666, priv);

--- a/drivers/input/ft5x06.c
+++ b/drivers/input/ft5x06.c
@@ -1175,7 +1175,7 @@ int ft5x06_register(FAR struct i2c_master_s *i2c,
 
   /* Register the device as an input device */
 
-  snprintf(devname, DEV_NAMELEN, DEV_FORMAT, minor);
+  snprintf(devname, sizeof(devname), DEV_FORMAT, minor);
   iinfo("Registering %s\n", devname);
 
   ret = register_driver(devname, &ft5x06_fops, 0666, priv);

--- a/drivers/input/max11802.c
+++ b/drivers/input/max11802.c
@@ -1236,7 +1236,7 @@ int max11802_register(FAR struct spi_dev_s *spi,
 
   /* Register the device as an input device */
 
-  snprintf(devname, DEV_NAMELEN, DEV_FORMAT, minor);
+  snprintf(devname, sizeof(devname), DEV_FORMAT, minor);
   iinfo("Registering %s\n", devname);
 
   ret = register_driver(devname, &max11802_fops, 0666, priv);

--- a/drivers/input/mxt.c
+++ b/drivers/input/mxt.c
@@ -1915,7 +1915,7 @@ int mxt_register(FAR struct i2c_master_s *i2c,
 
   /* Register the device as an input device */
 
-  snprintf(devname, DEV_NAMELEN, DEV_FORMAT, minor);
+  snprintf(devname, sizeof(devname), DEV_FORMAT, minor);
   iinfo("Registering %s\n", devname);
 
   ret = register_driver(devname, &mxt_fops, 0666, priv);

--- a/drivers/input/nunchuck.c
+++ b/drivers/input/nunchuck.c
@@ -97,16 +97,16 @@ static inline int nunchuck_takesem(sem_t *sem);
 static int     nunchuck_open(FAR struct file *filep);
 static int     nunchuck_close(FAR struct file *filep);
 static ssize_t nunchuck_read(FAR struct file *filep, FAR char *buffer,
-                         size_t buflen);
+                             size_t buflen);
 static int     nunchuck_ioctl(FAR struct file *filep, int cmd,
-                          unsigned long arg);
+                              unsigned long arg);
 
 /* I2C Helpers */
 
 static int     nunchuck_i2c_read(FAR struct nunchuck_dev_s *priv,
-                 FAR uint8_t *regval, int len);
+                                 FAR uint8_t *regval, int len);
 static int     nunchuck_i2c_write(FAR struct nunchuck_dev_s *priv,
-                 uint8_t const *data, int len);
+                                  uint8_t const *data, int len);
 static int     nunchuck_sample(FAR struct nunchuck_dev_s *priv,
                                FAR struct nunchuck_sample_s *buffer);
 

--- a/drivers/input/spq10kbd.c
+++ b/drivers/input/spq10kbd.c
@@ -1060,7 +1060,7 @@ int spq10kbd_register(FAR struct i2c_master_s *i2c,
 
   priv->config->enable(priv->config, true);
 
-  snprintf(kbddevname, DEV_NAMELEN, DEV_FORMAT, kbdminor);
+  snprintf(kbddevname, sizeof(kbddevname), DEV_FORMAT, kbdminor);
   iinfo("Registering %s\n", kbddevname);
   ret = register_driver(kbddevname, &g_hidkbd_fops, 0666, priv);
 

--- a/drivers/input/stmpe811_tsc.c
+++ b/drivers/input/stmpe811_tsc.c
@@ -91,20 +91,20 @@
 
 static void     stmpe811_notify(FAR struct stmpe811_dev_s *priv);
 static int      stmpe811_sample(FAR struct stmpe811_dev_s *priv,
-                  FAR struct stmpe811_sample_s *sample);
+                                FAR struct stmpe811_sample_s *sample);
 static inline int stmpe811_waitsample(FAR struct stmpe811_dev_s *priv,
-                  FAR struct stmpe811_sample_s *sample);
+                                      FAR struct stmpe811_sample_s *sample);
 
 /* Character driver methods */
 
 static int      stmpe811_open(FAR struct file *filep);
 static int      stmpe811_close(FAR struct file *filep);
 static ssize_t  stmpe811_read(FAR struct file *filep, FAR char *buffer,
-                  size_t len);
+                              size_t len);
 static int      stmpe811_ioctl(FAR struct file *filep, int cmd,
-                  unsigned long arg);
+                               unsigned long arg);
 static int      stmpe811_poll(FAR struct file *filep, struct pollfd *fds,
-                  bool setup);
+                              bool setup);
 
 /* Initialization logic */
 
@@ -886,7 +886,7 @@ int stmpe811_register(STMPE811_HANDLE handle, int minor)
 
   /* Register the character driver */
 
-  snprintf(devname, DEV_NAMELEN, DEV_FORMAT, minor);
+  snprintf(devname, sizeof(devname), DEV_FORMAT, minor);
   ret = register_driver(devname, &g_stmpe811fops, 0666, priv);
   if (ret < 0)
     {

--- a/drivers/input/touchscreen_upper.c
+++ b/drivers/input/touchscreen_upper.c
@@ -204,7 +204,7 @@ static int touch_close(FAR struct file *filep)
  ****************************************************************************/
 
 static ssize_t touch_write(FAR struct file *filep, FAR const char *buffer,
-                          size_t buflen)
+                           size_t buflen)
 {
   FAR struct inode *inode             = filep->f_inode;
   FAR struct touch_upperhalf_s *upper = inode->i_private;
@@ -222,8 +222,8 @@ static ssize_t touch_write(FAR struct file *filep, FAR const char *buffer,
  * Name: touch_read
  ****************************************************************************/
 
-static ssize_t
-touch_read(FAR struct file *filep, FAR char *buffer, size_t len)
+static ssize_t touch_read(FAR struct file *filep, FAR char *buffer,
+                          size_t len)
 {
   FAR struct touch_openpriv_s *openpriv = filep->f_priv;
   int ret;

--- a/drivers/input/tsc2007.c
+++ b/drivers/input/tsc2007.c
@@ -1267,7 +1267,7 @@ int tsc2007_register(FAR struct i2c_master_s *dev,
 
   /* Register the device as an input device */
 
-  snprintf(devname, DEV_NAMELEN, DEV_FORMAT, minor);
+  snprintf(devname, sizeof(devname), DEV_FORMAT, minor);
   iinfo("Registering %s\n", devname);
 
   ret = register_driver(devname, &tsc2007_fops, 0666, priv);

--- a/drivers/ioexpander/gpio.c
+++ b/drivers/ioexpander/gpio.c
@@ -44,8 +44,6 @@
  ****************************************************************************/
 
 static int     gpio_handler(FAR struct gpio_dev_s *dev, uint8_t pin);
-static int     gpio_open(FAR struct file *filep);
-static int     gpio_close(FAR struct file *filep);
 static ssize_t gpio_read(FAR struct file *filep, FAR char *buffer,
                          size_t buflen);
 static ssize_t gpio_write(FAR struct file *filep, FAR const char *buffer,
@@ -60,8 +58,8 @@ static int     gpio_ioctl(FAR struct file *filep, int cmd,
 
 static const struct file_operations g_gpio_drvrops =
 {
-  gpio_open,   /* open */
-  gpio_close,  /* close */
+  NULL,        /* open */
+  NULL,        /* close */
   gpio_read,   /* read */
   gpio_write,  /* write */
   gpio_seek,   /* seek */
@@ -103,33 +101,6 @@ static int gpio_handler(FAR struct gpio_dev_s *dev, uint8_t pin)
                          SI_QUEUE, &signal->gp_work);
     }
 
-  return OK;
-}
-
-/****************************************************************************
- * Name: gpio_open
- *
- * Description:
- *   Standard character driver open method.
- *
- ****************************************************************************/
-
-static int gpio_open(FAR struct file *filep)
-{
-  filep->f_pos = 0;
-  return OK;
-}
-
-/****************************************************************************
- * Name: gpio_close
- *
- * Description:
- *   Standard character driver close method.
- *
- ****************************************************************************/
-
-static int gpio_close(FAR struct file *filep)
-{
   return OK;
 }
 

--- a/drivers/lcd/ht16k33_14seg.c
+++ b/drivers/lcd/ht16k33_14seg.c
@@ -137,8 +137,6 @@ static void ht16k33_clear_display(FAR struct ht16k33_dev_s *priv);
 
 /* Character driver methods */
 
-static int     ht16k33_open(FAR struct file *filep);
-static int     ht16k33_close(FAR struct file *filep);
 static ssize_t ht16k33_read(FAR struct file *filep, FAR char *buffer,
                             size_t buflen);
 static ssize_t ht16k33_write(FAR struct file *filep, FAR const char *buffer,
@@ -146,7 +144,7 @@ static ssize_t ht16k33_write(FAR struct file *filep, FAR const char *buffer,
 static off_t   ht16k33_seek(FAR struct file *filep, off_t offset,
                             int whence);
 static int     ht16k33_ioctl(FAR struct file *filep, int cmd,
-                            unsigned long arg);
+                             unsigned long arg);
 
 /****************************************************************************
  * Private Data
@@ -154,8 +152,8 @@ static int     ht16k33_ioctl(FAR struct file *filep, int cmd,
 
 static const struct file_operations g_ht16k33fops =
 {
-  ht16k33_open,   /* open */
-  ht16k33_close,  /* close */
+  NULL,           /* open */
+  NULL,           /* close */
   ht16k33_read,   /* read */
   ht16k33_write,  /* write */
   ht16k33_seek,   /* seek */
@@ -774,37 +772,11 @@ static void lcd_init(FAR struct ht16k33_dev_s *priv)
  ****************************************************************************/
 
 static void lcd_curpos_to_fpos(FAR struct ht16k33_dev_s *priv,
-                              uint8_t row, uint8_t col, FAR off_t *fpos)
+                               uint8_t row, uint8_t col, FAR off_t *fpos)
 {
   /* the logical file position is the linear position plus any synthetic LF */
 
   *fpos = (row * HT16K33_MAX_COL) + col + row;
-}
-
-/****************************************************************************
- * Name: ht16k33_open
- *
- * Description:
- *   This function is called whenever the HT16K33 device is opened.
- *
- ****************************************************************************/
-
-static int ht16k33_open(FAR struct file *filep)
-{
-  return OK;
-}
-
-/****************************************************************************
- * Name: ht16k33_close
- *
- * Description:
- *   This routine is called when the LM-75 device is closed.
- *
- ****************************************************************************/
-
-static int ht16k33_close(FAR struct file *filep)
-{
-  return OK;
 }
 
 /****************************************************************************
@@ -822,7 +794,7 @@ static ssize_t ht16k33_read(FAR struct file *filep, FAR char *buffer,
  ****************************************************************************/
 
 static ssize_t ht16k33_write(FAR struct file *filep, FAR const char *buffer,
-                            size_t buflen)
+                             size_t buflen)
 {
   FAR struct inode *inode = filep->f_inode;
   FAR struct ht16k33_dev_s *priv = inode->i_private;
@@ -1031,7 +1003,7 @@ static off_t ht16k33_seek(FAR struct file *filep, off_t offset, int whence)
  ****************************************************************************/
 
 static int ht16k33_ioctl(FAR struct file *filep, int cmd,
-                             unsigned long arg)
+                         unsigned long arg)
 {
   switch (cmd)
     {
@@ -1155,7 +1127,7 @@ int ht16k33_register(int devno, FAR struct i2c_master_s *i2c)
 
   /* Create the character device name */
 
-  snprintf(devname, DEVNAME_FMTLEN, DEVNAME_FMT, devno);
+  snprintf(devname, sizeof(devname), DEVNAME_FMT, devno);
 
   /* Register the driver */
 

--- a/drivers/lcd/lcd_dev.c
+++ b/drivers/lcd/lcd_dev.c
@@ -59,8 +59,6 @@ struct lcddev_dev_s
 
 /* Character driver methods */
 
-static int lcddev_open(FAR struct file *filep);
-static int lcddev_close(FAR struct file *filep);
 static int lcddev_ioctl(FAR struct file *filep, int cmd,
                         unsigned long arg);
 
@@ -70,8 +68,8 @@ static int lcddev_ioctl(FAR struct file *filep, int cmd,
 
 static const struct file_operations lcddev_fops =
 {
-  lcddev_open,  /* open */
-  lcddev_close, /* close */
+  NULL,         /* open */
+  NULL,         /* close */
   NULL,         /* read */
   NULL,         /* write */
   NULL,         /* seek */
@@ -85,28 +83,6 @@ static const struct file_operations lcddev_fops =
 /****************************************************************************
  * Private Functions
  ****************************************************************************/
-
-/****************************************************************************
- * Name: lcddev_open
- ****************************************************************************/
-
-static int lcddev_open(FAR struct file *filep)
-{
-  /* Nothing to do */
-
-  return OK;
-}
-
-/****************************************************************************
- * Name: lcddev_close
- ****************************************************************************/
-
-static int lcddev_close(FAR struct file *filep)
-{
-  /* Nothing to do */
-
-  return OK;
-}
 
 /****************************************************************************
  * Name: lcddev_ioctl

--- a/drivers/lcd/pcf8574_lcd_backpack.c
+++ b/drivers/lcd/pcf8574_lcd_backpack.c
@@ -105,8 +105,8 @@ static off_t pcf8574_lcd_seek(FAR struct file *filep, off_t offset,
                               int whence);
 static int pcf8574_lcd_ioctl(FAR struct file *filep, int cmd,
                              unsigned long arg);
-static int pcf8574lcd_poll(FAR struct file *filep, FAR struct pollfd *fds,
-                           bool setup);
+static int pcf8574_lcd_poll(FAR struct file *filep, FAR struct pollfd *fds,
+                            bool setup);
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
 static int pcf8574_lcd_unlink(FAR struct inode *inode);
 #endif
@@ -123,7 +123,7 @@ static const struct file_operations g_pcf8574_lcd_fops =
   pcf8574_lcd_write,            /* write */
   pcf8574_lcd_seek,             /* seek */
   pcf8574_lcd_ioctl,            /* ioctl */
-  pcf8574lcd_poll               /* poll */
+  pcf8574_lcd_poll              /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , pcf8574_lcd_unlink          /* unlink */
 #endif
@@ -1548,11 +1548,11 @@ static int pcf8574_lcd_ioctl(FAR struct file *filep, int cmd,
 }
 
 /****************************************************************************
- * Name: pcf8574lcd_poll
+ * Name: pcf8574_lcd_poll
  ****************************************************************************/
 
-static int pcf8574lcd_poll(FAR struct file *filep, FAR struct pollfd *fds,
-                           bool setup)
+static int pcf8574_lcd_poll(FAR struct file *filep, FAR struct pollfd *fds,
+                            bool setup)
 {
   if (setup)
     {

--- a/drivers/lcd/st7032.c
+++ b/drivers/lcd/st7032.c
@@ -94,8 +94,6 @@ static void lcd_scroll_up(FAR struct st7032_dev_s *priv);
 
 /* Character driver methods */
 
-static int     st7032_open(FAR struct file *filep);
-static int     st7032_close(FAR struct file *filep);
 static ssize_t st7032_read(FAR struct file *filep, FAR char *buffer,
                             size_t buflen);
 static ssize_t st7032_write(FAR struct file *filep, FAR const char *buffer,
@@ -110,8 +108,8 @@ static int     st7032_ioctl(FAR struct file *filep, int cmd,
 
 static const struct file_operations g_st7032fops =
 {
-  st7032_open,   /* open */
-  st7032_close,  /* close */
+  NULL,          /* open */
+  NULL,          /* close */
   st7032_read,   /* read */
   st7032_write,  /* write */
   st7032_seek,   /* seek */
@@ -701,32 +699,6 @@ static void lcd_curpos_to_fpos(FAR struct st7032_dev_s *priv,
   /* the logical file position is the linear position plus any synthetic LF */
 
   *fpos = (row * ST7032_MAX_COL) + col + row;
-}
-
-/****************************************************************************
- * Name: st7032_open
- *
- * Description:
- *   This function is called whenever the ST7032 device is opened.
- *
- ****************************************************************************/
-
-static int st7032_open(FAR struct file *filep)
-{
-  return OK;
-}
-
-/****************************************************************************
- * Name: st7032_close
- *
- * Description:
- *   This routine is called when the LM-75 device is closed.
- *
- ****************************************************************************/
-
-static int st7032_close(FAR struct file *filep)
-{
-  return OK;
 }
 
 /****************************************************************************

--- a/drivers/leds/apa102.c
+++ b/drivers/leds/apa102.c
@@ -60,8 +60,6 @@ static inline void apa102_write32(FAR struct apa102_dev_s *priv,
 
 /* Character driver methods */
 
-static int     apa102_open(FAR struct file *filep);
-static int     apa102_close(FAR struct file *filep);
 static ssize_t apa102_read(FAR struct file *filep, FAR char *buffer,
                             size_t buflen);
 static ssize_t apa102_write(FAR struct file *filep, FAR const char *buffer,
@@ -73,8 +71,8 @@ static ssize_t apa102_write(FAR struct file *filep, FAR const char *buffer,
 
 static const struct file_operations g_apa102fops =
 {
-  apa102_open,   /* open */
-  apa102_close,  /* close */
+  NULL,          /* open */
+  NULL,          /* close */
   apa102_read,   /* read */
   apa102_write,  /* write */
   NULL,          /* seek */
@@ -139,32 +137,6 @@ static inline void apa102_write32(FAR struct apa102_dev_s *priv,
 }
 
 /****************************************************************************
- * Name: apa102_open
- *
- * Description:
- *   This function is called whenever the APA102 device is opened.
- *
- ****************************************************************************/
-
-static int apa102_open(FAR struct file *filep)
-{
-  return OK;
-}
-
-/****************************************************************************
- * Name: apa102_close
- *
- * Description:
- *   This routine is called when the APA102 device is closed.
- *
- ****************************************************************************/
-
-static int apa102_close(FAR struct file *filep)
-{
-  return OK;
-}
-
-/****************************************************************************
  * Name: apa102_read
  ****************************************************************************/
 
@@ -179,7 +151,7 @@ static ssize_t apa102_read(FAR struct file *filep, FAR char *buffer,
  ****************************************************************************/
 
 static ssize_t apa102_write(FAR struct file *filep, FAR const char *buffer,
-                          size_t buflen)
+                            size_t buflen)
 {
   FAR struct inode *inode = filep->f_inode;
   FAR struct apa102_dev_s *priv = inode->i_private;

--- a/drivers/leds/max7219.c
+++ b/drivers/leds/max7219.c
@@ -70,12 +70,10 @@ static inline void max7219_write16(FAR struct max7219_dev_s *priv,
 
 /* Character driver methods */
 
-static int     max7219_open(FAR struct file *filep);
-static int     max7219_close(FAR struct file *filep);
 static ssize_t max7219_read(FAR struct file *filep, FAR char *buffer,
                             size_t buflen);
 static ssize_t max7219_write(FAR struct file *filep, FAR const char *buffer,
-                            size_t buflen);
+                             size_t buflen);
 
 /****************************************************************************
  * Private Data
@@ -83,8 +81,8 @@ static ssize_t max7219_write(FAR struct file *filep, FAR const char *buffer,
 
 static const struct file_operations g_max7219fops =
 {
-  max7219_open,   /* open */
-  max7219_close,  /* close */
+  NULL,           /* open */
+  NULL,           /* close */
   max7219_read,   /* read */
   max7219_write,  /* write */
   NULL,           /* seek */
@@ -154,32 +152,6 @@ static inline void max7219_write16(FAR struct max7219_dev_s *priv,
 }
 
 /****************************************************************************
- * Name: max7219_open
- *
- * Description:
- *   This function is called whenever the MAX7219 device is opened.
- *
- ****************************************************************************/
-
-static int max7219_open(FAR struct file *filep)
-{
-  return OK;
-}
-
-/****************************************************************************
- * Name: max7219_close
- *
- * Description:
- *   This routine is called when the LM-75 device is closed.
- *
- ****************************************************************************/
-
-static int max7219_close(FAR struct file *filep)
-{
-  return OK;
-}
-
-/****************************************************************************
  * Name: max7219_read
  ****************************************************************************/
 
@@ -194,7 +166,7 @@ static ssize_t max7219_read(FAR struct file *filep,
  ****************************************************************************/
 
 static ssize_t max7219_write(FAR struct file *filep, FAR const char *buffer,
-                          size_t buflen)
+                             size_t buflen)
 {
   FAR struct inode *inode = filep->f_inode;
   FAR struct max7219_dev_s *priv = inode->i_private;

--- a/drivers/leds/ws2812.c
+++ b/drivers/leds/ws2812.c
@@ -111,8 +111,6 @@ static void ws2812_pack(FAR uint8_t *buf, uint32_t rgb);
 
 /* Character driver methods */
 
-static int     ws2812_open(FAR struct file *filep);
-static int     ws2812_close(FAR struct file *filep);
 static ssize_t ws2812_read(FAR struct file *filep, FAR char *buffer,
                            size_t buflen);
 static ssize_t ws2812_write(FAR struct file *filep, FAR const char *buffer,
@@ -125,8 +123,8 @@ static off_t   ws2812_seek(FAR struct file *filep, off_t offset, int whence);
 
 static const struct file_operations g_ws2812fops =
 {
-  ws2812_open,    /* open */
-  ws2812_close,   /* close */
+  NULL,           /* open */
+  NULL,           /* close */
   ws2812_read,    /* read */
   ws2812_write,   /* write */
   ws2812_seek,    /* seek */
@@ -204,32 +202,6 @@ static void ws2812_pack(FAR uint8_t *buf, uint32_t rgb)
           offset++;
         }
     }
-}
-
-/****************************************************************************
- * Name: ws2812_open
- *
- * Description:
- *   This function is called whenever the WS2812 device is opened.
- *
- ****************************************************************************/
-
-static int ws2812_open(FAR struct file *filep)
-{
-  return OK;
-}
-
-/****************************************************************************
- * Name: ws2812_close
- *
- * Description:
- *   This routine is called when the WS2812 device is closed.
- *
- ****************************************************************************/
-
-static int ws2812_close(FAR struct file *filep)
-{
-  return OK;
 }
 
 /****************************************************************************

--- a/drivers/math/cordic.c
+++ b/drivers/math/cordic.c
@@ -60,8 +60,6 @@ struct cordic_upperhalf_s
  * Private Function Prototypes
  ****************************************************************************/
 
-static int     cordic_open(FAR struct file *filep);
-static int     cordic_close(FAR struct file *filep);
 static ssize_t cordic_read(FAR struct file *filep, FAR char *buffer,
                           size_t buflen);
 static ssize_t cordic_write(FAR struct file *filep, FAR const char *buffer,
@@ -75,8 +73,8 @@ static int     cordic_ioctl(FAR struct file *filep, int cmd,
 
 static const struct file_operations g_cordicops =
 {
-  cordic_open,  /* open */
-  cordic_close, /* close */
+  NULL,         /* open */
+  NULL,         /* close */
   cordic_read,  /* read */
   cordic_write, /* write */
   NULL,         /* seek */
@@ -90,32 +88,6 @@ static const struct file_operations g_cordicops =
 /****************************************************************************
  * Private Functions
  ****************************************************************************/
-
-/****************************************************************************
- * Name: cordic_open
- *
- * Description:
- *   This function is called whenever the cordic timer device is opened.
- *
- ****************************************************************************/
-
-static int cordic_open(FAR struct file *filep)
-{
-  return OK;
-}
-
-/****************************************************************************
- * Name: cordic_close
- *
- * Description:
- *   This function is called when the cordic timer device is closed.
- *
- ****************************************************************************/
-
-static int cordic_close(FAR struct file *filep)
-{
-  return OK;
-}
 
 /****************************************************************************
  * Name: cordic_read

--- a/drivers/misc/lwl_console.c
+++ b/drivers/misc/lwl_console.c
@@ -110,8 +110,6 @@ static ssize_t lwlconsole_read(FAR struct file *filep, FAR char *buffer,
                                size_t buflen);
 static ssize_t lwlconsole_write(FAR struct file *filep,
                                 FAR const char *buffer, size_t buflen);
-static int lwlconsole_ioctl(FAR struct file *filep, int cmd,
-                            unsigned long arg);
 
 /****************************************************************************
  * Private Data
@@ -131,15 +129,15 @@ static struct lwl_entry_s g_d =
 
 static const struct file_operations g_consoleops =
 {
-  NULL,                       /* open */
-  NULL,                       /* close */
-  lwlconsole_read,            /* read */
-  lwlconsole_write,           /* write */
-  NULL,                       /* seek */
-  lwlconsole_ioctl,           /* ioctl */
-  NULL                        /* poll */
+  NULL,                 /* open */
+  NULL,                 /* close */
+  lwlconsole_read,      /* read */
+  lwlconsole_write,     /* write */
+  NULL,                 /* seek */
+  NULL,                 /* ioctl */
+  NULL                  /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
-  , NULL                      /* unlink */
+  , NULL                /* unlink */
 #endif
 };
 
@@ -225,16 +223,6 @@ static bool read8bits(uint8_t port, FAR uint8_t *store)
   g_d.upword = (g_d.upword & ~LWL_DNSENSEBIT) | LWL_DNSENSE(g_d.downword);
 
   return true;
-}
-
-/****************************************************************************
- * Name: lwlconsole_ioctl
- ****************************************************************************/
-
-static int lwlconsole_ioctl(FAR struct file *filep, int cmd,
-                            unsigned long arg)
-{
-  return -ENOTTY;
 }
 
 /****************************************************************************

--- a/drivers/modem/altair/altmdm.c
+++ b/drivers/modem/altair/altmdm.c
@@ -42,8 +42,6 @@
 
 /* Character driver methods. */
 
-static int altmdm_open(FAR struct file *filep);
-static int altmdm_close(FAR struct file *filep);
 static ssize_t altmdm_read(FAR struct file *filep, FAR char *buffer,
                            size_t len);
 static ssize_t altmdm_write(FAR struct file *filep, FAR const char *buffer,
@@ -58,15 +56,15 @@ static int altmdm_ioctl(FAR struct file *filep, int cmd, unsigned long arg);
 
 static const struct file_operations g_altmdmfops =
 {
-  altmdm_open,                  /* open */
-  altmdm_close,                 /* close */
-  altmdm_read,                  /* read */
-  altmdm_write,                 /* write */
-  NULL,                         /* seek */
-  altmdm_ioctl,                 /* ioctl */
-  NULL                          /* poll */
+  NULL,                 /* open */
+  NULL,                 /* close */
+  altmdm_read,          /* read */
+  altmdm_write,         /* write */
+  NULL,                 /* seek */
+  altmdm_ioctl,         /* ioctl */
+  NULL                  /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
-  , NULL                        /* unlink */
+  , NULL                /* unlink */
 #endif
 };
 
@@ -145,32 +143,6 @@ static int altmdm_uninitialize(FAR struct altmdm_dev_s *priv)
     }
 
   return ret;
-}
-
-/****************************************************************************
- * Name: altmdm_open
- *
- * Description:
- *   Standard character driver open method.
- *
- ****************************************************************************/
-
-static int altmdm_open(FAR struct file *filep)
-{
-  return OK;
-}
-
-/****************************************************************************
- * Name: altmdm_close
- *
- * Description:
- *   Standard character driver close method.
- *
- ****************************************************************************/
-
-static int altmdm_close(FAR struct file *filep)
-{
-  return OK;
 }
 
 /****************************************************************************

--- a/drivers/net/tun.c
+++ b/drivers/net/tun.c
@@ -212,7 +212,6 @@ static void tun_dev_uninit(FAR struct tun_device_s *priv);
 
 /* File interface */
 
-static int tun_open(FAR struct file *filep);
 static int tun_close(FAR struct file *filep);
 static ssize_t tun_read(FAR struct file *filep, FAR char *buffer,
                         size_t buflen);
@@ -231,7 +230,7 @@ static struct tun_device_s g_tun_devices[CONFIG_TUN_NINTERFACES];
 
 static const struct file_operations g_tun_file_ops =
 {
-  tun_open,     /* open */
+  NULL,         /* open */
   tun_close,    /* close */
   tun_read,     /* read */
   tun_write,    /* write */
@@ -1149,16 +1148,6 @@ static void tun_dev_uninit(FAR struct tun_device_s *priv)
   nxsem_destroy(&priv->waitsem);
   nxsem_destroy(&priv->read_wait_sem);
   nxsem_destroy(&priv->write_wait_sem);
-}
-
-/****************************************************************************
- * Name: tun_open
- ****************************************************************************/
-
-static int tun_open(FAR struct file *filep)
-{
-  filep->f_priv = 0;
-  return OK;
 }
 
 /****************************************************************************

--- a/drivers/power/powerled.c
+++ b/drivers/power/powerled.c
@@ -44,10 +44,10 @@
  * Private Function Prototypes
  ****************************************************************************/
 
-static int     powerled_open(FAR struct file *filep);
-static int     powerled_close(FAR struct file *filep);
-static int     powerled_ioctl(FAR struct file *filep, int cmd,
-                              unsigned long arg);
+static int powerled_open(FAR struct file *filep);
+static int powerled_close(FAR struct file *filep);
+static int powerled_ioctl(FAR struct file *filep, int cmd,
+                          unsigned long arg);
 
 /****************************************************************************
  * Private Data

--- a/drivers/rf/dat-31r5-sp.c
+++ b/drivers/rf/dat-31r5-sp.c
@@ -64,8 +64,6 @@ struct dat31r5sp_dev_s
 
 /* Character driver methods */
 
-static int dat31r5sp_open(FAR struct file *filep);
-static int dat31r5sp_close(FAR struct file *filep);
 static ssize_t dat31r5sp_read(FAR struct file *filep, FAR char *buffer,
                               size_t buflen);
 static ssize_t dat31r5sp_write(FAR struct file *filep,
@@ -79,8 +77,8 @@ static int dat31r5sp_ioctl(FAR struct file *filep, int cmd,
 
 static const struct file_operations g_dat31r5sp_fops =
 {
-  dat31r5sp_open,   /* open */
-  dat31r5sp_close,  /* close */
+  NULL,             /* open */
+  NULL,             /* close */
   dat31r5sp_read,   /* read */
   dat31r5sp_write,  /* write */
   NULL,             /* seek */
@@ -140,34 +138,6 @@ static void dat31r5sp_set_attenuation(FAR struct dat31r5sp_dev_s *priv,
   SPI_SELECT(priv->spi, priv->spidev, false);
 
   SPI_LOCK(priv->spi, false);
-}
-
-/****************************************************************************
- * Name: dat31r5sp_open
- *
- * Description:
- *   This function is called whenever the DAT-31R5-SP+ device is
- *   opened.
- *
- ****************************************************************************/
-
-static int dat31r5sp_open(FAR struct file *filep)
-{
-  return OK;
-}
-
-/****************************************************************************
- * Name: dat31r5sp_close
- *
- * Description:
- *   This function is called whenever the DAT-31R5-SP+ device is
- *   closed.
- *
- ****************************************************************************/
-
-static int dat31r5sp_close(FAR struct file *filep)
-{
-  return OK;
 }
 
 /****************************************************************************

--- a/drivers/sensors/adt7320.c
+++ b/drivers/sensors/adt7320.c
@@ -88,7 +88,6 @@ static int adt7320_readtemp(FAR struct adt7320_dev_s *priv, FAR b16_t *temp);
 /* Character driver methods */
 
 static int adt7320_open(FAR struct file *filep);
-static int adt7320_close(FAR struct file *filep);
 static ssize_t adt7320_read(FAR struct file *filep, FAR char *buffer,
                             size_t buflen);
 static ssize_t adt7320_write(FAR struct file *filep, FAR const char *buffer,
@@ -102,7 +101,7 @@ static int adt7320_ioctl(FAR struct file *filep, int cmd, unsigned long arg);
 static const struct file_operations g_adt7320fops =
 {
   adt7320_open,    /* open */
-  adt7320_close,   /* close */
+  NULL,            /* close */
   adt7320_read,    /* read */
   adt7320_write,   /* write */
   NULL,            /* seek */
@@ -333,19 +332,6 @@ static int adt7320_open(FAR struct file *filep)
       return -ENODEV;
     }
 
-  return OK;
-}
-
-/****************************************************************************
- * Name: adt7320_close
- *
- * Description:
- *   This routine is called when the ADT7320 device is closed.
- *
- ****************************************************************************/
-
-static int adt7320_close(FAR struct file *filep)
-{
   return OK;
 }
 

--- a/drivers/sensors/adxl345_base.c
+++ b/drivers/sensors/adxl345_base.c
@@ -49,8 +49,6 @@
 
 /* Character driver methods */
 
-static int     adxl345_open(FAR struct file *filep);
-static int     adxl345_close(FAR struct file *filep);
 static ssize_t adxl345_read(FAR struct file *filep, FAR char *buffer,
                             size_t len);
 
@@ -62,8 +60,8 @@ static ssize_t adxl345_read(FAR struct file *filep, FAR char *buffer,
 
 static const struct file_operations g_adxl345fops =
 {
-  adxl345_open,    /* open */
-  adxl345_close,   /* close */
+  NULL,            /* open */
+  NULL,            /* close */
   adxl345_read,    /* read */
   NULL,            /* write */
   NULL,            /* seek */
@@ -73,32 +71,6 @@ static const struct file_operations g_adxl345fops =
   , NULL           /* unlink */
 #endif
 };
-
-/****************************************************************************
- * Name: adxl345_open
- *
- * Description:
- *   Standard character driver open method.
- *
- ****************************************************************************/
-
-static int adxl345_open(FAR struct file *filep)
-{
-  return OK;
-}
-
-/****************************************************************************
- * Name: adxl345_close
- *
- * Description:
- *   Standard character driver close method.
- *
- ****************************************************************************/
-
-static int adxl345_close(FAR struct file *filep)
-{
-  return OK;
-}
 
 /****************************************************************************
  * Name: adxl345_read
@@ -210,7 +182,7 @@ int adxl345_register(ADXL345_HANDLE handle, int minor)
 
   /* Register the character driver */
 
-  snprintf(devname, DEV_NAMELEN, DEV_FORMAT, minor);
+  snprintf(devname, sizeof(devname), DEV_FORMAT, minor);
   ret = register_driver(devname, &g_adxl345fops, 0444, priv);
   if (ret < 0)
     {

--- a/drivers/sensors/apds9960.c
+++ b/drivers/sensors/apds9960.c
@@ -104,20 +104,20 @@ static bool    apds9960_isgestureavailable(FAR struct apds9960_dev_s *priv);
 /* I2C Helpers */
 
 static int     apds9960_i2c_read(FAR struct apds9960_dev_s *priv,
-                 uint8_t const regaddr, FAR uint8_t *regval, int len);
+                                 uint8_t const regaddr, FAR uint8_t *regval,
+                                 int len);
 static int     apds9960_i2c_read8(FAR struct apds9960_dev_s *priv,
-                 uint8_t const regaddr, FAR uint8_t *regval);
+                                  uint8_t const regaddr,
+                                  FAR uint8_t *regval);
 static int     apds9960_i2c_write(FAR struct apds9960_dev_s *priv,
-                 uint8_t const *data, int len);
+                                  uint8_t const *data, int len);
 static int     apds9960_i2c_write8(FAR struct apds9960_dev_s *priv,
-                 uint8_t const regaddr, uint8_t regval);
+                                   uint8_t const regaddr, uint8_t regval);
 
 /* Character driver methods */
 
-static int     apds9960_open(FAR struct file *filep);
-static int     apds9960_close(FAR struct file *filep);
 static ssize_t apds9960_read(FAR struct file *filep, FAR char *buffer,
-                 size_t buflen);
+                             size_t buflen);
 static ssize_t apds9960_write(FAR struct file *filep,
                  FAR const char *buffer, size_t buflen);
 
@@ -127,8 +127,8 @@ static ssize_t apds9960_write(FAR struct file *filep,
 
 static const struct file_operations g_apds9960_fops =
 {
-  apds9960_open,   /* open */
-  apds9960_close,  /* close */
+  NULL,            /* open */
+  NULL,            /* close */
   apds9960_read,   /* read */
   apds9960_write,  /* write */
   NULL,            /* seek */
@@ -1127,32 +1127,6 @@ static int apds9960_readgesture(FAR struct apds9960_dev_s *priv)
           return motion;
         }
     }
-}
-
-/****************************************************************************
- * Name: apds9960_open
- *
- * Description:
- *   This function is called whenever the APDS9960 device is opened.
- *
- ****************************************************************************/
-
-static int apds9960_open(FAR struct file *filep)
-{
-  return OK;
-}
-
-/****************************************************************************
- * Name: apds9960_close
- *
- * Description:
- *   This routine is called when the APDS9960 device is closed.
- *
- ****************************************************************************/
-
-static int apds9960_close(FAR struct file *filep)
-{
-  return OK;
 }
 
 /****************************************************************************

--- a/drivers/sensors/as726x.c
+++ b/drivers/sensors/as726x.c
@@ -93,14 +93,12 @@ static int16_t as726x_getchannel(FAR struct as726x_dev_s *priv,
 static uint8_t read_register(FAR struct as726x_dev_s *priv, uint8_t addr);
 static uint8_t as726x_read8(FAR struct as726x_dev_s *priv, uint8_t regval);
 static void write_register(FAR struct as726x_dev_s *priv, uint8_t addr,
-                          uint8_t val);
+                           uint8_t val);
 static void as726x_write8(FAR struct as726x_dev_s *priv, uint8_t regaddr,
                           uint8_t regval);
 
 /* Character driver methods */
 
-static int as726x_open(FAR struct file *filep);
-static int as726x_close(FAR struct file *filep);
 static ssize_t as726x_read(FAR struct file *filep, FAR char *buffer,
                            size_t buflen);
 static ssize_t as726x_write(FAR struct file *filep,
@@ -112,8 +110,8 @@ static ssize_t as726x_write(FAR struct file *filep,
 
 static const struct file_operations g_as726x_fops =
 {
-  as726x_open,                  /* open */
-  as726x_close,                 /* close */
+  NULL,                         /* open */
+  NULL,                         /* close */
   as726x_read,                  /* read */
   as726x_write,                 /* write */
   NULL,                         /* seek */
@@ -332,32 +330,6 @@ static void as726x_write8(FAR struct as726x_dev_s *priv, uint8_t regaddr,
 }
 
 /****************************************************************************
- * Name: as726x_open
- *
- * Description:
- *   This function is called whenever the AS726X device is opened.
- *
- ****************************************************************************/
-
-static int as726x_open(FAR struct file *filep)
-{
-  return OK;
-}
-
-/****************************************************************************
- * Name: as726x_close
- *
- * Description:
- *   This routine is called when the AS726X device is closed.
- *
- ****************************************************************************/
-
-static int as726x_close(FAR struct file *filep)
-{
-  return OK;
-}
-
-/****************************************************************************
  * Name: as726x_read
  ****************************************************************************/
 
@@ -445,7 +417,7 @@ int as726x_register(FAR const char *devpath, FAR struct i2c_master_s *i2c)
 
   /* Check HW version for AS7262 and AS7263 */
 
-  _sensor_version = as726x_read8(priv, AS726x_HW_VERSION);
+  _sensor_version = as726x_read8(priv, AS726X_HW_VERSION);
   if (_sensor_version != 0x3e && _sensor_version != 0x3f)
     {
       snerr("ID (should be 0x3e or 0x3f): 0x %d\n", ret);
@@ -455,7 +427,7 @@ int as726x_register(FAR const char *devpath, FAR struct i2c_master_s *i2c)
    * Read the register value toggle and disable led
    */
 
-  ret = as726x_read8(priv, AS726x_LED_CONTROL);
+  ret = as726x_read8(priv, AS726X_LED_CONTROL);
   if (ret < 0)
     {
       snerr("ERROR: Failed to initialize the AS726X!\n");
@@ -465,16 +437,16 @@ int as726x_register(FAR const char *devpath, FAR struct i2c_master_s *i2c)
   value  = ret;
   value &= ~(1 << 0);           /* Clear the bit */
 
-  as726x_write8(priv, AS726x_LED_CONTROL, value);
+  as726x_write8(priv, AS726X_LED_CONTROL, value);
 
   /* If you use Mode 2 or 3 (all the colors) then integration time is double.
    * 140*2 = 280ms between readings.
    * 50 * 2.8ms = 140ms. 0 to 255 is valid.
    */
 
-  as726x_write8(priv, AS726x_INT_T, AS726X_INTEGRATION_TIME);
+  as726x_write8(priv, AS726X_INT_T, AS726X_INTEGRATION_TIME);
 
-  ret = as726x_read8(priv, AS726x_CONTROL_SETUP);
+  ret = as726x_read8(priv, AS726X_CONTROL_SETUP);
   if (ret < 0)
     {
       snerr("ERROR: Failed to initialize the AS726X!\n");
@@ -485,9 +457,9 @@ int as726x_register(FAR const char *devpath, FAR struct i2c_master_s *i2c)
   value &= 0b11001111;          /* Clear GAIN bits */
   value |= (AS726X_GAIN << 4);  /* Set GAIN bits with user's choice */
 
-  as726x_write8(priv, AS726x_CONTROL_SETUP, value);
+  as726x_write8(priv, AS726X_CONTROL_SETUP, value);
 
-  ret = as726x_read8(priv, AS726x_CONTROL_SETUP);
+  ret = as726x_read8(priv, AS726X_CONTROL_SETUP);
   if (ret < 0)
     {
       snerr("ERROR: Failed to initialize the AS726X!\n");
@@ -499,7 +471,7 @@ int as726x_register(FAR const char *devpath, FAR struct i2c_master_s *i2c)
   value |= (AS726X_MEASURMENT_MODE << 2);   /* Set BANK bits with user's
                                              * choice */
 
-  as726x_write8(priv, AS726x_CONTROL_SETUP, value);
+  as726x_write8(priv, AS726X_CONTROL_SETUP, value);
 
   /* Register the character driver */
 

--- a/drivers/sensors/bh1750fvi.c
+++ b/drivers/sensors/bh1750fvi.c
@@ -64,20 +64,20 @@ struct bh1750fvi_dev_s
 /* I2C Helpers */
 
 static int     bh1750fvi_read16(FAR struct bh1750fvi_dev_s *priv,
-                 FAR uint16_t *regval);
+                                FAR uint16_t *regval);
 static int     bh1750fvi_write8(FAR struct bh1750fvi_dev_s *priv,
-                 uint8_t regval);
+                                uint8_t regval);
 
 /* Character driver methods */
 
 static int     bh1750fvi_open(FAR struct file *filep);
 static int     bh1750fvi_close(FAR struct file *filep);
 static ssize_t bh1750fvi_read(FAR struct file *filep, FAR char *buffer,
-                  size_t buflen);
+                              size_t buflen);
 static ssize_t bh1750fvi_write(FAR struct file *filep,
-                  FAR const char *buffer, size_t buflen);
+                               FAR const char *buffer, size_t buflen);
 static int     bh1750fvi_ioctl(FAR struct file *filep, int cmd,
-                  unsigned long arg);
+                               unsigned long arg);
 
 /****************************************************************************
  * Private Data
@@ -85,8 +85,8 @@ static int     bh1750fvi_ioctl(FAR struct file *filep, int cmd,
 
 static const struct file_operations g_bh1750fvi_fops =
 {
-  bh1750fvi_open,   /* open */
-  bh1750fvi_close,  /* close */
+  NULL,             /* open */
+  NULL,             /* close */
   bh1750fvi_read,   /* read */
   bh1750fvi_write,  /* write */
   NULL,             /* seek */
@@ -169,32 +169,6 @@ static int bh1750fvi_write8(FAR struct bh1750fvi_dev_s *priv, uint8_t regval)
     }
 
   return ret;
-}
-
-/****************************************************************************
- * Name: bh1750fvi_open
- *
- * Description:
- *   This function is called whenever the BH1750FVI device is opened.
- *
- ****************************************************************************/
-
-static int bh1750fvi_open(FAR struct file *filep)
-{
-  return OK;
-}
-
-/****************************************************************************
- * Name: bh1750fvi_close
- *
- * Description:
- *   This routine is called when the BH1750FVI device is closed.
- *
- ****************************************************************************/
-
-static int bh1750fvi_close(FAR struct file *filep)
-{
-  return OK;
 }
 
 /****************************************************************************

--- a/drivers/sensors/bmg160.c
+++ b/drivers/sensors/bmg160.c
@@ -87,7 +87,6 @@ static int bmg160_close(FAR struct file *filep);
 static ssize_t bmg160_read(FAR struct file *, FAR char *, size_t);
 static ssize_t bmg160_write(FAR struct file *filep, FAR const char *buffer,
                             size_t buflen);
-static int bmg160_ioctl(FAR struct file *filep, int cmd, unsigned long arg);
 
 /****************************************************************************
  * Private Data
@@ -100,7 +99,7 @@ static const struct file_operations g_bmg160_fops =
   bmg160_read,     /* read */
   bmg160_write,    /* write */
   NULL,            /* seek */
-  bmg160_ioctl,    /* ioctl */
+  NULL,            /* ioctl */
   NULL             /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , NULL           /* unlink */
@@ -480,27 +479,6 @@ static ssize_t bmg160_write(FAR struct file *filep, FAR const char *buffer,
                             size_t buflen)
 {
   return -ENOSYS;
-}
-
-/****************************************************************************
- * Name: bmg160_ioctl
- ****************************************************************************/
-
-static int bmg160_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
-{
-  int ret = OK;
-
-  switch (cmd)
-    {
-      /* Command was not recognized */
-
-    default:
-      snerr("ERROR: Unrecognized cmd: %d\n", cmd);
-      ret = -ENOTTY;
-      break;
-    }
-
-  return ret;
 }
 
 /****************************************************************************

--- a/drivers/sensors/bmp180.c
+++ b/drivers/sensors/bmp180.c
@@ -131,8 +131,6 @@ static int bmp180_getpressure(FAR struct bmp180_dev_s *priv);
 
 /* Character driver methods */
 
-static int bmp180_open(FAR struct file *filep);
-static int bmp180_close(FAR struct file *filep);
 static ssize_t bmp180_read(FAR struct file *filep, FAR char *buffer,
                            size_t buflen);
 static ssize_t bmp180_write(FAR struct file *filep, FAR const char *buffer,
@@ -144,8 +142,8 @@ static ssize_t bmp180_write(FAR struct file *filep, FAR const char *buffer,
 
 static const struct file_operations g_bmp180fops =
 {
-  bmp180_open,                  /* open */
-  bmp180_close,                 /* close */
+  NULL,                         /* open */
+  NULL,                         /* close */
   bmp180_read,                  /* read */
   bmp180_write,                 /* write */
   NULL,                         /* seek */
@@ -498,32 +496,6 @@ static int bmp180_getpressure(FAR struct bmp180_dev_s *priv)
 
   sninfo("Compressed pressure = %" PRId32 "\n", press);
   return press;
-}
-
-/****************************************************************************
- * Name: bmp180_open
- *
- * Description:
- *   This function is called whenever the BMP1801 device is opened.
- *
- ****************************************************************************/
-
-static int bmp180_open(FAR struct file *filep)
-{
-  return OK;
-}
-
-/****************************************************************************
- * Name: bmp180_close
- *
- * Description:
- *   This routine is called when the BMP180 device is closed.
- *
- ****************************************************************************/
-
-static int bmp180_close(FAR struct file *filep)
-{
-  return OK;
 }
 
 /****************************************************************************

--- a/drivers/sensors/dhtxx.c
+++ b/drivers/sensors/dhtxx.c
@@ -93,18 +93,15 @@ static bool dht_check_data(FAR struct dhtxx_sensor_data_s *data,
                            float min_hum, float max_hum,
                            float min_temp, float max_temp);
 static int  dht_parse_data(FAR struct dhtxx_dev_s *priv,
-                          FAR struct dhtxx_sensor_data_s *data);
+                           FAR struct dhtxx_sensor_data_s *data);
 
 /* Character driver methods */
 
 static int     dhtxx_open(FAR struct file *filep);
-static int     dhtxx_close(FAR struct file *filep);
 static ssize_t dhtxx_read(FAR struct file *filep, FAR char *buffer,
                           size_t buflen);
 static ssize_t dhtxx_write(FAR struct file *filep, FAR const char *buffer,
                           size_t buflen);
-static int     dhtxx_ioctl(FAR struct file *filep, int cmd,
-                          unsigned long arg);
 
 /****************************************************************************
  * Private Data
@@ -113,11 +110,11 @@ static int     dhtxx_ioctl(FAR struct file *filep, int cmd,
 static const struct file_operations g_dhtxxfops =
 {
   dhtxx_open,   /* open */
-  dhtxx_close,  /* close */
+  NULL,         /* close */
   dhtxx_read,   /* read */
   dhtxx_write,  /* write */
   NULL,         /* seek */
-  dhtxx_ioctl,  /* ioctl */
+  NULL,         /* ioctl */
   NULL          /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , NULL        /* unlink */
@@ -352,7 +349,7 @@ static int dht_parse_data(FAR struct dhtxx_dev_s *priv,
        */
 
       if (!dht_check_data(data, DHT11_MIN_HUM, DHT11_MAX_HUM,
-                        DHT11_MIN_TEMP, DHT11_MAX_TEMP))
+                          DHT11_MIN_TEMP, DHT11_MAX_TEMP))
         {
           ret = -1;
         }
@@ -369,7 +366,7 @@ static int dht_parse_data(FAR struct dhtxx_dev_s *priv,
         }
 
       if (!dht_check_data(data, DHT12_MIN_HUM, DHT12_MAX_HUM,
-                         DHT12_MIN_TEMP, DHT12_MAX_TEMP))
+                          DHT12_MIN_TEMP, DHT12_MAX_TEMP))
         {
           ret = -1;
         }
@@ -436,24 +433,11 @@ static int dhtxx_open(FAR struct file *filep)
 }
 
 /****************************************************************************
- * Name: dhtxx_close
- *
- * Description:
- *   This routine is called when the Dhtxx device is closed.
- *
- ****************************************************************************/
-
-static int dhtxx_close(FAR struct file *filep)
-{
-  return OK;
-}
-
-/****************************************************************************
  * Name: dhtxx_read
  ****************************************************************************/
 
 static ssize_t dhtxx_read(FAR struct file *filep, FAR char *buffer,
-                         size_t buflen)
+                          size_t buflen)
 {
   int ret = OK;
   FAR struct inode                *inode = filep->f_inode;
@@ -540,27 +524,6 @@ static ssize_t dhtxx_write(FAR struct file *filep, FAR const char *buffer,
                           size_t buflen)
 {
   return -ENOSYS;
-}
-
-/****************************************************************************
- * Name: dhtxx_ioctl
- ****************************************************************************/
-
-static int dhtxx_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
-{
-  int ret = OK;
-
-  switch (cmd)
-    {
-      /* Command was not recognized */
-
-    default:
-      snerr("ERROR: Unrecognized cmd: %d\n", cmd);
-      ret = -ENOTTY;
-      break;
-    }
-
-  return ret;
 }
 
 /****************************************************************************

--- a/drivers/sensors/ina219.c
+++ b/drivers/sensors/ina219.c
@@ -92,9 +92,9 @@ struct ina219_dev_s
 static int     ina219_write16(FAR struct ina219_dev_s *priv, uint8_t regaddr,
                               FAR uint16_t regvalue);
 static int     ina219_read16(FAR struct ina219_dev_s *priv, uint8_t regaddr,
-                              FAR uint16_t *regvalue);
+                             FAR uint16_t *regvalue);
 static int     ina219_readpower(FAR struct ina219_dev_s *priv,
-                                 FAR struct ina219_s *buffer);
+                                FAR struct ina219_s *buffer);
 
 /* Character driver methods */
 
@@ -104,8 +104,6 @@ static ssize_t ina219_read(FAR struct file *filep, FAR char *buffer,
                            size_t buflen);
 static ssize_t ina219_write(FAR struct file *filep, FAR const char *buffer,
                             size_t buflen);
-static int     ina219_ioctl(FAR struct file *filep, int cmd,
-                            unsigned long arg);
 
 /****************************************************************************
  * Private Data
@@ -118,7 +116,7 @@ static const struct file_operations g_ina219fops =
   ina219_read,     /* read */
   ina219_write,    /* write */
   NULL,            /* seek */
-  ina219_ioctl,    /* ioctl */
+  NULL,            /* ioctl */
   NULL             /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , NULL           /* unlink */
@@ -337,15 +335,6 @@ static ssize_t ina219_write(FAR struct file *filep, FAR const char *buffer,
                           size_t buflen)
 {
   return -ENOSYS;
-}
-
-/****************************************************************************
- * Name: ina219_ioctl
- ****************************************************************************/
-
-static int ina219_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
-{
-  return -ENOTTY;
 }
 
 /****************************************************************************

--- a/drivers/sensors/ina226.c
+++ b/drivers/sensors/ina226.c
@@ -74,9 +74,9 @@ struct ina226_dev_s
 static int     ina226_write16(FAR struct ina226_dev_s *priv, uint8_t regaddr,
                               FAR uint16_t regvalue);
 static int     ina226_read16(FAR struct ina226_dev_s *priv, uint8_t regaddr,
-                              FAR uint16_t *regvalue);
+                             FAR uint16_t *regvalue);
 static int     ina226_readpower(FAR struct ina226_dev_s *priv,
-                                 FAR struct ina226_s *buffer);
+                                FAR struct ina226_s *buffer);
 
 /* Character driver methods */
 
@@ -86,8 +86,6 @@ static ssize_t ina226_read(FAR struct file *filep, FAR char *buffer,
                            size_t buflen);
 static ssize_t ina226_write(FAR struct file *filep, FAR const char *buffer,
                             size_t buflen);
-static int     ina226_ioctl(FAR struct file *filep, int cmd,
-                            unsigned long arg);
 
 /****************************************************************************
  * Private Data
@@ -100,7 +98,7 @@ static const struct file_operations g_ina226fops =
   ina226_read,     /* read */
   ina226_write,    /* write */
   NULL,            /* seek */
-  ina226_ioctl,    /* ioctl */
+  NULL,            /* ioctl */
   NULL             /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , NULL           /* unlink */
@@ -316,15 +314,6 @@ static ssize_t ina226_write(FAR struct file *filep, FAR const char *buffer,
                           size_t buflen)
 {
   return -ENOSYS;
-}
-
-/****************************************************************************
- * Name: ina226_ioctl
- ****************************************************************************/
-
-static int ina226_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
-{
-  return -ENOTTY;
 }
 
 /****************************************************************************

--- a/drivers/sensors/ina3221.c
+++ b/drivers/sensors/ina3221.c
@@ -103,14 +103,10 @@ static int     ina3221_readpower(FAR struct ina3221_dev_s *priv,
 
 /* Character driver methods */
 
-static int     ina3221_open(FAR struct file *filep);
-static int     ina3221_close(FAR struct file *filep);
 static ssize_t ina3221_read(FAR struct file *filep, FAR char *buffer,
-                           size_t buflen);
+                            size_t buflen);
 static ssize_t ina3221_write(FAR struct file *filep, FAR const char *buffer,
                             size_t buflen);
-static int     ina3221_ioctl(FAR struct file *filep, int cmd,
-                            unsigned long arg);
 
 /****************************************************************************
  * Private Data
@@ -118,12 +114,12 @@ static int     ina3221_ioctl(FAR struct file *filep, int cmd,
 
 static const struct file_operations g_ina3221fops =
 {
-  ina3221_open,    /* open */
-  ina3221_close,   /* close */
+  NULL,            /* open */
+  NULL,            /* close */
   ina3221_read,    /* read */
   ina3221_write,   /* write */
   NULL,            /* seek */
-  ina3221_ioctl,   /* ioctl */
+  NULL,            /* ioctl */
   NULL             /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , NULL           /* unlink */
@@ -275,40 +271,6 @@ static int ina3221_readpower(FAR struct ina3221_dev_s *priv,
 }
 
 /****************************************************************************
- * Name: ina3221_open
- *
- * Description:
- *   This function is called whenever the INA3221 device is opened.
- *
- ****************************************************************************/
-
-static int ina3221_open(FAR struct file *filep)
-{
-  FAR struct inode *inode = filep->f_inode;
-  FAR struct ina3221_dev_s *priv = inode->i_private;
-
-  UNUSED(priv);
-  return OK;
-}
-
-/****************************************************************************
- * Name: ina3221_close
- *
- * Description:
- *   This routine is called when the INA3221 device is closed.
- *
- ****************************************************************************/
-
-static int ina3221_close(FAR struct file *filep)
-{
-  FAR struct inode *inode = filep->f_inode;
-  FAR struct ina3221_dev_s *priv = inode->i_private;
-
-  UNUSED(priv);
-  return OK;
-}
-
-/****************************************************************************
  * Name: ina3221_read
  ****************************************************************************/
 
@@ -360,15 +322,6 @@ static ssize_t ina3221_write(FAR struct file *filep, FAR const char *buffer,
                           size_t buflen)
 {
   return -ENOSYS;
-}
-
-/****************************************************************************
- * Name: ina3221_ioctl
- ****************************************************************************/
-
-static int ina3221_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
-{
-  return -ENOTTY;
 }
 
 /****************************************************************************

--- a/drivers/sensors/isl29023.c
+++ b/drivers/sensors/isl29023.c
@@ -106,16 +106,13 @@ static int isl29023_set_range(FAR struct isl29023_dev_s *dev,
 
 /* Driver methods */
 
-static int isl29023_open(FAR struct file *filep);
-static int isl29023_close(FAR struct file *filep);
-static ssize_t isl29023_read(FAR struct file *filep,
-                             FAR char *buffer,
+static ssize_t isl29023_read(FAR struct file *filep, FAR char *buffer,
                              size_t buflen);
 static ssize_t isl29023_write(FAR struct file *filep,
                               FAR const char *buffer,
                               size_t buflen);
-static int isl29023_ioctl(FAR struct file *filep,
-                          int cmd, unsigned long arg);
+static int isl29023_ioctl(FAR struct file *filep, int cmd,
+                          unsigned long arg);
 
 /****************************************************************************
  * Private Data
@@ -123,8 +120,8 @@ static int isl29023_ioctl(FAR struct file *filep,
 
 static const struct file_operations g_isl29023fops =
 {
-  isl29023_open,   /* open */
-  isl29023_close,  /* close */
+  NULL,            /* open */
+  NULL,            /* close */
   isl29023_read,   /* read */
   isl29023_write,  /* write */
   NULL,            /* seek */
@@ -224,32 +221,6 @@ static int isl29023_read_reg(FAR struct isl29023_dev_s *dev,
     }
 
   return ret;
-}
-
-/****************************************************************************
- * Name: isl29023_open
- *
- * Description:
- *   This function is called whenever the ISL29023 device is opened.
- *
- ****************************************************************************/
-
-static int isl29023_open(FAR struct file *filep)
-{
-  return OK;
-}
-
-/****************************************************************************
- * Name: isl29023_close
- *
- * Description:
- *   This routine is called when the ISL29023 device is closed.
- *
- ****************************************************************************/
-
-static int isl29023_close(FAR struct file *filep)
-{
-  return OK;
 }
 
 /****************************************************************************

--- a/drivers/sensors/kxtj9.c
+++ b/drivers/sensors/kxtj9.c
@@ -131,9 +131,9 @@ struct kxtj9_dev_s
 /* I2C helpers */
 
 static int     kxtj9_reg_read(FAR struct kxtj9_dev_s *priv, uint8_t regaddr,
-                 FAR uint8_t *regval, unsigned int len);
+                              FAR uint8_t *regval, unsigned int len);
 static int     kxtj9_reg_write(FAR struct kxtj9_dev_s *priv,
-                 uint8_t regaddr,  uint8_t regval);
+                               uint8_t regaddr,  uint8_t regval);
 
 /* KXTJ9 helpers */
 
@@ -146,14 +146,12 @@ static void    kxtj9_set_mode_standby(FAR struct kxtj9_dev_s *priv);
 
 /* Character driver methods */
 
-static int     kxtj9_open(FAR struct file *filep);
-static int     kxtj9_close(FAR struct file *filep);
 static ssize_t kxtj9_read(FAR struct file *filep, FAR char *buffer,
-                 size_t buflen);
+                          size_t buflen);
 static ssize_t kxtj9_write(FAR struct file *filep, FAR const char *buffer,
                  size_t buflen);
 static int     kxtj9_ioctl(FAR struct file *filep, int cmd,
-                 unsigned long arg);
+                           unsigned long arg);
 
 /****************************************************************************
  * Private Data
@@ -161,8 +159,8 @@ static int     kxtj9_ioctl(FAR struct file *filep, int cmd,
 
 static const struct file_operations g_fops =
 {
-  kxtj9_open,      /* open */
-  kxtj9_close,     /* close */
+  NULL,            /* open */
+  NULL,            /* close */
   kxtj9_read,      /* read */
   kxtj9_write,     /* write */
   NULL,            /* seek */
@@ -451,32 +449,6 @@ static int kxtj9_read_sensor_data(FAR struct kxtj9_dev_s *priv,
   add_sensor_randomness((acc_data[0] << 16) ^ (acc_data[1] << 8) ^
                         acc_data[2]);
 
-  return OK;
-}
-
-/****************************************************************************
- * Name: kxtj9_open
- *
- * Description:
- *   This method is called when the device is opened.
- *
- ****************************************************************************/
-
-static int kxtj9_open(FAR struct file *filep)
-{
-  return OK;
-}
-
-/****************************************************************************
- * Name: kxtj9_close
- *
- * Description:
- *   This method is called when the device is closed.
- *
- ****************************************************************************/
-
-static int kxtj9_close(FAR struct file *filep)
-{
   return OK;
 }
 

--- a/drivers/sensors/lis3dsh.c
+++ b/drivers/sensors/lis3dsh.c
@@ -92,7 +92,6 @@ static ssize_t lis3dsh_read(FAR struct file *, FAR char *buffer,
                             size_t buflen);
 static ssize_t lis3dsh_write(FAR struct file *filep, FAR const char *buffer,
                              size_t buflen);
-static int lis3dsh_ioctl(FAR struct file *filep, int cmd, unsigned long arg);
 
 /****************************************************************************
  * Private Data
@@ -105,7 +104,7 @@ static const struct file_operations g_lis3dsh_fops =
   lis3dsh_read,    /* read */
   lis3dsh_write,   /* write */
   NULL,            /* seek */
-  lis3dsh_ioctl,   /* ioctl */
+  NULL,            /* ioctl */
   NULL             /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , NULL           /* unlink */
@@ -493,27 +492,6 @@ static ssize_t lis3dsh_write(FAR struct file *filep, FAR const char *buffer,
                              size_t buflen)
 {
   return -ENOSYS;
-}
-
-/****************************************************************************
- * Name: lis3dsh_ioctl
- ****************************************************************************/
-
-static int lis3dsh_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
-{
-  int ret = OK;
-
-  switch (cmd)
-    {
-      /* Command was not recognized */
-
-    default:
-      snerr("ERROR: Unrecognized cmd: %d\n", cmd);
-      ret = -ENOTTY;
-      break;
-    }
-
-  return ret;
 }
 
 /****************************************************************************

--- a/drivers/sensors/lis3mdl.c
+++ b/drivers/sensors/lis3mdl.c
@@ -72,28 +72,27 @@ struct lis3mdl_dev_s
 
 static void lis3mdl_read_register(FAR struct lis3mdl_dev_s *dev,
                                   uint8_t const reg_addr,
-                                  uint8_t * reg_data);
+                                  uint8_t *reg_data);
 static void lis3mdl_write_register(FAR struct lis3mdl_dev_s *dev,
                                    uint8_t const reg_addr,
                                    uint8_t const reg_data);
 static void lis3mdl_reset(FAR struct lis3mdl_dev_s *dev);
 static void lis3mdl_read_measurement_data(FAR struct lis3mdl_dev_s *dev);
 static void lis3mdl_read_magnetic_data(FAR struct lis3mdl_dev_s *dev,
-                                       uint16_t * x_mag, uint16_t * y_mag,
-                                       uint16_t * z_mag);
+                                       uint16_t *x_mag, uint16_t *y_mag,
+                                       uint16_t *z_mag);
 static void lis3mdl_read_temperature(FAR struct lis3mdl_dev_s *dev,
-                                     uint16_t * temperature);
+                                     uint16_t *temperature);
 static int lis3mdl_interrupt_handler(int irq, FAR void *context);
 static void lis3mdl_worker(FAR void *arg);
 
 static int lis3mdl_open(FAR struct file *filep);
 static int lis3mdl_close(FAR struct file *filep);
-static ssize_t lis3mdl_read(FAR struct file *, FAR char *, size_t);
+static ssize_t lis3mdl_read(FAR struct file *filep, FAR char *buffer,
+                            size_t buflen);
 static ssize_t lis3mdl_write(FAR struct file *filep,
                              FAR const char *buffer,
                              size_t buflen);
-static int lis3mdl_ioctl(FAR struct file *filep,
-                         int cmd, unsigned long arg);
 
 /****************************************************************************
  * Private Data
@@ -106,7 +105,7 @@ static const struct file_operations g_lis3mdl_fops =
   lis3mdl_read,    /* read */
   lis3mdl_write,   /* write */
   NULL,            /* seek */
-  lis3mdl_ioctl,   /* ioctl */
+  NULL,            /* ioctl */
   NULL             /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , NULL           /* unlink */
@@ -537,27 +536,6 @@ static ssize_t lis3mdl_write(FAR struct file *filep, FAR const char *buffer,
                              size_t buflen)
 {
   return -ENOSYS;
-}
-
-/****************************************************************************
- * Name: lis3mdl_ioctl
- ****************************************************************************/
-
-static int lis3mdl_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
-{
-  int ret = OK;
-
-  switch (cmd)
-    {
-      /* Command was not recognized */
-
-    default:
-      snerr("ERROR: Unrecognized cmd: %d\n", cmd);
-      ret = -ENOTTY;
-      break;
-    }
-
-  return ret;
 }
 
 /****************************************************************************

--- a/drivers/sensors/lm75.c
+++ b/drivers/sensors/lm75.c
@@ -83,8 +83,6 @@ static int     lm75_writeconf(FAR struct lm75_dev_s *priv, uint8_t conf);
 
 /* Character driver methods */
 
-static int     lm75_open(FAR struct file *filep);
-static int     lm75_close(FAR struct file *filep);
 static ssize_t lm75_read(FAR struct file *filep, FAR char *buffer,
                          size_t buflen);
 static ssize_t lm75_write(FAR struct file *filep, FAR const char *buffer,
@@ -98,8 +96,8 @@ static int     lm75_ioctl(FAR struct file *filep, int cmd,
 
 static const struct file_operations g_lm75fops =
 {
-  lm75_open,       /* open */
-  lm75_close,      /* close */
+  NULL,            /* open */
+  NULL,            /* close */
   lm75_read,       /* read */
   lm75_write,      /* write */
   NULL,            /* seek */
@@ -336,32 +334,6 @@ static int lm75_writeconf(FAR struct lm75_dev_s *priv, uint8_t conf)
   /* Write the register address followed by the data (no RESTART) */
 
   return lm75_i2c_write(priv, buffer, 2);
-}
-
-/****************************************************************************
- * Name: lm75_open
- *
- * Description:
- *   This function is called whenever the LM-75 device is opened.
- *
- ****************************************************************************/
-
-static int lm75_open(FAR struct file *filep)
-{
-  return OK;
-}
-
-/****************************************************************************
- * Name: lm75_close
- *
- * Description:
- *   This routine is called when the LM-75 device is closed.
- *
- ****************************************************************************/
-
-static int lm75_close(FAR struct file *filep)
-{
-  return OK;
 }
 
 /****************************************************************************

--- a/drivers/sensors/lm92.c
+++ b/drivers/sensors/lm92.c
@@ -82,14 +82,12 @@ static int     lm92_writeconf(FAR struct lm92_dev_s *priv, uint8_t conf);
 
 /* Character driver methods */
 
-static int     lm92_open(FAR struct file *filep);
-static int     lm92_close(FAR struct file *filep);
 static ssize_t lm92_read(FAR struct file *filep, FAR char *buffer,
                          size_t buflen);
 static ssize_t lm92_write(FAR struct file *filep, FAR const char *buffer,
                           size_t buflen);
-static int     lm92_ioctl(FAR struct file *filep,
-                          int cmd, unsigned long arg);
+static int     lm92_ioctl(FAR struct file *filep, int cmd,
+                          unsigned long arg);
 
 /****************************************************************************
  * Private Data
@@ -97,8 +95,8 @@ static int     lm92_ioctl(FAR struct file *filep,
 
 static const struct file_operations g_lm92fops =
 {
-  lm92_open,       /* open */
-  lm92_close,      /* close */
+  NULL,            /* open */
+  NULL,            /* close */
   lm92_read,       /* read */
   lm92_write,      /* write */
   NULL,            /* seek */
@@ -374,32 +372,6 @@ static int lm92_readid(FAR struct lm92_dev_s *priv, FAR uint16_t *id)
 
   *id = (uint16_t)buffer[0] << 8 | (uint16_t)buffer[1];
   sninfo("id: %04x ret: %d\n", *id, ret);
-  return OK;
-}
-
-/****************************************************************************
- * Name: lm92_open
- *
- * Description:
- *   This function is called whenever the LM92 device is opened.
- *
- ****************************************************************************/
-
-static int lm92_open(FAR struct file *filep)
-{
-  return OK;
-}
-
-/****************************************************************************
- * Name: lm92_close
- *
- * Description:
- *   This function is called whenever the LM92 device is closed.
- *
- ****************************************************************************/
-
-static int lm92_close(FAR struct file *filep)
-{
   return OK;
 }
 

--- a/drivers/sensors/lsm303agr.c
+++ b/drivers/sensors/lsm303agr.c
@@ -99,10 +99,8 @@ static int lsm303agr_selftest(FAR struct lsm303agr_dev_s *priv,
 
 /* Character Driver Methods */
 
-static int lsm303agr_open(FAR struct file *filep);
-static int lsm303agr_close(FAR struct file *filep);
-static ssize_t lsm303agr_read(FAR struct file *filep,
-                              FAR char *buffer, size_t buflen);
+static ssize_t lsm303agr_read(FAR struct file *filep, FAR char *buffer,
+                              size_t buflen);
 static ssize_t lsm303agr_write(FAR struct file *filep,
                                FAR const char *buffer, size_t buflen);
 static int lsm303agr_ioctl(FAR struct file *filep, int cmd,
@@ -126,8 +124,8 @@ static double g_magnetofactor = 0;
 
 static const struct file_operations g_fops =
 {
-  lsm303agr_open,     /* open */
-  lsm303agr_close,    /* close */
+  NULL,               /* open */
+  NULL,               /* close */
   lsm303agr_read,     /* read */
   lsm303agr_write,    /* write */
   NULL,               /* seek */
@@ -930,33 +928,6 @@ static int lsm303agr_sensor_read(FAR struct lsm303agr_dev_s *priv,
   sdata->m_y_data = y_valg;
   sdata->m_z_data = z_valg;
 
-  return OK;
-}
-
-/****************************************************************************
- * Name: lsm303agr_open
- *
- * Description:
- *   This method is called when the device is opened.
- *
- ****************************************************************************/
-
-static int lsm303agr_open(FAR struct file *filep)
-{
-  sninfo("Device LSM303AGR opened!!\n");
-  return OK;
-}
-
-/****************************************************************************
- * Name: lsm303agr_close
- *
- * Description:
- *   This method is called when the device is closed.
- *
- ****************************************************************************/
-
-static int lsm303agr_close(FAR struct file *filep)
-{
   return OK;
 }
 

--- a/drivers/sensors/lsm6dsl.c
+++ b/drivers/sensors/lsm6dsl.c
@@ -107,10 +107,8 @@ static int lsm6dsl_selftest(FAR struct lsm6dsl_dev_s *priv, uint32_t mode);
 
 /* Character Driver Methods */
 
-static int lsm6dsl_open(FAR struct file *filep);
-static int lsm6dsl_close(FAR struct file *filep);
-static ssize_t lsm6dsl_read(FAR struct file *filep,
-                            FAR char *buffer, size_t buflen);
+static ssize_t lsm6dsl_read(FAR struct file *filep, FAR char *buffer,
+                            size_t buflen);
 static ssize_t lsm6dsl_write(FAR struct file *filep,
                              FAR const char *buffer, size_t buflen);
 static int lsm6dsl_ioctl(FAR struct file *filep, int cmd,
@@ -134,8 +132,8 @@ static double g_gyrofactor = 0;
 
 static const struct file_operations g_fops =
 {
-  lsm6dsl_open,    /* open */
-  lsm6dsl_close,   /* close */
+  NULL,            /* open */
+  NULL,            /* close */
   lsm6dsl_read,    /* read */
   lsm6dsl_write,   /* write */
   NULL,            /* seek */
@@ -953,33 +951,6 @@ static int lsm6dsl_sensor_read(FAR struct lsm6dsl_dev_s *priv,
   sdata->g_y_data = y_valg * g_gyrofactor;
   sdata->g_z_data = z_valg * g_gyrofactor;
 
-  return OK;
-}
-
-/****************************************************************************
- * Name: lsm6dsl_open
- *
- * Description:
- *   This method is called when the device is opened.
- *
- ****************************************************************************/
-
-static int lsm6dsl_open(FAR struct file *filep)
-{
-  sninfo("Device LSM6DSL opened!!\n");
-  return OK;
-}
-
-/****************************************************************************
- * Name: lsm6dsl_close
- *
- * Description:
- *   This method is called when the device is closed.
- *
- ****************************************************************************/
-
-static int lsm6dsl_close(FAR struct file *filep)
-{
   return OK;
 }
 

--- a/drivers/sensors/lsm9ds1.c
+++ b/drivers/sensors/lsm9ds1.c
@@ -562,8 +562,6 @@ static int lsm9ds1mag_setsamplerate(FAR struct lsm9ds1_dev_s *priv,
 
 /* Character Driver Methods */
 
-static int     lsm9ds1_open(FAR struct file *filep);
-static int     lsm9ds1_close(FAR struct file *filep);
 static ssize_t lsm9ds1_read(FAR struct file *filep, FAR char *buffer,
                             size_t buflen);
 static ssize_t lsm9ds1_write(FAR struct file *filep, FAR const char *buffer,
@@ -584,8 +582,8 @@ static int lsm9ds1_register(FAR const char *devpath,
 
 static const struct file_operations g_fops =
 {
-  lsm9ds1_open,    /* open */
-  lsm9ds1_close,   /* close */
+  NULL,            /* open */
+  NULL,            /* close */
   lsm9ds1_read,    /* read */
   lsm9ds1_write,   /* write */
   NULL,            /* seek */
@@ -1193,32 +1191,6 @@ static int lsm9ds1mag_setsamplerate(FAR struct lsm9ds1_dev_s *priv,
 
   return lsm9ds1_modifyreg8(priv, LSM9DS1_CTRL_REG1_M,
                             LSM9DS1_CTRL_REG1_M_DO_MASK, setbits);
-}
-
-/****************************************************************************
- * Name: lsm9ds1_open
- *
- * Description:
- *   This method is called when the device is opened.
- *
- ****************************************************************************/
-
-static int lsm9ds1_open(FAR struct file *filep)
-{
-  return OK;
-}
-
-/****************************************************************************
- * Name: lsm9ds1_close
- *
- * Description:
- *   This method is called when the device is closed.
- *
- ****************************************************************************/
-
-static int lsm9ds1_close(FAR struct file *filep)
-{
-  return OK;
 }
 
 /****************************************************************************

--- a/drivers/sensors/ltc4151.c
+++ b/drivers/sensors/ltc4151.c
@@ -74,14 +74,10 @@ static int     ltc4151_readpower(FAR struct ltc4151_dev_s *priv,
 
 /* Character driver methods */
 
-static int     ltc4151_open(FAR struct file *filep);
-static int     ltc4151_close(FAR struct file *filep);
 static ssize_t ltc4151_read(FAR struct file *filep, FAR char *buffer,
                             size_t buflen);
 static ssize_t ltc4151_write(FAR struct file *filep, FAR const char *buffer,
                              size_t buflen);
-static int     ltc4151_ioctl(FAR struct file *filep, int cmd,
-                             unsigned long arg);
 
 /****************************************************************************
  * Private Data
@@ -89,12 +85,12 @@ static int     ltc4151_ioctl(FAR struct file *filep, int cmd,
 
 static const struct file_operations g_ltc4151fops =
 {
-  ltc4151_open,    /* open */
-  ltc4151_close,   /* close */
+  NULL,            /* open */
+  NULL,            /* close */
   ltc4151_read,    /* read */
   ltc4151_write,   /* write */
   NULL,            /* seek */
-  ltc4151_ioctl,   /* ioctl */
+  NULL,            /* ioctl */
   NULL             /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , NULL           /* unlink */
@@ -204,32 +200,6 @@ static int ltc4151_readpower(FAR struct ltc4151_dev_s *priv,
 }
 
 /****************************************************************************
- * Name: ltc4151_open
- *
- * Description:
- *   This function is called whenever the LTC4151 device is opened.
- *
- ****************************************************************************/
-
-static int ltc4151_open(FAR struct file *filep)
-{
-  return OK;
-}
-
-/****************************************************************************
- * Name: ltc4151_close
- *
- * Description:
- *   This routine is called when the LTC4151 device is closed.
- *
- ****************************************************************************/
-
-static int ltc4151_close(FAR struct file *filep)
-{
-  return OK;
-}
-
-/****************************************************************************
  * Name: ltc4151_read
  ****************************************************************************/
 
@@ -281,15 +251,6 @@ static ssize_t ltc4151_write(FAR struct file *filep, FAR const char *buffer,
                           size_t buflen)
 {
   return -ENOSYS;
-}
-
-/****************************************************************************
- * Name: ltc4151_ioctl
- ****************************************************************************/
-
-static int ltc4151_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
-{
-  return -ENOTTY;
 }
 
 /****************************************************************************

--- a/drivers/sensors/max31855.c
+++ b/drivers/sensors/max31855.c
@@ -77,8 +77,6 @@ static void max31855_unlock(FAR struct spi_dev_s *spi);
 
 /* Character driver methods */
 
-static int     max31855_open(FAR struct file *filep);
-static int     max31855_close(FAR struct file *filep);
 static ssize_t max31855_read(FAR struct file *filep, FAR char *buffer,
                              size_t buflen);
 static ssize_t max31855_write(FAR struct file *filep, FAR const char *buffer,
@@ -90,8 +88,8 @@ static ssize_t max31855_write(FAR struct file *filep, FAR const char *buffer,
 
 static const struct file_operations g_max31855fops =
 {
-  max31855_open,   /* open */
-  max31855_close,  /* close */
+  NULL,            /* open */
+  NULL,            /* close */
   max31855_read,   /* read */
   max31855_write,  /* write */
   NULL,            /* seek */
@@ -134,32 +132,6 @@ static void max31855_lock(FAR struct spi_dev_s *spi)
 static void max31855_unlock(FAR struct spi_dev_s *spi)
 {
   SPI_LOCK(spi, false);
-}
-
-/****************************************************************************
- * Name: max31855_open
- *
- * Description:
- *   This function is called whenever the MAX31855 device is opened.
- *
- ****************************************************************************/
-
-static int max31855_open(FAR struct file *filep)
-{
-  return OK;
-}
-
-/****************************************************************************
- * Name: max31855_close
- *
- * Description:
- *   This routine is called when the MAX31855 device is closed.
- *
- ****************************************************************************/
-
-static int max31855_close(FAR struct file *filep)
-{
-  return OK;
 }
 
 /****************************************************************************

--- a/drivers/sensors/max6675.c
+++ b/drivers/sensors/max6675.c
@@ -73,9 +73,8 @@ static void    max6675_unlock(FAR struct spi_dev_s *spi);
 
 /* Character driver methods */
 
-static int     max6675_open(FAR struct file *filep);
-static int     max6675_close(FAR struct file *filep);
-static ssize_t max6675_read(FAR struct file *, FAR char *, size_t);
+static ssize_t max6675_read(FAR struct file *filep, FAR char *buffer,
+                            size_t buflen);
 static ssize_t max6675_write(FAR struct file *filep, FAR const char *buffer,
                              size_t buflen);
 
@@ -85,8 +84,8 @@ static ssize_t max6675_write(FAR struct file *filep, FAR const char *buffer,
 
 static const struct file_operations g_max6675fops =
 {
-  max6675_open,    /* open */
-  max6675_close,   /* close */
+  NULL,            /* open */
+  NULL,            /* close */
   max6675_read,    /* read */
   max6675_write,   /* write */
   NULL,            /* seek */
@@ -132,37 +131,11 @@ static void max6675_unlock(FAR struct spi_dev_s *spi)
 }
 
 /****************************************************************************
- * Name: max6675_open
- *
- * Description:
- *   This function is called whenever the MAX6675 device is opened.
- *
- ****************************************************************************/
-
-static int max6675_open(FAR struct file *filep)
-{
-  return OK;
-}
-
-/****************************************************************************
- * Name: max6675_close
- *
- * Description:
- *   This routine is called when the MAX6675 device is closed.
- *
- ****************************************************************************/
-
-static int max6675_close(FAR struct file *filep)
-{
-  return OK;
-}
-
-/****************************************************************************
  * Name: max6675_read
  ****************************************************************************/
 
-static ssize_t max6675_read(FAR struct file *filep,
-                            FAR char *buffer, size_t buflen)
+static ssize_t max6675_read(FAR struct file *filep, FAR char *buffer,
+                            size_t buflen)
 {
   FAR struct inode         *inode = filep->f_inode;
   FAR struct max6675_dev_s *priv  = inode->i_private;

--- a/drivers/sensors/mb7040.c
+++ b/drivers/sensors/mb7040.c
@@ -68,8 +68,6 @@ static int mb7040_changeaddr(FAR struct mb7040_dev_s *priv, uint8_t addr);
 
 /* Character Driver Methods */
 
-static int     mb7040_open(FAR struct file *filep);
-static int     mb7040_close(FAR struct file *filep);
 static ssize_t mb7040_read(FAR struct file *filep, FAR char *buffer,
                            size_t buflen);
 static ssize_t mb7040_write(FAR struct file *filep, FAR const char *buffer,
@@ -83,8 +81,8 @@ static int     mb7040_ioctl(FAR struct file *filep, int cmd,
 
 static const struct file_operations g_fops =
 {
-  mb7040_open,     /* open */
-  mb7040_close,    /* close */
+  NULL,            /* open */
+  NULL,            /* close */
   mb7040_read,     /* read */
   mb7040_write,    /* write */
   NULL,            /* seek */
@@ -213,32 +211,6 @@ static int mb7040_changeaddr(FAR struct mb7040_dev_s *priv, uint8_t addr)
 
   priv->addr = addr;
   return ret;
-}
-
-/****************************************************************************
- * Name: mb7040_open
- *
- * Description:
- *   This method is called when the device is opened.
- *
- ****************************************************************************/
-
-static int mb7040_open(FAR struct file *filep)
-{
-  return OK;
-}
-
-/****************************************************************************
- * Name: mb7040_close
- *
- * Description:
- *   This method is called when the device is closed.
- *
- ****************************************************************************/
-
-static int mb7040_close(FAR struct file *filep)
-{
-  return OK;
 }
 
 /****************************************************************************

--- a/drivers/sensors/mcp9844.c
+++ b/drivers/sensors/mcp9844.c
@@ -61,14 +61,13 @@ struct mcp9844_dev_s
 /* I2C helper functions */
 
 static int     mcp9844_read_u16(FAR struct mcp9844_dev_s *priv,
-                  uint8_t const regaddr, FAR uint16_t *value);
+                                uint8_t const regaddr, FAR uint16_t *value);
 static int     mcp9844_write_u16(FAR struct mcp9844_dev_s *priv,
-                  uint8_t const regaddr, uint16_t const regval);
+                                 uint8_t const regaddr,
+                                 uint16_t const regval);
 
 /* Character driver methods */
 
-static int     mcp9844_open(FAR struct file *filep);
-static int     mcp9844_close(FAR struct file *filep);
 static ssize_t mcp9844_read(FAR struct file *filep, FAR char *buffer,
                   size_t buflen);
 static ssize_t mcp9844_write(FAR struct file *filep, FAR const char *buffer,
@@ -82,8 +81,8 @@ static int     mcp9844_ioctl(FAR struct file *filep, int cmd,
 
 static const struct file_operations g_mcp9844_fops =
 {
-  mcp9844_open,    /* open */
-  mcp9844_close,   /* close */
+  NULL,            /* open */
+  NULL,            /* close */
   mcp9844_read,    /* read */
   mcp9844_write,   /* write */
   NULL,            /* seek */
@@ -178,32 +177,6 @@ static int mcp9844_write_u16(FAR struct mcp9844_dev_s *priv,
   /* Write the register address followed by the data (no RESTART) */
 
   return i2c_write(priv->i2c, &config, buffer, BUFFER_SIZE);
-}
-
-/****************************************************************************
- * Name: mcp9844_open
- *
- * Description:
- *   This function is called whenever the MCP9844 device is opened.
- *
- ****************************************************************************/
-
-static int mcp9844_open(FAR struct file *filep)
-{
-  return OK;
-}
-
-/****************************************************************************
- * Name: mcp9844_close
- *
- * Description:
- *   This routine is called when the MCP9844 device is closed.
- *
- ****************************************************************************/
-
-static int mcp9844_close(FAR struct file *filep)
-{
-  return OK;
 }
 
 /****************************************************************************

--- a/drivers/sensors/mlx90393.c
+++ b/drivers/sensors/mlx90393.c
@@ -91,9 +91,6 @@ static ssize_t mlx90393_read(FAR struct file *, FAR char *, size_t);
 static ssize_t mlx90393_write(FAR struct file *filep,
                               FAR const char *buffer,
                               size_t buflen);
-static int mlx90393_ioctl(FAR struct file *filep,
-                          int cmd,
-                          unsigned long arg);
 
 /****************************************************************************
  * Private Data
@@ -106,7 +103,7 @@ static const struct file_operations g_mlx90393_fops =
   mlx90393_read,   /* read */
   mlx90393_write,  /* write */
   NULL,            /* seek */
-  mlx90393_ioctl,  /* ioctl */
+  NULL,            /* ioctl */
   NULL             /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , NULL           /* unlink */
@@ -517,27 +514,6 @@ static ssize_t mlx90393_write(FAR struct file *filep, FAR const char *buffer,
                               size_t buflen)
 {
   return -ENOSYS;
-}
-
-/****************************************************************************
- * Name: mlx90393_ioctl
- ****************************************************************************/
-
-static int mlx90393_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
-{
-  int ret = OK;
-
-  switch (cmd)
-    {
-      /* Command was not recognized */
-
-    default:
-      snerr("ERROR: Unrecognized cmd: %d\n", cmd);
-      ret = -ENOTTY;
-      break;
-    }
-
-  return ret;
 }
 
 /****************************************************************************

--- a/drivers/sensors/mlx90614.c
+++ b/drivers/sensors/mlx90614.c
@@ -78,20 +78,18 @@ struct mlx90614_dev_s
 /* I2C Helpers */
 
 static int     mlx90614_read_word(FAR struct mlx90614_dev_s *priv,
-                  uint8_t cmd, FAR uint16_t *regval);
+                                  uint8_t cmd, FAR uint16_t *regval);
 static int     mlx90614_write_word(FAR struct mlx90614_dev_s *priv,
-                  uint8_t cmd, uint16_t regval);
+                                   uint8_t cmd, uint16_t regval);
 
 /* Character driver methods */
 
-static int     mlx90614_open(FAR struct file *filep);
-static int     mlx90614_close(FAR struct file *filep);
 static ssize_t mlx90614_read(FAR struct file *filep, FAR char *buffer,
-                  size_t buflen);
+                             size_t buflen);
 static ssize_t mlx90614_write(FAR struct file *filep,
                   FAR const char *buffer, size_t buflen);
 static int     mlx90614_ioctl(FAR struct file *filep, int cmd,
-                  unsigned long arg);
+                              unsigned long arg);
 
 /****************************************************************************
  * Private Data
@@ -99,8 +97,8 @@ static int     mlx90614_ioctl(FAR struct file *filep, int cmd,
 
 static const struct file_operations g_mlx90614_fops =
 {
-  mlx90614_open,   /* open */
-  mlx90614_close,  /* close */
+  NULL,            /* open */
+  NULL,            /* close */
   mlx90614_read,   /* read */
   mlx90614_write,  /* write */
   NULL,            /* seek */
@@ -262,32 +260,6 @@ static int mlx90614_write_word(FAR struct mlx90614_dev_s *priv, uint8_t cmd,
 
   sninfo("New address 0x%02x stored correctly!\n", regval);
 
-  return OK;
-}
-
-/****************************************************************************
- * Name: mlx90614_open
- *
- * Description:
- *   This function is called whenever the MLX90614 device is opened.
- *
- ****************************************************************************/
-
-static int mlx90614_open(FAR struct file *filep)
-{
-  return OK;
-}
-
-/****************************************************************************
- * Name: mlx90614_close
- *
- * Description:
- *   This routine is called when the MLX90614 device is closed.
- *
- ****************************************************************************/
-
-static int mlx90614_close(FAR struct file *filep)
-{
   return OK;
 }
 

--- a/drivers/sensors/mpl115a.c
+++ b/drivers/sensors/mpl115a.c
@@ -72,8 +72,6 @@ static int mpl115a_getpressure(FAR struct mpl115a_dev_s *priv);
 
 /* Character driver methods */
 
-static int     mpl115a_open(FAR struct file *filep);
-static int     mpl115a_close(FAR struct file *filep);
 static ssize_t mpl115a_read(FAR struct file *filep, FAR char *buffer,
                             size_t buflen);
 static ssize_t mpl115a_write(FAR struct file *filep, FAR const char *buffer,
@@ -85,8 +83,8 @@ static ssize_t mpl115a_write(FAR struct file *filep, FAR const char *buffer,
 
 static const struct file_operations g_mpl115afops =
 {
-  mpl115a_open,   /* open */
-  mpl115a_close,  /* close */
+  NULL,           /* open */
+  NULL,           /* close */
   mpl115a_read,   /* read */
   mpl115a_write,  /* write */
   NULL,           /* seek */
@@ -294,32 +292,6 @@ static int mpl115a_getpressure(FAR struct mpl115a_dev_s *priv)
 
   sninfo("Final Pressure = %d\n", pressure >> 4);
   return pressure;
-}
-
-/****************************************************************************
- * Name: mpl115a_open
- *
- * Description:
- *   This function is called whenever the MPL115A1 device is opened.
- *
- ****************************************************************************/
-
-static int mpl115a_open(FAR struct file *filep)
-{
-  return OK;
-}
-
-/****************************************************************************
- * Name: mpl115a_close
- *
- * Description:
- *   This routine is called when the LM-75 device is closed.
- *
- ****************************************************************************/
-
-static int mpl115a_close(FAR struct file *filep)
-{
-  return OK;
 }
 
 /****************************************************************************

--- a/drivers/sensors/mpu60x0.c
+++ b/drivers/sensors/mpu60x0.c
@@ -255,7 +255,6 @@ static ssize_t mpu_read(FAR struct file *filep, FAR char *buf, size_t len);
 static ssize_t mpu_write(FAR struct file *filep, FAR const char *buf,
                          size_t len);
 static off_t mpu_seek(FAR struct file *filep, off_t offset, int whence);
-static int mpu_ioctl(FAR struct file *filep, int cmd, unsigned long arg);
 
 /****************************************************************************
  * Private Data
@@ -268,7 +267,7 @@ static const struct file_operations g_mpu_fops =
   mpu_read,        /* read */
   mpu_write,       /* write */
   mpu_seek,        /* seek */
-  mpu_ioctl,       /* ioctl */
+  NULL,            /* ioctl */
   NULL             /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , NULL           /* unlink */
@@ -911,25 +910,6 @@ static off_t mpu_seek(FAR struct file *filep, off_t offset, int whence)
   snerr("ERROR: %p %p\n", inode, dev);
 
   return 0;
-}
-
-/****************************************************************************
- * Name: mpu60x0_ioctl
- ****************************************************************************/
-
-static int mpu_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
-{
-  FAR struct inode *inode = filep->f_inode;
-  FAR struct mpu_dev_s *dev = inode->i_private;
-
-  UNUSED(inode);
-  UNUSED(dev);
-
-  snerr("ERROR: %p %p\n", inode, dev);
-
-  /* ENOTTY is the standard return if an IOCTL command is not supported. */
-
-  return -ENOTTY;
 }
 
 /****************************************************************************

--- a/drivers/sensors/ms58xx.c
+++ b/drivers/sensors/ms58xx.c
@@ -140,8 +140,6 @@ static int ms58xx_measure(FAR struct ms58xx_dev_s *priv);
 
 /* Character Driver Methods */
 
-static int     ms58xx_open(FAR struct file *filep);
-static int     ms58xx_close(FAR struct file *filep);
 static ssize_t ms58xx_read(FAR struct file *filep, FAR char *buffer,
                            size_t buflen);
 static ssize_t ms58xx_write(FAR struct file *filep, FAR const char *buffer,
@@ -155,8 +153,8 @@ static int     ms58xx_ioctl(FAR struct file *filep, int cmd,
 
 static const struct file_operations g_fops =
 {
-  ms58xx_open,     /* open */
-  ms58xx_close,    /* close */
+  NULL,            /* open */
+  NULL,            /* close */
   ms58xx_read,     /* read */
   ms58xx_write,    /* write */
   NULL,            /* seek */
@@ -752,32 +750,6 @@ static int ms58xx_measure(FAR struct ms58xx_dev_s *priv)
   priv->temp = temp;
   priv->press = press;
   return ret;
-}
-
-/****************************************************************************
- * Name: ms58xx_open
- *
- * Description:
- *   This method is called when the device is opened.
- *
- ****************************************************************************/
-
-static int ms58xx_open(FAR struct file *filep)
-{
-  return OK;
-}
-
-/****************************************************************************
- * Name: ms58xx_close
- *
- * Description:
- *   This method is called when the device is closed.
- *
- ****************************************************************************/
-
-static int ms58xx_close(FAR struct file *filep)
-{
-  return OK;
 }
 
 /****************************************************************************

--- a/drivers/sensors/t67xx.c
+++ b/drivers/sensors/t67xx.c
@@ -136,10 +136,6 @@ static int t67xx_reset(FAR struct t67xx_dev_s *priv);
 
 /* Character driver methods */
 
-#ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
-static int     t67xx_open(FAR struct file *filep);
-static int     t67xx_close(FAR struct file *filep);
-#endif
 static ssize_t t67xx_read(FAR struct file *filep, FAR char *buffer,
                           size_t buflen);
 static ssize_t t67xx_write(FAR struct file *filep, FAR const char *buffer,
@@ -153,13 +149,8 @@ static int     t67xx_ioctl(FAR struct file *filep, int cmd,
 
 static const struct file_operations g_t67xxfops =
 {
-#ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
-  t67xx_open,     /* open */
-  t67xx_close,    /* close */
-#else
   NULL,           /* open */
   NULL,           /* close */
-#endif
   t67xx_read,     /* read */
   t67xx_write,    /* write */
   NULL,           /* seek */
@@ -566,44 +557,6 @@ static int t67xx_reset(FAR struct t67xx_dev_s *priv)
 
   return ret;
 }
-
-/****************************************************************************
- * Name: t67xx_open
- *
- * Description:
- *   This function is called whenever the T67XX device is opened.
- *
- ****************************************************************************/
-
-#ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
-static int t67xx_open(FAR struct file *filep)
-{
-  FAR struct inode *inode = filep->f_inode;
-  FAR struct t67xx_dev_s *priv = inode->i_private;
-
-  UNUSED(priv);
-  return OK;
-}
-#endif
-
-/****************************************************************************
- * Name: t67xx_close
- *
- * Description:
- *   This routine is called when the T67XX device is closed.
- *
- ****************************************************************************/
-
-#ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
-static int t67xx_close(FAR struct file *filep)
-{
-  FAR struct inode *inode = filep->f_inode;
-  FAR struct t67xx_dev_s *priv = inode->i_private;
-
-  UNUSED(priv);
-  return OK;
-}
-#endif
 
 /****************************************************************************
  * Name: t67xx_read

--- a/drivers/sensors/veml6070.c
+++ b/drivers/sensors/veml6070.c
@@ -65,16 +65,14 @@ struct veml6070_dev_s
 /* I2C Helpers */
 
 static int     veml6070_read8(FAR struct veml6070_dev_s *priv, int offset,
-                 FAR uint8_t *regval);
+                              FAR uint8_t *regval);
 static int     veml6070_write8(FAR struct veml6070_dev_s *priv,
-                 uint8_t regval);
+                               uint8_t regval);
 
 /* Character driver methods */
 
-static int     veml6070_open(FAR struct file *filep);
-static int     veml6070_close(FAR struct file *filep);
 static ssize_t veml6070_read(FAR struct file *filep, FAR char *buffer,
-                 size_t buflen);
+                             size_t buflen);
 static ssize_t veml6070_write(FAR struct file *filep,
                  FAR const char *buffer, size_t buflen);
 
@@ -84,8 +82,8 @@ static ssize_t veml6070_write(FAR struct file *filep,
 
 static const struct file_operations g_veml6070_fops =
 {
-  veml6070_open,   /* open */
-  veml6070_close,  /* close */
+  NULL,            /* open */
+  NULL,            /* close */
   veml6070_read,   /* read */
   veml6070_write,  /* write */
   NULL,            /* seek */
@@ -168,32 +166,6 @@ static int veml6070_write8(FAR struct veml6070_dev_s *priv, uint8_t regval)
     }
 
   return ret;
-}
-
-/****************************************************************************
- * Name: veml6070_open
- *
- * Description:
- *   This function is called whenever the VEML6070 device is opened.
- *
- ****************************************************************************/
-
-static int veml6070_open(FAR struct file *filep)
-{
-  return OK;
-}
-
-/****************************************************************************
- * Name: veml6070_close
- *
- * Description:
- *   This routine is called when the VEML6070 device is closed.
- *
- ****************************************************************************/
-
-static int veml6070_close(FAR struct file *filep)
-{
-  return OK;
 }
 
 /****************************************************************************

--- a/drivers/sensors/vl53l1x.c
+++ b/drivers/sensors/vl53l1x.c
@@ -230,8 +230,6 @@ static void vl53l1x_calibrateoffset(FAR struct vl53l1x_dev_s *priv,
 
 /* Character driver methods */
 
-static int vl53l1x_open(FAR struct file *filep);
-static int vl53l1x_close(FAR struct file *filep);
 static void vl53l1x_read(FAR struct file *filep, FAR char *buffer,
                          size_t buflen);
 static ssize_t vl53l1x_write(FAR struct file *filep, FAR const char *buffer,
@@ -244,15 +242,15 @@ static void vl53l1x_ioctl(FAR struct file *filep, int cmd, uint16_t arg);
 
 static const struct file_operations g_vl53l1xfops =
 {
-  vl53l1x_open,                 /* open */
-  vl53l1x_close,                /* close */
-  vl53l1x_read,                 /* read */
-  vl53l1x_write,                /* write */
-  NULL,                         /* seek */
-  vl53l1x_ioctl,                /* ioctl */
-  NULL                          /* poll */
+  NULL,                 /* open */
+  NULL,                 /* close */
+  vl53l1x_read,         /* read */
+  vl53l1x_write,        /* write */
+  NULL,                 /* seek */
+  vl53l1x_ioctl,        /* ioctl */
+  NULL                  /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
-  , NULL                        /* unlink */
+  , NULL                /* unlink */
 #endif
 };
 
@@ -1034,32 +1032,6 @@ static void vl53l1x_putreg32(FAR struct vl53l1x_dev_s *priv,
     }
 
   return;
-}
-
-/****************************************************************************
- * Name: vl53l1x_open
- *
- * Description:
- *   This function is called whenever the vl53l1x device is opened.
- *
- ****************************************************************************/
-
-static int vl53l1x_open(FAR struct file *filep)
-{
-  return OK;
-}
-
-/****************************************************************************
- * Name: vl53l1x_close
- *
- * Description:
- *   This routine is called when the vl53l1x device is closed.
- *
- ****************************************************************************/
-
-static int vl53l1x_close(FAR struct file *filep)
-{
-  return OK;
 }
 
 /****************************************************************************

--- a/drivers/sensors/xen1210.c
+++ b/drivers/sensors/xen1210.c
@@ -48,8 +48,6 @@
 
 /* Character driver methods */
 
-static int     xen1210_open(FAR struct file *filep);
-static int     xen1210_close(FAR struct file *filep);
 static ssize_t xen1210_read(FAR struct file *filep, FAR char *buffer,
                             size_t len);
 
@@ -61,8 +59,8 @@ static ssize_t xen1210_read(FAR struct file *filep, FAR char *buffer,
 
 static const struct file_operations g_xen1210fops =
 {
-  xen1210_open,    /* open */
-  xen1210_close,   /* close */
+  NULL,            /* open */
+  NULL,            /* close */
   xen1210_read,    /* read */
   NULL,            /* write */
   NULL,            /* seek */
@@ -92,32 +90,6 @@ static inline void xen1210_configspi(FAR struct spi_dev_s *spi)
   SPI_SETBITS(spi, 8);
   SPI_HWFEATURES(spi, 0);
   SPI_SETFREQUENCY(spi, XEN1210_SPI_MAXFREQUENCY);
-}
-
-/****************************************************************************
- * Name: xen1210_open
- *
- * Description:
- *   Standard character driver open method.
- *
- ****************************************************************************/
-
-static int xen1210_open(FAR struct file *filep)
-{
-  return OK;
-}
-
-/****************************************************************************
- * Name: xen1210_close
- *
- * Description:
- *   Standard character driver close method.
- *
- ****************************************************************************/
-
-static int xen1210_close(FAR struct file *filep)
-{
-  return OK;
 }
 
 /****************************************************************************
@@ -369,7 +341,7 @@ int xen1210_register(XEN1210_HANDLE handle, int minor)
 
   /* Register the character driver */
 
-  snprintf(devname, DEV_NAMELEN, DEV_FORMAT, minor);
+  snprintf(devname, sizeof(devname), DEV_FORMAT, minor);
   ret = register_driver(devname, &g_xen1210fops, 0444, priv);
   if (ret < 0)
     {

--- a/drivers/serial/pty.c
+++ b/drivers/serial/pty.c
@@ -105,12 +105,12 @@ static int     pty_pipe(FAR struct pty_devpair_s *devpair);
 static int     pty_open(FAR struct file *filep);
 static int     pty_close(FAR struct file *filep);
 static ssize_t pty_read(FAR struct file *filep, FAR char *buffer,
-                 size_t buflen);
+                        size_t buflen);
 static ssize_t pty_write(FAR struct file *filep, FAR const char *buffer,
-                 size_t buflen);
+                         size_t buflen);
 static int     pty_ioctl(FAR struct file *filep, int cmd, unsigned long arg);
 static int     pty_poll(FAR struct file *filep, FAR struct pollfd *fds,
-                 bool setup);
+                        bool setup);
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
 static int     pty_unlink(FAR struct inode *inode);
 #endif

--- a/drivers/serial/uart_bth4.c
+++ b/drivers/serial/uart_bth4.c
@@ -66,16 +66,16 @@ struct uart_bth4_s
  * Private Function Prototypes
  ****************************************************************************/
 
-static int     uart_bth4_open (FAR struct file *filep);
+static int     uart_bth4_open(FAR struct file *filep);
 static int     uart_bth4_close(FAR struct file *filep);
-static ssize_t uart_bth4_read (FAR struct file *filep,
-                               FAR char *buffer, size_t buflen);
+static ssize_t uart_bth4_read(FAR struct file *filep,
+                              FAR char *buffer, size_t buflen);
 static ssize_t uart_bth4_write(FAR struct file *filep,
                                FAR const char *buffer, size_t buflen);
 static int     uart_bth4_ioctl(FAR struct file *filep,
                                int cmd, unsigned long arg);
-static int     uart_bth4_poll (FAR struct file *filep,
-                               FAR struct pollfd *fds, bool setup);
+static int     uart_bth4_poll(FAR struct file *filep,
+                              FAR struct pollfd *fds, bool setup);
 
 /****************************************************************************
  * Private Data
@@ -84,7 +84,7 @@ static int     uart_bth4_poll (FAR struct file *filep,
 static const struct file_operations g_uart_bth4_ops =
 {
   uart_bth4_open,   /* open */
-  uart_bth4_close,  /* cose */
+  uart_bth4_close,  /* close */
   uart_bth4_read,   /* read */
   uart_bth4_write,  /* write */
   NULL,             /* seek */
@@ -344,14 +344,14 @@ out:
   return ret < 0 ? ret : buflen;
 }
 
-static int uart_bth4_ioctl(FAR struct file *filep,
-                           int cmd, unsigned long arg)
+static int uart_bth4_ioctl(FAR struct file *filep, int cmd,
+                           unsigned long arg)
 {
   return OK;
 }
 
-static int uart_bth4_poll(FAR struct file *filep,
-                          FAR struct pollfd *fds, bool setup)
+static int uart_bth4_poll(FAR struct file *filep, FAR struct pollfd *fds,
+                          bool setup)
 {
   FAR struct inode *inode = filep->f_inode;
   FAR struct uart_bth4_s *dev = inode->i_private;

--- a/drivers/spi/spi_slave_driver.c
+++ b/drivers/spi/spi_slave_driver.c
@@ -93,7 +93,7 @@ struct spi_slave_driver_s
 static int     spi_slave_open(FAR struct file *filep);
 static int     spi_slave_close(FAR struct file *filep);
 static ssize_t spi_slave_read(FAR struct file *filep, FAR char *buffer,
-                             size_t buflen);
+                              size_t buflen);
 static ssize_t spi_slave_write(FAR struct file *filep,
                                FAR const char *buffer, size_t buflen);
 static int     spi_slave_unlink(FAR struct inode *inode);
@@ -105,9 +105,9 @@ static void    spi_slave_select(FAR struct spi_slave_dev_s *sdev,
 static void    spi_slave_cmddata(FAR struct spi_slave_dev_s *sdev,
                                  bool data);
 static size_t  spi_slave_getdata(FAR struct spi_slave_dev_s *sdev,
-                                FAR const void **data);
+                                 FAR const void **data);
 static size_t  spi_slave_receive(FAR struct spi_slave_dev_s *sdev,
-                                FAR const void *data, size_t nwords);
+                                 FAR const void *data, size_t nwords);
 
 /****************************************************************************
  * Private Data
@@ -609,7 +609,7 @@ int spi_slave_register(FAR struct spi_slave_ctrlr_s *ctrlr, int bus)
 
   /* Create the character device name */
 
-  snprintf(devname, DEVNAME_FMTLEN, DEVNAME_FMT, bus);
+  snprintf(devname, sizeof(devname), DEVNAME_FMT, bus);
 
   /* Register the character driver */
 

--- a/drivers/syslog/syslog_console.c
+++ b/drivers/syslog/syslog_console.c
@@ -42,8 +42,6 @@ static ssize_t syslog_console_read(FAR struct file *filep, FAR char *buffer,
                                    size_t buflen);
 static ssize_t syslog_console_write(FAR struct file *filep,
                                     FAR const char *buffer, size_t buflen);
-static int     syslog_console_ioctl(FAR struct file *filep, int cmd,
-                                    unsigned long arg);
 
 /****************************************************************************
  * Private Data
@@ -56,7 +54,7 @@ static const struct file_operations g_consoleops =
   syslog_console_read,  /* read */
   syslog_console_write, /* write */
   NULL,                 /* seek */
-  syslog_console_ioctl, /* ioctl */
+  NULL,                 /* ioctl */
   NULL                  /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , NULL                /* unlink */
@@ -66,16 +64,6 @@ static const struct file_operations g_consoleops =
 /****************************************************************************
  * Private Functions
  ****************************************************************************/
-
-/****************************************************************************
- * Name: syslog_console_ioctl
- ****************************************************************************/
-
-static int syslog_console_ioctl(FAR struct file *filep, int cmd,
-                                unsigned long arg)
-{
-  return -ENOTTY;
-}
 
 /****************************************************************************
  * Name: syslog_console_read

--- a/drivers/timers/oneshot.c
+++ b/drivers/timers/oneshot.c
@@ -61,8 +61,6 @@ struct oneshot_dev_s
  * Private Function Prototypes
  ****************************************************************************/
 
-static int     oneshot_open(FAR struct file *filep);
-static int     oneshot_close(FAR struct file *filep);
 static ssize_t oneshot_read(FAR struct file *filep, FAR char *buffer,
                  size_t buflen);
 static ssize_t oneshot_write(FAR struct file *filep, FAR const char *buffer,
@@ -79,8 +77,8 @@ static void    oneshot_callback(FAR struct oneshot_lowerhalf_s *lower,
 
 static const struct file_operations g_oneshot_ops =
 {
-  oneshot_open,  /* open */
-  oneshot_close, /* close */
+  NULL,          /* open */
+  NULL,          /* close */
   oneshot_read,  /* read */
   oneshot_write, /* write */
   NULL,          /* seek */
@@ -108,38 +106,8 @@ static void oneshot_callback(FAR struct oneshot_lowerhalf_s *lower,
 
   /* Signal the waiter.. if there is one */
 
-  nxsig_notification(priv->od_pid, &priv->od_event,
-                     SI_QUEUE, &priv->od_work);
-}
-
-/****************************************************************************
- * Name: oneshot_open
- *
- * Description:
- *   This function is called whenever the PWM device is opened.
- *
- ****************************************************************************/
-
-static int oneshot_open(FAR struct file *filep)
-{
-  tmrinfo("Opening...\n");
-  DEBUGASSERT(filep != NULL && filep->f_inode != NULL);
-  return OK;
-}
-
-/****************************************************************************
- * Name: oneshot_close
- *
- * Description:
- *   This function is called when the PWM device is closed.
- *
- ****************************************************************************/
-
-static int oneshot_close(FAR struct file *filep)
-{
-  tmrinfo("Closing...\n");
-  DEBUGASSERT(filep != NULL && filep->f_inode != NULL);
-  return OK;
+  nxsig_notification(priv->od_pid, &priv->od_event, SI_QUEUE,
+                     &priv->od_work);
 }
 
 /****************************************************************************

--- a/drivers/usbdev/adb.c
+++ b/drivers/usbdev/adb.c
@@ -221,8 +221,6 @@ static ssize_t adb_char_read(FAR struct file *filep, FAR char *buffer,
                                size_t len);
 static ssize_t adb_char_write(FAR struct file *filep,
                                 FAR const char *buffer, size_t len);
-static int adb_char_ioctl(FAR struct file *filep, int cmd,
-                            unsigned long arg);
 static int adb_char_poll(FAR struct file *filep, FAR struct pollfd *fds,
                        bool setup);
 
@@ -257,7 +255,7 @@ static const struct file_operations g_adb_fops =
   adb_char_read,  /* read */
   adb_char_write, /* write */
   NULL,           /* seek */
-  adb_char_ioctl, /* ioctl */
+  NULL,           /* ioctl */
   adb_char_poll   /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , NULL          /* unlink */
@@ -1962,12 +1960,6 @@ static ssize_t adb_char_write(FAR struct file *filep,
 errout:
   nxsem_post(&priv->exclsem);
   return ret;
-}
-
-static int adb_char_ioctl(FAR struct file *filep, int cmd,
-                            unsigned long arg)
-{
-  return -EINVAL;
 }
 
 static int adb_char_poll(FAR struct file *filep, FAR struct pollfd *fds,

--- a/drivers/video/fb.c
+++ b/drivers/video/fb.c
@@ -62,12 +62,10 @@ struct fb_chardev_s
  * Private Function Prototypes
  ****************************************************************************/
 
-static int     fb_open(FAR struct file *filep);
-static int     fb_close(FAR struct file *filep);
 static ssize_t fb_read(FAR struct file *filep, FAR char *buffer,
-                 size_t buflen);
+                       size_t buflen);
 static ssize_t fb_write(FAR struct file *filep, FAR const char *buffer,
-                 size_t buflen);
+                        size_t buflen);
 static off_t   fb_seek(FAR struct file *filep, off_t offset, int whence);
 static int     fb_ioctl(FAR struct file *filep, int cmd, unsigned long arg);
 
@@ -77,8 +75,8 @@ static int     fb_ioctl(FAR struct file *filep, int cmd, unsigned long arg);
 
 static const struct file_operations fb_fops =
 {
-  fb_open,       /* open */
-  fb_close,      /* close */
+  NULL,          /* open */
+  NULL,          /* close */
   fb_read,       /* read */
   fb_write,      /* write */
   fb_seek,       /* seek */
@@ -92,34 +90,6 @@ static const struct file_operations fb_fops =
 /****************************************************************************
  * Private Functions
  ****************************************************************************/
-
-/****************************************************************************
- * Name: fb_open
- *
- * Description:
- *   This function is called whenever the framebuffer device is opened.
- *
- ****************************************************************************/
-
-static int fb_open(FAR struct file *filep)
-{
-  DEBUGASSERT(filep != NULL && filep->f_inode != NULL);
-  return OK;
-}
-
-/****************************************************************************
- * Name: fb_close
- *
- * Description:
- *   This function is called when the framebuffer device is closed.
- *
- ****************************************************************************/
-
-static int fb_close(FAR struct file *filep)
-{
-  DEBUGASSERT(filep != NULL && filep->f_inode != NULL);
-  return OK;
-}
 
 /****************************************************************************
  * Name: fb_read

--- a/drivers/video/max7456.c
+++ b/drivers/video/max7456.c
@@ -311,17 +311,12 @@ struct mx7_dev_s
  ****************************************************************************/
 
 static int mx7_open(FAR struct file *filep);
-static int mx7_close(FAR struct file *filep);
 static ssize_t mx7_read(FAR struct file *filep,
                         FAR char *buf, size_t len);
 static ssize_t mx7_write(FAR struct file *filep,
                          FAR const char *buf, size_t len);
-static int mx7_ioctl(FAR struct file *filep,
-                     int cmd, unsigned long arg);
 
 #if defined(DEBUG)
-static int mx7_debug_open(FAR struct file *filep);
-static int mx7_debug_close(FAR struct file *filep);
 static ssize_t mx7_debug_read(FAR struct file *filep,
                               FAR char *buf, size_t len);
 static ssize_t mx7_debug_write(FAR struct file *filep,
@@ -337,11 +332,11 @@ static ssize_t mx7_debug_write(FAR struct file *filep,
 static const struct file_operations g_mx7_fops =
 {
   mx7_open,      /* open */
-  mx7_close,     /* close */
+  NULL,          /* close */
   mx7_read,      /* read */
   mx7_write,     /* write */
   NULL,          /* seek */
-  mx7_ioctl,     /* ioctl */
+  NULL,          /* ioctl */
   NULL           /* poll */
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
   , NULL         /* unlink */
@@ -354,8 +349,8 @@ static const struct file_operations g_mx7_fops =
 
 static const struct file_operations g_mx7_debug_fops =
 {
-  mx7_debug_open,      /* open */
-  mx7_debug_close,     /* close */
+  NULL,                /* open */
+  NULL,                /* close */
   mx7_debug_read,      /* read */
   mx7_debug_write,     /* write */
   NULL,                /* seek */
@@ -1288,19 +1283,6 @@ static int mx7_open(FAR struct file *filep)
 }
 
 /****************************************************************************
- * Name: mx7_close
- *
- * Description:
- *   The usual file-operations close() method.
- ****************************************************************************/
-
-static int mx7_close(FAR struct file *filep)
-{
-  UNUSED(filep);
-  return 0;
-}
-
-/****************************************************************************
  * Name: mx7_read_cm
  *
  * Description:
@@ -1474,24 +1456,6 @@ static ssize_t mx7_write(FAR struct file *filep,
   return ret;
 }
 
-/****************************************************************************
- * Name: mx7_ioctl
- *
- * Description:
- *   Does nothing, because I don't like ioctls.
- *
- ****************************************************************************/
-
-static int mx7_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
-{
-  FAR struct inode *inode = filep->f_inode;
-  FAR struct mx7_dev_s *dev = inode->i_private;
-
-  UNUSED(inode);
-  UNUSED(dev);
-  return -ENOTTY;               /* unsupported ioctl */
-}
-
 #if defined(DEBUG)
 
 /****************************************************************************
@@ -1538,39 +1502,6 @@ static int hex_to_uint8(FAR const char *buf)
   /* Interpret as hex even without the leading "0x". */
 
   return strtol(buf, NULL, 16);
-}
-
-/****************************************************************************
- * Name: mx7_debug_open
- *
- * Description:
- *   Ordinary file-operations open() for debug-related interfaces.
- *
- ****************************************************************************/
-
-static int mx7_debug_open(FAR struct file *filep)
-{
-  FAR struct inode *inode = filep->f_inode;
-  FAR struct mx7_dev_s *dev = inode->i_private;
-  FAR const char *name = inode->i_name;
-
-  UNUSED(inode);
-  UNUSED(dev);
-  UNUSED(name);
-  return 0;
-}
-
-/****************************************************************************
- * Name: mx7_debug_close
- *
- * Description:
- *   Ordinary file-operations close() for debug-related interfaces.
- *
- ****************************************************************************/
-
-static int mx7_debug_close(FAR struct file *filep)
-{
-  return 0;
 }
 
 /****************************************************************************

--- a/drivers/wireless/gs2200m.c
+++ b/drivers/wireless/gs2200m.c
@@ -201,8 +201,6 @@ struct gs2200m_dev_s
 
 /* Character driver methods */
 
-static int     gs2200m_open(FAR struct file *filep);
-static int     gs2200m_close(FAR struct file *filep);
 static ssize_t gs2200m_read(FAR struct file *filep, FAR char *buff,
                             size_t len);
 static ssize_t gs2200m_write(FAR struct file *filep, FAR const char *buff,
@@ -227,8 +225,8 @@ static void _remove_all_pkt(FAR struct gs2200m_dev_s *dev, uint8_t c);
 
 static const struct file_operations g_gs2200m_fops =
 {
-  gs2200m_open,  /* open */
-  gs2200m_close, /* close */
+  NULL,          /* open */
+  NULL,          /* close */
   gs2200m_read,  /* read */
   gs2200m_write, /* write */
   NULL,          /* seek */
@@ -707,24 +705,6 @@ static int gs2200m_lock(FAR struct gs2200m_dev_s *dev)
 static void gs2200m_unlock(FAR struct gs2200m_dev_s *dev)
 {
   nxsem_post(&dev->dev_sem);
-}
-
-/****************************************************************************
- * Name: gs2200m_open
- ****************************************************************************/
-
-static int gs2200m_open(FAR struct file *filep)
-{
-  return OK;
-}
-
-/****************************************************************************
- * Name: gs2200m_close
- ****************************************************************************/
-
-static int gs2200m_close(FAR struct file *filep)
-{
-  return OK;
 }
 
 /****************************************************************************

--- a/drivers/wireless/nrf24l01.c
+++ b/drivers/wireless/nrf24l01.c
@@ -172,39 +172,39 @@ static void nrf24l01_lock(FAR struct spi_dev_s *spi);
 static void nrf24l01_unlock(FAR struct spi_dev_s *spi);
 
 static uint8_t nrf24l01_access(FAR struct nrf24l01_dev_s *dev,
-             nrf24l01_access_mode_t mode, uint8_t cmd, FAR uint8_t *buf,
-             int length);
+                               nrf24l01_access_mode_t mode, uint8_t cmd,
+                               FAR uint8_t *buf, int length);
 static uint8_t nrf24l01_flush_rx(FAR struct nrf24l01_dev_s *dev);
 static uint8_t nrf24l01_flush_tx(FAR struct nrf24l01_dev_s *dev);
 
 /* Read register from nrf24 */
 
 static uint8_t nrf24l01_readreg(FAR struct nrf24l01_dev_s *dev, uint8_t reg,
-             FAR uint8_t *value, int len);
+                                FAR uint8_t *value, int len);
 
 /* Read single byte value from a register of nrf24 */
 
 static uint8_t nrf24l01_readregbyte(FAR struct nrf24l01_dev_s *dev,
-             uint8_t reg);
+                                    uint8_t reg);
 static void nrf24l01_writeregbyte(FAR struct nrf24l01_dev_s *dev,
-             uint8_t reg, uint8_t value);
+                                  uint8_t reg, uint8_t value);
 static uint8_t nrf24l01_setregbit(FAR struct nrf24l01_dev_s *dev,
-             uint8_t reg, uint8_t value, bool set);
+                                  uint8_t reg, uint8_t value, bool set);
 static void nrf24l01_tostate(FAR struct nrf24l01_dev_s *dev,
-             nrf24l01_state_t state);
+                             nrf24l01_state_t state);
 static int nrf24l01_irqhandler(FAR int irq, FAR void *context,
-             FAR void *arg);
+                               FAR void *arg);
 static inline int nrf24l01_attachirq(FAR struct nrf24l01_dev_s *dev,
-             xcpt_t isr, FAR void *arg);
+                                     xcpt_t isr, FAR void *arg);
 static int dosend(FAR struct nrf24l01_dev_s *dev, FAR const uint8_t *data,
-             size_t datalen);
+                  size_t datalen);
 static int nrf24l01_unregister(FAR struct nrf24l01_dev_s *dev);
 
 #ifdef CONFIG_WL_NRF24L01_RXSUPPORT
 static void fifoput(FAR struct nrf24l01_dev_s *dev, uint8_t pipeno,
-             FAR uint8_t *buffer, uint8_t buflen);
+                    FAR uint8_t *buffer, uint8_t buflen);
 static uint8_t fifoget(FAR struct nrf24l01_dev_s *dev, FAR uint8_t *buffer,
-             uint8_t buflen, FAR uint8_t *pipeno);
+                       uint8_t buflen, FAR uint8_t *pipeno);
 static void nrf24l01_worker(FAR void *arg);
 #endif
 
@@ -218,13 +218,13 @@ static void binarycvt(FAR char *deststr, FAR const uint8_t *srcbin,
 static int nrf24l01_open(FAR struct file *filep);
 static int nrf24l01_close(FAR struct file *filep);
 static ssize_t nrf24l01_read(FAR struct file *filep, FAR char *buffer,
-             size_t buflen);
+                             size_t buflen);
 static ssize_t nrf24l01_write(FAR struct file *filep,
-             FAR const char *buffer, size_t buflen);
+                              FAR const char *buffer, size_t buflen);
 static int nrf24l01_ioctl(FAR struct file *filep, int cmd,
-             unsigned long arg);
+                          unsigned long arg);
 static int nrf24l01_poll(FAR struct file *filep, FAR struct pollfd *fds,
-             bool setup);
+                         bool setup);
 
 /****************************************************************************
  * Private Data
@@ -2120,6 +2120,6 @@ void nrf24l01_dumprxfifo(FAR struct nrf24l01_dev_s *dev)
 {
   syslog(LOG_INFO, "bytes count: %d\n", dev->fifo_len);
   syslog(LOG_INFO, "next read:   %d,  next write: %d\n",
-         dev->nxt_read, dev-> nxt_write);
+         dev->nxt_read, dev->nxt_write);
 }
 #endif /* CONFIG_DEBUG_WIRELESS && CONFIG_WL_NRF24L01_RXSUPPORT */

--- a/graphics/nxterm/nxterm_driver.c
+++ b/graphics/nxterm/nxterm_driver.c
@@ -43,7 +43,7 @@
 static int     nxterm_open(FAR struct file *filep);
 static int     nxterm_close(FAR struct file *filep);
 static ssize_t nxterm_write(FAR struct file *filep, FAR const char *buffer,
-                 size_t buflen);
+                            size_t buflen);
 static int     nxterm_ioctl(FAR struct file *filep, int cmd,
                             unsigned long arg);
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS

--- a/graphics/nxterm/nxterm_register.c
+++ b/graphics/nxterm/nxterm_register.c
@@ -138,7 +138,7 @@ FAR struct nxterm_state_s *
 
   /* Register the driver */
 
-  snprintf(devname, NX_DEVNAME_SIZE, NX_DEVNAME_FORMAT, minor);
+  snprintf(devname, sizeof(devname), NX_DEVNAME_FORMAT, minor);
   ret = register_driver(devname, &g_nxterm_drvrops, 0666, priv);
   if (ret < 0)
     {

--- a/include/nuttx/sensors/as726x.h
+++ b/include/nuttx/sensors/as726x.h
@@ -66,12 +66,12 @@
 
 /* Register addresses */
 
-#define AS726x_DEVICE_TYPE      0x00
-#define AS726x_HW_VERSION       0x01
-#define AS726x_CONTROL_SETUP    0x04
-#define AS726x_INT_T            0x05
-#define AS726x_DEVICE_TEMP      0x06
-#define AS726x_LED_CONTROL      0x07
+#define AS726X_DEVICE_TYPE      0x00
+#define AS726X_HW_VERSION       0x01
+#define AS726X_CONTROL_SETUP    0x04
+#define AS726X_INT_T            0x05
+#define AS726X_DEVICE_TEMP      0x06
+#define AS726X_LED_CONTROL      0x07
 
 #define AS72XX_SLAVE_STATUS_REG 0x00
 #define AS72XX_SLAVE_WRITE_REG  0x01

--- a/wireless/ieee802154/mac802154_device.c
+++ b/wireless/ieee802154/mac802154_device.c
@@ -130,11 +130,11 @@ static int mac802154dev_rxframe(FAR struct mac802154_chardevice_s *dev,
 static int  mac802154dev_open(FAR struct file *filep);
 static int  mac802154dev_close(FAR struct file *filep);
 static ssize_t mac802154dev_read(FAR struct file *filep, FAR char *buffer,
-              size_t len);
+                                 size_t len);
 static ssize_t mac802154dev_write(FAR struct file *filep,
-              FAR const char *buffer, size_t len);
+                                  FAR const char *buffer, size_t len);
 static int  mac802154dev_ioctl(FAR struct file *filep, int cmd,
-              unsigned long arg);
+                               unsigned long arg);
 
 /****************************************************************************
  * Private Data
@@ -142,9 +142,9 @@ static int  mac802154dev_ioctl(FAR struct file *filep, int cmd,
 
 static const struct file_operations mac802154dev_fops =
 {
-  mac802154dev_open , /* open */
+  mac802154dev_open,  /* open */
   mac802154dev_close, /* close */
-  mac802154dev_read , /* read */
+  mac802154dev_read,  /* read */
   mac802154dev_write, /* write */
   NULL,               /* seek */
   mac802154dev_ioctl, /* ioctl */


### PR DESCRIPTION
## Summary
- Remove unimplemented open/close/ioctl interfaces
- Fix style issues
- Use sizeof in snprintf

## Impact
None

## Testing
Pass CI