### PR TITLE
driver/mmcsdio: do not hold the semaphore on interrupt context

### DIFF
--- a/drivers/mmcsd/mmcsd_sdio.c
+++ b/drivers/mmcsd/mmcsd_sdio.c
@@ -256,7 +256,7 @@ static int mmcsd_takesem(FAR struct mmcsd_state_s *priv)
    * waiting)
    */
 
-  if (up_interrupt_context() == false)
+  if (!up_interrupt_context() && !sched_idletask())
     {
       ret = nxsem_wait_uninterruptible(&priv->sem);
       if (ret < 0)
@@ -282,7 +282,7 @@ static int mmcsd_takesem(FAR struct mmcsd_state_s *priv)
 
 static void mmcsd_givesem(FAR struct mmcsd_state_s *priv)
 {
-  if (up_interrupt_context() == false)
+  if (!up_interrupt_context() && !sched_idletask())
     {
       /* Release the SDIO bus lock, then the MMC/SD driver semaphore in the
        * opposite order that they were taken to assure that no deadlock


### PR DESCRIPTION
## Summary
so we can do the full dump to mmc/sd card in the panic case

## Impact
It's possible to call sdio_dev_s in panic handler

## Testing
Pass CI
