### PR TITLE
sched: remove DEBUGASSERT from nx_waitpid

### DIFF
--- a/sched/sched/sched_waitpid.c
+++ b/sched/sched/sched_waitpid.c
@@ -55,8 +55,6 @@ pid_t nx_waitpid(pid_t pid, int *stat_loc, int options)
   bool mystat = false;
   int ret;
 
-  DEBUGASSERT(stat_loc);
-
   /* NOTE: sched_lock() is not enough for SMP
    * because the child task is running on another CPU
    */
@@ -194,8 +192,6 @@ pid_t nx_waitpid(pid_t pid, int *stat_loc, int options)
   sigset_t set;
   int ret;
 
-  DEBUGASSERT(stat_loc);
-
   /* Create a signal set that contains only SIGCHLD */
 
   sigemptyset(&set);
@@ -312,7 +308,11 @@ pid_t nx_waitpid(pid_t pid, int *stat_loc, int options)
 
               /* The child has exited. Return the saved exit status */
 
-              *stat_loc = child->ch_status << 8;
+              if (stat_loc != NULL)
+                {
+                  *stat_loc = child->ch_status << 8;
+                }
+
               pid = child->ch_pid;
 
               /* Discard the child entry and break out of the loop */
@@ -340,7 +340,10 @@ pid_t nx_waitpid(pid_t pid, int *stat_loc, int options)
             {
               /* The child has exited. Return the saved exit status */
 
-              *stat_loc = child->ch_status << 8;
+              if (stat_loc != NULL)
+                {
+                  *stat_loc = child->ch_status << 8;
+                }
 
               /* Discard the child entry and break out of the loop */
 
@@ -415,7 +418,11 @@ pid_t nx_waitpid(pid_t pid, int *stat_loc, int options)
         {
           /* Yes... return the status and PID (in the event it was -1) */
 
-          *stat_loc = info.si_status << 8;
+          if (stat_loc != NULL)
+            {
+              *stat_loc = info.si_status << 8;
+            }
+
           pid = info.si_pid;
 
 #ifdef CONFIG_SCHED_CHILD_STATUS

--- a/sched/task/task_exithook.c
+++ b/sched/task/task_exithook.c
@@ -469,7 +469,7 @@ static inline void nxtask_exitwakeup(FAR struct tcb_s *tcb, int status)
            *  Hmmm.. what do we return to the others?
            */
 
-          if (group->tg_statloc)
+          if (group->tg_statloc != NULL)
             {
               *group->tg_statloc = status << 8;
             }


### PR DESCRIPTION
## Summary
`stat_loc` of `wait` and `waitpid` can be `NULL` according to POSIX (https://pubs.opengroup.org/onlinepubs/9699919799/functions/wait.html): `In this case, if the value of the argument stat_loc is not a null pointer, information shall be stored in the location pointed to by stat_loc.`

Remove `DEBUGASSERT(stat_loc);` from `nx_waitpid`

## Impact
Minimal if this was not reported by anyone till now

## Testing
Pass CI
Tested with SAME70-QMTECH board with `CONFIG_SCHED_HAVE_PARENT=n`