### PR TITLE
arch: Move group_addrenv to common place

### DIFF
--- a/arch/mips/src/common/mips_exit.c
+++ b/arch/mips/src/common/mips_exit.c
@@ -137,16 +137,6 @@ void up_exit(int status)
 
   nxsched_resume_scheduler(tcb);
 
-#ifdef CONFIG_ARCH_ADDRENV
-  /* Make sure that the address environment for the previously running
-   * task is closed down gracefully (data caches dump, MMU flushed) and
-   * set up the address environment for the new thread at the head of
-   * the ready-to-run list.
-   */
-
-  group_addrenv(tcb);
-#endif
-
   /* Then switch contexts */
 
   up_fullcontextrestore(tcb->xcp.regs);

--- a/arch/mips/src/mips32/mips_blocktask.c
+++ b/arch/mips/src/mips32/mips_blocktask.c
@@ -136,15 +136,6 @@ void up_block_task(struct tcb_s *tcb, tstate_t task_state)
 
           struct tcb_s *nexttcb = this_task();
 
-#ifdef CONFIG_ARCH_ADDRENV
-          /* Make sure that the address environment for the previously
-           * running task is closed down gracefully (data caches dump,
-           * MMU flushed) and set up the address environment for the new
-           * thread at the head of the ready-to-run list.
-           */
-
-          group_addrenv(nexttcb);
-#endif
           /* Reset scheduler parameters */
 
           nxsched_resume_scheduler(nexttcb);

--- a/arch/mips/src/mips32/mips_releasepending.c
+++ b/arch/mips/src/mips32/mips_releasepending.c
@@ -107,15 +107,6 @@ void up_release_pending(void)
 
           struct tcb_s *nexttcb = this_task();
 
-#ifdef CONFIG_ARCH_ADDRENV
-          /* Make sure that the address environment for the previously
-           * running task is closed down gracefully (data caches dump,
-           * MMU flushed) and set up the address environment for the new
-           * thread at the head of the ready-to-run list.
-           */
-
-          group_addrenv(nexttcb);
-#endif
           /* Update scheduler parameters */
 
           nxsched_resume_scheduler(nexttcb);

--- a/arch/mips/src/mips32/mips_reprioritizertr.c
+++ b/arch/mips/src/mips32/mips_reprioritizertr.c
@@ -159,15 +159,6 @@ void up_reprioritize_rtr(struct tcb_s *tcb, uint8_t priority)
 
               struct tcb_s *nexttcb = this_task();
 
-#ifdef CONFIG_ARCH_ADDRENV
-              /* Make sure that the address environment for the previously
-               * running task is closed down gracefully (data caches dump,
-               * MMU flushed) and set up the address environment for the new
-               * thread at the head of the ready-to-run list.
-               */
-
-              group_addrenv(nexttcb);
-#endif
               /* Update scheduler parameters */
 
               nxsched_resume_scheduler(nexttcb);

--- a/arch/mips/src/mips32/mips_unblocktask.c
+++ b/arch/mips/src/mips32/mips_unblocktask.c
@@ -122,15 +122,6 @@ void up_unblock_task(struct tcb_s *tcb)
 
           struct tcb_s *nexttcb = this_task();
 
-#ifdef CONFIG_ARCH_ADDRENV
-          /* Make sure that the address environment for the previously
-           * running task is closed down gracefully (data caches dump,
-           * MMU flushed) and set up the address environment for the new
-           * thread at the head of the ready-to-run list.
-           */
-
-          group_addrenv(nexttcb);
-#endif
           /* Update scheduler parameters */
 
           nxsched_resume_scheduler(nexttcb);

--- a/arch/misoc/src/lm32/lm32_blocktask.c
+++ b/arch/misoc/src/lm32/lm32_blocktask.c
@@ -136,15 +136,6 @@ void up_block_task(struct tcb_s *tcb, tstate_t task_state)
 
           struct tcb_s *nexttcb = this_task();
 
-#ifdef CONFIG_ARCH_ADDRENV
-          /* Make sure that the address environment for the previously
-           * running task is closed down gracefully (data caches dump,
-           * MMU flushed) and set up the address environment for the new
-           * thread at the head of the ready-to-run list.
-           */
-
-          group_addrenv(nexttcb);
-#endif
           /* Reset scheduler parameters */
 
           nxsched_resume_scheduler(nexttcb);

--- a/arch/misoc/src/lm32/lm32_exit.c
+++ b/arch/misoc/src/lm32/lm32_exit.c
@@ -127,16 +127,6 @@ void up_exit(int status)
 
   nxsched_resume_scheduler(tcb);
 
-#ifdef CONFIG_ARCH_ADDRENV
-  /* Make sure that the address environment for the previously running
-   * task is closed down gracefully (data caches dump, MMU flushed) and
-   * set up the address environment for the new thread at the head of
-   * the ready-to-run list.
-   */
-
-  group_addrenv(tcb);
-#endif
-
   /* Then switch contexts */
 
   up_fullcontextrestore(tcb->xcp.regs);

--- a/arch/misoc/src/lm32/lm32_releasepending.c
+++ b/arch/misoc/src/lm32/lm32_releasepending.c
@@ -105,15 +105,6 @@ void up_release_pending(void)
 
           struct tcb_s *nexttcb = this_task();
 
-#ifdef CONFIG_ARCH_ADDRENV
-          /* Make sure that the address environment for the previously
-           * running task is closed down gracefully (data caches dump,
-           * MMU flushed) and set up the address environment for the new
-           * thread at the head of the ready-to-run list.
-           */
-
-          group_addrenv(nexttcb);
-#endif
           /* Update scheduler parameters */
 
           nxsched_resume_scheduler(nexttcb);

--- a/arch/misoc/src/lm32/lm32_reprioritizertr.c
+++ b/arch/misoc/src/lm32/lm32_reprioritizertr.c
@@ -159,15 +159,6 @@ void up_reprioritize_rtr(struct tcb_s *tcb, uint8_t priority)
 
               struct tcb_s *nexttcb = this_task();
 
-#ifdef CONFIG_ARCH_ADDRENV
-              /* Make sure that the address environment for the previously
-               * running task is closed down gracefully (data caches dump,
-               * MMU flushed) and set up the address environment for the new
-               * thread at the head of the ready-to-run list.
-               */
-
-              group_addrenv(nexttcb);
-#endif
               /* Update scheduler parameters */
 
               nxsched_resume_scheduler(nexttcb);

--- a/arch/misoc/src/lm32/lm32_swint.c
+++ b/arch/misoc/src/lm32/lm32_swint.c
@@ -296,33 +296,5 @@ int lm32_swint(int irq, void *context, void *arg)
     }
 #endif
 
-#if defined(CONFIG_ARCH_FPU) || defined(CONFIG_ARCH_ADDRENV)
-  /* Check for a context switch.  If a context switch occurred, then
-   * g_current_regs will have a different value than it did on entry.  If an
-   * interrupt level context switch has occurred, then restore the floating
-   * point state and the establish the correct address environment before
-   * returning from the interrupt.
-   */
-
-  if (regs != g_current_regs)
-    {
-#ifdef CONFIG_ARCH_FPU
-      /* Restore floating point registers */
-
-      up_restorefpu((uint32_t *)g_current_regs);
-#endif
-
-#ifdef CONFIG_ARCH_ADDRENV
-      /* Make sure that the address environment for the previously
-       * running task is closed down gracefully (data caches dump,
-       * MMU flushed) and set up the address environment for the new
-       * thread at the head of the ready-to-run list.
-       */
-
-      group_addrenv(NULL);
-#endif
-    }
-#endif
-
   return OK;
 }

--- a/arch/misoc/src/lm32/lm32_unblocktask.c
+++ b/arch/misoc/src/lm32/lm32_unblocktask.c
@@ -122,15 +122,6 @@ void up_unblock_task(struct tcb_s *tcb)
 
           struct tcb_s *nexttcb = this_task();
 
-#ifdef CONFIG_ARCH_ADDRENV
-          /* Make sure that the address environment for the previously
-           * running task is closed down gracefully (data caches dump,
-           * MMU flushed) and set up the address environment for the new
-           * thread at the head of the ready-to-run list.
-           */
-
-          group_addrenv(nexttcb);
-#endif
           /* Update scheduler parameters */
 
           nxsched_resume_scheduler(nexttcb);

--- a/arch/misoc/src/minerva/minerva_blocktask.c
+++ b/arch/misoc/src/minerva/minerva_blocktask.c
@@ -136,15 +136,6 @@ void up_block_task(struct tcb_s *tcb, tstate_t task_state)
 
           struct tcb_s *nexttcb = this_task();
 
-#ifdef CONFIG_ARCH_ADDRENV
-          /* Make sure that the address environment for the previously
-           * running task is closed down gracefully (data caches dump, MMU
-           * flushed) and set up the address environment for the new thread
-           * at the head of the ready-to-run list.
-           */
-
-          group_addrenv(nexttcb);
-#endif
           /* Reset scheduler parameters */
 
           nxsched_resume_scheduler(nexttcb);

--- a/arch/misoc/src/minerva/minerva_exit.c
+++ b/arch/misoc/src/minerva/minerva_exit.c
@@ -127,16 +127,6 @@ void up_exit(int status)
 
   nxsched_resume_scheduler(tcb);
 
-#ifdef CONFIG_ARCH_ADDRENV
-  /* Make sure that the address environment for the previously running task
-   * is closed down gracefully (data caches dump, MMU flushed) and set up the
-   * address environment for the new thread at the head of the ready-to-run
-   * list.
-   */
-
-  group_addrenv(tcb);
-#endif
-
   /* Then switch contexts */
 
   up_fullcontextrestore(tcb->xcp.regs);

--- a/arch/misoc/src/minerva/minerva_releasepending.c
+++ b/arch/misoc/src/minerva/minerva_releasepending.c
@@ -105,15 +105,6 @@ void up_release_pending(void)
 
           struct tcb_s *nexttcb = this_task();
 
-#ifdef CONFIG_ARCH_ADDRENV
-          /* Make sure that the address environment for the previously
-           * running task is closed down gracefully (data caches dump, MMU
-           * flushed) and set up the address environment for the new thread
-           * at the head of the ready-to-run list.
-           */
-
-          group_addrenv(nexttcb);
-#endif
           /* Update scheduler parameters */
 
           nxsched_resume_scheduler(nexttcb);

--- a/arch/misoc/src/minerva/minerva_reprioritizertr.c
+++ b/arch/misoc/src/minerva/minerva_reprioritizertr.c
@@ -158,15 +158,6 @@ void up_reprioritize_rtr(struct tcb_s *tcb, uint8_t priority)
 
               struct tcb_s *nexttcb = this_task();
 
-#ifdef CONFIG_ARCH_ADDRENV
-              /* Make sure that the address environment for the previously
-               * running task is closed down gracefully (data caches dump,
-               * MMU flushed) and set up the address environment for the
-               * new thread at the head of the ready-to-run list.
-               */
-
-              group_addrenv(nexttcb);
-#endif
               /* Update scheduler parameters */
 
               nxsched_resume_scheduler(nexttcb);

--- a/arch/misoc/src/minerva/minerva_swint.c
+++ b/arch/misoc/src/minerva/minerva_swint.c
@@ -273,33 +273,5 @@ int minerva_swint(int irq, void *context, void *arg)
     }
 #endif
 
-#if defined(CONFIG_ARCH_FPU) || defined(CONFIG_ARCH_ADDRENV)
-  /* Check for a context switch.  If a context switch occurred, then
-   * g_current_regs will have a different value than it did on entry.  If an
-   * interrupt level context switch has occurred, then restore the floating
-   * point state and the establish the correct address environment before
-   * returning from the interrupt.
-   */
-
-  if (regs != g_current_regs)
-    {
-#ifdef CONFIG_ARCH_FPU
-      /* Restore floating point registers */
-
-      up_restorefpu((uint32_t *) g_current_regs);
-#endif
-
-#ifdef CONFIG_ARCH_ADDRENV
-      /* Make sure that the address environment for the previously running
-       * task is closed down gracefully (data caches dump, MMU flushed) and
-       * set up the address environment for the new thread at the head of
-       * the ready-to-run list.
-       */
-
-      group_addrenv(NULL);
-#endif
-    }
-#endif
-
   return OK;
 }

--- a/arch/misoc/src/minerva/minerva_unblocktask.c
+++ b/arch/misoc/src/minerva/minerva_unblocktask.c
@@ -122,15 +122,6 @@ void up_unblock_task(struct tcb_s *tcb)
 
           struct tcb_s *nexttcb = this_task();
 
-#ifdef CONFIG_ARCH_ADDRENV
-          /* Make sure that the address environment for the previously
-           * running task is closed down gracefully (data caches dump, MMU
-           * flushed) and set up the address environment for the new thread
-           * at the head of the ready-to-run list.
-           */
-
-          group_addrenv(nexttcb);
-#endif
           /* Update scheduler parameters */
 
           nxsched_resume_scheduler(nexttcb);

--- a/arch/sparc/src/common/up_exit.c
+++ b/arch/sparc/src/common/up_exit.c
@@ -156,16 +156,6 @@ void up_exit(int status)
 
   tcb = this_task();
 
-#ifdef CONFIG_ARCH_ADDRENV
-  /* Make sure that the address environment for the previously running
-   * task is closed down gracefully (data caches dump, MMU flushed) and
-   * set up the address environment for the new thread at the head of
-   * the ready-to-run list.
-   */
-
-  (void)group_addrenv(tcb);
-#endif
-
   /* Reset scheduler parameters */
 
   nxsched_resume_scheduler(tcb);

--- a/arch/sparc/src/sparc_v8/up_blocktask.c
+++ b/arch/sparc/src/sparc_v8/up_blocktask.c
@@ -138,15 +138,6 @@ void up_block_task(struct tcb_s *tcb, tstate_t task_state)
 
           struct tcb_s *nexttcb = this_task();
 
-#ifdef CONFIG_ARCH_ADDRENV
-          /* Make sure that the address environment for the previously
-           * running task is closed down gracefully (data caches dump,
-           * MMU flushed) and set up the address environment for the new
-           * thread at the head of the ready-to-run list.
-           */
-
-          (void)group_addrenv(nexttcb);
-#endif
           /* Reset scheduler parameters */
 
           nxsched_resume_scheduler(nexttcb);

--- a/arch/sparc/src/sparc_v8/up_unblocktask.c
+++ b/arch/sparc/src/sparc_v8/up_unblocktask.c
@@ -122,15 +122,6 @@ void up_unblock_task(struct tcb_s *tcb)
 
           struct tcb_s *nexttcb = this_task();
 
-#ifdef CONFIG_ARCH_ADDRENV
-          /* Make sure that the address environment for the previously
-           * running task is closed down gracefully (data caches dump,
-           * MMU flushed) and set up the address environment for the new
-           * thread at the head of the ready-to-run list.
-           */
-
-          (void)group_addrenv(nexttcb);
-#endif
           /* Update scheduler parameters */
 
           nxsched_resume_scheduler(nexttcb);

--- a/arch/xtensa/src/common/xtensa_exit.c
+++ b/arch/xtensa/src/common/xtensa_exit.c
@@ -143,16 +143,6 @@ void up_exit(int status)
 
   nxsched_resume_scheduler(tcb);
 
-#ifdef CONFIG_ARCH_ADDRENV
-  /* Make sure that the address environment for the previously running
-   * task is closed down gracefully (data caches dump, MMU flushed) and
-   * set up the address environment for the new thread at the head of
-   * the ready-to-run list.
-   */
-
-  group_addrenv(tcb);
-#endif
-
   /* Then switch contexts */
 
   xtensa_context_restore(tcb->xcp.regs);


### PR DESCRIPTION
## Summary

- addrenv, origin/addrenv) arch/sparc: Remove unneeded group_addrenv call which handled by up_doirq
- arch/xtensa: Remove unneeded group_addrenv call which handled by xtensa_irq_dispatch
- arch/misoc: Remove unneeded group_addrenv call which handled by [lm32|minerva]_doirq
- arch/mips: Remove unneeded group_addrenv call which handled by mips_doirq

## Impact
Fix the issue that address environment change too early, see https://github.com/apache/incubator-nuttx/pull/5913 for more info.

## Testing
Pass CI
