### PR TITLE
arch/stack_color: correct the stack top of running task

### DIFF
--- a/arch/arm/src/common/arm_checkstack.c
+++ b/arch/arm/src/common/arm_checkstack.c
@@ -148,28 +148,36 @@ static size_t do_stackcheck(FAR void *stackbase, size_t nbytes)
 
 void arm_stack_color(FAR void *stackbase, size_t nbytes)
 {
-  uintptr_t start;
-  uintptr_t end;
-  size_t nwords;
-  FAR uint32_t *ptr;
+  uint32_t *stkptr;
+  uintptr_t stkend;
+  size_t    nwords;
   uintptr_t sp;
 
   /* Take extra care that we do not write outside the stack boundaries */
 
-  start = STACK_ALIGN_UP((uintptr_t)stackbase);
-  end   = nbytes ? STACK_ALIGN_DOWN((uintptr_t)stackbase + nbytes) :
-          (uintptr_t)&sp; /* 0: colorize the running stack */
+  stkptr = (uint32_t *)STACK_ALIGN_UP((uintptr_t)stackbase);
 
-  /* Get the adjusted size based on the top and bottom of the stack */
+  if (nbytes == 0) /* 0: colorize the running stack */
+    {
+      stkend = up_getsp();
+      if (stkend > (uintptr_t)&sp)
+        {
+          stkend = (uintptr_t)&sp;
+        }
+    }
+  else
+    {
+      stkend = (uintptr_t)stackbase + nbytes;
+    }
 
-  nwords = (end - start) >> 2;
-  ptr  = (FAR uint32_t *)start;
+  stkend = STACK_ALIGN_DOWN(stkend);
+  nwords = (stkend - (uintptr_t)stackbase) >> 2;
 
   /* Set the entire stack to the coloration value */
 
   while (nwords-- > 0)
     {
-      *ptr++ = STACK_COLOR;
+      *stkptr++ = STACK_COLOR;
     }
 }
 

--- a/arch/arm/src/common/arm_checkstack.c
+++ b/arch/arm/src/common/arm_checkstack.c
@@ -39,22 +39,6 @@
 #ifdef CONFIG_STACK_COLORATION
 
 /****************************************************************************
- * Pre-processor Macros
- ****************************************************************************/
-
-/* 32bit alignment macros */
-
-#define INT32_ALIGN_MASK    (3)
-#define INT32_ALIGN_DOWN(a) ((a) & ~INT32_ALIGN_MASK)
-#define INT32_ALIGN_UP(a)   (((a) + INT32_ALIGN_MASK) & ~INT32_ALIGN_MASK)
-
-/****************************************************************************
- * Private Function Prototypes
- ****************************************************************************/
-
-static size_t do_stackcheck(FAR void *stackbase, size_t nbytes);
-
-/****************************************************************************
  * Private Functions
  ****************************************************************************/
 
@@ -89,8 +73,8 @@ static size_t do_stackcheck(FAR void *stackbase, size_t nbytes)
 
   /* Take extra care that we do not check outside the stack boundaries */
 
-  start = INT32_ALIGN_UP((uintptr_t)stackbase);
-  end   = INT32_ALIGN_DOWN((uintptr_t)stackbase + nbytes);
+  start = STACK_ALIGN_UP((uintptr_t)stackbase);
+  end   = STACK_ALIGN_DOWN((uintptr_t)stackbase + nbytes);
 
   /* Get the adjusted size based on the top and bottom of the stack */
 
@@ -172,8 +156,8 @@ void arm_stack_color(FAR void *stackbase, size_t nbytes)
 
   /* Take extra care that we do not write outside the stack boundaries */
 
-  start = INT32_ALIGN_UP((uintptr_t)stackbase);
-  end   = nbytes ? INT32_ALIGN_DOWN((uintptr_t)stackbase + nbytes) :
+  start = STACK_ALIGN_UP((uintptr_t)stackbase);
+  end   = nbytes ? STACK_ALIGN_DOWN((uintptr_t)stackbase + nbytes) :
           (uintptr_t)&sp; /* 0: colorize the running stack */
 
   /* Get the adjusted size based on the top and bottom of the stack */
@@ -230,16 +214,16 @@ size_t up_check_intstack(void)
 {
 #ifdef CONFIG_SMP
   return do_stackcheck((FAR void *)arm_intstack_alloc(),
-                        INT32_ALIGN_DOWN(CONFIG_ARCH_INTERRUPTSTACK));
+                        STACK_ALIGN_DOWN(CONFIG_ARCH_INTERRUPTSTACK));
 #else
   return do_stackcheck((FAR void *)&g_intstackalloc,
-                        INT32_ALIGN_DOWN(CONFIG_ARCH_INTERRUPTSTACK));
+                        STACK_ALIGN_DOWN(CONFIG_ARCH_INTERRUPTSTACK));
 #endif
 }
 
 size_t up_check_intstack_remain(void)
 {
-  return INT32_ALIGN_DOWN(CONFIG_ARCH_INTERRUPTSTACK) - up_check_intstack();
+  return STACK_ALIGN_DOWN(CONFIG_ARCH_INTERRUPTSTACK) - up_check_intstack();
 }
 #endif
 

--- a/arch/ceva/src/common/up_createstack.c
+++ b/arch/ceva/src/common/up_createstack.c
@@ -230,16 +230,29 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
 #ifdef CONFIG_STACK_COLORATION
 void up_stack_color(FAR void *stackbase, size_t nbytes)
 {
-  /* Take extra care that we do not write outsize the stack boundaries */
-
   uint32_t *stkptr;
   uintptr_t stkend;
   size_t    nwords;
   uintptr_t sp;
 
-  stkptr = (uint32_t *)(((uintptr_t)stackbase + 3) & ~3);
-  stkend = nbytes ? (((uintptr_t)stackbase + nbytes) & ~3) :
-           (uintptr_t)&sp; /* 0: colorize the running stack */
+  /* Take extra care that we do not write outside the stack boundaries */
+
+  stkptr = (uint32_t *)STACK_ALIGN_UP((uintptr_t)stackbase);
+
+  if (nbytes == 0) /* 0: colorize the running stack */
+    {
+      stkend = up_getsp();
+      if (stkend > (uintptr_t)&sp)
+        {
+          stkend = (uintptr_t)&sp;
+        }
+    }
+  else
+    {
+      stkend = (uintptr_t)stackbase + nbytes;
+    }
+
+  stkend = STACK_ALIGN_DOWN(stkend);
   nwords = (stkend - (uintptr_t)stackbase) >> 2;
 
   /* Set the entire stack to the coloration value */

--- a/arch/or1k/src/common/up_createstack.c
+++ b/arch/or1k/src/common/up_createstack.c
@@ -203,16 +203,29 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
 #ifdef CONFIG_STACK_COLORATION
 void up_stack_color(FAR void *stackbase, size_t nbytes)
 {
-  /* Take extra care that we do not write outsize the stack boundaries */
-
   uint32_t *stkptr;
   uintptr_t stkend;
   size_t    nwords;
   uintptr_t sp;
 
-  stkptr = (uint32_t *)(((uintptr_t)stackbase + 3) & ~3);
-  stkend = nbytes ? (((uintptr_t)stackbase + nbytes) & ~3) :
-           (uintptr_t)&sp; /* 0: colorize the running stack */
+  /* Take extra care that we do not write outside the stack boundaries */
+
+  stkptr = (uint32_t *)STACK_ALIGN_UP((uintptr_t)stackbase);
+
+  if (nbytes == 0) /* 0: colorize the running stack */
+    {
+      stkend = up_getsp();
+      if (stkend > (uintptr_t)&sp)
+        {
+          stkend = (uintptr_t)&sp;
+        }
+    }
+  else
+    {
+      stkend = (uintptr_t)stackbase + nbytes;
+    }
+
+  stkend = STACK_ALIGN_DOWN(stkend);
   nwords = (stkend - (uintptr_t)stackbase) >> 2;
 
   /* Set the entire stack to the coloration value */

--- a/arch/risc-v/src/common/riscv_createstack.c
+++ b/arch/risc-v/src/common/riscv_createstack.c
@@ -213,28 +213,36 @@ int up_create_stack(struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
 #ifdef CONFIG_STACK_COLORATION
 void riscv_stack_color(void *stackbase, size_t nbytes)
 {
-  uintptr_t start;
-  uintptr_t end;
-  size_t nwords;
-  uint32_t *ptr;
+  uint32_t *stkptr;
+  uintptr_t stkend;
+  size_t    nwords;
   uintptr_t sp;
 
   /* Take extra care that we do not write outside the stack boundaries */
 
-  start = STACK_ALIGN_UP((uintptr_t)stackbase);
-  end   = nbytes ? STACK_ALIGN_DOWN((uintptr_t)stackbase + nbytes) :
-          (uintptr_t)&sp; /* 0: colorize the running stack */
+  stkptr = (uint32_t *)STACK_ALIGN_UP((uintptr_t)stackbase);
 
-  /* Get the adjusted size based on the top and bottom of the stack */
+  if (nbytes == 0) /* 0: colorize the running stack */
+    {
+      stkend = up_getsp();
+      if (stkend > (uintptr_t)&sp)
+        {
+          stkend = (uintptr_t)&sp;
+        }
+    }
+  else
+    {
+      stkend = (uintptr_t)stackbase + nbytes;
+    }
 
-  nwords = (end - start) >> 2;
-  ptr  = (uint32_t *)start;
+  stkend = STACK_ALIGN_DOWN(stkend);
+  nwords = (stkend - (uintptr_t)stackbase) >> 2;
 
   /* Set the entire stack to the coloration value */
 
   while (nwords-- > 0)
     {
-      *ptr++ = STACK_COLOR;
+      *stkptr++ = STACK_COLOR;
     }
 }
 #endif

--- a/arch/sparc/src/common/up_checkstack.c
+++ b/arch/sparc/src/common/up_checkstack.c
@@ -40,22 +40,6 @@
 #ifdef CONFIG_STACK_COLORATION
 
 /****************************************************************************
- * Pre-processor Macros
- ****************************************************************************/
-
-/* 32bit alignment macros */
-
-#define INT32_ALIGN_MASK    (3)
-#define INT32_ALIGN_DOWN(a) ((a) & ~INT32_ALIGN_MASK)
-#define INT32_ALIGN_UP(a)   (((a) + INT32_ALIGN_MASK) & ~INT32_ALIGN_MASK)
-
-/****************************************************************************
- * Private Function Prototypes
- ****************************************************************************/
-
-static size_t do_stackcheck(FAR void *stackbase, size_t nbytes);
-
-/****************************************************************************
  * Private Functions
  ****************************************************************************/
 
@@ -90,8 +74,8 @@ static size_t do_stackcheck(FAR void *stackbase, size_t nbytes)
 
   /* Take extra care that we do not check outside the stack boundaries */
 
-  start = INT32_ALIGN_UP((uintptr_t)stackbase);
-  end   = INT32_ALIGN_DOWN((uintptr_t)stackbase + nbytes);
+  start = STACK_ALIGN_UP((uintptr_t)stackbase);
+  end   = STACK_ALIGN_DOWN((uintptr_t)stackbase + nbytes);
 
   /* Get the adjusted size based on the top and bottom of the stack */
 
@@ -173,8 +157,8 @@ void up_stack_color(FAR void *stackbase, size_t nbytes)
 
   /* Take extra care that we do not write outside the stack boundaries */
 
-  start = INT32_ALIGN_UP((uintptr_t)stackbase);
-  end   = nbytes ? INT32_ALIGN_DOWN((uintptr_t)stackbase + nbytes) :
+  start = STACK_ALIGN_UP((uintptr_t)stackbase);
+  end   = nbytes ? STACK_ALIGN_DOWN((uintptr_t)stackbase + nbytes) :
           (uintptr_t)&sp; /* 0: colorize the running stack */
 
   /* Get the adjusted size based on the top and bottom of the stack */
@@ -230,12 +214,12 @@ ssize_t up_check_stack_remain(void)
 size_t up_check_intstack(void)
 {
   return do_stackcheck((uintptr_t)&g_intstackalloc,
-                       (CONFIG_ARCH_INTERRUPTSTACK & ~3));
+                       STACK_ALIGN_DOWN(CONFIG_ARCH_INTERRUPTSTACK));
 }
 
 size_t up_check_intstack_remain(void)
 {
-  return (CONFIG_ARCH_INTERRUPTSTACK & ~3) - up_check_intstack();
+  return STACK_ALIGN_DOWN(CONFIG_ARCH_INTERRUPTSTACK) - up_check_intstack();
 }
 #endif
 

--- a/arch/sparc/src/common/up_checkstack.c
+++ b/arch/sparc/src/common/up_checkstack.c
@@ -149,28 +149,36 @@ static size_t do_stackcheck(FAR void *stackbase, size_t nbytes)
 
 void up_stack_color(FAR void *stackbase, size_t nbytes)
 {
-  uintptr_t start;
-  uintptr_t end;
-  size_t nwords;
-  FAR uint32_t *ptr;
+  uint32_t *stkptr;
+  uintptr_t stkend;
+  size_t    nwords;
   uintptr_t sp;
 
   /* Take extra care that we do not write outside the stack boundaries */
 
-  start = STACK_ALIGN_UP((uintptr_t)stackbase);
-  end   = nbytes ? STACK_ALIGN_DOWN((uintptr_t)stackbase + nbytes) :
-          (uintptr_t)&sp; /* 0: colorize the running stack */
+  stkptr = (uint32_t *)STACK_ALIGN_UP((uintptr_t)stackbase);
 
-  /* Get the adjusted size based on the top and bottom of the stack */
+  if (nbytes == 0) /* 0: colorize the running stack */
+    {
+      stkend = up_getsp();
+      if (stkend > (uintptr_t)&sp)
+        {
+          stkend = (uintptr_t)&sp;
+        }
+    }
+  else
+    {
+      stkend = (uintptr_t)stackbase + nbytes;
+    }
 
-  nwords = (end - start) >> 2;
-  ptr  = (FAR uint32_t *)start;
+  stkend = STACK_ALIGN_DOWN(stkend);
+  nwords = (stkend - (uintptr_t)stackbase) >> 2;
 
   /* Set the entire stack to the coloration value */
 
   while (nwords-- > 0)
     {
-      *ptr++ = STACK_COLOR;
+      *stkptr++ = STACK_COLOR;
     }
 }
 

--- a/arch/xtensa/src/common/xtensa_createstack.c
+++ b/arch/xtensa/src/common/xtensa_createstack.c
@@ -219,28 +219,36 @@ int up_create_stack(struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
 #ifdef CONFIG_STACK_COLORATION
 void xtensa_stack_color(void *stackbase, size_t nbytes)
 {
-  uintptr_t start;
-  uintptr_t end;
-  size_t nwords;
-  uint32_t *ptr;
+  uint32_t *stkptr;
+  uintptr_t stkend;
+  size_t    nwords;
   uintptr_t sp;
 
   /* Take extra care that we do not write outside the stack boundaries */
 
-  start = STACK_ALIGN_UP((uintptr_t)stackbase);
-  end   = nbytes ? STACK_ALIGN_DOWN((uintptr_t)stackbase + nbytes) :
-          (uintptr_t)&sp; /* 0: colorize the running stack */
+  stkptr = (uint32_t *)STACK_ALIGN_UP((uintptr_t)stackbase);
 
-  /* Get the adjusted size based on the top and bottom of the stack */
+  if (nbytes == 0) /* 0: colorize the running stack */
+    {
+      stkend = up_getsp();
+      if (stkend > (uintptr_t)&sp)
+        {
+          stkend = (uintptr_t)&sp;
+        }
+    }
+  else
+    {
+      stkend = (uintptr_t)stackbase + nbytes;
+    }
 
-  nwords = (end - start) >> 2;
-  ptr  = (uint32_t *)start;
+  stkend = STACK_ALIGN_DOWN(stkend);
+  nwords = (stkend - (uintptr_t)stackbase) >> 2;
 
   /* Set the entire stack to the coloration value */
 
   while (nwords-- > 0)
     {
-      *ptr++ = STACK_COLOR;
+      *stkptr++ = STACK_COLOR;
     }
 }
 #endif


### PR DESCRIPTION
## Summary

arch/stack_color: correct the stack top of running task
arch/[arm|sparc]: replace INT32_ALIGN_* to STACK_ALIGN_*

This PR to ensure the stack pointer is locate to the stack top

## Impact

N/A

## Testing

sim/nsh, sabre-6quad/smp