### PR TITLE
assert: static_assert is not support in c standard C89,C99

### DIFF
--- a/include/assert.h
+++ b/include/assert.h
@@ -77,7 +77,13 @@
  */
 
 #ifndef __cplusplus
-#  define static_assert _Static_assert
+#  if defined(__STDC_VERSION__) && __STDC_VERSION__  > 199901L
+#    define static_assert _Static_assert
+#  else
+#    define static_assert(cond, msg) \
+       extern int (*__static_assert_function (void)) \
+       [!!sizeof (struct { int __error_if_negative: (cond) ? 2 : -1; })]
+#  endif
 #endif
 
 /****************************************************************************


### PR DESCRIPTION
## Summary
static_assert is not support in c standard C89,C99

## Testing
CI
