### PR TITLE
arch/xtensa: Refactor assembly macros

### DIFF
--- a/arch/xtensa/src/common/xtensa_int_handlers.S
+++ b/arch/xtensa/src/common/xtensa_int_handlers.S
@@ -121,18 +121,58 @@ g_intstacktop:
 #endif
 
 /****************************************************************************
- * Macro dispatch_c_isr level mask
+ * Macro: ps_setup
+ *
+ * Description:
+ *   Set up PS for C, enable interrupts above this level and clear EXCM.
+ *
+ * Entry Conditions:
+ *   level - interrupt level
+ *   tmp   - scratch register
+ *
+ * Side Effects:
+ *   PS and scratch register modified
+ *
+ * Assumptions:
+ *   - PS.EXCM = 1, C calling disabled
+ *
+ ****************************************************************************/
+
+	.macro	ps_setup	level tmp
+
+#if 0 /* Nested interrupts no yet supported */
+#  ifdef __XTENSA_CALL0_ABI__
+	/* Disable interrupts at level and below */
+
+	movi	\tmp, PS_INTLEVEL(\level) | PS_UM
+#  else
+	movi	\tmp, PS_INTLEVEL(\level) | PS_UM | PS_WOE
+#  endif
+#else
+#  ifdef __XTENSA_CALL0_ABI__
+	/* Disable all low- and medium-priority interrupts.  Nested are not yet
+	 * supported.
+	 */
+
+	movi	\tmp, PS_INTLEVEL(XCHAL_EXCM_LEVEL) | PS_UM
+#  else
+	movi	\tmp, PS_INTLEVEL(XCHAL_EXCM_LEVEL) | PS_UM | PS_WOE
+#  endif
+#endif
+
+	wsr		\tmp, PS
+	rsync
+
+	.endm
+
+/****************************************************************************
+ * Macro dispatch_c_isr level mask tmp
  *
  * Description:
  *
- * This will dispatch to user handlers (if any) that are registered in the
- * XTOS dispatch table (_xtos_interrupt_table). These handlers would have
- * been registered by calling _xtos_set_interrupt_handler(). There is one
- * exception - the timer interrupt used by the OS will not be dispatched
- * to a user handler - this must be handled by the caller of this macro.
- *
- * Level triggered and software interrupts are automatically deasserted by
- * this code.
+ * This macro will dispatch the set of pending and enabled interrupts to
+ * their handlers. It just does the necessary configuration and ends up
+ * calling xtensa_int_decode.
  *
  * Assumptions:
  *   - PS.INTLEVEL is set to "level" at entry
@@ -150,7 +190,11 @@ g_intstacktop:
  *
  ****************************************************************************/
 
-	.macro	dispatch_c_isr	level mask
+	.macro	dispatch_c_isr	level mask tmp
+
+	/* Set up PS for C, enable interrupts above this level and clear EXCM. */
+
+	ps_setup	\level \tmp
 
 #ifdef __XTENSA_CALL0_ABI__
 	/* Get mask of pending, enabled interrupts at this level into a2. */
@@ -234,51 +278,6 @@ g_intstacktop:
 	.endm
 
 /****************************************************************************
- * Macro: ps_setup
- *
- * Description:
- *   Set up PS for C, enable interrupts above this level and clear EXCM.
- *
- * Entry Conditions:
- *   level - interrupt level
- *   tmp   - scratch register
- *
- * Side Effects:
- *   PS and scratch register modified
- *
- * Assumptions:
- *   - PS.EXCM = 1, C calling disabled
- *
- ****************************************************************************/
-
-	.macro	ps_setup	level tmp
-
-#if 0 /* Nested interrupts no yet supported */
-#  ifdef __XTENSA_CALL0_ABI__
-	/* Disable interrupts at level and below */
-
-	movi	\tmp, PS_INTLEVEL(\level) | PS_UM
-#  else
-	movi	\tmp, PS_INTLEVEL(\level) | PS_UM | PS_WOE
-#  endif
-#else
-#  ifdef __XTENSA_CALL0_ABI__
-	/* Disable all low- and medium-priority interrupts.  Nested are not yet
-	 * supported.
-	 */
-
-	movi	\tmp, PS_INTLEVEL(XCHAL_EXCM_LEVEL) | PS_UM
-#  else
-	movi	\tmp, PS_INTLEVEL(XCHAL_EXCM_LEVEL) | PS_UM | PS_WOE
-#  endif
-#endif
-
-	wsr		\tmp, PS
-	rsync
-
-	.endm
-
-/****************************************************************************
  * Public Functions
  ****************************************************************************/
 
@@ -322,10 +321,6 @@ _xtensa_level1_handler:
   setintstack a13 a14
 #endif
 
-	/* Set up PS for C, enable interrupts above this level and clear EXCM. */
-
-	ps_setup	1 a0
-
 	/* Decode and dispatch the interrupt.  In the event of an interrupt
 	 * level context dispatch_c_isr() will (1) switch stacks to the new
 	 * thread's and (2) provide the address of the register state save
@@ -333,7 +328,7 @@ _xtensa_level1_handler:
 	 * in the new thread's stack.
 	 */
 
-	dispatch_c_isr	1 XCHAL_INTLEVEL1_MASK
+	dispatch_c_isr	1 XCHAL_INTLEVEL1_MASK a0
 
 	/* Restore registers in preparation to return from interrupt */
 
@@ -420,10 +415,6 @@ _xtensa_level2_handler:
 	setintstack a13 a14
 #endif
 
-	/* Set up PS for C, enable interrupts above this level and clear EXCM. */
-
-	ps_setup	2 a0
-
 	/* Decode and dispatch the interrupt.  In the event of an interrupt
 	 * level context dispatch_c_isr() will (1) switch stacks to the new
 	 * thread's and (2) provide the address of the register state save
@@ -431,7 +422,7 @@ _xtensa_level2_handler:
 	 * in the new thread's stack.
 	 */
 
-	dispatch_c_isr	2 XCHAL_INTLEVEL2_MASK
+	dispatch_c_isr	2 XCHAL_INTLEVEL2_MASK a0
 
 	/* Restore registers in preparation to return from interrupt */
 
@@ -493,10 +484,6 @@ _xtensa_level3_handler:
 	setintstack a13 a14
 #endif
 
-	/* Set up PS for C, enable interrupts above this level and clear EXCM. */
-
-	ps_setup	3 a0
-
 	/* Decode and dispatch the interrupt.  In the event of an interrupt
 	 * level context dispatch_c_isr() will (1) switch stacks to the new
 	 * thread's and (2) provide the address of the register state save
@@ -504,7 +491,7 @@ _xtensa_level3_handler:
 	 * in the new thread's stack.
 	 */
 
-	dispatch_c_isr	3 XCHAL_INTLEVEL3_MASK
+	dispatch_c_isr	3 XCHAL_INTLEVEL3_MASK a0
 
 	/* Restore registers in preparation to return from interrupt */
 
@@ -566,10 +553,6 @@ _xtensa_level4_handler:
 	setintstack a13 a14
 #endif
 
-	/* Set up PS for C, enable interrupts above this level and clear EXCM. */
-
-	ps_setup	4 a0
-
 	/* Decode and dispatch the interrupt.  In the event of an interrupt
 	 * level context dispatch_c_isr() will (1) switch stacks to the new
 	 * thread's and (2) provide the address of the register state save
@@ -577,7 +560,7 @@ _xtensa_level4_handler:
 	 * in the new thread's stack.
 	 */
 
-	dispatch_c_isr	4 XCHAL_INTLEVEL4_MASK
+	dispatch_c_isr	4 XCHAL_INTLEVEL4_MASK a0
 
 	/* Restore registers in preparation to return from interrupt */
 
@@ -639,10 +622,6 @@ _xtensa_level5_handler:
 	setintstack a13 a14
 #endif
 
-	/* Set up PS for C, enable interrupts above this level and clear EXCM. */
-
-	ps_setup	5 a0
-
 	/* Decode and dispatch the interrupt.  In the event of an interrupt
 	 * level context dispatch_c_isr() will (1) switch stacks to the new
 	 * thread's and (2) provide the address of the register state save
@@ -650,7 +629,7 @@ _xtensa_level5_handler:
 	 * in the new thread's stack.
 	 */
 
-	dispatch_c_isr	5 XCHAL_INTLEVEL5_MASK
+	dispatch_c_isr	5 XCHAL_INTLEVEL5_MASK a0
 
 	/* Restore registers in preparation to return from interrupt */
 
@@ -712,10 +691,6 @@ _xtensa_level6_handler:
 	setintstack a13 a14
 #endif
 
-	/* Set up PS for C, enable interrupts above this level and clear EXCM. */
-
-	ps_setup	6 a0
-
 	/* Decode and dispatch the interrupt.  In the event of an interrupt
 	 * level context dispatch_c_isr() will (1) switch stacks to the new
 	 * thread's and (2) provide the address of the register state save
@@ -723,7 +698,7 @@ _xtensa_level6_handler:
 	 * in the new thread's stack.
 	 */
 
-	dispatch_c_isr	6 XCHAL_INTLEVEL6_MASK
+	dispatch_c_isr	6 XCHAL_INTLEVEL6_MASK a0
 
 	/* Restore registers in preparation to return from interrupt */
 

--- a/arch/xtensa/src/common/xtensa_int_handlers.S
+++ b/arch/xtensa/src/common/xtensa_int_handlers.S
@@ -64,9 +64,15 @@
 #include <arch/xtensa/xtensa_abi.h>
 #include <arch/xtensa/xtensa_specregs.h>
 
+#include "xtensa_macros.S"
+
 #include "chip.h"
 #include "xtensa.h"
 #include "xtensa_timer.h"
+
+/****************************************************************************
+ * Public Symbols
+ ****************************************************************************/
 
 #if !defined(CONFIG_SMP) && CONFIG_ARCH_INTERRUPTSTACK > 15
  .data
@@ -102,67 +108,6 @@ g_intstacktop:
 	and		\ain, \ain, \aout			/* ain  = ain & aout */
 	bnez	\ain, 1b					    /* Repeat until ain == 0 */
 	addi	\aout, \aout, 1				/* Return aout + 1 */
-	.endm
-
-/****************************************************************************
- * Name: setintstack
- *
- * Description:
- *   Set the current stack pointer to the "top" the interrupt stack.
- *   Single CPU case.
- *   Must be provided by MCU-specific logic in the SMP case.
- *
- ****************************************************************************/
-
-#if !defined(CONFIG_SMP) && CONFIG_ARCH_INTERRUPTSTACK > 15
-	.macro	setintstack tmp1 tmp2
-	movi		a1, g_intstacktop
-	.endm
-#endif
-
-/****************************************************************************
- * Macro: ps_setup
- *
- * Description:
- *   Set up PS for C, enable interrupts above this level and clear EXCM.
- *
- * Entry Conditions:
- *   level - interrupt level
- *   tmp   - scratch register
- *
- * Side Effects:
- *   PS and scratch register modified
- *
- * Assumptions:
- *   - PS.EXCM = 1, C calling disabled
- *
- ****************************************************************************/
-
-	.macro	ps_setup	level tmp
-
-#if 0 /* Nested interrupts no yet supported */
-#  ifdef __XTENSA_CALL0_ABI__
-	/* Disable interrupts at level and below */
-
-	movi	\tmp, PS_INTLEVEL(\level) | PS_UM
-#  else
-	movi	\tmp, PS_INTLEVEL(\level) | PS_UM | PS_WOE
-#  endif
-#else
-#  ifdef __XTENSA_CALL0_ABI__
-	/* Disable all low- and medium-priority interrupts.  Nested are not yet
-	 * supported.
-	 */
-
-	movi	\tmp, PS_INTLEVEL(XCHAL_EXCM_LEVEL) | PS_UM
-#  else
-	movi	\tmp, PS_INTLEVEL(XCHAL_EXCM_LEVEL) | PS_UM | PS_WOE
-#  endif
-#endif
-
-	wsr		\tmp, PS
-	rsync
-
 	.endm
 
 /****************************************************************************

--- a/arch/xtensa/src/common/xtensa_macros.S
+++ b/arch/xtensa/src/common/xtensa_macros.S
@@ -1,0 +1,94 @@
+/****************************************************************************
+ * arch/xtensa/src/common/xtensa_macros.S
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+.file "xtensa_macros.S"
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <arch/irq.h>
+#include <arch/chip/core-isa.h>
+#include <arch/xtensa/xtensa_abi.h>
+#include <arch/xtensa/xtensa_specregs.h>
+
+/****************************************************************************
+ * Name: setintstack
+ *
+ * Description:
+ *   Set the current stack pointer to the "top" the interrupt stack.
+ *   Single CPU case.
+ *   Must be provided by MCU-specific logic in the SMP case.
+ *
+ ****************************************************************************/
+
+#if !defined(CONFIG_SMP) && CONFIG_ARCH_INTERRUPTSTACK > 15
+	.macro	setintstack tmp1 tmp2
+	movi		a1, g_intstacktop
+	.endm
+#endif
+
+/****************************************************************************
+ * Macro: ps_setup
+ *
+ * Description:
+ *   Set up PS for C, enable interrupts above this level and clear EXCM.
+ *
+ * Entry Conditions:
+ *   level - interrupt level
+ *   tmp   - scratch register
+ *
+ * Side Effects:
+ *   PS and scratch register modified
+ *
+ * Assumptions:
+ *   - PS.EXCM = 1, C calling disabled
+ *
+ ****************************************************************************/
+
+	.macro	ps_setup	level tmp
+
+#if 0 /* Nested interrupts no yet supported */
+#  ifdef __XTENSA_CALL0_ABI__
+	/* Disable interrupts at level and below */
+
+	movi	\tmp, PS_INTLEVEL(\level) | PS_UM
+#  else
+	movi	\tmp, PS_INTLEVEL(\level) | PS_UM | PS_WOE
+#  endif
+#else
+#  ifdef __XTENSA_CALL0_ABI__
+	/* Disable all low- and medium-priority interrupts.  Nested are not yet
+	 * supported.
+	 */
+
+	movi	\tmp, PS_INTLEVEL(XCHAL_EXCM_LEVEL) | PS_UM
+#  else
+	movi	\tmp, PS_INTLEVEL(XCHAL_EXCM_LEVEL) | PS_UM | PS_WOE
+#  endif
+#endif
+
+	wsr		\tmp, PS
+	rsync
+
+	.endm
+

--- a/arch/xtensa/src/common/xtensa_panic.S
+++ b/arch/xtensa/src/common/xtensa_panic.S
@@ -64,27 +64,9 @@
 #include <arch/xtensa/core.h>
 #include <arch/xtensa/xtensa_specregs.h>
 
+#include "xtensa_macros.S"
+
 #include "chip.h"
-
-/****************************************************************************
- * Assembly Language Macros
- ****************************************************************************/
-
-/****************************************************************************
- * Name: setintstack
- *
- * Description:
- *   Set the current stack pointer to the "top" the interrupt stack.
- *   Single CPU case.
- *   Must be provided by MCU-specific logic in the SMP case.
- *
- ****************************************************************************/
-
-#if !defined(CONFIG_SMP) && CONFIG_ARCH_INTERRUPTSTACK > 15
-	.macro	setintstack tmp1 tmp2
-	movi		a1, g_intstacktop
-	.endm
-#endif
 
 /****************************************************************************
  * Public Functions
@@ -147,14 +129,7 @@ _xtensa_panic:
 
 	/* Set up PS for C, re-enable hi-pri interrupts, and clear EXCM. */
 
-#ifdef __XTENSA_CALL0_ABI__
-	movi	a0, PS_INTLEVEL(XCHAL_EXCM_LEVEL) | PS_UM
-#else
-	movi	a0, PS_INTLEVEL(XCHAL_EXCM_LEVEL) | PS_UM | PS_WOE
-#endif
-
-	wsr		a0, PS
-	rsync
+  ps_setup XCHAL_EXCM_LEVEL a0
 
 	/* Call C panic handler:  Arg1 (A2) = Exception code; Arg 2 (A3) = start
 	 * of the register save area.

--- a/arch/xtensa/src/common/xtensa_user_handler.S
+++ b/arch/xtensa/src/common/xtensa_user_handler.S
@@ -64,72 +64,9 @@
 #include <arch/xtensa/core.h>
 #include <arch/xtensa/xtensa_specregs.h>
 
+#include "xtensa_macros.S"
+
 #include "chip.h"
-
-/****************************************************************************
- * Assembly Language Macros
- ****************************************************************************/
-
-/****************************************************************************
- * Name: setintstack
- *
- * Description:
- *   Set the current stack pointer to the "top" the interrupt stack.
- *   Single CPU case.
- *   Must be provided by MCU-specific logic in the SMP case.
- *
- ****************************************************************************/
-
-#if !defined(CONFIG_SMP) && CONFIG_ARCH_INTERRUPTSTACK > 15
-	.macro	setintstack tmp1 tmp2
-	movi		a1, g_intstacktop
-	.endm
-#endif
-
-/****************************************************************************
- * Macro: ps_setup
- *
- * Description:
- *   Set up PS for C, enable interrupts above this level and clear EXCM.
- *
- * Entry Conditions:
- *   level - interrupt level
- *   tmp   - scratch register
- *
- * Side Effects:
- *   PS and scratch register modified
- *
- * Assumptions:
- *   - PS.EXCM = 1, C calling disabled
- *
- ****************************************************************************/
-
-	.macro	ps_setup	level tmp
-
-#if 0 /* Nested interrupts no yet supported */
-#  ifdef __XTENSA_CALL0_ABI__
-	/* Disable interrupts at level and below */
-
-	movi	\tmp, PS_INTLEVEL(\level) | PS_UM
-#  else
-	movi	\tmp, PS_INTLEVEL(\level) | PS_UM | PS_WOE
-#  endif
-#else
-#  ifdef __XTENSA_CALL0_ABI__
-	/* Disable all low- and medium-priority interrupts.  Nested are not yet
-	 * supported.
-	 */
-
-	movi	\tmp, PS_INTLEVEL(XCHAL_EXCM_LEVEL) | PS_UM
-#  else
-	movi	\tmp, PS_INTLEVEL(XCHAL_EXCM_LEVEL) | PS_UM | PS_WOE
-#  endif
-#endif
-
-	wsr		\tmp, PS
-	rsync
-
-	.endm
 
 /****************************************************************************
  * Waypoints


### PR DESCRIPTION
## Summary
1. Move the `ps_setup` macro to a common place to not call it each time.
2. Group different assembly macros in one file to avoid redefining them each time.
## Impact
N/A
## Testing

ESP32 defconfigs.