### PR TITLE
armv7/r:cp15_cache_all: fix error in LineSize 'r5' mask

### DIFF
--- a/arch/arm/src/armv7-a/cp15_flush_dcache_all.S
+++ b/arch/arm/src/armv7-a/cp15_flush_dcache_all.S
@@ -99,7 +99,7 @@ cp15_flush_dcache_all:
 	and		r0, r3, r1, lsr #13		/* r0=NumSets (number of sets - 1) */
 
 	ldr		r3,=0x7				/* Isolate the LineSize field (bits 0-2) */
-	and		r5, r3				/* r4=(Log2LineSize - 2) in word */
+	and		r5, r3, r1			/* r4=(Log2LineSize - 2) in word */
 	add		r5, #4				/* r4=Set/way operation line shfit */
 
 	ldr		r3, =0x3ff			/* Isolate the way field (bits 3-12) */

--- a/arch/arm/src/armv7-a/cp15_invalidate_dcache_all.S
+++ b/arch/arm/src/armv7-a/cp15_invalidate_dcache_all.S
@@ -99,7 +99,7 @@ cp15_invalidate_dcache_all:
 	and		r0, r3, r1, lsr #13		/* r0=NumSets (number of sets - 1) */
 
 	ldr		r3,=0x7				/* Isolate the LineSize field (bits 0-2) */
-	and		r5, r3				/* r4=(Log2LineSize - 2) in word */
+	and		r5, r3, r1			/* r4=(Log2LineSize - 2) in word */
 	add		r5, #4				/* r4=Set/way operation line shfit */
 
 	ldr		r3, =0x3ff			/* Isolate the way field (bits 3-12) */

--- a/arch/arm/src/armv7-r/cp15_clean_dcache_all.S
+++ b/arch/arm/src/armv7-r/cp15_clean_dcache_all.S
@@ -99,7 +99,7 @@ cp15_clean_dcache_all:
 	and		r0, r3, r1, lsr #13		/* r0=NumSets (number of sets - 1) */
 
 	ldr		r3,=0x7				/* Isolate the LineSize field (bits 0-2) */
-	and		r5, r3				/* r4=(Log2LineSize - 2) in word */
+	and		r5, r3, r1			/* r4=(Log2LineSize - 2) in word */
 	add		r5, #4				/* r4=Set/way operation line shfit */
 
 	ldr		r3, =0x3ff			/* Isolate the way field (bits 3-12) */

--- a/arch/arm/src/armv7-r/cp15_flush_dcache_all.S
+++ b/arch/arm/src/armv7-r/cp15_flush_dcache_all.S
@@ -99,7 +99,7 @@ cp15_flush_dcache_all:
 	and		r0, r3, r1, lsr #13		/* r0=NumSets (number of sets - 1) */
 
 	ldr		r3,=0x7				/* Isolate the LineSize field (bits 0-2) */
-	and		r5, r3				/* r4=(Log2LineSize - 2) in word */
+	and		r5, r3, r1			/* r4=(Log2LineSize - 2) in word */
 	add		r5, #4				/* r4=Set/way operation line shfit */
 
 	ldr		r3, =0x3ff			/* Isolate the way field (bits 3-12) */

--- a/arch/arm/src/armv7-r/cp15_invalidate_dcache_all.S
+++ b/arch/arm/src/armv7-r/cp15_invalidate_dcache_all.S
@@ -99,7 +99,7 @@ cp15_invalidate_dcache_all:
 	and		r0, r3, r1, lsr #13		/* r0=NumSets (number of sets - 1) */
 
 	ldr		r3,=0x7				/* Isolate the LineSize field (bits 0-2) */
-	and		r5, r3				/* r4=(Log2LineSize - 2) in word */
+	and		r5, r3, r1			/* r4=(Log2LineSize - 2) in word */
 	add		r5, #4				/* r4=Set/way operation line shfit */
 
 	ldr		r3, =0x3ff			/* Isolate the way field (bits 3-12) */


### PR DESCRIPTION
## Summary
Fix the issue reported here: https://github.com/apache/incubator-nuttx/pull/5650

## Impact
cache operation on armv7-a and armv7-r

## Testing
sabre-6quad:smp
