### PR TITLE
ARM/RISC-V: Fix xxx_assert from IRQ context

### DIFF
--- a/arch/arm/src/common/arm_assert.c
+++ b/arch/arm/src/common/arm_assert.c
@@ -366,8 +366,7 @@ static void arm_dumpstate(void)
 
   if (CURRENT_REGS)
     {
-      memcpy(rtcb->xcp.regs,
-             (uintptr_t *)CURRENT_REGS, XCPTCONTEXT_SIZE);
+      rtcb->xcp.regs = (uint32_t *)CURRENT_REGS;
     }
   else
     {

--- a/arch/risc-v/src/common/riscv_assert.c
+++ b/arch/risc-v/src/common/riscv_assert.c
@@ -332,8 +332,7 @@ static void riscv_dumpstate(void)
 
   if (CURRENT_REGS)
     {
-      memcpy(rtcb->xcp.regs,
-             (uintptr_t *)CURRENT_REGS, XCPTCONTEXT_SIZE);
+      rtcb->xcp.regs = (uintptr_t *)CURRENT_REGS;
     }
   else
     {


### PR DESCRIPTION
## Summary
Fixes the assert functions for ARM and RISC-V when the assertion happens in IRQ context, prior to the first context switch, e.g.
during nx_start().
## Impact
Minor, just fixes the system dump.
## Testing
MPFS icicle:nsh, testing NOT done for ARM but assume it works there just as well
