### PR TITLE
pm: Move pm_initialize call from driver_initialize to xxx_pminitialize

### DIFF
--- a/arch/arm/src/nrf52/nrf52_pminitialize.c
+++ b/arch/arm/src/nrf52/nrf52_pminitialize.c
@@ -23,6 +23,7 @@
  ****************************************************************************/
 
 #include <nuttx/config.h>
+#include <nuttx/power/pm.h>
 
 #include "arm_internal.h"
 
@@ -50,4 +51,7 @@
 
 void arm_pminitialize(void)
 {
+  /* Initialize the NuttX power management subsystem proper */
+
+  pm_initialize();
 }

--- a/arch/arm/src/s32k1xx/s32k1xx_pminitialize.c
+++ b/arch/arm/src/s32k1xx/s32k1xx_pminitialize.c
@@ -23,6 +23,7 @@
  ****************************************************************************/
 
 #include <nuttx/config.h>
+#include <nuttx/power/pm.h>
 
 #include "arm_internal.h"
 
@@ -52,6 +53,9 @@
 
 void arm_pminitialize(void)
 {
+  /* Initialize the NuttX power management subsystem proper */
+
+  pm_initialize();
 }
 
 #endif /* CONFIG_PM */

--- a/arch/arm/src/stm32/stm32_pminitialize.c
+++ b/arch/arm/src/stm32/stm32_pminitialize.c
@@ -23,6 +23,7 @@
  ****************************************************************************/
 
 #include <nuttx/config.h>
+#include <nuttx/power/pm.h>
 
 #include "arm_internal.h"
 #include "stm32_pm.h"
@@ -53,6 +54,9 @@
 
 void arm_pminitialize(void)
 {
+  /* Initialize the NuttX power management subsystem proper */
+
+  pm_initialize();
 }
 
 #endif /* CONFIG_PM */

--- a/arch/arm/src/stm32f7/stm32_pminitialize.c
+++ b/arch/arm/src/stm32f7/stm32_pminitialize.c
@@ -23,6 +23,7 @@
  ****************************************************************************/
 
 #include <nuttx/config.h>
+#include <nuttx/power/pm.h>
 
 #include "arm_internal.h"
 #include "stm32_pm.h"
@@ -53,6 +54,9 @@
 
 void arm_pminitialize(void)
 {
+  /* Initialize the NuttX power management subsystem proper */
+
+  pm_initialize();
 }
 
 #endif /* CONFIG_PM */

--- a/arch/arm/src/stm32h7/stm32_pminitialize.c
+++ b/arch/arm/src/stm32h7/stm32_pminitialize.c
@@ -23,6 +23,7 @@
  ****************************************************************************/
 
 #include <nuttx/config.h>
+#include <nuttx/power/pm.h>
 
 #include "arm_internal.h"
 #include "stm32_pm.h"
@@ -53,6 +54,9 @@
 
 void arm_pminitialize(void)
 {
+  /* Initialize the NuttX power management subsystem proper */
+
+  pm_initialize();
 }
 
 #endif /* CONFIG_PM */

--- a/arch/arm/src/stm32l4/stm32l4_pminitialize.c
+++ b/arch/arm/src/stm32l4/stm32l4_pminitialize.c
@@ -23,6 +23,7 @@
  ****************************************************************************/
 
 #include <nuttx/config.h>
+#include <nuttx/power/pm.h>
 
 #include "arm_internal.h"
 #include "stm32l4_pm.h"
@@ -53,6 +54,9 @@
 
 void arm_pminitialize(void)
 {
+  /* Initialize the NuttX power management subsystem proper */
+
+  pm_initialize();
 }
 
 #endif /* CONFIG_PM */

--- a/arch/ceva/src/common/up_idle.c
+++ b/arch/ceva/src/common/up_idle.c
@@ -163,5 +163,8 @@ void weak_function up_cpu_normal(void)
 #ifdef CONFIG_PM
 void up_pminitialize(void)
 {
+  /* Initialize the NuttX power management subsystem proper */
+
+  pm_initialize();
 }
 #endif

--- a/arch/risc-v/src/esp32c3/esp32c3_pminitialize.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_pminitialize.c
@@ -23,6 +23,7 @@
  ****************************************************************************/
 
 #include <nuttx/config.h>
+#include <nuttx/power/pm.h>
 
 #include "esp32c3_pm.h"
 
@@ -33,7 +34,7 @@
  ****************************************************************************/
 
 /****************************************************************************
- * Name: xtensa_pminitialize
+ * Name: riscv_pminitialize
  *
  * Description:
  *   Initialize the power management subsystem.
@@ -42,6 +43,9 @@
 
 void riscv_pminitialize(void)
 {
+  /* Initialize the NuttX power management subsystem proper */
+
+  pm_initialize();
 }
 
 #endif /* CONFIG_PM */

--- a/arch/sim/src/sim/up_initialize.c
+++ b/arch/sim/src/sim/up_initialize.c
@@ -27,6 +27,7 @@
 #include <nuttx/kthread.h>
 #include <nuttx/motor/foc/foc_dummy.h>
 #include <nuttx/mtd/mtd.h>
+#include <nuttx/power/pm.h>
 #include <nuttx/spi/spi_flash.h>
 #include <nuttx/spi/qspi_flash.h>
 
@@ -215,6 +216,16 @@ static int up_loop_task(int argc, char **argv)
 
 void up_initialize(void)
 {
+#ifdef CONFIG_PM
+  /* Initialize the power management subsystem.  This MCU-specific function
+   * must be called *very* early in the initialization sequence *before* any
+   * other device drivers are initialized (since they may attempt to register
+   * with the power management subsystem).
+   */
+
+  pm_initialize();
+#endif
+
   /* Register some tty-port to access tty-port on sim platform */
 
   up_uartinit();

--- a/arch/xtensa/src/esp32/esp32_pminitialize.c
+++ b/arch/xtensa/src/esp32/esp32_pminitialize.c
@@ -23,6 +23,7 @@
  ****************************************************************************/
 
 #include <nuttx/config.h>
+#include <nuttx/power/pm.h>
 
 #include "xtensa.h"
 #include "esp32_pm.h"
@@ -43,6 +44,10 @@
 
 void xtensa_pminitialize(void)
 {
+  /* Initialize the NuttX power management subsystem proper */
+
+  pm_initialize();
+
   /* Initialize RTC parameters */
 
   esp32_pminit();

--- a/boards/arm/stm32/mikroe-stm32f4/src/stm32_pm.c
+++ b/boards/arm/stm32/mikroe-stm32f4/src/stm32_pm.c
@@ -23,6 +23,7 @@
  ****************************************************************************/
 
 #include <nuttx/config.h>
+#include <nuttx/power/pm.h>
 
 #include "arm_internal.h"
 #include "stm32_pm.h"
@@ -54,6 +55,10 @@
 
 void arm_pminitialize(void)
 {
+  /* Initialize the NuttX power management subsystem proper */
+
+  pm_initialize();
+
 #if defined(CONFIG_ARCH_IDLE_CUSTOM) && defined(CONFIG_PM_BUTTONS)
   /* Initialize the buttons to wake up the system from low power modes */
 

--- a/boards/arm/stm32/omnibusf4/src/stm32_pm.c
+++ b/boards/arm/stm32/omnibusf4/src/stm32_pm.c
@@ -23,6 +23,7 @@
  ****************************************************************************/
 
 #include <nuttx/config.h>
+#include <nuttx/power/pm.h>
 
 #include "arm_internal.h"
 #include "stm32_pm.h"
@@ -54,6 +55,10 @@
 
 void arm_pminitialize(void)
 {
+  /* Initialize the NuttX power management subsystem proper */
+
+  pm_initialize();
+
 #if defined(CONFIG_ARCH_IDLE_CUSTOM) && defined(CONFIG_PM_BUTTONS)
   /* Initialize the buttons to wake up the system from low power modes */
 

--- a/boards/arm/stm32/stm3210e-eval/src/stm32_pm.c
+++ b/boards/arm/stm32/stm3210e-eval/src/stm32_pm.c
@@ -23,6 +23,7 @@
  ****************************************************************************/
 
 #include <nuttx/config.h>
+#include <nuttx/power/pm.h>
 
 #include "arm_internal.h"
 #include "stm32_pm.h"
@@ -54,6 +55,10 @@
 
 void arm_pminitialize(void)
 {
+  /* Initialize the NuttX power management subsystem proper */
+
+  pm_initialize();
+
 #if defined(CONFIG_ARCH_IDLE_CUSTOM) && defined(CONFIG_PM_BUTTONS)
   /* Initialize the buttons to wake up the system from low power modes */
 

--- a/boards/arm/stm32/stm32f4discovery/src/stm32_pm.c
+++ b/boards/arm/stm32/stm32f4discovery/src/stm32_pm.c
@@ -23,6 +23,7 @@
  ****************************************************************************/
 
 #include <nuttx/config.h>
+#include <nuttx/power/pm.h>
 
 #include "arm_internal.h"
 #include "stm32_pm.h"
@@ -54,6 +55,10 @@
 
 void arm_pminitialize(void)
 {
+  /* Initialize the NuttX power management subsystem proper */
+
+  pm_initialize();
+
 #if defined(CONFIG_ARCH_IDLE_CUSTOM) && defined(CONFIG_PM_BUTTONS)
   /* Initialize the buttons to wake up the system from low power modes */
 

--- a/drivers/drivers_initialize.c
+++ b/drivers/drivers_initialize.c
@@ -54,12 +54,6 @@
 
 void drivers_initialize(void)
 {
-#ifdef CONFIG_PM
-  /* Initialize power management subsystem proper */
-
-  pm_initialize();
-#endif
-
   /* Register devices */
 
   syslog_initialize();


### PR DESCRIPTION
## Summary
since it's too late with the below commit(https://github.com/apache/incubator-nuttx/pull/6035):
```
ommit a594a5d7a8dcd756884ca7d3449f37ba77f96af3
Author: chao.an <anchao@xiaomi.com>
Date:   Mon Apr 11 19:44:26 2022 +0800

    sched/init: drivers_initialize() should be late than up_initialize()

    up_initialize
    |
     ->up_serialinit
       |
        ->uart_register  /* ("/dev/console", &CONSOLE_DEV); */

    drivers_initialize
    |
     ->syslog_console_init
       |
        ->register_driver /* ("/dev/console", &g_consoleops, 0666, NULL); */
```

## Impact
pm

## Testing
local device
