### PR TITLE
arch: Fix compile error when enabling CONFIG_DUMP_ON_EXIT.

### DIFF
--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -781,6 +781,13 @@ config ARCH_STACKDUMP
 	---help---
 		Enable to do stack dumps after assertions
 
+config DUMP_ON_EXIT
+	bool "Dump all tasks state on exit"
+	default n
+	depends on DEBUG_SCHED_INFO
+	---help---
+		Dump all tasks state on exit()
+
 config ARCH_USBDUMP
 	bool "Dump USB trace data"
 	default n
@@ -931,13 +938,6 @@ config SUPPRESS_UART_CONFIG
 		Do not re-configure the serial console UART from its start-up state.
 		This is useful when a boot loader has already initialized the serial
 		port.
-
-config DUMP_ON_EXIT
-	bool "Dump task state"
-	default n
-	depends on DEBUG_SCHED_INFO
-	---help---
-		Dump task state on exit()
 
 endmenu # Bring-Up Options
 

--- a/arch/arm/src/common/arm_exit.c
+++ b/arch/arm/src/common/arm_exit.c
@@ -71,7 +71,7 @@ static void _up_dumponexit(FAR struct tcb_s *tcb, FAR void *arg)
   sinfo("  TCB=%p name=%s pid=%d\n", tcb, tcb->name, tcb->pid);
   sinfo("    priority=%d state=%d\n", tcb->sched_priority, tcb->task_state);
 
-  filelist = tcb->group->tg_filelist;
+  filelist = &tcb->group->tg_filelist;
   for (i = 0; i < filelist->fl_rows; i++)
     {
       for (j = 0; j < CONFIG_NFILE_DESCRIPTORS_PER_BLOCK; j++)

--- a/arch/arm/src/common/arm_exit.c
+++ b/arch/arm/src/common/arm_exit.c
@@ -115,14 +115,14 @@ void up_exit(int status)
 
   sinfo("TCB=%p exiting\n", tcb);
 
+  /* Destroy the task at the head of the ready to run list. */
+
+  nxtask_exit();
+
 #ifdef CONFIG_DUMP_ON_EXIT
   sinfo("Other tasks:\n");
   nxsched_foreach(_up_dumponexit, NULL);
 #endif
-
-  /* Destroy the task at the head of the ready to run list. */
-
-  nxtask_exit();
 
   /* Now, perform the context switch to the new ready-to-run task at the
    * head of the list.

--- a/arch/avr/src/common/up_exit.c
+++ b/arch/avr/src/common/up_exit.c
@@ -114,14 +114,14 @@ void up_exit(int status)
 
   sinfo("TCB=%p exiting\n", tcb);
 
+  /* Destroy the task at the head of the ready to run list. */
+
+  nxtask_exit();
+
 #ifdef CONFIG_DUMP_ON_EXIT
   sinfo("Other tasks:\n");
   nxsched_foreach(_up_dumponexit, NULL);
 #endif
-
-  /* Destroy the task at the head of the ready to run list. */
-
-  nxtask_exit();
 
   /* Now, perform the context switch to the new ready-to-run task at the
    * head of the list.

--- a/arch/avr/src/common/up_exit.c
+++ b/arch/avr/src/common/up_exit.c
@@ -70,7 +70,7 @@ static void _up_dumponexit(FAR struct tcb_s *tcb, FAR void *arg)
   sinfo("  TCB=%p name=%s pid=%d\n", tcb, tcb->name, tcb->pid);
   sinfo("    priority=%d state=%d\n", tcb->sched_priority, tcb->task_state);
 
-  filelist = tcb->group->tg_filelist;
+  filelist = &tcb->group->tg_filelist;
   for (i = 0; i < filelist->fl_rows; i++)
     {
       for (j = 0; j < CONFIG_NFILE_DESCRIPTORS_PER_BLOCK; j++)

--- a/arch/hc/src/common/up_exit.c
+++ b/arch/hc/src/common/up_exit.c
@@ -114,14 +114,14 @@ void up_exit(int status)
 
   sinfo("TCB=%p exiting\n", tcb);
 
+  /* Destroy the task at the head of the ready to run list. */
+
+  nxtask_exit();
+
 #ifdef CONFIG_DUMP_ON_EXIT
   sinfo("Other tasks:\n");
   nxsched_foreach(_up_dumponexit, NULL);
 #endif
-
-  /* Destroy the task at the head of the ready to run list. */
-
-  nxtask_exit();
 
   /* Now, perform the context switch to the new ready-to-run task at the
    * head of the list.

--- a/arch/hc/src/common/up_exit.c
+++ b/arch/hc/src/common/up_exit.c
@@ -70,7 +70,7 @@ static void _up_dumponexit(FAR struct tcb_s *tcb, FAR void *arg)
   sinfo("  TCB=%p name=%s pid=%d\n", tcb, tcb->name, tcb->pid);
   sinfo("    priority=%d state=%d\n", tcb->sched_priority, tcb->task_state);
 
-  filelist = tcb->group->tg_filelist;
+  filelist = &tcb->group->tg_filelist;
   for (i = 0; i < filelist->fl_rows; i++)
     {
       for (j = 0; j < CONFIG_NFILE_DESCRIPTORS_PER_BLOCK; j++)

--- a/arch/mips/src/common/mips_exit.c
+++ b/arch/mips/src/common/mips_exit.c
@@ -72,7 +72,7 @@ static void _up_dumponexit(FAR struct tcb_s *tcb, FAR void *arg)
   sinfo("  TCB=%p name=%s pid=%d\n", tcb, tcb->name, tcb->pid);
   sinfo("    priority=%d state=%d\n", tcb->sched_priority, tcb->task_state);
 
-  filelist = tcb->group->tg_filelist;
+  filelist = &tcb->group->tg_filelist;
   for (i = 0; i < filelist->fl_rows; i++)
     {
       for (j = 0; j < CONFIG_NFILE_DESCRIPTORS_PER_BLOCK; j++)

--- a/arch/mips/src/common/mips_exit.c
+++ b/arch/mips/src/common/mips_exit.c
@@ -116,14 +116,14 @@ void up_exit(int status)
 
   sinfo("TCB=%p exiting\n", tcb);
 
+  /* Destroy the task at the head of the ready to run list. */
+
+  nxtask_exit();
+
 #ifdef CONFIG_DUMP_ON_EXIT
   sinfo("Other tasks:\n");
   nxsched_foreach(_up_dumponexit, NULL);
 #endif
-
-  /* Destroy the task at the head of the ready to run list. */
-
-  nxtask_exit();
 
   /* Now, perform the context switch to the new ready-to-run task at the
    * head of the list.

--- a/arch/misoc/src/lm32/lm32_exit.c
+++ b/arch/misoc/src/lm32/lm32_exit.c
@@ -64,7 +64,7 @@ static void _up_dumponexit(FAR struct tcb_s *tcb, FAR void *arg)
   sinfo("  TCB=%p name=%s pid=%d\n", tcb, tcb->name, tcb->pid);
   sinfo("    priority=%d state=%d\n", tcb->sched_priority, tcb->task_state);
 
-  filelist = tcb->group->tg_filelist;
+  filelist = &tcb->group->tg_filelist;
   for (i = 0; i < filelist->fl_rows; i++)
     {
       for (j = 0; j < CONFIG_NFILE_DESCRIPTORS_PER_BLOCK; j++)

--- a/arch/misoc/src/lm32/lm32_exit.c
+++ b/arch/misoc/src/lm32/lm32_exit.c
@@ -108,14 +108,14 @@ void up_exit(int status)
 
   sinfo("TCB=%p exiting\n", tcb);
 
+  /* Destroy the task at the head of the ready to run list. */
+
+  nxtask_exit();
+
 #ifdef CONFIG_DUMP_ON_EXIT
   sinfo("Other tasks:\n");
   nxsched_foreach(_up_dumponexit, NULL);
 #endif
-
-  /* Destroy the task at the head of the ready to run list. */
-
-  nxtask_exit();
 
   /* Now, perform the context switch to the new ready-to-run task at the
    * head of the list.

--- a/arch/misoc/src/minerva/minerva_exit.c
+++ b/arch/misoc/src/minerva/minerva_exit.c
@@ -64,7 +64,7 @@ static void _up_dumponexit(FAR struct tcb_s *tcb, FAR void *arg)
   sinfo("  TCB=%p name=%s pid=%d\n", tcb, tcb->name, tcb->pid);
   sinfo("    priority=%d state=%d\n", tcb->sched_priority, tcb->task_state);
 
-  filelist = tcb->group->tg_filelist;
+  filelist = &tcb->group->tg_filelist;
   for (i = 0; i < filelist->fl_rows; i++)
     {
       for (j = 0; j < CONFIG_NFILE_DESCRIPTORS_PER_BLOCK; j++)

--- a/arch/misoc/src/minerva/minerva_exit.c
+++ b/arch/misoc/src/minerva/minerva_exit.c
@@ -108,14 +108,14 @@ void up_exit(int status)
 
   sinfo("TCB=%p exiting\n", tcb);
 
+  /* Destroy the task at the head of the ready to run list. */
+
+  nxtask_exit();
+
 #ifdef CONFIG_DUMP_ON_EXIT
   sinfo("Other tasks:\n");
   nxsched_foreach(_up_dumponexit, NULL);
 #endif
-
-  /* Destroy the task at the head of the ready to run list. */
-
-  nxtask_exit();
 
   /* Now, perform the context switch to the new ready-to-run task at the head
    * of the list.

--- a/arch/or1k/src/common/up_exit.c
+++ b/arch/or1k/src/common/up_exit.c
@@ -71,7 +71,7 @@ static void _up_dumponexit(FAR struct tcb_s *tcb, FAR void *arg)
   sinfo("  TCB=%p name=%s pid=%d\n", tcb, tcb->name, tcb->pid);
   sinfo("    priority=%d state=%d\n", tcb->sched_priority, tcb->task_state);
 
-  filelist = tcb->group->tg_filelist;
+  filelist = &tcb->group->tg_filelist;
   for (i = 0; i < filelist->fl_rows; i++)
     {
       for (j = 0; j < CONFIG_NFILE_DESCRIPTORS_PER_BLOCK; j++)

--- a/arch/or1k/src/common/up_exit.c
+++ b/arch/or1k/src/common/up_exit.c
@@ -115,14 +115,14 @@ void up_exit(int status)
 
   sinfo("TCB=%p exiting\n", tcb);
 
+  /* Destroy the task at the head of the ready to run list. */
+
+  nxtask_exit();
+
 #ifdef CONFIG_DUMP_ON_EXIT
   sinfo("Other tasks:\n");
   nxsched_foreach(_up_dumponexit, NULL);
 #endif
-
-  /* Destroy the task at the head of the ready to run list. */
-
-  nxtask_exit();
 
   /* Now, perform the context switch to the new ready-to-run task at the
    * head of the list.

--- a/arch/renesas/src/common/up_exit.c
+++ b/arch/renesas/src/common/up_exit.c
@@ -114,14 +114,14 @@ void up_exit(int status)
 
   sinfo("TCB=%p exiting\n", tcb);
 
+  /* Destroy the task at the head of the ready to run list. */
+
+  nxtask_exit();
+
 #ifdef CONFIG_DUMP_ON_EXIT
   sinfo("Other tasks:\n");
   nxsched_foreach(_up_dumponexit, NULL);
 #endif
-
-  /* Destroy the task at the head of the ready to run list. */
-
-  nxtask_exit();
 
   /* Now, perform the context switch to the new ready-to-run task at the
    * head of the list.

--- a/arch/renesas/src/common/up_exit.c
+++ b/arch/renesas/src/common/up_exit.c
@@ -70,7 +70,7 @@ static void _up_dumponexit(FAR struct tcb_s *tcb, FAR void *arg)
   sinfo("  TCB=%p name=%s\n", tcb, tcb->name);
   sinfo("    priority=%d state=%d\n", tcb->sched_priority, tcb->task_state);
 
-  filelist = tcb->group->tg_filelist;
+  filelist = &tcb->group->tg_filelist;
   for (i = 0; i < filelist->fl_rows; i++)
     {
       for (j = 0; j < CONFIG_NFILE_DESCRIPTORS_PER_BLOCK; j++)

--- a/arch/risc-v/src/common/riscv_exit.c
+++ b/arch/risc-v/src/common/riscv_exit.c
@@ -116,14 +116,14 @@ void up_exit(int status)
 
   sinfo("TCB=%p exiting\n", tcb);
 
+  /* Destroy the task at the head of the ready to run list. */
+
+  nxtask_exit();
+
 #ifdef CONFIG_DUMP_ON_EXIT
   sinfo("Other tasks:\n");
   nxsched_foreach(_up_dumponexit, NULL);
 #endif
-
-  /* Destroy the task at the head of the ready to run list. */
-
-  nxtask_exit();
 
   /* Now, perform the context switch to the new ready-to-run task at the
    * head of the list.

--- a/arch/risc-v/src/common/riscv_exit.c
+++ b/arch/risc-v/src/common/riscv_exit.c
@@ -72,7 +72,7 @@ static void _up_dumponexit(struct tcb_s *tcb, void *arg)
   sinfo("  TCB=%p name=%s pid=%d\n", tcb, tcb->name, tcb->pid);
   sinfo("    priority=%d state=%d\n", tcb->sched_priority, tcb->task_state);
 
-  filelist = tcb->group->tg_filelist;
+  filelist = &tcb->group->tg_filelist;
   for (i = 0; i < filelist->fl_rows; i++)
     {
       for (j = 0; j < CONFIG_NFILE_DESCRIPTORS_PER_BLOCK; j++)

--- a/arch/sparc/src/common/up_exit.c
+++ b/arch/sparc/src/common/up_exit.c
@@ -74,7 +74,7 @@ static void _up_dumponexit(FAR struct tcb_s *tcb, FAR void *arg)
   sinfo("  TCB=%p name=%s pid=%d\n", tcb, tcb->argv[0], tcb->pid);
   sinfo("    priority=%d state=%d\n", tcb->sched_priority, tcb->task_state);
 
-  filelist = tcb->group->tg_filelist;
+  filelist = &tcb->group->tg_filelist;
   for (i = 0; i < CONFIG_NFILE_DESCRIPTORS; i++)
     {
       struct inode *inode = filelist->fl_files[i].f_inode;

--- a/arch/sparc/src/common/up_exit.c
+++ b/arch/sparc/src/common/up_exit.c
@@ -137,11 +137,6 @@ void up_exit(int status)
 
   sinfo("TCB=%p exiting\n", tcb);
 
-#ifdef CONFIG_DUMP_ON_EXIT
-  sinfo("Other tasks:\n");
-  sched_foreach(_up_dumponexit, NULL);
-#endif
-
   /* Update scheduler parameters */
 
   nxsched_suspend_scheduler(tcb);
@@ -149,6 +144,11 @@ void up_exit(int status)
   /* Destroy the task at the head of the ready to run list. */
 
   (void)nxtask_exit();
+
+#ifdef CONFIG_DUMP_ON_EXIT
+  sinfo("Other tasks:\n");
+  sched_foreach(_up_dumponexit, NULL);
+#endif
 
   /* Now, perform the context switch to the new ready-to-run task at the
    * head of the list.

--- a/arch/x86/src/common/up_exit.c
+++ b/arch/x86/src/common/up_exit.c
@@ -114,14 +114,14 @@ void up_exit(int status)
 
   sinfo("TCB=%p exiting\n", tcb);
 
+  /* Destroy the task at the head of the ready to run list. */
+
+  nxtask_exit();
+
 #ifdef CONFIG_DUMP_ON_EXIT
   sinfo("Other tasks:\n");
   nxsched_foreach(_up_dumponexit, NULL);
 #endif
-
-  /* Destroy the task at the head of the ready to run list. */
-
-  nxtask_exit();
 
   /* Now, perform the context switch to the new ready-to-run task at the
    * head of the list.

--- a/arch/x86/src/common/up_exit.c
+++ b/arch/x86/src/common/up_exit.c
@@ -70,7 +70,7 @@ static void _up_dumponexit(FAR struct tcb_s *tcb, FAR void *arg)
   sinfo("  TCB=%p name=%s pid=%d\n", tcb, tcb->name, tcb->pid);
   sinfo("    priority=%d state=%d\n", tcb->sched_priority, tcb->task_state);
 
-  filelist = tcb->group->tg_filelist;
+  filelist = &tcb->group->tg_filelist;
   for (i = 0; i < filelist->fl_rows; i++)
     {
       for (j = 0; j < CONFIG_NFILE_DESCRIPTORS_PER_BLOCK; j++)

--- a/arch/x86_64/src/common/up_exit.c
+++ b/arch/x86_64/src/common/up_exit.c
@@ -114,14 +114,14 @@ void up_exit(int status)
 
   sinfo("TCB=%p exiting\n", this_task());
 
+  /* Destroy the task at the head of the ready to run list. */
+
+  nxtask_exit();
+
 #ifdef CONFIG_DUMP_ON_EXIT
   sinfo("Other tasks:\n");
   nxsched_foreach(_up_dumponexit, NULL);
 #endif
-
-  /* Destroy the task at the head of the ready to run list. */
-
-  nxtask_exit();
 
   /* Now, perform the context switch to the new ready-to-run task at the
    * head of the list.

--- a/arch/x86_64/src/common/up_exit.c
+++ b/arch/x86_64/src/common/up_exit.c
@@ -70,7 +70,7 @@ static void _up_dumponexit(FAR struct tcb_s *tcb, FAR void *arg)
   sinfo("  TCB=%p name=%s pid=%d\n", tcb, tcb->name, tcb->pid);
   sinfo("    priority=%d state=%d\n", tcb->sched_priority, tcb->task_state);
 
-  filelist = tcb->group->tg_filelist;
+  filelist = &tcb->group->tg_filelist;
   for (i = 0; i < filelist->fl_rows; i++)
     {
       for (j = 0; j < CONFIG_NFILE_DESCRIPTORS_PER_BLOCK; j++)

--- a/arch/xtensa/src/common/xtensa_exit.c
+++ b/arch/xtensa/src/common/xtensa_exit.c
@@ -116,11 +116,6 @@ void up_exit(int status)
 
   sinfo("TCB=%p exiting\n", tcb);
 
-#ifdef CONFIG_DUMP_ON_EXIT
-  sinfo("Other tasks:\n");
-  nxsched_foreach(_xtensa_dumponexit, NULL);
-#endif
-
 #if XCHAL_CP_NUM > 0
   /* Disable co-processor support for the task that is exit-ing. */
 
@@ -130,6 +125,11 @@ void up_exit(int status)
   /* Destroy the task at the head of the ready to run list. */
 
   nxtask_exit();
+
+#ifdef CONFIG_DUMP_ON_EXIT
+  sinfo("Other tasks:\n");
+  nxsched_foreach(_xtensa_dumponexit, NULL);
+#endif
 
   /* Now, perform the context switch to the new ready-to-run task at the
    * head of the list.

--- a/arch/xtensa/src/common/xtensa_exit.c
+++ b/arch/xtensa/src/common/xtensa_exit.c
@@ -72,7 +72,7 @@ static void _xtensa_dumponexit(struct tcb_s *tcb, void *arg)
   sinfo("  TCB=%p name=%s pid=%d\n", tcb, tcb->name, tcb->pid);
   sinfo("    priority=%d state=%d\n", tcb->sched_priority, tcb->task_state);
 
-  filelist = tcb->group->tg_filelist;
+  filelist = &tcb->group->tg_filelist;
   for (i = 0; i < filelist->fl_rows; i++)
     {
       for (j = 0; j < CONFIG_NFILE_DESCRIPTORS_PER_BLOCK; j++)

--- a/arch/z16/src/common/z16_exit.c
+++ b/arch/z16/src/common/z16_exit.c
@@ -70,7 +70,7 @@ static void _z16_dumponexit(FAR struct tcb_s *tcb, FAR void *arg)
   sinfo("  TCB=%p name=%s\n", tcb, tcb->name);
   sinfo("    priority=%d state=%d\n", tcb->sched_priority, tcb->task_state);
 
-  filelist = tcb->group->tg_filelist;
+  filelist = &tcb->group->tg_filelist;
   for (i = 0; i < filelist->fl_rows; i++)
     {
       for (j = 0; j < CONFIG_NFILE_DESCRIPTORS_PER_BLOCK; j++)

--- a/arch/z16/src/common/z16_exit.c
+++ b/arch/z16/src/common/z16_exit.c
@@ -114,14 +114,14 @@ void up_exit(int status)
 
   sinfo("TCB=%p exiting\n", tcb);
 
+  /* Destroy the task at the head of the ready to run list. */
+
+  nxtask_exit();
+
 #ifdef CONFIG_DUMP_ON_EXIT
   sinfo("Other tasks:\n");
   nxsched_foreach(_z16_dumponexit, NULL);
 #endif
-
-  /* Destroy the task at the head of the ready to run list. */
-
-  nxtask_exit();
 
   /* Now, perform the context switch to the new ready-to-run task at the
    * head of the list.

--- a/arch/z80/src/common/z80_exit.c
+++ b/arch/z80/src/common/z80_exit.c
@@ -116,14 +116,14 @@ void up_exit(int status)
 
   sinfo("TCB=%p exiting\n", tcb);
 
+  /* Destroy the task at the head of the ready to run list. */
+
+  nxtask_exit();
+
 #ifdef CONFIG_DUMP_ON_EXIT
   sinfo("Other tasks:\n");
   nxsched_foreach(_up_dumponexit, NULL);
 #endif
-
-  /* Destroy the task at the head of the ready to run list. */
-
-  nxtask_exit();
 
   /* Now, perform the context switch to the new ready-to-run task at the
    * head of the list.

--- a/arch/z80/src/common/z80_exit.c
+++ b/arch/z80/src/common/z80_exit.c
@@ -72,7 +72,7 @@ static void _up_dumponexit(FAR struct tcb_s *tcb, FAR void *arg)
   sinfo("  TCB=%p name=%s\n", tcb, tcb->name);
   sinfo("    priority=%d state=%d\n", tcb->sched_priority, tcb->task_state);
 
-  filelist = tcb->group->tg_filelist;
+  filelist = &tcb->group->tg_filelist;
   for (i = 0; i < filelist->fl_rows; i++)
     {
       for (j = 0; j < CONFIG_NFILE_DESCRIPTORS_PER_BLOCK; j++)


### PR DESCRIPTION
## Summary
Fix following error:
`error: incompatible types when assigning to type 'struct filelist *' from type 'struct filelist'
   filelist = tcb->group->tg_filelist;`
## Impact
Option is disabled by default.
## Testing
ESP32.
