### PR TITLE
compiler.h: optimization option is not supported before GCC 4.6

### DIFF
--- a/include/nuttx/compiler.h
+++ b/include/nuttx/compiler.h
@@ -379,9 +379,11 @@
 
 #  if defined(__clang__)
 #    define no_builtin(n) __attribute__((no_builtin(n)))
-#  else
+#  elif (__GNUC__ == 4 && __GNUC_MINOR__ >= 6) || (__GNUC__ > 4)
 #    define no_builtin(n) __attribute__((__optimize__("-fno-tree-loop-distribute-patterns")))
-#endif
+#  else
+#    define no_builtin(n)
+#  endif
 
 /* SDCC-specific definitions ************************************************/
 


### PR DESCRIPTION
## Summary
-fno-tree-loop-distribute-patterns is not supported before GCC 4.6

I confirmed that by searching "ftree-loop-distribute-patterns" in gcc 4.5.4 (https://ftp.gnu.org/gnu/gcc/gcc-4.5.4/) and gcc 4.6.0 (https://ftp.gnu.org/gnu/gcc/gcc-4.6.0/) release source code.
In the gcc source code, file gcc/common.opt lists all the optimize option.

## Testing
compile with gcc 4.5.1 and gcc 9.2.1
