### PR TITLE
nuttx: fix  coverity check error 

### DIFF
--- a/libs/libc/pthread/pthread_mutexattr_setrobust.c
+++ b/libs/libc/pthread/pthread_mutexattr_setrobust.c
@@ -62,7 +62,7 @@ int pthread_mutexattr_setrobust(pthread_mutexattr_t *attr, int robust)
 #elif defined(CONFIG_PTHREAD_MUTEX_BOTH)
 
   if (attr != NULL && (robust == PTHREAD_MUTEX_STALLED ||
-      robust == _PTHREAD_MFLAGS_ROBUST))
+      robust == PTHREAD_MUTEX_ROBUST))
     {
       attr->robust = robust;
       return OK;

--- a/sched/pthread/pthread_mutexinit.c
+++ b/sched/pthread/pthread_mutexinit.c
@@ -69,9 +69,9 @@ int pthread_mutex_init(FAR pthread_mutex_t *mutex,
 #endif
 #ifndef CONFIG_PTHREAD_MUTEX_UNSAFE
 #ifdef CONFIG_PTHREAD_MUTEX_DEFAULT_UNSAFE
-  uint8_t robust = PTHREAD_MUTEX_STALLED;
+  uint8_t flags = 0;
 #else
-  uint8_t robust = PTHREAD_MUTEX_ROBUST;
+  uint8_t flags = _PTHREAD_MFLAGS_ROBUST;
 #endif
 #endif
   int ret = OK;
@@ -97,7 +97,8 @@ int pthread_mutex_init(FAR pthread_mutex_t *mutex,
           type    = attr->type;
 #endif
 #ifdef CONFIG_PTHREAD_MUTEX_BOTH
-          robust  = attr->robust;
+          flags  = attr->robust == PTHREAD_MUTEX_ROBUST ?
+                   _PTHREAD_MFLAGS_ROBUST : 0;
 #endif
         }
 
@@ -127,8 +128,8 @@ int pthread_mutex_init(FAR pthread_mutex_t *mutex,
       /* Initial internal fields of the mutex */
 
       mutex->flink  = NULL;
-      mutex->flags  = (robust == PTHREAD_MUTEX_ROBUST ?
-                       _PTHREAD_MFLAGS_ROBUST : 0);
+
+      mutex->flags  = flags;
 #endif
 
 #ifdef CONFIG_PTHREAD_MUTEX_TYPES

--- a/sched/timer/timer_settime.c
+++ b/sched/timer/timer_settime.c
@@ -287,7 +287,7 @@ int timer_settime(timer_t timerid, int flags,
     {
       /* Calculate a delay corresponding to the absolute time in 'value' */
 
-      clock_abstime2ticks(timer->pt_clock, &value->it_value, &delay);
+      ret = clock_abstime2ticks(timer->pt_clock, &value->it_value, &delay);
     }
   else
     {
@@ -296,7 +296,14 @@ int timer_settime(timer_t timerid, int flags,
        * returns success.
        */
 
-      clock_time2ticks(&value->it_value, &delay);
+      ret = clock_time2ticks(&value->it_value, &delay);
+    }
+
+  if (ret < 0)
+    {
+      set_errno(-ret);
+      ret = ERROR;
+      goto errout;
     }
 
   /* If the time is in the past or now, then set up the next interval
@@ -324,6 +331,7 @@ int timer_settime(timer_t timerid, int flags,
         }
     }
 
+errout:
   leave_critical_section(intflags);
   return ret;
 }


### PR DESCRIPTION
## Summary

Patch 1:  fix deadcode in pthread_mutexinit
Patch 2: timer:settime: check return value of clock_abstime2ticks

## Impact

No. bug fix

## Testing

Testing in armv8-m board
