### PR TITLE
Remove FAR from the arch and board files of ceva/mips/misoc/or1k/sim/sparc/x86_64/xtensa

### DIFF
--- a/arch/ceva/include/syscall.h
+++ b/arch/ceva/include/syscall.h
@@ -89,7 +89,7 @@
 #ifndef CONFIG_BUILD_FLAT
 /* SYS call 4:
  *
- * void up_task_start(main_t taskentry, int argc, FAR char *argv[])
+ * void up_task_start(main_t taskentry, int argc, char *argv[])
  *        noreturn_function;
  */
 
@@ -106,7 +106,7 @@
 /* SYS call 6:
  *
  * void signal_handler(_sa_sigaction_t sighand, int signo,
- *                     FAR siginfo_t *info, FAR void *ucontext);
+ *                     siginfo_t *info, void *ucontext);
  */
 
 #define SYS_signal_handler        0x06

--- a/arch/ceva/include/xc5/irq.h
+++ b/arch/ceva/include/xc5/irq.h
@@ -131,7 +131,7 @@ struct xcptcontext
    * are pending signals to be processed.
    */
 
-  FAR void *sigdeliver; /* Actual type is sig_deliver_t */
+  void *sigdeliver; /* Actual type is sig_deliver_t */
 
   /* These are saved copies of the context used during
    * signal processing.

--- a/arch/ceva/include/xm6/irq.h
+++ b/arch/ceva/include/xm6/irq.h
@@ -134,7 +134,7 @@ struct xcptcontext
    * are pending signals to be processed.
    */
 
-  FAR void *sigdeliver; /* Actual type is sig_deliver_t */
+  void *sigdeliver; /* Actual type is sig_deliver_t */
 
   /* These are saved copies of the context used during
    * signal processing.

--- a/arch/ceva/include/xm6/spinlock.h
+++ b/arch/ceva/include/xm6/spinlock.h
@@ -95,7 +95,7 @@ static inline void up_dmb(void)
  *
  ****************************************************************************/
 
-static inline spinlock_t up_testset(volatile FAR spinlock_t *lock)
+static inline spinlock_t up_testset(volatile spinlock_t *lock)
 {
   irqstate_t flags;
   spinlock_t old;

--- a/arch/ceva/src/common/up_assert.c
+++ b/arch/ceva/src/common/up_assert.c
@@ -87,7 +87,7 @@ static void up_stackdump(uint32_t sp, uint32_t stack_base)
  ****************************************************************************/
 
 #ifdef CONFIG_STACK_COLORATION
-static void up_taskdump(FAR struct tcb_s *tcb, FAR void *arg)
+static void up_taskdump(struct tcb_s *tcb, void *arg)
 {
   /* Dump interesting properties of this task */
 
@@ -156,7 +156,7 @@ static inline void up_registerdump(void)
  ****************************************************************************/
 
 #ifdef CONFIG_ARCH_USBDUMP
-static int usbtrace_syslog(FAR const char *fmt, ...)
+static int usbtrace_syslog(const char *fmt, ...)
 {
   va_list ap;
 
@@ -168,7 +168,7 @@ static int usbtrace_syslog(FAR const char *fmt, ...)
   return 0;
 }
 
-static int assert_tracecallback(FAR struct usbtrace_s *trace, FAR void *arg)
+static int assert_tracecallback(struct usbtrace_s *trace, void *arg)
 {
   usbtrace_trprintf(usbtrace_syslog, trace->event, trace->value);
   return 0;

--- a/arch/ceva/src/common/up_checkstack.c
+++ b/arch/ceva/src/common/up_checkstack.c
@@ -59,7 +59,7 @@ static size_t do_stackcheck(uintptr_t alloc, size_t size);
 
 static size_t do_stackcheck(uintptr_t alloc, size_t size)
 {
-  FAR uint32_t *ptr;
+  uint32_t *ptr;
   size_t nwords;
   size_t mark;
 
@@ -71,7 +71,7 @@ static size_t do_stackcheck(uintptr_t alloc, size_t size)
    * that does not have the magic value is the high water mark.
    */
 
-  for (ptr = (FAR uint32_t *)alloc, mark = nwords;
+  for (ptr = (uint32_t *)alloc, mark = nwords;
        *ptr == STACK_COLOR && mark > 0;
        ptr++, mark--);
 
@@ -91,7 +91,7 @@ static size_t do_stackcheck(uintptr_t alloc, size_t size)
       int i;
       int j;
 
-      ptr = (FAR uint32_t *)start;
+      ptr = (uint32_t *)start;
       for (i = 0; i < nwords; i += 64)
         {
           for (j = 0; j < 64; j++)
@@ -139,13 +139,13 @@ static size_t do_stackcheck(uintptr_t alloc, size_t size)
  *
  ****************************************************************************/
 
-size_t up_check_tcbstack(FAR struct tcb_s *tcb)
+size_t up_check_tcbstack(struct tcb_s *tcb)
 {
   return do_stackcheck((uintptr_t)tcb->stack_alloc_ptr,
                        tcb->adj_stack_size);
 }
 
-ssize_t up_check_tcbstack_remain(FAR struct tcb_s *tcb)
+ssize_t up_check_tcbstack_remain(struct tcb_s *tcb)
 {
   return tcb->adj_stack_size - up_check_tcbstack(tcb);
 }

--- a/arch/ceva/src/common/up_createstack.c
+++ b/arch/ceva/src/common/up_createstack.c
@@ -89,7 +89,7 @@
  *
  ****************************************************************************/
 
-int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
+int up_create_stack(struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
 {
 #ifdef CONFIG_TLS
   /* The allocated stack size must not exceed the maximum possible for the
@@ -228,7 +228,7 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
  ****************************************************************************/
 
 #ifdef CONFIG_STACK_COLORATION
-void up_stack_color(FAR void *stackbase, size_t nbytes)
+void up_stack_color(void *stackbase, size_t nbytes)
 {
   uint32_t *stkptr;
   uintptr_t stkend;

--- a/arch/ceva/src/common/up_heap.c
+++ b/arch/ceva/src/common/up_heap.c
@@ -171,7 +171,7 @@ void *g_idle_topstack  = _START_HEAP;
  *
  ****************************************************************************/
 
-void up_allocate_heap(FAR void **heap_start, size_t *heap_size)
+void up_allocate_heap(void **heap_start, size_t *heap_size)
 {
   int i;
 
@@ -240,7 +240,7 @@ void up_allocate_heap(FAR void **heap_start, size_t *heap_size)
  ****************************************************************************/
 
 #ifdef CONFIG_MM_KERNEL_HEAP
-void up_allocate_kheap(FAR void **heap_start, size_t *heap_size)
+void up_allocate_kheap(void **heap_start, size_t *heap_size)
 {
   int i;
 

--- a/arch/ceva/src/common/up_internal.h
+++ b/arch/ceva/src/common/up_internal.h
@@ -266,8 +266,8 @@ uint32_t *up_doirq(int irq, uint32_t *regs);
 
 /* Exception Handlers */
 
-int  up_svcall(int irq, FAR void *context, FAR void *arg);
-int  up_hardfault(int irq, FAR void *context, FAR void *arg);
+int  up_svcall(int irq, void *context, void *arg);
+int  up_hardfault(int irq, void *context, void *arg);
 
 void up_svcall_handler(void);
 
@@ -325,7 +325,7 @@ void up_usbuninitialize(void);
 #endif
 
 #ifdef CONFIG_STACK_COLORATION
-void up_stack_color(FAR void *stackbase, size_t nbytes);
+void up_stack_color(void *stackbase, size_t nbytes);
 #endif
 
 #undef EXTERN

--- a/arch/ceva/src/common/up_releasestack.c
+++ b/arch/ceva/src/common/up_releasestack.c
@@ -79,7 +79,7 @@
  *
  ****************************************************************************/
 
-void up_release_stack(FAR struct tcb_s *dtcb, uint8_t ttype)
+void up_release_stack(struct tcb_s *dtcb, uint8_t ttype)
 {
   /* Is there a stack allocated? */
 

--- a/arch/ceva/src/common/up_schedulesigaction.c
+++ b/arch/ceva/src/common/up_schedulesigaction.c
@@ -141,7 +141,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
               /* Save the current register context location */
 
               tcb->xcp.saved_regs = g_current_regs[cpu];
-              tcb->xcp.sigdeliver = (FAR void *)sigdeliver;
+              tcb->xcp.sigdeliver = (void *)sigdeliver;
 
               /* Duplicate the register context.  These will be
                * restored by the signal trampoline after the signal has been
@@ -186,7 +186,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
           /* Save the current register context location */
 
           tcb->xcp.saved_regs = tcb->xcp.regs;
-          tcb->xcp.sigdeliver = (FAR void *)sigdeliver;
+          tcb->xcp.sigdeliver = (void *)sigdeliver;
 
           /* Duplicate the register context.  These will be restored
            * by the signal trampoline after the signal has been delivered.

--- a/arch/ceva/src/common/up_signal_dispatch.c
+++ b/arch/ceva/src/common/up_signal_dispatch.c
@@ -64,7 +64,7 @@
  ****************************************************************************/
 
 void up_signal_dispatch(_sa_sigaction_t sighand, int signo,
-                        FAR siginfo_t *info, FAR void *ucontext)
+                        siginfo_t *info, void *ucontext)
 {
   /* Let sys_call4() do all of the work */
 

--- a/arch/ceva/src/common/up_stackframe.c
+++ b/arch/ceva/src/common/up_stackframe.c
@@ -65,9 +65,9 @@
  *
  ****************************************************************************/
 
-FAR void *up_stack_frame(FAR struct tcb_s *tcb, size_t frame_size)
+void *up_stack_frame(struct tcb_s *tcb, size_t frame_size)
 {
-  FAR void *ret;
+  void *ret;
 
   /* Align the frame_size */
 
@@ -87,7 +87,7 @@ FAR void *up_stack_frame(FAR struct tcb_s *tcb, size_t frame_size)
 
   /* Save the adjusted stack values in the struct tcb_s */
 
-  tcb->stack_base_ptr  = (FAR uint8_t *)tcb->stack_base_ptr + frame_size;
+  tcb->stack_base_ptr  = (uint8_t *)tcb->stack_base_ptr + frame_size;
   tcb->adj_stack_size -= frame_size;
 
   /* And return the pointer to the allocated region */

--- a/arch/ceva/src/common/up_svcall.c
+++ b/arch/ceva/src/common/up_svcall.c
@@ -47,7 +47,7 @@
  *
  ****************************************************************************/
 
-int up_svcall(int irq, FAR void *context, FAR void *arg)
+int up_svcall(int irq, void *context, void *arg)
 {
   uint32_t *regs = (uint32_t *)context;
   uint32_t cmd;
@@ -192,7 +192,7 @@ int up_svcall(int irq, FAR void *context, FAR void *arg)
 
       /* A0=SYS_task_start:  This a user task start
        *
-       *   void up_task_start(main_t taskentry, int argc, FAR char *argv[]);
+       *   void up_task_start(main_t taskentry, int argc, char *argv[]);
        *
        * At this point, the following values are saved in context:
        *
@@ -264,7 +264,7 @@ int up_svcall(int irq, FAR void *context, FAR void *arg)
       /* A0=SYS_signal_handler:  This a user signal handler callback
        *
        * void signal_handler(_sa_sigaction_t sighand, int signo,
-       *                     FAR siginfo_t *info, FAR void *ucontext);
+       *                     siginfo_t *info, void *ucontext);
        *
        * At this point, the following values are saved in context:
        *
@@ -343,7 +343,7 @@ int up_svcall(int irq, FAR void *context, FAR void *arg)
       default:
         {
 #ifdef CONFIG_LIB_SYSCALL
-          FAR struct tcb_s *rtcb = sched_self();
+          struct tcb_s *rtcb = sched_self();
           int index = rtcb->xcp.nsyscalls;
 
           /* Verify that the SYS call number is within range */

--- a/arch/ceva/src/common/up_task_start.c
+++ b/arch/ceva/src/common/up_task_start.c
@@ -58,7 +58,7 @@
  *
  ****************************************************************************/
 
-void up_task_start(main_t taskentry, int argc, FAR char *argv[])
+void up_task_start(main_t taskentry, int argc, char *argv[])
 {
   /* Let sys_call3() do all of the work */
 

--- a/arch/ceva/src/common/up_usestack.c
+++ b/arch/ceva/src/common/up_usestack.c
@@ -64,7 +64,7 @@
  *
  ****************************************************************************/
 
-int up_use_stack(FAR struct tcb_s *tcb, FAR void *stack, size_t stack_size)
+int up_use_stack(struct tcb_s *tcb, void *stack, size_t stack_size)
 {
   uintptr_t top_of_stack;
   size_t size_of_stack;

--- a/arch/ceva/src/common/up_vfork.c
+++ b/arch/ceva/src/common/up_vfork.c
@@ -111,7 +111,7 @@ pid_t up_vfork(const uint32_t *regs)
 
   /* Allocate the stack for the TCB */
 
-  ret = up_create_stack((FAR struct tcb_s *)child, stacksize + argsize,
+  ret = up_create_stack((struct tcb_s *)child, stacksize + argsize,
                         parent->flags & TCB_FLAG_TTYPE_MASK);
   if (ret != OK)
     {
@@ -122,7 +122,7 @@ pid_t up_vfork(const uint32_t *regs)
 
   /* Allocate the memory and copy argument from parent task */
 
-  argv = up_stack_frame((FAR struct tcb_s *)child, argsize);
+  argv = up_stack_frame((struct tcb_s *)child, argsize);
   memcpy(argv, parent->stack_base_ptr, argsize);
 
   /* How much of the parent's stack was utilized?  The CEVA uses

--- a/arch/ceva/src/xc5/up_hardfault.c
+++ b/arch/ceva/src/xc5/up_hardfault.c
@@ -80,7 +80,7 @@
  *
  ****************************************************************************/
 
-int up_hardfault(int irq, FAR void *context, FAR void *arg)
+int up_hardfault(int irq, void *context, void *arg)
 {
   /* Dump some hard fault info */
 

--- a/arch/ceva/src/xm6/up_hardfault.c
+++ b/arch/ceva/src/xm6/up_hardfault.c
@@ -95,7 +95,7 @@
  *
  ****************************************************************************/
 
-int up_hardfault(int irq, FAR void *context, FAR void *arg)
+int up_hardfault(int irq, void *context, void *arg)
 {
   /* Dump some hard fault info */
 

--- a/arch/mips/src/common/mips_allocateheap.c
+++ b/arch/mips/src/common/mips_allocateheap.c
@@ -64,9 +64,9 @@
  *
  ****************************************************************************/
 
-void up_allocate_heap(FAR void **heap_start, size_t *heap_size)
+void up_allocate_heap(void **heap_start, size_t *heap_size)
 {
   board_autoled_on(LED_HEAPALLOCATE);
-  *heap_start = (FAR void *)g_idle_topstack;
+  *heap_start = (void *)g_idle_topstack;
   *heap_size = CONFIG_RAM_END - g_idle_topstack;
 }

--- a/arch/mips/src/common/mips_createstack.c
+++ b/arch/mips/src/common/mips_createstack.c
@@ -79,7 +79,7 @@
  *
  ****************************************************************************/
 
-int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
+int up_create_stack(struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
 {
 #ifdef CONFIG_TLS_ALIGNED
   /* The allocated stack size must not exceed the maximum possible for the

--- a/arch/mips/src/common/mips_exit.c
+++ b/arch/mips/src/common/mips_exit.c
@@ -63,9 +63,9 @@
  ****************************************************************************/
 
 #ifdef CONFIG_DUMP_ON_EXIT
-static void _up_dumponexit(FAR struct tcb_s *tcb, FAR void *arg)
+static void _up_dumponexit(struct tcb_s *tcb, void *arg)
 {
-  FAR struct filelist *filelist;
+  struct filelist *filelist;
   int i;
   int j;
 

--- a/arch/mips/src/common/mips_internal.h
+++ b/arch/mips/src/common/mips_internal.h
@@ -215,7 +215,7 @@ uint32_t *up_doirq(int irq, uint32_t *regs);
 
 /* Software interrupt 0 handler */
 
-int up_swint0(int irq, FAR void *context, FAR void *arg);
+int up_swint0(int irq, void *context, void *arg);
 
 /* Signals */
 

--- a/arch/mips/src/common/mips_releasestack.c
+++ b/arch/mips/src/common/mips_releasestack.c
@@ -75,7 +75,7 @@
  *
  ****************************************************************************/
 
-void up_release_stack(FAR struct tcb_s *dtcb, uint8_t ttype)
+void up_release_stack(struct tcb_s *dtcb, uint8_t ttype)
 {
   /* Is there a stack allocated? */
 

--- a/arch/mips/src/common/mips_stackframe.c
+++ b/arch/mips/src/common/mips_stackframe.c
@@ -68,9 +68,9 @@
  *
  ****************************************************************************/
 
-FAR void *up_stack_frame(FAR struct tcb_s *tcb, size_t frame_size)
+void *up_stack_frame(struct tcb_s *tcb, size_t frame_size)
 {
-  FAR void *ret;
+  void *ret;
 
   /* Align the frame_size */
 
@@ -88,7 +88,7 @@ FAR void *up_stack_frame(FAR struct tcb_s *tcb, size_t frame_size)
 
   /* Save the adjusted stack values in the struct tcb_s */
 
-  tcb->stack_base_ptr  = (FAR uint8_t *)tcb->stack_base_ptr + frame_size;
+  tcb->stack_base_ptr  = (uint8_t *)tcb->stack_base_ptr + frame_size;
   tcb->adj_stack_size -= frame_size;
 
   /* And return the pointer to the allocated region */

--- a/arch/mips/src/mips32/mips_assert.c
+++ b/arch/mips/src/mips32/mips_assert.c
@@ -99,7 +99,7 @@ static void _up_assert(void)
  ****************************************************************************/
 
 #ifdef CONFIG_ARCH_USBDUMP
-static int usbtrace_syslog(FAR const char *fmt, ...)
+static int usbtrace_syslog(const char *fmt, ...)
 {
   va_list ap;
 
@@ -111,7 +111,7 @@ static int usbtrace_syslog(FAR const char *fmt, ...)
   return OK;
 }
 
-static int assert_tracecallback(FAR struct usbtrace_s *trace, FAR void *arg)
+static int assert_tracecallback(struct usbtrace_s *trace, void *arg)
 {
   usbtrace_trprintf(usbtrace_syslog, trace->event, trace->value);
   return 0;

--- a/arch/mips/src/mips32/mips_dumpstate.c
+++ b/arch/mips/src/mips32/mips_dumpstate.c
@@ -128,7 +128,7 @@ static inline void mips_registerdump(void)
 
 void up_dumpstate(void)
 {
-  FAR struct tcb_s *rtcb = running_task();
+  struct tcb_s *rtcb = running_task();
   uint32_t sp = up_getsp();
   uint32_t ustackbase;
   uint32_t ustacksize;

--- a/arch/mips/src/mips32/mips_swint0.c
+++ b/arch/mips/src/mips32/mips_swint0.c
@@ -127,7 +127,7 @@ static void dispatch_syscall(void)
  *
  ****************************************************************************/
 
-int up_swint0(int irq, FAR void *context, FAR void *arg)
+int up_swint0(int irq, void *context, void *arg)
 {
   uint32_t *regs = (uint32_t *)context;
   uint32_t cause;
@@ -243,7 +243,7 @@ int up_swint0(int irq, FAR void *context, FAR void *arg)
       default:
         {
 #ifdef CONFIG_BUILD_KERNEL
-          FAR struct tcb_s *rtcb = nxsched_self();
+          struct tcb_s *rtcb = nxsched_self();
           int index = rtcb->xcp.nsyscalls;
 
           /* Verify that the SYS call number is within range */

--- a/arch/mips/src/pic32mx/pic32mx.h
+++ b/arch/mips/src/pic32mx/pic32mx.h
@@ -111,7 +111,7 @@
  * Public Types
  ************************************************************************************/
 
-typedef FAR void *DMA_HANDLE;
+typedef void *DMA_HANDLE;
 typedef void (*dma_callback_t)(DMA_HANDLE handle, void *arg, int result);
 
 /* The following is used for sampling DMA registers when CONFIG DEBUG_DMA
@@ -388,7 +388,7 @@ void pic32mx_dumpgpio(uint32_t pinset, const char *msg);
  ************************************************************************************/
 
 struct spi_dev_s;  /* Forward reference */
-FAR struct spi_dev_s *pic32mx_spibus_initialize(int port);
+struct spi_dev_s *pic32mx_spibus_initialize(int port);
 
 /************************************************************************************
  * Name:  pic32mx_spiNselect, pic32mx_spiNstatus, and pic32mx_spiNcmddata
@@ -419,38 +419,38 @@ FAR struct spi_dev_s *pic32mx_spibus_initialize(int port);
  ************************************************************************************/
 
 #ifdef CONFIG_PIC32MX_SPI1
-void  pic32mx_spi1select(FAR struct spi_dev_s *dev, uint32_t devid,
+void  pic32mx_spi1select(struct spi_dev_s *dev, uint32_t devid,
                          bool selected);
-uint8_t pic32mx_spi1status(FAR struct spi_dev_s *dev, uint32_t devid);
+uint8_t pic32mx_spi1status(struct spi_dev_s *dev, uint32_t devid);
 #ifdef CONFIG_SPI_CMDDATA
-int pic32mx_spi1cmddata(FAR struct spi_dev_s *dev, uint32_t devid, bool cmd);
+int pic32mx_spi1cmddata(struct spi_dev_s *dev, uint32_t devid, bool cmd);
 #endif
 #endif
 
 #ifdef CONFIG_PIC32MX_SPI2
-void  pic32mx_spi2select(FAR struct spi_dev_s *dev, uint32_t devid,
+void  pic32mx_spi2select(struct spi_dev_s *dev, uint32_t devid,
                          bool selected);
-uint8_t pic32mx_spi2status(FAR struct spi_dev_s *dev, uint32_t devid);
+uint8_t pic32mx_spi2status(struct spi_dev_s *dev, uint32_t devid);
 #ifdef CONFIG_SPI_CMDDATA
-int pic32mx_spi2cmddata(FAR struct spi_dev_s *dev, uint32_t devid, bool cmd);
+int pic32mx_spi2cmddata(struct spi_dev_s *dev, uint32_t devid, bool cmd);
 #endif
 #endif
 
 #ifdef CONFIG_PIC32MX_SPI3
-void  pic32mx_spi3select(FAR struct spi_dev_s *dev, uint32_t devid,
+void  pic32mx_spi3select(struct spi_dev_s *dev, uint32_t devid,
                          bool selected);
-uint8_t pic32mx_spi3status(FAR struct spi_dev_s *dev, uint32_t devid);
+uint8_t pic32mx_spi3status(struct spi_dev_s *dev, uint32_t devid);
 #ifdef CONFIG_SPI_CMDDATA
-int pic32mx_spi3cmddata(FAR struct spi_dev_s *dev, uint32_t devid, bool cmd);
+int pic32mx_spi3cmddata(struct spi_dev_s *dev, uint32_t devid, bool cmd);
 #endif
 #endif
 
 #ifdef CONFIG_PIC32MX_SPI3
-void  pic32mx_spi3select(FAR struct spi_dev_s *dev, uint32_t devid,
+void  pic32mx_spi3select(struct spi_dev_s *dev, uint32_t devid,
                          bool selected);
-uint8_t pic32mx_spi3status(FAR struct spi_dev_s *dev, uint32_t devid);
+uint8_t pic32mx_spi3status(struct spi_dev_s *dev, uint32_t devid);
 #ifdef CONFIG_SPI_CMDDATA
-int pic32mx_spi3cmddata(FAR struct spi_dev_s *dev, uint32_t devid, bool cmd);
+int pic32mx_spi3cmddata(struct spi_dev_s *dev, uint32_t devid, bool cmd);
 #endif
 #endif
 
@@ -589,7 +589,7 @@ void pic32mx_dmadump(DMA_HANDLE handle, const struct pic32mx_dmaregs_s *regs,
 
 #ifdef CONFIG_PIC32MX_USBDEV
 struct usbdev_s;
-int pic32mx_usbpullup(FAR struct usbdev_s *dev,  bool enable);
+int pic32mx_usbpullup(struct usbdev_s *dev,  bool enable);
 #endif
 
 /************************************************************************************
@@ -604,7 +604,7 @@ int pic32mx_usbpullup(FAR struct usbdev_s *dev,  bool enable);
  ************************************************************************************/
 
 #ifdef CONFIG_PIC32MX_USBDEV
-void pic32mx_usbsuspend(FAR struct usbdev_s *dev, bool resume);
+void pic32mx_usbsuspend(struct usbdev_s *dev, bool resume);
 #endif
 
 /************************************************************************************

--- a/arch/mips/src/pic32mx/pic32mx_ethernet.c
+++ b/arch/mips/src/pic32mx/pic32mx_ethernet.c
@@ -215,7 +215,7 @@
  * header
  */
 
-#define BUF ((FAR struct eth_hdr_s *)priv->pd_dev.d_buf)
+#define BUF ((struct eth_hdr_s *)priv->pd_dev.d_buf)
 
 /* PHYs *********************************************************************/
 
@@ -1889,7 +1889,7 @@ static void pic32mx_interrupt_work(void *arg)
  *
  ****************************************************************************/
 
-static int pic32mx_interrupt(int irq, void *context, FAR void *arg)
+static int pic32mx_interrupt(int irq, void *context, void *arg)
 {
   struct pic32mx_driver_s *priv;
   uint32_t status;

--- a/arch/mips/src/pic32mx/pic32mx_gpioirq.c
+++ b/arch/mips/src/pic32mx/pic32mx_gpioirq.c
@@ -84,7 +84,7 @@ static inline bool pic32mx_pullup(uint16_t pinset)
  *
  ****************************************************************************/
 
-static int pic32mx_cninterrupt(int irq, FAR void *context)
+static int pic32mx_cninterrupt(int irq, void *context)
 {
   int status;
   int ret = OK;

--- a/arch/mips/src/pic32mx/pic32mx_spi.c
+++ b/arch/mips/src/pic32mx/pic32mx_spi.c
@@ -87,22 +87,22 @@ struct pic32mx_dev_s
 
 /* Low-level register access */
 
-static uint32_t spi_getreg(FAR struct pic32mx_dev_s *priv,
+static uint32_t spi_getreg(struct pic32mx_dev_s *priv,
                   unsigned int offset);
-static void     spi_putreg(FAR struct pic32mx_dev_s *priv,
+static void     spi_putreg(struct pic32mx_dev_s *priv,
                   unsigned int offset, uint32_t value);
 
 /* SPI methods */
 
-static int      spi_lock(FAR struct spi_dev_s *dev, bool lock);
-static uint32_t spi_setfrequency(FAR struct spi_dev_s *dev,
+static int      spi_lock(struct spi_dev_s *dev, bool lock);
+static uint32_t spi_setfrequency(struct spi_dev_s *dev,
                                  uint32_t frequency);
-static void     spi_setmode(FAR struct spi_dev_s *dev, enum spi_mode_e mode);
-static void     spi_setbits(FAR struct spi_dev_s *dev, int nbits);
-static uint32_t spi_send(FAR struct spi_dev_s *dev, uint32_t wd);
-static void     spi_sndblock(FAR struct spi_dev_s *dev,
-                             FAR const void *buffer, size_t nwords);
-static void     spi_recvblock(FAR struct spi_dev_s *dev, FAR void *buffer,
+static void     spi_setmode(struct spi_dev_s *dev, enum spi_mode_e mode);
+static void     spi_setbits(struct spi_dev_s *dev, int nbits);
+static uint32_t spi_send(struct spi_dev_s *dev, uint32_t wd);
+static void     spi_sndblock(struct spi_dev_s *dev,
+                             const void *buffer, size_t nwords);
+static void     spi_recvblock(struct spi_dev_s *dev, void *buffer,
                               size_t nwords);
 
 /****************************************************************************
@@ -288,7 +288,7 @@ static struct pic32mx_dev_s g_spi4dev =
  ****************************************************************************/
 
 #ifdef CONFIG_PIC32MX_SPI_REGDEBUG
-static uint32_t spi_getreg(FAR struct pic32mx_dev_s *priv,
+static uint32_t spi_getreg(struct pic32mx_dev_s *priv,
                            unsigned int offset)
 {
   /* Last address, value, and count */
@@ -350,7 +350,7 @@ static uint32_t spi_getreg(FAR struct pic32mx_dev_s *priv,
   return value;
 }
 #else
-static uint32_t spi_getreg(FAR struct pic32mx_dev_s *priv,
+static uint32_t spi_getreg(struct pic32mx_dev_s *priv,
                            unsigned int offset)
 {
   return getreg32(priv->base + offset);
@@ -374,7 +374,7 @@ static uint32_t spi_getreg(FAR struct pic32mx_dev_s *priv,
  ****************************************************************************/
 
 #ifdef CONFIG_PIC32MX_SPI_REGDEBUG
-static void spi_putreg(FAR struct pic32mx_dev_s *priv, unsigned int offset,
+static void spi_putreg(struct pic32mx_dev_s *priv, unsigned int offset,
                        uint32_t value)
 {
   uint32_t addr;
@@ -392,7 +392,7 @@ static void spi_putreg(FAR struct pic32mx_dev_s *priv, unsigned int offset,
   putreg32(value, addr);
 }
 #else
-static void spi_putreg(FAR struct pic32mx_dev_s *priv, unsigned int offset,
+static void spi_putreg(struct pic32mx_dev_s *priv, unsigned int offset,
                        uint32_t value)
 {
   putreg32(value, priv->base + offset);
@@ -420,9 +420,9 @@ static void spi_putreg(FAR struct pic32mx_dev_s *priv, unsigned int offset,
  *
  ****************************************************************************/
 
-static int spi_lock(FAR struct spi_dev_s *dev, bool lock)
+static int spi_lock(struct spi_dev_s *dev, bool lock)
 {
-  FAR struct pic32mx_dev_s *priv = (FAR struct pic32mx_dev_s *)dev;
+  struct pic32mx_dev_s *priv = (struct pic32mx_dev_s *)dev;
   int ret;
 
   if (lock)
@@ -452,10 +452,10 @@ static int spi_lock(FAR struct spi_dev_s *dev, bool lock)
  *
  ****************************************************************************/
 
-static uint32_t spi_setfrequency(FAR struct spi_dev_s *dev,
+static uint32_t spi_setfrequency(struct spi_dev_s *dev,
                                  uint32_t frequency)
 {
-  FAR struct pic32mx_dev_s *priv = (FAR struct pic32mx_dev_s *)dev;
+  struct pic32mx_dev_s *priv = (struct pic32mx_dev_s *)dev;
   uint32_t divisor;
   uint32_t actual;
   uint32_t regval;
@@ -534,9 +534,9 @@ static uint32_t spi_setfrequency(FAR struct spi_dev_s *dev,
  *
  ****************************************************************************/
 
-static void spi_setmode(FAR struct spi_dev_s *dev, enum spi_mode_e mode)
+static void spi_setmode(struct spi_dev_s *dev, enum spi_mode_e mode)
 {
-  FAR struct pic32mx_dev_s *priv = (FAR struct pic32mx_dev_s *)dev;
+  struct pic32mx_dev_s *priv = (struct pic32mx_dev_s *)dev;
   uint32_t regval;
 
   spiinfo("Old mode: %d New mode: %d\n", priv->mode, mode);
@@ -624,9 +624,9 @@ static void spi_setmode(FAR struct spi_dev_s *dev, enum spi_mode_e mode)
  *
  ****************************************************************************/
 
-static void spi_setbits(FAR struct spi_dev_s *dev, int nbits)
+static void spi_setbits(struct spi_dev_s *dev, int nbits)
 {
-  FAR struct pic32mx_dev_s *priv = (FAR struct pic32mx_dev_s *)dev;
+  struct pic32mx_dev_s *priv = (struct pic32mx_dev_s *)dev;
   uint32_t setting;
   uint32_t regval;
 
@@ -688,9 +688,9 @@ static void spi_setbits(FAR struct spi_dev_s *dev, int nbits)
  *
  ****************************************************************************/
 
-static uint32_t spi_send(FAR struct spi_dev_s *dev, uint32_t wd)
+static uint32_t spi_send(struct spi_dev_s *dev, uint32_t wd)
 {
-  FAR struct pic32mx_dev_s *priv = (FAR struct pic32mx_dev_s *)dev;
+  struct pic32mx_dev_s *priv = (struct pic32mx_dev_s *)dev;
 
   spiinfo("wd: %04" PRIx32 "\n", wd);
 
@@ -739,11 +739,11 @@ static uint32_t spi_send(FAR struct spi_dev_s *dev, uint32_t wd)
  *
  ****************************************************************************/
 
-static void spi_sndblock(FAR struct spi_dev_s *dev, FAR const void *buffer,
+static void spi_sndblock(struct spi_dev_s *dev, const void *buffer,
                          size_t nwords)
 {
-  FAR struct pic32mx_dev_s *priv = (FAR struct pic32mx_dev_s *)dev;
-  FAR uint8_t *ptr = (FAR uint8_t *)buffer;
+  struct pic32mx_dev_s *priv = (struct pic32mx_dev_s *)dev;
+  uint8_t *ptr = (uint8_t *)buffer;
   uint32_t regval;
   uint8_t data;
 
@@ -801,11 +801,11 @@ static void spi_sndblock(FAR struct spi_dev_s *dev, FAR const void *buffer,
  *
  ****************************************************************************/
 
-static void spi_recvblock(FAR struct spi_dev_s *dev, FAR void *buffer,
+static void spi_recvblock(struct spi_dev_s *dev, void *buffer,
                           size_t nwords)
 {
-  FAR struct pic32mx_dev_s *priv = (FAR struct pic32mx_dev_s *)dev;
-  FAR uint8_t *ptr = (FAR uint8_t *)buffer;
+  struct pic32mx_dev_s *priv = (struct pic32mx_dev_s *)dev;
+  uint8_t *ptr = (uint8_t *)buffer;
 
   spiinfo("nwords: %d\n", nwords);
   while (nwords)
@@ -859,9 +859,9 @@ static void spi_recvblock(FAR struct spi_dev_s *dev, FAR void *buffer,
  *
  ****************************************************************************/
 
-FAR struct spi_dev_s *pic32mx_spibus_initialize(int port)
+struct spi_dev_s *pic32mx_spibus_initialize(int port)
 {
-  FAR struct pic32mx_dev_s *priv;
+  struct pic32mx_dev_s *priv;
   irqstate_t flags;
   uint32_t regval;
 
@@ -937,7 +937,7 @@ FAR struct spi_dev_s *pic32mx_spibus_initialize(int port)
 
   /* Select a default frequency of approx. 400KHz */
 
-  spi_setfrequency((FAR struct spi_dev_s *)priv, 400000);
+  spi_setfrequency((struct spi_dev_s *)priv, 400000);
 
   /* Clear the SPIROV overflow bit (SPIxSTAT:6). */
 

--- a/arch/mips/src/pic32mx/pic32mx_usbdev.c
+++ b/arch/mips/src/pic32mx/pic32mx_usbdev.c
@@ -484,7 +484,7 @@ static void pic32mx_ep0outcomplete(struct pic32mx_usbdev_s *priv);
 static void pic32mx_ep0incomplete(struct pic32mx_usbdev_s *priv);
 static void pic32mx_ep0transfer(struct pic32mx_usbdev_s *priv,
                 uint16_t ustat);
-static int  pic32mx_interrupt(int irq, void *context, FAR void *arg);
+static int  pic32mx_interrupt(int irq, void *context, void *arg);
 
 /* Endpoint helpers *********************************************************/
 
@@ -2697,7 +2697,7 @@ static void pic32mx_ep0transfer(struct pic32mx_usbdev_s *priv,
  * Name: pic32mx_interrupt
  ****************************************************************************/
 
-static int pic32mx_interrupt(int irq, void *context, FAR void *arg)
+static int pic32mx_interrupt(int irq, void *context, void *arg)
 {
   /* For now there is only one USB controller, but we will always refer to
    * it using a pointer to make any future ports to multiple USB controllers

--- a/arch/mips/src/pic32mz/pic32mz_dma.c
+++ b/arch/mips/src/pic32mz/pic32mz_dma.c
@@ -86,46 +86,46 @@ struct pic32mz_dmac_s
 static int pic32mz_dma_takesem(struct pic32mz_dmac_s *dmac);
 static inline void pic32mz_dma_givesem(struct pic32mz_dmac_s *dmac);
 
-static inline uint32_t pic32mz_dma_getreg(FAR struct pic32mz_dmach_s *dmach,
+static inline uint32_t pic32mz_dma_getreg(struct pic32mz_dmach_s *dmach,
                                           uint8_t offset);
-static inline void pic32mz_dma_putreg(FAR struct pic32mz_dmach_s *dmach,
+static inline void pic32mz_dma_putreg(struct pic32mz_dmach_s *dmach,
                                       uint8_t offset, uint32_t value);
-static inline void pic32mz_dma_modifyreg(FAR struct pic32mz_dmach_s *dmach,
+static inline void pic32mz_dma_modifyreg(struct pic32mz_dmach_s *dmach,
                                          uint8_t offset,
                                          uint32_t clrbits, uint32_t setbits);
 static inline uint32_t pic32mz_dma_getglobal(uint8_t offset);
 static inline void pic32mz_dma_putglobal(uint8_t offset, uint32_t value);
 
-static inline void pic32mz_dma_enable(FAR struct pic32mz_dmach_s *dmach);
-static inline void pic32mz_dma_disable(FAR struct pic32mz_dmach_s *dmach);
-static inline void pic32mz_dma_priority(FAR struct pic32mz_dmach_s *dmach,
+static inline void pic32mz_dma_enable(struct pic32mz_dmach_s *dmach);
+static inline void pic32mz_dma_disable(struct pic32mz_dmach_s *dmach);
+static inline void pic32mz_dma_priority(struct pic32mz_dmach_s *dmach,
                                         uint8_t priority);
-static inline void pic32mz_dma_srcaddr(FAR struct pic32mz_dmach_s *dmach,
+static inline void pic32mz_dma_srcaddr(struct pic32mz_dmach_s *dmach,
                                        uint32_t addr);
-static inline void pic32mz_dma_destaddr(FAR struct pic32mz_dmach_s *dmach,
+static inline void pic32mz_dma_destaddr(struct pic32mz_dmach_s *dmach,
                                         uint32_t addr);
-static inline void pic32mz_dma_srcsize(FAR struct pic32mz_dmach_s *dmach,
+static inline void pic32mz_dma_srcsize(struct pic32mz_dmach_s *dmach,
                                        uint16_t size);
-static inline void pic32mz_dma_destsize(FAR struct pic32mz_dmach_s *dmach,
+static inline void pic32mz_dma_destsize(struct pic32mz_dmach_s *dmach,
                                         uint16_t size);
-static inline void pic32mz_dma_cellsize(FAR struct pic32mz_dmach_s *dmach,
+static inline void pic32mz_dma_cellsize(struct pic32mz_dmach_s *dmach,
                                         uint16_t size);
-static inline void pic32mz_dma_startirq(FAR struct pic32mz_dmach_s *dmach,
+static inline void pic32mz_dma_startirq(struct pic32mz_dmach_s *dmach,
                                         int irq);
-static inline void pic32mz_dma_forcestart(FAR struct pic32mz_dmach_s *dmach);
-static inline void pic32mz_dma_abortirq(FAR struct pic32mz_dmach_s *dmach,
+static inline void pic32mz_dma_forcestart(struct pic32mz_dmach_s *dmach);
+static inline void pic32mz_dma_abortirq(struct pic32mz_dmach_s *dmach,
                                         int irq);
-static inline void pic32mz_dma_forceabort(FAR struct pic32mz_dmach_s *dmach);
+static inline void pic32mz_dma_forceabort(struct pic32mz_dmach_s *dmach);
 
-static inline void pic32mz_dma_intctrl(FAR struct pic32mz_dmach_s *dmach,
+static inline void pic32mz_dma_intctrl(struct pic32mz_dmach_s *dmach,
                                        uint8_t cfg);
-static inline void pic32mz_dma_intclr(FAR struct pic32mz_dmach_s *dmach);
-static int pic32mz_dma_interrupt(int irq, void *context, FAR void *arg);
+static inline void pic32mz_dma_intclr(struct pic32mz_dmach_s *dmach);
+static int pic32mz_dma_interrupt(int irq, void *context, void *arg);
 
-static void pic32mz_dma_mode(FAR struct pic32mz_dmach_s *dmach,
+static void pic32mz_dma_mode(struct pic32mz_dmach_s *dmach,
                              uint8_t mode);
-static void pic32mz_dma_config(FAR struct pic32mz_dmach_s *dmach,
-                               FAR const struct pic32mz_dma_chcfg_s *cfg);
+static void pic32mz_dma_config(struct pic32mz_dmach_s *dmach,
+                               const struct pic32mz_dma_chcfg_s *cfg);
 
 /****************************************************************************
  * Private Data
@@ -218,7 +218,7 @@ static inline void pic32mz_dma_givesem(struct pic32mz_dmac_s *dmac)
  *
  ****************************************************************************/
 
-static inline uint32_t pic32mz_dma_getreg(FAR struct pic32mz_dmach_s *dmach,
+static inline uint32_t pic32mz_dma_getreg(struct pic32mz_dmach_s *dmach,
                                           uint8_t offset)
 {
   return getreg32(dmach->base + offset);
@@ -232,7 +232,7 @@ static inline uint32_t pic32mz_dma_getreg(FAR struct pic32mz_dmach_s *dmach,
  *
  ****************************************************************************/
 
-static inline void pic32mz_dma_putreg(FAR struct pic32mz_dmach_s *dmach,
+static inline void pic32mz_dma_putreg(struct pic32mz_dmach_s *dmach,
                                       uint8_t offset, uint32_t value)
 {
   putreg32(value, dmach->base + offset);
@@ -246,7 +246,7 @@ static inline void pic32mz_dma_putreg(FAR struct pic32mz_dmach_s *dmach,
  *
  ****************************************************************************/
 
-static inline void pic32mz_dma_modifyreg(FAR struct pic32mz_dmach_s *dmach,
+static inline void pic32mz_dma_modifyreg(struct pic32mz_dmach_s *dmach,
                                          uint8_t offset,
                                          uint32_t clrbits, uint32_t setbits)
 {
@@ -287,7 +287,7 @@ static inline void pic32mz_dma_putglobal(uint8_t offset, uint32_t value)
  *
  ****************************************************************************/
 
-static inline void pic32mz_dma_enable(FAR struct pic32mz_dmach_s *dmach)
+static inline void pic32mz_dma_enable(struct pic32mz_dmach_s *dmach)
 {
   pic32mz_dma_putreg(dmach, PIC32MZ_DMA_CONSET_OFFSET, DMACH_CON_CHEN);
 }
@@ -300,7 +300,7 @@ static inline void pic32mz_dma_enable(FAR struct pic32mz_dmach_s *dmach)
  *
  ****************************************************************************/
 
-static inline void pic32mz_dma_disable(FAR struct pic32mz_dmach_s *dmach)
+static inline void pic32mz_dma_disable(struct pic32mz_dmach_s *dmach)
 {
   pic32mz_dma_putreg(dmach, PIC32MZ_DMA_CONCLR_OFFSET, DMACH_CON_CHEN);
 }
@@ -313,7 +313,7 @@ static inline void pic32mz_dma_disable(FAR struct pic32mz_dmach_s *dmach)
  *
  ****************************************************************************/
 
-static inline void pic32mz_dma_priority(FAR struct pic32mz_dmach_s *dmach,
+static inline void pic32mz_dma_priority(struct pic32mz_dmach_s *dmach,
                                         uint8_t priority)
 {
   /* Highest priority is 3. */
@@ -334,7 +334,7 @@ static inline void pic32mz_dma_priority(FAR struct pic32mz_dmach_s *dmach,
  *
  ****************************************************************************/
 
-static inline void pic32mz_dma_srcaddr(FAR struct pic32mz_dmach_s *dmach,
+static inline void pic32mz_dma_srcaddr(struct pic32mz_dmach_s *dmach,
                                        uint32_t addr)
 {
   pic32mz_dma_putreg(dmach, PIC32MZ_DMACH_SSA_OFFSET, PHYS_ADDR(addr));
@@ -348,7 +348,7 @@ static inline void pic32mz_dma_srcaddr(FAR struct pic32mz_dmach_s *dmach,
  *
  ****************************************************************************/
 
-static inline void pic32mz_dma_destaddr(FAR struct pic32mz_dmach_s *dmach,
+static inline void pic32mz_dma_destaddr(struct pic32mz_dmach_s *dmach,
                                         uint32_t addr)
 {
   pic32mz_dma_putreg(dmach, PIC32MZ_DMACH_DSA_OFFSET, PHYS_ADDR(addr));
@@ -362,7 +362,7 @@ static inline void pic32mz_dma_destaddr(FAR struct pic32mz_dmach_s *dmach,
  *
  ****************************************************************************/
 
-static inline void pic32mz_dma_srcsize(FAR struct pic32mz_dmach_s *dmach,
+static inline void pic32mz_dma_srcsize(struct pic32mz_dmach_s *dmach,
                                        uint16_t size)
 {
   pic32mz_dma_putreg(dmach, PIC32MZ_DMACH_SSIZ_OFFSET, size);
@@ -376,7 +376,7 @@ static inline void pic32mz_dma_srcsize(FAR struct pic32mz_dmach_s *dmach,
  *
  ****************************************************************************/
 
-static inline void pic32mz_dma_destsize(FAR struct pic32mz_dmach_s *dmach,
+static inline void pic32mz_dma_destsize(struct pic32mz_dmach_s *dmach,
                                         uint16_t size)
 {
   pic32mz_dma_putreg(dmach, PIC32MZ_DMACH_DSIZ_OFFSET, size);
@@ -390,7 +390,7 @@ static inline void pic32mz_dma_destsize(FAR struct pic32mz_dmach_s *dmach,
  *
  ****************************************************************************/
 
-static inline void pic32mz_dma_cellsize(FAR struct pic32mz_dmach_s *dmach,
+static inline void pic32mz_dma_cellsize(struct pic32mz_dmach_s *dmach,
                                         uint16_t size)
 {
   pic32mz_dma_putreg(dmach, PIC32MZ_DMACH_CSIZ_OFFSET, size);
@@ -404,7 +404,7 @@ static inline void pic32mz_dma_cellsize(FAR struct pic32mz_dmach_s *dmach,
  *
  ****************************************************************************/
 
-static inline void pic32mz_dma_startirq(FAR struct pic32mz_dmach_s *dmach,
+static inline void pic32mz_dma_startirq(struct pic32mz_dmach_s *dmach,
                                         int irq)
 {
   /* Enable start irq matching. */
@@ -426,7 +426,7 @@ static inline void pic32mz_dma_startirq(FAR struct pic32mz_dmach_s *dmach,
  *
  ****************************************************************************/
 
-static inline void pic32mz_dma_forcestart(FAR struct pic32mz_dmach_s *dmach)
+static inline void pic32mz_dma_forcestart(struct pic32mz_dmach_s *dmach)
 {
   pic32mz_dma_putreg(dmach, PIC32MZ_DMACH_ECONSET_OFFSET, DMACH_ECON_CFORCE);
 }
@@ -439,7 +439,7 @@ static inline void pic32mz_dma_forcestart(FAR struct pic32mz_dmach_s *dmach)
  *
  ****************************************************************************/
 
-static inline void pic32mz_dma_abortirq(FAR struct pic32mz_dmach_s *dmach,
+static inline void pic32mz_dma_abortirq(struct pic32mz_dmach_s *dmach,
                                         int irq)
 {
   /* Enable abort irq matching. */
@@ -461,7 +461,7 @@ static inline void pic32mz_dma_abortirq(FAR struct pic32mz_dmach_s *dmach,
  *
  ****************************************************************************/
 
-static inline void pic32mz_dma_forceabort(FAR struct pic32mz_dmach_s *dmach)
+static inline void pic32mz_dma_forceabort(struct pic32mz_dmach_s *dmach)
 {
   pic32mz_dma_putreg(dmach, PIC32MZ_DMACH_ECONSET_OFFSET, DMACH_ECON_CABORT);
 }
@@ -474,7 +474,7 @@ static inline void pic32mz_dma_forceabort(FAR struct pic32mz_dmach_s *dmach)
  *
  ****************************************************************************/
 
-static inline void pic32mz_dma_intclr(FAR struct pic32mz_dmach_s *dmach)
+static inline void pic32mz_dma_intclr(struct pic32mz_dmach_s *dmach)
 {
   pic32mz_dma_putreg(dmach, PIC32MZ_DMACH_INTCLR_OFFSET,
                      DMACH_INT_FLAGS_MASK);
@@ -488,7 +488,7 @@ static inline void pic32mz_dma_intclr(FAR struct pic32mz_dmach_s *dmach)
  *
  ****************************************************************************/
 
-static inline void pic32mz_dma_intctrl(FAR struct pic32mz_dmach_s *dmach,
+static inline void pic32mz_dma_intctrl(struct pic32mz_dmach_s *dmach,
                                        uint8_t cfg)
 {
   /* Clear all interrupts flags */
@@ -514,7 +514,7 @@ static inline void pic32mz_dma_intctrl(FAR struct pic32mz_dmach_s *dmach,
  *
  ****************************************************************************/
 
-static int pic32mz_dma_interrupt(int irq, void *context, FAR void *arg)
+static int pic32mz_dma_interrupt(int irq, void *context, void *arg)
 {
   struct pic32mz_dmach_s *dmach;
   uint8_t status;
@@ -553,7 +553,7 @@ static int pic32mz_dma_interrupt(int irq, void *context, FAR void *arg)
  *
  ****************************************************************************/
 
-static void pic32mz_dma_mode(FAR struct pic32mz_dmach_s *dmach,
+static void pic32mz_dma_mode(struct pic32mz_dmach_s *dmach,
                              uint8_t mode)
 {
   if (mode & PIC32MZ_DMA_MODE_BASIC)
@@ -576,8 +576,8 @@ static void pic32mz_dma_mode(FAR struct pic32mz_dmach_s *dmach,
  *
  ****************************************************************************/
 
-static void pic32mz_dma_config(FAR struct pic32mz_dmach_s *dmach,
-                               FAR const struct pic32mz_dma_chcfg_s *cfg)
+static void pic32mz_dma_config(struct pic32mz_dmach_s *dmach,
+                               const struct pic32mz_dma_chcfg_s *cfg)
 {
   /* Set the channel's priority */
 
@@ -888,7 +888,7 @@ void pic32mz_dma_free(DMA_HANDLE handle)
  ****************************************************************************/
 
 int pic32mz_dma_chcfg(DMA_HANDLE handle,
-                      FAR const struct pic32mz_dma_chcfg_s *cfg)
+                      const struct pic32mz_dma_chcfg_s *cfg)
 {
   struct pic32mz_dmach_s *dmach = (struct pic32mz_dmach_s *)handle;
 
@@ -908,7 +908,7 @@ int pic32mz_dma_chcfg(DMA_HANDLE handle,
  ****************************************************************************/
 
 int pic32mz_dma_xfrsetup(DMA_HANDLE handle,
-                         FAR const struct pic32mz_dma_xfrcfg_s *cfg)
+                         const struct pic32mz_dma_xfrcfg_s *cfg)
 {
   struct pic32mz_dmach_s *dmach = (struct pic32mz_dmach_s *)handle;
 

--- a/arch/mips/src/pic32mz/pic32mz_dma.h
+++ b/arch/mips/src/pic32mz/pic32mz_dma.h
@@ -80,7 +80,7 @@
 
 #ifndef __ASSEMBLY__
 
-typedef FAR void *DMA_HANDLE;
+typedef void *DMA_HANDLE;
 typedef void (*dma_callback_t)(DMA_HANDLE handle, uint8_t status, void *arg);
 
 /* DMA channel modes, arguments for pic32mz_dma_mode. */
@@ -247,7 +247,7 @@ void pic32mz_dma_free(DMA_HANDLE handle);
  ****************************************************************************/
 
 int pic32mz_dma_chcfg(DMA_HANDLE handle,
-                      FAR const struct pic32mz_dma_chcfg_s *cfg);
+                      const struct pic32mz_dma_chcfg_s *cfg);
 
 /****************************************************************************
  * Name: pic32mz_dma_xfrsetup
@@ -258,7 +258,7 @@ int pic32mz_dma_chcfg(DMA_HANDLE handle,
  ****************************************************************************/
 
 int pic32mz_dma_xfrsetup(DMA_HANDLE handle,
-                         FAR const struct pic32mz_dma_xfrcfg_s *cfg);
+                         const struct pic32mz_dma_xfrcfg_s *cfg);
 
 /****************************************************************************
  * Name: pic32mz_dma_start

--- a/arch/mips/src/pic32mz/pic32mz_ethernet.c
+++ b/arch/mips/src/pic32mz/pic32mz_ethernet.c
@@ -252,7 +252,7 @@
  * header
  */
 
-#define BUF ((FAR struct eth_hdr_s *)priv->pd_dev.d_buf)
+#define BUF ((struct eth_hdr_s *)priv->pd_dev.d_buf)
 
 /* PHYs *********************************************************************/
 
@@ -454,7 +454,7 @@ static void pic32mz_rxdone(struct pic32mz_driver_s *priv);
 static void pic32mz_txdone(struct pic32mz_driver_s *priv);
 
 static void pic32mz_interrupt_work(void *arg);
-static int  pic32mz_interrupt(int irq, void *context, FAR void *arg);
+static int  pic32mz_interrupt(int irq, void *context, void *arg);
 
 /* Watchdog timer expirations */
 
@@ -2019,7 +2019,7 @@ static void pic32mz_interrupt_work(void *arg)
  *
  ****************************************************************************/
 
-static int pic32mz_interrupt(int irq, void *context, FAR void *arg)
+static int pic32mz_interrupt(int irq, void *context, void *arg)
 {
   struct pic32mz_driver_s *priv;
   uint32_t status;

--- a/arch/mips/src/pic32mz/pic32mz_freerun.h
+++ b/arch/mips/src/pic32mz/pic32mz_freerun.h
@@ -47,13 +47,13 @@
 
 struct pic32mz_freerun_s
 {
-  uint8_t chan;                            /* The timer in use            */
-  uint8_t width;                           /* Width of timer (16- or 32)  */
-  FAR struct pic32mz_timer_dev_s *timer;   /* PIC32MZ timer driver        */
-  uint32_t freq;                           /* Timer's frequency (Hz)      */
+  uint8_t chan;                      /* The timer in use            */
+  uint8_t width;                     /* Width of timer (16- or 32)  */
+  struct pic32mz_timer_dev_s *timer; /* PIC32MZ timer driver        */
+  uint32_t freq;                     /* Timer's frequency (Hz)      */
 
 #ifndef CONFIG_CLOCK_TIMEKEEPING
-  uint32_t overflow;                       /* Timer's counter overflow    */
+  uint32_t overflow;                 /* Timer's counter overflow    */
 #endif
 
 #ifdef CONFIG_CLOCK_TIMEKEEPING

--- a/arch/mips/src/pic32mz/pic32mz_gpioirq.c
+++ b/arch/mips/src/pic32mz/pic32mz_gpioirq.c
@@ -58,7 +58,7 @@ static inline bool pic32mz_edgedetect(pinset_t pinset);
 static inline unsigned int pic32mz_edgemode(pinset_t pinset);
 static inline bool pic32mz_pullup(pinset_t pinset);
 static inline bool pic32mz_pulldown(pinset_t pinset);
-static int pic32mz_cninterrupt(int irq, FAR void *context, FAR void *arg);
+static int pic32mz_cninterrupt(int irq, void *context, void *arg);
 
 /****************************************************************************
  * Public Data
@@ -206,7 +206,7 @@ static inline unsigned int pic32mz_pin(pinset_t pinset)
  *
  ****************************************************************************/
 
-static int pic32mz_cninterrupt(int irq, FAR void *context, FAR void *arg)
+static int pic32mz_cninterrupt(int irq, void *context, void *arg)
 {
   struct ioport_level2_s *handlers;
   xcpt_t handler;

--- a/arch/mips/src/pic32mz/pic32mz_i2c.c
+++ b/arch/mips/src/pic32mz/pic32mz_i2c.c
@@ -219,47 +219,47 @@ struct pic32mz_i2c_priv_s
  ****************************************************************************/
 
 static inline uint32_t
-  pic32mz_i2c_getreg(FAR struct pic32mz_i2c_priv_s *priv,
+  pic32mz_i2c_getreg(struct pic32mz_i2c_priv_s *priv,
                      uint8_t offset);
-static inline void pic32mz_i2c_putreg(FAR struct pic32mz_i2c_priv_s *priv,
+static inline void pic32mz_i2c_putreg(struct pic32mz_i2c_priv_s *priv,
                                       uint8_t offset, uint32_t value);
-static inline void pic32mz_i2c_modifyreg(FAR struct pic32mz_i2c_priv_s *priv,
+static inline void pic32mz_i2c_modifyreg(struct pic32mz_i2c_priv_s *priv,
                                          uint8_t offset, uint32_t clearbits,
                                          uint32_t setbits);
 
 #ifdef CONFIG_PICM32MZ_I2C_DYNTIMEO
-static useconds_t pic32mz_i2c_tousecs(int msgc, FAR struct i2c_msg_s *msgs);
+static useconds_t pic32mz_i2c_tousecs(int msgc, struct i2c_msg_s *msgs);
 #endif /* CONFIG_PIC32MZ_I2C_DYNTIMEO */
 
 static inline int
-  pic32mz_i2c_sem_waitdone(FAR struct pic32mz_i2c_priv_s *priv);
+  pic32mz_i2c_sem_waitdone(struct pic32mz_i2c_priv_s *priv);
 static inline void
-  pic32mz_i2c_sem_waitidle(FAR struct pic32mz_i2c_priv_s *priv);
-static inline void pic32mz_i2c_sem_post(FAR struct pic32mz_i2c_priv_s *priv);
-static inline void pic32mz_i2c_sem_init(FAR struct pic32mz_i2c_priv_s *priv);
+  pic32mz_i2c_sem_waitidle(struct pic32mz_i2c_priv_s *priv);
+static inline void pic32mz_i2c_sem_post(struct pic32mz_i2c_priv_s *priv);
+static inline void pic32mz_i2c_sem_init(struct pic32mz_i2c_priv_s *priv);
 static inline void
-  pic32mz_i2c_sem_destroy(FAR struct pic32mz_i2c_priv_s *priv);
+  pic32mz_i2c_sem_destroy(struct pic32mz_i2c_priv_s *priv);
 
 #ifdef CONFIG_I2C_TRACE
-static void pic32mz_i2c_tracereset(FAR struct pic32mz_i2c_priv_s *priv);
-static void pic32mz_i2c_tracenew(FAR struct pic32mz_i2c_priv_s *priv,
+static void pic32mz_i2c_tracereset(struct pic32mz_i2c_priv_s *priv);
+static void pic32mz_i2c_tracenew(struct pic32mz_i2c_priv_s *priv,
                                  uint32_t status);
 static void
-  pic32mz_i2c_traceevent(FAR struct pic32mz_i2c_priv_s *priv,
+  pic32mz_i2c_traceevent(struct pic32mz_i2c_priv_s *priv,
                          enum pic32mz_trace_e event, uint32_t parm);
-static void pic32mz_i2c_tracedump(FAR struct pic32mz_i2c_priv_s *priv);
+static void pic32mz_i2c_tracedump(struct pic32mz_i2c_priv_s *priv);
 #endif /* CONFIG_I2C_TRACE */
 
 static inline int
-  pic32mz_i2c_setbaudrate(FAR struct pic32mz_i2c_priv_s *priv,
+  pic32mz_i2c_setbaudrate(struct pic32mz_i2c_priv_s *priv,
                           uint32_t frequency);
 static inline void
-  pic32mz_i2c_send_start(FAR struct pic32mz_i2c_priv_s *priv);
+  pic32mz_i2c_send_start(struct pic32mz_i2c_priv_s *priv);
 static inline void
-  pic32mz_i2c_send_stop(FAR struct pic32mz_i2c_priv_s *priv);
+  pic32mz_i2c_send_stop(struct pic32mz_i2c_priv_s *priv);
 static inline void
-  pic32mz_i2c_send_repeatedstart(FAR struct pic32mz_i2c_priv_s *priv);
-static inline void pic32mz_i2c_send_ack(FAR struct pic32mz_i2c_priv_s *priv,
+  pic32mz_i2c_send_repeatedstart(struct pic32mz_i2c_priv_s *priv);
+static inline void pic32mz_i2c_send_ack(struct pic32mz_i2c_priv_s *priv,
                                         bool ack);
 static inline void pic32mz_i2c_transmitbyte(struct pic32mz_i2c_priv_s *priv,
                                             uint8_t data);
@@ -267,23 +267,23 @@ static inline uint32_t
   pic32mz_i2c_receivebyte(struct pic32mz_i2c_priv_s *priv);
 
 static inline uint32_t
-  pic32mz_i2c_getstatus(FAR struct pic32mz_i2c_priv_s *priv);
+  pic32mz_i2c_getstatus(struct pic32mz_i2c_priv_s *priv);
 static inline bool
-  pic32mz_i2c_master_inactive(FAR struct pic32mz_i2c_priv_s *priv);
+  pic32mz_i2c_master_inactive(struct pic32mz_i2c_priv_s *priv);
 
 static int pic32mz_i2c_isr_process(struct pic32mz_i2c_priv_s * priv);
 
 #ifndef CONFIG_I2C_POLLED
-static int pic32mz_i2c_isr(int irq, void *context, FAR void *arg);
+static int pic32mz_i2c_isr(int irq, void *context, void *arg);
 #endif /* !CONFIG_I2C_POLLED */
 
-static int pic32mz_i2c_init(FAR struct pic32mz_i2c_priv_s *priv);
-static int pic32mz_i2c_deinit(FAR struct pic32mz_i2c_priv_s *priv);
+static int pic32mz_i2c_init(struct pic32mz_i2c_priv_s *priv);
+static int pic32mz_i2c_deinit(struct pic32mz_i2c_priv_s *priv);
 
-static int pic32mz_i2c_transfer(FAR struct i2c_master_s *dev,
-                                FAR struct i2c_msg_s *msgs, int count);
+static int pic32mz_i2c_transfer(struct i2c_master_s *dev,
+                                struct i2c_msg_s *msgs, int count);
 #ifdef CONFIG_I2C_RESET
-static int pic32mz_i2c_reset(FAR struct i2c_master_s *dev);
+static int pic32mz_i2c_reset(struct i2c_master_s *dev);
 #endif
 
 /****************************************************************************
@@ -465,7 +465,7 @@ static struct pic32mz_i2c_priv_s pic32mz_i2c5_priv =
  ****************************************************************************/
 
 #ifdef CONFIG_I2C_TRACE
-static void pic32mz_i2c_traceclear(FAR struct pic32mz_i2c_priv_s *priv)
+static void pic32mz_i2c_traceclear(struct pic32mz_i2c_priv_s *priv)
 {
   struct pic32mz_trace_s *trace = &priv->trace[priv->tndx];
 
@@ -476,7 +476,7 @@ static void pic32mz_i2c_traceclear(FAR struct pic32mz_i2c_priv_s *priv)
   trace->time   = 0;              /* Time of first status or event */
 }
 
-static void pic32mz_i2c_tracereset(FAR struct pic32mz_i2c_priv_s *priv)
+static void pic32mz_i2c_tracereset(struct pic32mz_i2c_priv_s *priv)
 {
   /* Reset the trace info for a new data collection */
 
@@ -485,7 +485,7 @@ static void pic32mz_i2c_tracereset(FAR struct pic32mz_i2c_priv_s *priv)
   pic32mz_i2c_traceclear(priv);
 }
 
-static void pic32mz_i2c_tracenew(FAR struct pic32mz_i2c_priv_s *priv,
+static void pic32mz_i2c_tracenew(struct pic32mz_i2c_priv_s *priv,
                                 uint32_t status)
 {
   struct pic32mz_trace_s *trace = &priv->trace[priv->tndx];
@@ -525,7 +525,7 @@ static void pic32mz_i2c_tracenew(FAR struct pic32mz_i2c_priv_s *priv,
     }
 }
 
-static void pic32mz_i2c_traceevent(FAR struct pic32mz_i2c_priv_s *priv,
+static void pic32mz_i2c_traceevent(struct pic32mz_i2c_priv_s *priv,
                                    enum pic32mz_trace_e event, uint32_t parm)
 {
   struct pic32mz_trace_s *trace;
@@ -552,7 +552,7 @@ static void pic32mz_i2c_traceevent(FAR struct pic32mz_i2c_priv_s *priv,
     }
 }
 
-static void pic32mz_i2c_tracedump(FAR struct pic32mz_i2c_priv_s *priv)
+static void pic32mz_i2c_tracedump(struct pic32mz_i2c_priv_s *priv)
 {
   struct pic32mz_trace_s *trace;
   int i;
@@ -581,7 +581,7 @@ static void pic32mz_i2c_tracedump(FAR struct pic32mz_i2c_priv_s *priv)
  ****************************************************************************/
 
 static inline uint32_t
-  pic32mz_i2c_getreg(FAR struct pic32mz_i2c_priv_s *priv, uint8_t offset)
+  pic32mz_i2c_getreg(struct pic32mz_i2c_priv_s *priv, uint8_t offset)
 {
   return getreg32(priv->config->base + offset);
 }
@@ -594,7 +594,7 @@ static inline uint32_t
  *
  ****************************************************************************/
 
-static inline void pic32mz_i2c_putreg(FAR struct pic32mz_i2c_priv_s *priv,
+static inline void pic32mz_i2c_putreg(struct pic32mz_i2c_priv_s *priv,
                                       uint8_t offset, uint32_t value)
 {
   putreg32(value, priv->config->base + offset);
@@ -608,7 +608,7 @@ static inline void pic32mz_i2c_putreg(FAR struct pic32mz_i2c_priv_s *priv,
  *
  ****************************************************************************/
 
-static inline void pic32mz_i2c_modifyreg(FAR struct pic32mz_i2c_priv_s *priv,
+static inline void pic32mz_i2c_modifyreg(struct pic32mz_i2c_priv_s *priv,
                                          uint8_t offset, uint32_t clearbits,
                                          uint32_t setbits)
 {
@@ -625,7 +625,7 @@ static inline void pic32mz_i2c_modifyreg(FAR struct pic32mz_i2c_priv_s *priv,
  ****************************************************************************/
 
 #ifdef CONFIG_PIC32MZ_I2C_DYNTIMEO
-static useconds_t pic32mz_i2c_tousecs(int msgc, FAR struct i2c_msg_s *msgs)
+static useconds_t pic32mz_i2c_tousecs(int msgc, struct i2c_msg_s *msgs)
 {
   size_t bytecount = 0;
   int i;
@@ -658,7 +658,7 @@ static useconds_t pic32mz_i2c_tousecs(int msgc, FAR struct i2c_msg_s *msgs)
 
 #ifndef CONFIG_I2C_POLLED
 static inline int
-  pic32mz_i2c_sem_waitdone(FAR struct pic32mz_i2c_priv_s *priv)
+  pic32mz_i2c_sem_waitdone(struct pic32mz_i2c_priv_s *priv)
 {
   struct timespec abstime;
   irqstate_t flags;
@@ -731,7 +731,7 @@ static inline int
 }
 #else
 static inline int
-  pic32mz_i2c_sem_waitdone(FAR struct pic32mz_i2c_priv_s *priv)
+  pic32mz_i2c_sem_waitdone(struct pic32mz_i2c_priv_s *priv)
 {
   clock_t timeout;
   clock_t start;
@@ -791,7 +791,7 @@ static inline int
  ****************************************************************************/
 
 static inline void
-  pic32mz_i2c_sem_waitidle(FAR struct pic32mz_i2c_priv_s *priv)
+  pic32mz_i2c_sem_waitidle(struct pic32mz_i2c_priv_s *priv)
 {
   uint32_t timeout;
   uint32_t start;
@@ -838,7 +838,7 @@ static inline void
  *
  ****************************************************************************/
 
-static inline void pic32mz_i2c_sem_post(FAR struct pic32mz_i2c_priv_s *priv)
+static inline void pic32mz_i2c_sem_post(struct pic32mz_i2c_priv_s *priv)
 {
   nxsem_post(&priv->sem_excl);
 }
@@ -851,7 +851,7 @@ static inline void pic32mz_i2c_sem_post(FAR struct pic32mz_i2c_priv_s *priv)
  *
  ****************************************************************************/
 
-static inline void pic32mz_i2c_sem_init(FAR struct pic32mz_i2c_priv_s *priv)
+static inline void pic32mz_i2c_sem_init(struct pic32mz_i2c_priv_s *priv)
 {
   nxsem_init(&priv->sem_excl, 0, 1);
 
@@ -874,7 +874,7 @@ static inline void pic32mz_i2c_sem_init(FAR struct pic32mz_i2c_priv_s *priv)
  ****************************************************************************/
 
 static inline void
-  pic32mz_i2c_sem_destroy(FAR struct pic32mz_i2c_priv_s *priv)
+  pic32mz_i2c_sem_destroy(struct pic32mz_i2c_priv_s *priv)
 {
   nxsem_destroy(&priv->sem_excl);
 #ifndef CONFIG_I2C_POLLED
@@ -1279,7 +1279,7 @@ static int pic32mz_i2c_isr_process(struct pic32mz_i2c_priv_s *priv)
  ****************************************************************************/
 
 #ifndef CONFIG_I2C_POLLED
-static int pic32mz_i2c_isr(int irq, void *context, FAR void *arg)
+static int pic32mz_i2c_isr(int irq, void *context, void *arg)
 {
   struct pic32mz_i2c_priv_s *priv = (struct pic32mz_i2c_priv_s *)arg;
 
@@ -1297,7 +1297,7 @@ static int pic32mz_i2c_isr(int irq, void *context, FAR void *arg)
  ****************************************************************************/
 
 static inline int
-  pic32mz_i2c_setbaudrate(FAR struct pic32mz_i2c_priv_s *priv,
+  pic32mz_i2c_setbaudrate(struct pic32mz_i2c_priv_s *priv,
                           uint32_t frequency)
 {
   uint32_t baudrate;
@@ -1347,7 +1347,7 @@ static inline int
  ****************************************************************************/
 
 static inline void
-  pic32mz_i2c_send_start(FAR struct pic32mz_i2c_priv_s *priv)
+  pic32mz_i2c_send_start(struct pic32mz_i2c_priv_s *priv)
 {
   pic32mz_i2c_putreg(priv, PIC32MZ_I2C_CONSET_OFFSET, I2C_CON_SEN);
 
@@ -1367,7 +1367,7 @@ static inline void
  *
  ****************************************************************************/
 
-static inline void pic32mz_i2c_send_stop(FAR struct pic32mz_i2c_priv_s *priv)
+static inline void pic32mz_i2c_send_stop(struct pic32mz_i2c_priv_s *priv)
 {
   pic32mz_i2c_putreg(priv, PIC32MZ_I2C_CONSET_OFFSET, I2C_CON_PEN);
 
@@ -1388,7 +1388,7 @@ static inline void pic32mz_i2c_send_stop(FAR struct pic32mz_i2c_priv_s *priv)
  ****************************************************************************/
 
 static inline void
-  pic32mz_i2c_send_repeatedstart(FAR struct pic32mz_i2c_priv_s *priv)
+  pic32mz_i2c_send_repeatedstart(struct pic32mz_i2c_priv_s *priv)
 {
   pic32mz_i2c_putreg(priv, PIC32MZ_I2C_CONSET_OFFSET, I2C_CON_RSEN);
 
@@ -1408,7 +1408,7 @@ static inline void
  *
  ****************************************************************************/
 
-static inline void pic32mz_i2c_send_ack(FAR struct pic32mz_i2c_priv_s *priv,
+static inline void pic32mz_i2c_send_ack(struct pic32mz_i2c_priv_s *priv,
                                         bool ack)
 {
   if (ack)
@@ -1486,7 +1486,7 @@ static inline uint32_t
  ****************************************************************************/
 
 static inline bool
-  pic32mz_i2c_master_inactive(FAR struct pic32mz_i2c_priv_s *priv)
+  pic32mz_i2c_master_inactive(struct pic32mz_i2c_priv_s *priv)
 {
   uint32_t con;
 
@@ -1504,7 +1504,7 @@ static inline bool
  ****************************************************************************/
 
 static inline uint32_t
-  pic32mz_i2c_getstatus(FAR struct pic32mz_i2c_priv_s *priv)
+  pic32mz_i2c_getstatus(struct pic32mz_i2c_priv_s *priv)
 {
   return pic32mz_i2c_getreg(priv, PIC32MZ_I2C_STAT_OFFSET);
 }
@@ -1517,7 +1517,7 @@ static inline uint32_t
  *
  ****************************************************************************/
 
-static int pic32mz_i2c_init(FAR struct pic32mz_i2c_priv_s *priv)
+static int pic32mz_i2c_init(struct pic32mz_i2c_priv_s *priv)
 {
   /* Force a frequency update */
 
@@ -1550,7 +1550,7 @@ static int pic32mz_i2c_init(FAR struct pic32mz_i2c_priv_s *priv)
  *
  ****************************************************************************/
 
-static int pic32mz_i2c_deinit(FAR struct pic32mz_i2c_priv_s *priv)
+static int pic32mz_i2c_deinit(struct pic32mz_i2c_priv_s *priv)
 {
   /* Disable I2C */
 
@@ -1580,10 +1580,10 @@ static int pic32mz_i2c_deinit(FAR struct pic32mz_i2c_priv_s *priv)
  *
  ****************************************************************************/
 
-static int pic32mz_i2c_transfer(FAR struct i2c_master_s *dev,
-                                FAR struct i2c_msg_s *msgs, int count)
+static int pic32mz_i2c_transfer(struct i2c_master_s *dev,
+                                struct i2c_msg_s *msgs, int count)
 {
-  FAR struct pic32mz_i2c_priv_s *priv = (struct pic32mz_i2c_priv_s *)dev;
+  struct pic32mz_i2c_priv_s *priv = (struct pic32mz_i2c_priv_s *)dev;
   uint32_t status = 0;
   int ret;
 
@@ -1702,9 +1702,9 @@ static int pic32mz_i2c_transfer(FAR struct i2c_master_s *dev,
  ****************************************************************************/
 
 #ifdef CONFIG_I2C_RESET
-static int pic32mz_i2c_reset(FAR struct i2c_master_s *dev)
+static int pic32mz_i2c_reset(struct i2c_master_s *dev)
 {
-  FAR struct pic32mz_i2c_priv_s *priv = (struct pic32mz_i2c_priv_s *)dev;
+  struct pic32mz_i2c_priv_s *priv = (struct pic32mz_i2c_priv_s *)dev;
   unsigned int clock_count;
   unsigned int stretch_count;
   uint32_t frequency;
@@ -1829,7 +1829,7 @@ out:
  *
  ****************************************************************************/
 
-FAR struct i2c_master_s *pic32mz_i2cbus_initialize(int port)
+struct i2c_master_s *pic32mz_i2cbus_initialize(int port)
 {
   struct pic32mz_i2c_priv_s * priv = NULL;
   irqstate_t flags;
@@ -1895,9 +1895,9 @@ FAR struct i2c_master_s *pic32mz_i2cbus_initialize(int port)
  *
  ****************************************************************************/
 
-int pic32mz_i2cbus_uninitialize(FAR struct i2c_master_s *dev)
+int pic32mz_i2cbus_uninitialize(struct i2c_master_s *dev)
 {
-  FAR struct pic32mz_i2c_priv_s *priv = (struct pic32mz_i2c_priv_s *)dev;
+  struct pic32mz_i2c_priv_s *priv = (struct pic32mz_i2c_priv_s *)dev;
   irqstate_t flags;
 
   DEBUGASSERT(dev);

--- a/arch/mips/src/pic32mz/pic32mz_i2c.h
+++ b/arch/mips/src/pic32mz/pic32mz_i2c.h
@@ -53,7 +53,7 @@
  *
  ****************************************************************************/
 
-FAR struct i2c_master_s *pic32mz_i2cbus_initialize(int port);
+struct i2c_master_s *pic32mz_i2cbus_initialize(int port);
 
 /****************************************************************************
  * Name: pic32mz_i2cbus_uninitialize
@@ -70,6 +70,6 @@ FAR struct i2c_master_s *pic32mz_i2cbus_initialize(int port);
  *
  ****************************************************************************/
 
-int pic32mz_i2cbus_uninitialize(FAR struct i2c_master_s *dev);
+int pic32mz_i2cbus_uninitialize(struct i2c_master_s *dev);
 
 #endif /* __ARCH_MIPS_SRC_PIC32MZ_PIC32MZ_I2C_H */

--- a/arch/mips/src/pic32mz/pic32mz_oneshot.h
+++ b/arch/mips/src/pic32mz/pic32mz_oneshot.h
@@ -66,17 +66,17 @@ typedef void (*oneshot_handler_t)(void *arg);
 
 struct pic32mz_oneshot_s
 {
-  uint8_t chan;                          /* The timer/counter in use      */
+  uint8_t chan;                       /* The timer/counter in use      */
 #if CONFIG_PIC32MZ_ONESHOT_MAXTIMERS > 1
-  uint8_t cbndx;                         /* Timer callback handler index  */
+  uint8_t cbndx;                      /* Timer callback handler index  */
 #endif
-  volatile bool running;                 /* True: the timer is running    */
-  FAR struct pic32mz_timer_dev_s *timer; /* PIC32MZ timer driver          */
-  volatile oneshot_handler_t handler;    /* Oneshot expiration callback   */
-  volatile void *arg;                    /* Callback's argument           */
-  uint32_t freq;                         /* Timer's frequency             */
-  uint32_t period;                       /* Timer's period                */
-  uint8_t  width;                        /* Timer's width                 */
+  volatile bool running;              /* True: the timer is running    */
+  struct pic32mz_timer_dev_s *timer;  /* PIC32MZ timer driver          */
+  volatile oneshot_handler_t handler; /* Oneshot expiration callback   */
+  volatile void *arg;                 /* Callback's argument           */
+  uint32_t freq;                      /* Timer's frequency             */
+  uint32_t period;                    /* Timer's period                */
+  uint8_t  width;                     /* Timer's width                 */
 };
 
 /****************************************************************************

--- a/arch/mips/src/pic32mz/pic32mz_oneshot_lowerhalf.c
+++ b/arch/mips/src/pic32mz/pic32mz_oneshot_lowerhalf.c
@@ -55,7 +55,7 @@ struct pic32mz_oneshot_lowerhalf_s
 
   struct pic32mz_oneshot_s oneshot; /* PIC32MZ-specific oneshot state  */
   oneshot_callback_t callback;      /* Handler that receives callback  */
-  FAR void *arg;                    /* Argument passed to the handler  */
+  void *arg;                        /* Argument passed to the handler  */
 };
 
 /****************************************************************************
@@ -64,13 +64,13 @@ struct pic32mz_oneshot_lowerhalf_s
 
 static void pic32mz_oneshot_handler(void *arg);
 
-static int pic32mz_max_delay(FAR struct oneshot_lowerhalf_s *lower,
-                             FAR struct timespec *ts);
-static int pic32mz_start(FAR struct oneshot_lowerhalf_s *lower,
-                         oneshot_callback_t callback, FAR void *arg,
-                         FAR const struct timespec *ts);
-static int pic32mz_cancel(FAR struct oneshot_lowerhalf_s *lower,
-                          FAR struct timespec *ts);
+static int pic32mz_max_delay(struct oneshot_lowerhalf_s *lower,
+                             struct timespec *ts);
+static int pic32mz_start(struct oneshot_lowerhalf_s *lower,
+                         oneshot_callback_t callback, void *arg,
+                         const struct timespec *ts);
+static int pic32mz_cancel(struct oneshot_lowerhalf_s *lower,
+                          struct timespec *ts);
 
 /****************************************************************************
  * Private Data
@@ -106,10 +106,10 @@ static const struct oneshot_operations_s g_oneshot_ops =
 
 static void pic32mz_oneshot_handler(void *arg)
 {
-  FAR struct pic32mz_oneshot_lowerhalf_s *priv =
-    (FAR struct pic32mz_oneshot_lowerhalf_s *)arg;
+  struct pic32mz_oneshot_lowerhalf_s *priv =
+    (struct pic32mz_oneshot_lowerhalf_s *)arg;
   oneshot_callback_t callback;
-  FAR void *cbarg;
+  void *cbarg;
 
   DEBUGASSERT(priv != NULL);
 
@@ -152,11 +152,11 @@ static void pic32mz_oneshot_handler(void *arg)
  *
  ****************************************************************************/
 
-static int pic32mz_max_delay(FAR struct oneshot_lowerhalf_s *lower,
-                             FAR struct timespec *ts)
+static int pic32mz_max_delay(struct oneshot_lowerhalf_s *lower,
+                             struct timespec *ts)
 {
-  FAR struct pic32mz_oneshot_lowerhalf_s *priv =
-    (FAR struct pic32mz_oneshot_lowerhalf_s *)lower;
+  struct pic32mz_oneshot_lowerhalf_s *priv =
+    (struct pic32mz_oneshot_lowerhalf_s *)lower;
   uint64_t usecs;
   int ret;
 
@@ -197,12 +197,12 @@ static int pic32mz_max_delay(FAR struct oneshot_lowerhalf_s *lower,
  *
  ****************************************************************************/
 
-static int pic32mz_start(FAR struct oneshot_lowerhalf_s *lower,
-                         oneshot_callback_t callback, FAR void *arg,
-                         FAR const struct timespec *ts)
+static int pic32mz_start(struct oneshot_lowerhalf_s *lower,
+                         oneshot_callback_t callback, void *arg,
+                         const struct timespec *ts)
 {
-  FAR struct pic32mz_oneshot_lowerhalf_s *priv =
-    (FAR struct pic32mz_oneshot_lowerhalf_s *)lower;
+  struct pic32mz_oneshot_lowerhalf_s *priv =
+    (struct pic32mz_oneshot_lowerhalf_s *)lower;
   irqstate_t flags;
   int ret;
 
@@ -250,11 +250,11 @@ static int pic32mz_start(FAR struct oneshot_lowerhalf_s *lower,
  *
  ****************************************************************************/
 
-static int pic32mz_cancel(FAR struct oneshot_lowerhalf_s *lower,
-                        FAR struct timespec *ts)
+static int pic32mz_cancel(struct oneshot_lowerhalf_s *lower,
+                        struct timespec *ts)
 {
-  FAR struct pic32mz_oneshot_lowerhalf_s *priv =
-    (FAR struct pic32mz_oneshot_lowerhalf_s *)lower;
+  struct pic32mz_oneshot_lowerhalf_s *priv =
+    (struct pic32mz_oneshot_lowerhalf_s *)lower;
   irqstate_t flags;
   int ret;
 
@@ -299,15 +299,15 @@ static int pic32mz_cancel(FAR struct oneshot_lowerhalf_s *lower,
  *
  ****************************************************************************/
 
-FAR struct oneshot_lowerhalf_s *oneshot_initialize(int chan,
+struct oneshot_lowerhalf_s *oneshot_initialize(int chan,
                                                    uint16_t resolution)
 {
-  FAR struct pic32mz_oneshot_lowerhalf_s *priv;
+  struct pic32mz_oneshot_lowerhalf_s *priv;
   int ret;
 
   /* Allocate an instance of the lower half driver */
 
-  priv = (FAR struct pic32mz_oneshot_lowerhalf_s *)
+  priv = (struct pic32mz_oneshot_lowerhalf_s *)
     kmm_zalloc(sizeof(struct pic32mz_oneshot_lowerhalf_s));
 
   if (priv == NULL)

--- a/arch/mips/src/pic32mz/pic32mz_serial.c
+++ b/arch/mips/src/pic32mz/pic32mz_serial.c
@@ -260,7 +260,7 @@ static int  up_setup(struct uart_dev_s *dev);
 static void up_shutdown(struct uart_dev_s *dev);
 static int  up_attach(struct uart_dev_s *dev);
 static void up_detach(struct uart_dev_s *dev);
-static int  up_interrupt(int irq, void *context, FAR void *arg);
+static int  up_interrupt(int irq, void *context, void *arg);
 static int  up_ioctl(struct file *filep, int cmd, unsigned long arg);
 static int  up_receive(struct uart_dev_s *dev, unsigned int *status);
 static void up_rxint(struct uart_dev_s *dev, bool enable);
@@ -692,7 +692,7 @@ static void up_detach(struct uart_dev_s *dev)
  *
  ****************************************************************************/
 
-static int up_interrupt(int irq, void *context, FAR void *arg)
+static int up_interrupt(int irq, void *context, void *arg)
 {
   struct uart_dev_s *dev = (struct uart_dev_s *)arg;
   struct up_dev_s *priv;

--- a/arch/mips/src/pic32mz/pic32mz_spi.c
+++ b/arch/mips/src/pic32mz/pic32mz_spi.c
@@ -126,7 +126,7 @@ struct pic32mz_config_s
 struct pic32mz_dev_s
 {
   struct spi_dev_s spidev;     /* Externally visible part of the SPI interface */
-  FAR const struct pic32mz_config_s *config;
+  const struct pic32mz_config_s *config;
   sem_t            exclsem;    /* Held while chip is selected for mutual exclusion */
   uint32_t         frequency;  /* Requested clock frequency */
   uint32_t         actual;     /* Actual clock frequency */
@@ -161,27 +161,27 @@ struct pic32mz_dev_s
 /* Low-level register access */
 
 #ifdef CONFIG_PIC32MZ_SPI_REGDEBUG
-static bool     spi_checkreg(FAR struct pic32mz_dev_s *priv,
+static bool     spi_checkreg(struct pic32mz_dev_s *priv,
                   uintptr_t regaddr, uint32_t regvaql, bool wr);
-static uint32_t spi_getreg(FAR struct pic32mz_dev_s *priv,
+static uint32_t spi_getreg(struct pic32mz_dev_s *priv,
                   unsigned int offset);
-static void     spi_putaddr(FAR struct pic32mz_dev_s *priv,
+static void     spi_putaddr(struct pic32mz_dev_s *priv,
                   uintptr_t regaddr, uint32_t value);
 #else
-static inline uint32_t spi_getreg(FAR struct pic32mz_dev_s *priv,
+static inline uint32_t spi_getreg(struct pic32mz_dev_s *priv,
                   unsigned int offset);
-static inline void     spi_putaddr(FAR struct pic32mz_dev_s *priv,
+static inline void     spi_putaddr(struct pic32mz_dev_s *priv,
                   uintptr_t regaddr, uint32_t value);
 #endif
-static inline void spi_putreg(FAR struct pic32mz_dev_s *priv,
+static inline void spi_putreg(struct pic32mz_dev_s *priv,
                   unsigned int offset, uint32_t value);
-static inline void spi_flush(FAR struct pic32mz_dev_s *priv);
+static inline void spi_flush(struct pic32mz_dev_s *priv);
 
-static void     spi_exchange16(FAR struct pic32mz_dev_s *priv,
-                   FAR const uint16_t *txbuffer, FAR uint16_t *rxbuffer,
+static void     spi_exchange16(struct pic32mz_dev_s *priv,
+                   const uint16_t *txbuffer, uint16_t *rxbuffer,
                    size_t nwords);
-static void     spi_exchange8(FAR struct pic32mz_dev_s *priv,
-                   FAR const uint8_t *txbuffer, FAR uint8_t *rxbuffer,
+static void     spi_exchange8(struct pic32mz_dev_s *priv,
+                   const uint8_t *txbuffer, uint8_t *rxbuffer,
                    size_t nbytes);
 
 /* DMA Support */
@@ -192,8 +192,8 @@ static void     spi_exchange8(FAR struct pic32mz_dev_s *priv,
                                                     &(s)->rxdmaregs[i])
 #    define spi_txdma_sample(s,i) pic32mz_dma_sample((s)->txdma,\
                                                     &(s)->txdmaregs[i])
-static void spi_dma_sampleinit(FAR struct pic32mz_dev_s *priv);
-static void spi_dma_sampledone(FAR struct pic32mz_dev_s *priv);
+static void spi_dma_sampleinit(struct pic32mz_dev_s *priv);
+static void spi_dma_sampledone(struct pic32mz_dev_s *priv);
 #  else
 #    define spi_rxdma_sample(s,i)
 #    define spi_txdma_sample(s,i)
@@ -207,26 +207,26 @@ static void spi_dmatimeout(wdparm_t arg);
 
 /* SPI methods */
 
-static int      spi_lock(FAR struct spi_dev_s *dev, bool lock);
-static uint32_t spi_setfrequency(FAR struct spi_dev_s *dev,
+static int      spi_lock(struct spi_dev_s *dev, bool lock);
+static uint32_t spi_setfrequency(struct spi_dev_s *dev,
                    uint32_t frequency);
-static void     spi_setmode(FAR struct spi_dev_s *dev, enum spi_mode_e mode);
-static void     spi_setbits(FAR struct spi_dev_s *dev, int nbits);
-static uint32_t spi_send(FAR struct spi_dev_s *dev, uint32_t wd);
-static void     spi_exchange(FAR struct spi_dev_s *dev,
-                             FAR const void *txbuffer, FAR void *rxbuffer,
+static void     spi_setmode(struct spi_dev_s *dev, enum spi_mode_e mode);
+static void     spi_setbits(struct spi_dev_s *dev, int nbits);
+static uint32_t spi_send(struct spi_dev_s *dev, uint32_t wd);
+static void     spi_exchange(struct spi_dev_s *dev,
+                             const void *txbuffer, void *rxbuffer,
                              size_t nwords);
 #ifdef CONFIG_PIC32MZ_SPI_DMA
-static void     spi_exchange_nodma(FAR struct spi_dev_s *dev,
-                                   FAR const void *txbuffer,
-                                   FAR void *rxbuffer,
+static void     spi_exchange_nodma(struct spi_dev_s *dev,
+                                   const void *txbuffer,
+                                   void *rxbuffer,
                                    size_t nwords);
 #endif
 
 #ifndef CONFIG_SPI_EXCHANGE
-static void     spi_sndblock(FAR struct spi_dev_s *dev,
-                             FAR const void *buffer, size_t nwords);
-static void     spi_recvblock(FAR struct spi_dev_s *dev, FAR void *buffer,
+static void     spi_sndblock(struct spi_dev_s *dev,
+                             const void *buffer, size_t nwords);
+static void     spi_recvblock(struct spi_dev_s *dev, void *buffer,
                               size_t nwords);
 #endif
 
@@ -612,7 +612,7 @@ static bool spi_checkreg(struct pic32mz_dev_s *priv, uintptr_t regaddr,
  ****************************************************************************/
 
 #ifdef CONFIG_PIC32MZ_SPI_REGDEBUG
-static uint32_t spi_getreg(FAR struct pic32mz_dev_s *priv,
+static uint32_t spi_getreg(struct pic32mz_dev_s *priv,
                            unsigned int offset)
 {
   uintptr_t regaddr;
@@ -638,7 +638,7 @@ static uint32_t spi_getreg(FAR struct pic32mz_dev_s *priv,
   return regval;
 }
 #else
-static inline uint32_t spi_getreg(FAR struct pic32mz_dev_s *priv,
+static inline uint32_t spi_getreg(struct pic32mz_dev_s *priv,
                                   unsigned int offset)
 {
   return getreg32(priv->config->base + offset);
@@ -662,7 +662,7 @@ static inline uint32_t spi_getreg(FAR struct pic32mz_dev_s *priv,
  ****************************************************************************/
 
 #ifdef CONFIG_PIC32MZ_SPI_REGDEBUG
-static void spi_putaddr(FAR struct pic32mz_dev_s *priv, uintptr_t regaddr,
+static void spi_putaddr(struct pic32mz_dev_s *priv, uintptr_t regaddr,
                         uint32_t regval)
 {
   /* Should we print something? */
@@ -680,7 +680,7 @@ static void spi_putaddr(FAR struct pic32mz_dev_s *priv, uintptr_t regaddr,
   putreg32(regval, regaddr);
 }
 #else
-static inline void spi_putaddr(FAR struct pic32mz_dev_s *priv,
+static inline void spi_putaddr(struct pic32mz_dev_s *priv,
                                uintptr_t regaddr, uint32_t regval)
 {
   /* Write the value to the register */
@@ -705,7 +705,7 @@ static inline void spi_putaddr(FAR struct pic32mz_dev_s *priv,
  *
  ****************************************************************************/
 
-static inline void spi_putreg(FAR struct pic32mz_dev_s *priv,
+static inline void spi_putreg(struct pic32mz_dev_s *priv,
                               unsigned int offset, uint32_t regval)
 {
   spi_putaddr(priv, priv->config->base + offset, regval);
@@ -725,7 +725,7 @@ static inline void spi_putreg(FAR struct pic32mz_dev_s *priv,
  *
  ****************************************************************************/
 
-static inline void spi_flush(FAR struct pic32mz_dev_s *priv)
+static inline void spi_flush(struct pic32mz_dev_s *priv)
 {
   /* Make sure that no TX activity is in progress... waiting if necessary */
 
@@ -756,7 +756,7 @@ static inline void spi_flush(FAR struct pic32mz_dev_s *priv)
  ****************************************************************************/
 
 #ifdef CONFIG_PIC32MZ_SPI_DMADEBUG
-static void spi_dma_sampleinit(FAR struct pic32mz_dev_s *priv)
+static void spi_dma_sampleinit(struct pic32mz_dev_s *priv)
 {
   /* Put contents of register samples into a known state */
 
@@ -787,7 +787,7 @@ static void spi_dma_sampleinit(FAR struct pic32mz_dev_s *priv)
  ****************************************************************************/
 
 #ifdef CONFIG_PIC32MZ_SPI_DMADEBUG
-static void spi_dma_sampledone(FAR struct pic32mz_dev_s *priv)
+static void spi_dma_sampledone(struct pic32mz_dev_s *priv)
 {
   /* Sample the final registers */
 
@@ -1016,8 +1016,8 @@ static void spi_dmatimeout(wdparm_t arg)
  *
  ****************************************************************************/
 
-static void spi_exchange8(FAR struct pic32mz_dev_s *priv,
-                          FAR const uint8_t *txbuffer, FAR uint8_t *rxbuffer,
+static void spi_exchange8(struct pic32mz_dev_s *priv,
+                          const uint8_t *txbuffer, uint8_t *rxbuffer,
                           size_t nbytes)
 {
   uint32_t regval;
@@ -1091,9 +1091,9 @@ static void spi_exchange8(FAR struct pic32mz_dev_s *priv,
  *
  ****************************************************************************/
 
-static void spi_exchange16(FAR struct pic32mz_dev_s *priv,
-                           FAR const uint16_t *txbuffer,
-                           FAR uint16_t *rxbuffer, size_t nwords)
+static void spi_exchange16(struct pic32mz_dev_s *priv,
+                           const uint16_t *txbuffer,
+                           uint16_t *rxbuffer, size_t nwords)
 {
   uint32_t regval;
   uint16_t data;
@@ -1169,9 +1169,9 @@ static void spi_exchange16(FAR struct pic32mz_dev_s *priv,
  *
  ****************************************************************************/
 
-static int spi_lock(FAR struct spi_dev_s *dev, bool lock)
+static int spi_lock(struct spi_dev_s *dev, bool lock)
 {
-  FAR struct pic32mz_dev_s *priv = (FAR struct pic32mz_dev_s *)dev;
+  struct pic32mz_dev_s *priv = (struct pic32mz_dev_s *)dev;
   int ret;
 
   if (lock)
@@ -1201,10 +1201,10 @@ static int spi_lock(FAR struct spi_dev_s *dev, bool lock)
  *
  ****************************************************************************/
 
-static uint32_t spi_setfrequency(FAR struct spi_dev_s *dev,
+static uint32_t spi_setfrequency(struct spi_dev_s *dev,
                                  uint32_t frequency)
 {
-  FAR struct pic32mz_dev_s *priv = (FAR struct pic32mz_dev_s *)dev;
+  struct pic32mz_dev_s *priv = (struct pic32mz_dev_s *)dev;
   uint32_t divisor;
   uint32_t actual;
   uint32_t regval;
@@ -1273,9 +1273,9 @@ static uint32_t spi_setfrequency(FAR struct spi_dev_s *dev,
  *
  ****************************************************************************/
 
-static void spi_setmode(FAR struct spi_dev_s *dev, enum spi_mode_e mode)
+static void spi_setmode(struct spi_dev_s *dev, enum spi_mode_e mode)
 {
-  FAR struct pic32mz_dev_s *priv = (FAR struct pic32mz_dev_s *)dev;
+  struct pic32mz_dev_s *priv = (struct pic32mz_dev_s *)dev;
 
   /* Has the mode changed? */
 
@@ -1359,9 +1359,9 @@ static void spi_setmode(FAR struct spi_dev_s *dev, enum spi_mode_e mode)
  *
  ****************************************************************************/
 
-static void spi_setbits(FAR struct spi_dev_s *dev, int nbits)
+static void spi_setbits(struct spi_dev_s *dev, int nbits)
 {
-  FAR struct pic32mz_dev_s *priv = (FAR struct pic32mz_dev_s *)dev;
+  struct pic32mz_dev_s *priv = (struct pic32mz_dev_s *)dev;
   uint32_t setting;
   uint32_t regval;
 
@@ -1419,9 +1419,9 @@ static void spi_setbits(FAR struct spi_dev_s *dev, int nbits)
  *
  ****************************************************************************/
 
-static uint32_t spi_send(FAR struct spi_dev_s *dev, uint32_t wd)
+static uint32_t spi_send(struct spi_dev_s *dev, uint32_t wd)
 {
-  FAR struct pic32mz_dev_s *priv = (FAR struct pic32mz_dev_s *)dev;
+  struct pic32mz_dev_s *priv = (struct pic32mz_dev_s *)dev;
 
   DEBUGASSERT(priv);
 
@@ -1489,15 +1489,15 @@ static uint32_t spi_send(FAR struct spi_dev_s *dev, uint32_t wd)
  ****************************************************************************/
 
 #ifdef CONFIG_PIC32MZ_SPI_DMA
-static void spi_exchange_nodma(FAR struct spi_dev_s *dev,
-                               FAR const void *txbuffer,
-                               FAR void *rxbuffer, size_t nwords)
+static void spi_exchange_nodma(struct spi_dev_s *dev,
+                               const void *txbuffer,
+                               void *rxbuffer, size_t nwords)
 #else
-static void spi_exchange(FAR struct spi_dev_s *dev, FAR const void *txbuffer,
-                         FAR void *rxbuffer, size_t nwords)
+static void spi_exchange(struct spi_dev_s *dev, const void *txbuffer,
+                         void *rxbuffer, size_t nwords)
 #endif
 {
-  FAR struct pic32mz_dev_s *priv = (FAR struct pic32mz_dev_s *)dev;
+  struct pic32mz_dev_s *priv = (struct pic32mz_dev_s *)dev;
 
   DEBUGASSERT(priv);
 
@@ -1509,23 +1509,23 @@ static void spi_exchange(FAR struct spi_dev_s *dev, FAR const void *txbuffer,
     {
       /* spi_exchange16() can do this. */
 
-      spi_exchange16(priv, (FAR const uint16_t *)txbuffer,
-                     (FAR uint16_t *)rxbuffer, nwords);
+      spi_exchange16(priv, (const uint16_t *)txbuffer,
+                     (uint16_t *)rxbuffer, nwords);
     }
   else
     {
       /* spi_exchange8() can do this. */
 
-      spi_exchange8(priv, (FAR const uint8_t *)txbuffer,
-                    (FAR uint8_t *)rxbuffer, nwords);
+      spi_exchange8(priv, (const uint8_t *)txbuffer,
+                    (uint8_t *)rxbuffer, nwords);
     }
 }
 
 #ifdef CONFIG_PIC32MZ_SPI_DMA
-static void spi_exchange(FAR struct spi_dev_s *dev, FAR const void *txbuffer,
-                         FAR void *rxbuffer, size_t nwords)
+static void spi_exchange(struct spi_dev_s *dev, const void *txbuffer,
+                         void *rxbuffer, size_t nwords)
 {
-  FAR struct pic32mz_dev_s *priv = (FAR struct pic32mz_dev_s *)dev;
+  struct pic32mz_dev_s *priv = (struct pic32mz_dev_s *)dev;
   struct pic32mz_dma_chcfg_s rxcfg;
   struct pic32mz_dma_chcfg_s txcfg;
   struct pic32mz_dma_xfrcfg_s rxxfr;
@@ -1850,7 +1850,7 @@ static void spi_exchange(FAR struct spi_dev_s *dev, FAR const void *txbuffer,
  ****************************************************************************/
 
 #ifndef CONFIG_SPI_EXCHANGE
-static void spi_sndblock(FAR struct spi_dev_s *dev, FAR const void *buffer,
+static void spi_sndblock(struct spi_dev_s *dev, const void *buffer,
                          size_t nwords)
 {
   /* spi_exchange() can do this. */
@@ -1881,7 +1881,7 @@ static void spi_sndblock(FAR struct spi_dev_s *dev, FAR const void *buffer,
  ****************************************************************************/
 
 #ifndef CONFIG_SPI_EXCHANGE
-static void spi_recvblock(FAR struct spi_dev_s *dev, FAR void *buffer,
+static void spi_recvblock(struct spi_dev_s *dev, void *buffer,
                           size_t nwords)
 {
   /* spi_exchange() can do this. */
@@ -1908,9 +1908,9 @@ static void spi_recvblock(FAR struct spi_dev_s *dev, FAR void *buffer,
  *
  ****************************************************************************/
 
-FAR struct spi_dev_s *pic32mz_spibus_initialize(int port)
+struct spi_dev_s *pic32mz_spibus_initialize(int port)
 {
-  FAR struct pic32mz_dev_s *priv;
+  struct pic32mz_dev_s *priv;
   uintptr_t regaddr;
   irqstate_t flags;
   uint32_t regval;
@@ -2056,7 +2056,7 @@ FAR struct spi_dev_s *pic32mz_spibus_initialize(int port)
 
   /* Select a default frequency of approx. 400KHz */
 
-  spi_setfrequency((FAR struct spi_dev_s *)priv, 400000);
+  spi_setfrequency((struct spi_dev_s *)priv, 400000);
 
   /* Clear the SPIROV overflow bit (SPIxSTAT:6). */
 

--- a/arch/mips/src/pic32mz/pic32mz_spi.h
+++ b/arch/mips/src/pic32mz/pic32mz_spi.h
@@ -71,7 +71,7 @@ struct spi_dev_s;  /* Forward reference */
  *
  ****************************************************************************/
 
-FAR struct spi_dev_s *pic32mz_spibus_initialize(int port);
+struct spi_dev_s *pic32mz_spibus_initialize(int port);
 
 /****************************************************************************
  * Name:  pic32mz_spiNselect, pic32mz_spiNstatus, and pic32mz_spiNcmddata
@@ -103,56 +103,56 @@ FAR struct spi_dev_s *pic32mz_spibus_initialize(int port);
  ****************************************************************************/
 
 #ifdef CONFIG_PIC32MZ_SPI1
-void pic32mz_spi1select(FAR struct spi_dev_s *dev, uint32_t devid,
+void pic32mz_spi1select(struct spi_dev_s *dev, uint32_t devid,
                         bool selected);
-uint8_t pic32mz_spi1status(FAR struct spi_dev_s *dev, uint32_t devid);
+uint8_t pic32mz_spi1status(struct spi_dev_s *dev, uint32_t devid);
 #ifdef CONFIG_SPI_CMDDATA
-int pic32mz_spi1cmddata(FAR struct spi_dev_s *dev, uint32_t devid, bool cmd);
+int pic32mz_spi1cmddata(struct spi_dev_s *dev, uint32_t devid, bool cmd);
 #endif
 #endif
 
 #ifdef CONFIG_PIC32MZ_SPI2
-void pic32mz_spi2select(FAR struct spi_dev_s *dev, uint32_t devid,
+void pic32mz_spi2select(struct spi_dev_s *dev, uint32_t devid,
                         bool selected);
-uint8_t pic32mz_spi2status(FAR struct spi_dev_s *dev, uint32_t devid);
+uint8_t pic32mz_spi2status(struct spi_dev_s *dev, uint32_t devid);
 #ifdef CONFIG_SPI_CMDDATA
-int pic32mz_spi2cmddata(FAR struct spi_dev_s *dev, uint32_t devid, bool cmd);
+int pic32mz_spi2cmddata(struct spi_dev_s *dev, uint32_t devid, bool cmd);
 #endif
 #endif
 
 #ifdef CONFIG_PIC32MZ_SPI3
-void pic32mz_spi3select(FAR struct spi_dev_s *dev, uint32_t devid,
+void pic32mz_spi3select(struct spi_dev_s *dev, uint32_t devid,
                         bool selected);
-uint8_t pic32mz_spi3status(FAR struct spi_dev_s *dev, uint32_t devid);
+uint8_t pic32mz_spi3status(struct spi_dev_s *dev, uint32_t devid);
 #ifdef CONFIG_SPI_CMDDATA
-int pic32mz_spi3cmddata(FAR struct spi_dev_s *dev, uint32_t devid, bool cmd);
+int pic32mz_spi3cmddata(struct spi_dev_s *dev, uint32_t devid, bool cmd);
 #endif
 #endif
 
 #ifdef CONFIG_PIC32MZ_SPI4
-void pic32mz_spi4select(FAR struct spi_dev_s *dev, uint32_t devid,
+void pic32mz_spi4select(struct spi_dev_s *dev, uint32_t devid,
                         bool selected);
-uint8_t pic32mz_spi4status(FAR struct spi_dev_s *dev, uint32_t devid);
+uint8_t pic32mz_spi4status(struct spi_dev_s *dev, uint32_t devid);
 #ifdef CONFIG_SPI_CMDDATA
-int pic32mz_spi4cmddata(FAR struct spi_dev_s *dev, uint32_t devid, bool cmd);
+int pic32mz_spi4cmddata(struct spi_dev_s *dev, uint32_t devid, bool cmd);
 #endif
 #endif
 
 #ifdef CONFIG_PIC32MZ_SPI5
-void pic32mz_spi5select(FAR struct spi_dev_s *dev, uint32_t devid,
+void pic32mz_spi5select(struct spi_dev_s *dev, uint32_t devid,
                         bool selected);
-uint8_t pic32mz_spi5status(FAR struct spi_dev_s *dev, uint32_t devid);
+uint8_t pic32mz_spi5status(struct spi_dev_s *dev, uint32_t devid);
 #ifdef CONFIG_SPI_CMDDATA
-int pic32mz_spi5cmddata(FAR struct spi_dev_s *dev, uint32_t devid, bool cmd);
+int pic32mz_spi5cmddata(struct spi_dev_s *dev, uint32_t devid, bool cmd);
 #endif
 #endif
 
 #ifdef CONFIG_PIC32MZ_SPI6
-void pic32mz_spi6select(FAR struct spi_dev_s *dev, uint32_t devid,
+void pic32mz_spi6select(struct spi_dev_s *dev, uint32_t devid,
                         bool selected);
-uint8_t pic32mz_spi6status(FAR struct spi_dev_s *dev, uint32_t devid);
+uint8_t pic32mz_spi6status(struct spi_dev_s *dev, uint32_t devid);
 #ifdef CONFIG_SPI_CMDDATA
-int pic32mz_spi6cmddata(FAR struct spi_dev_s *dev, uint32_t devid, bool cmd);
+int pic32mz_spi6cmddata(struct spi_dev_s *dev, uint32_t devid, bool cmd);
 #endif
 #endif
 
@@ -178,39 +178,39 @@ int pic32mz_spi6cmddata(FAR struct spi_dev_s *dev, uint32_t devid, bool cmd);
 
 #ifdef CONFIG_SPI_CALLBACK
 #ifdef CONFIG_PIC32MZ_SPI1
-int pic32mz_spi1register(FAR struct spi_dev_s *dev,
+int pic32mz_spi1register(struct spi_dev_s *dev,
                          spi_mediachange_t callback,
-                         FAR void *arg);
+                         void *arg);
 #endif
 
 #ifdef CONFIG_PIC32MZ_SPI2
-int pic32mz_spi2register(FAR struct spi_dev_s *dev,
+int pic32mz_spi2register(struct spi_dev_s *dev,
                          spi_mediachange_t callback,
-                         FAR void *arg);
+                         void *arg);
 #endif
 
 #ifdef CONFIG_PIC32MZ_SPI3
-int pic32mz_spi3register(FAR struct spi_dev_s *dev,
+int pic32mz_spi3register(struct spi_dev_s *dev,
                          spi_mediachange_t callback,
-                         FAR void *arg);
+                         void *arg);
 #endif
 
 #ifdef CONFIG_PIC32MZ_SPI4
-int pic32mz_spi4register(FAR struct spi_dev_s *dev,
+int pic32mz_spi4register(struct spi_dev_s *dev,
                          spi_mediachange_t callback,
-                         FAR void *arg);
+                         void *arg);
 #endif
 
 #ifdef CONFIG_PIC32MZ_SPI5
-int pic32mz_spi5register(FAR struct spi_dev_s *dev,
+int pic32mz_spi5register(struct spi_dev_s *dev,
                          spi_mediachange_t callback,
-                         FAR void *arg);
+                         void *arg);
 #endif
 
 #ifdef CONFIG_PIC32MZ_SPI6
-int pic32mz_spi6register(FAR struct spi_dev_s *dev,
+int pic32mz_spi6register(struct spi_dev_s *dev,
                          spi_mediachange_t callback,
-                         FAR void *arg);
+                         void *arg);
 #endif
 #endif /* CONFIG_SPI_CALLBACK */
 

--- a/arch/mips/src/pic32mz/pic32mz_timer.c
+++ b/arch/mips/src/pic32mz/pic32mz_timer.c
@@ -126,46 +126,46 @@ struct pic32mz_timer_priv_s
 
 /* Helpers */
 
-static inline uint32_t pic32mz_getreg(FAR struct pic32mz_timer_dev_s *dev,
+static inline uint32_t pic32mz_getreg(struct pic32mz_timer_dev_s *dev,
                                       uint16_t offset);
-static inline void pic32mz_putreg(FAR struct pic32mz_timer_dev_s *dev,
+static inline void pic32mz_putreg(struct pic32mz_timer_dev_s *dev,
                                   uint16_t offset, uint32_t value);
-static inline bool pic32mz_timer_mode32(FAR struct pic32mz_timer_dev_s *dev);
+static inline bool pic32mz_timer_mode32(struct pic32mz_timer_dev_s *dev);
 static inline uint32_t pic32mz_timer_oddoffset(uint32_t evenoffset);
 static inline uint32_t
-  pic32mz_timer_nextirq(FAR struct pic32mz_timer_dev_s *dev);
+  pic32mz_timer_nextirq(struct pic32mz_timer_dev_s *dev);
 
-static void pic32mz_timer_stopinidle(FAR struct pic32mz_timer_dev_s *dev,
+static void pic32mz_timer_stopinidle(struct pic32mz_timer_dev_s *dev,
                                     bool stop);
-static void pic32mz_timer_enablegate(FAR struct pic32mz_timer_dev_s *dev,
+static void pic32mz_timer_enablegate(struct pic32mz_timer_dev_s *dev,
                                      bool enable);
-static void pic32mz_timer_setprescale(FAR struct pic32mz_timer_dev_s *dev,
+static void pic32mz_timer_setprescale(struct pic32mz_timer_dev_s *dev,
                                       uint8_t prescale);
-static void pic32mz_timer_setmode32(FAR struct pic32mz_timer_dev_s *dev,
+static void pic32mz_timer_setmode32(struct pic32mz_timer_dev_s *dev,
                                     bool enable);
-static void pic32mz_timer_extclocksource(FAR struct pic32mz_timer_dev_s *dev,
+static void pic32mz_timer_extclocksource(struct pic32mz_timer_dev_s *dev,
                                          bool enable);
-static void pic32mz_timer_inithardware(FAR struct pic32mz_timer_dev_s *dev);
+static void pic32mz_timer_inithardware(struct pic32mz_timer_dev_s *dev);
 
 /* Timer's methods */
 
-static void pic32mz_timer_start(FAR struct pic32mz_timer_dev_s *dev);
-static void pic32mz_timer_stop(FAR struct pic32mz_timer_dev_s *dev);
-static void pic32mz_timer_setperiod(FAR struct pic32mz_timer_dev_s *dev,
+static void pic32mz_timer_start(struct pic32mz_timer_dev_s *dev);
+static void pic32mz_timer_stop(struct pic32mz_timer_dev_s *dev);
+static void pic32mz_timer_setperiod(struct pic32mz_timer_dev_s *dev,
                                     uint32_t period);
 static
-uint32_t pic32mz_timer_getcounter(FAR struct pic32mz_timer_dev_s *dev);
-static void pic32mz_timer_setcounter(FAR struct pic32mz_timer_dev_s *dev,
+uint32_t pic32mz_timer_getcounter(struct pic32mz_timer_dev_s *dev);
+static void pic32mz_timer_setcounter(struct pic32mz_timer_dev_s *dev,
                                      uint32_t count);
-static uint32_t pic32mz_timer_getfreq(FAR struct pic32mz_timer_dev_s *dev);
-static bool pic32mz_timer_setfreq(FAR struct pic32mz_timer_dev_s *dev,
+static uint32_t pic32mz_timer_getfreq(struct pic32mz_timer_dev_s *dev);
+static bool pic32mz_timer_setfreq(struct pic32mz_timer_dev_s *dev,
                                   uint32_t freq);
-static uint8_t pic32mz_timer_getwidth(FAR struct pic32mz_timer_dev_s *dev);
+static uint8_t pic32mz_timer_getwidth(struct pic32mz_timer_dev_s *dev);
 
-static int  pic32mz_timer_setisr(FAR struct pic32mz_timer_dev_s *dev,
+static int  pic32mz_timer_setisr(struct pic32mz_timer_dev_s *dev,
                                  xcpt_t handler, void *arg);
-static void pic32mz_timer_ackint(FAR struct pic32mz_timer_dev_s *dev);
-static bool  pic32mz_timer_checkint(FAR struct pic32mz_timer_dev_s *dev);
+static void pic32mz_timer_ackint(struct pic32mz_timer_dev_s *dev);
+static bool  pic32mz_timer_checkint(struct pic32mz_timer_dev_s *dev);
 
 /****************************************************************************
  * Private Data
@@ -519,11 +519,11 @@ static struct pic32mz_timer_priv_s pic32mz_t9_priv =
  *
  ****************************************************************************/
 
-static inline uint32_t pic32mz_getreg(FAR struct pic32mz_timer_dev_s *dev,
+static inline uint32_t pic32mz_getreg(struct pic32mz_timer_dev_s *dev,
                                       uint16_t offset)
 {
-  FAR struct pic32mz_timer_priv_s *priv =
-    (FAR struct pic32mz_timer_priv_s *)dev;
+  struct pic32mz_timer_priv_s *priv =
+    (struct pic32mz_timer_priv_s *)dev;
 
   return getreg32(priv->config->base + offset);
 }
@@ -536,11 +536,11 @@ static inline uint32_t pic32mz_getreg(FAR struct pic32mz_timer_dev_s *dev,
  *
  ****************************************************************************/
 
-static inline void pic32mz_putreg(FAR struct pic32mz_timer_dev_s *dev,
+static inline void pic32mz_putreg(struct pic32mz_timer_dev_s *dev,
                                   uint16_t offset, uint32_t value)
 {
-  FAR struct pic32mz_timer_priv_s *priv =
-    (FAR struct pic32mz_timer_priv_s *)dev;
+  struct pic32mz_timer_priv_s *priv =
+    (struct pic32mz_timer_priv_s *)dev;
 
   putreg32(value, priv->config->base + offset);
 }
@@ -553,9 +553,9 @@ static inline void pic32mz_putreg(FAR struct pic32mz_timer_dev_s *dev,
  *
  ****************************************************************************/
 
-static inline bool pic32mz_timer_mode32(FAR struct pic32mz_timer_dev_s *dev)
+static inline bool pic32mz_timer_mode32(struct pic32mz_timer_dev_s *dev)
 {
-  return ((FAR struct pic32mz_timer_priv_s *)dev)->config->mode32;
+  return ((struct pic32mz_timer_priv_s *)dev)->config->mode32;
 }
 
 /****************************************************************************
@@ -588,11 +588,11 @@ static inline uint32_t pic32mz_timer_oddoffset(uint32_t evenoffset)
  ****************************************************************************/
 
 static inline uint32_t
-  pic32mz_timer_nextirq(FAR struct pic32mz_timer_dev_s *dev)
+  pic32mz_timer_nextirq(struct pic32mz_timer_dev_s *dev)
 {
   uint32_t irq;
 
-  irq = ((FAR struct pic32mz_timer_priv_s *)dev)->config->irq;
+  irq = ((struct pic32mz_timer_priv_s *)dev)->config->irq;
 
   /* The irq offsets between odd and even timers
    * are not always the same.
@@ -616,7 +616,7 @@ static inline uint32_t
  *
  ****************************************************************************/
 
-static void pic32mz_timer_start(FAR struct pic32mz_timer_dev_s *dev)
+static void pic32mz_timer_start(struct pic32mz_timer_dev_s *dev)
 {
   pic32mz_putreg(dev, PIC32MZ_TIMER_CONSET_OFFSET, TIMER_CON_ON);
 }
@@ -629,7 +629,7 @@ static void pic32mz_timer_start(FAR struct pic32mz_timer_dev_s *dev)
  *
  ****************************************************************************/
 
-static void pic32mz_timer_stop(FAR struct pic32mz_timer_dev_s *dev)
+static void pic32mz_timer_stop(struct pic32mz_timer_dev_s *dev)
 {
   pic32mz_putreg(dev, PIC32MZ_TIMER_CONCLR_OFFSET, TIMER_CON_ON);
 }
@@ -642,7 +642,7 @@ static void pic32mz_timer_stop(FAR struct pic32mz_timer_dev_s *dev)
  *
  ****************************************************************************/
 
-static void pic32mz_timer_stopinidle(FAR struct pic32mz_timer_dev_s *dev,
+static void pic32mz_timer_stopinidle(struct pic32mz_timer_dev_s *dev,
                                      bool stop)
 {
   if (stop)
@@ -665,7 +665,7 @@ static void pic32mz_timer_stopinidle(FAR struct pic32mz_timer_dev_s *dev,
         }
     }
 
-  ((FAR struct pic32mz_timer_priv_s *)dev)->config->stopinidle = stop;
+  ((struct pic32mz_timer_priv_s *)dev)->config->stopinidle = stop;
 }
 
 /****************************************************************************
@@ -677,11 +677,11 @@ static void pic32mz_timer_stopinidle(FAR struct pic32mz_timer_dev_s *dev,
  *
  ****************************************************************************/
 
-static void pic32mz_timer_enablegate(FAR struct pic32mz_timer_dev_s *dev,
+static void pic32mz_timer_enablegate(struct pic32mz_timer_dev_s *dev,
                                      bool enable)
 {
-  FAR struct pic32mz_timer_priv_s *priv =
-    (FAR struct pic32mz_timer_priv_s *)dev;
+  struct pic32mz_timer_priv_s *priv =
+    (struct pic32mz_timer_priv_s *)dev;
 
   if (enable)
     {
@@ -708,13 +708,13 @@ static void pic32mz_timer_enablegate(FAR struct pic32mz_timer_dev_s *dev,
  *
  ****************************************************************************/
 
-static void pic32mz_timer_setprescale(FAR struct pic32mz_timer_dev_s *dev,
+static void pic32mz_timer_setprescale(struct pic32mz_timer_dev_s *dev,
                                       uint8_t prescale)
 {
   pic32mz_putreg(dev, PIC32MZ_TIMER_CONSET_OFFSET,
                  (prescale << TIMER_CON_TCKPS_SHIFT));
 
-  ((FAR struct pic32mz_timer_priv_s *)dev)->config->prescale = prescale;
+  ((struct pic32mz_timer_priv_s *)dev)->config->prescale = prescale;
 }
 
 /****************************************************************************
@@ -726,7 +726,7 @@ static void pic32mz_timer_setprescale(FAR struct pic32mz_timer_dev_s *dev,
  *
  ****************************************************************************/
 
-static void pic32mz_timer_setmode32(FAR struct pic32mz_timer_dev_s *dev,
+static void pic32mz_timer_setmode32(struct pic32mz_timer_dev_s *dev,
                                     bool enable)
 {
   /* Only even timers have the TIMER_CON_T32 bit. */
@@ -740,7 +740,7 @@ static void pic32mz_timer_setmode32(FAR struct pic32mz_timer_dev_s *dev,
       pic32mz_putreg(dev, PIC32MZ_TIMER_CONCLR_OFFSET, TIMER_CON_T32);
     }
 
-  ((FAR struct pic32mz_timer_priv_s *)dev)->config->mode32 = enable;
+  ((struct pic32mz_timer_priv_s *)dev)->config->mode32 = enable;
 }
 
 /****************************************************************************
@@ -751,11 +751,11 @@ static void pic32mz_timer_setmode32(FAR struct pic32mz_timer_dev_s *dev,
  *
  ****************************************************************************/
 
-static void pic32mz_timer_extclocksource(FAR struct pic32mz_timer_dev_s *dev,
+static void pic32mz_timer_extclocksource(struct pic32mz_timer_dev_s *dev,
                                          bool enable)
 {
-  FAR struct pic32mz_timer_priv_s *priv =
-    (FAR struct pic32mz_timer_priv_s *)dev;
+  struct pic32mz_timer_priv_s *priv =
+    (struct pic32mz_timer_priv_s *)dev;
 
   if (enable)
     {
@@ -784,10 +784,10 @@ static void pic32mz_timer_extclocksource(FAR struct pic32mz_timer_dev_s *dev,
  *
  ****************************************************************************/
 
-static void pic32mz_timer_inithardware(FAR struct pic32mz_timer_dev_s *dev)
+static void pic32mz_timer_inithardware(struct pic32mz_timer_dev_s *dev)
 {
-  FAR struct pic32mz_timer_priv_s *priv =
-    (FAR struct pic32mz_timer_priv_s *)dev;
+  struct pic32mz_timer_priv_s *priv =
+    (struct pic32mz_timer_priv_s *)dev;
 
   /* Initialize the hardware using the startup configuration.
    *
@@ -828,7 +828,7 @@ static void pic32mz_timer_inithardware(FAR struct pic32mz_timer_dev_s *dev)
  *
  ****************************************************************************/
 
-static void pic32mz_timer_setperiod(FAR struct pic32mz_timer_dev_s *dev,
+static void pic32mz_timer_setperiod(struct pic32mz_timer_dev_s *dev,
                                     uint32_t period)
 {
   /* In 32bit mode:
@@ -857,7 +857,7 @@ static void pic32mz_timer_setperiod(FAR struct pic32mz_timer_dev_s *dev,
  *
  ****************************************************************************/
 
-static uint32_t pic32mz_timer_getcounter(FAR struct pic32mz_timer_dev_s *dev)
+static uint32_t pic32mz_timer_getcounter(struct pic32mz_timer_dev_s *dev)
 {
   /* In 32bit mode:
    *  - even timers represent the least significant half words.
@@ -890,7 +890,7 @@ static uint32_t pic32mz_timer_getcounter(FAR struct pic32mz_timer_dev_s *dev)
  *
  ****************************************************************************/
 
-static void pic32mz_timer_setcounter(FAR struct pic32mz_timer_dev_s *dev,
+static void pic32mz_timer_setcounter(struct pic32mz_timer_dev_s *dev,
                                      uint32_t count)
 {
   /* In 32bit mode:
@@ -919,12 +919,12 @@ static void pic32mz_timer_setcounter(FAR struct pic32mz_timer_dev_s *dev,
  *
  ****************************************************************************/
 
-static uint32_t pic32mz_timer_getfreq(FAR struct pic32mz_timer_dev_s *dev)
+static uint32_t pic32mz_timer_getfreq(struct pic32mz_timer_dev_s *dev)
 {
   uint8_t prescale;
   uint32_t freq;
 
-  prescale = ((FAR struct pic32mz_timer_priv_s *)dev)->config->prescale;
+  prescale = ((struct pic32mz_timer_priv_s *)dev)->config->prescale;
 
   /* The prescale values are not a continuous power of 2.
    * There is a gap between 64 and 256 (the 128 is skipped).
@@ -950,7 +950,7 @@ static uint32_t pic32mz_timer_getfreq(FAR struct pic32mz_timer_dev_s *dev)
  *
  ****************************************************************************/
 
-static bool pic32mz_timer_setfreq(FAR struct pic32mz_timer_dev_s *dev,
+static bool pic32mz_timer_setfreq(struct pic32mz_timer_dev_s *dev,
                                   uint32_t freq)
 {
   uint16_t prescale;
@@ -1038,7 +1038,7 @@ static bool pic32mz_timer_setfreq(FAR struct pic32mz_timer_dev_s *dev,
  *
  ****************************************************************************/
 
-static uint8_t pic32mz_timer_getwidth(FAR struct pic32mz_timer_dev_s *dev)
+static uint8_t pic32mz_timer_getwidth(struct pic32mz_timer_dev_s *dev)
 {
   return pic32mz_timer_mode32(dev) ? 32 : 16;
 }
@@ -1051,11 +1051,11 @@ static uint8_t pic32mz_timer_getwidth(FAR struct pic32mz_timer_dev_s *dev)
  *
  ****************************************************************************/
 
-static int  pic32mz_timer_setisr(FAR struct pic32mz_timer_dev_s *dev,
-                                 xcpt_t handler, FAR void *arg)
+static int  pic32mz_timer_setisr(struct pic32mz_timer_dev_s *dev,
+                                 xcpt_t handler, void *arg)
 {
-  FAR struct pic32mz_timer_priv_s *priv =
-    (FAR struct pic32mz_timer_priv_s *)dev;
+  struct pic32mz_timer_priv_s *priv =
+    (struct pic32mz_timer_priv_s *)dev;
 
   /* Disable interrupt when callback is removed */
 
@@ -1108,9 +1108,9 @@ static int  pic32mz_timer_setisr(FAR struct pic32mz_timer_dev_s *dev,
  *
  ****************************************************************************/
 
-static void pic32mz_timer_ackint(FAR struct pic32mz_timer_dev_s *dev)
+static void pic32mz_timer_ackint(struct pic32mz_timer_dev_s *dev)
 {
-  up_clrpend_irq(((FAR struct pic32mz_timer_priv_s *)dev)->config->irq);
+  up_clrpend_irq(((struct pic32mz_timer_priv_s *)dev)->config->irq);
 
   if (pic32mz_timer_mode32(dev))
     {
@@ -1128,7 +1128,7 @@ static void pic32mz_timer_ackint(FAR struct pic32mz_timer_dev_s *dev)
  *
  ****************************************************************************/
 
-static bool  pic32mz_timer_checkint(FAR struct pic32mz_timer_dev_s *dev)
+static bool  pic32mz_timer_checkint(struct pic32mz_timer_dev_s *dev)
 {
   if (pic32mz_timer_mode32(dev))
     {
@@ -1138,8 +1138,8 @@ static bool  pic32mz_timer_checkint(FAR struct pic32mz_timer_dev_s *dev)
     }
   else
     {
-      FAR struct pic32mz_timer_priv_s *priv =
-          (FAR struct pic32mz_timer_priv_s *)dev;
+      struct pic32mz_timer_priv_s *priv =
+          (struct pic32mz_timer_priv_s *)dev;
 
       return up_pending_irq(priv->config->irq);
     }
@@ -1153,7 +1153,7 @@ static bool  pic32mz_timer_checkint(FAR struct pic32mz_timer_dev_s *dev)
  * Name: pic32mz_timer_init
  ****************************************************************************/
 
-FAR struct pic32mz_timer_dev_s *pic32mz_timer_init(int timer)
+struct pic32mz_timer_dev_s *pic32mz_timer_init(int timer)
 {
   struct pic32mz_timer_dev_s *dev = NULL;
 
@@ -1161,49 +1161,49 @@ FAR struct pic32mz_timer_dev_s *pic32mz_timer_init(int timer)
     {
 #ifdef CONFIG_PIC32MZ_T2
       case 2:
-        dev = (FAR struct pic32mz_timer_dev_s *)&pic32mz_t2_priv;
+        dev = (struct pic32mz_timer_dev_s *)&pic32mz_t2_priv;
         break;
 #endif
 #ifdef CONFIG_PIC32MZ_T3
       case 3:
-        dev = (FAR struct pic32mz_timer_dev_s *)&pic32mz_t3_priv;
+        dev = (struct pic32mz_timer_dev_s *)&pic32mz_t3_priv;
         break;
 #endif
 #ifdef CONFIG_PIC32MZ_T4
       case 4:
-        dev = (FAR struct pic32mz_timer_dev_s *)&pic32mz_t4_priv;
+        dev = (struct pic32mz_timer_dev_s *)&pic32mz_t4_priv;
         break;
 #endif
 #ifdef CONFIG_PIC32MZ_T5
       case 5:
-        dev = (FAR struct pic32mz_timer_dev_s *)&pic32mz_t5_priv;
+        dev = (struct pic32mz_timer_dev_s *)&pic32mz_t5_priv;
         break;
 #endif
 #ifdef CONFIG_PIC32MZ_T6
       case 6:
-        dev = (FAR struct pic32mz_timer_dev_s *)&pic32mz_t6_priv;
+        dev = (struct pic32mz_timer_dev_s *)&pic32mz_t6_priv;
         break;
 #endif
 #ifdef CONFIG_PIC32MZ_T7
       case 7:
-        dev = (FAR struct pic32mz_timer_dev_s *)&pic32mz_t7_priv;
+        dev = (struct pic32mz_timer_dev_s *)&pic32mz_t7_priv;
         break;
 #endif
 #ifdef CONFIG_PIC32MZ_T8
       case 8:
-        dev = (FAR struct pic32mz_timer_dev_s *)&pic32mz_t8_priv;
+        dev = (struct pic32mz_timer_dev_s *)&pic32mz_t8_priv;
         break;
 #endif
 #ifdef CONFIG_PIC32MZ_T9
       case 9:
-        dev = (FAR struct pic32mz_timer_dev_s *)&pic32mz_t9_priv;
+        dev = (struct pic32mz_timer_dev_s *)&pic32mz_t9_priv;
         break;
 #endif
       default:
         return NULL;
     }
 
-  if (((FAR struct pic32mz_timer_priv_s *)dev)->inuse)
+  if (((struct pic32mz_timer_priv_s *)dev)->inuse)
     {
       return NULL;
     }
@@ -1213,20 +1213,20 @@ FAR struct pic32mz_timer_dev_s *pic32mz_timer_init(int timer)
 
       pic32mz_timer_inithardware(dev);
 
-      ((FAR struct pic32mz_timer_priv_s *)dev)->inuse = true;
+      ((struct pic32mz_timer_priv_s *)dev)->inuse = true;
 
       return dev;
     }
 }
 
-int pic32mz_timer_deinit(FAR struct pic32mz_timer_dev_s *dev)
+int pic32mz_timer_deinit(struct pic32mz_timer_dev_s *dev)
 {
   /* Stop the timer in case it was still running
    * and mark it as unused.
    */
 
   pic32mz_timer_stop(dev);
-  ((FAR struct pic32mz_timer_priv_s *)dev)->inuse = false;
+  ((struct pic32mz_timer_priv_s *)dev)->inuse = false;
 
   return OK;
 }

--- a/arch/mips/src/pic32mz/pic32mz_timer.h
+++ b/arch/mips/src/pic32mz/pic32mz_timer.h
@@ -69,28 +69,28 @@ struct pic32mz_timer_ops_s
 {
   /* Timer's methods */
 
-  void     (*start)(FAR struct pic32mz_timer_dev_s *dev);
-  void     (*stop)(FAR struct pic32mz_timer_dev_s *dev);
-  void     (*setperiod)(FAR struct pic32mz_timer_dev_s *dev, uint32_t p);
-  uint32_t (*getcounter)(FAR struct pic32mz_timer_dev_s *dev);
-  void     (*setcounter)(FAR struct pic32mz_timer_dev_s *dev, uint32_t c);
-  uint32_t (*getfreq)(FAR struct pic32mz_timer_dev_s *dev);
-  bool     (*setfreq)(FAR struct pic32mz_timer_dev_s *dev, uint32_t freq);
-  uint8_t  (*getwidth)(FAR struct pic32mz_timer_dev_s *dev);
+  void     (*start)(struct pic32mz_timer_dev_s *dev);
+  void     (*stop)(struct pic32mz_timer_dev_s *dev);
+  void     (*setperiod)(struct pic32mz_timer_dev_s *dev, uint32_t p);
+  uint32_t (*getcounter)(struct pic32mz_timer_dev_s *dev);
+  void     (*setcounter)(struct pic32mz_timer_dev_s *dev, uint32_t c);
+  uint32_t (*getfreq)(struct pic32mz_timer_dev_s *dev);
+  bool     (*setfreq)(struct pic32mz_timer_dev_s *dev, uint32_t freq);
+  uint8_t  (*getwidth)(struct pic32mz_timer_dev_s *dev);
 
   /* Timer's interrupts */
 
-  int      (*setisr)(FAR struct pic32mz_timer_dev_s *dev, xcpt_t handler,
+  int      (*setisr)(struct pic32mz_timer_dev_s *dev, xcpt_t handler,
                      void * arg);
-  void     (*ackint)(FAR struct pic32mz_timer_dev_s *dev);
-  bool     (*checkint)(FAR struct pic32mz_timer_dev_s *dev);
+  void     (*ackint)(struct pic32mz_timer_dev_s *dev);
+  bool     (*checkint)(struct pic32mz_timer_dev_s *dev);
 };
 
 /* Timer's Device Structure */
 
 struct pic32mz_timer_dev_s
 {
-  FAR struct pic32mz_timer_ops_s *ops;
+  struct pic32mz_timer_ops_s *ops;
 };
 
 /****************************************************************************
@@ -105,7 +105,7 @@ struct pic32mz_timer_dev_s
  *
  ****************************************************************************/
 
-FAR struct pic32mz_timer_dev_s *pic32mz_timer_init(int timer);
+struct pic32mz_timer_dev_s *pic32mz_timer_init(int timer);
 
 /****************************************************************************
  * Name: pic32mz_timer_deinit
@@ -115,7 +115,7 @@ FAR struct pic32mz_timer_dev_s *pic32mz_timer_init(int timer);
  *
  ****************************************************************************/
 
-int pic32mz_timer_deinit(FAR struct pic32mz_timer_dev_s *dev);
+int pic32mz_timer_deinit(struct pic32mz_timer_dev_s *dev);
 
 /****************************************************************************
  * Name: pic32mz_timer_initialize
@@ -136,7 +136,7 @@ int pic32mz_timer_deinit(FAR struct pic32mz_timer_dev_s *dev);
  ****************************************************************************/
 
 #ifdef CONFIG_TIMER
-int pic32mz_timer_initialize(FAR const char *devpath, int timer);
+int pic32mz_timer_initialize(const char *devpath, int timer);
 #endif
 
 #undef EXTERN

--- a/arch/mips/src/pic32mz/pic32mz_usbdev.h
+++ b/arch/mips/src/pic32mz/pic32mz_usbdev.h
@@ -71,7 +71,7 @@ extern "C"
 
 #ifdef CONFIG_PIC32MZ_USBDEV
 struct usbdev_s;
-int pic32mz_usbpullup(FAR struct usbdev_s *dev,  bool enable);
+int pic32mz_usbpullup(struct usbdev_s *dev,  bool enable);
 #endif
 
 /************************************************************************************
@@ -86,7 +86,7 @@ int pic32mz_usbpullup(FAR struct usbdev_s *dev,  bool enable);
  ************************************************************************************/
 
 #ifdef CONFIG_PIC32MZ_USBDEV
-void pic32mz_usbsuspend(FAR struct usbdev_s *dev, bool resume);
+void pic32mz_usbsuspend(struct usbdev_s *dev, bool resume);
 #endif
 
 /************************************************************************************

--- a/arch/misoc/src/common/misoc_net.c
+++ b/arch/misoc/src/common/misoc_net.c
@@ -88,7 +88,7 @@
 
 /* This is a helper pointer for accessing the contents of Ethernet header */
 
-#define BUF ((FAR struct eth_hdr_s *)priv->misoc_net_dev.d_buf)
+#define BUF ((struct eth_hdr_s *)priv->misoc_net_dev.d_buf)
 
 /****************************************************************************
  * Private Types
@@ -135,42 +135,42 @@ static struct misoc_net_driver_s g_misoc_net[CONFIG_MISOC_NET_NINTERFACES];
 
 /* Common TX logic */
 
-static int  misoc_net_transmit(FAR struct misoc_net_driver_s *priv);
-static int  misoc_net_txpoll(FAR struct net_driver_s *dev);
+static int  misoc_net_transmit(struct misoc_net_driver_s *priv);
+static int  misoc_net_txpoll(struct net_driver_s *dev);
 
 /* Interrupt handling */
 
-static void misoc_net_receive(FAR struct misoc_net_driver_s *priv);
-static void misoc_net_txdone(FAR struct misoc_net_driver_s *priv);
+static void misoc_net_receive(struct misoc_net_driver_s *priv);
+static void misoc_net_txdone(struct misoc_net_driver_s *priv);
 
-static void misoc_net_interrupt_work(FAR void *arg);
-static int  misoc_net_interrupt(int irq, FAR void *context, FAR void *arg);
+static void misoc_net_interrupt_work(void *arg);
+static int  misoc_net_interrupt(int irq, void *context, void *arg);
 
 /* Watchdog timer expirations */
 
-static void misoc_net_txtimeout_work(FAR void *arg);
+static void misoc_net_txtimeout_work(void *arg);
 static void misoc_net_txtimeout_expiry(wdparm_t arg);
 
-static void misoc_net_poll_work(FAR void *arg);
+static void misoc_net_poll_work(void *arg);
 static void misoc_net_poll_expiry(wdparm_t arg);
 
 /* NuttX callback functions */
 
-static int misoc_net_ifup(FAR struct net_driver_s *dev);
-static int misoc_net_ifdown(FAR struct net_driver_s *dev);
+static int misoc_net_ifup(struct net_driver_s *dev);
+static int misoc_net_ifdown(struct net_driver_s *dev);
 
-static void misoc_net_txavail_work(FAR void *arg);
-static int misoc_net_txavail(FAR struct net_driver_s *dev);
+static void misoc_net_txavail_work(void *arg);
+static int misoc_net_txavail(struct net_driver_s *dev);
 
 #if defined(CONFIG_NET_MCASTGROUP) || defined(CONFIG_NET_ICMPv6)
-static int misoc_net_addmac(FAR struct net_driver_s *dev,
-                            FAR const uint8_t *mac);
+static int misoc_net_addmac(struct net_driver_s *dev,
+                            const uint8_t *mac);
 #ifdef CONFIG_NET_MCASTGROUP
-static int misoc_net_rmmac(FAR struct net_driver_s *dev,
-                           FAR const uint8_t *mac);
+static int misoc_net_rmmac(struct net_driver_s *dev,
+                           const uint8_t *mac);
 #endif
 #ifdef CONFIG_NET_ICMPv6
-static void misoc_net_ipv6multicast(FAR struct misoc_net_driver_s *priv);
+static void misoc_net_ipv6multicast(struct misoc_net_driver_s *priv);
 #endif
 #endif
 
@@ -197,7 +197,7 @@ static void misoc_net_ipv6multicast(FAR struct misoc_net_driver_s *priv);
  *
  ****************************************************************************/
 
-static int misoc_net_transmit(FAR struct misoc_net_driver_s *priv)
+static int misoc_net_transmit(struct misoc_net_driver_s *priv)
 {
   /* Verify that the hardware is ready to send another packet.  If we get
    * here, then we are committed to sending a packet; Higher level logic
@@ -286,10 +286,10 @@ static int misoc_net_transmit(FAR struct misoc_net_driver_s *priv)
  *
  ****************************************************************************/
 
-static int misoc_net_txpoll(FAR struct net_driver_s *dev)
+static int misoc_net_txpoll(struct net_driver_s *dev)
 {
-  FAR struct misoc_net_driver_s *priv =
-    (FAR struct misoc_net_driver_s *)dev->d_private;
+  struct misoc_net_driver_s *priv =
+    (struct misoc_net_driver_s *)dev->d_private;
 
   /* If the polling resulted in data that should be sent out on the network,
    * the field d_len is set to a value > 0.
@@ -355,7 +355,7 @@ static int misoc_net_txpoll(FAR struct net_driver_s *dev)
  *
  ****************************************************************************/
 
-static void misoc_net_receive(FAR struct misoc_net_driver_s *priv)
+static void misoc_net_receive(struct misoc_net_driver_s *priv)
 {
   uint8_t rxslot;
   uint32_t rxlen;
@@ -529,7 +529,7 @@ static void misoc_net_receive(FAR struct misoc_net_driver_s *priv)
  *
  ****************************************************************************/
 
-static void misoc_net_txdone(FAR struct misoc_net_driver_s *priv)
+static void misoc_net_txdone(struct misoc_net_driver_s *priv)
 {
   /* Check for errors and update statistics */
 
@@ -569,9 +569,9 @@ static void misoc_net_txdone(FAR struct misoc_net_driver_s *priv)
  *
  ****************************************************************************/
 
-static void misoc_net_interrupt_work(FAR void *arg)
+static void misoc_net_interrupt_work(void *arg)
 {
-  FAR struct misoc_net_driver_s *priv = (FAR struct misoc_net_driver_s *)arg;
+  struct misoc_net_driver_s *priv = (struct misoc_net_driver_s *)arg;
 
   /* Process pending Ethernet interrupts */
 
@@ -624,9 +624,9 @@ static void misoc_net_interrupt_work(FAR void *arg)
  *
  ****************************************************************************/
 
-static int misoc_net_interrupt(int irq, FAR void *context, FAR void *arg)
+static int misoc_net_interrupt(int irq, void *context, void *arg)
 {
-  FAR struct misoc_net_driver_s *priv = &g_misoc_net[0];
+  struct misoc_net_driver_s *priv = &g_misoc_net[0];
 
   /* Disable further Ethernet interrupts.  Because Ethernet interrupts are
    * also disabled if the TX timeout event occurs, there can be no race
@@ -672,9 +672,9 @@ static int misoc_net_interrupt(int irq, FAR void *context, FAR void *arg)
  *
  ****************************************************************************/
 
-static void misoc_net_txtimeout_work(FAR void *arg)
+static void misoc_net_txtimeout_work(void *arg)
 {
-  FAR struct misoc_net_driver_s *priv = (FAR struct misoc_net_driver_s *)arg;
+  struct misoc_net_driver_s *priv = (struct misoc_net_driver_s *)arg;
 
   /* Increment statistics and dump debug info */
 
@@ -709,7 +709,7 @@ static void misoc_net_txtimeout_work(FAR void *arg)
 
 static void misoc_net_txtimeout_expiry(wdparm_t arg)
 {
-  FAR struct misoc_net_driver_s *priv = (FAR struct misoc_net_driver_s *)arg;
+  struct misoc_net_driver_s *priv = (struct misoc_net_driver_s *)arg;
 
 #if 0 /* REVISIT */
   /* Disable further Ethernet interrupts.  This will prevent some race
@@ -743,9 +743,9 @@ static void misoc_net_txtimeout_expiry(wdparm_t arg)
  *
  ****************************************************************************/
 
-static void misoc_net_poll_work(FAR void *arg)
+static void misoc_net_poll_work(void *arg)
 {
-  FAR struct misoc_net_driver_s *priv = (FAR struct misoc_net_driver_s *)arg;
+  struct misoc_net_driver_s *priv = (struct misoc_net_driver_s *)arg;
 
   /* Perform the poll */
 
@@ -789,7 +789,7 @@ static void misoc_net_poll_work(FAR void *arg)
 
 static void misoc_net_poll_expiry(wdparm_t arg)
 {
-  FAR struct misoc_net_driver_s *priv = (FAR struct misoc_net_driver_s *)arg;
+  struct misoc_net_driver_s *priv = (struct misoc_net_driver_s *)arg;
 
   /* Schedule to perform the interrupt processing on the worker thread. */
 
@@ -814,11 +814,11 @@ static void misoc_net_poll_expiry(wdparm_t arg)
  *
  ****************************************************************************/
 
-static int misoc_net_ifup(FAR struct net_driver_s *dev)
+static int misoc_net_ifup(struct net_driver_s *dev)
 {
   irqstate_t flags;
-  FAR struct misoc_net_driver_s *priv =
-    (FAR struct misoc_net_driver_s *)dev->d_private;
+  struct misoc_net_driver_s *priv =
+    (struct misoc_net_driver_s *)dev->d_private;
 
 #ifdef CONFIG_NET_IPv4
   ninfo("Bringing up: %d.%d.%d.%d\n",
@@ -877,10 +877,10 @@ static int misoc_net_ifup(FAR struct net_driver_s *dev)
  *
  ****************************************************************************/
 
-static int misoc_net_ifdown(FAR struct net_driver_s *dev)
+static int misoc_net_ifdown(struct net_driver_s *dev)
 {
-  FAR struct misoc_net_driver_s *priv =
-    (FAR struct misoc_net_driver_s *)dev->d_private;
+  struct misoc_net_driver_s *priv =
+    (struct misoc_net_driver_s *)dev->d_private;
   irqstate_t flags;
 
   /* Disable the Ethernet interrupt */
@@ -925,10 +925,10 @@ static int misoc_net_ifdown(FAR struct net_driver_s *dev)
  *
  ****************************************************************************/
 
-static void misoc_net_txavail_work(FAR void *arg)
+static void misoc_net_txavail_work(void *arg)
 {
-  FAR struct misoc_net_driver_s *priv =
-    (FAR struct misoc_net_driver_s *)arg;
+  struct misoc_net_driver_s *priv =
+    (struct misoc_net_driver_s *)arg;
 
   /* Ignore the notification if the interface is not yet up */
 
@@ -967,10 +967,10 @@ static void misoc_net_txavail_work(FAR void *arg)
  *
  ****************************************************************************/
 
-static int misoc_net_txavail(FAR struct net_driver_s *dev)
+static int misoc_net_txavail(struct net_driver_s *dev)
 {
-  FAR struct misoc_net_driver_s *priv =
-    (FAR struct misoc_net_driver_s *)dev->d_private;
+  struct misoc_net_driver_s *priv =
+    (struct misoc_net_driver_s *)dev->d_private;
 
   /* Is our single work structure available?  It may not be if there are
    * pending interrupt actions and we will have to ignore the Tx
@@ -1007,11 +1007,11 @@ static int misoc_net_txavail(FAR struct net_driver_s *dev)
  ****************************************************************************/
 
 #if defined(CONFIG_NET_MCASTGROUP) || defined(CONFIG_NET_ICMPv6)
-static int misoc_net_addmac(FAR struct net_driver_s *dev,
-                            FAR const uint8_t *mac)
+static int misoc_net_addmac(struct net_driver_s *dev,
+                            const uint8_t *mac)
 {
-  FAR struct misoc_net_driver_s *priv =
-    (FAR struct misoc_net_driver_s *)dev->d_private;
+  struct misoc_net_driver_s *priv =
+    (struct misoc_net_driver_s *)dev->d_private;
 
   /* Add the MAC address to the hardware multicast routing table */
 
@@ -1038,11 +1038,11 @@ static int misoc_net_addmac(FAR struct net_driver_s *dev,
  ****************************************************************************/
 
 #ifdef CONFIG_NET_MCASTGROUP
-static int misoc_net_rmmac(FAR struct net_driver_s *dev,
-                           FAR const uint8_t *mac)
+static int misoc_net_rmmac(struct net_driver_s *dev,
+                           const uint8_t *mac)
 {
-  FAR struct misoc_net_driver_s *priv =
-    (FAR struct misoc_net_driver_s *)dev->d_private;
+  struct misoc_net_driver_s *priv =
+    (struct misoc_net_driver_s *)dev->d_private;
 
   /* Add the MAC address to the hardware multicast routing table */
 
@@ -1067,9 +1067,9 @@ static int misoc_net_rmmac(FAR struct net_driver_s *dev,
  ****************************************************************************/
 
 #ifdef CONFIG_NET_ICMPv6
-static void misoc_net_ipv6multicast(FAR struct misoc_net_driver_s *priv)
+static void misoc_net_ipv6multicast(struct misoc_net_driver_s *priv)
 {
-  FAR struct net_driver_s *dev;
+  struct net_driver_s *dev;
   uint16_t tmp16;
   uint8_t mac[6];
 
@@ -1146,7 +1146,7 @@ static void misoc_net_ipv6multicast(FAR struct misoc_net_driver_s *priv)
 
 int misoc_net_initialize(int intf)
 {
-  FAR struct misoc_net_driver_s *priv;
+  struct misoc_net_driver_s *priv;
 
   /* Get the interface structure associated with this interface number. */
 

--- a/arch/misoc/src/common/misoc_serial.c
+++ b/arch/misoc/src/common/misoc_serial.c
@@ -141,7 +141,7 @@ static int  misoc_setup(struct uart_dev_s *dev);
 static void misoc_shutdown(struct uart_dev_s *dev);
 static int  misoc_attach(struct uart_dev_s *dev);
 static void misoc_detach(struct uart_dev_s *dev);
-static int  misoc_uart_interrupt(int irq, void *context, FAR void *arg);
+static int  misoc_uart_interrupt(int irq, void *context, void *arg);
 static int  misoc_ioctl(struct file *filep, int cmd, unsigned long arg);
 static int  misoc_receive(struct uart_dev_s *dev, uint32_t *status);
 static void misoc_rxint(struct uart_dev_s *dev, bool enable);
@@ -335,7 +335,7 @@ static void misoc_detach(struct uart_dev_s *dev)
  *
  ****************************************************************************/
 
-static int misoc_uart_interrupt(int irq, void *context, FAR void *arg)
+static int misoc_uart_interrupt(int irq, void *context, void *arg)
 {
   struct uart_dev_s *dev = (struct uart_dev_s *)arg;
   uint32_t stat;

--- a/arch/misoc/src/lm32/lm32.h
+++ b/arch/misoc/src/lm32/lm32.h
@@ -115,7 +115,7 @@ uint32_t *lm32_doirq(int irq, uint32_t *regs);
 
 /* Software interrupts ******************************************************/
 
-int lm32_swint(int irq, FAR void *context, FAR void *arg);
+int lm32_swint(int irq, void *context, void *arg);
 
 /* Signal handling **********************************************************/
 

--- a/arch/misoc/src/lm32/lm32_allocateheap.c
+++ b/arch/misoc/src/lm32/lm32_allocateheap.c
@@ -64,9 +64,9 @@
  *
  ****************************************************************************/
 
-void up_allocate_heap(FAR void **heap_start, size_t *heap_size)
+void up_allocate_heap(void **heap_start, size_t *heap_size)
 {
   board_autoled_on(LED_HEAPALLOCATE);
-  *heap_start = (FAR void *)g_idle_topstack;
+  *heap_start = (void *)g_idle_topstack;
   *heap_size = CONFIG_RAM_END - g_idle_topstack;
 }

--- a/arch/misoc/src/lm32/lm32_assert.c
+++ b/arch/misoc/src/lm32/lm32_assert.c
@@ -104,7 +104,7 @@ static void _up_assert(void)
  ****************************************************************************/
 
 #ifdef CONFIG_ARCH_USBDUMP
-static int usbtrace_syslog(FAR const char *fmt, ...)
+static int usbtrace_syslog(const char *fmt, ...)
 {
   va_list ap;
 
@@ -116,7 +116,7 @@ static int usbtrace_syslog(FAR const char *fmt, ...)
   return OK;
 }
 
-static int assert_tracecallback(FAR struct usbtrace_s *trace, FAR void *arg)
+static int assert_tracecallback(struct usbtrace_s *trace, void *arg)
 {
   usbtrace_trprintf(usbtrace_syslog, trace->event, trace->value);
   return 0;

--- a/arch/misoc/src/lm32/lm32_createstack.c
+++ b/arch/misoc/src/lm32/lm32_createstack.c
@@ -79,7 +79,7 @@
  *
  ****************************************************************************/
 
-int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
+int up_create_stack(struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
 {
 #ifdef CONFIG_TLS_ALIGNED
   /* The allocated stack size must not exceed the maximum possible for the

--- a/arch/misoc/src/lm32/lm32_dumpstate.c
+++ b/arch/misoc/src/lm32/lm32_dumpstate.c
@@ -114,7 +114,7 @@ static inline void lm32_registerdump(void)
 
 void lm32_dumpstate(void)
 {
-  FAR struct tcb_s *rtcb = running_task();
+  struct tcb_s *rtcb = running_task();
   uint32_t sp = up_getsp();
   uint32_t ustackbase;
   uint32_t ustacksize;

--- a/arch/misoc/src/lm32/lm32_exit.c
+++ b/arch/misoc/src/lm32/lm32_exit.c
@@ -55,9 +55,9 @@
  ****************************************************************************/
 
 #ifdef CONFIG_DUMP_ON_EXIT
-static void _up_dumponexit(FAR struct tcb_s *tcb, FAR void *arg)
+static void _up_dumponexit(struct tcb_s *tcb, void *arg)
 {
-  FAR struct filelist *filelist;
+  struct filelist *filelist;
   int i;
   int j;
 

--- a/arch/misoc/src/lm32/lm32_releasestack.c
+++ b/arch/misoc/src/lm32/lm32_releasestack.c
@@ -67,7 +67,7 @@
  *
  ****************************************************************************/
 
-void up_release_stack(FAR struct tcb_s *dtcb, uint8_t ttype)
+void up_release_stack(struct tcb_s *dtcb, uint8_t ttype)
 {
   /* Is there a stack allocated? */
 

--- a/arch/misoc/src/lm32/lm32_stackframe.c
+++ b/arch/misoc/src/lm32/lm32_stackframe.c
@@ -68,9 +68,9 @@
  *
  ****************************************************************************/
 
-FAR void *up_stack_frame(FAR struct tcb_s *tcb, size_t frame_size)
+void *up_stack_frame(struct tcb_s *tcb, size_t frame_size)
 {
-  FAR void *ret;
+  void *ret;
 
   /* Align the frame_size */
 
@@ -88,7 +88,7 @@ FAR void *up_stack_frame(FAR struct tcb_s *tcb, size_t frame_size)
 
   /* Save the adjusted stack values in the struct tcb_s */
 
-  tcb->stack_base_ptr  = (FAR uint8_t *)tcb->stack_base_ptr + frame_size;
+  tcb->stack_base_ptr  = (uint8_t *)tcb->stack_base_ptr + frame_size;
   tcb->adj_stack_size -= frame_size;
 
   /* And return the pointer to the allocated region */

--- a/arch/misoc/src/lm32/lm32_swint.c
+++ b/arch/misoc/src/lm32/lm32_swint.c
@@ -127,7 +127,7 @@ static void dispatch_syscall(void)
  *
  ****************************************************************************/
 
-int lm32_swint(int irq, FAR void *context, FAR void *arg)
+int lm32_swint(int irq, void *context, void *arg)
 {
   uint32_t *regs = (uint32_t *)context;
 
@@ -244,7 +244,7 @@ int lm32_swint(int irq, FAR void *context, FAR void *arg)
       default:
         {
 #ifdef CONFIG_BUILD_KERNEL
-          FAR struct tcb_s *rtcb = nxsched_self();
+          struct tcb_s *rtcb = nxsched_self();
           int index = rtcb->xcp.nsyscalls;
 
           /* Verify that the SYS call number is within range */

--- a/arch/misoc/src/minerva/minerva.h
+++ b/arch/misoc/src/minerva/minerva.h
@@ -115,7 +115,7 @@ uint32_t *minerva_doirq(int irq, uint32_t * regs);
 
 /* Software interrupts ******************************************************/
 
-int minerva_swint(int irq, FAR void *context, FAR void *arg);
+int minerva_swint(int irq, void *context, void *arg);
 
 /* Signal handling **********************************************************/
 

--- a/arch/misoc/src/minerva/minerva_allocateheap.c
+++ b/arch/misoc/src/minerva/minerva_allocateheap.c
@@ -52,9 +52,9 @@
  *
  ****************************************************************************/
 
-void up_allocate_heap(FAR void **heap_start, size_t * heap_size)
+void up_allocate_heap(void **heap_start, size_t * heap_size)
 {
   board_autoled_on(LED_HEAPALLOCATE);
-  *heap_start = (FAR void *)g_idle_topstack;
+  *heap_start = (void *)g_idle_topstack;
   *heap_size = CONFIG_RAM_END - g_idle_topstack;
 }

--- a/arch/misoc/src/minerva/minerva_assert.c
+++ b/arch/misoc/src/minerva/minerva_assert.c
@@ -104,7 +104,7 @@ static void _up_assert(void)
  ****************************************************************************/
 
 #ifdef CONFIG_ARCH_USBDUMP
-static int usbtrace_syslog(FAR const char *fmt, ...)
+static int usbtrace_syslog(const char *fmt, ...)
 {
   va_list ap;
 
@@ -116,7 +116,7 @@ static int usbtrace_syslog(FAR const char *fmt, ...)
   return OK;
 }
 
-static int assert_tracecallback(FAR struct usbtrace_s *trace, FAR void *arg)
+static int assert_tracecallback(struct usbtrace_s *trace, void *arg)
 {
   usbtrace_trprintf(usbtrace_syslog, trace->event, trace->value);
   return 0;

--- a/arch/misoc/src/minerva/minerva_createstack.c
+++ b/arch/misoc/src/minerva/minerva_createstack.c
@@ -79,7 +79,7 @@
  *
  ****************************************************************************/
 
-int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
+int up_create_stack(struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
 {
 #ifdef CONFIG_TLS_ALIGNED
   /* The allocated stack size must not exceed the maximum possible for the

--- a/arch/misoc/src/minerva/minerva_dumpstate.c
+++ b/arch/misoc/src/minerva/minerva_dumpstate.c
@@ -113,7 +113,7 @@ static inline void mineva_registerdump(void)
 
 void minerva_dumpstate(void)
 {
-  FAR struct tcb_s *rtcb = running_task();
+  struct tcb_s *rtcb = running_task();
   uint32_t sp = up_getsp();
   uint32_t ustackbase;
   uint32_t ustacksize;

--- a/arch/misoc/src/minerva/minerva_exit.c
+++ b/arch/misoc/src/minerva/minerva_exit.c
@@ -55,9 +55,9 @@
  ****************************************************************************/
 
 #ifdef CONFIG_DUMP_ON_EXIT
-static void _up_dumponexit(FAR struct tcb_s *tcb, FAR void *arg)
+static void _up_dumponexit(struct tcb_s *tcb, void *arg)
 {
-  FAR struct filelist *filelist;
+  struct filelist *filelist;
   int i;
   int j;
 

--- a/arch/misoc/src/minerva/minerva_releasestack.c
+++ b/arch/misoc/src/minerva/minerva_releasestack.c
@@ -67,7 +67,7 @@
  *
  ****************************************************************************/
 
-void up_release_stack(FAR struct tcb_s *dtcb, uint8_t ttype)
+void up_release_stack(struct tcb_s *dtcb, uint8_t ttype)
 {
   /* Is there a stack allocated? */
 

--- a/arch/misoc/src/minerva/minerva_stackframe.c
+++ b/arch/misoc/src/minerva/minerva_stackframe.c
@@ -68,9 +68,9 @@
  *
  ****************************************************************************/
 
-FAR void *up_stack_frame(FAR struct tcb_s *tcb, size_t frame_size)
+void *up_stack_frame(struct tcb_s *tcb, size_t frame_size)
 {
-  FAR void *ret;
+  void *ret;
 
   /* Align the frame_size */
 
@@ -88,7 +88,7 @@ FAR void *up_stack_frame(FAR struct tcb_s *tcb, size_t frame_size)
 
   /* Save the adjusted stack values in the struct tcb_s */
 
-  tcb->stack_base_ptr  = (FAR uint8_t *)tcb->stack_base_ptr + frame_size;
+  tcb->stack_base_ptr  = (uint8_t *)tcb->stack_base_ptr + frame_size;
   tcb->adj_stack_size -= frame_size;
 
   /* And return the pointer to the allocated region */

--- a/arch/misoc/src/minerva/minerva_swint.c
+++ b/arch/misoc/src/minerva/minerva_swint.c
@@ -124,7 +124,7 @@ static void dispatch_syscall(void) naked_function;
  *
  ****************************************************************************/
 
-int minerva_swint(int irq, FAR void *context, FAR void *arg)
+int minerva_swint(int irq, void *context, void *arg)
 {
   uint32_t *regs = (uint32_t *) context;
 
@@ -220,7 +220,7 @@ int minerva_swint(int irq, FAR void *context, FAR void *arg)
     default:
       {
 #ifdef CONFIG_BUILD_KERNEL
-        FAR struct tcb_s *rtcb = nxsched_self();
+        struct tcb_s *rtcb = nxsched_self();
         int index = rtcb->xcp.nsyscalls;
 
         /* Verify that the SYS call number is within range */

--- a/arch/or1k/include/arch.h
+++ b/arch/or1k/include/arch.h
@@ -106,12 +106,12 @@ struct group_addrenv_s
 {
   /* Level 1 page table entries for each group section */
 
-  FAR uintptr_t *text[ARCH_TEXT_NSECTS];
-  FAR uintptr_t *data[ARCH_DATA_NSECTS];
+  uintptr_t *text[ARCH_TEXT_NSECTS];
+  uintptr_t *data[ARCH_DATA_NSECTS];
 #ifdef CONFIG_BUILD_KERNEL
-  FAR uintptr_t *heap[ARCH_HEAP_NSECTS];
+  uintptr_t *heap[ARCH_HEAP_NSECTS];
 #ifdef CONFIG_MM_SHM
-  FAR uintptr_t *shm[ARCH_SHM_NSECTS];
+  uintptr_t *shm[ARCH_SHM_NSECTS];
 #endif
 
   /* Initial heap allocation (in bytes).  This exists only provide an
@@ -137,12 +137,12 @@ typedef struct group_addrenv_s group_addrenv_t;
 
 struct save_addrenv_s
 {
-  FAR uint32_t text[ARCH_TEXT_NSECTS];
-  FAR uint32_t data[ARCH_DATA_NSECTS];
+  uint32_t text[ARCH_TEXT_NSECTS];
+  uint32_t data[ARCH_DATA_NSECTS];
 #ifdef CONFIG_BUILD_KERNEL
-  FAR uint32_t heap[ARCH_HEAP_NSECTS];
+  uint32_t heap[ARCH_HEAP_NSECTS];
 #ifdef CONFIG_MM_SHM
-  FAR uint32_t shm[ARCH_SHM_NSECTS];
+  uint32_t shm[ARCH_SHM_NSECTS];
 #endif
 #endif
 };

--- a/arch/or1k/src/common/up_allocateheap.c
+++ b/arch/or1k/src/common/up_allocateheap.c
@@ -97,9 +97,9 @@
  ****************************************************************************/
 
 #ifdef CONFIG_BUILD_KERNEL
-void up_allocate_kheap(FAR void **heap_start, size_t *heap_size)
+void up_allocate_kheap(void **heap_start, size_t *heap_size)
 #else
-void up_allocate_heap(FAR void **heap_start, size_t *heap_size)
+void up_allocate_heap(void **heap_start, size_t *heap_size)
 #endif
 {
 #if defined(CONFIG_BUILD_PROTECTED) && defined(CONFIG_MM_KERNEL_HEAP)
@@ -117,13 +117,13 @@ void up_allocate_heap(FAR void **heap_start, size_t *heap_size)
   /* Return the user-space heap settings */
 
   board_autoled_on(LED_HEAPALLOCATE);
-  *heap_start = (FAR void *)ubase;
+  *heap_start = (void *)ubase;
   *heap_size  = usize;
 #else
 
   /* Return the heap settings */
 
-  *heap_start = (FAR void *)g_idle_topstack;
+  *heap_start = (void *)g_idle_topstack;
   *heap_size  = CONFIG_RAM_END - *(uint32_t *)heap_start;
 
   board_autoled_on(LED_HEAPALLOCATE);
@@ -142,7 +142,7 @@ void up_allocate_heap(FAR void **heap_start, size_t *heap_size)
  ****************************************************************************/
 
 #if defined(CONFIG_BUILD_PROTECTED) && defined(CONFIG_MM_KERNEL_HEAP)
-void up_allocate_kheap(FAR void **heap_start, size_t *heap_size)
+void up_allocate_kheap(void **heap_start, size_t *heap_size)
 {
   /* Get the unaligned size and position of the user-space heap.
    * This heap begins after the user-space .bss section at an offset
@@ -157,7 +157,7 @@ void up_allocate_kheap(FAR void **heap_start, size_t *heap_size)
    * that was not dedicated to the user heap).
    */
 
-  *heap_start = (FAR void *)USERSPACE->us_bssend;
+  *heap_start = (void *)USERSPACE->us_bssend;
   *heap_size  = ubase - (uintptr_t)USERSPACE->us_bssend;
 }
 #endif

--- a/arch/or1k/src/common/up_assert.c
+++ b/arch/or1k/src/common/up_assert.c
@@ -94,7 +94,7 @@ static void or1k_stackdump(uint32_t sp, uint32_t stack_top)
  ****************************************************************************/
 
 #ifdef CONFIG_STACK_COLORATION
-static void up_taskdump(FAR struct tcb_s *tcb, FAR void *arg)
+static void up_taskdump(struct tcb_s *tcb, void *arg)
 {
   /* Dump interesting properties of this task */
 
@@ -167,7 +167,7 @@ static inline void or1k_registerdump(void)
  ****************************************************************************/
 
 #ifdef CONFIG_ARCH_USBDUMP
-static int usbtrace_syslog(FAR const char *fmt, ...)
+static int usbtrace_syslog(const char *fmt, ...)
 {
   va_list ap;
   int ret;
@@ -180,7 +180,7 @@ static int usbtrace_syslog(FAR const char *fmt, ...)
   return ret;
 }
 
-static int assert_tracecallback(FAR struct usbtrace_s *trace, FAR void *arg)
+static int assert_tracecallback(struct usbtrace_s *trace, void *arg)
 {
   usbtrace_trprintf(usbtrace_syslog, trace->event, trace->value);
   return 0;
@@ -194,7 +194,7 @@ static int assert_tracecallback(FAR struct usbtrace_s *trace, FAR void *arg)
 #ifdef CONFIG_ARCH_STACKDUMP
 static void up_dumpstate(void)
 {
-  FAR struct tcb_s *rtcb = running_task();
+  struct tcb_s *rtcb = running_task();
   uint32_t sp = up_getsp();
   uint32_t ustackbase;
   uint32_t ustacksize;

--- a/arch/or1k/src/common/up_checkstack.c
+++ b/arch/or1k/src/common/up_checkstack.c
@@ -67,9 +67,9 @@ static size_t do_stackcheck(uintptr_t alloc, size_t size);
 
 static size_t do_stackcheck(uintptr_t alloc, size_t size)
 {
-  FAR uintptr_t start;
-  FAR uintptr_t end;
-  FAR uint32_t *ptr;
+  uintptr_t start;
+  uintptr_t end;
+  uint32_t *ptr;
   size_t mark;
 
   if (size == 0)
@@ -86,7 +86,7 @@ static size_t do_stackcheck(uintptr_t alloc, size_t size)
 
   size  = end - start;
 
-  for (ptr = (FAR uint32_t *)start, mark = (size >> 2);
+  for (ptr = (uint32_t *)start, mark = (size >> 2);
        *ptr == STACK_COLOR && mark > 0;
        ptr++, mark--);
 
@@ -115,12 +115,12 @@ static size_t do_stackcheck(uintptr_t alloc, size_t size)
  *
  ****************************************************************************/
 
-size_t up_check_tcbstack(FAR struct tcb_s *tcb)
+size_t up_check_tcbstack(struct tcb_s *tcb)
 {
   return do_stackcheck((uintptr_t)tcb->stack_base_ptr, tcb->adj_stack_size);
 }
 
-ssize_t up_check_tcbstack_remain(FAR struct tcb_s *tcb)
+ssize_t up_check_tcbstack_remain(struct tcb_s *tcb)
 {
   return tcb->adj_stack_size - up_check_tcbstack(tcb);
 }

--- a/arch/or1k/src/common/up_createstack.c
+++ b/arch/or1k/src/common/up_createstack.c
@@ -81,7 +81,7 @@
  *
  ****************************************************************************/
 
-int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
+int up_create_stack(struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
 {
 #ifdef CONFIG_TLS_ALIGNED
   /* The allocated stack size must not exceed the maximum possible for the
@@ -201,7 +201,7 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
  ****************************************************************************/
 
 #ifdef CONFIG_STACK_COLORATION
-void up_stack_color(FAR void *stackbase, size_t nbytes)
+void up_stack_color(void *stackbase, size_t nbytes)
 {
   uint32_t *stkptr;
   uintptr_t stkend;

--- a/arch/or1k/src/common/up_exit.c
+++ b/arch/or1k/src/common/up_exit.c
@@ -62,9 +62,9 @@
  ****************************************************************************/
 
 #ifdef CONFIG_DUMP_ON_EXIT
-static void _up_dumponexit(FAR struct tcb_s *tcb, FAR void *arg)
+static void _up_dumponexit(struct tcb_s *tcb, void *arg)
 {
-  FAR struct filelist *filelist;
+  struct filelist *filelist;
   int i;
   int j;
 

--- a/arch/or1k/src/common/up_internal.h
+++ b/arch/or1k/src/common/up_internal.h
@@ -267,8 +267,8 @@ uint32_t *up_doirq(int irq, uint32_t *regs);
 
 /* Exception Handlers */
 
-int  up_hardfault(int irq, FAR void *context, FAR void *arg);
-int  up_memfault(int irq, FAR void *context, FAR void *arg);
+int  up_hardfault(int irq, void *context, void *arg);
+int  up_memfault(int irq, void *context, void *arg);
 
 /* Interrupt acknowledge and dispatch */
 
@@ -343,7 +343,7 @@ void up_usbuninitialize(void);
 
 /* Debug ********************************************************************/
 #ifdef CONFIG_STACK_COLORATION
-void up_stack_color(FAR void *stackbase, size_t nbytes);
+void up_stack_color(void *stackbase, size_t nbytes);
 #endif
 
 #undef EXTERN

--- a/arch/or1k/src/common/up_releasestack.c
+++ b/arch/or1k/src/common/up_releasestack.c
@@ -71,7 +71,7 @@
  *
  ****************************************************************************/
 
-void up_release_stack(FAR struct tcb_s *dtcb, uint8_t ttype)
+void up_release_stack(struct tcb_s *dtcb, uint8_t ttype)
 {
   /* Is there a stack allocated? */
 

--- a/arch/or1k/src/common/up_stackframe.c
+++ b/arch/or1k/src/common/up_stackframe.c
@@ -69,9 +69,9 @@
  *
  ****************************************************************************/
 
-FAR void *up_stack_frame(FAR struct tcb_s *tcb, size_t frame_size)
+void *up_stack_frame(struct tcb_s *tcb, size_t frame_size)
 {
-  FAR void *ret;
+  void *ret;
 
   /* Align the frame_size */
 
@@ -89,7 +89,7 @@ FAR void *up_stack_frame(FAR struct tcb_s *tcb, size_t frame_size)
 
   /* Save the adjusted stack values in the struct tcb_s */
 
-  tcb->stack_base_ptr  = (FAR uint8_t *)tcb->stack_base_ptr + frame_size;
+  tcb->stack_base_ptr  = (uint8_t *)tcb->stack_base_ptr + frame_size;
   tcb->adj_stack_size -= frame_size;
 
   /* And return the pointer to the allocated region */

--- a/arch/or1k/src/common/up_task_start.c
+++ b/arch/or1k/src/common/up_task_start.c
@@ -61,7 +61,7 @@
  *
  ****************************************************************************/
 
-void up_task_start(main_t taskentry, int argc, FAR char *argv[])
+void up_task_start(main_t taskentry, int argc, char *argv[])
 {
   /* Let sys_call3() do all of the work */
 

--- a/arch/sim/src/sim/up_ajoystick.c
+++ b/arch/sim/src/sim/up_ajoystick.c
@@ -47,14 +47,14 @@
  ****************************************************************************/
 
 static ajoy_buttonset_t ajoy_supported(
-  FAR const struct ajoy_lowerhalf_s *lower);
-static int ajoy_sample(FAR const struct ajoy_lowerhalf_s *lower,
-                       FAR struct ajoy_sample_s *sample);
+  const struct ajoy_lowerhalf_s *lower);
+static int ajoy_sample(const struct ajoy_lowerhalf_s *lower,
+                       struct ajoy_sample_s *sample);
 static ajoy_buttonset_t ajoy_buttons(
-  FAR const struct ajoy_lowerhalf_s *lower);
-static void ajoy_enable(FAR const struct ajoy_lowerhalf_s *lower,
-                         ajoy_buttonset_t press, ajoy_buttonset_t release,
-                         ajoy_handler_t handler, FAR void *arg);
+  const struct ajoy_lowerhalf_s *lower);
+static void ajoy_enable(const struct ajoy_lowerhalf_s *lower,
+                        ajoy_buttonset_t press, ajoy_buttonset_t release,
+                        ajoy_handler_t handler, void *arg);
 
 /****************************************************************************
  * Private Data
@@ -95,7 +95,7 @@ static ajoy_buttonset_t g_ajoy_rset;       /* Set of releases waited for */
  ****************************************************************************/
 
 static ajoy_buttonset_t ajoy_supported(
-  FAR const struct ajoy_lowerhalf_s *lower)
+  const struct ajoy_lowerhalf_s *lower)
 {
   return (ajoy_buttonset_t)AJOY_SUPPORTED;
 }
@@ -108,8 +108,8 @@ static ajoy_buttonset_t ajoy_supported(
  *
  ****************************************************************************/
 
-static int ajoy_sample(FAR const struct ajoy_lowerhalf_s *lower,
-                       FAR struct ajoy_sample_s *sample)
+static int ajoy_sample(const struct ajoy_lowerhalf_s *lower,
+                       struct ajoy_sample_s *sample)
 {
   memcpy(sample, &g_ajoy_sample, sizeof(struct ajoy_sample_s));
   g_ajoy_buttons = g_ajoy_sample.as_buttons;
@@ -126,7 +126,7 @@ static int ajoy_sample(FAR const struct ajoy_lowerhalf_s *lower,
  ****************************************************************************/
 
 static ajoy_buttonset_t ajoy_buttons(
-  FAR const struct ajoy_lowerhalf_s *lower)
+  const struct ajoy_lowerhalf_s *lower)
 {
   g_ajoy_valid   = false;
   g_ajoy_buttons = g_ajoy_sample.as_buttons;
@@ -142,9 +142,9 @@ static ajoy_buttonset_t ajoy_buttons(
  *
  ****************************************************************************/
 
-static void ajoy_enable(FAR const struct ajoy_lowerhalf_s *lower,
+static void ajoy_enable(const struct ajoy_lowerhalf_s *lower,
                         ajoy_buttonset_t press, ajoy_buttonset_t release,
-                        ajoy_handler_t handler, FAR void *arg)
+                        ajoy_handler_t handler, void *arg)
 {
   g_ajoy_handler = NULL;
   g_ajoy_pset    = press;

--- a/arch/sim/src/sim/up_alsa.c
+++ b/arch/sim/src/sim/up_alsa.c
@@ -71,7 +71,7 @@ static int sim_audio_getcaps(struct audio_lowerhalf_s *dev, int type,
                              struct audio_caps_s *caps);
 #ifdef CONFIG_AUDIO_MULTI_SESSION
 static int sim_audio_configure(struct audio_lowerhalf_s *dev,
-                               FAR void *session,
+                               void *session,
                                const struct audio_caps_s *caps);
 #else
 static int sim_audio_configure(struct audio_lowerhalf_s *dev,
@@ -362,7 +362,7 @@ static int sim_audio_getcaps(struct audio_lowerhalf_s *dev, int type,
 
 #ifdef CONFIG_AUDIO_MULTI_SESSION
 static int sim_audio_configure(struct audio_lowerhalf_s *dev,
-                               FAR void *session,
+                               void *session,
                                const struct audio_caps_s *caps)
 #else
 static int sim_audio_configure(struct audio_lowerhalf_s *dev,

--- a/arch/sim/src/sim/up_assert.c
+++ b/arch/sim/src/sim/up_assert.c
@@ -73,7 +73,7 @@
 
 void up_assert(const char *filename, int lineno)
 {
-  FAR struct tcb_s *rtcb = running_task();
+  struct tcb_s *rtcb = running_task();
 
   /* Flush any buffered SYSLOG data (prior to the assertion) */
 

--- a/arch/sim/src/sim/up_blockdevice.c
+++ b/arch/sim/src/sim/up_blockdevice.c
@@ -53,6 +53,6 @@
 
 void up_registerblockdevice(void)
 {
-  ramdisk_register(0, (FAR uint8_t *)up_deviceimage(), NSECTORS,
+  ramdisk_register(0, (uint8_t *)up_deviceimage(), NSECTORS,
                    LOGICAL_SECTOR_SIZE, RDFLAG_WRENABLED | RDFLAG_FUNLINK);
 }

--- a/arch/sim/src/sim/up_blocktask.c
+++ b/arch/sim/src/sim/up_blocktask.c
@@ -60,7 +60,7 @@
 
 void up_block_task(struct tcb_s *tcb, tstate_t task_state)
 {
-  FAR struct tcb_s *rtcb = this_task();
+  struct tcb_s *rtcb = this_task();
   bool switch_needed;
 
   /* Verify that the context switch can be performed */

--- a/arch/sim/src/sim/up_checkstack.c
+++ b/arch/sim/src/sim/up_checkstack.c
@@ -61,9 +61,9 @@ static size_t do_stackcheck(uintptr_t alloc, size_t size);
 
 static size_t do_stackcheck(uintptr_t alloc, size_t size)
 {
-  FAR uintptr_t start;
-  FAR uintptr_t end;
-  FAR uint32_t *ptr;
+  uintptr_t start;
+  uintptr_t end;
+  uint32_t *ptr;
   size_t mark;
 
   if (size == 0)
@@ -86,7 +86,7 @@ static size_t do_stackcheck(uintptr_t alloc, size_t size)
    * that does not have the magic value is the high water mark.
    */
 
-  for (ptr = (FAR uint32_t *)start, mark = (size >> 2);
+  for (ptr = (uint32_t *)start, mark = (size >> 2);
        *ptr == STACK_COLOR && mark > 0;
        ptr++, mark--);
 
@@ -106,7 +106,7 @@ static size_t do_stackcheck(uintptr_t alloc, size_t size)
       int i;
       int j;
 
-      ptr = (FAR uint32_t *)start;
+      ptr = (uint32_t *)start;
       for (i = 0; i < size; i += 4 * 64)
         {
           for (j = 0; j < 64; j++)
@@ -154,12 +154,12 @@ static size_t do_stackcheck(uintptr_t alloc, size_t size)
  *
  ****************************************************************************/
 
-size_t up_check_tcbstack(FAR struct tcb_s *tcb)
+size_t up_check_tcbstack(struct tcb_s *tcb)
 {
   return do_stackcheck((uintptr_t)tcb->stack_base_ptr, tcb->adj_stack_size);
 }
 
-ssize_t up_check_tcbstack_remain(FAR struct tcb_s *tcb)
+ssize_t up_check_tcbstack_remain(struct tcb_s *tcb)
 {
   return tcb->adj_stack_size - up_check_tcbstack(tcb);
 }

--- a/arch/sim/src/sim/up_cpuidlestack.c
+++ b/arch/sim/src/sim/up_cpuidlestack.c
@@ -76,7 +76,7 @@
  *
  ****************************************************************************/
 
-int up_cpu_idlestack(int cpu, FAR struct tcb_s *tcb, size_t stack_size)
+int up_cpu_idlestack(int cpu, struct tcb_s *tcb, size_t stack_size)
 {
   return up_create_stack(tcb, stack_size, TCB_FLAG_TTYPE_KERNEL);
 }

--- a/arch/sim/src/sim/up_createstack.c
+++ b/arch/sim/src/sim/up_createstack.c
@@ -71,7 +71,7 @@
  *
  ****************************************************************************/
 
-int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
+int up_create_stack(struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
 {
   stack_size += CONFIG_SIM_STACKSIZE_ADJUSTMENT;
 
@@ -156,7 +156,7 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
  ****************************************************************************/
 
 #ifdef CONFIG_STACK_COLORATION
-void nostackprotect_function up_stack_color(FAR void *stackbase,
+void nostackprotect_function up_stack_color(void *stackbase,
                                             size_t nbytes)
 {
   uint32_t *stkptr;

--- a/arch/sim/src/sim/up_exit.c
+++ b/arch/sim/src/sim/up_exit.c
@@ -49,7 +49,7 @@
 
 void up_exit(int status)
 {
-  FAR struct tcb_s *tcb;
+  struct tcb_s *tcb;
 
   /* Make sure that we are in a critical section with local interrupts.
    * The IRQ state will be restored when the next task is started.

--- a/arch/sim/src/sim/up_framebuffer.c
+++ b/arch/sim/src/sim/up_framebuffer.c
@@ -69,30 +69,30 @@
  * configuration of each color plane.
  */
 
-static int up_getvideoinfo(FAR struct fb_vtable_s *vtable,
-                           FAR struct fb_videoinfo_s *vinfo);
-static int up_getplaneinfo(FAR struct fb_vtable_s *vtable, int planeno,
-                           FAR struct fb_planeinfo_s *pinfo);
+static int up_getvideoinfo(struct fb_vtable_s *vtable,
+                           struct fb_videoinfo_s *vinfo);
+static int up_getplaneinfo(struct fb_vtable_s *vtable, int planeno,
+                           struct fb_planeinfo_s *pinfo);
 
 /* The following is provided only if the video hardware supports
  * RGB color mapping.
  */
 
 #ifdef CONFIG_FB_CMAP
-static int up_getcmap(FAR struct fb_vtable_s *vtable,
-                      FAR struct fb_cmap_s *cmap);
-static int up_putcmap(FAR struct fb_vtable_s *vtable,
-                      FAR const struct fb_cmap_s *cmap);
+static int up_getcmap(struct fb_vtable_s *vtable,
+                      struct fb_cmap_s *cmap);
+static int up_putcmap(struct fb_vtable_s *vtable,
+                      const struct fb_cmap_s *cmap);
 #endif
   /* The following is provided only if the video hardware supports
    * a hardware cursor
    */
 
 #ifdef CONFIG_FB_HWCURSOR
-static int up_getcursor(FAR struct fb_vtable_s *vtable,
-                        FAR struct fb_cursorattrib_s *attrib);
-static int up_setcursor(FAR struct fb_vtable_s *vtable,
-                        FAR struct fb_setcursor_s *settings);
+static int up_getcursor(struct fb_vtable_s *vtable,
+                        struct fb_cursorattrib_s *attrib);
+static int up_setcursor(struct fb_vtable_s *vtable,
+                        struct fb_setcursor_s *settings);
 #endif
 
 /****************************************************************************
@@ -120,7 +120,7 @@ static const struct fb_videoinfo_s g_videoinfo =
 
 static const struct fb_planeinfo_s g_planeinfo =
 {
-  .fbmem    = (FAR void *)&g_fb,
+  .fbmem    = (void *)&g_fb,
   .fblen    = FB_SIZE,
   .stride   = FB_WIDTH,
   .display  = 0,
@@ -172,8 +172,8 @@ struct fb_vtable_s g_fbobject =
  * Name: up_getvideoinfo
  ****************************************************************************/
 
-static int up_getvideoinfo(FAR struct fb_vtable_s *vtable,
-                           FAR struct fb_videoinfo_s *vinfo)
+static int up_getvideoinfo(struct fb_vtable_s *vtable,
+                           struct fb_videoinfo_s *vinfo)
 {
   ginfo("vtable=%p vinfo=%p\n", vtable, vinfo);
   if (vtable && vinfo)
@@ -190,8 +190,8 @@ static int up_getvideoinfo(FAR struct fb_vtable_s *vtable,
  * Name: up_getplaneinfo
  ****************************************************************************/
 
-static int up_getplaneinfo(FAR struct fb_vtable_s *vtable, int planeno,
-                           FAR struct fb_planeinfo_s *pinfo)
+static int up_getplaneinfo(struct fb_vtable_s *vtable, int planeno,
+                           struct fb_planeinfo_s *pinfo)
 {
   ginfo("vtable=%p planeno=%d pinfo=%p\n", vtable, planeno, pinfo);
   if (vtable && planeno == 0 && pinfo)
@@ -209,8 +209,8 @@ static int up_getplaneinfo(FAR struct fb_vtable_s *vtable, int planeno,
  ****************************************************************************/
 
 #ifdef CONFIG_FB_CMAP
-static int up_getcmap(FAR struct fb_vtable_s *vtable,
-                      FAR struct fb_cmap_s *cmap)
+static int up_getcmap(struct fb_vtable_s *vtable,
+                      struct fb_cmap_s *cmap)
 {
   int len;
   int i;
@@ -242,8 +242,8 @@ static int up_getcmap(FAR struct fb_vtable_s *vtable,
  ****************************************************************************/
 
 #ifdef CONFIG_FB_CMAP
-static int up_putcmap(FAR struct fb_vtable_s *vtable,
-                      FAR const struct fb_cmap_s *cmap)
+static int up_putcmap(struct fb_vtable_s *vtable,
+                      const struct fb_cmap_s *cmap)
 {
 #ifdef CONFIG_SIM_X11FB
   return up_x11cmap(cmap->first, cmap->len, cmap->red, cmap->green,
@@ -266,8 +266,8 @@ static int up_putcmap(FAR struct fb_vtable_s *vtable,
  ****************************************************************************/
 
 #ifdef CONFIG_FB_HWCURSOR
-static int up_getcursor(FAR struct fb_vtable_s *vtable,
-                        FAR struct fb_cursorattrib_s *attrib)
+static int up_getcursor(struct fb_vtable_s *vtable,
+                        struct fb_cursorattrib_s *attrib)
 {
   ginfo("vtable=%p attrib=%p\n", vtable, attrib);
   if (vtable && attrib)
@@ -296,8 +296,8 @@ static int up_getcursor(FAR struct fb_vtable_s *vtable,
  ****************************************************************************/
 
 #ifdef CONFIG_FB_HWCURSOR
-static int up_setcursor(FAR struct fb_vtable_s *vtable,
-                       FAR struct fb_setcursor_s *settings)
+static int up_setcursor(struct fb_vtable_s *vtable,
+                       struct fb_setcursor_s *settings)
 {
   ginfo("vtable=%p settings=%p\n", vtable, settings);
   if (vtable && settings)
@@ -339,7 +339,7 @@ static int up_setcursor(FAR struct fb_vtable_s *vtable,
  ****************************************************************************/
 
 #ifdef CONFIG_SIM_X11FB
-static void up_updatework(FAR void *arg)
+static void up_updatework(void *arg)
 {
   work_queue(LPWORK, &g_updatework, up_updatework, NULL, MSEC2TICK(33));
   up_x11update();
@@ -402,7 +402,7 @@ int up_fbinitialize(int display)
  *
  ****************************************************************************/
 
-FAR struct fb_vtable_s *up_fbgetvplane(int display, int vplane)
+struct fb_vtable_s *up_fbgetvplane(int display, int vplane)
 {
   if (vplane == 0)
     {

--- a/arch/sim/src/sim/up_hcisocket.c
+++ b/arch/sim/src/sim/up_hcisocket.c
@@ -57,7 +57,7 @@
 
 struct bthcisock_s
 {
-  FAR struct bt_driver_s drv;
+  struct bt_driver_s drv;
   int                    id;
   int                    fd;
   sq_entry_t             link;
@@ -67,12 +67,12 @@ struct bthcisock_s
  * Private Function Prototypes
  ****************************************************************************/
 
-static int  bthcisock_send(FAR struct bt_driver_s *drv,
+static int  bthcisock_send(struct bt_driver_s *drv,
                            enum bt_buf_type_e type,
-                           FAR void *data, size_t len);
-static int  bthcisock_open(FAR struct bt_driver_s *drv);
-static void bthcisock_close(FAR struct bt_driver_s *drv);
-static int  bthcisock_receive(FAR struct bt_driver_s *drv);
+                           void *data, size_t len);
+static int  bthcisock_open(struct bt_driver_s *drv);
+static void bthcisock_close(struct bt_driver_s *drv);
+static int  bthcisock_receive(struct bt_driver_s *drv);
 
 /****************************************************************************
  * Private Data
@@ -84,12 +84,12 @@ static sq_queue_t        g_bthcisock_list;
  * Private Functions
  ****************************************************************************/
 
-static int bthcisock_send(FAR struct bt_driver_s *drv,
+static int bthcisock_send(struct bt_driver_s *drv,
                           enum bt_buf_type_e type,
-                          FAR void *data, size_t len)
+                          void *data, size_t len)
 {
-  FAR struct bthcisock_s *dev = (FAR struct bthcisock_s *)drv;
-  FAR char *hdr = (FAR char *)data - drv->head_reserve;
+  struct bthcisock_s *dev = (struct bthcisock_s *)drv;
+  char *hdr = (char *)data - drv->head_reserve;
   int ret;
 
   if (type == BT_CMD)
@@ -114,17 +114,17 @@ static int bthcisock_send(FAR struct bt_driver_s *drv,
   return ret < 0 ? ret : len;
 }
 
-static void bthcisock_close(FAR struct bt_driver_s *drv)
+static void bthcisock_close(struct bt_driver_s *drv)
 {
-  FAR struct bthcisock_s *dev = (FAR struct bthcisock_s *)drv;
+  struct bthcisock_s *dev = (struct bthcisock_s *)drv;
 
   bthcisock_host_close(dev->fd);
   dev->fd = -1;
 }
 
-static int bthcisock_receive(FAR struct bt_driver_s *drv)
+static int bthcisock_receive(struct bt_driver_s *drv)
 {
-  FAR struct bthcisock_s *dev = (FAR struct bthcisock_s *)drv;
+  struct bthcisock_s *dev = (struct bthcisock_s *)drv;
   char data[BLUETOOTH_RX_FRAMELEN];
   enum bt_buf_type_e type;
   int ret;
@@ -157,9 +157,9 @@ static int bthcisock_receive(FAR struct bt_driver_s *drv)
                            ret - H4_HEADER_SIZE);
 }
 
-static int bthcisock_open(FAR struct bt_driver_s *drv)
+static int bthcisock_open(struct bt_driver_s *drv)
 {
-  FAR struct bthcisock_s *dev = (FAR struct bthcisock_s *)drv;
+  struct bthcisock_s *dev = (struct bthcisock_s *)drv;
   int fd;
 
   fd = bthcisock_host_open(dev->id);
@@ -174,14 +174,14 @@ static int bthcisock_open(FAR struct bt_driver_s *drv)
   return OK;
 }
 
-static FAR struct bthcisock_s *bthcisock_alloc(int dev_id)
+static struct bthcisock_s *bthcisock_alloc(int dev_id)
 {
   /* Register the driver with the Bluetooth stack */
 
-  FAR struct bthcisock_s *dev;
-  FAR struct bt_driver_s *drv;
+  struct bthcisock_s *dev;
+  struct bt_driver_s *drv;
 
-  dev = (FAR struct bthcisock_s *)kmm_zalloc(sizeof(*dev));
+  dev = (struct bthcisock_s *)kmm_zalloc(sizeof(*dev));
   if (dev == NULL)
     {
       return NULL;
@@ -221,7 +221,7 @@ static FAR struct bthcisock_s *bthcisock_alloc(int dev_id)
 
 int bthcisock_register(int dev_id)
 {
-  FAR struct bthcisock_s *dev;
+  struct bthcisock_s *dev;
 #if defined(CONFIG_UART_BTH4)
   char name[32];
 #endif
@@ -264,8 +264,8 @@ int bthcisock_register(int dev_id)
 
 int bthcisock_loop(void)
 {
-  FAR struct bthcisock_s *dev;
-  FAR sq_entry_t *entry;
+  struct bthcisock_s *dev;
+  sq_entry_t *entry;
 
   for (entry = sq_peek(&g_bthcisock_list); entry; entry = sq_next(entry))
     {

--- a/arch/sim/src/sim/up_heap.c
+++ b/arch/sim/src/sim/up_heap.c
@@ -45,7 +45,7 @@
 
 struct mm_delaynode_s
 {
-  FAR struct mm_delaynode_s *flink;
+  struct mm_delaynode_s *flink;
 };
 
 struct mm_heap_s
@@ -61,10 +61,10 @@ struct mm_heap_s
  * Private Functions
  ****************************************************************************/
 
-static void mm_add_delaylist(FAR struct mm_heap_s *heap, FAR void *mem)
+static void mm_add_delaylist(struct mm_heap_s *heap, void *mem)
 {
 #if defined(CONFIG_BUILD_FLAT) || defined(__KERNEL__)
-  FAR struct mm_delaynode_s *tmp = mem;
+  struct mm_delaynode_s *tmp = mem;
   irqstate_t flags;
 
   /* Delay the deallocation until a more appropriate time. */
@@ -78,10 +78,10 @@ static void mm_add_delaylist(FAR struct mm_heap_s *heap, FAR void *mem)
 #endif
 }
 
-static void mm_free_delaylist(FAR struct mm_heap_s *heap)
+static void mm_free_delaylist(struct mm_heap_s *heap)
 {
 #if defined(CONFIG_BUILD_FLAT) || defined(__KERNEL__)
-  FAR struct mm_delaynode_s *tmp;
+  struct mm_delaynode_s *tmp;
   irqstate_t flags;
 
   /* Move the delay list to local */
@@ -97,7 +97,7 @@ static void mm_free_delaylist(FAR struct mm_heap_s *heap)
 
   while (tmp)
     {
-      FAR void *address;
+      void *address;
 
       /* Get the first delayed deallocation */
 
@@ -136,12 +136,12 @@ static void mm_free_delaylist(FAR struct mm_heap_s *heap)
  *
  ****************************************************************************/
 
-FAR struct mm_heap_s *mm_initialize(FAR const char *name,
-                                    FAR void *heap_start, size_t heap_size)
+struct mm_heap_s *mm_initialize(const char *name,
+                                    void *heap_start, size_t heap_size)
 {
-  FAR struct mm_heap_s *heap;
+  struct mm_heap_s *heap;
 
-  heap = host_memalign(sizeof(FAR void *), sizeof(*heap));
+  heap = host_memalign(sizeof(void *), sizeof(*heap));
   DEBUGASSERT(heap);
 
   memset(heap, 0, sizeof(struct mm_heap_s));
@@ -173,7 +173,7 @@ FAR struct mm_heap_s *mm_initialize(FAR const char *name,
  *
  ****************************************************************************/
 
-void mm_addregion(FAR struct mm_heap_s *heap, FAR void *heapstart,
+void mm_addregion(struct mm_heap_s *heap, void *heapstart,
                   size_t heapsize)
 {
 }
@@ -189,7 +189,7 @@ void mm_addregion(FAR struct mm_heap_s *heap, FAR void *heapstart,
  *
  ****************************************************************************/
 
-FAR void *mm_malloc(FAR struct mm_heap_s *heap, size_t size)
+void *mm_malloc(struct mm_heap_s *heap, size_t size)
 {
   return mm_realloc(heap, NULL, size);
 }
@@ -203,7 +203,7 @@ FAR void *mm_malloc(FAR struct mm_heap_s *heap, size_t size)
  *
  ****************************************************************************/
 
-FAR void mm_free(FAR struct mm_heap_s *heap, FAR void *mem)
+void mm_free(struct mm_heap_s *heap, void *mem)
 {
 #if defined(CONFIG_BUILD_FLAT) || defined(__KERNEL__)
   /* Check current environment */
@@ -255,7 +255,7 @@ FAR void mm_free(FAR struct mm_heap_s *heap, FAR void *mem)
  *
  ****************************************************************************/
 
-FAR void *mm_realloc(FAR struct mm_heap_s *heap, FAR void *oldmem,
+void *mm_realloc(struct mm_heap_s *heap, void *oldmem,
                     size_t size)
 {
   mm_free_delaylist(heap);
@@ -270,7 +270,7 @@ FAR void *mm_realloc(FAR struct mm_heap_s *heap, FAR void *oldmem,
  *
  ****************************************************************************/
 
-FAR void *mm_calloc(FAR struct mm_heap_s *heap, size_t n, size_t elem_size)
+void *mm_calloc(struct mm_heap_s *heap, size_t n, size_t elem_size)
 {
   size_t size = n * elem_size;
 
@@ -290,9 +290,9 @@ FAR void *mm_calloc(FAR struct mm_heap_s *heap, size_t n, size_t elem_size)
  *
  ****************************************************************************/
 
-FAR void *mm_zalloc(FAR struct mm_heap_s *heap, size_t size)
+void *mm_zalloc(struct mm_heap_s *heap, size_t size)
 {
-  FAR void *ptr;
+  void *ptr;
 
   ptr = mm_malloc(heap, size);
   if (ptr != NULL)
@@ -316,7 +316,7 @@ FAR void *mm_zalloc(FAR struct mm_heap_s *heap, size_t size)
  *
  ****************************************************************************/
 
-FAR void *mm_memalign(FAR struct mm_heap_s *heap, size_t alignment,
+void *mm_memalign(struct mm_heap_s *heap, size_t alignment,
                       size_t size)
 {
   mm_free_delaylist(heap);
@@ -340,7 +340,7 @@ FAR void *mm_memalign(FAR struct mm_heap_s *heap, size_t alignment,
  *
  ****************************************************************************/
 
-bool mm_heapmember(FAR struct mm_heap_s *heap, FAR void *mem)
+bool mm_heapmember(struct mm_heap_s *heap, void *mem)
 {
   return true;
 }
@@ -354,7 +354,7 @@ bool mm_heapmember(FAR struct mm_heap_s *heap, FAR void *mem)
  *
  ****************************************************************************/
 
-FAR void *mm_brkaddr(FAR struct mm_heap_s *heap, int region)
+void *mm_brkaddr(struct mm_heap_s *heap, int region)
 {
   return NULL;
 }
@@ -368,7 +368,7 @@ FAR void *mm_brkaddr(FAR struct mm_heap_s *heap, int region)
  *
  ****************************************************************************/
 
-void mm_extend(FAR struct mm_heap_s *heap, FAR void *mem, size_t size,
+void mm_extend(struct mm_heap_s *heap, void *mem, size_t size,
                int region)
 {
 }
@@ -381,7 +381,7 @@ void mm_extend(FAR struct mm_heap_s *heap, FAR void *mem, size_t size,
  *
  ****************************************************************************/
 
-int mm_mallinfo(FAR struct mm_heap_s *heap, FAR struct mallinfo *info)
+int mm_mallinfo(struct mm_heap_s *heap, struct mallinfo *info)
 {
   memset(info, 0, sizeof(struct mallinfo));
   host_mallinfo(&info->aordblks, &info->uordblks);
@@ -396,7 +396,7 @@ int mm_mallinfo(FAR struct mm_heap_s *heap, FAR struct mallinfo *info)
  *
  ****************************************************************************/
 
-void mm_memdump(FAR struct mm_heap_s *heap, pid_t pid)
+void mm_memdump(struct mm_heap_s *heap, pid_t pid)
 {
 }
 
@@ -410,7 +410,7 @@ void mm_memdump(FAR struct mm_heap_s *heap, pid_t pid)
  *
  ****************************************************************************/
 
-void mm_checkcorruption(FAR struct mm_heap_s *heap)
+void mm_checkcorruption(struct mm_heap_s *heap)
 {
 }
 
@@ -420,7 +420,7 @@ void mm_checkcorruption(FAR struct mm_heap_s *heap)
  * Name: malloc_size
  ****************************************************************************/
 
-size_t mm_malloc_size(FAR void *mem)
+size_t mm_malloc_size(void *mem)
 {
   return host_malloc_size(mem);
 }

--- a/arch/sim/src/sim/up_initialize.c
+++ b/arch/sim/src/sim/up_initialize.c
@@ -50,12 +50,12 @@
 static void up_init_smartfs(void)
 {
 #if defined(CONFIG_MTD_M25P) || defined(CONFIG_MTD_W25) || defined(CONFIG_MTD_SST26)
-  FAR struct mtd_dev_s *mtd;
-  FAR struct spi_dev_s *spi;
+  struct mtd_dev_s *mtd;
+  struct spi_dev_s *spi;
   int minor = 0;
 #endif
 #ifdef CONFIG_MTD_N25QXXX
-  FAR struct qspi_dev_s *qspi;
+  struct qspi_dev_s *qspi;
 #endif
 
 #ifdef CONFIG_SPI_FLASH
@@ -138,7 +138,7 @@ static void up_init_smartfs(void)
 }
 #endif
 
-static int up_loop_task(int argc, FAR char **argv)
+static int up_loop_task(int argc, char **argv)
 {
   while (1)
     {

--- a/arch/sim/src/sim/up_keyboard.c
+++ b/arch/sim/src/sim/up_keyboard.c
@@ -70,7 +70,7 @@ static struct up_dev_s g_simkeyboard;
 int sim_kbd_initialize(void)
 {
   int                  ret;
-  FAR struct up_dev_s *priv = &g_simkeyboard;
+  struct up_dev_s *priv = &g_simkeyboard;
 
   memset(priv, 0, sizeof(*priv));
 
@@ -96,7 +96,7 @@ int sim_kbd_initialize(void)
 
 void up_kbdevent(uint32_t key, bool is_press)
 {
-  FAR struct up_dev_s *priv = (FAR struct up_dev_s *) &g_simkeyboard;
+  struct up_dev_s *priv = (struct up_dev_s *) &g_simkeyboard;
   uint32_t types[2] =
     {
       KEYBOARD_RELEASE, KEYBOARD_PRESS

--- a/arch/sim/src/sim/up_lcd.c
+++ b/arch/sim/src/sim/up_lcd.c
@@ -103,19 +103,19 @@ struct sim_dev_s
 /* LCD Data Transfer Methods */
 
 static int sim_putrun(fb_coord_t row, fb_coord_t col,
-                      FAR const uint8_t *buffer, size_t npixels);
+                      const uint8_t *buffer, size_t npixels);
 static int sim_putarea(fb_coord_t row_start, fb_coord_t row_end,
                        fb_coord_t col_start, fb_coord_t col_end,
-                       FAR const uint8_t *buffer);
-static int sim_getrun(fb_coord_t row, fb_coord_t col, FAR uint8_t *buffer,
+                       const uint8_t *buffer);
+static int sim_getrun(fb_coord_t row, fb_coord_t col, uint8_t *buffer,
                       size_t npixels);
 
 /* LCD Configuration */
 
-static int sim_getvideoinfo(FAR struct lcd_dev_s *dev,
-                            FAR struct fb_videoinfo_s *vinfo);
-static int sim_getplaneinfo(FAR struct lcd_dev_s *dev, unsigned int planeno,
-                            FAR struct lcd_planeinfo_s *pinfo);
+static int sim_getvideoinfo(struct lcd_dev_s *dev,
+                            struct fb_videoinfo_s *vinfo);
+static int sim_getplaneinfo(struct lcd_dev_s *dev, unsigned int planeno,
+                            struct lcd_planeinfo_s *pinfo);
 
 /* LCD RGB Mapping */
 
@@ -178,7 +178,7 @@ static struct lcd_planeinfo_s g_planeinfo =
   .putarea = sim_putarea,                /* Put a rectangular area to LCD */
   .getrun  = sim_getrun,                 /* Get a run from LCD memory */
 #ifndef CONFIG_SIM_X11FB
-  .buffer  = (FAR uint8_t *)g_runbuffer, /* Run scratch buffer */
+  .buffer  = (uint8_t *)g_runbuffer, /* Run scratch buffer */
 #endif
   .bpp     = CONFIG_SIM_FBBPP,           /* Bits-per-pixel */
 };
@@ -226,7 +226,7 @@ static struct sim_dev_s g_lcddev =
  ****************************************************************************/
 
 static int sim_putrun(fb_coord_t row, fb_coord_t col,
-                      FAR const uint8_t *buffer, size_t npixels)
+                      const uint8_t *buffer, size_t npixels)
 {
   lcdinfo("row: %d col: %d npixels: %d\n", row, col, npixels);
 
@@ -255,7 +255,7 @@ static int sim_putrun(fb_coord_t row, fb_coord_t col,
 
 static int sim_putarea(fb_coord_t row_start, fb_coord_t row_end,
                        fb_coord_t col_start, fb_coord_t col_end,
-                       FAR const uint8_t *buffer)
+                       const uint8_t *buffer)
 {
   fb_coord_t row;
   size_t rows;
@@ -309,7 +309,7 @@ static int sim_putarea(fb_coord_t row_start, fb_coord_t row_end,
  *
  ****************************************************************************/
 
-static int sim_getrun(fb_coord_t row, fb_coord_t col, FAR uint8_t *buffer,
+static int sim_getrun(fb_coord_t row, fb_coord_t col, uint8_t *buffer,
                       size_t npixels)
 {
   lcdinfo("row: %d col: %d npixels: %d\n", row, col, npixels);
@@ -324,8 +324,8 @@ static int sim_getrun(fb_coord_t row, fb_coord_t col, FAR uint8_t *buffer,
  *
  ****************************************************************************/
 
-static int sim_getvideoinfo(FAR struct lcd_dev_s *dev,
-                            FAR struct fb_videoinfo_s *vinfo)
+static int sim_getvideoinfo(struct lcd_dev_s *dev,
+                            struct fb_videoinfo_s *vinfo)
 {
   DEBUGASSERT(dev && vinfo);
   ginfo("fmt: %d xres: %d yres: %d nplanes: %d\n",
@@ -344,8 +344,8 @@ static int sim_getvideoinfo(FAR struct lcd_dev_s *dev,
  *
  ****************************************************************************/
 
-static int sim_getplaneinfo(FAR struct lcd_dev_s *dev, unsigned int planeno,
-                              FAR struct lcd_planeinfo_s *pinfo)
+static int sim_getplaneinfo(struct lcd_dev_s *dev, unsigned int planeno,
+                              struct lcd_planeinfo_s *pinfo)
 {
   DEBUGASSERT(dev && pinfo && planeno == 0);
   ginfo("planeno: %d bpp: %d\n", planeno, g_planeinfo.bpp);
@@ -423,7 +423,7 @@ static int sim_setcontrast(struct lcd_dev_s *dev, unsigned int contrast)
  ****************************************************************************/
 
 #ifdef CONFIG_SIM_X11FB
-static void up_updatework(FAR void *arg)
+static void up_updatework(void *arg)
 {
   work_queue(LPWORK, &g_updatework, up_updatework, NULL, MSEC2TICK(33));
   up_x11update();
@@ -474,7 +474,7 @@ int board_lcd_initialize(void)
  *
  ****************************************************************************/
 
-FAR struct lcd_dev_s *board_lcd_getdev(int lcddev)
+struct lcd_dev_s *board_lcd_getdev(int lcddev)
 {
   DEBUGASSERT(lcddev == 0);
   return &g_lcddev.dev;

--- a/arch/sim/src/sim/up_netdriver.c
+++ b/arch/sim/src/sim/up_netdriver.c
@@ -89,7 +89,7 @@ static struct net_driver_s g_sim_dev;
  * Private Functions
  ****************************************************************************/
 
-static void netdriver_reply(FAR struct net_driver_s *dev)
+static void netdriver_reply(struct net_driver_s *dev)
 {
   /* If the receiving resulted in data that should be sent out on
    * the network, the field d_len is set to a value > 0.
@@ -127,10 +127,10 @@ static void netdriver_reply(FAR struct net_driver_s *dev)
     }
 }
 
-static void netdriver_recv_work(FAR void *arg)
+static void netdriver_recv_work(void *arg)
 {
-  FAR struct net_driver_s *dev = arg;
-  FAR struct eth_hdr_s *eth;
+  struct net_driver_s *dev = arg;
+  struct eth_hdr_s *eth;
 
   net_lock();
 
@@ -144,7 +144,7 @@ static void netdriver_recv_work(FAR void *arg)
        * on a data received event
        */
 
-      dev->d_len = netdev_read((FAR unsigned char *)dev->d_buf,
+      dev->d_len = netdev_read((unsigned char *)dev->d_buf,
                                dev->d_pktsize);
       if (dev->d_len > 0)
         {
@@ -154,7 +154,7 @@ static void netdriver_recv_work(FAR void *arg)
            * destination == our MAC address
            */
 
-          eth = (FAR struct eth_hdr_s *)dev->d_buf;
+          eth = (struct eth_hdr_s *)dev->d_buf;
           if (dev->d_len > ETH_HDRLEN)
             {
 #ifdef CONFIG_NET_PKT
@@ -240,7 +240,7 @@ static void netdriver_recv_work(FAR void *arg)
   net_unlock();
 }
 
-static int netdriver_txpoll(FAR struct net_driver_s *dev)
+static int netdriver_txpoll(struct net_driver_s *dev)
 {
   /* If the polling resulted in data that should be sent out on the network,
    * the field d_len is set to a value > 0.
@@ -287,9 +287,9 @@ static int netdriver_txpoll(FAR struct net_driver_s *dev)
   return 0;
 }
 
-static void netdriver_timer_work(FAR void *arg)
+static void netdriver_timer_work(void *arg)
 {
-  FAR struct net_driver_s *dev = arg;
+  struct net_driver_s *dev = arg;
 
   net_lock();
   if (IFF_IS_UP(dev->d_flags))
@@ -301,7 +301,7 @@ static void netdriver_timer_work(FAR void *arg)
   net_unlock();
 }
 
-static int netdriver_ifup(FAR struct net_driver_s *dev)
+static int netdriver_ifup(struct net_driver_s *dev)
 {
   netdev_ifup(dev->d_ipaddr);
   work_queue(LPWORK, &g_timer_work, netdriver_timer_work, dev, CLK_TCK);
@@ -309,7 +309,7 @@ static int netdriver_ifup(FAR struct net_driver_s *dev)
   return OK;
 }
 
-static int netdriver_ifdown(FAR struct net_driver_s *dev)
+static int netdriver_ifdown(struct net_driver_s *dev)
 {
   netdev_carrier_off(dev);
   work_cancel(LPWORK, &g_timer_work);
@@ -317,9 +317,9 @@ static int netdriver_ifdown(FAR struct net_driver_s *dev)
   return OK;
 }
 
-static void netdriver_txavail_work(FAR void *arg)
+static void netdriver_txavail_work(void *arg)
 {
-  FAR struct net_driver_s *dev = arg;
+  struct net_driver_s *dev = arg;
 
   net_lock();
   if (IFF_IS_UP(dev->d_flags))
@@ -330,7 +330,7 @@ static void netdriver_txavail_work(FAR void *arg)
   net_unlock();
 }
 
-static int netdriver_txavail(FAR struct net_driver_s *dev)
+static int netdriver_txavail(struct net_driver_s *dev)
 {
   if (work_available(&g_avail_work))
     {
@@ -340,20 +340,20 @@ static int netdriver_txavail(FAR struct net_driver_s *dev)
   return OK;
 }
 
-static void netdriver_txdone_interrupt(FAR void *priv)
+static void netdriver_txdone_interrupt(void *priv)
 {
   if (work_available(&g_avail_work))
     {
-      FAR struct net_driver_s *dev = (FAR struct net_driver_s *)priv;
+      struct net_driver_s *dev = (struct net_driver_s *)priv;
       work_queue(LPWORK, &g_avail_work, netdriver_txavail_work, dev, 0);
     }
 }
 
-static void netdriver_rxready_interrupt(FAR void *priv)
+static void netdriver_rxready_interrupt(void *priv)
 {
   if (work_available(&g_recv_work))
     {
-      FAR struct net_driver_s *dev = (FAR struct net_driver_s *)priv;
+      struct net_driver_s *dev = (struct net_driver_s *)priv;
       work_queue(LPWORK, &g_recv_work, netdriver_recv_work, dev, 0);
     }
 }
@@ -364,7 +364,7 @@ static void netdriver_rxready_interrupt(FAR void *priv)
 
 int netdriver_init(void)
 {
-  FAR struct net_driver_s *dev = &g_sim_dev;
+  struct net_driver_s *dev = &g_sim_dev;
   void *pktbuf;
   int pktsize;
 

--- a/arch/sim/src/sim/up_oneshot.c
+++ b/arch/sim/src/sim/up_oneshot.c
@@ -61,8 +61,8 @@ struct sim_oneshot_lowerhalf_s
   sq_entry_t link;
   struct timespec alarm;
 
-  oneshot_callback_t callback;    /* internal handler that receives callback */
-  FAR void *arg;                  /* Argument that is passed to the handler */
+  oneshot_callback_t callback; /* internal handler that receives callback */
+  void *arg;                   /* Argument that is passed to the handler */
 };
 
 /****************************************************************************
@@ -71,15 +71,15 @@ struct sim_oneshot_lowerhalf_s
 
 static void sim_process_tick(sq_entry_t *entry);
 
-static int sim_max_delay(FAR struct oneshot_lowerhalf_s *lower,
-                         FAR struct timespec *ts);
-static int sim_start(FAR struct oneshot_lowerhalf_s *lower,
-                     oneshot_callback_t callback, FAR void *arg,
-                     FAR const struct timespec *ts);
-static int sim_cancel(FAR struct oneshot_lowerhalf_s *lower,
-                      FAR struct timespec *ts);
-static int sim_current(FAR struct oneshot_lowerhalf_s *lower,
-                       FAR struct timespec *ts);
+static int sim_max_delay(struct oneshot_lowerhalf_s *lower,
+                         struct timespec *ts);
+static int sim_start(struct oneshot_lowerhalf_s *lower,
+                     oneshot_callback_t callback, void *arg,
+                     const struct timespec *ts);
+static int sim_cancel(struct oneshot_lowerhalf_s *lower,
+                      struct timespec *ts);
+static int sim_current(struct oneshot_lowerhalf_s *lower,
+                       struct timespec *ts);
 
 /****************************************************************************
  * Private Data
@@ -109,7 +109,7 @@ static const struct oneshot_operations_s g_oneshot_ops =
  *
  ****************************************************************************/
 
-static inline void sim_timer_current(FAR struct timespec *ts)
+static inline void sim_timer_current(struct timespec *ts)
 {
   uint64_t nsec;
   time_t sec;
@@ -133,7 +133,7 @@ static inline void sim_timer_current(FAR struct timespec *ts)
 
 static void sim_timer_update(void)
 {
-  FAR sq_entry_t *entry;
+  sq_entry_t *entry;
 
   for (entry = sq_peek(&g_oneshot_list); entry; entry = sq_next(entry))
     {
@@ -157,10 +157,10 @@ static void sim_timer_update(void)
 
 static void sim_process_tick(sq_entry_t *entry)
 {
-  FAR struct sim_oneshot_lowerhalf_s *priv =
+  struct sim_oneshot_lowerhalf_s *priv =
     container_of(entry, struct sim_oneshot_lowerhalf_s, link);
   oneshot_callback_t callback;
-  FAR void *cbarg;
+  void *cbarg;
 
   DEBUGASSERT(priv != NULL);
 
@@ -207,8 +207,8 @@ static void sim_process_tick(sq_entry_t *entry)
  *
  ****************************************************************************/
 
-static int sim_max_delay(FAR struct oneshot_lowerhalf_s *lower,
-                         FAR struct timespec *ts)
+static int sim_max_delay(struct oneshot_lowerhalf_s *lower,
+                         struct timespec *ts)
 {
   DEBUGASSERT(ts != NULL);
 
@@ -237,12 +237,12 @@ static int sim_max_delay(FAR struct oneshot_lowerhalf_s *lower,
  *
  ****************************************************************************/
 
-static int sim_start(FAR struct oneshot_lowerhalf_s *lower,
-                     oneshot_callback_t callback, FAR void *arg,
-                     FAR const struct timespec *ts)
+static int sim_start(struct oneshot_lowerhalf_s *lower,
+                     oneshot_callback_t callback, void *arg,
+                     const struct timespec *ts)
 {
-  FAR struct sim_oneshot_lowerhalf_s *priv =
-    (FAR struct sim_oneshot_lowerhalf_s *)lower;
+  struct sim_oneshot_lowerhalf_s *priv =
+    (struct sim_oneshot_lowerhalf_s *)lower;
   struct timespec current;
 
   DEBUGASSERT(priv != NULL && callback != NULL && ts != NULL);
@@ -280,11 +280,11 @@ static int sim_start(FAR struct oneshot_lowerhalf_s *lower,
  *
  ****************************************************************************/
 
-static int sim_cancel(FAR struct oneshot_lowerhalf_s *lower,
-                      FAR struct timespec *ts)
+static int sim_cancel(struct oneshot_lowerhalf_s *lower,
+                      struct timespec *ts)
 {
-  FAR struct sim_oneshot_lowerhalf_s *priv =
-    (FAR struct sim_oneshot_lowerhalf_s *)lower;
+  struct sim_oneshot_lowerhalf_s *priv =
+    (struct sim_oneshot_lowerhalf_s *)lower;
   struct timespec current;
 
   DEBUGASSERT(priv != NULL && ts != NULL);
@@ -317,8 +317,8 @@ static int sim_cancel(FAR struct oneshot_lowerhalf_s *lower,
  *
  ****************************************************************************/
 
-static int sim_current(FAR struct oneshot_lowerhalf_s *lower,
-                       FAR struct timespec *ts)
+static int sim_current(struct oneshot_lowerhalf_s *lower,
+                       struct timespec *ts)
 {
   DEBUGASSERT(ts != NULL);
 
@@ -342,7 +342,7 @@ static int sim_current(FAR struct oneshot_lowerhalf_s *lower,
  *
  ****************************************************************************/
 
-static int sim_alarm_handler(int irq, FAR void *context, FAR void *arg)
+static int sim_alarm_handler(int irq, void *context, void *arg)
 {
   sim_timer_update();
   return OK;
@@ -372,14 +372,14 @@ static int sim_alarm_handler(int irq, FAR void *context, FAR void *arg)
  *
  ****************************************************************************/
 
-FAR struct oneshot_lowerhalf_s *oneshot_initialize(int chan,
+struct oneshot_lowerhalf_s *oneshot_initialize(int chan,
                                                    uint16_t resolution)
 {
-  FAR struct sim_oneshot_lowerhalf_s *priv;
+  struct sim_oneshot_lowerhalf_s *priv;
 
   /* Allocate an instance of the lower half driver */
 
-  priv = (FAR struct sim_oneshot_lowerhalf_s *)
+  priv = (struct sim_oneshot_lowerhalf_s *)
     kmm_zalloc(sizeof(struct sim_oneshot_lowerhalf_s));
 
   if (priv == NULL)

--- a/arch/sim/src/sim/up_releasepending.c
+++ b/arch/sim/src/sim/up_releasepending.c
@@ -50,7 +50,7 @@
 
 void up_release_pending(void)
 {
-  FAR struct tcb_s *rtcb = this_task();
+  struct tcb_s *rtcb = this_task();
 
   sinfo("From TCB=%p\n", rtcb);
 

--- a/arch/sim/src/sim/up_releasestack.c
+++ b/arch/sim/src/sim/up_releasestack.c
@@ -58,7 +58,7 @@
  *
  ****************************************************************************/
 
-void up_release_stack(FAR struct tcb_s *dtcb, uint8_t ttype)
+void up_release_stack(struct tcb_s *dtcb, uint8_t ttype)
 {
   /* Is there a stack allocated? */
 

--- a/arch/sim/src/sim/up_reprioritizertr.c
+++ b/arch/sim/src/sim/up_reprioritizertr.c
@@ -77,7 +77,7 @@ void up_reprioritize_rtr(struct tcb_s *tcb, uint8_t priority)
     }
   else
     {
-      FAR struct tcb_s *rtcb = this_task();
+      struct tcb_s *rtcb = this_task();
       bool switch_needed;
 
       sinfo("TCB=%p PRI=%d\n", tcb, priority);

--- a/arch/sim/src/sim/up_romgetc.c
+++ b/arch/sim/src/sim/up_romgetc.c
@@ -63,7 +63,7 @@
  *
  ****************************************************************************/
 
-char up_romgetc(FAR const char *ptr)
+char up_romgetc(const char *ptr)
 {
   /* This is basically a No-Op if enabled in the simulation environment */
 

--- a/arch/sim/src/sim/up_rtc.c
+++ b/arch/sim/src/sim/up_rtc.c
@@ -35,11 +35,11 @@
  * Private Function Prototypes
  ****************************************************************************/
 
-static int sim_rtc_rdtime(FAR struct rtc_lowerhalf_s *lower,
-                          FAR struct rtc_time *rtctime);
-static int sim_rtc_settime(FAR struct rtc_lowerhalf_s *lower,
-                           FAR const struct rtc_time *rtctime);
-static bool sim_rtc_havesettime(FAR struct rtc_lowerhalf_s *lower);
+static int sim_rtc_rdtime(struct rtc_lowerhalf_s *lower,
+                          struct rtc_time *rtctime);
+static int sim_rtc_settime(struct rtc_lowerhalf_s *lower,
+                           const struct rtc_time *rtctime);
+static bool sim_rtc_havesettime(struct rtc_lowerhalf_s *lower);
 
 /****************************************************************************
  * Private Data
@@ -63,8 +63,8 @@ static int64_t g_sim_delta;
  * Private Functions
  ****************************************************************************/
 
-static int sim_rtc_rdtime(FAR struct rtc_lowerhalf_s *lower,
-                          FAR struct rtc_time *rtctime)
+static int sim_rtc_rdtime(struct rtc_lowerhalf_s *lower,
+                          struct rtc_time *rtctime)
 {
   uint64_t nsec;
   time_t sec;
@@ -74,16 +74,16 @@ static int sim_rtc_rdtime(FAR struct rtc_lowerhalf_s *lower,
   sec   = nsec / NSEC_PER_SEC;
   nsec -= sec * NSEC_PER_SEC;
 
-  gmtime_r(&sec, (FAR struct tm *)rtctime);
+  gmtime_r(&sec, (struct tm *)rtctime);
   rtctime->tm_nsec = nsec;
 
   return OK;
 }
 
-static int sim_rtc_settime(FAR struct rtc_lowerhalf_s *lower,
-                           FAR const struct rtc_time *rtctime)
+static int sim_rtc_settime(struct rtc_lowerhalf_s *lower,
+                           const struct rtc_time *rtctime)
 {
-  g_sim_delta = timegm((FAR struct tm *)rtctime);
+  g_sim_delta = timegm((struct tm *)rtctime);
   g_sim_delta *= NSEC_PER_SEC;
   g_sim_delta += rtctime->tm_nsec;
   g_sim_delta -= host_gettime(true);
@@ -91,7 +91,7 @@ static int sim_rtc_settime(FAR struct rtc_lowerhalf_s *lower,
   return OK;
 }
 
-static bool sim_rtc_havesettime(FAR struct rtc_lowerhalf_s *lower)
+static bool sim_rtc_havesettime(struct rtc_lowerhalf_s *lower)
 {
   return true;
 }
@@ -123,7 +123,7 @@ static bool sim_rtc_havesettime(FAR struct rtc_lowerhalf_s *lower)
 
 int up_rtc_initialize(void)
 {
-  FAR struct rtc_lowerhalf_s *rtc = &g_sim_rtc;
+  struct rtc_lowerhalf_s *rtc = &g_sim_rtc;
   bool sync = true;
 
 #ifdef CONFIG_RTC_RPMSG_SERVER

--- a/arch/sim/src/sim/up_smpsignal.c
+++ b/arch/sim/src/sim/up_smpsignal.c
@@ -71,7 +71,7 @@ static volatile spinlock_t g_cpu_paused[CONFIG_SMP_NCPUS];
  *
  ****************************************************************************/
 
-static int sim_cpupause_handler(int irq, FAR void *context, FAR void *arg)
+static int sim_cpupause_handler(int irq, void *context, void *arg)
 {
   int cpu = this_cpu();
 
@@ -221,7 +221,7 @@ __attribute__ ((visibility("default")))
 void up_cpu_started(void)
 {
 #ifdef CONFIG_SCHED_INSTRUMENTATION
-  FAR struct tcb_s *tcb = this_task();
+  struct tcb_s *tcb = this_task();
 
   /* Notify that this CPU has started */
 
@@ -262,7 +262,7 @@ void up_cpu_started(void)
 
 int up_cpu_start(int cpu)
 {
-  FAR struct tcb_s *tcb = current_task(cpu);
+  struct tcb_s *tcb = current_task(cpu);
 
 #ifdef CONFIG_SCHED_INSTRUMENTATION
   /* Notify of the start event */

--- a/arch/sim/src/sim/up_stackframe.c
+++ b/arch/sim/src/sim/up_stackframe.c
@@ -69,9 +69,9 @@
  *
  ****************************************************************************/
 
-FAR void *up_stack_frame(FAR struct tcb_s *tcb, size_t frame_size)
+void *up_stack_frame(struct tcb_s *tcb, size_t frame_size)
 {
-  FAR void *ret;
+  void *ret;
 
   /* Align the frame_size */
 
@@ -89,7 +89,7 @@ FAR void *up_stack_frame(FAR struct tcb_s *tcb, size_t frame_size)
 
   /* Save the adjusted stack values in the struct tcb_s */
 
-  tcb->stack_base_ptr  = (FAR uint8_t *)tcb->stack_base_ptr + frame_size;
+  tcb->stack_base_ptr  = (uint8_t *)tcb->stack_base_ptr + frame_size;
   tcb->adj_stack_size -= frame_size;
 
   /* And return a pointer to the allocated memory */

--- a/arch/sim/src/sim/up_touchscreen.c
+++ b/arch/sim/src/sim/up_touchscreen.c
@@ -96,7 +96,7 @@ static struct up_dev_s g_simtouchscreen;
 
 int sim_tsc_initialize(int minor)
 {
-  FAR struct up_dev_s *priv = (FAR struct up_dev_s *)&g_simtouchscreen;
+  struct up_dev_s *priv = (struct up_dev_s *)&g_simtouchscreen;
   char devname[DEV_NAMELEN];
   int ret;
 
@@ -150,7 +150,7 @@ int sim_tsc_initialize(int minor)
 
 int sim_tsc_uninitialize(void)
 {
-  FAR struct up_dev_s *priv = (FAR struct up_dev_s *)&g_simtouchscreen;
+  struct up_dev_s *priv = (struct up_dev_s *)&g_simtouchscreen;
   char devname[DEV_NAMELEN];
 
   /* Stop the event loop (Hmm.. the caller must be sure that there are no
@@ -176,7 +176,7 @@ int sim_tsc_uninitialize(void)
 
 void up_buttonevent(int x, int y, int buttons)
 {
-  FAR struct up_dev_s  *priv = (FAR struct up_dev_s *)&g_simtouchscreen;
+  struct up_dev_s  *priv = (struct up_dev_s *)&g_simtouchscreen;
   struct touch_sample_s sample;   /* Sampled touch point data */
   bool                  pendown;  /* true: pen is down */
 

--- a/arch/sim/src/sim/up_uart.c
+++ b/arch/sim/src/sim/up_uart.c
@@ -48,7 +48,7 @@ struct tty_priv_s
 {
   /* tty-port path name */
 
-  FAR const char *path;
+  const char *path;
 
   /* The file descriptor. It is returned by open */
 
@@ -59,21 +59,21 @@ struct tty_priv_s
  * Private Function Prototypes
  ****************************************************************************/
 
-static int  tty_setup(FAR struct uart_dev_s *dev);
-static void tty_shutdown(FAR struct uart_dev_s *dev);
-static int  tty_attach(FAR struct uart_dev_s *dev);
-static void tty_detach(FAR struct uart_dev_s *dev);
-static int  tty_ioctl(FAR struct file *filep, int cmd,
+static int  tty_setup(struct uart_dev_s *dev);
+static void tty_shutdown(struct uart_dev_s *dev);
+static int  tty_attach(struct uart_dev_s *dev);
+static void tty_detach(struct uart_dev_s *dev);
+static int  tty_ioctl(struct file *filep, int cmd,
                       unsigned long arg);
-static int  tty_receive(FAR struct uart_dev_s *dev, uint32_t *status);
-static void tty_rxint(FAR struct uart_dev_s *dev, bool enable);
-static bool tty_rxavailable(FAR struct uart_dev_s *dev);
-static bool tty_rxflowcontrol(FAR struct uart_dev_s *dev,
+static int  tty_receive(struct uart_dev_s *dev, uint32_t *status);
+static void tty_rxint(struct uart_dev_s *dev, bool enable);
+static bool tty_rxavailable(struct uart_dev_s *dev);
+static bool tty_rxflowcontrol(struct uart_dev_s *dev,
                               unsigned int nbuffered, bool upper);
-static void tty_send(FAR struct uart_dev_s *dev, int ch);
-static void tty_txint(FAR struct uart_dev_s *dev, bool enable);
-static bool tty_txready(FAR struct uart_dev_s *dev);
-static bool tty_txempty(FAR struct uart_dev_s *dev);
+static void tty_send(struct uart_dev_s *dev, int ch);
+static void tty_txint(struct uart_dev_s *dev, bool enable);
+static bool tty_txready(struct uart_dev_s *dev);
+static bool tty_txempty(struct uart_dev_s *dev);
 
 /****************************************************************************
  * Private Data
@@ -251,9 +251,9 @@ static struct uart_dev_s g_tty3_dev =
  *
  ****************************************************************************/
 
-static int tty_setup(FAR struct uart_dev_s *dev)
+static int tty_setup(struct uart_dev_s *dev)
 {
-  FAR struct tty_priv_s *priv = dev->priv;
+  struct tty_priv_s *priv = dev->priv;
 
   if (!dev->isconsole && priv->fd < 0)
     {
@@ -278,7 +278,7 @@ static int tty_setup(FAR struct uart_dev_s *dev)
 
 static void tty_shutdown(struct uart_dev_s *dev)
 {
-  FAR struct tty_priv_s *priv = dev->priv;
+  struct tty_priv_s *priv = dev->priv;
 
   if (!dev->isconsole && priv->fd >= 0)
     {
@@ -320,7 +320,7 @@ static int tty_attach(struct uart_dev_s *dev)
  *
  ****************************************************************************/
 
-static void tty_detach(FAR struct uart_dev_s *dev)
+static void tty_detach(struct uart_dev_s *dev)
 {
 }
 
@@ -335,10 +335,10 @@ static void tty_detach(FAR struct uart_dev_s *dev)
 static int tty_ioctl(struct file *filep, int cmd, unsigned long arg)
 {
 #ifdef CONFIG_SERIAL_TERMIOS
-  FAR struct inode *inode = filep->f_inode;
-  FAR struct uart_dev_s *dev = inode->i_private;
-  FAR struct tty_priv_s *priv = dev->priv;
-  FAR struct termios *termiosp = (FAR struct termios *)(uintptr_t)arg;
+  struct inode *inode = filep->f_inode;
+  struct uart_dev_s *dev = inode->i_private;
+  struct tty_priv_s *priv = dev->priv;
+  struct termios *termiosp = (struct termios *)(uintptr_t)arg;
 
   if (!termiosp)
     {
@@ -372,7 +372,7 @@ static int tty_ioctl(struct file *filep, int cmd, unsigned long arg)
 
 static int tty_receive(struct uart_dev_s *dev, uint32_t *status)
 {
-  FAR struct tty_priv_s *priv = dev->priv;
+  struct tty_priv_s *priv = dev->priv;
 
   *status = 0;
   return simuart_getc(dev->isconsole ? 0 : priv->fd);
@@ -400,7 +400,7 @@ static void tty_rxint(struct uart_dev_s *dev, bool enable)
 
 static bool tty_rxavailable(struct uart_dev_s *dev)
 {
-  FAR struct tty_priv_s *priv = dev->priv;
+  struct tty_priv_s *priv = dev->priv;
 
   return simuart_checkc(dev->isconsole ? 0 : priv->fd);
 }
@@ -414,10 +414,10 @@ static bool tty_rxavailable(struct uart_dev_s *dev)
  *
  ****************************************************************************/
 
-static bool tty_rxflowcontrol(FAR struct uart_dev_s *dev,
+static bool tty_rxflowcontrol(struct uart_dev_s *dev,
                               unsigned int nbuffered, bool upper)
 {
-  FAR struct uart_buffer_s *rxbuf = &dev->recv;
+  struct uart_buffer_s *rxbuf = &dev->recv;
 
   if (nbuffered == rxbuf->size)
     {
@@ -437,7 +437,7 @@ static bool tty_rxflowcontrol(FAR struct uart_dev_s *dev,
 
 static void tty_send(struct uart_dev_s *dev, int ch)
 {
-  FAR struct tty_priv_s *priv = dev->priv;
+  struct tty_priv_s *priv = dev->priv;
 
   /* For console device */
 

--- a/arch/sim/src/sim/up_unblocktask.c
+++ b/arch/sim/src/sim/up_unblocktask.c
@@ -54,9 +54,9 @@
  *
  ****************************************************************************/
 
-void up_unblock_task(FAR struct tcb_s *tcb)
+void up_unblock_task(struct tcb_s *tcb)
 {
-  FAR struct tcb_s *rtcb = this_task();
+  struct tcb_s *rtcb = this_task();
 
   /* Verify that the context switch can be performed */
 

--- a/arch/sim/src/sim/up_usestack.c
+++ b/arch/sim/src/sim/up_usestack.c
@@ -66,7 +66,7 @@
  *
  ****************************************************************************/
 
-int up_use_stack(FAR struct tcb_s *tcb, FAR void *stack, size_t stack_size)
+int up_use_stack(struct tcb_s *tcb, void *stack, size_t stack_size)
 {
 #if CONFIG_SIM_STACKSIZE_ADJUSTMENT == 0
   uintptr_t top_of_stack;

--- a/arch/sim/src/sim/up_usrsock.c
+++ b/arch/sim/src/sim/up_usrsock.c
@@ -56,8 +56,8 @@ struct usrsock_s
  * Private Function Prototypes
  ****************************************************************************/
 
-typedef int (*usrsock_handler_t)(FAR struct usrsock_s *usrsock,
-                                 FAR const void *data, size_t len);
+typedef int (*usrsock_handler_t)(struct usrsock_s *usrsock,
+                                 const void *data, size_t len);
 
 /****************************************************************************
  * Private Data
@@ -69,10 +69,10 @@ static struct usrsock_s g_usrsock;
  * Private Functions
  ****************************************************************************/
 
-static int usrsock_send(FAR struct usrsock_s *usrsock,
-                        FAR const void *buf, size_t len)
+static int usrsock_send(struct usrsock_s *usrsock,
+                        const void *buf, size_t len)
 {
-  FAR uint8_t *data = (FAR uint8_t *)buf;
+  uint8_t *data = (uint8_t *)buf;
   ssize_t ret;
 
   while (len > 0)
@@ -90,7 +90,7 @@ static int usrsock_send(FAR struct usrsock_s *usrsock,
   return 0;
 }
 
-static int usrsock_send_ack(FAR struct usrsock_s *usrsock,
+static int usrsock_send_ack(struct usrsock_s *usrsock,
                             uint64_t xid, int32_t result)
 {
   struct usrsock_message_req_ack_s ack;
@@ -104,8 +104,8 @@ static int usrsock_send_ack(FAR struct usrsock_s *usrsock,
   return usrsock_send(usrsock, &ack, sizeof(ack));
 }
 
-static int usrsock_send_dack(FAR struct usrsock_s *usrsock,
-                             FAR struct usrsock_message_datareq_ack_s *ack,
+static int usrsock_send_dack(struct usrsock_s *usrsock,
+                             struct usrsock_message_datareq_ack_s *ack,
                              uint64_t xid, int32_t result,
                              uint16_t valuelen,
                              uint16_t valuelen_nontrunc)
@@ -133,7 +133,7 @@ static int usrsock_send_dack(FAR struct usrsock_s *usrsock,
   return usrsock_send(usrsock, ack, sizeof(*ack) + valuelen + result);
 }
 
-static int usrsock_send_event(FAR struct usrsock_s *usrsock,
+static int usrsock_send_event(struct usrsock_s *usrsock,
                               int16_t usockid, uint16_t events)
 {
   struct usrsock_message_socket_event_s event;
@@ -147,10 +147,10 @@ static int usrsock_send_event(FAR struct usrsock_s *usrsock,
   return usrsock_send(usrsock, &event, sizeof(event));
 }
 
-static int usrsock_socket_handler(FAR struct usrsock_s *usrsock,
-                                  FAR const void *data, size_t len)
+static int usrsock_socket_handler(struct usrsock_s *usrsock,
+                                  const void *data, size_t len)
 {
-  FAR const struct usrsock_request_socket_s *req = data;
+  const struct usrsock_request_socket_s *req = data;
   int fd = usrsock_host_socket(req->domain, req->type, req->protocol);
   int ret = usrsock_send_ack(usrsock, req->head.xid, fd);
 
@@ -162,35 +162,35 @@ static int usrsock_socket_handler(FAR struct usrsock_s *usrsock,
   return ret;
 }
 
-static int usrsock_close_handler(FAR struct usrsock_s *usrsock,
-                                 FAR const void *data, size_t len)
+static int usrsock_close_handler(struct usrsock_s *usrsock,
+                                 const void *data, size_t len)
 {
-  FAR const struct usrsock_request_close_s *req = data;
+  const struct usrsock_request_close_s *req = data;
   int ret = usrsock_host_close(req->usockid);
 
   return usrsock_send_ack(usrsock, req->head.xid, ret);
 }
 
-static int usrsock_connect_handler(FAR struct usrsock_s *usrsock,
-                                   FAR const void *data, size_t len)
+static int usrsock_connect_handler(struct usrsock_s *usrsock,
+                                   const void *data, size_t len)
 {
-  FAR const struct usrsock_request_connect_s *req = data;
+  const struct usrsock_request_connect_s *req = data;
   int ret = usrsock_host_connect(req->usockid,
-                                 (FAR const struct sockaddr *)(req + 1),
+                                 (const struct sockaddr *)(req + 1),
                                  req->addrlen);
 
   return usrsock_send_ack(usrsock, req->head.xid, ret);
 }
 
-static int usrsock_sendto_handler(FAR struct usrsock_s *usrsock,
-                                  FAR const void *data, size_t len)
+static int usrsock_sendto_handler(struct usrsock_s *usrsock,
+                                  const void *data, size_t len)
 {
-  FAR const struct usrsock_request_sendto_s *req = data;
+  const struct usrsock_request_sendto_s *req = data;
   int ret = usrsock_host_sendto(req->usockid,
-                                (FAR const void *)(req + 1) + req->addrlen,
+                                (const void *)(req + 1) + req->addrlen,
                                 req->buflen, req->flags,
                                 req->addrlen ?
-                                (FAR const struct sockaddr *)(req + 1) :
+                                (const struct sockaddr *)(req + 1) :
                                 NULL, req->addrlen);
   bool sent = (ret > 0);
 
@@ -204,11 +204,11 @@ static int usrsock_sendto_handler(FAR struct usrsock_s *usrsock,
   return ret;
 }
 
-static int usrsock_recvfrom_handler(FAR struct usrsock_s *usrsock,
-                                    FAR const void *data, size_t len)
+static int usrsock_recvfrom_handler(struct usrsock_s *usrsock,
+                                    const void *data, size_t len)
 {
-  FAR const struct usrsock_request_recvfrom_s *req = data;
-  FAR struct usrsock_message_datareq_ack_s *ack;
+  const struct usrsock_request_recvfrom_s *req = data;
+  struct usrsock_message_datareq_ack_s *ack;
   socklen_t outaddrlen = req->max_addrlen;
   socklen_t inaddrlen = req->max_addrlen;
   size_t buflen = req->max_buflen;
@@ -221,40 +221,40 @@ static int usrsock_recvfrom_handler(FAR struct usrsock_s *usrsock,
     }
 
   ret = usrsock_host_recvfrom(req->usockid,
-                              (FAR void *)(ack + 1) + inaddrlen,
+                              (void *)(ack + 1) + inaddrlen,
                               buflen, req->flags,
                               outaddrlen ?
-                              (FAR struct sockaddr *)(ack + 1) : NULL,
+                              (struct sockaddr *)(ack + 1) : NULL,
                               outaddrlen ? &outaddrlen : NULL);
   if (ret > 0 && outaddrlen < inaddrlen)
     {
-      memcpy((FAR void *)(ack + 1) + outaddrlen,
-             (FAR void *)(ack + 1) + inaddrlen, ret);
+      memcpy((void *)(ack + 1) + outaddrlen,
+             (void *)(ack + 1) + inaddrlen, ret);
     }
 
   return usrsock_send_dack(usrsock, ack, req->head.xid,
                            ret, inaddrlen, outaddrlen);
 }
 
-static int usrsock_setsockopt_handler(FAR struct usrsock_s *usrsock,
-                                      FAR const void *data, size_t len)
+static int usrsock_setsockopt_handler(struct usrsock_s *usrsock,
+                                      const void *data, size_t len)
 {
-  FAR const struct usrsock_request_setsockopt_s *req = data;
+  const struct usrsock_request_setsockopt_s *req = data;
   int ret = usrsock_host_setsockopt(req->usockid, req->level,
                                     req->option, req + 1, req->valuelen);
 
   return usrsock_send_ack(usrsock, req->head.xid, ret);
 }
 
-static int usrsock_getsockopt_handler(FAR struct usrsock_s *usrsock,
-                                      FAR const void *data, size_t len)
+static int usrsock_getsockopt_handler(struct usrsock_s *usrsock,
+                                      const void *data, size_t len)
 {
-  FAR const struct usrsock_request_getsockopt_s *req = data;
-  FAR struct usrsock_message_datareq_ack_s *ack;
+  const struct usrsock_request_getsockopt_s *req = data;
+  struct usrsock_message_datareq_ack_s *ack;
   socklen_t optlen = req->max_valuelen;
   int ret;
 
-  ack = (FAR struct usrsock_message_datareq_ack_s *)usrsock->out;
+  ack = (struct usrsock_message_datareq_ack_s *)usrsock->out;
   ret = usrsock_host_getsockopt(req->usockid,
                                 req->level, req->option,
                                 ack + 1, &optlen);
@@ -263,74 +263,74 @@ static int usrsock_getsockopt_handler(FAR struct usrsock_s *usrsock,
                            ret, optlen, optlen);
 }
 
-static int usrsock_getsockname_handler(FAR struct usrsock_s *usrsock,
-                                       FAR const void *data, size_t len)
+static int usrsock_getsockname_handler(struct usrsock_s *usrsock,
+                                       const void *data, size_t len)
 {
-  FAR const struct usrsock_request_getsockname_s *req = data;
-  FAR struct usrsock_message_datareq_ack_s *ack;
+  const struct usrsock_request_getsockname_s *req = data;
+  struct usrsock_message_datareq_ack_s *ack;
   socklen_t outaddrlen = req->max_addrlen;
   socklen_t inaddrlen = req->max_addrlen;
   int ret;
 
-  ack = (FAR struct usrsock_message_datareq_ack_s *)usrsock->out;
+  ack = (struct usrsock_message_datareq_ack_s *)usrsock->out;
   ret = usrsock_host_getsockname(req->usockid,
-          (FAR struct sockaddr *)(ack + 1), &outaddrlen);
+          (struct sockaddr *)(ack + 1), &outaddrlen);
 
   return usrsock_send_dack(usrsock, ack, req->head.xid,
                            ret, inaddrlen, outaddrlen);
 }
 
-static int usrsock_getpeername_handler(FAR struct usrsock_s *usrsock,
-                                       FAR const void *data, size_t len)
+static int usrsock_getpeername_handler(struct usrsock_s *usrsock,
+                                       const void *data, size_t len)
 {
-  FAR const struct usrsock_request_getpeername_s *req = data;
-  FAR struct usrsock_message_datareq_ack_s *ack;
+  const struct usrsock_request_getpeername_s *req = data;
+  struct usrsock_message_datareq_ack_s *ack;
   socklen_t outaddrlen = req->max_addrlen;
   socklen_t inaddrlen = req->max_addrlen;
   int ret;
 
-  ack = (FAR struct usrsock_message_datareq_ack_s *)usrsock->out;
+  ack = (struct usrsock_message_datareq_ack_s *)usrsock->out;
   ret = usrsock_host_getpeername(req->usockid,
-          (FAR struct sockaddr *)(ack + 1), &outaddrlen);
+          (struct sockaddr *)(ack + 1), &outaddrlen);
 
   return usrsock_send_dack(usrsock, ack, req->head.xid,
                            ret, inaddrlen, outaddrlen);
 }
 
-static int usrsock_bind_handler(FAR struct usrsock_s *usrsock,
-                                FAR const void *data, size_t len)
+static int usrsock_bind_handler(struct usrsock_s *usrsock,
+                                const void *data, size_t len)
 {
-  FAR const struct usrsock_request_bind_s *req = data;
+  const struct usrsock_request_bind_s *req = data;
   int ret = usrsock_host_bind(req->usockid,
-                              (FAR const struct sockaddr *)(req + 1),
+                              (const struct sockaddr *)(req + 1),
                               req->addrlen);
 
   return usrsock_send_ack(usrsock, req->head.xid, ret);
 }
 
-static int usrsock_listen_handler(FAR struct usrsock_s *usrsock,
-                                  FAR const void *data, size_t len)
+static int usrsock_listen_handler(struct usrsock_s *usrsock,
+                                  const void *data, size_t len)
 {
-  FAR const struct usrsock_request_listen_s *req = data;
+  const struct usrsock_request_listen_s *req = data;
   int ret = usrsock_host_listen(req->usockid, req->backlog);
 
   return usrsock_send_ack(usrsock, req->head.xid, ret);
 }
 
-static int usrsock_accept_handler(FAR struct usrsock_s *usrsock,
-                                  FAR const void *data, size_t len)
+static int usrsock_accept_handler(struct usrsock_s *usrsock,
+                                  const void *data, size_t len)
 {
-  FAR const struct usrsock_request_accept_s *req = data;
-  FAR struct usrsock_message_datareq_ack_s *ack;
+  const struct usrsock_request_accept_s *req = data;
+  struct usrsock_message_datareq_ack_s *ack;
   socklen_t outaddrlen = req->max_addrlen;
   socklen_t inaddrlen = req->max_addrlen;
   int sockfd;
   int ret;
 
-  ack = (FAR struct usrsock_message_datareq_ack_s *)usrsock->out;
+  ack = (struct usrsock_message_datareq_ack_s *)usrsock->out;
   sockfd = usrsock_host_accept(req->usockid,
                                outaddrlen ?
-                               (FAR struct sockaddr *)(ack + 1) : NULL,
+                               (struct sockaddr *)(ack + 1) : NULL,
                                outaddrlen ? &outaddrlen : NULL);
   if (sockfd >= 0)
     {
@@ -338,11 +338,11 @@ static int usrsock_accept_handler(FAR struct usrsock_s *usrsock,
 
       if (outaddrlen <= inaddrlen)
         {
-          *(FAR int16_t *)((FAR void *)(ack + 1) + outaddrlen) = sockfd;
+          *(int16_t *)((void *)(ack + 1) + outaddrlen) = sockfd;
         }
       else
         {
-          *(FAR int16_t *)((FAR void *)(ack + 1) + inaddrlen) = sockfd;
+          *(int16_t *)((void *)(ack + 1) + inaddrlen) = sockfd;
         }
 
       ret = sizeof(int16_t); /* Return usockid size */
@@ -362,14 +362,14 @@ static int usrsock_accept_handler(FAR struct usrsock_s *usrsock,
   return ret;
 }
 
-static int usrsock_ioctl_handler(FAR struct usrsock_s *usrsock,
-                                 FAR const void *data, size_t len)
+static int usrsock_ioctl_handler(struct usrsock_s *usrsock,
+                                 const void *data, size_t len)
 {
-  FAR const struct usrsock_request_ioctl_s *req = data;
-  FAR struct usrsock_message_datareq_ack_s *ack;
+  const struct usrsock_request_ioctl_s *req = data;
+  struct usrsock_message_datareq_ack_s *ack;
   int ret;
 
-  ack = (FAR struct usrsock_message_datareq_ack_s *)usrsock->out;
+  ack = (struct usrsock_message_datareq_ack_s *)usrsock->out;
   memcpy(ack + 1, req + 1, req->arglen);
   ret = usrsock_host_ioctl(req->usockid, req->cmd,
                            (unsigned long)(ack + 1));
@@ -412,7 +412,7 @@ int usrsock_init(void)
 
 void usrsock_loop(void)
 {
-  FAR struct usrsock_request_common_s *common;
+  struct usrsock_request_common_s *common;
   int ret;
   struct pollfd pfd =
     {
@@ -426,7 +426,7 @@ void usrsock_loop(void)
       ret = file_read(&g_usrsock.usock, g_usrsock.in, sizeof(g_usrsock.in));
       if (ret > 0)
         {
-          common = (FAR struct usrsock_request_common_s *)g_usrsock.in;
+          common = (struct usrsock_request_common_s *)g_usrsock.in;
 
           if (common->reqid >= 0 &&
               common->reqid < USRSOCK_REQUEST__MAX)

--- a/arch/sparc/src/bm3803/bm3803-timerisr.c
+++ b/arch/sparc/src/bm3803/bm3803-timerisr.c
@@ -77,7 +77,7 @@
  *
  ****************************************************************************/
 
-static int bm3803_timerisr(int irq, uint32_t *regs, FAR void *arg)
+static int bm3803_timerisr(int irq, uint32_t *regs, void *arg)
 {
   /* Clear the pending timer interrupt */
 

--- a/arch/sparc/src/bm3803/bm3803_exti_gpio.c
+++ b/arch/sparc/src/bm3803/bm3803_exti_gpio.c
@@ -173,7 +173,7 @@ static int bm3803_exti3_isr(int irq, void *context, void  * arg)
 int bm3803_gpioset_irq(uint32_t pinset, bool enable, bool trig, bool edge,
                        xcpt_t func, void *arg)
 {
-  FAR struct gpio_callback_s *shared_cbs;
+  struct gpio_callback_s *shared_cbs;
   uint32_t pin = pinset & 0x3;
 
   uint32_t en = 0x80 << (pin * 8);

--- a/arch/sparc/src/bm3803/bm3803_freerun.c
+++ b/arch/sparc/src/bm3803/bm3803_freerun.c
@@ -59,9 +59,9 @@
  *
  ****************************************************************************/
 
-static int bm3803_freerun_handler(int irq, FAR void *context, void *arg)
+static int bm3803_freerun_handler(int irq, void *context, void *arg)
 {
-  FAR struct bm3803_freerun_s *freerun = (FAR struct bm3803_freerun_s *) arg;
+  struct bm3803_freerun_s *freerun = (struct bm3803_freerun_s *) arg;
 
   DEBUGASSERT(freerun != NULL && freerun->overflow < UINT24_MAX);
   freerun->overflow++;
@@ -92,7 +92,7 @@ static int bm3803_freerun_handler(int irq, FAR void *context, void *arg)
  *
  ****************************************************************************/
 
-int bm3803_freerun_initialize(FAR struct bm3803_freerun_s *freerun, int chan,
+int bm3803_freerun_initialize(struct bm3803_freerun_s *freerun, int chan,
                                uint16_t resolution)
 {
   uint32_t frequency;
@@ -156,8 +156,8 @@ int bm3803_freerun_initialize(FAR struct bm3803_freerun_s *freerun, int chan,
  *
  ****************************************************************************/
 
-int bm3803_freerun_counter(FAR struct bm3803_freerun_s *freerun,
-                            FAR struct timespec *ts)
+int bm3803_freerun_counter(struct bm3803_freerun_s *freerun,
+                            struct timespec *ts)
 {
   uint64_t usec;
   uint32_t counter;
@@ -253,7 +253,7 @@ int bm3803_freerun_counter(FAR struct bm3803_freerun_s *freerun,
  *
  ****************************************************************************/
 
-int bm3803_freerun_uninitialize(FAR struct bm3803_freerun_s *freerun)
+int bm3803_freerun_uninitialize(struct bm3803_freerun_s *freerun)
 {
   DEBUGASSERT(freerun && freerun->tch);
 

--- a/arch/sparc/src/bm3803/bm3803_freerun.h
+++ b/arch/sparc/src/bm3803/bm3803_freerun.h
@@ -47,10 +47,10 @@
 
 struct bm3803_freerun_s
 {
-  uint8_t chan;                     /* The timer/counter in use */
-  bool running;                     /* True: the timer is running */
-  uint32_t overflow;                /* Timer counter overflow */
-  FAR struct bm3803_tim_dev_s *tch; /* Handle returned by bm3803_tim_init() */
+  uint8_t chan;                 /* The timer/counter in use */
+  bool running;                 /* True: the timer is running */
+  uint32_t overflow;            /* Timer counter overflow */
+  struct bm3803_tim_dev_s *tch; /* Handle returned by bm3803_tim_init() */
   uint32_t frequency;
 };
 

--- a/arch/sparc/src/bm3803/bm3803_oneshot.c
+++ b/arch/sparc/src/bm3803/bm3803_oneshot.c
@@ -73,7 +73,7 @@ static int bm3803_oneshot_handler(int irq, void *context, void *arg)
 {
   struct bm3803_oneshot_s *oneshot = (struct bm3803_oneshot_s *) arg;
   oneshot_handler_t oneshot_handler;
-  FAR void *oneshot_arg;
+  void *oneshot_arg;
 
   tmrinfo("Expired...\n");
   DEBUGASSERT(oneshot != NULL && oneshot->handler);
@@ -124,7 +124,7 @@ static int bm3803_oneshot_handler(int irq, void *context, void *arg)
  *
  ****************************************************************************/
 
-int bm3803_oneshot_initialize(FAR struct bm3803_oneshot_s *oneshot,
+int bm3803_oneshot_initialize(struct bm3803_oneshot_s *oneshot,
                                int chan, uint16_t resolution)
 {
   uint32_t frequency;
@@ -166,8 +166,8 @@ int bm3803_oneshot_initialize(FAR struct bm3803_oneshot_s *oneshot,
  *
  ****************************************************************************/
 
-int bm3803_oneshot_max_delay(FAR struct bm3803_oneshot_s *oneshot,
-                              FAR uint64_t *usec)
+int bm3803_oneshot_max_delay(struct bm3803_oneshot_s *oneshot,
+                              uint64_t *usec)
 {
   DEBUGASSERT(oneshot != NULL && usec != NULL);
 
@@ -196,9 +196,9 @@ int bm3803_oneshot_max_delay(FAR struct bm3803_oneshot_s *oneshot,
  *
  ****************************************************************************/
 
-int bm3803_oneshot_start(FAR struct bm3803_oneshot_s *oneshot,
-                          oneshot_handler_t handler, FAR void *arg,
-                          FAR const struct timespec *ts)
+int bm3803_oneshot_start(struct bm3803_oneshot_s *oneshot,
+                          oneshot_handler_t handler, void *arg,
+                          const struct timespec *ts)
 {
   uint64_t usec;
   uint64_t period;
@@ -292,8 +292,8 @@ int bm3803_oneshot_start(FAR struct bm3803_oneshot_s *oneshot,
  *
  ****************************************************************************/
 
-int bm3803_oneshot_cancel(FAR struct bm3803_oneshot_s *oneshot,
-                           FAR struct timespec *ts)
+int bm3803_oneshot_cancel(struct bm3803_oneshot_s *oneshot,
+                           struct timespec *ts)
 {
   irqstate_t flags;
   uint64_t usec;

--- a/arch/sparc/src/bm3803/bm3803_oneshot.h
+++ b/arch/sparc/src/bm3803/bm3803_oneshot.h
@@ -63,7 +63,7 @@ struct bm3803_oneshot_s
   uint8_t chan;                       /* The timer/counter in use */
 
   volatile bool running;              /* True: the timer is running */
-  FAR struct bm3803_tim_dev_s *tch;   /* Pointer returned by
+  struct bm3803_tim_dev_s *tch;       /* Pointer returned by
                                        * bm3803_tim_init() */
   volatile oneshot_handler_t handler; /* Oneshot expiration callback */
   volatile void *arg;                 /* The argument that will accompany

--- a/arch/sparc/src/bm3803/bm3803_oneshot_lowerhalf.c
+++ b/arch/sparc/src/bm3803/bm3803_oneshot_lowerhalf.c
@@ -51,7 +51,7 @@ struct bm3803_oneshot_lowerhalf_s
    * compatible to struct bm3803_oneshot_lowerhalf_s and vice versa.
    */
 
-  struct oneshot_lowerhalf_s lh;  /* Common lower-half driver fields */
+  struct oneshot_lowerhalf_s lh; /* Common lower-half driver fields */
 
   /* Private lower half data follows */
 
@@ -59,7 +59,7 @@ struct bm3803_oneshot_lowerhalf_s
 
   struct bm3803_oneshot_s oneshot;
   oneshot_callback_t callback;   /* internal handler that receives callback */
-  FAR void *arg;                 /* Argument that is passed to the handler */
+  void *arg;                     /* Argument that is passed to the handler */
 };
 
 /****************************************************************************
@@ -68,13 +68,13 @@ struct bm3803_oneshot_lowerhalf_s
 
 static void bm3803_oneshot_handler(void *arg);
 
-static int bm3803_max_delay(FAR struct oneshot_lowerhalf_s *lower,
-                             FAR struct timespec *ts);
-static int bm3803_start(FAR struct oneshot_lowerhalf_s *lower,
-                         oneshot_callback_t callback, FAR void *arg,
-                         FAR const struct timespec *ts);
-static int bm3803_cancel(FAR struct oneshot_lowerhalf_s *lower,
-                          FAR struct timespec *ts);
+static int bm3803_max_delay(struct oneshot_lowerhalf_s *lower,
+                             struct timespec *ts);
+static int bm3803_start(struct oneshot_lowerhalf_s *lower,
+                         oneshot_callback_t callback, void *arg,
+                         const struct timespec *ts);
+static int bm3803_cancel(struct oneshot_lowerhalf_s *lower,
+                          struct timespec *ts);
 
 /****************************************************************************
  * Private Data
@@ -110,10 +110,10 @@ static const struct oneshot_operations_s g_oneshot_ops =
 
 static void bm3803_oneshot_handler(void *arg)
 {
-  FAR struct bm3803_oneshot_lowerhalf_s *priv =
-    (FAR struct bm3803_oneshot_lowerhalf_s *)arg;
+  struct bm3803_oneshot_lowerhalf_s *priv =
+    (struct bm3803_oneshot_lowerhalf_s *)arg;
   oneshot_callback_t callback;
-  FAR void *cbarg;
+  void *cbarg;
 
   DEBUGASSERT(priv != NULL);
 
@@ -156,11 +156,11 @@ static void bm3803_oneshot_handler(void *arg)
  *
  ****************************************************************************/
 
-static int bm3803_max_delay(FAR struct oneshot_lowerhalf_s *lower,
-                             FAR struct timespec *ts)
+static int bm3803_max_delay(struct oneshot_lowerhalf_s *lower,
+                             struct timespec *ts)
 {
-  FAR struct bm3803_oneshot_lowerhalf_s *priv =
-    (FAR struct bm3803_oneshot_lowerhalf_s *)lower;
+  struct bm3803_oneshot_lowerhalf_s *priv =
+    (struct bm3803_oneshot_lowerhalf_s *)lower;
   uint64_t usecs;
   int ret;
 
@@ -198,12 +198,12 @@ static int bm3803_max_delay(FAR struct oneshot_lowerhalf_s *lower,
  *
  ****************************************************************************/
 
-static int bm3803_start(FAR struct oneshot_lowerhalf_s *lower,
-                       oneshot_callback_t callback, FAR void *arg,
-                       FAR const struct timespec *ts)
+static int bm3803_start(struct oneshot_lowerhalf_s *lower,
+                       oneshot_callback_t callback, void *arg,
+                       const struct timespec *ts)
 {
-  FAR struct bm3803_oneshot_lowerhalf_s *priv =
-    (FAR struct bm3803_oneshot_lowerhalf_s *)lower;
+  struct bm3803_oneshot_lowerhalf_s *priv =
+    (struct bm3803_oneshot_lowerhalf_s *)lower;
   irqstate_t flags;
   int ret;
 
@@ -250,11 +250,11 @@ static int bm3803_start(FAR struct oneshot_lowerhalf_s *lower,
  *
  ****************************************************************************/
 
-static int bm3803_cancel(FAR struct oneshot_lowerhalf_s *lower,
-                        FAR struct timespec *ts)
+static int bm3803_cancel(struct oneshot_lowerhalf_s *lower,
+                        struct timespec *ts)
 {
-  FAR struct bm3803_oneshot_lowerhalf_s *priv =
-    (FAR struct bm3803_oneshot_lowerhalf_s *)lower;
+  struct bm3803_oneshot_lowerhalf_s *priv =
+    (struct bm3803_oneshot_lowerhalf_s *)lower;
   irqstate_t flags;
   int ret;
 
@@ -299,15 +299,15 @@ static int bm3803_cancel(FAR struct oneshot_lowerhalf_s *lower,
  *
  ****************************************************************************/
 
-FAR struct oneshot_lowerhalf_s *oneshot_initialize(int chan,
+struct oneshot_lowerhalf_s *oneshot_initialize(int chan,
                                                    uint16_t resolution)
 {
-  FAR struct bm3803_oneshot_lowerhalf_s *priv;
+  struct bm3803_oneshot_lowerhalf_s *priv;
   int ret;
 
   /* Allocate an instance of the lower half driver */
 
-  priv = (FAR struct bm3803_oneshot_lowerhalf_s *)
+  priv = (struct bm3803_oneshot_lowerhalf_s *)
     kmm_zalloc(sizeof(struct bm3803_oneshot_lowerhalf_s));
 
   if (priv == NULL)

--- a/arch/sparc/src/bm3803/bm3803_tickless.c
+++ b/arch/sparc/src/bm3803/bm3803_tickless.c
@@ -27,10 +27,10 @@
  *
  *   void up_timer_initialize(void): Initializes the timer facilities.
  *     Called early in the initialization sequence (by up_initialize()).
- *   int up_timer_gettime(FAR struct timespec *ts):  Returns the current
+ *   int up_timer_gettime(struct timespec *ts):  Returns the current
  *     time from the platform specific time source.
  *   int up_timer_cancel(void):  Cancels the interval timer.
- *   int up_timer_start(FAR const struct timespec *ts): Start (or re-starts)
+ *   int up_timer_start(const struct timespec *ts): Start (or re-starts)
  *     the interval timer.
  *
  * The RTOS will provide the following interfaces for use by the platform-
@@ -139,7 +139,7 @@ static struct bm3803_tickless_s g_tickless;
  *
  ****************************************************************************/
 
-static void bm3803_oneshot_handler(FAR void *arg)
+static void bm3803_oneshot_handler(void *arg)
 {
   tmrinfo("Expired...\n");
   nxsched_timer_expiration();
@@ -235,7 +235,7 @@ void up_timer_initialize(void)
  *   up_timer_initialize() was called).  This function is functionally
  *   equivalent to:
  *
- *      int clock_gettime(clockid_t clockid, FAR struct timespec *ts);
+ *      int clock_gettime(clockid_t clockid, struct timespec *ts);
  *
  *   when clockid is CLOCK_MONOTONIC.
  *
@@ -260,7 +260,7 @@ void up_timer_initialize(void)
  *
  ****************************************************************************/
 
-int up_timer_gettime(FAR struct timespec *ts)
+int up_timer_gettime(struct timespec *ts)
 {
   return bm3803_freerun_counter(&g_tickless.freerun, ts);
 }
@@ -301,7 +301,7 @@ int up_timer_gettime(FAR struct timespec *ts)
  *
  ****************************************************************************/
 
-int up_timer_cancel(FAR struct timespec *ts)
+int up_timer_cancel(struct timespec *ts)
 {
   return bm3803_oneshot_cancel(&g_tickless.oneshot, ts);
 }
@@ -331,7 +331,7 @@ int up_timer_cancel(FAR struct timespec *ts)
  *
  ****************************************************************************/
 
-int up_timer_start(FAR const struct timespec *ts)
+int up_timer_start(const struct timespec *ts)
 {
   return bm3803_oneshot_start(&g_tickless.oneshot, bm3803_oneshot_handler,
                               NULL, ts);

--- a/arch/sparc/src/bm3803/bm3803_tim.c
+++ b/arch/sparc/src/bm3803/bm3803_tim.c
@@ -59,7 +59,7 @@
 
 struct bm3803_tim_priv_s
 {
-  FAR const struct bm3803_tim_ops_s *ops;
+  const struct bm3803_tim_ops_s *ops;
   enum bm3803_tim_mode_e mode;
   uint32_t base;                      /* TIMn base address */
 };
@@ -70,43 +70,43 @@ struct bm3803_tim_priv_s
 
 /* Register helpers */
 
-static inline uint16_t bm3803_getreg16(FAR struct bm3803_tim_dev_s *dev,
+static inline uint16_t bm3803_getreg16(struct bm3803_tim_dev_s *dev,
                                         uint8_t offset);
-static inline void bm3803_putreg16(FAR struct bm3803_tim_dev_s *dev,
+static inline void bm3803_putreg16(struct bm3803_tim_dev_s *dev,
                                     uint8_t offset, uint16_t value);
-static inline void bm3803_modifyreg32(FAR struct bm3803_tim_dev_s *dev,
+static inline void bm3803_modifyreg32(struct bm3803_tim_dev_s *dev,
                                        uint8_t offset, uint32_t clearbits,
                                        uint32_t setbits);
-static inline uint32_t bm3803_getreg32(FAR struct bm3803_tim_dev_s *dev,
+static inline uint32_t bm3803_getreg32(struct bm3803_tim_dev_s *dev,
                                         uint8_t offset);
-static inline void bm3803_putreg32(FAR struct bm3803_tim_dev_s *dev,
+static inline void bm3803_putreg32(struct bm3803_tim_dev_s *dev,
                                     uint8_t offset, uint32_t value);
 
 /* Timer helpers */
 
-static void bm3803_tim_reload_counter(FAR struct bm3803_tim_dev_s *dev);
-static void bm3803_tim_enable(FAR struct bm3803_tim_dev_s *dev);
-static void bm3803_tim_disable(FAR struct bm3803_tim_dev_s *dev);
-static void bm3803_tim_reset(FAR struct bm3803_tim_dev_s *dev);
+static void bm3803_tim_reload_counter(struct bm3803_tim_dev_s *dev);
+static void bm3803_tim_enable(struct bm3803_tim_dev_s *dev);
+static void bm3803_tim_disable(struct bm3803_tim_dev_s *dev);
+static void bm3803_tim_reset(struct bm3803_tim_dev_s *dev);
 
 /* Timer methods */
 
-static int bm3803_tim_setmode(FAR struct bm3803_tim_dev_s *dev,
+static int bm3803_tim_setmode(struct bm3803_tim_dev_s *dev,
                                enum bm3803_tim_mode_e mode);
 
-static int bm3803_tim_setclock(FAR struct bm3803_tim_dev_s *dev,
+static int bm3803_tim_setclock(struct bm3803_tim_dev_s *dev,
                                 uint32_t freq);
-static uint32_t  bm3803_tim_getclock(FAR struct bm3803_tim_dev_s *dev);
-static void bm3803_tim_setperiod(FAR struct bm3803_tim_dev_s *dev,
+static uint32_t  bm3803_tim_getclock(struct bm3803_tim_dev_s *dev);
+static void bm3803_tim_setperiod(struct bm3803_tim_dev_s *dev,
                                   uint32_t period);
-static uint32_t bm3803_tim_getperiod(FAR struct bm3803_tim_dev_s *dev);
-static uint32_t bm3803_tim_getcounter(FAR struct bm3803_tim_dev_s *dev);
+static uint32_t bm3803_tim_getperiod(struct bm3803_tim_dev_s *dev);
+static uint32_t bm3803_tim_getcounter(struct bm3803_tim_dev_s *dev);
 
-static int bm3803_tim_setisr(FAR struct bm3803_tim_dev_s *dev,
+static int bm3803_tim_setisr(struct bm3803_tim_dev_s *dev,
                               xcpt_t handler, void *arg, int source);
 
-static int bm3803_tim_checkint(FAR struct bm3803_tim_dev_s *dev, int source);
-static void bm3803_tim_clrint(FAR struct bm3803_tim_dev_s *dev, int source);
+static int bm3803_tim_checkint(struct bm3803_tim_dev_s *dev, int source);
+static void bm3803_tim_clrint(struct bm3803_tim_dev_s *dev, int source);
 /****************************************************************************
  * Private Data
  ****************************************************************************/
@@ -153,7 +153,7 @@ struct bm3803_tim_priv_s bm3803_tim2_priv =
  *
  ****************************************************************************/
 
-static inline uint16_t bm3803_getreg16(FAR struct bm3803_tim_dev_s *dev,
+static inline uint16_t bm3803_getreg16(struct bm3803_tim_dev_s *dev,
                                         uint8_t offset)
 {
   return getreg16(((struct bm3803_tim_priv_s *)dev)->base + offset);
@@ -167,7 +167,7 @@ static inline uint16_t bm3803_getreg16(FAR struct bm3803_tim_dev_s *dev,
  *
  ****************************************************************************/
 
-static inline void bm3803_putreg16(FAR struct bm3803_tim_dev_s *dev,
+static inline void bm3803_putreg16(struct bm3803_tim_dev_s *dev,
                                     uint8_t offset, uint16_t value)
 {
   putreg16(value, ((struct bm3803_tim_priv_s *)dev)->base + offset);
@@ -181,7 +181,7 @@ static inline void bm3803_putreg16(FAR struct bm3803_tim_dev_s *dev,
  *
  ****************************************************************************/
 
-static inline void bm3803_modifyreg32(FAR struct bm3803_tim_dev_s *dev,
+static inline void bm3803_modifyreg32(struct bm3803_tim_dev_s *dev,
                                        uint8_t offset, uint32_t clearbits,
                                        uint32_t setbits)
 {
@@ -198,7 +198,7 @@ static inline void bm3803_modifyreg32(FAR struct bm3803_tim_dev_s *dev,
  *
  ****************************************************************************/
 
-static inline uint32_t bm3803_getreg32(FAR struct bm3803_tim_dev_s *dev,
+static inline uint32_t bm3803_getreg32(struct bm3803_tim_dev_s *dev,
                                         uint8_t offset)
 {
   return getreg32(((struct bm3803_tim_priv_s *)dev)->base + offset);
@@ -213,7 +213,7 @@ static inline uint32_t bm3803_getreg32(FAR struct bm3803_tim_dev_s *dev,
  *
  ****************************************************************************/
 
-static inline void bm3803_putreg32(FAR struct bm3803_tim_dev_s *dev,
+static inline void bm3803_putreg32(struct bm3803_tim_dev_s *dev,
                                     uint8_t offset, uint32_t value)
 {
   putreg32(value, ((struct bm3803_tim_priv_s *)dev)->base + offset);
@@ -223,7 +223,7 @@ static inline void bm3803_putreg32(FAR struct bm3803_tim_dev_s *dev,
  * Name: bm3803_tim_reload_counter
  ****************************************************************************/
 
-static void bm3803_tim_reload_counter(FAR struct bm3803_tim_dev_s *dev)
+static void bm3803_tim_reload_counter(struct bm3803_tim_dev_s *dev)
 {
   uint32_t val = bm3803_getreg32(dev, BM3803_TIM_CR_OFFSET);
   val |= TIMER_LOADCOUNT;
@@ -234,7 +234,7 @@ static void bm3803_tim_reload_counter(FAR struct bm3803_tim_dev_s *dev)
  * Name: bm3803_tim_enable
  ****************************************************************************/
 
-static void bm3803_tim_enable(FAR struct bm3803_tim_dev_s *dev)
+static void bm3803_tim_enable(struct bm3803_tim_dev_s *dev)
 {
   uint32_t val = bm3803_getreg32(dev, BM3803_TIM_CR_OFFSET);
   val |= TIMER_ENABLE | TIMER_RELOADCOUNT;
@@ -246,7 +246,7 @@ static void bm3803_tim_enable(FAR struct bm3803_tim_dev_s *dev)
  * Name: bm3803_tim_disable
  ****************************************************************************/
 
-static void bm3803_tim_disable(FAR struct bm3803_tim_dev_s *dev)
+static void bm3803_tim_disable(struct bm3803_tim_dev_s *dev)
 {
   uint32_t val = bm3803_getreg32(dev, BM3803_TIM_CR_OFFSET);
   val &= ~TIMER_ENABLE;
@@ -261,7 +261,7 @@ static void bm3803_tim_disable(FAR struct bm3803_tim_dev_s *dev)
  *
  ****************************************************************************/
 
-static void bm3803_tim_reset(FAR struct bm3803_tim_dev_s *dev)
+static void bm3803_tim_reset(struct bm3803_tim_dev_s *dev)
 {
   ((struct bm3803_tim_priv_s *)dev)->mode = BM3803_TIM_MODE_DISABLED;
   bm3803_tim_disable(dev);
@@ -271,7 +271,7 @@ static void bm3803_tim_reset(FAR struct bm3803_tim_dev_s *dev)
  * Name: bm3803_tim_setmode
  ****************************************************************************/
 
-static int bm3803_tim_setmode(FAR struct bm3803_tim_dev_s *dev,
+static int bm3803_tim_setmode(struct bm3803_tim_dev_s *dev,
                                enum bm3803_tim_mode_e mode)
 {
   uint32_t val = bm3803_getreg32(dev, BM3803_TIM_CR_OFFSET);
@@ -304,7 +304,7 @@ static int bm3803_tim_setmode(FAR struct bm3803_tim_dev_s *dev,
  * Name: bm3803_tim_setclock
  ****************************************************************************/
 
-static int bm3803_tim_setclock(FAR struct bm3803_tim_dev_s *dev,
+static int bm3803_tim_setclock(struct bm3803_tim_dev_s *dev,
                                 uint32_t freq)
 {
   uint32_t freqin;
@@ -377,7 +377,7 @@ static int bm3803_tim_setclock(FAR struct bm3803_tim_dev_s *dev,
  * Name: bm3803_tim_getclock
  ****************************************************************************/
 
-static uint32_t bm3803_tim_getclock(FAR struct bm3803_tim_dev_s *dev)
+static uint32_t bm3803_tim_getclock(struct bm3803_tim_dev_s *dev)
 {
   uint32_t freqin;
   uint32_t clock;
@@ -418,7 +418,7 @@ static uint32_t bm3803_tim_getclock(FAR struct bm3803_tim_dev_s *dev)
  * Name: bm3803_tim_setperiod
  ****************************************************************************/
 
-static void bm3803_tim_setperiod(FAR struct bm3803_tim_dev_s *dev,
+static void bm3803_tim_setperiod(struct bm3803_tim_dev_s *dev,
                                 uint32_t period)
 {
   DEBUGASSERT(dev != NULL);
@@ -430,7 +430,7 @@ static void bm3803_tim_setperiod(FAR struct bm3803_tim_dev_s *dev,
  * Name: bm3803_tim_getperiod
  ****************************************************************************/
 
-static uint32_t bm3803_tim_getperiod (FAR struct bm3803_tim_dev_s *dev)
+static uint32_t bm3803_tim_getperiod (struct bm3803_tim_dev_s *dev)
 {
   DEBUGASSERT(dev != NULL);
   return 0xffffff & bm3803_getreg32(dev, BM3803_TIM_ARR_OFFSET);
@@ -440,7 +440,7 @@ static uint32_t bm3803_tim_getperiod (FAR struct bm3803_tim_dev_s *dev)
  * Name: bm3803_tim_getcounter
  ****************************************************************************/
 
-static uint32_t bm3803_tim_getcounter(FAR struct bm3803_tim_dev_s *dev)
+static uint32_t bm3803_tim_getcounter(struct bm3803_tim_dev_s *dev)
 {
   DEBUGASSERT(dev != NULL);
   uint32_t counter = bm3803_getreg32(dev, BM3803_TIM_CNT_OFFSET);
@@ -452,7 +452,7 @@ static uint32_t bm3803_tim_getcounter(FAR struct bm3803_tim_dev_s *dev)
  * Name: bm3803_tim_setisr
  ****************************************************************************/
 
-static int bm3803_tim_setisr(FAR struct bm3803_tim_dev_s *dev,
+static int bm3803_tim_setisr(struct bm3803_tim_dev_s *dev,
                               xcpt_t handler, void *arg, int source)
 {
   int vectorno;
@@ -500,7 +500,7 @@ static int bm3803_tim_setisr(FAR struct bm3803_tim_dev_s *dev,
  * Name: bm3803_tim_clrint
  ****************************************************************************/
 
-static void bm3803_tim_clrint(FAR struct bm3803_tim_dev_s *dev, int source)
+static void bm3803_tim_clrint(struct bm3803_tim_dev_s *dev, int source)
 {
   int vectorno;
 
@@ -532,7 +532,7 @@ static void bm3803_tim_clrint(FAR struct bm3803_tim_dev_s *dev, int source)
  * Name: bm3803_tim_checkint
  ****************************************************************************/
 
-static int bm3803_tim_checkint(FAR struct bm3803_tim_dev_s *dev, int source)
+static int bm3803_tim_checkint(struct bm3803_tim_dev_s *dev, int source)
 {
   int vectorno;
 
@@ -568,7 +568,7 @@ static int bm3803_tim_checkint(FAR struct bm3803_tim_dev_s *dev, int source)
  * Name: bm3803_tim_init
  ****************************************************************************/
 
-FAR struct bm3803_tim_dev_s *bm3803_tim_init(int timer)
+struct bm3803_tim_dev_s *bm3803_tim_init(int timer)
 {
   struct bm3803_tim_dev_s *dev = NULL;
 
@@ -613,7 +613,7 @@ FAR struct bm3803_tim_dev_s *bm3803_tim_init(int timer)
  *
  ****************************************************************************/
 
-int bm3803_tim_deinit(FAR struct bm3803_tim_dev_s *dev)
+int bm3803_tim_deinit(struct bm3803_tim_dev_s *dev)
 {
   DEBUGASSERT(dev != NULL);
 

--- a/arch/sparc/src/bm3803/bm3803_tim.h
+++ b/arch/sparc/src/bm3803/bm3803_tim.h
@@ -99,29 +99,29 @@ struct bm3803_tim_ops_s
 {
   /* Basic Timers */
 
-  int  (*setmode)(FAR struct bm3803_tim_dev_s *dev,
+  int  (*setmode)(struct bm3803_tim_dev_s *dev,
                   enum bm3803_tim_mode_e mode);
-  int  (*setclock)(FAR struct bm3803_tim_dev_s *dev, uint32_t freq);
-  uint32_t (*getclock)(FAR struct bm3803_tim_dev_s *dev);
-  void (*setperiod)(FAR struct bm3803_tim_dev_s *dev, uint32_t period);
-  uint32_t (*getperiod)(FAR struct bm3803_tim_dev_s *dev);
-  uint32_t (*getcounter)(FAR struct bm3803_tim_dev_s *dev);
+  int  (*setclock)(struct bm3803_tim_dev_s *dev, uint32_t freq);
+  uint32_t (*getclock)(struct bm3803_tim_dev_s *dev);
+  void (*setperiod)(struct bm3803_tim_dev_s *dev, uint32_t period);
+  uint32_t (*getperiod)(struct bm3803_tim_dev_s *dev);
+  uint32_t (*getcounter)(struct bm3803_tim_dev_s *dev);
 
   /* Timer interrupts */
 
-  int  (*setisr)(FAR struct bm3803_tim_dev_s *dev,
+  int  (*setisr)(struct bm3803_tim_dev_s *dev,
                  xcpt_t handler, void *arg, int source);
-  void (*clrint)(FAR struct bm3803_tim_dev_s *dev, int source);
-  int  (*checkint)(FAR struct bm3803_tim_dev_s *dev, int source);
+  void (*clrint)(struct bm3803_tim_dev_s *dev, int source);
+  int  (*checkint)(struct bm3803_tim_dev_s *dev, int source);
 };
 
 /* Power-up timer and get its structure */
 
-FAR struct bm3803_tim_dev_s *bm3803_tim_init(int timer);
+struct bm3803_tim_dev_s *bm3803_tim_init(int timer);
 
 /* Power-down timer, mark it as unused */
 
-int bm3803_tim_deinit(FAR struct bm3803_tim_dev_s *dev);
+int bm3803_tim_deinit(struct bm3803_tim_dev_s *dev);
 
 /****************************************************************************
  * Name: bm3803_timer_initialize
@@ -142,7 +142,7 @@ int bm3803_tim_deinit(FAR struct bm3803_tim_dev_s *dev);
  ****************************************************************************/
 
 #ifdef CONFIG_TIMER
-int bm3803_timer_initialize(FAR const char *devpath, int timer);
+int bm3803_timer_initialize(const char *devpath, int timer);
 #endif
 
 #undef EXTERN

--- a/arch/sparc/src/bm3803/bm3803_tim_lowerhalf.c
+++ b/arch/sparc/src/bm3803/bm3803_tim_lowerhalf.c
@@ -58,15 +58,15 @@
 
 struct bm3803_lowerhalf_s
 {
-  FAR const struct timer_ops_s *ops;        /* Lower half operations */
-  FAR struct bm3803_tim_dev_s *tim;         /* stm32 timer driver */
-  tccb_t                        callback;   /* Current upper half interrupt
-                                             * callback */
-  FAR void                     *arg;        /* Argument passed to upper half
-                                             * callback */
-  bool                          started;    /* True: Timer has been started */
-  const uint8_t                 resolution; /* Number of bits in the timer
-                                             * (16 or 32 bits) */
+  const struct timer_ops_s *ops;        /* Lower half operations */
+  struct bm3803_tim_dev_s  *tim;        /* stm32 timer driver */
+  tccb_t                    callback;   /* Current upper half interrupt
+                                         * callback */
+  void                     *arg;        /* Argument passed to upper half
+                                         * callback */
+  bool                      started;    /* True: Timer has been started */
+  const uint8_t             resolution; /* Number of bits in the timer
+                                         * (16 or 32 bits) */
 };
 
 /****************************************************************************
@@ -79,14 +79,14 @@ static int bm3803_timer_handler(int irq, void *context, void *arg);
 
 /* "Lower half" driver methods **********************************************/
 
-static int bm3803_start(FAR struct timer_lowerhalf_s *lower);
-static int bm3803_stop(FAR struct timer_lowerhalf_s *lower);
-static int bm3803_getstatus(FAR struct timer_lowerhalf_s *lower,
-                             FAR struct timer_status_s *status);
-static int bm3803_settimeout(FAR struct timer_lowerhalf_s *lower,
+static int bm3803_start(struct timer_lowerhalf_s *lower);
+static int bm3803_stop(struct timer_lowerhalf_s *lower);
+static int bm3803_getstatus(struct timer_lowerhalf_s *lower,
+                             struct timer_status_s *status);
+static int bm3803_settimeout(struct timer_lowerhalf_s *lower,
                               uint32_t timeout);
-static void bm3803_setcallback(FAR struct timer_lowerhalf_s *lower,
-                                tccb_t callback, FAR void *arg);
+static void bm3803_setcallback(struct timer_lowerhalf_s *lower,
+                                tccb_t callback, void *arg);
 
 /****************************************************************************
  * Private Data
@@ -138,8 +138,8 @@ static struct bm3803_lowerhalf_s g_tim2_lowerhalf =
 
 static int bm3803_timer_handler(int irq, void *context, void *arg)
 {
-  FAR struct bm3803_lowerhalf_s *lower =
-                                       (FAR struct bm3803_lowerhalf_s *)arg;
+  struct bm3803_lowerhalf_s *lower =
+                                       (struct bm3803_lowerhalf_s *)arg;
   uint32_t next_interval_us = 0;
 
   BM3803_TIM_ACKINT(lower->tim, 0);
@@ -174,10 +174,10 @@ static int bm3803_timer_handler(int irq, void *context, void *arg)
  *
  ****************************************************************************/
 
-static int bm3803_start(FAR struct timer_lowerhalf_s *lower)
+static int bm3803_start(struct timer_lowerhalf_s *lower)
 {
-  FAR struct bm3803_lowerhalf_s *priv =
-                                      (FAR struct bm3803_lowerhalf_s *)lower;
+  struct bm3803_lowerhalf_s *priv =
+                                      (struct bm3803_lowerhalf_s *)lower;
 
   if (!priv->started)
     {
@@ -212,10 +212,10 @@ static int bm3803_start(FAR struct timer_lowerhalf_s *lower)
  *
  ****************************************************************************/
 
-static int bm3803_stop(FAR struct timer_lowerhalf_s *lower)
+static int bm3803_stop(struct timer_lowerhalf_s *lower)
 {
-  FAR struct bm3803_lowerhalf_s *priv =
-                                      (FAR struct bm3803_lowerhalf_s *)lower;
+  struct bm3803_lowerhalf_s *priv =
+                                      (struct bm3803_lowerhalf_s *)lower;
 
   if (priv->started)
     {
@@ -246,11 +246,11 @@ static int bm3803_stop(FAR struct timer_lowerhalf_s *lower)
  *
  ****************************************************************************/
 
-static int bm3803_getstatus(FAR struct timer_lowerhalf_s *lower,
-                             FAR struct timer_status_s *status)
+static int bm3803_getstatus(struct timer_lowerhalf_s *lower,
+                             struct timer_status_s *status)
 {
-  FAR struct bm3803_lowerhalf_s *priv =
-                                      (FAR struct bm3803_lowerhalf_s *)lower;
+  struct bm3803_lowerhalf_s *priv =
+                                      (struct bm3803_lowerhalf_s *)lower;
   uint64_t maxtimeout;
   uint32_t timeout;
   uint32_t clock;
@@ -313,11 +313,11 @@ static int bm3803_getstatus(FAR struct timer_lowerhalf_s *lower,
  *
  ****************************************************************************/
 
-static int bm3803_settimeout(FAR struct timer_lowerhalf_s *lower,
+static int bm3803_settimeout(struct timer_lowerhalf_s *lower,
                               uint32_t timeout)
 {
-  FAR struct bm3803_lowerhalf_s *priv =
-                                      (FAR struct bm3803_lowerhalf_s *)lower;
+  struct bm3803_lowerhalf_s *priv =
+                                      (struct bm3803_lowerhalf_s *)lower;
   uint64_t maxtimeout;
 
   if (priv->started)
@@ -361,11 +361,11 @@ static int bm3803_settimeout(FAR struct timer_lowerhalf_s *lower,
  *
  ****************************************************************************/
 
-static void bm3803_setcallback(FAR struct timer_lowerhalf_s *lower,
-                                tccb_t callback, FAR void *arg)
+static void bm3803_setcallback(struct timer_lowerhalf_s *lower,
+                                tccb_t callback, void *arg)
 {
-  FAR struct bm3803_lowerhalf_s *priv =
-                                      (FAR struct bm3803_lowerhalf_s *)lower;
+  struct bm3803_lowerhalf_s *priv =
+                                      (struct bm3803_lowerhalf_s *)lower;
   irqstate_t flags = enter_critical_section();
 
   /* Save the new callback */
@@ -407,9 +407,9 @@ static void bm3803_setcallback(FAR struct timer_lowerhalf_s *lower,
  *
  ****************************************************************************/
 
-int bm3803_timer_initialize(FAR const char *devpath, int timer)
+int bm3803_timer_initialize(const char *devpath, int timer)
 {
-  FAR struct bm3803_lowerhalf_s *lower;
+  struct bm3803_lowerhalf_s *lower;
 
   switch (timer)
     {
@@ -445,8 +445,8 @@ int bm3803_timer_initialize(FAR const char *devpath, int timer)
    * REVISIT: The returned handle is discard here.
    */
 
-  FAR void *drvr = timer_register(devpath,
-                                  (FAR struct timer_lowerhalf_s *)lower);
+  void *drvr = timer_register(devpath,
+                                  (struct timer_lowerhalf_s *)lower);
   if (drvr == NULL)
     {
       /* The actual cause of the failure may have been a failure to allocate

--- a/arch/sparc/src/bm3803/bm3803_wdg.c
+++ b/arch/sparc/src/bm3803/bm3803_wdg.c
@@ -63,7 +63,7 @@ struct bm3803_lowerhalf_s
 {
   /* Lower half operations */
 
-  FAR const struct watchdog_ops_s  *ops;
+  const struct watchdog_ops_s  *ops;
   uint32_t timeout;    /* The (actual) selected timeout */
   uint32_t lastreset;  /* The last reset time */
   bool     started;    /* true: The watchdog timer has been started */
@@ -80,16 +80,16 @@ struct bm3803_lowerhalf_s
 # define        bm3803_getreg(addr)     getreg32(addr)
 # define        bm3803_putreg(val,addr) putreg32(val,addr)
 
-static inline void bm3803_setreload(FAR struct bm3803_lowerhalf_s *priv);
+static inline void bm3803_setreload(struct bm3803_lowerhalf_s *priv);
 
 /* "Lower half" driver methods **********************************************/
 
-static int      bm3803_start(FAR struct watchdog_lowerhalf_s *lower);
-static int      bm3803_stop(FAR struct watchdog_lowerhalf_s *lower);
-static int      bm3803_keepalive(FAR struct watchdog_lowerhalf_s *lower);
-static int      bm3803_getstatus(FAR struct watchdog_lowerhalf_s *lower,
-                  FAR struct watchdog_status_s *status);
-static int      bm3803_settimeout(FAR struct watchdog_lowerhalf_s *lower,
+static int      bm3803_start(struct watchdog_lowerhalf_s *lower);
+static int      bm3803_stop(struct watchdog_lowerhalf_s *lower);
+static int      bm3803_keepalive(struct watchdog_lowerhalf_s *lower);
+static int      bm3803_getstatus(struct watchdog_lowerhalf_s *lower,
+                  struct watchdog_status_s *status);
+static int      bm3803_settimeout(struct watchdog_lowerhalf_s *lower,
                   uint32_t timeout);
 
 /****************************************************************************
@@ -129,7 +129,7 @@ static struct bm3803_lowerhalf_s g_wdgdev;
  *
  ****************************************************************************/
 
-static inline void bm3803_setreload(FAR struct bm3803_lowerhalf_s *priv)
+static inline void bm3803_setreload(struct bm3803_lowerhalf_s *priv)
 {
   /* Set the reload value */
 
@@ -151,10 +151,10 @@ static inline void bm3803_setreload(FAR struct bm3803_lowerhalf_s *priv)
  *
  ****************************************************************************/
 
-static int bm3803_start(FAR struct watchdog_lowerhalf_s *lower)
+static int bm3803_start(struct watchdog_lowerhalf_s *lower)
 {
-  FAR struct bm3803_lowerhalf_s *priv =
-                                      (FAR struct bm3803_lowerhalf_s *)lower;
+  struct bm3803_lowerhalf_s *priv =
+                                      (struct bm3803_lowerhalf_s *)lower;
   irqstate_t flags;
   uint32_t val = bm3803_getreg(BM3803_TIM1_BASE + BM3803_TIM_CR_OFFSET);
   val |= TIMER_WDG;
@@ -202,7 +202,7 @@ static int bm3803_start(FAR struct watchdog_lowerhalf_s *lower)
  *
  ****************************************************************************/
 
-static int bm3803_stop(FAR struct watchdog_lowerhalf_s *lower)
+static int bm3803_stop(struct watchdog_lowerhalf_s *lower)
 {
   uint32_t val = bm3803_getreg(BM3803_TIM1_BASE + BM3803_TIM_CR_OFFSET);
 
@@ -232,10 +232,10 @@ static int bm3803_stop(FAR struct watchdog_lowerhalf_s *lower)
  *
  ****************************************************************************/
 
-static int bm3803_keepalive(FAR struct watchdog_lowerhalf_s *lower)
+static int bm3803_keepalive(struct watchdog_lowerhalf_s *lower)
 {
-  FAR struct bm3803_lowerhalf_s *priv =
-                                      (FAR struct bm3803_lowerhalf_s *)lower;
+  struct bm3803_lowerhalf_s *priv =
+                                      (struct bm3803_lowerhalf_s *)lower;
   irqstate_t flags;
 
   wdinfo("Entry\n");
@@ -266,11 +266,11 @@ static int bm3803_keepalive(FAR struct watchdog_lowerhalf_s *lower)
  *
  ****************************************************************************/
 
-static int bm3803_getstatus(FAR struct watchdog_lowerhalf_s *lower,
-                             FAR struct watchdog_status_s *status)
+static int bm3803_getstatus(struct watchdog_lowerhalf_s *lower,
+                             struct watchdog_status_s *status)
 {
-  FAR struct bm3803_lowerhalf_s *priv =
-                                      (FAR struct bm3803_lowerhalf_s *)lower;
+  struct bm3803_lowerhalf_s *priv =
+                                      (struct bm3803_lowerhalf_s *)lower;
   uint32_t ticks;
   uint32_t elapsed;
 
@@ -326,11 +326,11 @@ static int bm3803_getstatus(FAR struct watchdog_lowerhalf_s *lower,
  *
  ****************************************************************************/
 
-static int bm3803_settimeout(FAR struct watchdog_lowerhalf_s *lower,
+static int bm3803_settimeout(struct watchdog_lowerhalf_s *lower,
                               uint32_t timeout)
 {
-  FAR struct bm3803_lowerhalf_s *priv =
-                                      (FAR struct bm3803_lowerhalf_s *)lower;
+  struct bm3803_lowerhalf_s *priv =
+                                      (struct bm3803_lowerhalf_s *)lower;
   uint32_t reload;
   uint16_t prescaler;
   uint32_t freqin;
@@ -402,9 +402,9 @@ static int bm3803_settimeout(FAR struct watchdog_lowerhalf_s *lower,
  *
  ****************************************************************************/
 
-void bm3803_wdginitialize(FAR const char *devpath)
+void bm3803_wdginitialize(const char *devpath)
 {
-  FAR struct bm3803_lowerhalf_s *priv = &g_wdgdev;
+  struct bm3803_lowerhalf_s *priv = &g_wdgdev;
 
   wdinfo("Entry: devpath=%s \n", devpath);
 
@@ -422,12 +422,12 @@ void bm3803_wdginitialize(FAR const char *devpath)
    * device option bits, the watchdog is automatically enabled at power-on.
    */
 
-  bm3803_settimeout((FAR struct watchdog_lowerhalf_s *)priv,
+  bm3803_settimeout((struct watchdog_lowerhalf_s *)priv,
                     CONFIG_BM3803_WDG_DEFTIMOUT);
 
   /* Register the watchdog driver as /dev/watchdog0 */
 
-  (void)watchdog_register(devpath, (FAR struct watchdog_lowerhalf_s *)priv);
+  (void)watchdog_register(devpath, (struct watchdog_lowerhalf_s *)priv);
 }
 
 #endif /* CONFIG_WATCHDOG && CONFIG_BM3803_WDG */

--- a/arch/sparc/src/bm3803/bm3803_wdg.h
+++ b/arch/sparc/src/bm3803/bm3803_wdg.h
@@ -65,7 +65,7 @@ extern "C"
  ****************************************************************************/
 
 #ifdef CONFIG_BM3803_WDG
-void bm3803_wdginitialize(FAR const char *devpath);
+void bm3803_wdginitialize(const char *devpath);
 #endif
 
 #undef EXTERN

--- a/arch/sparc/src/bm3823/bm3823-timerisr.c
+++ b/arch/sparc/src/bm3823/bm3823-timerisr.c
@@ -78,7 +78,7 @@
  *
  ****************************************************************************/
 
-static int bm3823_timerisr(int irq, uint32_t *regs, FAR void *arg)
+static int bm3823_timerisr(int irq, uint32_t *regs, void *arg)
 {
   /* Clear the pending timer interrupt */
 

--- a/arch/sparc/src/common/up_allocateheap.c
+++ b/arch/sparc/src/common/up_allocateheap.c
@@ -64,8 +64,8 @@
  *
  ****************************************************************************/
 
-void up_allocate_heap(FAR void **heap_start, size_t *heap_size)
+void up_allocate_heap(void **heap_start, size_t *heap_size)
 {
-  *heap_start = (FAR void *)g_idle_topstack;
+  *heap_start = (void *)g_idle_topstack;
   *heap_size = CONFIG_RAM_END - g_idle_topstack;
 }

--- a/arch/sparc/src/common/up_assert.c
+++ b/arch/sparc/src/common/up_assert.c
@@ -101,7 +101,7 @@ static void _up_assert(int errorcode)
  ****************************************************************************/
 
 #ifdef CONFIG_ARCH_USBDUMP
-static int usbtrace_syslog(FAR const char *fmt, ...)
+static int usbtrace_syslog(const char *fmt, ...)
 {
   va_list ap;
 
@@ -113,7 +113,7 @@ static int usbtrace_syslog(FAR const char *fmt, ...)
   return 0;
 }
 
-static int assert_tracecallback(FAR struct usbtrace_s *trace, FAR void *arg)
+static int assert_tracecallback(struct usbtrace_s *trace, void *arg)
 {
   usbtrace_trprintf(usbtrace_syslog, trace->event, trace->value);
   return 0;

--- a/arch/sparc/src/common/up_checkstack.c
+++ b/arch/sparc/src/common/up_checkstack.c
@@ -60,11 +60,11 @@
  *
  ****************************************************************************/
 
-static size_t do_stackcheck(FAR void *stackbase, size_t nbytes)
+static size_t do_stackcheck(void *stackbase, size_t nbytes)
 {
   uintptr_t start;
   uintptr_t end;
-  FAR uint32_t *ptr;
+  uint32_t *ptr;
   size_t mark;
 
   if (nbytes == 0)
@@ -87,7 +87,7 @@ static size_t do_stackcheck(FAR void *stackbase, size_t nbytes)
    * that does not have the magic value is the high water mark.
    */
 
-  for (ptr = (FAR uint32_t *)start, mark = (nbytes >> 2);
+  for (ptr = (uint32_t *)start, mark = (nbytes >> 2);
        *ptr == STACK_COLOR && mark > 0;
        ptr++, mark--);
 
@@ -107,7 +107,7 @@ static size_t do_stackcheck(FAR void *stackbase, size_t nbytes)
       int i;
       int j;
 
-      ptr = (FAR uint32_t *)start;
+      ptr = (uint32_t *)start;
       for (i = 0; i < size; i += 4 * 64)
         {
           for (j = 0; j < 64; j++)
@@ -147,7 +147,7 @@ static size_t do_stackcheck(FAR void *stackbase, size_t nbytes)
  *
  ****************************************************************************/
 
-void up_stack_color(FAR void *stackbase, size_t nbytes)
+void up_stack_color(void *stackbase, size_t nbytes)
 {
   uint32_t *stkptr;
   uintptr_t stkend;
@@ -198,12 +198,12 @@ void up_stack_color(FAR void *stackbase, size_t nbytes)
  *
  ****************************************************************************/
 
-size_t up_check_tcbstack(FAR struct tcb_s *tcb)
+size_t up_check_tcbstack(struct tcb_s *tcb)
 {
   return do_stackcheck(tcb->stack_base_ptr, tcb->adj_stack_size);
 }
 
-ssize_t up_check_tcbstack_remain(FAR struct tcb_s *tcb)
+ssize_t up_check_tcbstack_remain(struct tcb_s *tcb)
 {
   return tcb->adj_stack_size - up_check_tcbstack(tcb);
 }

--- a/arch/sparc/src/common/up_createstack.c
+++ b/arch/sparc/src/common/up_createstack.c
@@ -77,7 +77,7 @@
  *
  ****************************************************************************/
 
-int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
+int up_create_stack(struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
 {
   /* Is there already a stack allocated of a different size?  Because of
    * alignment issues, stack_size might erroneously appear to be of a

--- a/arch/sparc/src/common/up_exit.c
+++ b/arch/sparc/src/common/up_exit.c
@@ -63,11 +63,11 @@
  ****************************************************************************/
 
 #ifdef CONFIG_DUMP_ON_EXIT
-static void _up_dumponexit(FAR struct tcb_s *tcb, FAR void *arg)
+static void _up_dumponexit(struct tcb_s *tcb, void *arg)
 {
-  FAR struct filelist *filelist;
+  struct filelist *filelist;
 #if CONFIG_NFILE_STREAMS > 0
-  FAR struct streamlist *streamlist;
+  struct streamlist *streamlist;
 #endif
   int i;
 

--- a/arch/sparc/src/common/up_internal.h
+++ b/arch/sparc/src/common/up_internal.h
@@ -206,11 +206,11 @@ void up_dumpstate(void);
 
 /* Software interrupt 0 handler */
 
-int up_swint0(int irq, FAR void *context, FAR void *arg);
+int up_swint0(int irq, void *context, void *arg);
 
 /* Software interrupt 1 handler */
 
-int up_swint1(int irq, FAR void *context, FAR void *arg);
+int up_swint1(int irq, void *context, void *arg);
 
 /* Signals */
 
@@ -265,7 +265,7 @@ void up_usbuninitialize(void);
 
 /* Debug ********************************************************************/
 #ifdef CONFIG_STACK_COLORATION
-void up_stack_color(FAR void *stackbase, size_t nbytes);
+void up_stack_color(void *stackbase, size_t nbytes);
 #endif
 
 #endif /* __ASSEMBLY__ */

--- a/arch/sparc/src/common/up_releasestack.c
+++ b/arch/sparc/src/common/up_releasestack.c
@@ -75,7 +75,7 @@
  *
  ****************************************************************************/
 
-void up_release_stack(FAR struct tcb_s *dtcb, uint8_t ttype)
+void up_release_stack(struct tcb_s *dtcb, uint8_t ttype)
 {
   /* Is there a stack allocated? */
 

--- a/arch/sparc/src/common/up_stackframe.c
+++ b/arch/sparc/src/common/up_stackframe.c
@@ -69,9 +69,9 @@
  *
  ****************************************************************************/
 
-FAR void *up_stack_frame(FAR struct tcb_s *tcb, size_t frame_size)
+void *up_stack_frame(struct tcb_s *tcb, size_t frame_size)
 {
-  FAR void *ret;
+  void *ret;
 
   /* Align the frame_size */
 
@@ -89,7 +89,7 @@ FAR void *up_stack_frame(FAR struct tcb_s *tcb, size_t frame_size)
 
   /* Save the adjusted stack values in the struct tcb_s */
 
-  tcb->stack_base_ptr  = (FAR uint8_t *)tcb->stack_base_ptr + frame_size;
+  tcb->stack_base_ptr  = (uint8_t *)tcb->stack_base_ptr + frame_size;
   tcb->adj_stack_size -= frame_size;
 
   /* And return the pointer to the allocated region */

--- a/arch/sparc/src/sparc_v8/up_romgetc.c
+++ b/arch/sparc/src/sparc_v8/up_romgetc.c
@@ -84,7 +84,7 @@
  *
  ****************************************************************************/
 
-char up_romgetc(FAR const char *ptr)
+char up_romgetc(const char *ptr)
 {
   return pgm_read_byte_near(ptr);
 }

--- a/arch/sparc/src/sparc_v8/up_swint1.c
+++ b/arch/sparc/src/sparc_v8/up_swint1.c
@@ -81,7 +81,7 @@ static void dispatch_syscall(void)
  *
  ****************************************************************************/
 
-int up_swint1(int irq, FAR void *context, FAR void *arg)
+int up_swint1(int irq, void *context, void *arg)
 {
   uint32_t *regs = (uint32_t *)context;
 
@@ -187,7 +187,7 @@ int up_swint1(int irq, FAR void *context, FAR void *arg)
       default:
         {
 #ifdef CONFIG_BUILD_KERNEL
-          FAR struct tcb_s *rtcb = sched_self();
+          struct tcb_s *rtcb = sched_self();
           int index = rtcb->xcp.nsyscalls;
 
           /* Verify that the SYS call number is within range */

--- a/arch/x86_64/src/common/up_allocateheap.c
+++ b/arch/x86_64/src/common/up_allocateheap.c
@@ -67,7 +67,7 @@ const uintptr_t g_idle_topstack = (uintptr_t)&_ebss +
  *
  ****************************************************************************/
 
-void up_allocate_heap(FAR void **heap_start, size_t *heap_size)
+void up_allocate_heap(void **heap_start, size_t *heap_size)
 {
   board_autoled_on(LED_HEAPALLOCATE);
 

--- a/arch/x86_64/src/common/up_assert.c
+++ b/arch/x86_64/src/common/up_assert.c
@@ -89,7 +89,7 @@ static void x86_64_stackdump(uint64_t sp, uint64_t stack_top)
  ****************************************************************************/
 
 #ifdef CONFIG_ARCH_USBDUMP
-static int usbtrace_syslog(FAR const char *fmt, ...)
+static int usbtrace_syslog(const char *fmt, ...)
 {
   va_list ap;
 
@@ -101,7 +101,7 @@ static int usbtrace_syslog(FAR const char *fmt, ...)
   return OK;
 }
 
-static int assert_tracecallback(FAR struct usbtrace_s *trace, FAR void *arg)
+static int assert_tracecallback(struct usbtrace_s *trace, void *arg)
 {
   usbtrace_trprintf(usbtrace_syslog, trace->event, trace->value);
   return 0;
@@ -115,7 +115,7 @@ static int assert_tracecallback(FAR struct usbtrace_s *trace, FAR void *arg)
 #ifdef CONFIG_ARCH_STACKDUMP
 static void up_dumpstate(void)
 {
-  FAR struct tcb_s *rtcb = running_task();
+  struct tcb_s *rtcb = running_task();
   uint64_t sp = up_getsp();
   uint64_t ustackbase;
   uint64_t ustacksize;

--- a/arch/x86_64/src/common/up_exit.c
+++ b/arch/x86_64/src/common/up_exit.c
@@ -61,9 +61,9 @@
  ****************************************************************************/
 
 #ifdef CONFIG_DUMP_ON_EXIT
-static void _up_dumponexit(FAR struct tcb_s *tcb, FAR void *arg)
+static void _up_dumponexit(struct tcb_s *tcb, void *arg)
 {
-  FAR struct filelist *filelist;
+  struct filelist *filelist;
   int i;
   int j;
 

--- a/arch/x86_64/src/intel64/intel64_tickless.c
+++ b/arch/x86_64/src/intel64/intel64_tickless.c
@@ -27,10 +27,10 @@
  *
  *   void sim_timer_initialize(void): Initializes the timer facilities.
  *     Called early in the initialization sequence (by up_initialize()).
- *   int up_timer_gettime(FAR struct timespec *ts):  Returns the current
+ *   int up_timer_gettime(struct timespec *ts):  Returns the current
  *     time from the platform specific time source.
  *   int up_timer_cancel(void):  Cancels the interval timer.
- *   int up_timer_start(FAR const struct timespec *ts): Start (or re-starts)
+ *   int up_timer_start(const struct timespec *ts): Start (or re-starts)
  *     the interval timer.
  *
  * The RTOS will provide the following interfaces for use by the platform-
@@ -137,14 +137,14 @@ void up_timer_initialize(void)
   return;
 }
 
-static inline uint64_t up_ts2tick(FAR const struct timespec *ts)
+static inline uint64_t up_ts2tick(const struct timespec *ts)
 {
   return ROUND_INT_DIV((uint64_t)ts->tv_nsec * x86_64_timer_freq,
                        NS_PER_SEC) +
          (uint64_t)ts->tv_sec * x86_64_timer_freq;
 }
 
-static inline void up_tick2ts(uint64_t tick, FAR struct timespec *ts)
+static inline void up_tick2ts(uint64_t tick, struct timespec *ts)
 {
   ts->tv_sec  = (tick / x86_64_timer_freq);
   ts->tv_nsec = (uint64_t)(ROUND_INT_DIV((tick % x86_64_timer_freq) *
@@ -182,7 +182,7 @@ static inline void up_tmr_sync_down(void)
  *   sim_timer_initialize() was called).  This function is functionally
  *   equivalent to:
  *
- *      int clock_gettime(clockid_t clockid, FAR struct timespec *ts);
+ *      int clock_gettime(clockid_t clockid, struct timespec *ts);
  *
  *   when clockid is CLOCK_MONOTONIC.
  *
@@ -207,7 +207,7 @@ static inline void up_tmr_sync_down(void)
  *
  ****************************************************************************/
 
-int up_timer_gettime(FAR struct timespec *ts)
+int up_timer_gettime(struct timespec *ts)
 {
   uint64_t diff = (rdtsc() - g_start_tsc);
   up_tick2ts(diff, ts);
@@ -247,7 +247,7 @@ int up_timer_gettime(FAR struct timespec *ts)
  *
  ****************************************************************************/
 
-int up_timer_cancel(FAR struct timespec *ts)
+int up_timer_cancel(struct timespec *ts)
 {
   up_tmr_sync_up();
 
@@ -298,7 +298,7 @@ int up_timer_cancel(FAR struct timespec *ts)
  *
  ****************************************************************************/
 
-int up_timer_start(FAR const struct timespec *ts)
+int up_timer_start(const struct timespec *ts)
 {
   uint64_t ticks;
 
@@ -375,7 +375,7 @@ void up_timer_expire(void)
  *
  ****************************************************************************/
 
-int up_alarm_cancel(FAR struct timespec *ts)
+int up_alarm_cancel(struct timespec *ts)
 {
   up_tmr_sync_up();
 
@@ -418,7 +418,7 @@ int up_alarm_cancel(FAR struct timespec *ts)
  *
  ****************************************************************************/
 
-int up_alarm_start(FAR const struct timespec *ts)
+int up_alarm_start(const struct timespec *ts)
 {
   uint64_t ticks;
 

--- a/arch/x86_64/src/intel64/up_createstack.c
+++ b/arch/x86_64/src/intel64/up_createstack.c
@@ -88,7 +88,7 @@
  *
  ****************************************************************************/
 
-int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
+int up_create_stack(struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
 {
 #ifdef CONFIG_TLS_ALIGNED
   /* The allocated stack size must not exceed the maximum possible for the

--- a/arch/x86_64/src/intel64/up_releasestack.c
+++ b/arch/x86_64/src/intel64/up_releasestack.c
@@ -77,7 +77,7 @@
  *
  ****************************************************************************/
 
-void up_release_stack(FAR struct tcb_s *dtcb, uint8_t ttype)
+void up_release_stack(struct tcb_s *dtcb, uint8_t ttype)
 {
   /* Is there a stack allocated? */
 

--- a/arch/x86_64/src/intel64/up_rtc.c
+++ b/arch/x86_64/src/intel64/up_rtc.c
@@ -139,7 +139,7 @@ int up_rtc_initialize(void)
  *
  ************************************************************************************/
 
-int up_rtc_gettime(FAR struct timespec *tp)
+int up_rtc_gettime(struct timespec *tp)
 {
   uint64_t tmp;
 
@@ -165,7 +165,7 @@ int up_rtc_gettime(FAR struct timespec *tp)
  *
  ************************************************************************************/
 
-int up_rtc_settime(FAR const struct timespec *tp)
+int up_rtc_settime(const struct timespec *tp)
 {
   /* What so ever.. */
 

--- a/arch/x86_64/src/intel64/up_stackframe.c
+++ b/arch/x86_64/src/intel64/up_stackframe.c
@@ -69,9 +69,9 @@
  *
  ****************************************************************************/
 
-FAR void *up_stack_frame(FAR struct tcb_s *tcb, size_t frame_size)
+void *up_stack_frame(struct tcb_s *tcb, size_t frame_size)
 {
-  FAR void *ret;
+  void *ret;
 
   /* Align the frame_size */
 
@@ -89,7 +89,7 @@ FAR void *up_stack_frame(FAR struct tcb_s *tcb, size_t frame_size)
 
   /* Save the adjusted stack values in the struct tcb_s */
 
-  tcb->stack_base_ptr  = (FAR uint8_t *)tcb->stack_base_ptr + frame_size;
+  tcb->stack_base_ptr  = (uint8_t *)tcb->stack_base_ptr + frame_size;
   tcb->adj_stack_size -= frame_size;
 
   /* And return the pointer to the allocated region */

--- a/arch/xtensa/src/common/xtensa_backtrace.c
+++ b/arch/xtensa/src/common/xtensa_backtrace.c
@@ -233,7 +233,7 @@ int up_backtrace(struct tcb_s *tcb, void **buffer, int size, int skip)
       if (up_interrupt_context())
         {
 #if CONFIG_ARCH_INTERRUPTSTACK > 15
-          FAR void *istackbase;
+          void *istackbase;
 #ifdef CONFIG_SMP
           istackbase = xtensa_intstack_alloc();
 #else

--- a/arch/xtensa/src/esp32/esp32_oneshot_lowerhalf.c
+++ b/arch/xtensa/src/esp32/esp32_oneshot_lowerhalf.c
@@ -118,7 +118,7 @@ static void esp32_oneshot_lh_handler(void *arg)
   struct esp32_oneshot_lowerhalf_s *priv =
     (struct esp32_oneshot_lowerhalf_s *)arg;
   oneshot_callback_t callback;
-  FAR void *cb_arg;
+  void *cb_arg;
 
   DEBUGASSERT(priv != NULL);
   DEBUGASSERT(priv->callback != NULL);

--- a/arch/xtensa/src/esp32/esp32_twai.h
+++ b/arch/xtensa/src/esp32/esp32_twai.h
@@ -66,7 +66,7 @@ extern "C"
 
 #if defined(CONFIG_CAN) && defined(CONFIG_ESP32_TWAI)
 struct can_dev_s;
-FAR struct can_dev_s *esp32_twaiinitialize(int port);
+struct can_dev_s *esp32_twaiinitialize(int port);
 #endif
 
 #ifdef __cplusplus

--- a/arch/xtensa/src/esp32s2/esp32s2_oneshot_lowerhalf.c
+++ b/arch/xtensa/src/esp32s2/esp32s2_oneshot_lowerhalf.c
@@ -115,7 +115,7 @@ static void esp32s2_oneshot_lh_handler(void *arg)
   struct esp32s2_oneshot_lowerhalf_s *priv =
     (struct esp32s2_oneshot_lowerhalf_s *)arg;
   oneshot_callback_t callback;
-  FAR void *cb_arg;
+  void *cb_arg;
 
   DEBUGASSERT(priv != NULL);
   DEBUGASSERT(priv->callback != NULL);

--- a/arch/xtensa/src/esp32s3/esp32s3_oneshot_lowerhalf.c
+++ b/arch/xtensa/src/esp32s3/esp32s3_oneshot_lowerhalf.c
@@ -117,7 +117,7 @@ static void oneshot_lh_handler(void *arg)
   struct esp32s3_oneshot_lowerhalf_s *priv =
     (struct esp32s3_oneshot_lowerhalf_s *)arg;
   oneshot_callback_t callback;
-  FAR void *cb_arg;
+  void *cb_arg;
 
   DEBUGASSERT(priv != NULL);
   DEBUGASSERT(priv->callback != NULL);

--- a/boards/mips/pic32mx/mirtoo/README.txt
+++ b/boards/mips/pic32mx/mirtoo/README.txt
@@ -583,7 +583,7 @@ Analog Input
   #include <nuttx/spi/spi.h>
   #include <nuttx/analog/pga11x.h>
 
-  FAR struct spi_dev_s *spi;
+  struct spi_dev_s *spi;
   PGA11X_HANDLE handle;
 
   /* Get the SPI port */

--- a/boards/mips/pic32mx/mirtoo/src/pic32_appinit.c
+++ b/boards/mips/pic32mx/mirtoo/src/pic32_appinit.c
@@ -101,8 +101,8 @@
 int board_app_initialize(uintptr_t arg)
 {
 #ifdef HAVE_SST25
-  FAR struct spi_dev_s *spi;
-  FAR struct mtd_dev_s *mtd;
+  struct spi_dev_s *spi;
+  struct mtd_dev_s *mtd;
   int ret;
 
   /* Get the SPI port */

--- a/boards/mips/pic32mx/mirtoo/src/pic32_leds.c
+++ b/boards/mips/pic32mx/mirtoo/src/pic32_leds.c
@@ -139,7 +139,7 @@ static const uint16_t g_ledpincfg[PIC32MX_MIRTOO_NLEDS] =
  ****************************************************************************/
 
 #ifdef CONFIG_ARCH_LEDS
-static void pic32mx_setleds(FAR const struct led_setting_s *setting)
+static void pic32mx_setleds(const struct led_setting_s *setting)
 {
   /* LEDs are pulled up so writing a low value (false) illuminates them */
 

--- a/boards/mips/pic32mx/mirtoo/src/pic32_spi2.c
+++ b/boards/mips/pic32mx/mirtoo/src/pic32_spi2.c
@@ -146,7 +146,7 @@ void weak_function pic32mx_spi2initialize(void)
 
 struct spi_dev_s;
 
-void  pic32mx_spi2select(FAR struct spi_dev_s *dev, uint32_t devid,
+void  pic32mx_spi2select(struct spi_dev_s *dev, uint32_t devid,
                          bool selected)
 {
   spiinfo("devid: %d CS: %s\n", (int)devid,
@@ -162,13 +162,13 @@ void  pic32mx_spi2select(FAR struct spi_dev_s *dev, uint32_t devid,
     }
 }
 
-uint8_t pic32mx_spi2status(FAR struct spi_dev_s *dev, uint32_t devid)
+uint8_t pic32mx_spi2status(struct spi_dev_s *dev, uint32_t devid)
 {
   return 0;
 }
 
 #ifdef CONFIG_SPI_CMDDATA
-int pic32mx_spi2cmddata(FAR struct spi_dev_s *dev, uint32_t devid, bool cmd)
+int pic32mx_spi2cmddata(struct spi_dev_s *dev, uint32_t devid, bool cmd)
 {
   return 0;
 }

--- a/boards/mips/pic32mx/pic32mx-starterkit/src/pic32mx_appinit.c
+++ b/boards/mips/pic32mx/pic32mx-starterkit/src/pic32mx_appinit.c
@@ -206,7 +206,7 @@ static int nsh_waiter(int argc, char *argv[])
 #ifdef NSH_HAVEMMCSD
 static int nsh_sdinitialize(void)
 {
-  FAR struct spi_dev_s *spi;
+  struct spi_dev_s *spi;
   int ret;
 
   /* Get the SPI port */
@@ -302,7 +302,7 @@ static int nsh_usbhostinitialize(void)
 
       ret = kthread_create("usbhost", CONFIG_USBHOST_DEFPRIO,
                            CONFIG_USBHOST_STACKSIZE,
-                           (main_t)nsh_waiter, (FAR char * const *)NULL);
+                           (main_t)nsh_waiter, (char * const *)NULL);
       return ret < 0 ? -ENOEXEC : OK;
     }
 

--- a/boards/mips/pic32mx/pic32mx-starterkit/src/pic32mx_leds.c
+++ b/boards/mips/pic32mx/pic32mx-starterkit/src/pic32mx_leds.c
@@ -144,7 +144,7 @@ static const uint16_t g_ledpincfg[PIC32MX_STARTERKIT_NLEDS] =
  ****************************************************************************/
 
 #ifdef CONFIG_ARCH_LEDS
-static void pic32mx_setleds(FAR const struct led_setting_s *setting)
+static void pic32mx_setleds(const struct led_setting_s *setting)
 {
   if (setting->led1 != LED_NC)
     {

--- a/boards/mips/pic32mx/pic32mx-starterkit/src/pic32mx_spi.c
+++ b/boards/mips/pic32mx/pic32mx-starterkit/src/pic32mx_spi.c
@@ -93,7 +93,7 @@ void weak_function pic32mx_spidev_initialize(void)
 struct spi_dev_s;
 
 #ifdef CONFIG_PIC32MX_SPI1
-void  pic32mx_spi1select(FAR struct spi_dev_s *dev, uint32_t devid,
+void  pic32mx_spi1select(struct spi_dev_s *dev, uint32_t devid,
                          bool selected)
 {
   spiinfo("devid: %d CS: %s\n",
@@ -101,7 +101,7 @@ void  pic32mx_spi1select(FAR struct spi_dev_s *dev, uint32_t devid,
 #warning "Missing logic"
 }
 
-uint8_t pic32mx_spi1status(FAR struct spi_dev_s *dev, uint32_t devid)
+uint8_t pic32mx_spi1status(struct spi_dev_s *dev, uint32_t devid)
 {
   spiinfo("Returning nothing\n");
 #warning "Missing logic"
@@ -109,7 +109,7 @@ uint8_t pic32mx_spi1status(FAR struct spi_dev_s *dev, uint32_t devid)
 }
 
 #ifdef CONFIG_SPI_CMDDATA
-int pic32mx_spi1cmddata(FAR struct spi_dev_s *dev,
+int pic32mx_spi1cmddata(struct spi_dev_s *dev,
                         uint32_t devid, bool cmd)
 {
 #warning "Missing logic"
@@ -119,7 +119,7 @@ int pic32mx_spi1cmddata(FAR struct spi_dev_s *dev,
 #endif
 
 #ifdef CONFIG_PIC32MX_SPI1
-void  pic32mx_spi1select(FAR struct spi_dev_s *dev, uint32_t devid,
+void  pic32mx_spi1select(struct spi_dev_s *dev, uint32_t devid,
                          bool selected)
 {
   spiinfo("devid: %d CS: %s\n", (int)devid,
@@ -127,7 +127,7 @@ void  pic32mx_spi1select(FAR struct spi_dev_s *dev, uint32_t devid,
 #warning "Missing logic"
 }
 
-uint8_t pic32mx_spi1status(FAR struct spi_dev_s *dev, uint32_t devid)
+uint8_t pic32mx_spi1status(struct spi_dev_s *dev, uint32_t devid)
 {
   spiinfo("Returning nothing\n");
 #warning "Missing logic"
@@ -135,7 +135,7 @@ uint8_t pic32mx_spi1status(FAR struct spi_dev_s *dev, uint32_t devid)
 }
 
 #ifdef CONFIG_SPI_CMDDATA
-int pic32mx_spi1cmddata(FAR struct spi_dev_s *dev, uint32_t devid, bool cmd)
+int pic32mx_spi1cmddata(struct spi_dev_s *dev, uint32_t devid, bool cmd)
 {
 #warning "Missing logic"
   return 0;
@@ -144,7 +144,7 @@ int pic32mx_spi1cmddata(FAR struct spi_dev_s *dev, uint32_t devid, bool cmd)
 #endif
 
 #ifdef CONFIG_PIC32MX_SPI3
-void  pic32mx_spi3select(FAR struct spi_dev_s *dev, uint32_t devid,
+void  pic32mx_spi3select(struct spi_dev_s *dev, uint32_t devid,
                          bool selected)
 {
   spiinfo("devid: %d CS: %s\n", (int)devid,
@@ -152,7 +152,7 @@ void  pic32mx_spi3select(FAR struct spi_dev_s *dev, uint32_t devid,
 #warning "Missing logic"
 }
 
-uint8_t pic32mx_spi3status(FAR struct spi_dev_s *dev, uint32_t devid)
+uint8_t pic32mx_spi3status(struct spi_dev_s *dev, uint32_t devid)
 {
   spiinfo("Returning nothing\n");
 #warning "Missing logic"
@@ -160,7 +160,7 @@ uint8_t pic32mx_spi3status(FAR struct spi_dev_s *dev, uint32_t devid)
 }
 
 #ifdef CONFIG_SPI_CMDDATA
-int pic32mx_spi3cmddata(FAR struct spi_dev_s *dev, uint32_t devid, bool cmd)
+int pic32mx_spi3cmddata(struct spi_dev_s *dev, uint32_t devid, bool cmd)
 {
 #warning "Missing logic"
   return 0;
@@ -169,7 +169,7 @@ int pic32mx_spi3cmddata(FAR struct spi_dev_s *dev, uint32_t devid, bool cmd)
 #endif
 
 #ifdef CONFIG_PIC32MX_SPI4
-void  pic32mx_spi4select(FAR struct spi_dev_s *dev, uint32_t devid,
+void  pic32mx_spi4select(struct spi_dev_s *dev, uint32_t devid,
                          bool selected)
 {
   spiinfo("devid: %d CS: %s\n", (int)devid,
@@ -177,7 +177,7 @@ void  pic32mx_spi4select(FAR struct spi_dev_s *dev, uint32_t devid,
 #warning "Missing logic"
 }
 
-uint8_t pic32mx_spi4status(FAR struct spi_dev_s *dev, uint32_t devid)
+uint8_t pic32mx_spi4status(struct spi_dev_s *dev, uint32_t devid)
 {
   spiinfo("Returning nothing\n");
 #warning "Missing logic"
@@ -185,7 +185,7 @@ uint8_t pic32mx_spi4status(FAR struct spi_dev_s *dev, uint32_t devid)
 }
 
 #ifdef CONFIG_SPI_CMDDATA
-int pic32mx_spi4cmddata(FAR struct spi_dev_s *dev, uint32_t devid, bool cmd)
+int pic32mx_spi4cmddata(struct spi_dev_s *dev, uint32_t devid, bool cmd)
 {
 #warning "Missing logic"
   return 0;

--- a/boards/mips/pic32mx/pic32mx-starterkit/src/pic32mx_usbdev.c
+++ b/boards/mips/pic32mx/pic32mx-starterkit/src/pic32mx_usbdev.c
@@ -130,7 +130,7 @@ void weak_function pic32mx_usbdevinitialize(void)
  *
  ****************************************************************************/
 
-int pic32mx_usbpullup(FAR struct usbdev_s *dev,  bool enable)
+int pic32mx_usbpullup(struct usbdev_s *dev,  bool enable)
 {
   /* The PIC32 Ethernet Starter Kit does not have a USB pull-up */
 
@@ -148,7 +148,7 @@ int pic32mx_usbpullup(FAR struct usbdev_s *dev,  bool enable)
  *
  ****************************************************************************/
 
-void pic32mx_usbsuspend(FAR struct usbdev_s *dev, bool resume)
+void pic32mx_usbsuspend(struct usbdev_s *dev, bool resume)
 {
   /* Do nothing */
 }

--- a/boards/mips/pic32mx/pic32mx7mmb/src/pic32_bringup.c
+++ b/boards/mips/pic32mx/pic32mx7mmb/src/pic32_bringup.c
@@ -208,7 +208,7 @@ static int nsh_waiter(int argc, char *argv[])
 #ifdef NSH_HAVEMMCSD
 static int nsh_sdinitialize(void)
 {
-  FAR struct spi_dev_s *spi;
+  struct spi_dev_s *spi;
   int ret;
 
   /* Get the SPI port */
@@ -315,7 +315,7 @@ static int nsh_usbhostinitialize(void)
 
       ret = kthread_create("usbhost", CONFIG_USBHOST_DEFPRIO,
                            CONFIG_USBHOST_STACKSIZE,
-                           (main_t)nsh_waiter, (FAR char * const *)NULL);
+                           (main_t)nsh_waiter, (char * const *)NULL);
       return ret < 0 ? -ENOEXEC : OK;
     }
 

--- a/boards/mips/pic32mx/pic32mx7mmb/src/pic32_leds.c
+++ b/boards/mips/pic32mx/pic32mx7mmb/src/pic32_leds.c
@@ -149,7 +149,7 @@ static const uint16_t g_ledpincfg[PIC32MX_PIC32MX7MMB_NLEDS] =
  ****************************************************************************/
 
 #ifdef CONFIG_ARCH_LEDS
-static void pic32mx_setleds(FAR const struct led_setting_s *setting)
+static void pic32mx_setleds(const struct led_setting_s *setting)
 {
   /* LEDs are pulled up so writing a low value (false) illuminates them */
 

--- a/boards/mips/pic32mx/pic32mx7mmb/src/pic32_mio283qt2.c
+++ b/boards/mips/pic32mx/pic32mx7mmb/src/pic32_mio283qt2.c
@@ -125,7 +125,7 @@ struct pic32mx7mmb_dev_s
   bool                   data;     /* true=data selected */
   bool                   selected; /* true=LCD selected */
   bool                   reading;  /* true=We are in a read sequence */
-  FAR struct lcd_dev_s  *drvr;     /* The saved instance of the LCD driver */
+  struct lcd_dev_s      *drvr;     /* The saved instance of the LCD driver */
 };
 
 /****************************************************************************
@@ -134,14 +134,14 @@ struct pic32mx7mmb_dev_s
 
 /* Low Level LCD access */
 
-static void pic32mx_select(FAR struct mio283qt2_lcd_s *dev);
-static void pic32mx_deselect(FAR struct mio283qt2_lcd_s *dev);
-static void pic32mx_index(FAR struct mio283qt2_lcd_s *dev, uint8_t index);
+static void pic32mx_select(struct mio283qt2_lcd_s *dev);
+static void pic32mx_deselect(struct mio283qt2_lcd_s *dev);
+static void pic32mx_index(struct mio283qt2_lcd_s *dev, uint8_t index);
 #ifndef CONFIG_MIO283QT2_WRONLY
-static uint16_t pic32mx_read(FAR struct mio283qt2_lcd_s *dev);
+static uint16_t pic32mx_read(struct mio283qt2_lcd_s *dev);
 #endif
-static void pic32mx_write(FAR struct mio283qt2_lcd_s *dev, uint16_t data);
-static void pic32mx_backlight(FAR struct mio283qt2_lcd_s *dev, int power);
+static void pic32mx_write(struct mio283qt2_lcd_s *dev, uint16_t data);
+static void pic32mx_backlight(struct mio283qt2_lcd_s *dev, int power);
 
 /****************************************************************************
  * Private Data
@@ -177,7 +177,7 @@ static struct pic32mx7mmb_dev_s g_pic32mx7mmb_lcd =
  *
  ****************************************************************************/
 
-static void pic32mx_command(FAR struct pic32mx7mmb_dev_s *priv)
+static void pic32mx_command(struct pic32mx7mmb_dev_s *priv)
 {
   /* Low selects command */
 
@@ -198,7 +198,7 @@ static void pic32mx_command(FAR struct pic32mx7mmb_dev_s *priv)
  *
  ****************************************************************************/
 
-static void pic32mx_data(FAR struct pic32mx7mmb_dev_s *priv)
+static void pic32mx_data(struct pic32mx7mmb_dev_s *priv)
 {
   /* Hi selects data */
 
@@ -232,9 +232,9 @@ static void pic32mx_busywait(void)
  *
  ****************************************************************************/
 
-static void pic32mx_select(FAR struct mio283qt2_lcd_s *dev)
+static void pic32mx_select(struct mio283qt2_lcd_s *dev)
 {
-  FAR struct pic32mx7mmb_dev_s *priv = (FAR struct pic32mx7mmb_dev_s *)dev;
+  struct pic32mx7mmb_dev_s *priv = (struct pic32mx7mmb_dev_s *)dev;
 
   /* CS low selects */
 
@@ -255,9 +255,9 @@ static void pic32mx_select(FAR struct mio283qt2_lcd_s *dev)
  *
  ****************************************************************************/
 
-static void pic32mx_deselect(FAR struct mio283qt2_lcd_s *dev)
+static void pic32mx_deselect(struct mio283qt2_lcd_s *dev)
 {
-  FAR struct pic32mx7mmb_dev_s *priv = (FAR struct pic32mx7mmb_dev_s *)dev;
+  struct pic32mx7mmb_dev_s *priv = (struct pic32mx7mmb_dev_s *)dev;
 
   /* CS high de-selects */
 
@@ -278,9 +278,9 @@ static void pic32mx_deselect(FAR struct mio283qt2_lcd_s *dev)
  *
  ****************************************************************************/
 
-static void pic32mx_index(FAR struct mio283qt2_lcd_s *dev, uint8_t index)
+static void pic32mx_index(struct mio283qt2_lcd_s *dev, uint8_t index)
 {
-  FAR struct pic32mx7mmb_dev_s *priv = (FAR struct pic32mx7mmb_dev_s *)dev;
+  struct pic32mx7mmb_dev_s *priv = (struct pic32mx7mmb_dev_s *)dev;
 
   /* Make sure that the PMP is not busy from the last transaction.
    * Read data is not available until the busy bit becomes zero.
@@ -303,9 +303,9 @@ static void pic32mx_index(FAR struct mio283qt2_lcd_s *dev, uint8_t index)
  ****************************************************************************/
 
 #ifndef CONFIG_MIO283QT2_WRONLY
-static uint16_t pic32mx_read(FAR struct mio283qt2_lcd_s *dev)
+static uint16_t pic32mx_read(struct mio283qt2_lcd_s *dev)
 {
-  FAR struct pic32mx7mmb_dev_s *priv = (FAR struct pic32mx7mmb_dev_s *)dev;
+  struct pic32mx7mmb_dev_s *priv = (struct pic32mx7mmb_dev_s *)dev;
   uint16_t data;
 
   /* Make sure that the PMP is not busy from the last transaction.
@@ -340,9 +340,9 @@ static uint16_t pic32mx_read(FAR struct mio283qt2_lcd_s *dev)
  *
  ****************************************************************************/
 
-static void pic32mx_write(FAR struct mio283qt2_lcd_s *dev, uint16_t data)
+static void pic32mx_write(struct mio283qt2_lcd_s *dev, uint16_t data)
 {
-  FAR struct pic32mx7mmb_dev_s *priv = (FAR struct pic32mx7mmb_dev_s *)dev;
+  struct pic32mx7mmb_dev_s *priv = (struct pic32mx7mmb_dev_s *)dev;
 
   /* Make sure that the PMP is not busy from the last transaction */
 
@@ -366,7 +366,7 @@ static void pic32mx_write(FAR struct mio283qt2_lcd_s *dev, uint16_t data)
  *
  ****************************************************************************/
 
-static void pic32mx_backlight(FAR struct mio283qt2_lcd_s *dev, int power)
+static void pic32mx_backlight(struct mio283qt2_lcd_s *dev, int power)
 {
   /* For now, we just control the backlight as a discrete.
    * Pulse width modulation would be required to vary the backlight level.
@@ -469,7 +469,7 @@ int board_lcd_initialize(void)
  *
  ****************************************************************************/
 
-FAR struct lcd_dev_s *board_lcd_getdev(int lcddev)
+struct lcd_dev_s *board_lcd_getdev(int lcddev)
 {
   DEBUGASSERT(lcddev == 0);
   return g_pic32mx7mmb_lcd.drvr;

--- a/boards/mips/pic32mx/pic32mx7mmb/src/pic32_spi.c
+++ b/boards/mips/pic32mx/pic32mx7mmb/src/pic32_spi.c
@@ -119,7 +119,7 @@ void weak_function pic32mx_spidev_initialize(void)
 struct spi_dev_s;
 
 #ifdef CONFIG_PIC32MX_SPI1
-void  pic32mx_spi1select(FAR struct spi_dev_s *dev, uint32_t devid,
+void  pic32mx_spi1select(struct spi_dev_s *dev, uint32_t devid,
                          bool selected)
 {
   spiinfo("devid: %d CS: %s\n", (int)devid,
@@ -131,7 +131,7 @@ void  pic32mx_spi1select(FAR struct spi_dev_s *dev, uint32_t devid,
     }
 }
 
-uint8_t pic32mx_spi1status(FAR struct spi_dev_s *dev, uint32_t devid)
+uint8_t pic32mx_spi1status(struct spi_dev_s *dev, uint32_t devid)
 {
   uint8_t ret = 0;
 
@@ -157,7 +157,7 @@ uint8_t pic32mx_spi1status(FAR struct spi_dev_s *dev, uint32_t devid)
 }
 
 #ifdef CONFIG_SPI_CMDDATA
-int pic32mx_spi1cmddata(FAR struct spi_dev_s *dev, uint32_t devid, bool cmd)
+int pic32mx_spi1cmddata(struct spi_dev_s *dev, uint32_t devid, bool cmd)
 {
 #warning "Missing logic"
   return 0;
@@ -166,7 +166,7 @@ int pic32mx_spi1cmddata(FAR struct spi_dev_s *dev, uint32_t devid, bool cmd)
 #endif
 
 #ifdef CONFIG_PIC32MX_SPI2
-void  pic31mx_spi2select(FAR struct spi_dev_s *dev, uint32_t devid,
+void  pic31mx_spi2select(struct spi_dev_s *dev, uint32_t devid,
                          bool selected)
 {
   spiinfo("devid: %d CS: %s\n", (int)devid,
@@ -174,7 +174,7 @@ void  pic31mx_spi2select(FAR struct spi_dev_s *dev, uint32_t devid,
 #warning "Missing logic"
 }
 
-uint8_t pic31mx_spi2status(FAR struct spi_dev_s *dev, uint32_t devid)
+uint8_t pic31mx_spi2status(struct spi_dev_s *dev, uint32_t devid)
 {
   spiinfo("Returning nothing\n");
 #warning "Missing logic"
@@ -182,7 +182,7 @@ uint8_t pic31mx_spi2status(FAR struct spi_dev_s *dev, uint32_t devid)
 }
 
 #ifdef CONFIG_SPI_CMDDATA
-int pic31mx_spi2cmddata(FAR struct spi_dev_s *dev, uint32_t devid, bool cmd)
+int pic31mx_spi2cmddata(struct spi_dev_s *dev, uint32_t devid, bool cmd)
 {
 #warning "Missing logic"
   return 0;
@@ -191,7 +191,7 @@ int pic31mx_spi2cmddata(FAR struct spi_dev_s *dev, uint32_t devid, bool cmd)
 #endif
 
 #ifdef CONFIG_PIC32MX_SPI3
-void  pic32mx_spi3select(FAR struct spi_dev_s *dev, uint32_t devid,
+void  pic32mx_spi3select(struct spi_dev_s *dev, uint32_t devid,
                          bool selected)
 {
   spiinfo("devid: %d CS: %s\n", (int)devid,
@@ -199,7 +199,7 @@ void  pic32mx_spi3select(FAR struct spi_dev_s *dev, uint32_t devid,
 #warning "Missing logic"
 }
 
-uint8_t pic32mx_spi3status(FAR struct spi_dev_s *dev, uint32_t devid)
+uint8_t pic32mx_spi3status(struct spi_dev_s *dev, uint32_t devid)
 {
   spiinfo("Returning nothing\n");
 #warning "Missing logic"
@@ -207,7 +207,7 @@ uint8_t pic32mx_spi3status(FAR struct spi_dev_s *dev, uint32_t devid)
 }
 
 #ifdef CONFIG_SPI_CMDDATA
-int pic32mx_spi3cmddata(FAR struct spi_dev_s *dev, uint32_t devid, bool cmd)
+int pic32mx_spi3cmddata(struct spi_dev_s *dev, uint32_t devid, bool cmd)
 {
 #warning "Missing logic"
   return 0;
@@ -216,7 +216,7 @@ int pic32mx_spi3cmddata(FAR struct spi_dev_s *dev, uint32_t devid, bool cmd)
 #endif
 
 #ifdef CONFIG_PIC32MX_SPI4
-void  pic32mx_spi4select(FAR struct spi_dev_s *dev, uint32_t devid,
+void  pic32mx_spi4select(struct spi_dev_s *dev, uint32_t devid,
                          bool selected)
 {
   spiinfo("devid: %d CS: %s\n", (int)devid,
@@ -224,7 +224,7 @@ void  pic32mx_spi4select(FAR struct spi_dev_s *dev, uint32_t devid,
 #warning "Missing logic"
 }
 
-uint8_t pic32mx_spi4status(FAR struct spi_dev_s *dev, uint32_t devid)
+uint8_t pic32mx_spi4status(struct spi_dev_s *dev, uint32_t devid)
 {
   spiinfo("Returning nothing\n");
 #warning "Missing logic"
@@ -232,7 +232,7 @@ uint8_t pic32mx_spi4status(FAR struct spi_dev_s *dev, uint32_t devid)
 }
 
 #ifdef CONFIG_SPI_CMDDATA
-int pic32mx_spi4cmddata(FAR struct spi_dev_s *dev, uint32_t devid, bool cmd)
+int pic32mx_spi4cmddata(struct spi_dev_s *dev, uint32_t devid, bool cmd)
 {
 #warning "Missing logic"
   return 0;

--- a/boards/mips/pic32mx/pic32mx7mmb/src/pic32_touchscreen.c
+++ b/boards/mips/pic32mx/pic32mx7mmb/src/pic32_touchscreen.c
@@ -218,20 +218,20 @@ static void tc_xplus_sample(void);
 static void tc_xminus_sample(void);
 static inline bool tc_valid_sample(uint16_t sample);
 
-static void tc_notify(FAR struct tc_dev_s *priv);
-static int tc_sample(FAR struct tc_dev_s *priv,
-                     FAR struct tc_sample_s *sample);
-static int tc_waitsample(FAR struct tc_dev_s *priv,
-                         FAR struct tc_sample_s *sample);
-static void tc_worker(FAR void *arg);
+static void tc_notify(struct tc_dev_s *priv);
+static int tc_sample(struct tc_dev_s *priv,
+                     struct tc_sample_s *sample);
+static int tc_waitsample(struct tc_dev_s *priv,
+                         struct tc_sample_s *sample);
+static void tc_worker(void *arg);
 
 /* Character driver methods */
 
-static int tc_open(FAR struct file *filep);
-static int tc_close(FAR struct file *filep);
-static ssize_t tc_read(FAR struct file *filep, FAR char *buffer, size_t len);
-static int tc_ioctl(FAR struct file *filep, int cmd, unsigned long arg);
-static int tc_poll(FAR struct file *filep, struct pollfd *fds, bool setup);
+static int tc_open(struct file *filep);
+static int tc_close(struct file *filep);
+static ssize_t tc_read(struct file *filep, char *buffer, size_t len);
+static int tc_ioctl(struct file *filep, int cmd, unsigned long arg);
+static int tc_poll(struct file *filep, struct pollfd *fds, bool setup);
 
 /****************************************************************************
  * Private Data
@@ -473,7 +473,7 @@ static inline bool tc_valid_sample(uint16_t sample)
  * Name: tc_notify
  ****************************************************************************/
 
-static void tc_notify(FAR struct tc_dev_s *priv)
+static void tc_notify(struct tc_dev_s *priv)
 {
   int i;
 
@@ -516,8 +516,8 @@ static void tc_notify(FAR struct tc_dev_s *priv)
  *
  ****************************************************************************/
 
-static int tc_sample(FAR struct tc_dev_s *priv,
-                          FAR struct tc_sample_s *sample)
+static int tc_sample(struct tc_dev_s *priv,
+                          struct tc_sample_s *sample)
 {
   int ret = -EAGAIN;
 
@@ -561,8 +561,8 @@ static int tc_sample(FAR struct tc_dev_s *priv,
  * Name: tc_waitsample
  ****************************************************************************/
 
-static int tc_waitsample(FAR struct tc_dev_s *priv,
-                              FAR struct tc_sample_s *sample)
+static int tc_waitsample(struct tc_dev_s *priv,
+                              struct tc_sample_s *sample)
 {
   int ret;
 
@@ -619,9 +619,9 @@ errout:
  * Name: tc_worker
  ****************************************************************************/
 
-static void tc_worker(FAR void *arg)
+static void tc_worker(void *arg)
 {
-  FAR struct tc_dev_s *priv = (FAR struct tc_dev_s *)arg;
+  struct tc_dev_s *priv = (struct tc_dev_s *)arg;
   uint32_t delay;
   uint16_t value;
   uint16_t newx;
@@ -974,11 +974,11 @@ static void tc_worker(FAR void *arg)
  * Name: tc_open
  ****************************************************************************/
 
-static int tc_open(FAR struct file *filep)
+static int tc_open(struct file *filep)
 {
 #ifdef CONFIG_TOUCHSCREEN_REFCNT
-  FAR struct inode         *inode;
-  FAR struct tc_dev_s *priv;
+  struct inode         *inode;
+  struct tc_dev_s *priv;
   uint8_t                   tmp;
   int                       ret;
 
@@ -986,7 +986,7 @@ static int tc_open(FAR struct file *filep)
   inode = filep->f_inode;
 
   DEBUGASSERT(inode && inode->i_private);
-  priv  = (FAR struct tc_dev_s *)inode->i_private;
+  priv  = (struct tc_dev_s *)inode->i_private;
 
   /* Get exclusive access to the driver data structure */
 
@@ -1027,18 +1027,18 @@ errout_with_sem:
  * Name: tc_close
  ****************************************************************************/
 
-static int tc_close(FAR struct file *filep)
+static int tc_close(struct file *filep)
 {
 #ifdef CONFIG_TOUCHSCREEN_REFCNT
-  FAR struct inode         *inode;
-  FAR struct tc_dev_s *priv;
+  struct inode         *inode;
+  struct tc_dev_s *priv;
   int                       ret;
 
   DEBUGASSERT(filep);
   inode = filep->f_inode;
 
   DEBUGASSERT(inode && inode->i_private);
-  priv  = (FAR struct tc_dev_s *)inode->i_private;
+  priv  = (struct tc_dev_s *)inode->i_private;
 
   /* Get exclusive access to the driver data structure */
 
@@ -1067,11 +1067,11 @@ static int tc_close(FAR struct file *filep)
  * Name: tc_read
  ****************************************************************************/
 
-static ssize_t tc_read(FAR struct file *filep, FAR char *buffer, size_t len)
+static ssize_t tc_read(struct file *filep, char *buffer, size_t len)
 {
-  FAR struct inode          *inode;
-  FAR struct tc_dev_s  *priv;
-  FAR struct touch_sample_s *report;
+  struct inode          *inode;
+  struct tc_dev_s  *priv;
+  struct touch_sample_s *report;
   struct tc_sample_s    sample;
   int                        ret;
 
@@ -1079,7 +1079,7 @@ static ssize_t tc_read(FAR struct file *filep, FAR char *buffer, size_t len)
   inode = filep->f_inode;
 
   DEBUGASSERT(inode && inode->i_private);
-  priv  = (FAR struct tc_dev_s *)inode->i_private;
+  priv  = (struct tc_dev_s *)inode->i_private;
 
   /* Verify that the caller has provided a buffer large enough to receive
    * the touch data.
@@ -1133,7 +1133,7 @@ static ssize_t tc_read(FAR struct file *filep, FAR char *buffer, size_t len)
    * to the caller.
    */
 
-  report = (FAR struct touch_sample_s *)buffer;
+  report = (struct touch_sample_s *)buffer;
   memset(report, 0, SIZEOF_TOUCH_SAMPLE_S(1));
   report->npoints            = 1;
   report->point[0].id        = sample.id;
@@ -1188,14 +1188,14 @@ errout:
  * Name: tc_ioctl
  ****************************************************************************/
 
-static int tc_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
+static int tc_ioctl(struct file *filep, int cmd, unsigned long arg)
 {
 #if 1
   iinfo("cmd: %d arg: %ld\n", cmd, arg);
   return -ENOTTY; /* None yet supported */
 #else
-  FAR struct inode         *inode;
-  FAR struct tc_dev_s *priv;
+  struct inode         *inode;
+  struct tc_dev_s *priv;
   int                       ret;
 
   iinfo("cmd: %d arg: %ld\n", cmd, arg);
@@ -1203,7 +1203,7 @@ static int tc_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
   inode = filep->f_inode;
 
   DEBUGASSERT(inode && inode->i_private);
-  priv  = (FAR struct tc_dev_s *)inode->i_private;
+  priv  = (struct tc_dev_s *)inode->i_private;
 
   /* Get exclusive access to the driver data structure */
 
@@ -1233,11 +1233,11 @@ static int tc_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
  * Name: tc_poll
  ****************************************************************************/
 
-static int tc_poll(FAR struct file *filep, FAR struct pollfd *fds,
+static int tc_poll(struct file *filep, struct pollfd *fds,
                         bool setup)
 {
-  FAR struct inode         *inode;
-  FAR struct tc_dev_s *priv;
+  struct inode         *inode;
+  struct tc_dev_s *priv;
   int                       ret;
   int                       i;
 
@@ -1246,7 +1246,7 @@ static int tc_poll(FAR struct file *filep, FAR struct pollfd *fds,
   inode = filep->f_inode;
 
   DEBUGASSERT(inode && inode->i_private);
-  priv  = (FAR struct tc_dev_s *)inode->i_private;
+  priv  = (struct tc_dev_s *)inode->i_private;
 
   /* Are we setting up the poll?  Or tearing it down? */
 
@@ -1342,7 +1342,7 @@ errout:
 
 int pic32mx_tsc_setup(int minor)
 {
-  FAR struct tc_dev_s *priv;
+  struct tc_dev_s *priv;
   char devname[DEV_NAMELEN];
   int ret;
 
@@ -1365,7 +1365,7 @@ int pic32mx_tsc_setup(int minor)
 #ifndef CONFIG_TOUCHSCREEN_MULTIPLE
   priv = &g_touchscreen;
 #else
-  priv = (FAR struct tc_dev_s *)kmm_malloc(sizeof(struct tc_dev_s));
+  priv = (struct tc_dev_s *)kmm_malloc(sizeof(struct tc_dev_s));
   if (!priv)
     {
       ierr("ERROR: kmm_malloc(%d) failed\n", sizeof(struct tc_dev_s));

--- a/boards/mips/pic32mx/pic32mx7mmb/src/pic32_usbdev.c
+++ b/boards/mips/pic32mx/pic32mx7mmb/src/pic32_usbdev.c
@@ -130,7 +130,7 @@ void weak_function pic32mx_usbdevinitialize(void)
  *
  ****************************************************************************/
 
-int pic32mx_usbpullup(FAR struct usbdev_s *dev,  bool enable)
+int pic32mx_usbpullup(struct usbdev_s *dev,  bool enable)
 {
   /* The Mikroelektronika PIC32MX7 MMB does not have a USB pull-up */
 
@@ -149,7 +149,7 @@ int pic32mx_usbpullup(FAR struct usbdev_s *dev,  bool enable)
  *
  ****************************************************************************/
 
-void pic32mx_usbsuspend(FAR struct usbdev_s *dev, bool resume)
+void pic32mx_usbsuspend(struct usbdev_s *dev, bool resume)
 {
   /* Do nothing */
 }

--- a/boards/mips/pic32mx/sure-pic32mx/src/pic32mx_appinit.c
+++ b/boards/mips/pic32mx/sure-pic32mx/src/pic32mx_appinit.c
@@ -209,7 +209,7 @@ static int nsh_waiter(int argc, char *argv[])
 #ifdef NSH_HAVE_MMCSD
 static int nsh_sdinitialize(void)
 {
-  FAR struct spi_dev_s *spi;
+  struct spi_dev_s *spi;
   int ret;
 
   /* Get the SPI port */
@@ -315,7 +315,7 @@ static int nsh_usbhostinitialize(void)
 
       ret = kthread_create("usbhost", CONFIG_USBHOST_DEFPRIO,
                            CONFIG_USBHOST_STACKSIZE,
-                           (main_t)nsh_waiter, (FAR char * const *)NULL);
+                           (main_t)nsh_waiter, (char * const *)NULL);
       return ret < 0 ? -ENOEXEC : OK;
     }
 

--- a/boards/mips/pic32mx/sure-pic32mx/src/pic32mx_autoleds.c
+++ b/boards/mips/pic32mx/sure-pic32mx/src/pic32mx_autoleds.c
@@ -115,7 +115,7 @@ static const struct led_setting_s g_ledoffvalues[LED_NVALUES] =
  * Name: pic32mx_setleds
  ****************************************************************************/
 
-static void pic32mx_setleds(FAR const struct led_setting_s *setting)
+static void pic32mx_setleds(const struct led_setting_s *setting)
 {
   if (setting->usb != LED_NC)
     {

--- a/boards/mips/pic32mx/sure-pic32mx/src/pic32mx_buttons.c
+++ b/boards/mips/pic32mx/sure-pic32mx/src/pic32mx_buttons.c
@@ -193,7 +193,7 @@ uint32_t board_buttons(void)
  ****************************************************************************/
 
 #ifdef CONFIG_ARCH_IRQBUTTONS
-int board_button_irq(int id, xcpt_t irqhandler, FAR void *arg)
+int board_button_irq(int id, xcpt_t irqhandler, void *arg)
 {
   int ret = -EINVAL;
 

--- a/boards/mips/pic32mx/sure-pic32mx/src/pic32mx_lcd1602.c
+++ b/boards/mips/pic32mx/sure-pic32mx/src/pic32mx_lcd1602.c
@@ -124,7 +124,7 @@
 struct lcd_instream_s
 {
   struct lib_instream_s stream;
-  FAR const char *buffer;
+  const char *buffer;
   ssize_t nbytes;
 };
 
@@ -145,9 +145,9 @@ struct lcd1602_2
 /* Debug */
 
 #ifdef CONFIG_DEBUG_LCD_INFO
-static void lcd_dumpstate(FAR const char *msg);
-static void lcd_dumpstream(FAR const char *msg,
-                           FAR const struct lcd_instream_s *stream);
+static void lcd_dumpstate(const char *msg);
+static void lcd_dumpstream(const char *msg,
+                           const struct lcd_instream_s *stream);
 #else
 #  define lcd_dumpstate(msg)
 #  define lcd_dumpstream(msg, stream)
@@ -155,7 +155,7 @@ static void lcd_dumpstream(FAR const char *msg,
 
 /* Internal functions */
 
-static int lcd_getstream(FAR struct lib_instream_s *instream);
+static int lcd_getstream(struct lib_instream_s *instream);
 static void lcd_brightness(uint8_t brightness);
 static void lcd_shortdelay(int delay);
 static void lcd_wrcommand(uint8_t cmd);
@@ -170,10 +170,10 @@ static void lcd_action(enum slcdcode_e code, uint8_t count);
 
 /* Character driver operations */
 
-static ssize_t lcd_read(FAR struct file *, FAR char *, size_t);
-static ssize_t lcd_write(FAR struct file *, FAR const char *, size_t);
-static int lcd_ioctl(FAR struct file *filep, int cmd, unsigned long arg);
-static int lcd_poll(FAR struct file *filep, FAR struct pollfd *fds,
+static ssize_t lcd_read(struct file *, char *, size_t);
+static ssize_t lcd_write(struct file *, const char *, size_t);
+static int lcd_ioctl(struct file *filep, int cmd, unsigned long arg);
+static int lcd_poll(struct file *filep, struct pollfd *fds,
                     bool setup);
 
 /****************************************************************************
@@ -209,7 +209,7 @@ static struct lcd1602_2 g_lcd1602;
  ****************************************************************************/
 
 #ifdef CONFIG_DEBUG_LCD_INFO
-static void lcd_dumpstate(FAR const char *msg)
+static void lcd_dumpstate(const char *msg)
 {
   uint8_t buffer[LCD_NCOLUMNS];
   uint8_t ch;
@@ -244,8 +244,8 @@ static void lcd_dumpstate(FAR const char *msg)
  ****************************************************************************/
 
 #ifdef CONFIG_DEBUG_LCD_INFO
-static void lcd_dumpstream(FAR const char *msg,
-                           FAR const struct lcd_instream_s *stream)
+static void lcd_dumpstream(const char *msg,
+                           const struct lcd_instream_s *stream)
 {
   lcdinfo("%s:\n", msg);
   lcdinfo("  nget: %d nbytes: %d\n",
@@ -262,10 +262,10 @@ static void lcd_dumpstream(FAR const char *msg,
  *
  ****************************************************************************/
 
-static int lcd_getstream(FAR struct lib_instream_s *instream)
+static int lcd_getstream(struct lib_instream_s *instream)
 {
-  FAR struct lcd_instream_s *lcdstream =
-                            (FAR struct lcd_instream_s *)instream;
+  struct lcd_instream_s *lcdstream =
+                            (struct lcd_instream_s *)instream;
 
   DEBUGASSERT(lcdstream && lcdstream->buffer);
   if (lcdstream->nbytes > 0)
@@ -792,7 +792,7 @@ static void lcd_action(enum slcdcode_e code, uint8_t count)
  * Name: lcd_read
  ****************************************************************************/
 
-static ssize_t lcd_read(FAR struct file *filep, FAR char *buffer, size_t len)
+static ssize_t lcd_read(struct file *filep, char *buffer, size_t len)
 {
   uint8_t row;
   uint8_t column;
@@ -826,7 +826,7 @@ static ssize_t lcd_read(FAR struct file *filep, FAR char *buffer, size_t len)
  * Name: lcd_write
  ****************************************************************************/
 
-static ssize_t lcd_write(FAR struct file *filep,  FAR const char *buffer,
+static ssize_t lcd_write(struct file *filep,  const char *buffer,
                          size_t len)
 {
   struct lcd_instream_s instream;
@@ -912,7 +912,7 @@ static ssize_t lcd_write(FAR struct file *filep,  FAR const char *buffer,
  * Name: lcd_ioctl
  ****************************************************************************/
 
-static int lcd_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
+static int lcd_ioctl(struct file *filep, int cmd, unsigned long arg)
 {
   switch (cmd)
     {
@@ -924,8 +924,8 @@ static int lcd_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
 
       case SLCDIOC_GETATTRIBUTES:
         {
-          FAR struct slcd_attributes_s *attr =
-                            (FAR struct slcd_attributes_s *)((uintptr_t)arg);
+          struct slcd_attributes_s *attr =
+                            (struct slcd_attributes_s *)((uintptr_t)arg);
 
           lcdinfo("SLCDIOC_GETATTRIBUTES:\n");
 
@@ -950,8 +950,8 @@ static int lcd_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
 
       case SLCDIOC_CURPOS:
         {
-          FAR struct slcd_curpos_s *curpos =
-                              (FAR struct slcd_curpos_s *)((uintptr_t)arg);
+          struct slcd_curpos_s *curpos =
+                              (struct slcd_curpos_s *)((uintptr_t)arg);
 
           lcdinfo("SLCDIOC_CURPOS: row=%d column=%d\n",
                    g_lcd1602.currow, g_lcd1602.curcol);
@@ -974,7 +974,7 @@ static int lcd_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
 
       case SLCDIOC_GETBRIGHTNESS:
         {
-          FAR int *brightness = (FAR int *)((uintptr_t)arg);
+          int *brightness = (int *)((uintptr_t)arg);
           if (!brightness)
             {
               return -EINVAL;
@@ -1017,7 +1017,7 @@ static int lcd_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
  * Name: lcd_poll
  ****************************************************************************/
 
-static int lcd_poll(FAR struct file *filep, FAR struct pollfd *fds,
+static int lcd_poll(struct file *filep, struct pollfd *fds,
                         bool setup)
 {
   if (setup)

--- a/boards/mips/pic32mx/sure-pic32mx/src/pic32mx_spi.c
+++ b/boards/mips/pic32mx/sure-pic32mx/src/pic32mx_spi.c
@@ -163,7 +163,7 @@ void weak_function pic32mx_spidev_initialize(void)
  ****************************************************************************/
 
 #ifdef CONFIG_PIC32MX_SPI2
-void pic32mx_spi2select(FAR struct spi_dev_s *dev, uint32_t devid,
+void pic32mx_spi2select(struct spi_dev_s *dev, uint32_t devid,
                         bool selected)
 {
   spiinfo("devid: %d CS: %s\n",
@@ -186,7 +186,7 @@ void pic32mx_spi2select(FAR struct spi_dev_s *dev, uint32_t devid,
 #endif
 }
 
-uint8_t pic32mx_spi2status(FAR struct spi_dev_s *dev, uint32_t devid)
+uint8_t pic32mx_spi2status(struct spi_dev_s *dev, uint32_t devid)
 {
   uint8_t ret = 0;
 

--- a/boards/mips/pic32mx/sure-pic32mx/src/pic32mx_usbdev.c
+++ b/boards/mips/pic32mx/sure-pic32mx/src/pic32mx_usbdev.c
@@ -140,7 +140,7 @@ void weak_function pic32mx_usbdevinitialize(void)
  *
  ****************************************************************************/
 
-int pic32mx_usbpullup(FAR struct usbdev_s *dev,  bool enable)
+int pic32mx_usbpullup(struct usbdev_s *dev,  bool enable)
 {
   /* The Sure PIC32MX does not have a USB pull-up */
 
@@ -158,7 +158,7 @@ int pic32mx_usbpullup(FAR struct usbdev_s *dev,  bool enable)
  *
  ****************************************************************************/
 
-void pic32mx_usbsuspend(FAR struct usbdev_s *dev, bool resume)
+void pic32mx_usbsuspend(struct usbdev_s *dev, bool resume)
 {
   /* Do nothing */
 }

--- a/boards/mips/pic32mx/ubw32/src/pic32_buttons.c
+++ b/boards/mips/pic32mx/ubw32/src/pic32_buttons.c
@@ -168,7 +168,7 @@ uint32_t board_buttons(void)
  ****************************************************************************/
 
 #ifdef CONFIG_ARCH_IRQBUTTONS
-int board_button_irq(int id, xcpt_t irqhandler, FAR void *arg)
+int board_button_irq(int id, xcpt_t irqhandler, void *arg)
 {
   int ret = -EINVAL;
 

--- a/boards/mips/pic32mx/ubw32/src/pic32_leds.c
+++ b/boards/mips/pic32mx/ubw32/src/pic32_leds.c
@@ -145,7 +145,7 @@ static const uint16_t g_ledpincfg[PIC32MX_UBW32_NLEDS] =
  ****************************************************************************/
 
 #ifdef CONFIG_ARCH_LEDS
-static void pic32mx_setleds(FAR const struct led_setting_s *setting)
+static void pic32mx_setleds(const struct led_setting_s *setting)
 {
   if (setting->led1 != LED_NC)
     {

--- a/boards/mips/pic32mx/ubw32/src/pic32_usbdev.c
+++ b/boards/mips/pic32mx/ubw32/src/pic32_usbdev.c
@@ -111,7 +111,7 @@ void weak_function pic32mx_usbdevinitialize(void)
  *
  ****************************************************************************/
 
-int pic32mx_usbpullup(FAR struct usbdev_s *dev,  bool enable)
+int pic32mx_usbpullup(struct usbdev_s *dev,  bool enable)
 {
   /* The UBW32 does not have a USB pull-up */
 
@@ -129,7 +129,7 @@ int pic32mx_usbpullup(FAR struct usbdev_s *dev,  bool enable)
  *
  ****************************************************************************/
 
-void pic32mx_usbsuspend(FAR struct usbdev_s *dev, bool resume)
+void pic32mx_usbsuspend(struct usbdev_s *dev, bool resume)
 {
   /* Do nothing */
 }

--- a/boards/mips/pic32mz/chipkit-wifire/src/pic32mz_buttons.c
+++ b/boards/mips/pic32mz/chipkit-wifire/src/pic32mz_buttons.c
@@ -131,7 +131,7 @@ uint32_t board_buttons(void)
  ****************************************************************************/
 
 #ifdef CONFIG_ARCH_IRQBUTTONS
-int board_button_irq(int id, xcpt_t irqhandler, FAR void *arg)
+int board_button_irq(int id, xcpt_t irqhandler, void *arg)
 {
 #ifdef CONFIG_PIC32MZ_GPIOIRQ_PORTA
   int ret = OK;

--- a/boards/mips/pic32mz/chipkit-wifire/src/pic32mz_spi.c
+++ b/boards/mips/pic32mz/chipkit-wifire/src/pic32mz_spi.c
@@ -89,21 +89,21 @@ void weak_function pic32mz_spidev_initialize(void)
 struct spi_dev_s;
 
 #ifdef CONFIG_PIC32MZ_SPI1
-void  pic32mz_spi1select(FAR struct spi_dev_s *dev, uint32_t devid,
+void  pic32mz_spi1select(struct spi_dev_s *dev, uint32_t devid,
                          bool selected)
 {
   spiinfo("devid: %d CS: %s\n", (int)devid,
            selected ? "assert" : "de-assert");
 }
 
-uint8_t pic32mz_spi1status(FAR struct spi_dev_s *dev, uint32_t devid)
+uint8_t pic32mz_spi1status(struct spi_dev_s *dev, uint32_t devid)
 {
   spiinfo("Returning nothing\n");
   return 0;
 }
 
 #ifdef CONFIG_SPI_CMDDATA
-int pic32mz_spi1cmddata(FAR struct spi_dev_s *dev, uint32_t devid, bool cmd)
+int pic32mz_spi1cmddata(struct spi_dev_s *dev, uint32_t devid, bool cmd)
 {
   return 0;
 }
@@ -111,21 +111,21 @@ int pic32mz_spi1cmddata(FAR struct spi_dev_s *dev, uint32_t devid, bool cmd)
 #endif /* CONFIG_PIC32MZ_SPI1 */
 
 #ifdef CONFIG_PIC32MZ_SPI2
-void  pic32mz_spi2select(FAR struct spi_dev_s *dev, uint32_t devid,
+void  pic32mz_spi2select(struct spi_dev_s *dev, uint32_t devid,
                          bool selected)
 {
   spiinfo("devid: %d CS: %s\n", (int)devid,
            selected ? "assert" : "de-assert");
 }
 
-uint8_t pic32mz_spi2status(FAR struct spi_dev_s *dev, uint32_t devid)
+uint8_t pic32mz_spi2status(struct spi_dev_s *dev, uint32_t devid)
 {
   spiinfo("Returning nothing\n");
   return 0;
 }
 
 #ifdef CONFIG_SPI_CMDDATA
-int pic32mz_spi2cmddata(FAR struct spi_dev_s *dev, uint32_t devid, bool cmd)
+int pic32mz_spi2cmddata(struct spi_dev_s *dev, uint32_t devid, bool cmd)
 {
   return 0;
 }
@@ -133,21 +133,21 @@ int pic32mz_spi2cmddata(FAR struct spi_dev_s *dev, uint32_t devid, bool cmd)
 #endif /* CONFIG_PIC32MZ_SPI2 */
 
 #ifdef CONFIG_PIC32MZ_SPI3
-void  pic32mz_spi3select(FAR struct spi_dev_s *dev, uint32_t devid,
+void  pic32mz_spi3select(struct spi_dev_s *dev, uint32_t devid,
                          bool selected)
 {
   spiinfo("devid: %d CS: %s\n", (int)devid,
            selected ? "assert" : "de-assert");
 }
 
-uint8_t pic32mz_spi3status(FAR struct spi_dev_s *dev, uint32_t devid)
+uint8_t pic32mz_spi3status(struct spi_dev_s *dev, uint32_t devid)
 {
   spiinfo("Returning nothing\n");
   return 0;
 }
 
 #ifdef CONFIG_SPI_CMDDATA
-int pic32mz_spi3cmddata(FAR struct spi_dev_s *dev, uint32_t devid, bool cmd)
+int pic32mz_spi3cmddata(struct spi_dev_s *dev, uint32_t devid, bool cmd)
 {
   return 0;
 }
@@ -155,21 +155,21 @@ int pic32mz_spi3cmddata(FAR struct spi_dev_s *dev, uint32_t devid, bool cmd)
 #endif /* CONFIG_PIC32MZ_SPI3 */
 
 #ifdef CONFIG_PIC32MZ_SPI4
-void  pic32mz_spi4select(FAR struct spi_dev_s *dev, uint32_t devid,
+void  pic32mz_spi4select(struct spi_dev_s *dev, uint32_t devid,
                          bool selected)
 {
   spiinfo("devid: %d CS: %s\n", (int)devid,
            selected ? "assert" : "de-assert");
 }
 
-uint8_t pic32mz_spi4status(FAR struct spi_dev_s *dev, uint32_t devid)
+uint8_t pic32mz_spi4status(struct spi_dev_s *dev, uint32_t devid)
 {
   spiinfo("Returning nothing\n");
   return 0;
 }
 
 #ifdef CONFIG_SPI_CMDDATA
-int pic32mz_spi4cmddata(FAR struct spi_dev_s *dev, uint32_t devid, bool cmd)
+int pic32mz_spi4cmddata(struct spi_dev_s *dev, uint32_t devid, bool cmd)
 {
   return 0;
 }
@@ -177,14 +177,14 @@ int pic32mz_spi4cmddata(FAR struct spi_dev_s *dev, uint32_t devid, bool cmd)
 #endif /* CONFIG_PIC32MZ_SPI4 */
 
 #ifdef CONFIG_PIC32MZ_SPI5
-void  pic32mz_spi5select(FAR struct spi_dev_s *dev, uint32_t devid,
+void  pic32mz_spi5select(struct spi_dev_s *dev, uint32_t devid,
                          bool selected)
 {
   spiinfo("devid: %d CS: %s\n", (int)devid,
            selected ? "assert" : "de-assert");
 }
 
-uint8_t pic32mz_spi5status(FAR struct spi_dev_s *dev, uint32_t devid)
+uint8_t pic32mz_spi5status(struct spi_dev_s *dev, uint32_t devid)
 {
   spiinfo("Returning nothing\n");
 #warning "Missing logic"
@@ -192,7 +192,7 @@ uint8_t pic32mz_spi5status(FAR struct spi_dev_s *dev, uint32_t devid)
 }
 
 #ifdef CONFIG_SPI_CMDDATA
-int pic32mz_spi5cmddata(FAR struct spi_dev_s *dev, uint32_t devid, bool cmd)
+int pic32mz_spi5cmddata(struct spi_dev_s *dev, uint32_t devid, bool cmd)
 {
 #warning "Missing logic"
   return 0;
@@ -201,7 +201,7 @@ int pic32mz_spi5cmddata(FAR struct spi_dev_s *dev, uint32_t devid, bool cmd)
 #endif /* CONFIG_PIC32MZ_SPI5 */
 
 #ifdef CONFIG_PIC32MZ_SPI6
-void  pic32mz_spi6select(FAR struct spi_dev_s *dev, uint32_t devid,
+void  pic32mz_spi6select(struct spi_dev_s *dev, uint32_t devid,
                          bool selected)
 {
   spiinfo("devid: %d CS: %s\n", (int)devid,
@@ -209,7 +209,7 @@ void  pic32mz_spi6select(FAR struct spi_dev_s *dev, uint32_t devid,
 #warning "Missing logic"
 }
 
-uint8_t pic32mz_spi6status(FAR struct spi_dev_s *dev, uint32_t devid)
+uint8_t pic32mz_spi6status(struct spi_dev_s *dev, uint32_t devid)
 {
   spiinfo("Returning nothing\n");
 #warning "Missing logic"
@@ -217,7 +217,7 @@ uint8_t pic32mz_spi6status(FAR struct spi_dev_s *dev, uint32_t devid)
 }
 
 #ifdef CONFIG_SPI_CMDDATA
-int pic32mz_spi6cmddata(FAR struct spi_dev_s *dev, uint32_t devid, bool cmd)
+int pic32mz_spi6cmddata(struct spi_dev_s *dev, uint32_t devid, bool cmd)
 {
 #warning "Missing logic"
   return 0;
@@ -247,8 +247,8 @@ int pic32mz_spi6cmddata(FAR struct spi_dev_s *dev, uint32_t devid, bool cmd)
 
 #ifdef CONFIG_SPI_CALLBACK
 #ifdef CONFIG_PIC32MZ_SPI1
-int pic32mz_spi1register(FAR struct spi_dev_s *dev,
-                         spi_mediachange_t callback, FAR void *arg)
+int pic32mz_spi1register(struct spi_dev_s *dev,
+                         spi_mediachange_t callback, void *arg)
 {
 #warning Missing logic
   return -ENOSYS;
@@ -256,8 +256,8 @@ int pic32mz_spi1register(FAR struct spi_dev_s *dev,
 #endif /* CONFIG_PIC32MZ_SPI1 */
 
 #ifdef CONFIG_PIC32MZ_SPI2
-int pic32mz_spi2register(FAR struct spi_dev_s *dev,
-                         spi_mediachange_t callback, FAR void *arg)
+int pic32mz_spi2register(struct spi_dev_s *dev,
+                         spi_mediachange_t callback, void *arg)
 {
 #warning Missing logic
   return -ENOSYS;
@@ -265,8 +265,8 @@ int pic32mz_spi2register(FAR struct spi_dev_s *dev,
 #endif /* CONFIG_PIC32MZ_SPI2 */
 
 #ifdef CONFIG_PIC32MZ_SPI3
-int pic32mz_spi3register(FAR struct spi_dev_s *dev,
-                         spi_mediachange_t callback, FAR void *arg)
+int pic32mz_spi3register(struct spi_dev_s *dev,
+                         spi_mediachange_t callback, void *arg)
 {
 #warning Missing logic
   return -ENOSYS;
@@ -274,8 +274,8 @@ int pic32mz_spi3register(FAR struct spi_dev_s *dev,
 #endif /* CONFIG_PIC32MZ_SPI3 */
 
 #ifdef CONFIG_PIC32MZ_SPI4
-int pic32mz_spi4register(FAR struct spi_dev_s *dev,
-                         spi_mediachange_t callback, FAR void *arg)
+int pic32mz_spi4register(struct spi_dev_s *dev,
+                         spi_mediachange_t callback, void *arg)
 {
 #warning Missing logic
   return -ENOSYS;
@@ -283,8 +283,8 @@ int pic32mz_spi4register(FAR struct spi_dev_s *dev,
 #endif /* CONFIG_PIC32MZ_SPI4 */
 
 #ifdef CONFIG_PIC32MZ_SPI5
-int pic32mz_spi5register(FAR struct spi_dev_s *dev,
-                         spi_mediachange_t callback, FAR void *arg)
+int pic32mz_spi5register(struct spi_dev_s *dev,
+                         spi_mediachange_t callback, void *arg)
 {
 #warning Missing logic
   return -ENOSYS;
@@ -292,8 +292,8 @@ int pic32mz_spi5register(FAR struct spi_dev_s *dev,
 #endif /* CONFIG_PIC32MZ_SPI5 */
 
 #ifdef CONFIG_PIC32MZ_SPI6
-int pic32mz_spi6register(FAR struct spi_dev_s *dev,
-                         spi_mediachange_t callback, FAR void *arg)
+int pic32mz_spi6register(struct spi_dev_s *dev,
+                         spi_mediachange_t callback, void *arg)
 {
 #warning Missing logic
   return -ENOSYS;

--- a/boards/mips/pic32mz/flipnclick-pic32mz/src/flipnclick-pic32mz.h
+++ b/boards/mips/pic32mz/flipnclick-pic32mz/src/flipnclick-pic32mz.h
@@ -269,7 +269,7 @@ int pic32mz_bringup(void);
 
 #ifdef HAVE_SSD1306
 struct lcd_dev_s;  /* Forward reference */
-FAR struct lcd_dev_s *pic32mz_graphics_setup(unsigned int devno);
+struct lcd_dev_s *pic32mz_graphics_setup(unsigned int devno);
 #endif
 
 #undef EXTERN

--- a/boards/mips/pic32mz/flipnclick-pic32mz/src/pic32mz_buttons.c
+++ b/boards/mips/pic32mz/flipnclick-pic32mz/src/pic32mz_buttons.c
@@ -131,7 +131,7 @@ uint32_t board_buttons(void)
  ****************************************************************************/
 
 #ifdef CONFIG_ARCH_IRQBUTTONS
-int board_button_irq(int id, xcpt_t irqhandler, FAR void *arg)
+int board_button_irq(int id, xcpt_t irqhandler, void *arg)
 {
 #ifdef CONFIG_PIC32MZ_GPIOIRQ_PORTD
   int ret = OK;

--- a/boards/mips/pic32mz/flipnclick-pic32mz/src/pic32mz_spi.c
+++ b/boards/mips/pic32mz/flipnclick-pic32mz/src/pic32mz_spi.c
@@ -96,7 +96,7 @@ void weak_function pic32mz_spidev_initialize(void)
 struct spi_dev_s;
 
 #ifdef CONFIG_PIC32MZ_SPI1
-void  pic32mz_spi1select(FAR struct spi_dev_s *dev, uint32_t devid,
+void  pic32mz_spi1select(struct spi_dev_s *dev, uint32_t devid,
                          bool selected)
 {
   spiinfo("devid: %d CS: %s\n", (int)devid,
@@ -115,14 +115,14 @@ void  pic32mz_spi1select(FAR struct spi_dev_s *dev, uint32_t devid,
 #endif
 }
 
-uint8_t pic32mz_spi1status(FAR struct spi_dev_s *dev, uint32_t devid)
+uint8_t pic32mz_spi1status(struct spi_dev_s *dev, uint32_t devid)
 {
   spiinfo("Returning nothing\n");
   return 0;
 }
 
 #ifdef CONFIG_SPI_CMDDATA
-int pic32mz_spi1cmddata(FAR struct spi_dev_s *dev, uint32_t devid, bool cmd)
+int pic32mz_spi1cmddata(struct spi_dev_s *dev, uint32_t devid, bool cmd)
 {
 #if defined(CONFIG_FLIPNCLICK_PIC32MZ_SSD1306_MBC) || \
     defined(CONFIG_FLIPNCLICK_PIC32MZ_SSD1306_MBD)
@@ -142,7 +142,7 @@ int pic32mz_spi1cmddata(FAR struct spi_dev_s *dev, uint32_t devid, bool cmd)
 #endif /* CONFIG_PIC32MZ_SPI1 */
 
 #ifdef CONFIG_PIC32MZ_SPI2
-void  pic32mz_spi2select(FAR struct spi_dev_s *dev, uint32_t devid,
+void  pic32mz_spi2select(struct spi_dev_s *dev, uint32_t devid,
                          bool selected)
 {
   spiinfo("devid: %d CS: %s\n", (int)devid,
@@ -161,14 +161,14 @@ void  pic32mz_spi2select(FAR struct spi_dev_s *dev, uint32_t devid,
 #endif
 }
 
-uint8_t pic32mz_spi2status(FAR struct spi_dev_s *dev, uint32_t devid)
+uint8_t pic32mz_spi2status(struct spi_dev_s *dev, uint32_t devid)
 {
   spiinfo("Returning nothing\n");
   return 0;
 }
 
 #ifdef CONFIG_SPI_CMDDATA
-int pic32mz_spi2cmddata(FAR struct spi_dev_s *dev, uint32_t devid, bool cmd)
+int pic32mz_spi2cmddata(struct spi_dev_s *dev, uint32_t devid, bool cmd)
 {
 #if defined(CONFIG_FLIPNCLICK_PIC32MZ_SSD1306_MBA) || \
     defined(CONFIG_FLIPNCLICK_PIC32MZ_SSD1306_MBB)
@@ -188,21 +188,21 @@ int pic32mz_spi2cmddata(FAR struct spi_dev_s *dev, uint32_t devid, bool cmd)
 #endif /* CONFIG_PIC32MZ_SPI2 */
 
 #ifdef CONFIG_PIC32MZ_SPI3
-void  pic32mz_spi3select(FAR struct spi_dev_s *dev, uint32_t devid,
+void  pic32mz_spi3select(struct spi_dev_s *dev, uint32_t devid,
                          bool selected)
 {
   spiinfo("devid: %d CS: %s\n", (int)devid,
            selected ? "assert" : "de-assert");
 }
 
-uint8_t pic32mz_spi3status(FAR struct spi_dev_s *dev, uint32_t devid)
+uint8_t pic32mz_spi3status(struct spi_dev_s *dev, uint32_t devid)
 {
   spiinfo("Returning nothing\n");
   return 0;
 }
 
 #ifdef CONFIG_SPI_CMDDATA
-int pic32mz_spi3cmddata(FAR struct spi_dev_s *dev, uint32_t devid, bool cmd)
+int pic32mz_spi3cmddata(struct spi_dev_s *dev, uint32_t devid, bool cmd)
 {
   return 0;
 }
@@ -210,21 +210,21 @@ int pic32mz_spi3cmddata(FAR struct spi_dev_s *dev, uint32_t devid, bool cmd)
 #endif /* CONFIG_PIC32MZ_SPI3 */
 
 #ifdef CONFIG_PIC32MZ_SPI4
-void  pic32mz_spi4select(FAR struct spi_dev_s *dev, uint32_t devid,
+void  pic32mz_spi4select(struct spi_dev_s *dev, uint32_t devid,
                          bool selected)
 {
   spiinfo("devid: %d CS: %s\n", (int)devid,
            selected ? "assert" : "de-assert");
 }
 
-uint8_t pic32mz_spi4status(FAR struct spi_dev_s *dev, uint32_t devid)
+uint8_t pic32mz_spi4status(struct spi_dev_s *dev, uint32_t devid)
 {
   spiinfo("Returning nothing\n");
   return 0;
 }
 
 #ifdef CONFIG_SPI_CMDDATA
-int pic32mz_spi4cmddata(FAR struct spi_dev_s *dev, uint32_t devid, bool cmd)
+int pic32mz_spi4cmddata(struct spi_dev_s *dev, uint32_t devid, bool cmd)
 {
   return 0;
 }
@@ -232,14 +232,14 @@ int pic32mz_spi4cmddata(FAR struct spi_dev_s *dev, uint32_t devid, bool cmd)
 #endif /* CONFIG_PIC32MZ_SPI4 */
 
 #ifdef CONFIG_PIC32MZ_SPI5
-void  pic32mz_spi5select(FAR struct spi_dev_s *dev, uint32_t devid,
+void  pic32mz_spi5select(struct spi_dev_s *dev, uint32_t devid,
                          bool selected)
 {
   spiinfo("devid: %d CS: %s\n", (int)devid,
            selected ? "assert" : "de-assert");
 }
 
-uint8_t pic32mz_spi5status(FAR struct spi_dev_s *dev, uint32_t devid)
+uint8_t pic32mz_spi5status(struct spi_dev_s *dev, uint32_t devid)
 {
   spiinfo("Returning nothing\n");
 #warning "Missing logic"
@@ -247,7 +247,7 @@ uint8_t pic32mz_spi5status(FAR struct spi_dev_s *dev, uint32_t devid)
 }
 
 #ifdef CONFIG_SPI_CMDDATA
-int pic32mz_spi5cmddata(FAR struct spi_dev_s *dev, uint32_t devid, bool cmd)
+int pic32mz_spi5cmddata(struct spi_dev_s *dev, uint32_t devid, bool cmd)
 {
 #warning "Missing logic"
   return 0;
@@ -256,7 +256,7 @@ int pic32mz_spi5cmddata(FAR struct spi_dev_s *dev, uint32_t devid, bool cmd)
 #endif /* CONFIG_PIC32MZ_SPI5 */
 
 #ifdef CONFIG_PIC32MZ_SPI6
-void  pic32mz_spi6select(FAR struct spi_dev_s *dev, uint32_t devid,
+void  pic32mz_spi6select(struct spi_dev_s *dev, uint32_t devid,
                          bool selected)
 {
   spiinfo("devid: %d CS: %s\n", (int)devid,
@@ -264,7 +264,7 @@ void  pic32mz_spi6select(FAR struct spi_dev_s *dev, uint32_t devid,
 #warning "Missing logic"
 }
 
-uint8_t pic32mz_spi6status(FAR struct spi_dev_s *dev, uint32_t devid)
+uint8_t pic32mz_spi6status(struct spi_dev_s *dev, uint32_t devid)
 {
   spiinfo("Returning nothing\n");
 #warning "Missing logic"
@@ -272,7 +272,7 @@ uint8_t pic32mz_spi6status(FAR struct spi_dev_s *dev, uint32_t devid)
 }
 
 #ifdef CONFIG_SPI_CMDDATA
-int pic32mz_spi6cmddata(FAR struct spi_dev_s *dev, uint32_t devid, bool cmd)
+int pic32mz_spi6cmddata(struct spi_dev_s *dev, uint32_t devid, bool cmd)
 {
 #warning "Missing logic"
   return 0;
@@ -302,8 +302,8 @@ int pic32mz_spi6cmddata(FAR struct spi_dev_s *dev, uint32_t devid, bool cmd)
 
 #ifdef CONFIG_SPI_CALLBACK
 #ifdef CONFIG_PIC32MZ_SPI1
-int pic32mz_spi1register(FAR struct spi_dev_s *dev,
-                         spi_mediachange_t callback, FAR void *arg)
+int pic32mz_spi1register(struct spi_dev_s *dev,
+                         spi_mediachange_t callback, void *arg)
 {
 #warning Missing logic
   return -ENOSYS;
@@ -311,8 +311,8 @@ int pic32mz_spi1register(FAR struct spi_dev_s *dev,
 #endif /* CONFIG_PIC32MZ_SPI1 */
 
 #ifdef CONFIG_PIC32MZ_SPI2
-int pic32mz_spi2register(FAR struct spi_dev_s *dev,
-                         spi_mediachange_t callback, FAR void *arg)
+int pic32mz_spi2register(struct spi_dev_s *dev,
+                         spi_mediachange_t callback, void *arg)
 {
 #warning Missing logic
   return -ENOSYS;
@@ -320,8 +320,8 @@ int pic32mz_spi2register(FAR struct spi_dev_s *dev,
 #endif /* CONFIG_PIC32MZ_SPI2 */
 
 #ifdef CONFIG_PIC32MZ_SPI3
-int pic32mz_spi3register(FAR struct spi_dev_s *dev,
-                         spi_mediachange_t callback, FAR void *arg)
+int pic32mz_spi3register(struct spi_dev_s *dev,
+                         spi_mediachange_t callback, void *arg)
 {
 #warning Missing logic
   return -ENOSYS;
@@ -329,8 +329,8 @@ int pic32mz_spi3register(FAR struct spi_dev_s *dev,
 #endif /* CONFIG_PIC32MZ_SPI3 */
 
 #ifdef CONFIG_PIC32MZ_SPI4
-int pic32mz_spi4register(FAR struct spi_dev_s *dev,
-                         spi_mediachange_t callback, FAR void *arg)
+int pic32mz_spi4register(struct spi_dev_s *dev,
+                         spi_mediachange_t callback, void *arg)
 {
 #warning Missing logic
   return -ENOSYS;
@@ -338,8 +338,8 @@ int pic32mz_spi4register(FAR struct spi_dev_s *dev,
 #endif /* CONFIG_PIC32MZ_SPI4 */
 
 #ifdef CONFIG_PIC32MZ_SPI5
-int pic32mz_spi5register(FAR struct spi_dev_s *dev,
-                         spi_mediachange_t callback, FAR void *arg)
+int pic32mz_spi5register(struct spi_dev_s *dev,
+                         spi_mediachange_t callback, void *arg)
 {
 #warning Missing logic
   return -ENOSYS;
@@ -347,8 +347,8 @@ int pic32mz_spi5register(FAR struct spi_dev_s *dev,
 #endif /* CONFIG_PIC32MZ_SPI5 */
 
 #ifdef CONFIG_PIC32MZ_SPI6
-int pic32mz_spi6register(FAR struct spi_dev_s *dev,
-                         spi_mediachange_t callback, FAR void *arg)
+int pic32mz_spi6register(struct spi_dev_s *dev,
+                         spi_mediachange_t callback, void *arg)
 {
 #warning Missing logic
   return -ENOSYS;

--- a/boards/mips/pic32mz/flipnclick-pic32mz/src/pic32mz_ssd1306.c
+++ b/boards/mips/pic32mz/flipnclick-pic32mz/src/pic32mz_ssd1306.c
@@ -83,10 +83,10 @@
  *
  ****************************************************************************/
 
-FAR struct lcd_dev_s *pic32mz_graphics_setup(unsigned int devno)
+struct lcd_dev_s *pic32mz_graphics_setup(unsigned int devno)
 {
-  FAR struct spi_dev_s *spi;
-  FAR struct lcd_dev_s *dev;
+  struct spi_dev_s *spi;
+  struct lcd_dev_s *dev;
 
   /* Configure the OLED GPIOs. This initial configuration is RESET low,
    * putting the OLED into reset state.
@@ -149,7 +149,7 @@ FAR struct lcd_dev_s *pic32mz_graphics_setup(unsigned int devno)
  ****************************************************************************/
 
 #ifdef CONFIG_NXSTART_EXTERNINIT
-FAR struct lcd_dev_s *board_graphics_setup(unsigned int devno)
+struct lcd_dev_s *board_graphics_setup(unsigned int devno)
 {
   return pic32mz_graphics_setup(devno);
 }

--- a/boards/mips/pic32mz/pic32mz-starterkit/src/pic32mz_autoleds.c
+++ b/boards/mips/pic32mz/pic32mz-starterkit/src/pic32mz_autoleds.c
@@ -124,7 +124,7 @@ static const struct led_setting_s g_ledoffvalues[LED_NVALUES] =
  * Name: pic32mz_setleds
  ****************************************************************************/
 
-static void pic32mz_setleds(FAR const struct led_setting_s *setting)
+static void pic32mz_setleds(const struct led_setting_s *setting)
 {
   if (setting->led1 != LED_NC)
     {

--- a/boards/mips/pic32mz/pic32mz-starterkit/src/pic32mz_bringup.c
+++ b/boards/mips/pic32mz/pic32mz-starterkit/src/pic32mz_bringup.c
@@ -53,7 +53,7 @@
 #ifdef PIC32MZ_HAVE_MMCSD
 static int nsh_sdinitialize(void)
 {
-  FAR struct spi_dev_s *spi;
+  struct spi_dev_s *spi;
   int ret;
 
   /* Get the SPI port */

--- a/boards/mips/pic32mz/pic32mz-starterkit/src/pic32mz_buttons.c
+++ b/boards/mips/pic32mz/pic32mz-starterkit/src/pic32mz_buttons.c
@@ -139,7 +139,7 @@ uint32_t board_buttons(void)
  ****************************************************************************/
 
 #ifdef CONFIG_ARCH_IRQBUTTONS
-int board_button_irq(int id, xcpt_t irqhandler, FAR void *arg)
+int board_button_irq(int id, xcpt_t irqhandler, void *arg)
 {
 #ifdef CONFIG_PIC32MZ_GPIOIRQ_PORTB
   int ret = OK;

--- a/boards/mips/pic32mz/pic32mz-starterkit/src/pic32mz_spi.c
+++ b/boards/mips/pic32mz/pic32mz-starterkit/src/pic32mz_spi.c
@@ -90,7 +90,7 @@ void weak_function pic32mz_spidev_initialize(void)
 struct spi_dev_s;
 
 #ifdef CONFIG_PIC32MZ_SPI1
-void  pic32mz_spi1select(FAR struct spi_dev_s *dev, uint32_t devid,
+void  pic32mz_spi1select(struct spi_dev_s *dev, uint32_t devid,
                          bool selected)
 {
   spiinfo("devid: %d CS: %s\n",
@@ -98,7 +98,7 @@ void  pic32mz_spi1select(FAR struct spi_dev_s *dev, uint32_t devid,
 #warning "Missing logic"
 }
 
-uint8_t pic32mz_spi1status(FAR struct spi_dev_s *dev, uint32_t devid)
+uint8_t pic32mz_spi1status(struct spi_dev_s *dev, uint32_t devid)
 {
   spiinfo("Returning nothing\n");
 #warning "Missing logic"
@@ -106,7 +106,7 @@ uint8_t pic32mz_spi1status(FAR struct spi_dev_s *dev, uint32_t devid)
 }
 
 #ifdef CONFIG_SPI_CMDDATA
-int pic32mz_spi1cmddata(FAR struct spi_dev_s *dev, uint32_t devid, bool cmd)
+int pic32mz_spi1cmddata(struct spi_dev_s *dev, uint32_t devid, bool cmd)
 {
 #warning "Missing logic"
   return 0;
@@ -115,7 +115,7 @@ int pic32mz_spi1cmddata(FAR struct spi_dev_s *dev, uint32_t devid, bool cmd)
 #endif
 
 #ifdef CONFIG_PIC32MZ_SPI2
-void  pic32mz_spi2select(FAR struct spi_dev_s *dev, uint32_t devid,
+void  pic32mz_spi2select(struct spi_dev_s *dev, uint32_t devid,
                          bool selected)
 {
   spiinfo("devid: %d CS: %s\n",
@@ -123,7 +123,7 @@ void  pic32mz_spi2select(FAR struct spi_dev_s *dev, uint32_t devid,
 #warning "Missing logic"
 }
 
-uint8_t pic32mz_spi2status(FAR struct spi_dev_s *dev, uint32_t devid)
+uint8_t pic32mz_spi2status(struct spi_dev_s *dev, uint32_t devid)
 {
   spiinfo("Returning nothing\n");
 #warning "Missing logic"
@@ -131,7 +131,7 @@ uint8_t pic32mz_spi2status(FAR struct spi_dev_s *dev, uint32_t devid)
 }
 
 #ifdef CONFIG_SPI_CMDDATA
-int pic32mz_spi2cmddata(FAR struct spi_dev_s *dev, uint32_t devid, bool cmd)
+int pic32mz_spi2cmddata(struct spi_dev_s *dev, uint32_t devid, bool cmd)
 {
 #warning "Missing logic"
   return 0;
@@ -140,7 +140,7 @@ int pic32mz_spi2cmddata(FAR struct spi_dev_s *dev, uint32_t devid, bool cmd)
 #endif
 
 #ifdef CONFIG_PIC32MZ_SPI3
-void  pic32mz_spi3select(FAR struct spi_dev_s *dev, uint32_t devid,
+void  pic32mz_spi3select(struct spi_dev_s *dev, uint32_t devid,
                          bool selected)
 {
   spiinfo("devid: %d CS: %s\n",
@@ -148,7 +148,7 @@ void  pic32mz_spi3select(FAR struct spi_dev_s *dev, uint32_t devid,
 #warning "Missing logic"
 }
 
-uint8_t pic32mz_spi3status(FAR struct spi_dev_s *dev, uint32_t devid)
+uint8_t pic32mz_spi3status(struct spi_dev_s *dev, uint32_t devid)
 {
   spiinfo("Returning nothing\n");
 #warning "Missing logic"
@@ -156,7 +156,7 @@ uint8_t pic32mz_spi3status(FAR struct spi_dev_s *dev, uint32_t devid)
 }
 
 #ifdef CONFIG_SPI_CMDDATA
-int pic32mz_spi3cmddata(FAR struct spi_dev_s *dev, uint32_t devid, bool cmd)
+int pic32mz_spi3cmddata(struct spi_dev_s *dev, uint32_t devid, bool cmd)
 {
 #warning "Missing logic"
   return 0;
@@ -165,7 +165,7 @@ int pic32mz_spi3cmddata(FAR struct spi_dev_s *dev, uint32_t devid, bool cmd)
 #endif
 
 #ifdef CONFIG_PIC32MZ_SPI4
-void  pic32mz_spi4select(FAR struct spi_dev_s *dev, uint32_t devid,
+void  pic32mz_spi4select(struct spi_dev_s *dev, uint32_t devid,
                          bool selected)
 {
   spiinfo("devid: %d CS: %s\n",
@@ -173,7 +173,7 @@ void  pic32mz_spi4select(FAR struct spi_dev_s *dev, uint32_t devid,
 #warning "Missing logic"
 }
 
-uint8_t pic32mz_spi4status(FAR struct spi_dev_s *dev, uint32_t devid)
+uint8_t pic32mz_spi4status(struct spi_dev_s *dev, uint32_t devid)
 {
   spiinfo("Returning nothing\n");
 #warning "Missing logic"
@@ -181,7 +181,7 @@ uint8_t pic32mz_spi4status(FAR struct spi_dev_s *dev, uint32_t devid)
 }
 
 #ifdef CONFIG_SPI_CMDDATA
-int pic32mz_spi4cmddata(FAR struct spi_dev_s *dev, uint32_t devid, bool cmd)
+int pic32mz_spi4cmddata(struct spi_dev_s *dev, uint32_t devid, bool cmd)
 {
 #warning "Missing logic"
   return 0;
@@ -190,7 +190,7 @@ int pic32mz_spi4cmddata(FAR struct spi_dev_s *dev, uint32_t devid, bool cmd)
 #endif
 
 #ifdef CONFIG_PIC32MZ_SPI5
-void  pic32mz_spi5select(FAR struct spi_dev_s *dev, uint32_t devid,
+void  pic32mz_spi5select(struct spi_dev_s *dev, uint32_t devid,
                          bool selected)
 {
   spiinfo("devid: %d CS: %s\n",
@@ -198,7 +198,7 @@ void  pic32mz_spi5select(FAR struct spi_dev_s *dev, uint32_t devid,
 #warning "Missing logic"
 }
 
-uint8_t pic32mz_spi5status(FAR struct spi_dev_s *dev, uint32_t devid)
+uint8_t pic32mz_spi5status(struct spi_dev_s *dev, uint32_t devid)
 {
   spiinfo("Returning nothing\n");
 #warning "Missing logic"
@@ -206,7 +206,7 @@ uint8_t pic32mz_spi5status(FAR struct spi_dev_s *dev, uint32_t devid)
 }
 
 #ifdef CONFIG_SPI_CMDDATA
-int pic32mz_spi5cmddata(FAR struct spi_dev_s *dev, uint32_t devid,
+int pic32mz_spi5cmddata(struct spi_dev_s *dev, uint32_t devid,
                         bool cmd)
 {
 #warning "Missing logic"
@@ -216,7 +216,7 @@ int pic32mz_spi5cmddata(FAR struct spi_dev_s *dev, uint32_t devid,
 #endif
 
 #ifdef CONFIG_PIC32MZ_SPI6
-void  pic32mz_spi6select(FAR struct spi_dev_s *dev, uint32_t devid,
+void  pic32mz_spi6select(struct spi_dev_s *dev, uint32_t devid,
                          bool selected)
 {
   spiinfo("devid: %d CS: %s\n", (int)devid,
@@ -224,7 +224,7 @@ void  pic32mz_spi6select(FAR struct spi_dev_s *dev, uint32_t devid,
 #warning "Missing logic"
 }
 
-uint8_t pic32mz_spi6status(FAR struct spi_dev_s *dev, uint32_t devid)
+uint8_t pic32mz_spi6status(struct spi_dev_s *dev, uint32_t devid)
 {
   spiinfo("Returning nothing\n");
 #warning "Missing logic"
@@ -232,7 +232,7 @@ uint8_t pic32mz_spi6status(FAR struct spi_dev_s *dev, uint32_t devid)
 }
 
 #ifdef CONFIG_SPI_CMDDATA
-int pic32mz_spi6cmddata(FAR struct spi_dev_s *dev, uint32_t devid, bool cmd)
+int pic32mz_spi6cmddata(struct spi_dev_s *dev, uint32_t devid, bool cmd)
 {
 #warning "Missing logic"
   return 0;

--- a/boards/sim/sim/sim/src/sim_bringup.c
+++ b/boards/sim/sim/sim/src/sim_bringup.c
@@ -89,19 +89,19 @@ void rpmsg_serialinit(void)
 int sim_bringup(void)
 {
 #ifdef CONFIG_ONESHOT
-  FAR struct oneshot_lowerhalf_s *oneshot;
+  struct oneshot_lowerhalf_s *oneshot;
 #endif
 #ifdef CONFIG_RAMMTD
-  FAR uint8_t *ramstart;
+  uint8_t *ramstart;
 #endif
 #ifdef CONFIG_SIM_I2CBUS
-  FAR struct i2c_master_s *i2cbus;
+  struct i2c_master_s *i2cbus;
 #endif
 #ifdef CONFIG_MPU60X0_I2C
-  FAR struct mpu_config_s *mpu_config;
+  struct mpu_config_s *mpu_config;
 #endif
 #ifdef CONFIG_SIM_SPI
-  FAR struct spi_dev_s *spidev;
+  struct spi_dev_s *spidev;
 #endif
   int ret = OK;
 
@@ -152,7 +152,7 @@ int sim_bringup(void)
 #ifdef CONFIG_RAMMTD
   /* Create a RAM MTD device if configured */
 
-  ramstart = (FAR uint8_t *)kmm_malloc(128 * 1024);
+  ramstart = (uint8_t *)kmm_malloc(128 * 1024);
   if (ramstart == NULL)
     {
       syslog(LOG_ERR, "ERROR: Allocation for RAM MTD failed\n");
@@ -161,7 +161,7 @@ int sim_bringup(void)
     {
       /* Initialized the RAM MTD */
 
-      FAR struct mtd_dev_s *mtd = rammtd_initialize(ramstart, 128 * 1024);
+      struct mtd_dev_s *mtd = rammtd_initialize(ramstart, 128 * 1024);
       if (mtd == NULL)
         {
           syslog(LOG_ERR, "ERROR: rammtd_initialize failed\n");

--- a/boards/sim/sim/sim/src/sim_buttons.c
+++ b/boards/sim/sim/sim/src/sim_buttons.c
@@ -46,7 +46,7 @@
 
 uint32_t g_buttons = 0;
 xcpt_t g_handler = NULL;
-FAR void *g_arg = 0;
+void *g_arg = 0;
 
 /****************************************************************************
  * Public Data
@@ -111,7 +111,7 @@ uint32_t board_buttons(void)
  ****************************************************************************/
 
 #ifdef CONFIG_ARCH_IRQBUTTONS
-int board_button_irq(int id, xcpt_t irqhandler, FAR void *arg)
+int board_button_irq(int id, xcpt_t irqhandler, void *arg)
 {
   int ret = -EINVAL;
 

--- a/boards/sim/sim/sim/src/sim_foc.c
+++ b/boards/sim/sim/sim/src/sim_foc.c
@@ -56,7 +56,7 @@
 
 int sim_foc_setup(void)
 {
-  FAR struct foc_dev_s *foc[CONFIG_MOTOR_FOC_INST];
+  struct foc_dev_s *foc[CONFIG_MOTOR_FOC_INST];
   static bool           initialized = false;
   int                   ret         = OK;
   int                   i           = 0;

--- a/boards/sim/sim/sim/src/sim_gpio.c
+++ b/boards/sim/sim/sim/src/sim_gpio.c
@@ -58,11 +58,11 @@ struct simgpint_dev_s
  * Private Function Prototypes
  ****************************************************************************/
 
-static int gpin_read(FAR struct gpio_dev_s *dev, FAR bool *value);
-static int gpout_write(FAR struct gpio_dev_s *dev, bool value);
-static int gpint_attach(FAR struct gpio_dev_s *dev,
+static int gpin_read(struct gpio_dev_s *dev, bool *value);
+static int gpout_write(struct gpio_dev_s *dev, bool value);
+static int gpint_attach(struct gpio_dev_s *dev,
                         pin_interrupt_t callback);
-static int gpint_enable(FAR struct gpio_dev_s *dev, bool enable);
+static int gpint_enable(struct gpio_dev_s *dev, bool enable);
 
 /****************************************************************************
  * Private Data
@@ -131,7 +131,7 @@ static struct simgpint_dev_s g_gpint =
 
 static int sim_interrupt(wdparm_t arg)
 {
-  FAR struct simgpint_dev_s *simgpint = (FAR struct simgpint_dev_s *)arg;
+  struct simgpint_dev_s *simgpint = (struct simgpint_dev_s *)arg;
 
   DEBUGASSERT(simgpint != NULL && simgpint->callback != NULL);
   gpioinfo("Interrupt! callback=%p\n", simgpint->callback);
@@ -140,9 +140,9 @@ static int sim_interrupt(wdparm_t arg)
   return OK;
 }
 
-static int gpin_read(FAR struct gpio_dev_s *dev, FAR bool *value)
+static int gpin_read(struct gpio_dev_s *dev, bool *value)
 {
-  FAR struct simgpio_dev_s *simgpio = (FAR struct simgpio_dev_s *)dev;
+  struct simgpio_dev_s *simgpio = (struct simgpio_dev_s *)dev;
 
   DEBUGASSERT(simgpio != NULL && value != NULL);
   gpioinfo("Reading %d (next=%d)\n",
@@ -153,9 +153,9 @@ static int gpin_read(FAR struct gpio_dev_s *dev, FAR bool *value)
   return OK;
 }
 
-static int gpout_write(FAR struct gpio_dev_s *dev, bool value)
+static int gpout_write(struct gpio_dev_s *dev, bool value)
 {
-  FAR struct simgpio_dev_s *simgpio = (FAR struct simgpio_dev_s *)dev;
+  struct simgpio_dev_s *simgpio = (struct simgpio_dev_s *)dev;
 
   DEBUGASSERT(simgpio != NULL);
   gpioinfo("Writing %d\n", (int)value);
@@ -164,10 +164,10 @@ static int gpout_write(FAR struct gpio_dev_s *dev, bool value)
   return OK;
 }
 
-static int gpint_attach(FAR struct gpio_dev_s *dev,
+static int gpint_attach(struct gpio_dev_s *dev,
                         pin_interrupt_t callback)
 {
-  FAR struct simgpint_dev_s *simgpint = (FAR struct simgpint_dev_s *)dev;
+  struct simgpint_dev_s *simgpint = (struct simgpint_dev_s *)dev;
 
   gpioinfo("Cancel 1 second timer\n");
   wd_cancel(&simgpint->wdog);
@@ -177,9 +177,9 @@ static int gpint_attach(FAR struct gpio_dev_s *dev,
   return OK;
 }
 
-static int gpint_enable(FAR struct gpio_dev_s *dev, bool enable)
+static int gpint_enable(struct gpio_dev_s *dev, bool enable)
 {
-  FAR struct simgpint_dev_s *simgpint = (FAR struct simgpint_dev_s *)dev;
+  struct simgpint_dev_s *simgpint = (struct simgpint_dev_s *)dev;
 
   if (enable)
     {

--- a/boards/sim/sim/sim/src/sim_ioexpander.c
+++ b/boards/sim/sim/sim/src/sim_ioexpander.c
@@ -50,7 +50,7 @@ int sim_gpio_initialize(void)
 {
   /* Get an instance of the simulated I/O expander */
 
-  FAR struct ioexpander_dev_s *ioe = ioe_dummy_initialize();
+  struct ioexpander_dev_s *ioe = ioe_dummy_initialize();
   if (ioe == NULL)
     {
       gpioerr("ERROR: ioe_dummy_initialize failed\n");
@@ -63,36 +63,36 @@ int sim_gpio_initialize(void)
 
   IOEXP_SETDIRECTION(ioe, 0, IOEXPANDER_DIRECTION_IN);
   IOEXP_SETOPTION(ioe, 0, IOEXPANDER_OPTION_INVERT,
-                  (FAR void *)IOEXPANDER_VAL_NORMAL);
+                  (void *)IOEXPANDER_VAL_NORMAL);
   IOEXP_SETOPTION(ioe, 0, IOEXPANDER_OPTION_INTCFG,
-                  (FAR void *)IOEXPANDER_VAL_DISABLE);
+                  (void *)IOEXPANDER_VAL_DISABLE);
   gpio_lower_half(ioe, 0, GPIO_INPUT_PIN, 0);
 
   /* Pin 1: an non-inverted, output pin */
 
   IOEXP_SETDIRECTION(ioe, 1, IOEXPANDER_DIRECTION_OUT);
   IOEXP_SETOPTION(ioe, 1, IOEXPANDER_OPTION_INVERT,
-                  (FAR void *)IOEXPANDER_VAL_NORMAL);
+                  (void *)IOEXPANDER_VAL_NORMAL);
   IOEXP_SETOPTION(ioe, 2, IOEXPANDER_OPTION_INTCFG,
-                  (FAR void *)IOEXPANDER_VAL_DISABLE);
+                  (void *)IOEXPANDER_VAL_DISABLE);
   gpio_lower_half(ioe, 1, GPIO_OUTPUT_PIN, 1);
 
   /* Pin 2: an non-inverted, edge interrupting pin */
 
   IOEXP_SETDIRECTION(ioe, 2, IOEXPANDER_DIRECTION_IN);
   IOEXP_SETOPTION(ioe, 2, IOEXPANDER_OPTION_INVERT,
-                  (FAR void *)IOEXPANDER_VAL_NORMAL);
+                  (void *)IOEXPANDER_VAL_NORMAL);
   IOEXP_SETOPTION(ioe, 2, IOEXPANDER_OPTION_INTCFG,
-                  (FAR void *)IOEXPANDER_VAL_BOTH);
+                  (void *)IOEXPANDER_VAL_BOTH);
   gpio_lower_half(ioe, 2, GPIO_INTERRUPT_PIN, 2);
 
   /* Pin 3: a non-inverted, level interrupting pin */
 
   IOEXP_SETDIRECTION(ioe, 3, IOEXPANDER_DIRECTION_IN);
   IOEXP_SETOPTION(ioe, 3, IOEXPANDER_OPTION_INVERT,
-                  (FAR void *)IOEXPANDER_VAL_NORMAL);
+                  (void *)IOEXPANDER_VAL_NORMAL);
   IOEXP_SETOPTION(ioe, 3, IOEXPANDER_OPTION_INTCFG,
-                  (FAR void *)IOEXPANDER_VAL_HIGH);
+                  (void *)IOEXPANDER_VAL_HIGH);
   gpio_lower_half(ioe, 3, GPIO_INTERRUPT_PIN, 3);
 
   return 0;

--- a/boards/sparc/bm3803/xx3803/src/bm3803_am29lv.c
+++ b/boards/sparc/bm3803/xx3803/src/bm3803_am29lv.c
@@ -81,9 +81,9 @@ int bm3803_am29lv_initialize(int minor)
 {
   int ret;
 #ifdef HAVE_AM29LV
-  FAR struct mtd_dev_s *mtd;
+  struct mtd_dev_s *mtd;
 #if defined(CONFIG_MTD_PARTITION_NAMES)
-  FAR const char *partname = CONFIG_XX3803_FLASH_PART_NAMES;
+  const char *partname = CONFIG_XX3803_FLASH_PART_NAMES;
 #endif
 
   /* Now bind the SPI interface to the W25 SPI FLASH driver */

--- a/boards/sparc/bm3803/xx3803/src/bm3803_wdt.c
+++ b/boards/sparc/bm3803/xx3803/src/bm3803_wdt.c
@@ -51,7 +51,7 @@
 
 static int wdog_daemon(int argc, char *argv[])
 {
-  FAR struct file filestruct;
+  struct file filestruct;
   int ret;
 
   /* Open watchdog device */
@@ -108,7 +108,7 @@ exit_close_dev:
 
 int xx3803_watchdog_initialize(void)
 {
-  FAR struct file filestruct;
+  struct file filestruct;
   int ret = 0;
 
   /* Open the watchdog device */
@@ -149,7 +149,7 @@ int xx3803_watchdog_initialize(void)
   int taskid = kthread_create(CONFIG_XX3803_WDG_THREAD_NAME,
                               CONFIG_XX3803_WDG_THREAD_PRIORITY,
                               CONFIG_XX3803_WDG_THREAD_STACKSIZE,
-                              (main_t)wdog_daemon, (FAR char * const *)NULL);
+                              (main_t)wdog_daemon, (char * const *)NULL);
 
   DEBUGASSERT(taskid > 0);
   UNUSED(taskid);

--- a/boards/sparc/bm3823/xx3823/src/bm3823_am29lv.c
+++ b/boards/sparc/bm3823/xx3823/src/bm3823_am29lv.c
@@ -81,10 +81,10 @@ int bm3823_am29lv_initialize(int minor)
 {
   int ret;
 #ifdef HAVE_AM29LV
-  FAR struct mtd_dev_s *mtd;
-  FAR struct mtd_geometry_s geo;
+  struct mtd_dev_s *mtd;
+  struct mtd_geometry_s geo;
 #if defined(CONFIG_MTD_PARTITION_NAMES)
-  FAR const char *partname = CONFIG_XX3823_FLASH_PART_NAMES;
+  const char *partname = CONFIG_XX3823_FLASH_PART_NAMES;
 #endif
 
   /* Now bind the SPI interface to the W25 SPI FLASH driver */

--- a/boards/xtensa/esp32/common/src/esp32_board_i2c.c
+++ b/boards/xtensa/esp32/common/src/esp32_board_i2c.c
@@ -49,7 +49,7 @@
 
 int esp32_i2c_register(int bus)
 {
-  FAR struct i2c_master_s *i2c;
+  struct i2c_master_s *i2c;
   int ret;
 
   i2c = esp32_i2cbus_initialize(bus);

--- a/boards/xtensa/esp32/common/src/esp32_board_spi.c
+++ b/boards/xtensa/esp32/common/src/esp32_board_spi.c
@@ -41,7 +41,7 @@
  * Name: spi_status
  ****************************************************************************/
 
-static inline uint8_t spi_status(FAR struct spi_dev_s *dev, uint32_t devid)
+static inline uint8_t spi_status(struct spi_dev_s *dev, uint32_t devid)
 {
   uint8_t status = 0;
 
@@ -68,7 +68,7 @@ static inline uint8_t spi_status(FAR struct spi_dev_s *dev, uint32_t devid)
 
 #ifdef CONFIG_SPI_CMDDATA
 
-static inline int spi_cmddata(FAR struct spi_dev_s *dev, uint32_t devid,
+static inline int spi_cmddata(struct spi_dev_s *dev, uint32_t devid,
                               bool cmd)
 {
 #ifdef CONFIG_LCD_ILI9341
@@ -99,7 +99,7 @@ static inline int spi_cmddata(FAR struct spi_dev_s *dev, uint32_t devid,
 
 #ifdef CONFIG_ESP32_SPI2
 
-uint8_t esp32_spi2_status(FAR struct spi_dev_s *dev, uint32_t devid)
+uint8_t esp32_spi2_status(struct spi_dev_s *dev, uint32_t devid)
 {
   return spi_status(dev, devid);
 }
@@ -112,7 +112,7 @@ uint8_t esp32_spi2_status(FAR struct spi_dev_s *dev, uint32_t devid)
 
 #if defined(CONFIG_ESP32_SPI2) && defined(CONFIG_SPI_CMDDATA)
 
-int esp32_spi2_cmddata(FAR struct spi_dev_s *dev, uint32_t devid, bool cmd)
+int esp32_spi2_cmddata(struct spi_dev_s *dev, uint32_t devid, bool cmd)
 {
   spiinfo("devid: %" PRIu32 " CMD: %s\n", devid, cmd ? "command" :
           "data");
@@ -128,7 +128,7 @@ int esp32_spi2_cmddata(FAR struct spi_dev_s *dev, uint32_t devid, bool cmd)
 
 #ifdef CONFIG_ESP32_SPI3
 
-uint8_t esp32_spi3_status(FAR struct spi_dev_s *dev, uint32_t devid)
+uint8_t esp32_spi3_status(struct spi_dev_s *dev, uint32_t devid)
 {
   return spi_status(dev, devid);
 }
@@ -141,7 +141,7 @@ uint8_t esp32_spi3_status(FAR struct spi_dev_s *dev, uint32_t devid)
 
 #if defined(CONFIG_ESP32_SPI3) && defined(CONFIG_SPI_CMDDATA)
 
-int esp32_spi3_cmddata(FAR struct spi_dev_s *dev, uint32_t devid, bool cmd)
+int esp32_spi3_cmddata(struct spi_dev_s *dev, uint32_t devid, bool cmd)
 {
   spiinfo("devid: %" PRIu32 " CMD: %s\n", devid, cmd ? "command" :
           "data");

--- a/boards/xtensa/esp32/common/src/esp32_board_spidev.c
+++ b/boards/xtensa/esp32/common/src/esp32_board_spidev.c
@@ -47,7 +47,7 @@
 int board_spidev_initialize(int port)
 {
   int ret;
-  FAR struct spi_dev_s *spi;
+  struct spi_dev_s *spi;
 
   spiinfo("Initializing /dev/spi%d...\n", port);
 

--- a/boards/xtensa/esp32/common/src/esp32_board_spiflash.c
+++ b/boards/xtensa/esp32/common/src/esp32_board_spiflash.c
@@ -122,7 +122,7 @@ static const struct ota_partition_s g_ota_partition_table[] =
 #ifdef CONFIG_ESP32_HAVE_OTA_PARTITION
 static int init_ota_partitions(void)
 {
-  FAR struct mtd_dev_s *mtd;
+  struct mtd_dev_s *mtd;
 #ifdef CONFIG_BCH
   char blockdev[18];
 #endif
@@ -176,7 +176,7 @@ static int init_ota_partitions(void)
  ****************************************************************************/
 
 #ifdef CONFIG_ESP32_SPIFLASH_SMARTFS
-static int setup_smartfs(int smartn, FAR struct mtd_dev_s *mtd,
+static int setup_smartfs(int smartn, struct mtd_dev_s *mtd,
                          const char *mnt_pt)
 {
   int ret = OK;
@@ -236,7 +236,7 @@ static int setup_smartfs(int smartn, FAR struct mtd_dev_s *mtd,
  ****************************************************************************/
 
 #ifdef CONFIG_ESP32_SPIFLASH_LITTLEFS
-static int setup_littlefs(const char *path, FAR struct mtd_dev_s *mtd,
+static int setup_littlefs(const char *path, struct mtd_dev_s *mtd,
                           const char *mnt_pt, int priv)
 {
   int ret = OK;
@@ -284,7 +284,7 @@ static int setup_littlefs(const char *path, FAR struct mtd_dev_s *mtd,
  ****************************************************************************/
 
 #ifdef CONFIG_ESP32_SPIFLASH_SPIFFS
-static int setup_spiffs(const char *path, FAR struct mtd_dev_s *mtd,
+static int setup_spiffs(const char *path, struct mtd_dev_s *mtd,
                         const char *mnt_pt, int priv)
 {
   int ret = OK;
@@ -326,7 +326,7 @@ static int setup_spiffs(const char *path, FAR struct mtd_dev_s *mtd,
  ****************************************************************************/
 
 #ifdef CONFIG_ESP32_SPIFLASH_NXFFS
-static int setup_nxffs(FAR struct mtd_dev_s *mtd, const char *mnt_pt)
+static int setup_nxffs(struct mtd_dev_s *mtd, const char *mnt_pt)
 {
   int ret = OK;
 
@@ -366,7 +366,7 @@ static int setup_nxffs(FAR struct mtd_dev_s *mtd, const char *mnt_pt)
 static int init_wifi_partition(void)
 {
   int ret = OK;
-  FAR struct mtd_dev_s *mtd;
+  struct mtd_dev_s *mtd;
 
   mtd = esp32_spiflash_alloc_mtdpart(CONFIG_ESP32_WIFI_MTD_OFFSET,
                                      CONFIG_ESP32_WIFI_MTD_SIZE,
@@ -431,7 +431,7 @@ static int init_wifi_partition(void)
 static int init_storage_partition(void)
 {
   int ret = OK;
-  FAR struct mtd_dev_s *mtd;
+  struct mtd_dev_s *mtd;
 
   mtd = esp32_spiflash_alloc_mtdpart(CONFIG_ESP32_STORAGE_MTD_OFFSET,
                                      CONFIG_ESP32_STORAGE_MTD_SIZE,

--- a/boards/xtensa/esp32/common/src/esp32_ili9341.c
+++ b/boards/xtensa/esp32/common/src/esp32_ili9341.c
@@ -82,19 +82,19 @@ struct ili93414ws_lcd_s
  * Private Function Protototypes
  ****************************************************************************/
 
-static void esp32_ili93414ws_select(FAR struct ili9341_lcd_s *lcd);
-static void esp32_ili93414ws_deselect(FAR struct ili9341_lcd_s *lcd);
-static int esp32_ili93414ws_backlight(FAR struct ili9341_lcd_s *lcd,
+static void esp32_ili93414ws_select(struct ili9341_lcd_s *lcd);
+static void esp32_ili93414ws_deselect(struct ili9341_lcd_s *lcd);
+static int esp32_ili93414ws_backlight(struct ili9341_lcd_s *lcd,
                                       int level);
-static int esp32_ili93414ws_sendcmd(FAR struct ili9341_lcd_s *lcd,
+static int esp32_ili93414ws_sendcmd(struct ili9341_lcd_s *lcd,
                                     const uint8_t cmd);
-static int esp32_ili93414ws_sendparam(FAR struct ili9341_lcd_s *lcd,
+static int esp32_ili93414ws_sendparam(struct ili9341_lcd_s *lcd,
                                       const uint8_t param);
-static int esp32_ili93414ws_sendgram(FAR struct ili9341_lcd_s *lcd,
+static int esp32_ili93414ws_sendgram(struct ili9341_lcd_s *lcd,
                                      const uint16_t *wd, uint32_t nwords);
-static int esp32_ili93414ws_recvparam(FAR struct ili9341_lcd_s *lcd,
+static int esp32_ili93414ws_recvparam(struct ili9341_lcd_s *lcd,
                                       uint8_t *param);
-static int esp32_ili93414ws_recvgram(FAR struct ili9341_lcd_s *lcd,
+static int esp32_ili93414ws_recvgram(struct ili9341_lcd_s *lcd,
                                      uint16_t *wd, uint32_t nwords);
 
 /****************************************************************************
@@ -119,9 +119,9 @@ static struct lcd_dev_s *g_lcd = NULL;
  *
  ****************************************************************************/
 
-static void esp32_ili93414ws_select(FAR struct ili9341_lcd_s *lcd)
+static void esp32_ili93414ws_select(struct ili9341_lcd_s *lcd)
 {
-  FAR struct ili93414ws_lcd_s *priv = (FAR struct ili93414ws_lcd_s *)lcd;
+  struct ili93414ws_lcd_s *priv = (struct ili93414ws_lcd_s *)lcd;
 
   SPI_LOCK(priv->spi, true);
   SPI_SELECT(priv->spi, SPIDEV_DISPLAY(0), true);
@@ -138,9 +138,9 @@ static void esp32_ili93414ws_select(FAR struct ili9341_lcd_s *lcd)
  *
  ****************************************************************************/
 
-static void esp32_ili93414ws_deselect(FAR struct ili9341_lcd_s *lcd)
+static void esp32_ili93414ws_deselect(struct ili9341_lcd_s *lcd)
 {
-  FAR struct ili93414ws_lcd_s *priv = (FAR struct ili93414ws_lcd_s *)lcd;
+  struct ili93414ws_lcd_s *priv = (struct ili93414ws_lcd_s *)lcd;
 
   SPI_SELECT(priv->spi, SPIDEV_DISPLAY(0), false);
   SPI_LOCK(priv->spi, false);
@@ -168,7 +168,7 @@ static void esp32_ili93414ws_deselect(FAR struct ili9341_lcd_s *lcd)
  *
  ****************************************************************************/
 
-static int esp32_ili93414ws_backlight(FAR struct ili9341_lcd_s *lcd,
+static int esp32_ili93414ws_backlight(struct ili9341_lcd_s *lcd,
                                       int level)
 {
   if (level > 0)
@@ -200,10 +200,10 @@ static int esp32_ili93414ws_backlight(FAR struct ili9341_lcd_s *lcd,
  *
  ****************************************************************************/
 
-static int esp32_ili93414ws_sendcmd(FAR struct ili9341_lcd_s *lcd,
+static int esp32_ili93414ws_sendcmd(struct ili9341_lcd_s *lcd,
                                     const uint8_t cmd)
 {
-  FAR struct ili93414ws_lcd_s *priv = (FAR struct ili93414ws_lcd_s *)lcd;
+  struct ili93414ws_lcd_s *priv = (struct ili93414ws_lcd_s *)lcd;
 
   lcdinfo("%02x\n", cmd);
 
@@ -231,10 +231,10 @@ static int esp32_ili93414ws_sendcmd(FAR struct ili9341_lcd_s *lcd,
  *
  ****************************************************************************/
 
-static int esp32_ili93414ws_sendparam(FAR struct ili9341_lcd_s *lcd,
+static int esp32_ili93414ws_sendparam(struct ili9341_lcd_s *lcd,
                                       const uint8_t param)
 {
-  FAR struct ili93414ws_lcd_s *priv = (FAR struct ili93414ws_lcd_s *)lcd;
+  struct ili93414ws_lcd_s *priv = (struct ili93414ws_lcd_s *)lcd;
 
   lcdinfo("param=%04x\n", param);
 
@@ -262,10 +262,10 @@ static int esp32_ili93414ws_sendparam(FAR struct ili9341_lcd_s *lcd,
  *
  ****************************************************************************/
 
-static int esp32_ili93414ws_sendgram(FAR struct ili9341_lcd_s *lcd,
+static int esp32_ili93414ws_sendgram(struct ili9341_lcd_s *lcd,
                                      const uint16_t *wd, uint32_t nwords)
 {
-  FAR struct ili93414ws_lcd_s *priv = (FAR struct ili93414ws_lcd_s *)lcd;
+  struct ili93414ws_lcd_s *priv = (struct ili93414ws_lcd_s *)lcd;
 
   lcdinfo("lcd:%p, wd=%p, nwords=%" PRIu32 "\n", lcd, wd, nwords);
 
@@ -290,10 +290,10 @@ static int esp32_ili93414ws_sendgram(FAR struct ili9341_lcd_s *lcd,
  *
  ****************************************************************************/
 
-static int esp32_ili93414ws_recvparam(FAR struct ili9341_lcd_s *lcd,
+static int esp32_ili93414ws_recvparam(struct ili9341_lcd_s *lcd,
                                       uint8_t *param)
 {
-  FAR struct ili93414ws_lcd_s *priv = (FAR struct ili93414ws_lcd_s *)lcd;
+  struct ili93414ws_lcd_s *priv = (struct ili93414ws_lcd_s *)lcd;
 
   SPI_SETBITS(priv->spi, 8);
 
@@ -320,10 +320,10 @@ static int esp32_ili93414ws_recvparam(FAR struct ili9341_lcd_s *lcd,
  *
  ****************************************************************************/
 
-static int esp32_ili93414ws_recvgram(FAR struct ili9341_lcd_s *lcd,
+static int esp32_ili93414ws_recvgram(struct ili9341_lcd_s *lcd,
                                      uint16_t *wd, uint32_t nwords)
 {
-  FAR struct ili93414ws_lcd_s *priv = (FAR struct ili93414ws_lcd_s *)lcd;
+  struct ili93414ws_lcd_s *priv = (struct ili93414ws_lcd_s *)lcd;
 
   lcdinfo("wd=%p, nwords=%" PRIu32 "\n", wd, nwords);
 
@@ -349,8 +349,8 @@ static int esp32_ili93414ws_recvgram(FAR struct ili9341_lcd_s *lcd,
 
 int board_lcd_initialize(void)
 {
-  FAR struct ili93414ws_lcd_s *priv = &g_lcddev;
-  FAR struct spi_dev_s *spi;
+  struct ili93414ws_lcd_s *priv = &g_lcddev;
+  struct spi_dev_s *spi;
   lcdinfo("Initializing LCD\n");
 
   if (g_lcd == NULL)
@@ -423,7 +423,7 @@ int board_lcd_initialize(void)
  *
  ****************************************************************************/
 
-FAR struct lcd_dev_s *board_lcd_getdev(int lcddev)
+struct lcd_dev_s *board_lcd_getdev(int lcddev)
 {
   if (lcddev == 0)
     {

--- a/boards/xtensa/esp32/common/src/esp32_lcd_backpack.c
+++ b/boards/xtensa/esp32/common/src/esp32_lcd_backpack.c
@@ -59,9 +59,9 @@
 
 int board_lcd_backpack_init(int devno, int busno, int rows, int cols)
 {
-  FAR struct pcf8574_lcd_backpack_config_s cfg =
+  struct pcf8574_lcd_backpack_config_s cfg =
              LCD_I2C_BACKPACK_CFG_SAINSMART;
-  FAR struct i2c_master_s *i2c;
+  struct i2c_master_s *i2c;
   char devpath[12];
   int ret;
 

--- a/boards/xtensa/esp32/common/src/esp32_mcp2515.c
+++ b/boards/xtensa/esp32/common/src/esp32_mcp2515.c
@@ -62,9 +62,9 @@ struct esp32_mcp2515config_s
 
   /* Additional private definitions only known to this driver */
 
-  FAR struct mcp2515_can_s *handle; /* The MCP2515 driver handle */
-  mcp2515_handler_t handler;        /* The MCP2515 interrupt handler */
-  FAR void *arg;                    /* Argument to pass to the interrupt handler */
+  struct mcp2515_can_s *handle; /* The MCP2515 driver handle */
+  mcp2515_handler_t handler;    /* The MCP2515 interrupt handler */
+  void *arg;                    /* Argument to pass to the interrupt handler */
 };
 
 /****************************************************************************
@@ -78,8 +78,8 @@ struct esp32_mcp2515config_s
  *   attach  - Attach the MCP2515 interrupt handler to the GPIO interrupt
  */
 
-static int  mcp2515_attach(FAR struct mcp2515_config_s *state,
-                           mcp2515_handler_t handler, FAR void *arg);
+static int  mcp2515_attach(struct mcp2515_config_s *state,
+                           mcp2515_handler_t handler, void *arg);
 
 /****************************************************************************
  * Private Data
@@ -118,10 +118,10 @@ static struct esp32_mcp2515config_s g_mcp2515config =
 
 /* This is the MCP2515 Interrupt handler */
 
-int mcp2515_interrupt(int irq, FAR void *context, FAR void *arg)
+int mcp2515_interrupt(int irq, void *context, void *arg)
 {
-  FAR struct esp32_mcp2515config_s *priv =
-             (FAR struct esp32_mcp2515config_s *)arg;
+  struct esp32_mcp2515config_s *priv =
+             (struct esp32_mcp2515config_s *)arg;
 
   DEBUGASSERT(priv != NULL);
 
@@ -137,11 +137,11 @@ int mcp2515_interrupt(int irq, FAR void *context, FAR void *arg)
   return OK;
 }
 
-static int mcp2515_attach(FAR struct mcp2515_config_s *state,
-                          mcp2515_handler_t handler, FAR void *arg)
+static int mcp2515_attach(struct mcp2515_config_s *state,
+                          mcp2515_handler_t handler, void *arg)
 {
-  FAR struct esp32_mcp2515config_s *priv =
-             (FAR struct esp32_mcp2515config_s *)state;
+  struct esp32_mcp2515config_s *priv =
+             (struct esp32_mcp2515config_s *)state;
   irqstate_t flags;
   int irq = ESP32_PIN2IRQ(GPIO_MCP2515_IRQ);
   int ret;
@@ -192,9 +192,9 @@ static int mcp2515_attach(FAR struct mcp2515_config_s *state,
 
 int board_mcp2515_initialize(int devno)
 {
-  FAR struct spi_dev_s     *spi;
-  FAR struct can_dev_s     *can;
-  FAR struct mcp2515_can_s *mcp2515;
+  struct spi_dev_s     *spi;
+  struct can_dev_s     *can;
+  struct mcp2515_can_s *mcp2515;
   char devpath[10];
   int ret;
 

--- a/boards/xtensa/esp32/common/src/esp32_oneshot.c
+++ b/boards/xtensa/esp32/common/src/esp32_oneshot.c
@@ -54,7 +54,7 @@
 int esp32_oneshot_init(int timer, uint16_t resolution)
 {
   int ret = OK;
-  FAR struct oneshot_lowerhalf_s *os_lower = NULL;
+  struct oneshot_lowerhalf_s *os_lower = NULL;
 
   os_lower = oneshot_initialize(timer, resolution);
   if (os_lower != NULL)

--- a/boards/xtensa/esp32/common/src/esp32_ssd1306.c
+++ b/boards/xtensa/esp32/common/src/esp32_ssd1306.c
@@ -55,7 +55,7 @@
  * Private Data
  ****************************************************************************/
 
-static FAR struct lcd_dev_s    *g_lcddev;
+static struct lcd_dev_s    *g_lcddev;
 
 /* Configuration ************************************************************/
 
@@ -69,7 +69,7 @@ static FAR struct lcd_dev_s    *g_lcddev;
 
 int board_lcd_initialize(void)
 {
-  FAR struct i2c_master_s *i2c;
+  struct i2c_master_s *i2c;
   const int busno = OLED_I2C_PORT;
   const int devno = 0;
   int ret = OK;
@@ -130,7 +130,7 @@ int board_lcd_initialize(void)
  * Name:  board_lcd_getdev
  ****************************************************************************/
 
-FAR struct lcd_dev_s *board_lcd_getdev(int lcddev)
+struct lcd_dev_s *board_lcd_getdev(int lcddev)
 {
   if (lcddev == 0)
     {

--- a/boards/xtensa/esp32/esp32-devkitc/src/esp32_boot.c
+++ b/boards/xtensa/esp32/esp32-devkitc/src/esp32_boot.c
@@ -89,7 +89,7 @@ void board_late_initialize(void)
    * SMP bringup is complete.
    */
 
-  umm_addregion((FAR void *)HEAP_REGION_ROMAPP_START,
+  umm_addregion((void *)HEAP_REGION_ROMAPP_START,
                 (size_t)(HEAP_REGION_ROMAPP_END - HEAP_REGION_ROMAPP_START));
 #endif
 }

--- a/boards/xtensa/esp32/esp32-devkitc/src/esp32_buttons.c
+++ b/boards/xtensa/esp32/esp32-devkitc/src/esp32_buttons.c
@@ -127,7 +127,7 @@ uint32_t board_buttons(void)
  ****************************************************************************/
 
 #ifdef CONFIG_ARCH_IRQBUTTONS
-int board_button_irq(int id, xcpt_t irqhandler, FAR void *arg)
+int board_button_irq(int id, xcpt_t irqhandler, void *arg)
 {
   int ret;
   DEBUGASSERT(id == BUTTON_BOOT);

--- a/boards/xtensa/esp32/esp32-devkitc/src/esp32_gpio.c
+++ b/boards/xtensa/esp32/esp32-devkitc/src/esp32_gpio.c
@@ -87,19 +87,19 @@ struct esp32gpint_dev_s
  ****************************************************************************/
 
 #if BOARD_NGPIOOUT > 0
-static int gpout_read(FAR struct gpio_dev_s *dev, FAR bool *value);
-static int gpout_write(FAR struct gpio_dev_s *dev, bool value);
+static int gpout_read(struct gpio_dev_s *dev, bool *value);
+static int gpout_write(struct gpio_dev_s *dev, bool value);
 #endif
 
 #if BOARD_NGPIOIN > 0
-static int gpin_read(FAR struct gpio_dev_s *dev, FAR bool *value);
+static int gpin_read(struct gpio_dev_s *dev, bool *value);
 #endif
 
 #if BOARD_NGPIOINT > 0
-static int gpint_read(FAR struct gpio_dev_s *dev, FAR bool *value);
-static int gpint_attach(FAR struct gpio_dev_s *dev,
+static int gpint_read(struct gpio_dev_s *dev, bool *value);
+static int gpint_attach(struct gpio_dev_s *dev,
                         pin_interrupt_t callback);
-static int gpint_enable(FAR struct gpio_dev_s *dev, bool enable);
+static int gpint_enable(struct gpio_dev_s *dev, bool enable);
 #endif
 
 /****************************************************************************
@@ -172,9 +172,9 @@ static struct esp32gpint_dev_s g_gpint[BOARD_NGPIOINT];
  ****************************************************************************/
 
 #if BOARD_NGPIOOUT > 0
-static int gpout_read(FAR struct gpio_dev_s *dev, FAR bool *value)
+static int gpout_read(struct gpio_dev_s *dev, bool *value)
 {
-  FAR struct esp32gpio_dev_s *esp32gpio = (FAR struct esp32gpio_dev_s *)dev;
+  struct esp32gpio_dev_s *esp32gpio = (struct esp32gpio_dev_s *)dev;
 
   DEBUGASSERT(esp32gpio != NULL && value != NULL);
   DEBUGASSERT(esp32gpio->id < BOARD_NGPIOOUT);
@@ -188,9 +188,9 @@ static int gpout_read(FAR struct gpio_dev_s *dev, FAR bool *value)
  * Name: gpout_write
  ****************************************************************************/
 
-static int gpout_write(FAR struct gpio_dev_s *dev, bool value)
+static int gpout_write(struct gpio_dev_s *dev, bool value)
 {
-  FAR struct esp32gpio_dev_s *esp32gpio = (FAR struct esp32gpio_dev_s *)dev;
+  struct esp32gpio_dev_s *esp32gpio = (struct esp32gpio_dev_s *)dev;
 
   DEBUGASSERT(esp32gpio != NULL);
   DEBUGASSERT(esp32gpio->id < BOARD_NGPIOOUT);
@@ -206,9 +206,9 @@ static int gpout_write(FAR struct gpio_dev_s *dev, bool value)
  ****************************************************************************/
 
 #if BOARD_NGPIOIN > 0
-static int gpin_read(FAR struct gpio_dev_s *dev, FAR bool *value)
+static int gpin_read(struct gpio_dev_s *dev, bool *value)
 {
-  FAR struct esp32gpio_dev_s *esp32gpio = (FAR struct esp32gpio_dev_s *)dev;
+  struct esp32gpio_dev_s *esp32gpio = (struct esp32gpio_dev_s *)dev;
 
   DEBUGASSERT(esp32gpio != NULL && value != NULL);
   DEBUGASSERT(esp32gpio->id < BOARD_NGPIOIN);
@@ -226,8 +226,8 @@ static int gpin_read(FAR struct gpio_dev_s *dev, FAR bool *value)
 #if BOARD_NGPIOINT > 0
 static int esp32gpio_interrupt(int irq, void *context, void *arg)
 {
-  FAR struct esp32gpint_dev_s *esp32gpint =
-    (FAR struct esp32gpint_dev_s *)arg;
+  struct esp32gpint_dev_s *esp32gpint =
+    (struct esp32gpint_dev_s *)arg;
 
   DEBUGASSERT(esp32gpint != NULL && esp32gpint->callback != NULL);
   gpioinfo("Interrupt! callback=%p\n", esp32gpint->callback);
@@ -241,10 +241,10 @@ static int esp32gpio_interrupt(int irq, void *context, void *arg)
  * Name: gpint_read
  ****************************************************************************/
 
-static int gpint_read(FAR struct gpio_dev_s *dev, FAR bool *value)
+static int gpint_read(struct gpio_dev_s *dev, bool *value)
 {
-  FAR struct esp32gpint_dev_s *esp32gpint =
-    (FAR struct esp32gpint_dev_s *)dev;
+  struct esp32gpint_dev_s *esp32gpint =
+    (struct esp32gpint_dev_s *)dev;
 
   DEBUGASSERT(esp32gpint != NULL && value != NULL);
   DEBUGASSERT(esp32gpint->esp32gpio.id < BOARD_NGPIOINT);
@@ -258,11 +258,11 @@ static int gpint_read(FAR struct gpio_dev_s *dev, FAR bool *value)
  * Name: gpint_attach
  ****************************************************************************/
 
-static int gpint_attach(FAR struct gpio_dev_s *dev,
+static int gpint_attach(struct gpio_dev_s *dev,
                         pin_interrupt_t callback)
 {
-  FAR struct esp32gpint_dev_s *esp32gpint =
-    (FAR struct esp32gpint_dev_s *)dev;
+  struct esp32gpint_dev_s *esp32gpint =
+    (struct esp32gpint_dev_s *)dev;
   int irq = ESP32_PIN2IRQ(g_gpiointinputs[esp32gpint->esp32gpio.id]);
   int ret;
 
@@ -289,10 +289,10 @@ static int gpint_attach(FAR struct gpio_dev_s *dev,
  * Name: gpint_enable
  ****************************************************************************/
 
-static int gpint_enable(FAR struct gpio_dev_s *dev, bool enable)
+static int gpint_enable(struct gpio_dev_s *dev, bool enable)
 {
-  FAR struct esp32gpint_dev_s *esp32gpint =
-    (FAR struct esp32gpint_dev_s *)dev;
+  struct esp32gpint_dev_s *esp32gpint =
+    (struct esp32gpint_dev_s *)dev;
   int irq = ESP32_PIN2IRQ(g_gpiointinputs[esp32gpint->esp32gpio.id]);
 
   if (enable)

--- a/boards/xtensa/esp32/esp32-ethernet-kit/src/esp32_boot.c
+++ b/boards/xtensa/esp32/esp32-ethernet-kit/src/esp32_boot.c
@@ -89,7 +89,7 @@ void board_late_initialize(void)
    * SMP bringup is complete.
    */
 
-  umm_addregion((FAR void *)HEAP_REGION_ROMAPP_START,
+  umm_addregion((void *)HEAP_REGION_ROMAPP_START,
                 (size_t)(HEAP_REGION_ROMAPP_END - HEAP_REGION_ROMAPP_START));
 #endif
 }

--- a/boards/xtensa/esp32/esp32-ethernet-kit/src/esp32_buttons.c
+++ b/boards/xtensa/esp32/esp32-ethernet-kit/src/esp32_buttons.c
@@ -127,7 +127,7 @@ uint32_t board_buttons(void)
  ****************************************************************************/
 
 #ifdef CONFIG_ARCH_IRQBUTTONS
-int board_button_irq(int id, xcpt_t irqhandler, FAR void *arg)
+int board_button_irq(int id, xcpt_t irqhandler, void *arg)
 {
   int ret;
   DEBUGASSERT(id == BUTTON_BOOT);

--- a/boards/xtensa/esp32/esp32-wrover-kit/src/esp32_boot.c
+++ b/boards/xtensa/esp32/esp32-wrover-kit/src/esp32_boot.c
@@ -94,7 +94,7 @@ void board_late_initialize(void)
    * SMP bringup is complete.
    */
 
-  umm_addregion((FAR void *)HEAP_REGION_ROMAPP_START,
+  umm_addregion((void *)HEAP_REGION_ROMAPP_START,
                 (size_t)(HEAP_REGION_ROMAPP_END - HEAP_REGION_ROMAPP_START));
 #endif
 }

--- a/boards/xtensa/esp32/esp32-wrover-kit/src/esp32_buttons.c
+++ b/boards/xtensa/esp32/esp32-wrover-kit/src/esp32_buttons.c
@@ -127,7 +127,7 @@ uint32_t board_buttons(void)
  ****************************************************************************/
 
 #ifdef CONFIG_ARCH_IRQBUTTONS
-int board_button_irq(int id, xcpt_t irqhandler, FAR void *arg)
+int board_button_irq(int id, xcpt_t irqhandler, void *arg)
 {
   int ret;
   DEBUGASSERT(id == BUTTON_BOOT);

--- a/boards/xtensa/esp32/esp32-wrover-kit/src/esp32_gpio.c
+++ b/boards/xtensa/esp32/esp32-wrover-kit/src/esp32_gpio.c
@@ -87,19 +87,19 @@ struct esp32gpint_dev_s
  ****************************************************************************/
 
 #if BOARD_NGPIOOUT > 0
-static int gpout_read(FAR struct gpio_dev_s *dev, FAR bool *value);
-static int gpout_write(FAR struct gpio_dev_s *dev, bool value);
+static int gpout_read(struct gpio_dev_s *dev, bool *value);
+static int gpout_write(struct gpio_dev_s *dev, bool value);
 #endif
 
 #if BOARD_NGPIOIN > 0
-static int gpin_read(FAR struct gpio_dev_s *dev, FAR bool *value);
+static int gpin_read(struct gpio_dev_s *dev, bool *value);
 #endif
 
 #if BOARD_NGPIOINT > 0
-static int gpint_read(FAR struct gpio_dev_s *dev, FAR bool *value);
-static int gpint_attach(FAR struct gpio_dev_s *dev,
+static int gpint_read(struct gpio_dev_s *dev, bool *value);
+static int gpint_attach(struct gpio_dev_s *dev,
                         pin_interrupt_t callback);
-static int gpint_enable(FAR struct gpio_dev_s *dev, bool enable);
+static int gpint_enable(struct gpio_dev_s *dev, bool enable);
 #endif
 
 /****************************************************************************
@@ -172,9 +172,9 @@ static struct esp32gpint_dev_s g_gpint[BOARD_NGPIOINT];
  ****************************************************************************/
 
 #if BOARD_NGPIOOUT > 0
-static int gpout_read(FAR struct gpio_dev_s *dev, FAR bool *value)
+static int gpout_read(struct gpio_dev_s *dev, bool *value)
 {
-  FAR struct esp32gpio_dev_s *esp32gpio = (FAR struct esp32gpio_dev_s *)dev;
+  struct esp32gpio_dev_s *esp32gpio = (struct esp32gpio_dev_s *)dev;
 
   DEBUGASSERT(esp32gpio != NULL && value != NULL);
   DEBUGASSERT(esp32gpio->id < BOARD_NGPIOOUT);
@@ -188,9 +188,9 @@ static int gpout_read(FAR struct gpio_dev_s *dev, FAR bool *value)
  * Name: gpout_write
  ****************************************************************************/
 
-static int gpout_write(FAR struct gpio_dev_s *dev, bool value)
+static int gpout_write(struct gpio_dev_s *dev, bool value)
 {
-  FAR struct esp32gpio_dev_s *esp32gpio = (FAR struct esp32gpio_dev_s *)dev;
+  struct esp32gpio_dev_s *esp32gpio = (struct esp32gpio_dev_s *)dev;
 
   DEBUGASSERT(esp32gpio != NULL);
   DEBUGASSERT(esp32gpio->id < BOARD_NGPIOOUT);
@@ -206,9 +206,9 @@ static int gpout_write(FAR struct gpio_dev_s *dev, bool value)
  ****************************************************************************/
 
 #if BOARD_NGPIOIN > 0
-static int gpin_read(FAR struct gpio_dev_s *dev, FAR bool *value)
+static int gpin_read(struct gpio_dev_s *dev, bool *value)
 {
-  FAR struct esp32gpio_dev_s *esp32gpio = (FAR struct esp32gpio_dev_s *)dev;
+  struct esp32gpio_dev_s *esp32gpio = (struct esp32gpio_dev_s *)dev;
 
   DEBUGASSERT(esp32gpio != NULL && value != NULL);
   DEBUGASSERT(esp32gpio->id < BOARD_NGPIOIN);
@@ -226,8 +226,8 @@ static int gpin_read(FAR struct gpio_dev_s *dev, FAR bool *value)
 #if BOARD_NGPIOINT > 0
 static int esp32gpio_interrupt(int irq, void *context, void *arg)
 {
-  FAR struct esp32gpint_dev_s *esp32gpint =
-    (FAR struct esp32gpint_dev_s *)arg;
+  struct esp32gpint_dev_s *esp32gpint =
+    (struct esp32gpint_dev_s *)arg;
 
   DEBUGASSERT(esp32gpint != NULL && esp32gpint->callback != NULL);
   gpioinfo("Interrupt! callback=%p\n", esp32gpint->callback);
@@ -241,10 +241,10 @@ static int esp32gpio_interrupt(int irq, void *context, void *arg)
  * Name: gpint_read
  ****************************************************************************/
 
-static int gpint_read(FAR struct gpio_dev_s *dev, FAR bool *value)
+static int gpint_read(struct gpio_dev_s *dev, bool *value)
 {
-  FAR struct esp32gpint_dev_s *esp32gpint =
-    (FAR struct esp32gpint_dev_s *)dev;
+  struct esp32gpint_dev_s *esp32gpint =
+    (struct esp32gpint_dev_s *)dev;
 
   DEBUGASSERT(esp32gpint != NULL && value != NULL);
   DEBUGASSERT(esp32gpint->esp32gpio.id < BOARD_NGPIOINT);
@@ -258,11 +258,11 @@ static int gpint_read(FAR struct gpio_dev_s *dev, FAR bool *value)
  * Name: gpint_attach
  ****************************************************************************/
 
-static int gpint_attach(FAR struct gpio_dev_s *dev,
+static int gpint_attach(struct gpio_dev_s *dev,
                         pin_interrupt_t callback)
 {
-  FAR struct esp32gpint_dev_s *esp32gpint =
-    (FAR struct esp32gpint_dev_s *)dev;
+  struct esp32gpint_dev_s *esp32gpint =
+    (struct esp32gpint_dev_s *)dev;
   int irq = ESP32_PIN2IRQ(g_gpiointinputs[esp32gpint->esp32gpio.id]);
   int ret;
 
@@ -289,10 +289,10 @@ static int gpint_attach(FAR struct gpio_dev_s *dev,
  * Name: gpint_enable
  ****************************************************************************/
 
-static int gpint_enable(FAR struct gpio_dev_s *dev, bool enable)
+static int gpint_enable(struct gpio_dev_s *dev, bool enable)
 {
-  FAR struct esp32gpint_dev_s *esp32gpint =
-    (FAR struct esp32gpint_dev_s *)dev;
+  struct esp32gpint_dev_s *esp32gpint =
+    (struct esp32gpint_dev_s *)dev;
   int irq = ESP32_PIN2IRQ(g_gpiointinputs[esp32gpint->esp32gpio.id]);
 
   if (enable)

--- a/boards/xtensa/esp32/ttgo_lora_esp32/src/esp32_boot.c
+++ b/boards/xtensa/esp32/ttgo_lora_esp32/src/esp32_boot.c
@@ -89,7 +89,7 @@ void board_late_initialize(void)
    * SMP bringup is complete.
    */
 
-  umm_addregion((FAR void *)HEAP_REGION_ROMAPP_START,
+  umm_addregion((void *)HEAP_REGION_ROMAPP_START,
                 (size_t)(HEAP_REGION_ROMAPP_END - HEAP_REGION_ROMAPP_START));
 #endif
 }

--- a/boards/xtensa/esp32/ttgo_lora_esp32/src/esp32_buttons.c
+++ b/boards/xtensa/esp32/ttgo_lora_esp32/src/esp32_buttons.c
@@ -127,7 +127,7 @@ uint32_t board_buttons(void)
  ****************************************************************************/
 
 #ifdef CONFIG_ARCH_IRQBUTTONS
-int board_button_irq(int id, xcpt_t irqhandler, FAR void *arg)
+int board_button_irq(int id, xcpt_t irqhandler, void *arg)
 {
   int ret;
   DEBUGASSERT(id == BUTTON_BOOT);

--- a/boards/xtensa/esp32/ttgo_lora_esp32/src/esp32_gpio.c
+++ b/boards/xtensa/esp32/ttgo_lora_esp32/src/esp32_gpio.c
@@ -87,19 +87,19 @@ struct esp32gpint_dev_s
  ****************************************************************************/
 
 #if BOARD_NGPIOOUT > 0
-static int gpout_read(FAR struct gpio_dev_s *dev, FAR bool *value);
-static int gpout_write(FAR struct gpio_dev_s *dev, bool value);
+static int gpout_read(struct gpio_dev_s *dev, bool *value);
+static int gpout_write(struct gpio_dev_s *dev, bool value);
 #endif
 
 #if BOARD_NGPIOIN > 0
-static int gpin_read(FAR struct gpio_dev_s *dev, FAR bool *value);
+static int gpin_read(struct gpio_dev_s *dev, bool *value);
 #endif
 
 #if BOARD_NGPIOINT > 0
-static int gpint_read(FAR struct gpio_dev_s *dev, FAR bool *value);
-static int gpint_attach(FAR struct gpio_dev_s *dev,
+static int gpint_read(struct gpio_dev_s *dev, bool *value);
+static int gpint_attach(struct gpio_dev_s *dev,
                         pin_interrupt_t callback);
-static int gpint_enable(FAR struct gpio_dev_s *dev, bool enable);
+static int gpint_enable(struct gpio_dev_s *dev, bool enable);
 #endif
 
 /****************************************************************************
@@ -172,9 +172,9 @@ static struct esp32gpint_dev_s g_gpint[BOARD_NGPIOINT];
  ****************************************************************************/
 
 #if BOARD_NGPIOOUT > 0
-static int gpout_read(FAR struct gpio_dev_s *dev, FAR bool *value)
+static int gpout_read(struct gpio_dev_s *dev, bool *value)
 {
-  FAR struct esp32gpio_dev_s *esp32gpio = (FAR struct esp32gpio_dev_s *)dev;
+  struct esp32gpio_dev_s *esp32gpio = (struct esp32gpio_dev_s *)dev;
 
   DEBUGASSERT(esp32gpio != NULL && value != NULL);
   DEBUGASSERT(esp32gpio->id < BOARD_NGPIOOUT);
@@ -188,9 +188,9 @@ static int gpout_read(FAR struct gpio_dev_s *dev, FAR bool *value)
  * Name: gpout_write
  ****************************************************************************/
 
-static int gpout_write(FAR struct gpio_dev_s *dev, bool value)
+static int gpout_write(struct gpio_dev_s *dev, bool value)
 {
-  FAR struct esp32gpio_dev_s *esp32gpio = (FAR struct esp32gpio_dev_s *)dev;
+  struct esp32gpio_dev_s *esp32gpio = (struct esp32gpio_dev_s *)dev;
 
   DEBUGASSERT(esp32gpio != NULL);
   DEBUGASSERT(esp32gpio->id < BOARD_NGPIOOUT);
@@ -206,9 +206,9 @@ static int gpout_write(FAR struct gpio_dev_s *dev, bool value)
  ****************************************************************************/
 
 #if BOARD_NGPIOIN > 0
-static int gpin_read(FAR struct gpio_dev_s *dev, FAR bool *value)
+static int gpin_read(struct gpio_dev_s *dev, bool *value)
 {
-  FAR struct esp32gpio_dev_s *esp32gpio = (FAR struct esp32gpio_dev_s *)dev;
+  struct esp32gpio_dev_s *esp32gpio = (struct esp32gpio_dev_s *)dev;
 
   DEBUGASSERT(esp32gpio != NULL && value != NULL);
   DEBUGASSERT(esp32gpio->id < BOARD_NGPIOIN);
@@ -226,8 +226,8 @@ static int gpin_read(FAR struct gpio_dev_s *dev, FAR bool *value)
 #if BOARD_NGPIOINT > 0
 static int esp32gpio_interrupt(int irq, void *context, void *arg)
 {
-  FAR struct esp32gpint_dev_s *esp32gpint =
-    (FAR struct esp32gpint_dev_s *)arg;
+  struct esp32gpint_dev_s *esp32gpint =
+    (struct esp32gpint_dev_s *)arg;
 
   DEBUGASSERT(esp32gpint != NULL && esp32gpint->callback != NULL);
   gpioinfo("Interrupt! callback=%p\n", esp32gpint->callback);
@@ -241,10 +241,10 @@ static int esp32gpio_interrupt(int irq, void *context, void *arg)
  * Name: gpint_read
  ****************************************************************************/
 
-static int gpint_read(FAR struct gpio_dev_s *dev, FAR bool *value)
+static int gpint_read(struct gpio_dev_s *dev, bool *value)
 {
-  FAR struct esp32gpint_dev_s *esp32gpint =
-    (FAR struct esp32gpint_dev_s *)dev;
+  struct esp32gpint_dev_s *esp32gpint =
+    (struct esp32gpint_dev_s *)dev;
 
   DEBUGASSERT(esp32gpint != NULL && value != NULL);
   DEBUGASSERT(esp32gpint->esp32gpio.id < BOARD_NGPIOINT);
@@ -258,11 +258,11 @@ static int gpint_read(FAR struct gpio_dev_s *dev, FAR bool *value)
  * Name: gpint_attach
  ****************************************************************************/
 
-static int gpint_attach(FAR struct gpio_dev_s *dev,
+static int gpint_attach(struct gpio_dev_s *dev,
                         pin_interrupt_t callback)
 {
-  FAR struct esp32gpint_dev_s *esp32gpint =
-    (FAR struct esp32gpint_dev_s *)dev;
+  struct esp32gpint_dev_s *esp32gpint =
+    (struct esp32gpint_dev_s *)dev;
   int irq = ESP32_PIN2IRQ(g_gpiointinputs[esp32gpint->esp32gpio.id]);
   int ret;
 
@@ -289,10 +289,10 @@ static int gpint_attach(FAR struct gpio_dev_s *dev,
  * Name: gpint_enable
  ****************************************************************************/
 
-static int gpint_enable(FAR struct gpio_dev_s *dev, bool enable)
+static int gpint_enable(struct gpio_dev_s *dev, bool enable)
 {
-  FAR struct esp32gpint_dev_s *esp32gpint =
-    (FAR struct esp32gpint_dev_s *)dev;
+  struct esp32gpint_dev_s *esp32gpint =
+    (struct esp32gpint_dev_s *)dev;
   int irq = ESP32_PIN2IRQ(g_gpiointinputs[esp32gpint->esp32gpio.id]);
 
   if (enable)

--- a/boards/xtensa/esp32s2/esp32s2-saola-1/src/esp32s2_gpio.c
+++ b/boards/xtensa/esp32s2/esp32s2-saola-1/src/esp32s2_gpio.c
@@ -83,19 +83,19 @@ struct esp32s2gpint_dev_s
  ****************************************************************************/
 
 #if BOARD_NGPIOOUT > 0
-static int gpout_read(FAR struct gpio_dev_s *dev, FAR bool *value);
-static int gpout_write(FAR struct gpio_dev_s *dev, bool value);
+static int gpout_read(struct gpio_dev_s *dev, bool *value);
+static int gpout_write(struct gpio_dev_s *dev, bool value);
 #endif
 
 #if BOARD_NGPIOIN > 0
-static int gpin_read(FAR struct gpio_dev_s *dev, FAR bool *value);
+static int gpin_read(struct gpio_dev_s *dev, bool *value);
 #endif
 
 #if BOARD_NGPIOINT > 0
-static int gpint_read(FAR struct gpio_dev_s *dev, FAR bool *value);
-static int gpint_attach(FAR struct gpio_dev_s *dev,
+static int gpint_read(struct gpio_dev_s *dev, bool *value);
+static int gpint_attach(struct gpio_dev_s *dev,
                         pin_interrupt_t callback);
-static int gpint_enable(FAR struct gpio_dev_s *dev, bool enable);
+static int gpint_enable(struct gpio_dev_s *dev, bool enable);
 #endif
 
 /****************************************************************************
@@ -179,10 +179,10 @@ static struct esp32s2gpint_dev_s g_gpint[BOARD_NGPIOINT];
  ****************************************************************************/
 
 #if BOARD_NGPIOOUT > 0
-static int gpout_read(FAR struct gpio_dev_s *dev, FAR bool *value)
+static int gpout_read(struct gpio_dev_s *dev, bool *value)
 {
-  FAR struct esp32s2gpio_dev_s *esp32s2gpio =
-    (FAR struct esp32s2gpio_dev_s *)dev;
+  struct esp32s2gpio_dev_s *esp32s2gpio =
+    (struct esp32s2gpio_dev_s *)dev;
 
   DEBUGASSERT(esp32s2gpio != NULL && value != NULL);
   DEBUGASSERT(esp32s2gpio->id < BOARD_NGPIOOUT);
@@ -207,10 +207,10 @@ static int gpout_read(FAR struct gpio_dev_s *dev, FAR bool *value)
  *
  ****************************************************************************/
 
-static int gpout_write(FAR struct gpio_dev_s *dev, bool value)
+static int gpout_write(struct gpio_dev_s *dev, bool value)
 {
-  FAR struct esp32s2gpio_dev_s *esp32s2gpio =
-    (FAR struct esp32s2gpio_dev_s *)dev;
+  struct esp32s2gpio_dev_s *esp32s2gpio =
+    (struct esp32s2gpio_dev_s *)dev;
 
   DEBUGASSERT(esp32s2gpio != NULL);
   DEBUGASSERT(esp32s2gpio->id < BOARD_NGPIOOUT);
@@ -237,10 +237,10 @@ static int gpout_write(FAR struct gpio_dev_s *dev, bool value)
  ****************************************************************************/
 
 #if BOARD_NGPIOIN > 0
-static int gpin_read(FAR struct gpio_dev_s *dev, FAR bool *value)
+static int gpin_read(struct gpio_dev_s *dev, bool *value)
 {
-  FAR struct esp32s2gpio_dev_s *esp32s2gpio =
-    (FAR struct esp32s2gpio_dev_s *)dev;
+  struct esp32s2gpio_dev_s *esp32s2gpio =
+    (struct esp32s2gpio_dev_s *)dev;
 
   DEBUGASSERT(esp32s2gpio != NULL && value != NULL);
   DEBUGASSERT(esp32s2gpio->id < BOARD_NGPIOIN);
@@ -262,8 +262,8 @@ static int gpin_read(FAR struct gpio_dev_s *dev, FAR bool *value)
 #if BOARD_NGPIOINT > 0
 static int esp32s2gpio_interrupt(int irq, void *context, void *arg)
 {
-  FAR struct esp32s2gpint_dev_s *esp32s2gpint =
-    (FAR struct esp32s2gpint_dev_s *)arg;
+  struct esp32s2gpint_dev_s *esp32s2gpint =
+    (struct esp32s2gpint_dev_s *)arg;
 
   DEBUGASSERT(esp32s2gpint != NULL && esp32s2gpint->callback != NULL);
   gpioinfo("Interrupt! callback=%p\n", esp32s2gpint->callback);
@@ -288,10 +288,10 @@ static int esp32s2gpio_interrupt(int irq, void *context, void *arg)
  *
  ****************************************************************************/
 
-static int gpint_read(FAR struct gpio_dev_s *dev, FAR bool *value)
+static int gpint_read(struct gpio_dev_s *dev, bool *value)
 {
-  FAR struct esp32s2gpint_dev_s *esp32s2gpint =
-    (FAR struct esp32s2gpint_dev_s *)dev;
+  struct esp32s2gpint_dev_s *esp32s2gpint =
+    (struct esp32s2gpint_dev_s *)dev;
 
   DEBUGASSERT(esp32s2gpint != NULL && value != NULL);
   DEBUGASSERT(esp32s2gpint->esp32s2gpio.id < BOARD_NGPIOINT);
@@ -318,11 +318,11 @@ static int gpint_read(FAR struct gpio_dev_s *dev, FAR bool *value)
  *
  ****************************************************************************/
 
-static int gpint_attach(FAR struct gpio_dev_s *dev,
+static int gpint_attach(struct gpio_dev_s *dev,
                         pin_interrupt_t callback)
 {
-  FAR struct esp32s2gpint_dev_s *esp32s2gpint =
-    (FAR struct esp32s2gpint_dev_s *)dev;
+  struct esp32s2gpint_dev_s *esp32s2gpint =
+    (struct esp32s2gpint_dev_s *)dev;
   int irq = ESP32S2_PIN2IRQ(g_gpiointinputs[esp32s2gpint->esp32s2gpio.id]);
   int ret;
 
@@ -360,10 +360,10 @@ static int gpint_attach(FAR struct gpio_dev_s *dev,
  *
  ****************************************************************************/
 
-static int gpint_enable(FAR struct gpio_dev_s *dev, bool enable)
+static int gpint_enable(struct gpio_dev_s *dev, bool enable)
 {
-  FAR struct esp32s2gpint_dev_s *esp32s2gpint =
-    (FAR struct esp32s2gpint_dev_s *)dev;
+  struct esp32s2gpint_dev_s *esp32s2gpint =
+    (struct esp32s2gpint_dev_s *)dev;
   int irq = ESP32S2_PIN2IRQ(g_gpiointinputs[esp32s2gpint->esp32s2gpio.id]);
 
   if (enable)

--- a/boards/xtensa/esp32s3/common/src/esp32s3_board_spiflash.c
+++ b/boards/xtensa/esp32s3/common/src/esp32s3_board_spiflash.c
@@ -69,7 +69,7 @@
  ****************************************************************************/
 
 #if defined (CONFIG_ESP32S3_SPIFLASH_SMARTFS)
-static int setup_smartfs(int smartn, FAR struct mtd_dev_s *mtd,
+static int setup_smartfs(int smartn, struct mtd_dev_s *mtd,
                          const char *mnt_pt)
 {
   int ret = OK;
@@ -130,7 +130,7 @@ static int setup_smartfs(int smartn, FAR struct mtd_dev_s *mtd,
  ****************************************************************************/
 
 #if defined (CONFIG_ESP32S3_SPIFLASH_LITTLEFS)
-static int setup_littlefs(const char *path, FAR struct mtd_dev_s *mtd,
+static int setup_littlefs(const char *path, struct mtd_dev_s *mtd,
                           const char *mnt_pt, int priv)
 {
   int ret = OK;
@@ -178,7 +178,7 @@ static int setup_littlefs(const char *path, FAR struct mtd_dev_s *mtd,
  ****************************************************************************/
 
 #if defined (CONFIG_ESP32S3_SPIFLASH_SPIFFS)
-static int setup_spiffs(const char *path, FAR struct mtd_dev_s *mtd,
+static int setup_spiffs(const char *path, struct mtd_dev_s *mtd,
                         const char *mnt_pt, int priv)
 {
   int ret = OK;
@@ -220,7 +220,7 @@ static int setup_spiffs(const char *path, FAR struct mtd_dev_s *mtd,
  ****************************************************************************/
 
 #if defined (CONFIG_ESP32S3_SPIFLASH_NXFFS)
-static int setup_nxffs(FAR struct mtd_dev_s *mtd, const char *mnt_pt)
+static int setup_nxffs(struct mtd_dev_s *mtd, const char *mnt_pt)
 {
   int ret = OK;
 
@@ -259,7 +259,7 @@ static int setup_nxffs(FAR struct mtd_dev_s *mtd, const char *mnt_pt)
 static int init_storage_partition(void)
 {
   int ret = OK;
-  FAR struct mtd_dev_s *mtd;
+  struct mtd_dev_s *mtd;
 
   mtd = esp32s3_spiflash_alloc_mtdpart(CONFIG_ESP32S3_STORAGE_MTD_OFFSET,
                                        CONFIG_ESP32S3_STORAGE_MTD_SIZE,

--- a/boards/xtensa/esp32s3/esp32s3-devkit/src/esp32s3_buttons.c
+++ b/boards/xtensa/esp32s3/esp32s3-devkit/src/esp32s3_buttons.c
@@ -125,7 +125,7 @@ uint32_t board_buttons(void)
  ****************************************************************************/
 
 #ifdef CONFIG_ARCH_IRQBUTTONS
-int board_button_irq(int id, xcpt_t irqhandler, FAR void *arg)
+int board_button_irq(int id, xcpt_t irqhandler, void *arg)
 {
   int ret;
   DEBUGASSERT(id == BUTTON_BOOT);


### PR DESCRIPTION
## Summary

- arch/xtensa: Remove FAR from chip and board folder
- arch/ceva: Remove FAR from chip folder 
- arch/sim: Remove FAR from chip and board folder
- arch/x86_64: Remove FAR from chip folder 
- arch/or1k: Remove FAR from chip folder
- arch/misoc: Remove FAR from chip folder
- arch/mips: Remove FAR from chip and board folder 
- arch/sparc: Remove FAR from chip and board folder

## Impact
Minor

## Testing
Pass CI
