### PR TITLE
libc: Don't duplicate string in chdir and lib_restoredir

### DIFF
--- a/libs/libc/stdlib/lib_realpath.c
+++ b/libs/libc/stdlib/lib_realpath.c
@@ -67,6 +67,7 @@ FAR char *realpath(FAR const char *path, FAR char *resolved)
       fres = resolved = lib_malloc(PATH_MAX);
       if (resolved == NULL)
         {
+          set_errno(ENOMEM);
           return NULL;
         }
     }

--- a/libs/libc/unistd/lib_chdir.c
+++ b/libs/libc/unistd/lib_chdir.c
@@ -26,37 +26,12 @@
 
 #include <sys/stat.h>
 #include <stdlib.h>
-#include <string.h>
 #include <unistd.h>
 #include <errno.h>
 
 #include "libc.h"
 
 #ifndef CONFIG_DISABLE_ENVIRON
-
-/****************************************************************************
- * Private Functions
- ****************************************************************************/
-
-/****************************************************************************
- * Name: _trimdir
- ****************************************************************************/
-
-#if 0
-static inline void _trimdir(char *path)
-{
-  /* Skip any trailing '/' characters (unless it is also the leading '/') */
-
-  int len = strlen(path) - 1;
-  while (len > 0 && path[len] == '/')
-    {
-      path[len] = '\0';
-      len--;
-    }
-}
-#else
-#  define _trimdir(p)
-#endif
 
 /****************************************************************************
  * Public Functions
@@ -98,42 +73,35 @@ static inline void _trimdir(char *path)
 int chdir(FAR const char *path)
 {
   struct stat buf;
-  char *oldpwd;
-  char *alloc;
-  char *abspath;
-  int errcode;
+  FAR char *oldpwd;
+  FAR char *abspath;
   int ret;
-
-  /* Verify the input parameters */
-
-  if (!path)
-    {
-      errcode = ENOENT;
-      goto errout;
-    }
 
   /* Verify that 'path' refers to a directory */
 
   ret = stat(path, &buf);
   if (ret < 0)
     {
-      errcode = ENOENT;
-      goto errout;
+      return ret;
     }
 
   /* Something exists here... is it a directory? */
 
   if (!S_ISDIR(buf.st_mode))
     {
-      errcode = ENOTDIR;
-      goto errout;
+      set_errno(ENOTDIR);
+      return ERROR;
     }
 
   /* Yes, it is a directory.
    * Remove any trailing '/' characters from the path
    */
 
-  _trimdir(path);
+  abspath = realpath(path, NULL);
+  if (abspath == NULL)
+    {
+      return ERROR;
+    }
 
   /* Replace any preceding OLDPWD with the current PWD (this is to
    * support 'cd -' in NSH)
@@ -146,26 +114,14 @@ int chdir(FAR const char *path)
       oldpwd = CONFIG_LIBC_HOMEDIR;
     }
 
-  alloc = strdup(oldpwd);  /* kludge needed because environment is realloc'ed */
-  setenv("OLDPWD", alloc, TRUE);
-  lib_free(alloc);
+  setenv("OLDPWD", oldpwd, TRUE);
 
   /* Set the cwd to the input 'path' */
 
-  abspath = realpath(path, NULL);
-  if (abspath == NULL)
-    {
-      errcode = ENOENT;
-      goto errout;
-    }
-
-  setenv("PWD", abspath, TRUE);
+  ret = setenv("PWD", abspath, TRUE);
   lib_free(abspath);
   sched_unlock();
-  return OK;
 
-errout:
-  set_errno(errcode);
-  return ERROR;
+  return ret;
 }
 #endif /* !CONFIG_DISABLE_ENVIRON */

--- a/libs/libc/unistd/lib_restoredir.c
+++ b/libs/libc/unistd/lib_restoredir.c
@@ -24,11 +24,9 @@
 
 #include <nuttx/config.h>
 
-#include <string.h>
+#include <stdlib.h>
 #include <unistd.h>
 #include <errno.h>
-
-#include "libc.h"
 
 #ifndef CONFIG_DISABLE_ENVIRON
 
@@ -42,15 +40,13 @@
 
 int lib_restoredir(void)
 {
-  char *oldpwd;
+  FAR char *oldpwd;
   int ret = OK;
 
   oldpwd = getenv("OLDPWD");
   if (oldpwd)
     {
-      oldpwd = strdup(oldpwd);  /* kludge needed because environment is realloc'ed */
       ret = setenv("PWD", oldpwd, TRUE);
-      lib_free(oldpwd);
     }
 
   return ret;


### PR DESCRIPTION
## Summary
since the new layout(#6083) doesn't reallocate the unchanged environ variable anymore.

## Impact
Minor

## Testing
ostest in sim:asan
