### PR TITLE
[RISC-V] PMP: Restrict Fence instruction for chips that support S-mode

### DIFF
--- a/arch/risc-v/src/common/riscv_pmp.c
+++ b/arch/risc-v/src/common/riscv_pmp.c
@@ -600,9 +600,14 @@ int riscv_config_pmp_region(uintptr_t region, uintptr_t attr,
 #   error "XLEN of risc-v not supported"
 # endif
 
-  /* fence is needed when page-based virtual memory is implemented */
+#ifdef CONFIG_ARCH_USE_S_MODE
+  /* Fence is needed when page-based virtual memory is implemented.
+   * If page-based virtual memory is not implemented, memory accesses check
+   * the PMP settings synchronously, so no SFENCE.VMA is needed.
+   */
 
   __asm volatile("sfence.vma x0, x0" : : : "memory");
+#endif
 
   return OK;
 }

--- a/arch/risc-v/src/common/riscv_swint.c
+++ b/arch/risc-v/src/common/riscv_swint.c
@@ -555,7 +555,7 @@ int riscv_swint(int irq, void *context, void *arg)
     }
   else
     {
-      svcinfo("SWInt Return: %d\n", regs[REG_A0]);
+      svcinfo("SWInt Return: %" PRIxPTR "\n", regs[REG_A0]);
     }
 #endif
 


### PR DESCRIPTION
## Summary
This PR intends to fix the usage of PMP driver for RISC-V chips that do not implement page-based virtual memory.
If page-based virtual memory is not implemented, memory accesses check the PMP settings synchronously, so no `SFENCE.VMA` is needed.

Reference:
**3.7.2 Physical Memory Protection and Paging** section from working draft of RISC-V Privileged Spec:
https://github.com/riscv/riscv-isa-manual/releases/download/draft-20220427-db7a4a0/riscv-privileged.pdf
https://github.com/riscv/riscv-isa-manual/blob/master/src/machine.tex#L3788-L3789

## Impact
Enable the PMP driver for RISC-V chips that do not implement page-based virtual memory (e.g. Espressif ESP32-C3).

## Testing
`esp32c3-devkit`
