### PR TITLE
tools:minidumpserver.py support xtensa

### DIFF
--- a/tools/minidumpserver.py
+++ b/tools/minidumpserver.py
@@ -165,6 +165,28 @@ reg_table = {
         "T6": 31,
         "PC": 32,
     },
+    "xtensa": {
+        "PC": 0,
+        "SAR": 68,
+        "PS": 73,
+        "SCOM": 29,
+        "A0": 21,
+        "A1": 22,
+        "A2": 23,
+        "A3": 24,
+        "A4": 25,
+        "A5": 26,
+        "A6": 27,
+        "A7": 28,
+        "A8": 29,
+        "A9": 30,
+        "A10": 31,
+        "A11": 32,
+        "A12": 33,
+        "A13": 34,
+        "A14": 35,
+        "A15": 36,
+    }
 }
 
 
@@ -200,7 +222,7 @@ class dump_log_file:
                     logger.error("%s not supported" % (self.arch))
                 # init register list
                 if len(self.registers) == 0:
-                    for x in range(len(reg_table[self.arch])):
+                    for x in range(max(reg_table[self.arch].values()) + 1):
                         self.registers.append(b"x")
 
                 # find register value


### PR DESCRIPTION
Signed-off-by: anjiahao <anjiahao@xiaomi.com>

## Summary
support crash log debug on xtensa
## problem
The register sequence numbers of different xtensa gdb versions are inconsistent. In minidumpsevers.py, xtensa is tested based on xtensa-esp32-gdb. I have tried to use the latest version of gdb source code to compile the xtensa architecture. The register sequence and endian is on xtensa-esp32-gdb different.
