### PR TITLE
arch/risc-v: add support for GCC LTO

### DIFF
--- a/arch/risc-v/src/Makefile
+++ b/arch/risc-v/src/Makefile
@@ -90,8 +90,15 @@ BIN  = libarch$(LIBEXT)
 
 LDFLAGS += $(addprefix -T,$(call CONVERT_PATH,$(ARCHSCRIPT))) $(EXTRALINKCMDS)
 
-LDSTARTGROUP ?= --start-group
-LDENDGROUP ?= --end-group
+ifeq ($(LD),$(CC))
+  LDSTARTGROUP ?= -Wl,--start-group
+  LDENDGROUP   ?= -Wl,--end-group
+  LDFLAGS      := $(addprefix -Xlinker ,$(LDFLAGS))
+  LDFLAGS      += $(CFLAGS)
+else
+  LDSTARTGROUP ?= --start-group
+  LDENDGROUP   ?= --end-group
+endif
 
 BOARDMAKE = $(if $(wildcard board$(DELIM)Makefile),y,)
 

--- a/arch/risc-v/src/common/Toolchain.defs
+++ b/arch/risc-v/src/common/Toolchain.defs
@@ -146,15 +146,29 @@ endif
 
 # Default toolchain
 
-CC = $(CROSSDEV)gcc
-CXX = $(CROSSDEV)g++
-CPP = $(CROSSDEV)gcc -E -P -x c
-LD = $(CROSSDEV)ld
-STRIP = $(CROSSDEV)strip --strip-unneeded
-AR = $(CROSSDEV)ar rcs
-NM = $(CROSSDEV)nm
+CC      = $(CROSSDEV)gcc
+CXX     = $(CROSSDEV)g++
+CPP     = $(CROSSDEV)gcc -E -P -x c
+STRIP   = $(CROSSDEV)strip --strip-unneeded
 OBJCOPY = $(CROSSDEV)objcopy
 OBJDUMP = $(CROSSDEV)objdump
+LD      = $(CROSSDEV)ld
+AR      = $(CROSSDEV)ar rcs
+NM      = $(CROSSDEV)nm
+
+# Link Time Optimization
+
+ifeq ($(CONFIG_LTO_FULL),y)
+  MAXOPTIMIZATION += -flto
+  ifeq ($(CONFIG_RISCV_TOOLCHAIN),GNU_RVG)
+    LD := $(CROSSDEV)gcc
+    AR := $(CROSSDEV)gcc-ar rcs
+    NM := $(CROSSDEV)gcc-nm
+    MAXOPTIMIZATION += -fuse-linker-plugin
+    MAXOPTIMIZATION += -fno-builtin
+    MAXOPTIMIZATION += -nodefaultlibs
+  endif
+endif
 
 # Add the builtin library
 


### PR DESCRIPTION
## Summary

arch/risc-v: add support for GCC LTO

Reference: https://github.com/apache/incubator-nuttx/pull/6123

## Impact

GCC link-time optimizer

## Testing

bl602evb/wifi
`+CONFIG_LTO_FULL=y`

