### PR TITLE
arch/xtensa: Simply use xtensa_createstack for CPU1 idle task.

### DIFF
--- a/arch/xtensa/src/esp32/esp32_cpuidlestack.c
+++ b/arch/xtensa/src/esp32/esp32_cpuidlestack.c
@@ -34,11 +34,6 @@
  * Public Data
  ****************************************************************************/
 
-/* Address of the CPU0 IDLE thread */
-
-uint32_t g_cpu1_idlestack[CPU1_IDLETHREAD_STACKWORDS]
-  aligned_data(16) locate_data(".noinit");
-
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
@@ -81,41 +76,14 @@ uint32_t g_cpu1_idlestack[CPU1_IDLETHREAD_STACKWORDS]
  *                  being created for.
  *   - tcb:         The TCB of new CPU IDLE task
  *   - stack_size:  The requested stack size for the IDLE task.  At least
- *                  this much must be allocated.  This should be
- *                  CONFIG_IDLETHREAD_STACKSIZE.
+ *                  this much must be allocated.
  *
  ****************************************************************************/
 
 int up_cpu_idlestack(int cpu, struct tcb_s *tcb, size_t stack_size)
 {
-  /* XTENSA uses a push-down stack:  the stack grows toward lower* addresses
-   * in memory.  The stack pointer register points to the lowest, valid
-   * working address (the "top" of the stack).  Items on the stack are
-   * referenced as positive word offsets from sp.
-   */
-
-  /* Save information about pre-allocated IDLE thread stack */
-
-  tcb->stack_alloc_ptr = g_cpu1_idlestack;
-  tcb->adj_stack_size  = CPU1_IDLETHREAD_STACKSIZE;
-  tcb->stack_base_ptr  = tcb->stack_alloc_ptr;
-
-#ifdef CONFIG_STACK_COLORATION
-    {
-      register uint32_t *ptr;
-      register int i;
-
-      /* If stack debug is enabled, then fill the stack with a recognizable
-       * value that we can use later to test for high water marks.
-       */
-
-      for (i = 0, ptr = (uint32_t *)tcb->stack_alloc_ptr;
-           i < tcb->adj_stack_size;
-           i += sizeof(uint32_t))
-        {
-          *ptr++ = STACK_COLOR;
-        }
-    }
+#if CONFIG_SMP_NCPUS > 1
+  up_create_stack(tcb, stack_size, TCB_FLAG_TTYPE_KERNEL);
 #endif
 
 #if XCHAL_CP_NUM > 0

--- a/arch/xtensa/src/esp32/esp32_smp.h
+++ b/arch/xtensa/src/esp32/esp32_smp.h
@@ -33,24 +33,9 @@
  * Pre-procesor Definitions
  ****************************************************************************/
 
-/* An IDLE thread stack size for CPU0 must be defined */
-
-#if !defined(CONFIG_IDLETHREAD_STACKSIZE)
-#  error CONFIG_IDLETHREAD_STACKSIZE is not defined
-#elif CONFIG_IDLETHREAD_STACKSIZE < 16
-#  error CONFIG_IDLETHREAD_STACKSIZE is to small
-#endif
-
-#define CPU1_IDLETHREAD_STACKSIZE ((CONFIG_IDLETHREAD_STACKSIZE + 15) & ~15)
-#define CPU1_IDLETHREAD_STACKWORDS (CPU1_IDLETHREAD_STACKSIZE >> 2)
-
 /****************************************************************************
  * Public Data
  ****************************************************************************/
-
-/* This is the CPU1 IDLE stack */
-
-extern uint32_t g_cpu1_idlestack[CPU1_IDLETHREAD_STACKWORDS];
 
 /****************************************************************************
  * Public Function Prototypes

--- a/arch/xtensa/src/esp32s3/esp32s3_cpuidlestack.c
+++ b/arch/xtensa/src/esp32s3/esp32s3_cpuidlestack.c
@@ -34,11 +34,6 @@
  * Public Data
  ****************************************************************************/
 
-/* Address of the CPU1 IDLE thread */
-
-uint32_t g_cpu1_idlestack[CPU1_IDLETHREAD_STACKWORDS]
-  aligned_data(16) locate_data(".noinit");
-
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
@@ -81,41 +76,14 @@ uint32_t g_cpu1_idlestack[CPU1_IDLETHREAD_STACKWORDS]
  *                  being created for.
  *   - tcb:         The TCB of new CPU IDLE task
  *   - stack_size:  The requested stack size for the IDLE task.  At least
- *                  this much must be allocated.  This should be
- *                  CONFIG_IDLETHREAD_STACKSIZE.
+ *                  this much must be allocated.
  *
  ****************************************************************************/
 
 int up_cpu_idlestack(int cpu, struct tcb_s *tcb, size_t stack_size)
 {
-  /* XTENSA uses a push-down stack:  the stack grows toward lower* addresses
-   * in memory.  The stack pointer register points to the lowest, valid
-   * working address (the "top" of the stack).  Items on the stack are
-   * referenced as positive word offsets from sp.
-   */
-
-  /* Save information about pre-allocated IDLE thread stack */
-
-  tcb->stack_alloc_ptr = g_cpu1_idlestack;
-  tcb->adj_stack_size  = CPU1_IDLETHREAD_STACKSIZE;
-  tcb->stack_base_ptr  = tcb->stack_alloc_ptr;
-
-#ifdef CONFIG_STACK_COLORATION
-    {
-      register uint32_t *ptr;
-      register int i;
-
-      /* If stack debug is enabled, then fill the stack with a recognizable
-       * value that we can use later to test for high water marks.
-       */
-
-      for (i = 0, ptr = (uint32_t *)tcb->stack_alloc_ptr;
-           i < tcb->adj_stack_size;
-           i += sizeof(uint32_t))
-        {
-          *ptr++ = STACK_COLOR;
-        }
-    }
+#if CONFIG_SMP_NCPUS > 1
+  up_create_stack(tcb, stack_size, TCB_FLAG_TTYPE_KERNEL);
 #endif
 
   return OK;

--- a/arch/xtensa/src/esp32s3/esp32s3_smp.h
+++ b/arch/xtensa/src/esp32s3/esp32s3_smp.h
@@ -33,24 +33,9 @@
  * Pre-procesor Definitions
  ****************************************************************************/
 
-/* An IDLE thread stack size for CPU0 must be defined */
-
-#if !defined(CONFIG_IDLETHREAD_STACKSIZE)
-#  error CONFIG_IDLETHREAD_STACKSIZE is not defined
-#elif CONFIG_IDLETHREAD_STACKSIZE < 16
-#  error CONFIG_IDLETHREAD_STACKSIZE is to small
-#endif
-
-#define CPU1_IDLETHREAD_STACKSIZE ((CONFIG_IDLETHREAD_STACKSIZE + 15) & ~15)
-#define CPU1_IDLETHREAD_STACKWORDS (CPU1_IDLETHREAD_STACKSIZE >> 2)
-
 /****************************************************************************
  * Public Data
  ****************************************************************************/
-
-/* This is the CPU1 IDLE stack */
-
-extern uint32_t g_cpu1_idlestack[CPU1_IDLETHREAD_STACKWORDS];
 
 /****************************************************************************
  * Public Function Prototypes


### PR DESCRIPTION

## Summary
Simply use xtensa_createstack for CPU1 idle task. All the rest of the setup including stack coloration is already done in `xtensa_createstack`.
## Impact
N/A
## Testing
esp32
