### PR TITLE
libs/libc/string: unify implementation across the functions

### DIFF
--- a/libs/libc/string/lib_strcasecmp.c
+++ b/libs/libc/string/lib_strcasecmp.c
@@ -35,10 +35,11 @@
 #undef strcasecmp /* See mm/README.txt */
 int strcasecmp(FAR const char *cs, FAR const char *ct)
 {
-  int result;
+  register int result;
   for (; ; )
     {
-      if ((result = (int)toupper(*cs) - (int)toupper(*ct)) != 0 || !*cs)
+      if ((result = toupper(*cs) - toupper(*ct)) != 0 ||
+          *cs == '\0')
         {
           break;
         }

--- a/libs/libc/string/lib_strcasestr.c
+++ b/libs/libc/string/lib_strcasestr.c
@@ -36,15 +36,12 @@ static FAR char *strcasechr(FAR const char *s, int uc)
 {
   register char ch;
 
-  if (s)
+  for (; *s; s++)
     {
-      for (; *s; s++)
+      ch = *s;
+      if (toupper(ch) == uc)
         {
-          ch = *s;
-          if (toupper(ch) == uc)
-            {
-              return (FAR char *)s;
-            }
+          return (FAR char *)s;
         }
     }
 

--- a/libs/libc/string/lib_strcmp.c
+++ b/libs/libc/string/lib_strcmp.c
@@ -38,7 +38,7 @@ int strcmp(FAR const char *cs, FAR const char *ct)
   for (; ; )
     {
       if ((result = (unsigned char)*cs - (unsigned char)*ct++) != 0 ||
-          !*cs++)
+          *cs++ == '\0')
         {
           break;
         }

--- a/libs/libc/string/lib_strncasecmp.c
+++ b/libs/libc/string/lib_strncasecmp.c
@@ -34,12 +34,13 @@
 
 #ifndef CONFIG_ARCH_STRNCASECMP
 #undef strncasecmp /* See mm/README.txt */
-int strncasecmp(const char *cs, const char *ct, size_t nb)
+int strncasecmp(FAR const char *cs, FAR const char *ct, size_t nb)
 {
-  int result = 0;
+  register int result = 0;
   for (; nb > 0; nb--)
     {
-      if ((result = (int)toupper(*cs) - (int)toupper(*ct)) != 0 || !*cs)
+      if ((result = toupper(*cs) - toupper(*ct)) != 0 ||
+          *cs == '\0')
         {
           break;
         }

--- a/libs/libc/string/lib_strncat.c
+++ b/libs/libc/string/lib_strncat.c
@@ -32,9 +32,9 @@
 
 #ifndef CONFIG_ARCH_STRNCAT
 #undef strncat /* See mm/README.txt */
-char *strncat(char *dest, const char *src, size_t n)
+FAR char *strncat(FAR char *dest, FAR const char *src, size_t n)
 {
-  char *ret   = dest;
+  FAR char *ret = dest;
 
   dest  += strlen(dest);
   for (; n > 0 && *src != '\0' ; n--)

--- a/libs/libc/string/lib_strncmp.c
+++ b/libs/libc/string/lib_strncmp.c
@@ -32,13 +32,13 @@
 
 #ifndef CONFIG_ARCH_STRNCMP
 #undef strncmp /* See mm/README.txt */
-int strncmp(const char *cs, const char *ct, size_t nb)
+int strncmp(FAR const char *cs, FAR const char *ct, size_t nb)
 {
-  int result = 0;
+  register int result = 0;
   for (; nb > 0; nb--)
     {
       if ((result = (unsigned char)*cs - (unsigned char)*ct++) != 0 ||
-          !*cs++)
+          *cs++ == '\0')
         {
           break;
         }


### PR DESCRIPTION
## Summary
1. Add missing `FAR`
2. Detect end of string using compare with `'\0'`
3. Remove redundant cast
4. Add `register` to compare return value
5. Remove `NULL` check in `strcasechr`

## Impact
Should be none. Refactoring only

## Testing
Pass CI