### PR TITLE
xtensa: Fix backtrace on exceptions

### DIFF
--- a/arch/xtensa/src/common/xtensa_int_handlers.S
+++ b/arch/xtensa/src/common/xtensa_int_handlers.S
@@ -188,27 +188,27 @@ g_intstacktop:
 	and		a6, a6, a3				/* a6 = Set of pending, enabled interrupts for this level */
 	beqz	a6, 1f						/* Nothing to do */
 
-  /* At this point, the exception frame should have been allocated and filled,
-   * and current sp points to the interrupt stack (if enabled). Copy the
-   * pre-exception's base save area below the current SP.
-   */
+	/* At this point, the exception frame should have been allocated and filled,
+	 * and current sp points to the interrupt stack (if enabled). Copy the
+	 * pre-exception's base save area below the current SP. We saved the SP in A12
+	 * before getting here.
+	 */
 
 #ifdef CONFIG_XTENSA_INTBACKTRACE
-  rsr  a0, EXCSAVE_1 + \level - 1  /* Get exception frame pointer stored in EXCSAVE_x */
-  l32i a3, a0, (4 * REG_A0)        /* Copy pre-exception a0 (return address) */
-  s32e a3, sp, -16
-  l32i a3, a0, (4 * REG_A1)        /* Copy pre-exception a1 (stack pointer) */
-  s32e a3, sp, -12
+	l32i a3, a12, (4 * REG_A0)        /* Copy pre-exception a0 (return address) */
+	s32e a3, sp, -16
+	l32i a3, a12, (4 * REG_A1)        /* Copy pre-exception a1 (stack pointer) */
+	s32e a3, sp, -12
 
-  /* Backtracing only needs a0 and a1, no need to create full base save area.
-   * Also need to change current frame's return address to point to pre-exception's
-   * last run instruction.
-   */
+	/* Backtracing only needs a0 and a1, no need to create full base save area.
+	 * Also need to change current frame's return address to point to pre-exception's
+	 * last run instruction.
+	 */
 
-  rsr a0, EPC_1 + \level - 1  /* return address */
-  movi a4, 0xc0000000         /* constant with top 2 bits set (call size) */
-  or a0, a0, a4               /* set top 2 bits */
-  addx2 a0, a4, a0            /* clear top bit -- simulating call4 size   */
+	rsr a0, EPC_1 + \level - 1  /* return address */
+	movi a4, 0xc0000000         /* constant with top 2 bits set (call size) */
+	or a0, a0, a4               /* set top 2 bits */
+	addx2 a0, a4, a0            /* clear top bit -- simulating call4 size   */
 #endif
 
 	/* Call xtensa_int_decode passing the address of the register save area
@@ -304,10 +304,6 @@ _xtensa_level1_handler:
 	rsr		a0, EXCSAVE_1					            /* Save interruptee's a0 */
 	s32i	a0, sp, (4 * REG_A0)
 	s32i	a2, sp, (4 * REG_A2)
-
-#ifdef CONFIG_XTENSA_INTBACKTRACE
-  wsr sp, EXCSAVE_1
-#endif
 
 	/* Save rest of interrupt context. */
 
@@ -407,10 +403,6 @@ _xtensa_level2_handler:
 	s32i	a0, sp, (4 * REG_A0)
 	s32i	a2, sp, (4 * REG_A2)
 
-#ifdef CONFIG_XTENSA_INTBACKTRACE
-  wsr sp, EXCSAVE_2
-#endif
-
 	/* Save rest of interrupt context. */
 
 	call0	_xtensa_context_save
@@ -483,10 +475,6 @@ _xtensa_level3_handler:
 	rsr		a0, EXCSAVE_3					/* Save interruptee's a0 */
 	s32i	a0, sp, (4 * REG_A0)
 	s32i	a2, sp, (4 * REG_A2)
-
-#ifdef CONFIG_XTENSA_INTBACKTRACE
-  wsr sp, EXCSAVE_3
-#endif
 
 	/* Save rest of interrupt context. */
 
@@ -561,10 +549,6 @@ _xtensa_level4_handler:
 	s32i	a0, sp, (4 * REG_A0)
 	s32i	a2, sp, (4 * REG_A2)
 
-#ifdef CONFIG_XTENSA_INTBACKTRACE
-  wsr sp, EXCSAVE_4
-#endif
-
 	/* Save rest of interrupt context. */
 
 	call0	_xtensa_context_save
@@ -638,10 +622,6 @@ _xtensa_level5_handler:
 	s32i	a0, sp, (4 * REG_A0)
 	s32i	a2, sp, (4 * REG_A2)
 
-#ifdef CONFIG_XTENSA_INTBACKTRACE
-  wsr sp, EXCSAVE_5
-#endif
-
 	/* Save rest of interrupt context. */
 
 	call0	_xtensa_context_save
@@ -714,10 +694,6 @@ _xtensa_level6_handler:
 	rsr		a0, EXCSAVE_6					/* Save interruptee's a0 */
 	s32i	a0, sp, (4 * REG_A0)
 	s32i	a2, sp, (4 * REG_A2)
-
-#ifdef CONFIG_XTENSA_INTBACKTRACE
-  wsr sp, EXCSAVE_6
-#endif
 
 	/* Save rest of interrupt context. */
 

--- a/arch/xtensa/src/common/xtensa_user_handler.S
+++ b/arch/xtensa/src/common/xtensa_user_handler.S
@@ -220,6 +220,10 @@ _xtensa_user_handler:
 	s32i	a0, sp, (4 * REG_A0)
 	s32i	a2, sp, (4 * REG_A2)
 
+#ifdef CONFIG_XTENSA_INTBACKTRACE
+	wsr sp, EXCSAVE_1
+#endif
+
 	/* Save EXCCAUSE and EXCVADDR into the user frame */
 
 	rsr		a0, EXCCAUSE
@@ -252,10 +256,12 @@ _xtensa_user_handler:
    */
 
 #ifdef CONFIG_XTENSA_INTBACKTRACE
-  l32i    a3, sp, (4 * REG_A0)     /* Copy pre-exception a0 (return address) */
+  rsr     a0, EXCSAVE_1            /* Get exception frame pointer stored in EXCSAVE_1 */
+  l32i    a3, a0, (4 * REG_A0)     /* Copy pre-exception a0 (return address) */
   s32e    a3, sp, -16
-  l32i    a3, sp, (4 * REG_A1)     /* Copy pre-exception a1 (stack pointer) */
+  l32i    a3, a0, (4 * REG_A1)     /* Copy pre-exception a1 (stack pointer) */
   s32e    a3, sp, -12
+
   rsr     a0, EPC_1                /* return address for debug backtrace */
   movi    a4, 0xc0000000           /* constant with top 2 bits set (call size) */
   or      a0, a0, a4               /* set top 2 bits */

--- a/arch/xtensa/src/common/xtensa_user_handler.S
+++ b/arch/xtensa/src/common/xtensa_user_handler.S
@@ -245,12 +245,7 @@ _xtensa_user_handler:
 
 	/* Set up PS for C, re-enable hi-pri interrupts, and clear EXCM. */
 
-#ifdef __XTENSA_CALL0_ABI__
-	movi	a0, PS_INTLEVEL(XCHAL_EXCM_LEVEL) | PS_UM
-#else
-	movi	a0, PS_INTLEVEL(XCHAL_EXCM_LEVEL) | PS_UM | PS_WOE
-#endif
-	wsr		a0, PS
+	ps_setup	1 a0
 
   /* Create pseudo base save area. At this point, sp is still pointing to the
    * allocated and filled exception stack frame.
@@ -263,11 +258,8 @@ _xtensa_user_handler:
   s32e    a3, sp, -12
   rsr     a0, EPC_1                /* return address for debug backtrace */
   movi    a4, 0xc0000000           /* constant with top 2 bits set (call size) */
-  rsync                            /* wait for WSR.PS to complete */
   or      a0, a0, a4               /* set top 2 bits */
   addx2   a0, a4, a0               /* clear top bit -- thus simulating call4 size */
-#else
-  rsync                            /* wait for WSR.PS to complete */
 #endif
 
 	/* Call xtensa_user, passing both the EXCCAUSE and a pointer to the

--- a/arch/xtensa/src/common/xtensa_user_handler.S
+++ b/arch/xtensa/src/common/xtensa_user_handler.S
@@ -220,10 +220,6 @@ _xtensa_user_handler:
 	s32i	a0, sp, (4 * REG_A0)
 	s32i	a2, sp, (4 * REG_A2)
 
-#ifdef CONFIG_XTENSA_INTBACKTRACE
-	wsr sp, EXCSAVE_1
-#endif
-
 	/* Save EXCCAUSE and EXCVADDR into the user frame */
 
 	rsr		a0, EXCCAUSE
@@ -251,21 +247,21 @@ _xtensa_user_handler:
 
 	ps_setup	1 a0
 
-  /* Create pseudo base save area. At this point, sp is still pointing to the
-   * allocated and filled exception stack frame.
-   */
+	/* Create pseudo base save area. At this point, a12 points to the
+	 * allocated and filled exception stack frame (old value of SP in case of
+	 * an interrupt stack).
+	 */
 
 #ifdef CONFIG_XTENSA_INTBACKTRACE
-  rsr     a0, EXCSAVE_1            /* Get exception frame pointer stored in EXCSAVE_1 */
-  l32i    a3, a0, (4 * REG_A0)     /* Copy pre-exception a0 (return address) */
-  s32e    a3, sp, -16
-  l32i    a3, a0, (4 * REG_A1)     /* Copy pre-exception a1 (stack pointer) */
-  s32e    a3, sp, -12
+	l32i    a3, a12, (4 * REG_A0)     /* Copy pre-exception a0 (return address) */
+	s32e    a3, sp, -16
+	l32i    a3, a12, (4 * REG_A1)     /* Copy pre-exception a1 (stack pointer) */
+	s32e    a3, sp, -12
 
-  rsr     a0, EPC_1                /* return address for debug backtrace */
-  movi    a4, 0xc0000000           /* constant with top 2 bits set (call size) */
-  or      a0, a0, a4               /* set top 2 bits */
-  addx2   a0, a4, a0               /* clear top bit -- thus simulating call4 size */
+	rsr     a0, EPC_1                /* return address for debug backtrace */
+	movi    a4, 0xc0000000           /* constant with top 2 bits set (call size) */
+	or      a0, a0, a4               /* set top 2 bits */
+	addx2   a0, a4, a0               /* clear top bit -- thus simulating call4 size */
 #endif
 
 	/* Call xtensa_user, passing both the EXCCAUSE and a pointer to the


### PR DESCRIPTION
## Summary
Full backtrace was not available, because the code responsable for retrieving the correct registers (A0 and A1) was reading them from an incorrect SP.
## Impact
Xtensa
## Testing

before:
```gdb
(gdb) bt
#0  xtensa_assert () at common/xtensa_assert.c:129
#1  0x400d402e in xtensa_user_panic (exccause=29, regs=0x3ffe0b88) at common/xtensa_assert.c:311
#2  0x400d39a6 in xtensa_user (exccause=29, regs=0x3ffe0b88) at chip/esp32_user.c:438
#3  0x4008086f in _xtensa_user_handler () at common/xtensa_user_handler.S:276
Backtrace stopped: previous frame inner to this frame (corrupt stack?)
```
after
```gdb
(gdb) bt
#0  xtensa_assert () at common/xtensa_assert.c:129
#1  0x400d402e in xtensa_user_panic (exccause=29, regs=0x3ffe0b88) at common/xtensa_assert.c:311
#2  0x400d39a6 in xtensa_user (exccause=29, regs=0x3ffe0b88) at chip/esp32_user.c:438
#3  0x40080875 in _xtensa_user_handler () at common/xtensa_user_handler.S:282
#4  0x400dd66a in hello_main (argc=0, argv=0x0) at hello_main.c:40
#5  0x400d2607 in nxtask_startup (entrypt=0x400dd65c <hello_main>, argc=1, argv=0x3ffe0480) at sched/task_startup.c:70
#6  0x400d13e3 in nxtask_start () at task/task_start.c:133
```