### PR TITLE
fs:oflag need consistent with psock

### DIFF
--- a/fs/socket/socket.c
+++ b/fs/socket/socket.c
@@ -261,6 +261,11 @@ int socket(int domain, int type, int protocol)
       oflags |= O_CLOEXEC;
     }
 
+  if (type & SOCK_NONBLOCK)
+    {
+      oflags |= O_NONBLOCK;
+    }
+
   psock = kmm_zalloc(sizeof(*psock));
   if (psock == NULL)
     {


### PR DESCRIPTION
if don't consistent with psock,call fcntl will have differet flag
Signed-off-by: anjiahao <anjiahao@xiaomi.com>

## Testing
pass ci
