### PR TITLE
risc-v/c906: fix build break

### DIFF
--- a/arch/risc-v/src/c906/c906_timerisr.c
+++ b/arch/risc-v/src/c906/c906_timerisr.c
@@ -24,6 +24,7 @@
 
 #include <nuttx/config.h>
 
+#include <assert.h>
 #include <stdint.h>
 #include <time.h>
 #include <debug.h>


### PR DESCRIPTION
## Summary

risc-v/c906: fix build break

```
chip/c906_timerisr.c: In function 'up_timer_initialize':
Error: chip/c906_timerisr.c:71:3: error: implicit declaration of function 'DEBUGASSERT' [-Werror=implicit-function-declaration]
   DEBUGASSERT(lower);
   ^~~~~~~~~~~
cc1: all warnings being treated as errors
```

Signed-off-by: chao.an <anchao@xiaomi.com>


## Impact

Regression by:
https://github.com/apache/incubator-nuttx/pull/6034

## Testing

