### PR TITLE
syscall: Fix prototype of exec() to syscall.csv

### DIFF
--- a/syscall/syscall.csv
+++ b/syscall/syscall.csv
@@ -23,7 +23,7 @@
 "dup","unistd.h","","int","int"
 "dup2","unistd.h","","int","int","int"
 "eventfd","sys/eventfd.h","defined(CONFIG_EVENT_FD)","int","unsigned int","int"
-"exec","nuttx/binfmt/binfmt.h","!defined(CONFIG_BINFMT_DISABLE) && !defined(CONFIG_BUILD_KERNEL)","int","FAR const char *","FAR char * const *","FAR const struct symtab_s *","int"
+"exec","nuttx/binfmt/binfmt.h","!defined(CONFIG_BINFMT_DISABLE) && !defined(CONFIG_BUILD_KERNEL)","int","FAR const char *","FAR char * const *","FAR char * const *","FAR const struct symtab_s *","int"
 "execve","unistd.h","!defined(CONFIG_BINFMT_DISABLE) && defined(CONFIG_LIBC_EXECFUNCS)","int","FAR const char *","FAR char * const []|FAR char * const *","FAR char * const []|FAR char * const *"
 "exit","stdlib.h","","noreturn","int"
 "fchmod","sys/stat.h","","int","int","mode_t"


### PR DESCRIPTION
## Summary
The prototype was wrong
## Impact
Fix build error
## Testing
Build passes
