### PR TITLE
driver/ioexpander: remove response about irq_handler

### DIFF
--- a/drivers/ioexpander/ioe_rpmsg.c
+++ b/drivers/ioexpander/ioe_rpmsg.c
@@ -452,8 +452,9 @@ static void ioe_rpmsg_irqworker(FAR void *priv_)
   msg.cbfunc = cb->cbfunc;
   msg.cbarg  = cb->cbarg;
 
-  ioe_rpmsg_sendrecv(cb->ept, IOE_RPMSG_IRQ,
-                     (struct ioe_rpmsg_header_s *)&msg, sizeof(msg));
+  msg.header.command  = IOE_RPMSG_IRQ;
+  msg.header.response = 0;
+  rpmsg_send(cb->ept, &msg, sizeof(msg));
 
   cb->pendset = 0;
 }


### PR DESCRIPTION

## Summary
driver/ioexpander: remove response about irq_handler

Signed-off-by: Jiuzhu Dong <dongjiuzhu1@xiaomi.com>

## Impact
normal using rpmsg ioexpander in irq mode
## Testing
Ci
