### PR TITLE
semaphore: fix usage of NXSEM_INITIALIZER

### DIFF
--- a/fs/aio/aio_initialize.c
+++ b/fs/aio/aio_initialize.c
@@ -50,7 +50,7 @@ static dq_queue_t g_aioc_free;
 /* This counting semaphore tracks the number of free AIO containers */
 
 static sem_t g_aioc_freesem = NXSEM_INITIALIZER(CONFIG_FS_NAIOC,
-                                                SEM_PRIO_NONE);
+                                                PRIOINHERIT_FLAGS_DISABLE);
 
 /* This binary semaphore supports exclusive access to the list of pending
  * asynchronous I/O.  g_aio_holder and a_aio_count support the reentrant

--- a/sched/wqueue/kwork_thread.c
+++ b/sched/wqueue/kwork_thread.c
@@ -80,7 +80,7 @@
 struct hp_wqueue_s g_hpwork =
 {
   {},
-  NXSEM_INITIALIZER(0, SEM_PRIO_NONE),
+  NXSEM_INITIALIZER(0, PRIOINHERIT_FLAGS_DISABLE),
 };
 
 #endif /* CONFIG_SCHED_HPWORK */
@@ -91,7 +91,7 @@ struct hp_wqueue_s g_hpwork =
 struct lp_wqueue_s g_lpwork =
 {
   {},
-  NXSEM_INITIALIZER(0, SEM_PRIO_NONE),
+  NXSEM_INITIALIZER(0, PRIOINHERIT_FLAGS_DISABLE),
 };
 
 #endif /* CONFIG_SCHED_LPWORK */


### PR DESCRIPTION
## Summary
Fix of https://github.com/apache/incubator-nuttx/issues/6084

## Impact
Configurations with `CONFIG_PRIORITY_INHERITANCE=y`

## Testing
Pass CI