### PR TITLE
Minor correct for environment variables

### DIFF
--- a/binfmt/binfmt_execmodule.c
+++ b/binfmt/binfmt_execmodule.c
@@ -153,7 +153,7 @@ int exec_module(FAR const struct binary_s *binp,
 
   /* Make a copy of the environment here */
 
-  if (envp || (envp = get_environ_ptr()))
+  if (envp || (envp = environ))
     {
       envp = binfmt_copyenv(envp);
       if (!envp)

--- a/include/cxx/cstdlib
+++ b/include/cxx/cstdlib
@@ -42,9 +42,6 @@ namespace std
 
   // Environment variable support
 
-#ifndef CONFIG_DISABLE_ENVIRON
-  using ::get_environ_ptr;
-#endif
   using ::getenv;
   using ::putenv;
   using ::clearenv;

--- a/include/stdlib.h
+++ b/include/stdlib.h
@@ -62,7 +62,11 @@
  * function call.  However, get_environ_ptr() can be used in its place.
  */
 
-#define environ get_environ_ptr()
+#ifdef CONFIG_DISABLE_ENVIRON
+#  define environ NULL
+#else
+#  define environ get_environ_ptr()
+#endif
 
 #if defined(CONFIG_FS_LARGEFILE) && defined(CONFIG_HAVE_LONG_LONG)
 #  define mkstemp64            mkstemp
@@ -138,11 +142,7 @@ void      arc4random_buf(FAR void *bytes, size_t nbytes);
 
 /* Environment variable support */
 
-#ifdef CONFIG_DISABLE_ENVIRON
-#  define get_environ_ptr() NULL
-#else
 FAR char **get_environ_ptr(void);
-#endif
 FAR char *getenv(FAR const char *name);
 int       putenv(FAR const char *string);
 int       clearenv(void);

--- a/sched/environ/env_dup.c
+++ b/sched/environ/env_dup.c
@@ -78,7 +78,7 @@ int env_dup(FAR struct task_group_s *group, FAR char * const *envcp)
 
   /* Is there an environment ? */
 
-  if (envcp || (envcp = (FAR char * const *)ptcb->group->tg_envp))
+  if (envcp || (envcp = ptcb->group->tg_envp))
     {
       /* Count the strings */
 

--- a/sched/task/task_posixspawn.c
+++ b/sched/task/task_posixspawn.c
@@ -276,12 +276,8 @@ static int nxposix_spawn_proxy(int argc, FAR char *argv[])
  *     array of pointers to null-terminated strings. The list is terminated
  *     with a null pointer.
  *
- *   envp - The envp[] argument is not used by NuttX and may be NULL.  In
- *     standard implementations, envp[] is an array of character pointers to
- *     null-terminated strings that provide the environment for the new
- *     process image. The environment array is terminated by a null pointer.
- *     In NuttX, the envp[] argument is ignored and the new task will simply
- *     inherit the environment of the parent task.
+ *   envp - envp[] is an array of character pointers to null-terminated
+ *     strings that provide the environment for the new process image.
  *
  * Returned Value:
  *   posix_spawn() and posix_spawnp() will return zero on success.
@@ -297,8 +293,6 @@ static int nxposix_spawn_proxy(int argc, FAR char *argv[])
  *     depending upon the setting of CONFIG_LIBC_ENVPATH: If
  *     CONFIG_LIBC_ENVPATH is defined, then only posix_spawnp() behavior
  *     is supported; otherwise, only posix_spawn behavior is supported.
- *   - The 'envp' argument is not used and the 'environ' variable is not
- *     altered (NuttX does not support the 'environ' variable).
  *   - Process groups are not supported (POSIX_SPAWN_SETPGROUP).
  *   - Effective user IDs are not supported (POSIX_SPAWN_RESETIDS).
  *   - Signal default actions cannot be modified in the newly task executed

--- a/sched/task/task_spawn.c
+++ b/sched/task/task_spawn.c
@@ -292,7 +292,8 @@ static int nxtask_spawn_proxy(int argc, FAR char *argv[])
  *     array of pointers to null-terminated strings. The list is terminated
  *     with a null pointer.
  *
- *   envp - The envp[] argument is not used by NuttX and may be NULL.
+ *   envp - envp[] is an array of character pointers to null-terminated
+ *     strings that provide the environment for the new process image.
  *
  * Returned Value:
  *   task_spawn() will return process ID of new task on success.

--- a/sched/task/task_vfork.c
+++ b/sched/task/task_vfork.c
@@ -154,7 +154,7 @@ FAR struct task_tcb_s *nxtask_setup_vfork(start_t retaddr)
 
   /* Duplicate the parent tasks environment */
 
-  ret = env_dup(child->cmn.group, get_environ_ptr());
+  ret = env_dup(child->cmn.group, environ);
   if (ret < 0)
     {
       goto errout_with_tcb;


### PR DESCRIPTION
## Summary

- sched/task: Correct the comment about environment variable
- sched/environ: Remove the unneeded cast in env_dup
- environ: Don't expose get_environ_ptr in csdlib

## Impact
environment variables

## Testing
Pass CI
