### PR TITLE
RISC-V: Fix system crash when FPU is in use

### DIFF
--- a/arch/risc-v/src/common/riscv_exception_common.S
+++ b/arch/risc-v/src/common/riscv_exception_common.S
@@ -127,6 +127,8 @@ exception_common:
 
   mv         sp, a0
 
+  riscv_loadfpu   sp
+
   REGLOAD    s0, REG_EPC(sp)      /* restore sepc */
   csrw       CSR_EPC, s0
 
@@ -134,7 +136,6 @@ exception_common:
   csrw       CSR_STATUS, s0
 
   load_ctx   sp
-  riscv_loadfpu   sp
 
   REGLOAD    sp, REG_SP(sp)      /* restore original sp */
 

--- a/arch/risc-v/src/common/supervisor/riscv_dispatch_syscall.S
+++ b/arch/risc-v/src/common/supervisor/riscv_dispatch_syscall.S
@@ -109,6 +109,8 @@ riscv_dispatch_syscall:
 
   mv         sp, a0                    /* use sp, as a0 gets wiped */
 
+  riscv_loadfpu sp
+
   REGLOAD    s0, REG_EPC(sp)           /* restore epc */
   csrw       CSR_EPC, s0
 
@@ -127,7 +129,6 @@ riscv_dispatch_syscall:
   csrw       CSR_STATUS, s0
 
   load_ctx   sp
-  riscv_loadfpu sp
 
   REGLOAD    sp, REG_SP(sp)            /* restore original sp */
 


### PR DESCRIPTION
FPU registers need to be written prior to updating CSR_STATUS

## Summary
Fixes full system crash due to illegal instruction when accessing FPU when it is too late
## Impact
Fixes system crash
## Testing
icicle:nsh and icicle:knsh, ostest fails at once prior fix, passes with fix
