### PR TITLE
sched/environ: Ensure tg_envp terminated by double '\0'

### DIFF
--- a/sched/environ/env_dup.c
+++ b/sched/environ/env_dup.c
@@ -94,7 +94,7 @@ int env_dup(FAR struct task_group_s *group)
         {
           /* There is an environment, duplicate it */
 
-          envp = (FAR char *)group_malloc(group, envlen);
+          envp = (FAR char *)group_malloc(group, envlen + 1);
           if (envp == NULL)
             {
               /* The parent's environment can not be inherited due to a
@@ -108,7 +108,7 @@ int env_dup(FAR struct task_group_s *group)
             {
               /* Duplicate the parent environment. */
 
-              memcpy(envp, ptcb->group->tg_envp, envlen);
+              memcpy(envp, ptcb->group->tg_envp, envlen + 1);
             }
         }
 

--- a/sched/environ/env_removevar.c
+++ b/sched/environ/env_removevar.c
@@ -83,10 +83,7 @@ int env_removevar(FAR struct task_group_s *group, FAR char *pvar)
        * this is inefficient, but robably not high duty.
        */
 
-      while (count-- > 0)
-        {
-          *dest++ = *src++;
-        }
+      memmove(dest, src, count + 1);
 
       /* Then set to the new allocation size.  The caller is expected to
        * call realloc at some point but we don't do that here because the

--- a/sched/environ/env_setenv.c
+++ b/sched/environ/env_setenv.c
@@ -145,7 +145,8 @@ int setenv(FAR const char *name, FAR const char *value, int overwrite)
   if (group->tg_envp)
     {
       newsize = group->tg_envsize + varlen;
-      newenvp = (FAR char *)group_realloc(group, group->tg_envp, newsize);
+      newenvp = (FAR char *)group_realloc(group, group->tg_envp,
+                                          newsize + 1);
       if (!newenvp)
         {
           ret = ENOMEM;
@@ -157,7 +158,7 @@ int setenv(FAR const char *name, FAR const char *value, int overwrite)
   else
     {
       newsize = varlen;
-      newenvp = (FAR char *)group_malloc(group, varlen);
+      newenvp = (FAR char *)group_malloc(group, varlen + 1);
       if (!newenvp)
         {
           ret = ENOMEM;
@@ -166,6 +167,8 @@ int setenv(FAR const char *name, FAR const char *value, int overwrite)
 
       pvar = newenvp;
     }
+
+  newenvp[newsize] = '\0';
 
   /* Save the new buffer and size */
 

--- a/sched/environ/env_unsetenv.c
+++ b/sched/environ/env_unsetenv.c
@@ -97,7 +97,7 @@ int unsetenv(FAR const char *name)
           /* Reallocate the environment to reclaim a little memory */
 
           newenvp = (FAR char *)group_realloc(group, group->tg_envp,
-                                              newsize);
+                                              newsize + 1);
 
           if (newenvp == NULL)
             {


### PR DESCRIPTION
## Summary
so we can compute the whole environ string length from it

## Impact
Minor

## Testing
Pass CI
