### PR TITLE
boards/boardctl: correct boarctl return value

### DIFF
--- a/boards/boardctl.c
+++ b/boards/boardctl.c
@@ -823,7 +823,7 @@ int boardctl(unsigned int cmd, uintptr_t arg)
       return ERROR;
     }
 
-  return OK;
+  return ret;
 }
 
 #endif /* CONFIG_BOARDCTL */


### PR DESCRIPTION
## Summary
- Correct boardctl function's return value
- In case of BOARDIOC_TESTSET, `ret` has 0 or 1 or an error,
  but `ret` is ignored except error.

## Impact
- boardctl return value except errors

## Testing
- custom Cortex-A9 board
