### PR TITLE
boards/esp32_twai: Remove arm_arch.h from comment

### DIFF
--- a/boards/xtensa/esp32/esp32-devkitc/src/esp32_twai.c
+++ b/boards/xtensa/esp32/esp32-devkitc/src/esp32_twai.c
@@ -31,7 +31,6 @@
 #include <arch/board/board.h>
 
 #include "chip.h"
-/* #include "arm_arch.h" */
 
 #include "esp32_twai.h"
 #include "esp32-devkitc.h"


### PR DESCRIPTION
## Summary

## Impact
Minor change

## Testing

