### PR TITLE
Stm32f746 audio

### DIFF
--- a/arch/arm/src/stm32f7/stm32_ltdc.c
+++ b/arch/arm/src/stm32f7/stm32_ltdc.c
@@ -1283,9 +1283,11 @@ static void stm32_ltdc_periphconfig(void)
 
   reginfo("configured RCC_PLLSAI=%08x\n", getreg32(STM32_RCC_PLLSAICFGR));
 
-  /* Configure dedicated clock external */
+  /* Configure dedicated clock external.
+   * Division factor for LCD_CLK in DCKCFGR1
+   */
 
-  reginfo("configured RCC_DCKCFGR=%08x\n", getreg32(STM32_RCC_DCKCFGR));
+  reginfo("configured RCC_DCKCFGR1=%08x\n", getreg32(STM32_RCC_DCKCFGR1));
 
   /* Configure LTDC_SSCR */
 


### PR DESCRIPTION
## Summary
STM32_RCC_DCKCFGR is not defined for the stm32f746, since the stm32f746 has two configuration registers STM32_RCC_DCKCFGR1 and STM32_RCC_DCKCFGR2. Since the LTDC is only affected by clocks steered by
the first register, I suppose it should be the register to be output. (I assume this to be a C&P error coming from
stm32f/stm32_ltdc.c, where the definition stems from stm32/hardware/stm32f40xxx_rcc.h.)

## Impact
Bug-Fix

## Testing
I'm only wondering why I never encountered that compile error before. However, the affected source file seems
to compile properly after the fix.
