### PR TITLE
RISC-V: Support for mtimer in S-mode

### DIFF
--- a/arch/risc-v/src/common/riscv_internal.h
+++ b/arch/risc-v/src/common/riscv_internal.h
@@ -250,6 +250,13 @@ int riscv_check_pmp_access(uintptr_t attr, uintptr_t base, uintptr_t size);
 int riscv_configured_pmp_regions(void);
 int riscv_next_free_pmp_region(void);
 
+/* RISC-V SBI wrappers ******************************************************/
+
+#ifdef CONFIG_ARCH_USE_S_MODE
+void riscv_sbi_set_timer(uint64_t stime_value);
+uint64_t riscv_sbi_get_time(void);
+#endif
+
 /* Power management *********************************************************/
 
 #ifdef CONFIG_PM

--- a/arch/risc-v/src/common/riscv_mtimer.c
+++ b/arch/risc-v/src/common/riscv_mtimer.c
@@ -80,6 +80,7 @@ static const struct oneshot_operations_s g_riscv_mtimer_ops =
  * Private Functions
  ****************************************************************************/
 
+#ifndef CONFIG_ARCH_USE_S_MODE
 static uint64_t riscv_mtimer_get_mtime(struct riscv_mtimer_lowerhalf_s *priv)
 {
 #ifdef CONFIG_ARCH_RV64
@@ -114,6 +115,20 @@ static void riscv_mtimer_set_mtimecmp(struct riscv_mtimer_lowerhalf_s *priv,
 
   __DMB();
 }
+#else
+static uint64_t riscv_mtimer_get_mtime(struct riscv_mtimer_lowerhalf_s *priv)
+{
+  UNUSED(priv);
+  return riscv_sbi_get_time();
+}
+
+static void riscv_mtimer_set_mtimecmp(struct riscv_mtimer_lowerhalf_s *priv,
+                                      uint64_t value)
+{
+  UNUSED(priv);
+  riscv_sbi_set_timer(value);
+}
+#endif
 
 /****************************************************************************
  * Name: riscv_mtimer_max_delay

--- a/arch/risc-v/src/common/supervisor/Make.defs
+++ b/arch/risc-v/src/common/supervisor/Make.defs
@@ -22,7 +22,7 @@
 
 CMN_ASRCS += riscv_dispatch_syscall.S
 CMN_CSRCS += riscv_perform_syscall.c
-CMN_CSRCS += riscv_percpu.c
+CMN_CSRCS += riscv_percpu.c riscv_sbi.c
 
 INCLUDES += ${shell $(INCDIR) "$(CC)" $(ARCH_SRCDIR)$(DELIM)common$(DELIM)supervisor}
 VPATH += common$(DELIM)supervisor

--- a/arch/risc-v/src/common/supervisor/riscv_sbi.c
+++ b/arch/risc-v/src/common/supervisor/riscv_sbi.c
@@ -1,0 +1,89 @@
+/****************************************************************************
+ * arch/risc-v/src/common/supervisor/riscv_sbi.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+#include <nuttx/arch.h>
+
+#include <stdint.h>
+
+#include "riscv_internal.h"
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+#ifdef CONFIG_ARCH_RV64
+static inline uint64_t rdtime(void)
+{
+  uint32_t hi;
+  uint32_t lo;
+
+  do
+    {
+      hi = READ_CSR(timeh);
+      lo = READ_CSR(time);
+    }
+  while (hi != READ_CSR(timeh));
+
+  return (((uint64_t) hi) << 32) | lo;
+}
+#else
+#define rdtime() READ_CSR(time)
+#endif /* CONFIG_ARCH_RV64 */
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: riscv_sbi_set_timer
+ *
+ * Description:
+ *   Set new compare match value for timer
+ *
+ * Input Parameters:
+ *   stime_value - Value to set
+ *
+ ****************************************************************************/
+
+void riscv_sbi_set_timer(uint64_t stime_value)
+{
+#error "Missing functionality..."
+}
+
+/****************************************************************************
+ * Name: riscv_sbi_get_time
+ *
+ * Description:
+ *   Get value of mtime
+ *
+ * Return:
+ *   Value of mtime
+ *
+ ****************************************************************************/
+
+uint64_t riscv_sbi_get_time(void)
+{
+  return rdtime();
+}


### PR DESCRIPTION
## Summary
Forward mtimer register access to SBI
## Impact
Allows S-mode kernel to use mtimer
## Testing
MPFS icicle:knsh
