### PR TITLE
arch/risc-v: Enable FPU for K210

### DIFF
--- a/arch/risc-v/Kconfig
+++ b/arch/risc-v/Kconfig
@@ -27,6 +27,8 @@ config ARCH_CHIP_K210
 	select ARCH_RV_ISA_M
 	select ARCH_RV_ISA_A
 	select ARCH_RV_ISA_C
+	select ARCH_HAVE_FPU
+	select ARCH_HAVE_DPFPU
 	select ARCH_HAVE_MPU
 	select ARCH_HAVE_TESTSET
 	select ARCH_HAVE_MULTICPU

--- a/arch/risc-v/src/k210/Make.defs
+++ b/arch/risc-v/src/k210/Make.defs
@@ -54,6 +54,11 @@ ifeq ($(CONFIG_ARCH_HAVE_VFORK),y)
 CMN_CSRCS += riscv_vfork.c
 endif
 
+ifeq ($(CONFIG_ARCH_FPU),y)
+CMN_ASRCS += riscv_fpu.S
+CMN_CSRCS += riscv_fpucmp.c
+endif
+
 # Specify our C code within this directory to be included
 CHIP_CSRCS  = k210_allocateheap.c k210_clockconfig.c
 CHIP_CSRCS += k210_irq.c k210_irq_dispatch.c

--- a/arch/risc-v/src/k210/k210_start.c
+++ b/arch/risc-v/src/k210/k210_start.c
@@ -67,6 +67,10 @@ void __k210_start(uint32_t mhartid)
   const uint32_t *src;
   uint32_t *dest;
 
+  /* Configure FPU */
+
+  riscv_fpuconfig();
+
   if (0 < mhartid)
     {
       goto cpu1;


### PR DESCRIPTION
## Summary

K210 support rv64gc ISA, now we enable F/D extension for it.

Note: QEMU for K210 don't support FPU now.

## Impact
K210
## Testing

maix-bit
