### PR TITLE
arm/a1x: fix compile break

### DIFF
--- a/arch/arm/src/a1x/a1x_pio.c
+++ b/arch/arm/src/a1x/a1x_pio.c
@@ -90,12 +90,11 @@ static inline int a1x_pio_pin(pio_pinset_t cfgset)
  ****************************************************************************/
 
 #ifdef CONFIG_A1X_PIO_IRQ
-static int a1x_pio_interrupt(int irq, void *context)
+static int a1x_pio_interrupt(int irq, void *context, void *arg)
 {
   uint32_t status;
   uint32_t mask;
   uint32_t pending;
-  int irq;
 
   /* Read the set of pending GPIO interrupts */
 
@@ -147,13 +146,15 @@ static int a1x_pio_interrupt(int irq, void *context)
             {
               /* Yes.. dispatch the interrupt */
 
-              arm_doirq(irq, regs);
+              arm_doirq(irq, context);
             }
 
           irq++;
           pending >>= 1;
         }
     }
+
+  return OK;
 }
 #endif
 
@@ -173,18 +174,15 @@ static int a1x_pio_interrupt(int irq, void *context)
 #ifdef CONFIG_A1X_PIO_IRQ
 void a1x_pio_irqinitialize(void)
 {
-  int ret;
-
   /* Disable all external PIO interrupts */
 
   putreg32(0, A1X_PIO_INT_CTL);
 
   /* Attach the PIO interrupt handler */
 
-  ret = irq_attach(A1X_IRQ_PIO)
-  if (ret < 0)
+  if (irq_attach(A1X_IRQ_PIO, a1x_pio_interrupt, NULL) < 0)
     {
-      return ret;
+      return;
     }
 
   /* And enable the PIO interrupt */
@@ -403,7 +401,7 @@ void a1x_pio_irqenable(int irq)
     {
       /* Convert the IRQ number to a bit position */
 
-      pin = irq - A1X_PIO_EINT0
+      pin = irq - A1X_PIO_EINT0;
 
       /* Un-mask the interrupt be setting the corresponding bit in the
        * PIO INT CTL register.
@@ -411,7 +409,7 @@ void a1x_pio_irqenable(int irq)
 
       flags   = enter_critical_section();
       regval  = getreg32(A1X_PIO_INT_CTL);
-      regval |= PIO_INT_CTL(irq);
+      regval |= PIO_INT_CTL(pin);
       leave_critical_section(flags);
     }
 }
@@ -436,7 +434,7 @@ void a1x_pio_irqdisable(int irq)
     {
       /* Convert the IRQ number to a bit position */
 
-      pin = irq - A1X_PIO_EINT0
+      pin = irq - A1X_PIO_EINT0;
 
       /* Mask the interrupt be clearning the corresponding bit in the
        * PIO INT CTL register.
@@ -444,7 +442,7 @@ void a1x_pio_irqdisable(int irq)
 
       flags   = enter_critical_section();
       regval  = getreg32(A1X_PIO_INT_CTL);
-      regval &= ~PIO_INT_CTL(irq);
+      regval &= ~PIO_INT_CTL(pin);
       leave_critical_section(flags);
     }
 }


### PR DESCRIPTION

## Summary

arm/a1x: fix compile break

Signed-off-by: chao.an <anchao@xiaomi.com>

## Impact

N/A

## Testing

ci check