### PR TITLE
boards/arm/a1x: Remove the check CONFIG_ARCH_FPU around arm_fpuconfig

### DIFF
--- a/boards/arm/a1x/pcduino-a10/configs/nsh/pcduino-140107.patch
+++ b/boards/arm/a1x/pcduino-a10/configs/nsh/pcduino-140107.patch
@@ -26,10 +26,8 @@ index 3cc6323..ad42790 100644
  
    /* Initialize the FPU */
  
- #ifdef CONFIG_ARCH_FPU
 +syslog(LOG_INFO, "Calling arm_fpuconfig\n"); // REMOVE ME
    arm_fpuconfig();
- #endif
  
    /* Perform common, low-level chip initialization (might do nothing) */
  


### PR DESCRIPTION
## Summary
forget in below change(#6042):
```
commit df5a8a53ae92606e2d65149c6b5159b82dfc5d76
Author: Xiang Xiao <xiaoxiang@xiaomi.com>
Date:   Tue Apr 12 03:18:46 2022 +0800

    arch/arm: Move FPU initialization to common place

    Signed-off-by: Xiang Xiao <xiaoxiang@xiaomi.com>
```

## Impact
Minor

## Testing

