### PR TITLE
MPFS: Set correct interrupt per mode (M-/S-mode) for mtimer

### DIFF
--- a/arch/risc-v/src/mpfs/mpfs_timerisr.c
+++ b/arch/risc-v/src/mpfs/mpfs_timerisr.c
@@ -68,7 +68,7 @@ void up_timer_initialize(void)
 
   struct oneshot_lowerhalf_s *lower = riscv_mtimer_initialize(
     MPFS_CLINT_MTIME, MPFS_CLINT_MTIMECMP0 + hart_id * sizeof(uintptr_t),
-    RISCV_IRQ_MTIMER, MTIMER_FREQ);
+    RISCV_IRQ_TIMER, MTIMER_FREQ);
 
   DEBUGASSERT(lower);
 


### PR DESCRIPTION
## Summary
Use the mode dependent macro to select interrupt source for riscv_mtimer_initialize
## Impact
Alarm timer works with S-mode in MPFS
## Testing
MPFS icicle:knsh
