### PR TITLE
arch/clang: add support for Clang LTO

### DIFF
--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -222,6 +222,49 @@ config ARCH_TOOLCHAIN_GNU
 	bool
 	default n
 
+config ARCH_TOOLCHAIN_CLANG
+	bool
+	select ARCH_TOOLCHAIN_GNU
+	default n
+
+choice
+	prompt "Link Time Optimization (LTO)"
+	default LTO_NONE
+	---help---
+		This option enables Link Time Optimization (LTO), which allows the
+		compiler to optimize binaries globally.
+
+		If unsure, select LTO_NONE. Note that LTO is very resource-intensive
+		so it's disabled by default.
+
+config LTO_NONE
+	bool "None"
+	---help---
+		Build the kernel normally, without Link Time Optimization (LTO).
+
+config LTO_FULL
+	bool "GNU Full LTO (EXPERIMENTAL)"
+	depends on ARCH_TOOLCHAIN_GNU || ARCH_TOOLCHAIN_CLANG
+	---help---
+		Link time optimization is implemented as a GCC front end for a bytecode
+		bytecode representation of GIMPLE that is emitted in special sections
+		of .o files. Currently, LTO support is enabled in most ELF-based systems,
+		as well as darwin, cygwin and mingw systems.
+
+config LTO_THIN
+	bool "Clang ThinLTO (EXPERIMENTAL)"
+	depends on ARCH_TOOLCHAIN_CLANG
+	---help---
+		This option enables Clang's ThinLTO, which allows for parallel
+		optimization and faster incremental compiles compared to the
+		CONFIG_LTO_FULL option. More information can be found
+		from Clang's documentation:
+
+		https://clang.llvm.org/docs/ThinLTO.html
+
+		If unsure, say Y.
+endchoice
+
 config ARCH_GNU_NO_WEAKFUNCTIONS
 	bool
 	depends on ARCH_TOOLCHAIN_GNU

--- a/arch/arm/src/armv6-m/Kconfig
+++ b/arch/arm/src/armv6-m/Kconfig
@@ -22,6 +22,6 @@ config ARMV6M_TOOLCHAIN_GNU_EABI
 
 config ARMV6M_TOOLCHAIN_CLANG
 	bool "Generic Clang toolchain"
-	select ARCH_TOOLCHAIN_GNU
+	select ARCH_TOOLCHAIN_CLANG
 
 endchoice

--- a/arch/arm/src/armv6-m/Kconfig
+++ b/arch/arm/src/armv6-m/Kconfig
@@ -20,4 +20,8 @@ config ARMV6M_TOOLCHAIN_GNU_EABI
 		This option should work for any modern GNU toolchain (GCC 4.5 or newer)
 		configured for arm-none-eabi.
 
+config ARMV6M_TOOLCHAIN_CLANG
+	bool "Generic Clang toolchain"
+	select ARCH_TOOLCHAIN_GNU
+
 endchoice

--- a/arch/arm/src/armv6-m/Toolchain.defs
+++ b/arch/arm/src/armv6-m/Toolchain.defs
@@ -35,6 +35,10 @@ ifeq ($(filter y, $(CONFIG_ARMV6M_TOOLCHAIN_GNU_EABI)),y)
   CONFIG_ARMV6M_TOOLCHAIN ?= GNU_EABI
 endif
 
+ifeq ($(filter y, $(CONFIG_ARMV6M_TOOLCHAIN_CLANG)),y)
+  CONFIG_ARMV6M_TOOLCHAIN ?= CLANG
+endif
+
 #
 # Supported toolchains
 #
@@ -53,6 +57,8 @@ endif
 
 ifeq ($(CONFIG_DEBUG_CUSTOMOPT),y)
   MAXOPTIMIZATION := $(CONFIG_DEBUG_OPTLEVEL)
+else ifeq ($(CONFIG_ARMV6M_TOOLCHAIN),CLANG)
+  MAXOPTIMIZATION ?= -Oz
 else
   MAXOPTIMIZATION ?= -Os
 endif
@@ -63,19 +69,67 @@ else
   MAXOPTIMIZATION += -fomit-frame-pointer
 endif
 
+# Parametrization for ARCHCPUFLAGS
+
+TOOLCHAIN_MTUNE  := -mcpu=cortex-m0 -mthumb
+TOOLCHAIN_MFLOAT := -mfloat-abi=soft
+
+# Clang Configuration files
+
+ifeq ($(CONFIG_ARMV6M_TOOLCHAIN),CLANG)
+  TOOLCHAIN_MARCH := --config armv6m_soft_nofp_nosys
+endif
+
 # NuttX buildroot under Linux or Cygwin
 
 ifeq ($(CONFIG_ARMV6M_TOOLCHAIN),BUILDROOT)
   CROSSDEV ?= arm-nuttx-eabi-
-  ARCHCPUFLAGS = -mcpu=cortex-m0 -mthumb -mfloat-abi=soft
+  ARCHCPUFLAGS = $(TOOLCHAIN_MARCH) $(TOOLCHAIN_MTUNE) $(TOOLCHAIN_MFLOAT)
 endif
 
 # Generic GNU EABI toolchain
 
 ifeq ($(CONFIG_ARMV6M_TOOLCHAIN),GNU_EABI)
   CROSSDEV ?= arm-none-eabi-
-  ARCHCPUFLAGS = -mcpu=cortex-m0 -mthumb -mfloat-abi=soft
+  ARCHCPUFLAGS = $(TOOLCHAIN_MARCH) $(TOOLCHAIN_MTUNE) $(TOOLCHAIN_MFLOAT)
 endif
+
+# Clang toolchain
+
+ifeq ($(CONFIG_ARMV6M_TOOLCHAIN),CLANG)
+  ARCHCPUFLAGS = $(TOOLCHAIN_MARCH) $(TOOLCHAIN_MTUNE) $(TOOLCHAIN_MFLOAT)
+
+  CC      = clang
+  CXX     = clang++
+  CPP     = clang -E -P -x c
+  LD      = ld.lld -m armelf
+  STRIP   = llvm-strip --strip-unneeded
+  AR      = llvm-ar rcs
+  NM      = llvm-nm
+  OBJCOPY = llvm-objcopy
+  OBJDUMP = llvm-objdump
+
+  # Since the no_builtin attribute is not fully supported on Clang
+  # disable the built-in functions, refer:
+  # https://github.com/apache/incubator-nuttx/pull/5971
+
+  MAXOPTIMIZATION += -fno-builtin
+
+# Default toolchain
+
+else
+  CC      = $(CROSSDEV)gcc
+  CXX     = $(CROSSDEV)g++
+  CPP     = $(CROSSDEV)gcc -E -P -x c
+  LD      = $(CROSSDEV)ld
+  STRIP   = $(CROSSDEV)strip --strip-unneeded
+  AR      = $(CROSSDEV)ar rcs
+  NM      = $(CROSSDEV)nm
+  OBJCOPY = $(CROSSDEV)objcopy
+  OBJDUMP = $(CROSSDEV)objdump
+endif
+
+# Architecture flags
 
 ifeq ($(CONFIG_MM_KASAN),y)
   ARCHCPUFLAGS += -fsanitize=kernel-address
@@ -92,21 +146,16 @@ ifneq ($(CONFIG_CXX_RTTI),y)
   ARCHCXXFLAGS += -fno-rtti
 endif
 
-# Default toolchain
-
-CC = $(CROSSDEV)gcc
-CXX = $(CROSSDEV)g++
-CPP = $(CROSSDEV)gcc -E -P -x c
-LD = $(CROSSDEV)ld
-STRIP = $(CROSSDEV)strip --strip-unneeded
-AR = $(CROSSDEV)ar rcs
-NM = $(CROSSDEV)nm
-OBJCOPY = $(CROSSDEV)objcopy
-OBJDUMP = $(CROSSDEV)objdump
-
 # Add the builtin library
 
-EXTRA_LIBS += $(wildcard $(shell $(CC) $(ARCHCPUFLAGS) --print-libgcc-file-name))
+COMPILER_RT_LIB = $(shell $(CC) $(ARCHCPUFLAGS) --print-libgcc-file-name)
+ifeq ($(wildcard $(COMPILER_RT_LIB)),)
+  # if "--print-libgcc-file-name" unable to find the correct libgcc PATH
+  # then go ahead and try "--print-file-name"
+  COMPILER_RT_LIB := $(wildcard $(shell $(CC) $(ARCHCPUFLAGS) --print-file-name $(notdir $(COMPILER_RT_LIB))))
+endif
+
+EXTRA_LIBS += $(COMPILER_RT_LIB)
 
 ifneq ($(CONFIG_LIBM),y)
   EXTRA_LIBS += $(wildcard $(shell $(CC) $(ARCHCPUFLAGS) --print-file-name=libm.a))

--- a/arch/arm/src/armv6-m/Toolchain.defs
+++ b/arch/arm/src/armv6-m/Toolchain.defs
@@ -80,6 +80,14 @@ ifeq ($(CONFIG_ARMV6M_TOOLCHAIN),CLANG)
   TOOLCHAIN_MARCH := --config armv6m_soft_nofp_nosys
 endif
 
+# Link Time Optimization
+
+ifeq ($(CONFIG_LTO_THIN),y)
+  MAXOPTIMIZATION += -flto=thin
+else ifeq ($(CONFIG_LTO_FULL),y)
+  MAXOPTIMIZATION += -flto
+endif
+
 # NuttX buildroot under Linux or Cygwin
 
 ifeq ($(CONFIG_ARMV6M_TOOLCHAIN),BUILDROOT)

--- a/arch/arm/src/armv7-m/Kconfig
+++ b/arch/arm/src/armv7-m/Kconfig
@@ -110,7 +110,7 @@ config ARMV7M_TOOLCHAIN_GNU_EABI
 
 config ARMV7M_TOOLCHAIN_CLANG
 	bool "Generic Clang toolchain"
-	select ARCH_TOOLCHAIN_GNU
+	select ARCH_TOOLCHAIN_CLANG
 
 endchoice
 

--- a/arch/arm/src/armv7-m/Toolchain.defs
+++ b/arch/arm/src/armv7-m/Toolchain.defs
@@ -130,6 +130,14 @@ ifeq ($(CONFIG_ARMV7M_TOOLCHAIN),CLANG)
 
 endif
 
+# Link Time Optimization
+
+ifeq ($(CONFIG_LTO_THIN),y)
+  MAXOPTIMIZATION += -flto=thin
+else ifeq ($(CONFIG_LTO_FULL),y)
+  MAXOPTIMIZATION += -flto
+endif
+
 # NuttX buildroot under Linux or Cygwin
 
 ifeq ($(CONFIG_ARMV7M_TOOLCHAIN),BUILDROOT)

--- a/arch/arm/src/armv8-m/Kconfig
+++ b/arch/arm/src/armv8-m/Kconfig
@@ -85,7 +85,7 @@ config ARMV8M_TOOLCHAIN_GNU_EABI
 
 config ARMV8M_TOOLCHAIN_CLANG
 	bool "Generic Clang toolchain"
-	select ARCH_TOOLCHAIN_GNU
+	select ARCH_TOOLCHAIN_CLANG
 
 endchoice
 

--- a/arch/arm/src/armv8-m/Toolchain.defs
+++ b/arch/arm/src/armv8-m/Toolchain.defs
@@ -139,6 +139,14 @@ ifeq ($(CONFIG_ARMV8M_TOOLCHAIN),CLANG)
 
 endif
 
+# Link Time Optimization
+
+ifeq ($(CONFIG_LTO_THIN),y)
+  MAXOPTIMIZATION += -flto=thin
+else ifeq ($(CONFIG_LTO_FULL),y)
+  MAXOPTIMIZATION += -flto
+endif
+
 # NuttX buildroot under Linux or Cygwin
 
 ifeq ($(CONFIG_ARMV8M_TOOLCHAIN),BUILDROOT)


### PR DESCRIPTION
## Summary

arch/clang: add support for Clang LTO

add support of Clang's Link Time Optimization (LTO) on NuttX build system

Reference:
https://llvm.org/docs/LinkTimeOptimization.html

Signed-off-by: chao.an <anchao@xiaomi.com>


## Impact

Clang + LTO

## Testing
CPU frequency:    `200MHz`
Core:                    `Cortex-M55`
GCC Options: 
`-march=armv8.1-m.main+mve.fp+fp.dp  -mtune=cortex-m55 -mthumb -mfpu=fpv5-d16 -mfloat-abi=hard`
Clang Configuration:
`--config armv8.1m.main_hard_fp_nosys`
[gen_defconfig.txt](https://github.com/apache/incubator-nuttx/files/8518309/gen_defconfig.txt)

1. Code Size

![b0a1bc5f-467f-4e24-af8a-99b479c5566a](https://user-images.githubusercontent.com/758493/163985684-bd94e0cc-806d-4b57-b679-2421056b12c0.png)

![bb8f21a8-512d-4520-b377-61ae50466d7f](https://user-images.githubusercontent.com/758493/163985766-84d64a74-a12f-428c-9746-123663057b96.png)

2. Coremark

![27b43ea1-aeec-4e60-ab0e-568194c9d895](https://user-images.githubusercontent.com/758493/163985814-502b0560-224c-495c-ab11-2a08ad452f25.png)
![0fe9284c-18d2-41d8-8040-fbfb88b091f1](https://user-images.githubusercontent.com/758493/163985831-79de68d7-404d-49d2-b0db-fb88c2f5dfff.png)

3. LVGL BenchMark

Weighted FPS

![f0999f8a-c2d9-4a75-99a3-752bee15ad86](https://user-images.githubusercontent.com/758493/163985938-322076eb-9f11-4d88-8905-a7b50b0e0fff.png)
![49a42f87-79bb-4100-b0e2-0e139a666896](https://user-images.githubusercontent.com/758493/163985949-f2d31258-4e8c-4c1a-87ca-049158c1f5c4.png)


All Cases

![8183bda1-bcec-4225-b906-b1d3ad79b863](https://user-images.githubusercontent.com/758493/163986045-02e5a1fd-767a-4eb8-a19f-9768a7388cc1.png)
![3071c750-af0f-412c-b454-4846e437416a](https://user-images.githubusercontent.com/758493/163986063-8856b914-80e4-4e96-8220-6ab460d59fb4.png)
