### PR TITLE
pipe: Increase buffer size by one byte to ompensate the full indicator

### DIFF
--- a/drivers/pipes/pipe_common.c
+++ b/drivers/pipes/pipe_common.c
@@ -144,7 +144,7 @@ FAR struct pipe_dev_s *pipecommon_allocdev(size_t bufsize)
       nxsem_set_protocol(&dev->d_rdsem, SEM_PRIO_NONE);
       nxsem_set_protocol(&dev->d_wrsem, SEM_PRIO_NONE);
 
-      dev->d_bufsize = bufsize;
+      dev->d_bufsize = bufsize + 1; /* +1 to compensate the full indicator */
     }
 
   return dev;


### PR DESCRIPTION
## Summary
Fix the bug reported here: #6112

## Impact
pipe's FIONSPACE

## Testing

