### PR TITLE
riscv/Makefile: Delete old target used for debugging.

### DIFF
--- a/arch/risc-v/src/Makefile
+++ b/arch/risc-v/src/Makefile
@@ -213,9 +213,4 @@ endif
 	$(call DELFILE, Make.dep)
 	$(call DELFILE, .depend)
 
-info:
-	@echo $(HEAD_OBJ)
-	@echo $(ASRCS)
-	@echo $(CONFIG_ARCH_CHIP)
-
 -include Make.dep


### PR DESCRIPTION

## Summary
This target seems to have been added with the initial support https://github.com/apache/incubator-nuttx/commit/201a32cf8cfa0302a2843f36111f6a90d0faad19 and was used for debugging.
It's not used nor needed now.
## Impact
N/A
## Testing

ESP32-C3