### PR TITLE
boards/risc-v: Remove "MAXOPTIMIZATION = -Os" from Make.defs

### DIFF
--- a/boards/risc-v/c906/smartl-c906/scripts/Make.defs
+++ b/boards/risc-v/c906/smartl-c906/scripts/Make.defs
@@ -35,8 +35,6 @@ ifeq ($(CONFIG_DEBUG_SYMBOLS),y)
   ASARCHCPUFLAGS += -Wa,-g
 endif
 
-MAXOPTIMIZATION = -Os
-
 ifneq ($(CONFIG_DEBUG_NOOPT),y)
   ARCHOPTIMIZATION += $(MAXOPTIMIZATION) -fno-strict-aliasing
 endif

--- a/boards/risc-v/fe310/hifive1-revb/scripts/Make.defs
+++ b/boards/risc-v/fe310/hifive1-revb/scripts/Make.defs
@@ -35,8 +35,6 @@ ifeq ($(CONFIG_DEBUG_SYMBOLS),y)
   ASARCHCPUFLAGS += -Wa,-g
 endif
 
-MAXOPTIMIZATION = -Os
-
 ifneq ($(CONFIG_DEBUG_NOOPT),y)
   ARCHOPTIMIZATION += $(MAXOPTIMIZATION) -fno-strict-aliasing
 endif

--- a/boards/risc-v/k210/maix-bit/scripts/Make.defs
+++ b/boards/risc-v/k210/maix-bit/scripts/Make.defs
@@ -31,8 +31,6 @@ ifeq ($(CONFIG_DEBUG_SYMBOLS),y)
   ASARCHCPUFLAGS += -Wa,-g
 endif
 
-MAXOPTIMIZATION = -Os
-
 ifneq ($(CONFIG_DEBUG_NOOPT),y)
   ARCHOPTIMIZATION += $(MAXOPTIMIZATION) -fno-strict-aliasing
 endif

--- a/boards/risc-v/litex/arty_a7/scripts/Make.defs
+++ b/boards/risc-v/litex/arty_a7/scripts/Make.defs
@@ -31,8 +31,6 @@ ifeq ($(CONFIG_DEBUG_SYMBOLS),y)
   ASARCHCPUFLAGS += -Wa,-g
 endif
 
-MAXOPTIMIZATION = -Os
-
 ifneq ($(CONFIG_DEBUG_NOOPT),y)
   ARCHOPTIMIZATION += $(MAXOPTIMIZATION) -fno-strict-aliasing
 endif

--- a/boards/risc-v/mpfs/icicle/scripts/Make.defs
+++ b/boards/risc-v/mpfs/icicle/scripts/Make.defs
@@ -50,8 +50,6 @@ ifeq ($(CONFIG_DEBUG_SYMBOLS),y)
   ASARCHCPUFLAGS += -Wa,-g
 endif
 
-MAXOPTIMIZATION = -Os
-
 ifneq ($(CONFIG_DEBUG_NOOPT),y)
   ARCHOPTIMIZATION += $(MAXOPTIMIZATION) -fno-strict-aliasing
 endif

--- a/boards/risc-v/mpfs/m100pfsevp/scripts/Make.defs
+++ b/boards/risc-v/mpfs/m100pfsevp/scripts/Make.defs
@@ -35,8 +35,6 @@ ifeq ($(CONFIG_DEBUG_SYMBOLS),y)
   ASARCHCPUFLAGS += -Wa,-g
 endif
 
-MAXOPTIMIZATION = -Os
-
 ifneq ($(CONFIG_DEBUG_NOOPT),y)
   ARCHOPTIMIZATION += $(MAXOPTIMIZATION) -fno-strict-aliasing
 endif

--- a/boards/risc-v/qemu-rv/rv-virt/scripts/Make.defs
+++ b/boards/risc-v/qemu-rv/rv-virt/scripts/Make.defs
@@ -33,8 +33,6 @@ ifeq ($(CONFIG_DEBUG_SYMBOLS),y)
   ASARCHCPUFLAGS += -Wa,-g
 endif
 
-MAXOPTIMIZATION = -Os
-
 ifneq ($(CONFIG_DEBUG_NOOPT),y)
   ARCHOPTIMIZATION += $(MAXOPTIMIZATION) -fno-strict-aliasing
 endif

--- a/boards/risc-v/rv32m1/rv32m1-vega/scripts/Make.defs
+++ b/boards/risc-v/rv32m1/rv32m1-vega/scripts/Make.defs
@@ -39,8 +39,6 @@ ifeq ($(CONFIG_DEBUG_SYMBOLS),y)
   ASARCHCPUFLAGS += -Wa,-g
 endif
 
-MAXOPTIMIZATION = -Os
-
 ifneq ($(CONFIG_DEBUG_NOOPT),y)
   ARCHOPTIMIZATION += $(MAXOPTIMIZATION) -fno-strict-aliasing
 endif


### PR DESCRIPTION
## Summary
since it is already defined in Toolchain.defs

## Impact
Code refactor only

## Testing
Pass CI
