### PR TITLE
arm/armv[7|8]m: compare of hardware fp registers should skip REG_FP_RESERVED

### DIFF
--- a/arch/arm/src/armv7-m/arm_fpucmp.c
+++ b/arch/arm/src/armv7-m/arm_fpucmp.c
@@ -53,7 +53,10 @@ bool up_fpucmp(const void *saveregs1, const void *saveregs2)
   const uint32_t *regs1 = saveregs1;
   const uint32_t *regs2 = saveregs2;
 
-  return memcmp(&regs1[REG_S0], &regs2[REG_S0], 4 * HW_FPU_REGS) == 0 &&
+  /* compare of hardware fp registers should skip REG_FP_RESERVED */
+
+  return memcmp(&regs1[REG_S0], &regs2[REG_S0],
+                4 * (HW_FPU_REGS - 1)) == 0 &&
          memcmp(&regs1[REG_S16], &regs2[REG_S16], 4 * SW_FPU_REGS) == 0;
 }
 #endif /* CONFIG_ARCH_FPU */

--- a/arch/arm/src/armv7-m/arm_initialstate.c
+++ b/arch/arm/src/armv7-m/arm_initialstate.c
@@ -146,7 +146,6 @@ void up_initial_state(struct tcb_s *tcb)
 
 #ifdef CONFIG_ARCH_FPU
   xcp->regs[REG_FPSCR] = 0;      /* REVISIT: Initial FPSCR should be configurable */
-  xcp->regs[REG_FP_RESERVED] = 0;
 #endif /* CONFIG_ARCH_FPU */
 
   /* Enable or disable interrupts, based on user configuration */

--- a/arch/arm/src/armv8-m/arm_fpucmp.c
+++ b/arch/arm/src/armv8-m/arm_fpucmp.c
@@ -53,7 +53,10 @@ bool up_fpucmp(const void *saveregs1, const void *saveregs2)
   const uint32_t *regs1 = saveregs1;
   const uint32_t *regs2 = saveregs2;
 
-  return memcmp(&regs1[REG_S0], &regs2[REG_S0], 4 * HW_FPU_REGS) == 0 &&
+  /* compare of hardware fp registers should skip REG_FP_RESERVED */
+
+  return memcmp(&regs1[REG_S0], &regs2[REG_S0],
+                4 * (HW_FPU_REGS - 1)) == 0 &&
          memcmp(&regs1[REG_S16], &regs2[REG_S16], 4 * SW_FPU_REGS) == 0;
 }
 #endif /* CONFIG_ARCH_FPU */

--- a/arch/arm/src/armv8-m/arm_initialstate.c
+++ b/arch/arm/src/armv8-m/arm_initialstate.c
@@ -152,7 +152,6 @@ void up_initial_state(struct tcb_s *tcb)
 
 #ifdef CONFIG_ARCH_FPU
   xcp->regs[REG_FPSCR] |= ARMV8M_FPSCR_LTPSIZE_NONE;
-  xcp->regs[REG_FP_RESERVED] = 0;
 #endif /* CONFIG_ARCH_FPU */
 
   /* Enable or disable interrupts, based on user configuration */


### PR DESCRIPTION
## Summary

arm/armv[7|8]m: compare of hardware fp registers should skip REG_FP_RESERVED

## Impact

Fix fpu test break by:
https://github.com/apache/incubator-nuttx/pull/6073
Reported by @masayuki2009 
https://github.com/apache/incubator-nuttx/pull/6073#issuecomment-1104640815

## Testing

spresense:smp