### PR TITLE
MPFS: Remove # CONFIG_ARCH_FPU is not set from defconfigs

### DIFF
--- a/arch/risc-v/src/opensbi/Make.defs
+++ b/arch/risc-v/src/opensbi/Make.defs
@@ -30,6 +30,7 @@ OPENSBI_CSRCS += opensbi/opensbi-3rdparty/lib/utils/timer/aclint_mtimer.c
 
 OPENSBI_ASRCS += opensbi/opensbi-3rdparty/lib/sbi/sbi_expected_trap.S
 OPENSBI_ASRCS += opensbi/opensbi-3rdparty/lib/sbi/sbi_hfence.S
+OPENSBI_ASRCS += opensbi/opensbi-3rdparty/lib/sbi/riscv_hardfp.S
 
 OPENSBI_UNPACK  = opensbi-3rdparty
 OPENSBI_COMMIT  = 4998a712b2ab504eff306110879ee05af6050177

--- a/boards/risc-v/mpfs/icicle/configs/hwtest/defconfig
+++ b/boards/risc-v/mpfs/icicle/configs/hwtest/defconfig
@@ -5,7 +5,6 @@
 # You can then do "make savedefconfig" to generate a new defconfig file that includes your
 # modifications.
 #
-# CONFIG_ARCH_FPU is not set
 # CONFIG_DISABLE_OS_API is not set
 # CONFIG_NSH_DISABLE_LOSMART is not set
 # CONFIG_SPI_CALLBACK is not set

--- a/boards/risc-v/mpfs/icicle/configs/network/defconfig
+++ b/boards/risc-v/mpfs/icicle/configs/network/defconfig
@@ -5,7 +5,6 @@
 # You can then do "make savedefconfig" to generate a new defconfig file that includes your
 # modifications.
 #
-# CONFIG_ARCH_FPU is not set
 # CONFIG_DISABLE_OS_API is not set
 # CONFIG_NDEBUG is not set
 # CONFIG_NSH_DISABLE_LOSMART is not set

--- a/boards/risc-v/mpfs/icicle/configs/nsh/defconfig
+++ b/boards/risc-v/mpfs/icicle/configs/nsh/defconfig
@@ -5,7 +5,6 @@
 # You can then do "make savedefconfig" to generate a new defconfig file that includes your
 # modifications.
 #
-# CONFIG_ARCH_FPU is not set
 # CONFIG_DISABLE_OS_API is not set
 # CONFIG_NSH_DISABLE_LOSMART is not set
 CONFIG_ARCH="risc-v"

--- a/boards/risc-v/mpfs/icicle/configs/opensbi/defconfig
+++ b/boards/risc-v/mpfs/icicle/configs/opensbi/defconfig
@@ -5,7 +5,6 @@
 # You can then do "make savedefconfig" to generate a new defconfig file that includes your
 # modifications.
 #
-# CONFIG_ARCH_FPU is not set
 # CONFIG_DISABLE_OS_API is not set
 CONFIG_ARCH="risc-v"
 CONFIG_ARCH_BOARD="icicle"

--- a/boards/risc-v/mpfs/m100pfsevp/configs/nsh/defconfig
+++ b/boards/risc-v/mpfs/m100pfsevp/configs/nsh/defconfig
@@ -5,7 +5,6 @@
 # You can then do "make savedefconfig" to generate a new defconfig file that includes your
 # modifications.
 #
-# CONFIG_ARCH_FPU is not set
 # CONFIG_DISABLE_OS_API is not set
 # CONFIG_NSH_DISABLE_LOSMART is not set
 CONFIG_ARCH="risc-v"


### PR DESCRIPTION
For some reason # CONFIG_ARCH_FPU is not set also unsets ARCH_FPU
for the .config file, meaning FPU support is not built.

## Summary
Without this, FPU does not get enabled
## Impact

## Testing

