### PR TITLE
arch/xtensa: Color the other CPUs task when they are created.

### DIFF
--- a/arch/xtensa/src/esp32/esp32_cpuidlestack.c
+++ b/arch/xtensa/src/esp32/esp32_cpuidlestack.c
@@ -100,6 +100,24 @@ int up_cpu_idlestack(int cpu, struct tcb_s *tcb, size_t stack_size)
   tcb->adj_stack_size  = CPU1_IDLETHREAD_STACKSIZE;
   tcb->stack_base_ptr  = tcb->stack_alloc_ptr;
 
+#ifdef CONFIG_STACK_COLORATION
+    {
+      register uint32_t *ptr;
+      register int i;
+
+      /* If stack debug is enabled, then fill the stack with a recognizable
+       * value that we can use later to test for high water marks.
+       */
+
+      for (i = 0, ptr = (uint32_t *)tcb->stack_alloc_ptr;
+           i < tcb->adj_stack_size;
+           i += sizeof(uint32_t))
+        {
+          *ptr++ = STACK_COLOR;
+        }
+    }
+#endif
+
 #if XCHAL_CP_NUM > 0
   /* REVISIT: Does it make since to have co-processors enabled on the IDLE
    * thread?

--- a/arch/xtensa/src/esp32/esp32_cpustart.c
+++ b/arch/xtensa/src/esp32/esp32_cpustart.c
@@ -129,24 +129,6 @@ void IRAM_ATTR xtensa_appcpu_start(void)
   struct tcb_s *tcb = this_task();
   register uint32_t sp;
 
-#ifdef CONFIG_STACK_COLORATION
-    {
-      register uint32_t *ptr;
-      register int i;
-
-      /* If stack debug is enabled, then fill the stack with a recognizable
-       * value that we can use later to test for high water marks.
-       */
-
-      for (i = 0, ptr = (uint32_t *)tcb->stack_alloc_ptr;
-           i < tcb->adj_stack_size;
-           i += sizeof(uint32_t))
-        {
-          *ptr++ = STACK_COLOR;
-        }
-    }
-#endif
-
   /* Move to the stack assigned to us by up_smp_start immediately.  Although
    * we were give a stack pointer at start-up, we don't know where that stack
    * pointer is positioned respect to our memory map.  The only safe option

--- a/arch/xtensa/src/esp32s3/esp32s3_cpuidlestack.c
+++ b/arch/xtensa/src/esp32s3/esp32s3_cpuidlestack.c
@@ -100,6 +100,24 @@ int up_cpu_idlestack(int cpu, struct tcb_s *tcb, size_t stack_size)
   tcb->adj_stack_size  = CPU1_IDLETHREAD_STACKSIZE;
   tcb->stack_base_ptr  = tcb->stack_alloc_ptr;
 
+#ifdef CONFIG_STACK_COLORATION
+    {
+      register uint32_t *ptr;
+      register int i;
+
+      /* If stack debug is enabled, then fill the stack with a recognizable
+       * value that we can use later to test for high water marks.
+       */
+
+      for (i = 0, ptr = (uint32_t *)tcb->stack_alloc_ptr;
+           i < tcb->adj_stack_size;
+           i += sizeof(uint32_t))
+        {
+          *ptr++ = STACK_COLOR;
+        }
+    }
+#endif
+
   return OK;
 }
 

--- a/arch/xtensa/src/esp32s3/esp32s3_cpustart.c
+++ b/arch/xtensa/src/esp32s3/esp32s3_cpustart.c
@@ -109,24 +109,6 @@ void xtensa_appcpu_start(void)
   struct tcb_s *tcb = this_task();
   register uint32_t sp;
 
-#ifdef CONFIG_STACK_COLORATION
-    {
-      register uint32_t *ptr;
-      register int i;
-
-      /* If stack debug is enabled, then fill the stack with a recognizable
-       * value that we can use later to test for high water marks.
-       */
-
-      for (i = 0, ptr = (uint32_t *)tcb->stack_alloc_ptr;
-           i < tcb->adj_stack_size;
-           i += sizeof(uint32_t))
-        {
-          *ptr++ = STACK_COLOR;
-        }
-    }
-#endif
-
   /* Move to the stack assigned to us by up_smp_start immediately.  Although
    * we were give a stack pointer at start-up, we don't know where that stack
    * pointer is positioned respect to our memory map.  The only safe option


### PR DESCRIPTION
## Summary
Color the other CPUs task when they are created, that's the safest place because at that point we still didn't touch any its values.

## Impact
Xtensa
## Testing
esp32-devkitc:smp
