### PR TITLE
arch/risc-v/riscv_misaligned: Correct sw source register

### DIFF
--- a/arch/risc-v/src/common/riscv_misaligned.c
+++ b/arch/risc-v/src/common/riscv_misaligned.c
@@ -447,7 +447,7 @@ static bool decode_insn(uintptr_t *regs, riscv_insn_ctx_t *ctx)
       case INSN_FSD:
         _alert("Misaligned float instruction not support yet\n");
       default:
-        _alert("Uncompressed: %lx\n", insn.insn);
+        _alert("Uncompressed: %x\n", insn.insn);
         return false;
     }
 

--- a/arch/risc-v/src/common/riscv_misaligned.c
+++ b/arch/risc-v/src/common/riscv_misaligned.c
@@ -363,6 +363,7 @@ static bool decode_insn_compressed(uintptr_t *regs, riscv_insn_ctx_t *ctx)
 
 static bool decode_insn(uintptr_t *regs, riscv_insn_ctx_t *ctx)
 {
+  static const uintptr_t x0;
   uint32_t in;
   int32_t imm;
   riscv_insn_t insn;
@@ -418,7 +419,17 @@ static bool decode_insn(uintptr_t *regs, riscv_insn_ctx_t *ctx)
         imm = sext(insn.s.imm2 | insn.s.imm1 << 5, 12);
 
         ctx->dest = (uint8_t *)regs[insn.s.rs1] + imm;
-        ctx->src = (uint8_t *)&regs[insn.s.rs2];
+
+        /* If source register is x0, target it to constant register */
+
+        if (insn.s.rs2 == 0)
+          {
+            ctx->src = (uint8_t *)&x0;
+          }
+        else
+          {
+            ctx->src = (uint8_t *)&regs[insn.s.rs2];
+          }
 
         /* Get data wide bit */
 


### PR DESCRIPTION
## Summary
If source register of sw instruction is x0, we must point it to a constant zero
since in NuttX's context, value of index 0 is EPC.
## Impact
misaligned handler
## Testing
K210/BL602
