### PR TITLE
arch/risc-v: Don't clear reserved bits in fcsr in riscv_fpuconfig

### DIFF
--- a/arch/risc-v/src/common/riscv_fpu.S
+++ b/arch/risc-v/src/common/riscv_fpu.S
@@ -64,7 +64,11 @@
 riscv_fpuconfig:
     li           a0, MSTATUS_FS_INIT
     csrs         CSR_STATUS, a0
-    csrwi        fcsr, 0
+
+    fsflags      zero
+    fsrm         zero
+
+    fence.i
     ret
 
 #endif /* CONFIG_ARCH_FPU */


### PR DESCRIPTION
## Summary
Only clear/set `frm` and `fflags` , don't touch reserved bits (fcsr[31:8]).
## Impact
riscv_fpuconfig
## Testing
QEMU and k210 (not upstreamed yet)
