### PR TITLE
UMM: Implement getter for address environment heap start vaddr

### DIFF
--- a/arch/arm/src/armv7-a/arm_addrenv.c
+++ b/arch/arm/src/armv7-a/arm_addrenv.c
@@ -448,6 +448,33 @@ int up_addrenv_vdata(group_addrenv_t *addrenv, uintptr_t textsize,
 }
 
 /****************************************************************************
+ * Name: up_addrenv_vheap
+ *
+ * Description:
+ *   Return the heap virtual address associated with the newly created
+ *   address environment.  This function is used by the binary loaders in
+ *   order get an address that can be used to initialize the new task.
+ *
+ * Input Parameters:
+ *   addrenv - The representation of the task address environment previously
+ *      returned by up_addrenv_create.
+ *   vheap - The location to return the virtual address.
+ *
+ * Returned Value:
+ *   Zero (OK) on success; a negated errno value on failure.
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_BUILD_KERNEL
+int up_addrenv_vheap(const group_addrenv_t *addrenv, void **vheap)
+{
+  DEBUGASSERT(addrenv && vheap);
+  *vheap = (void *)CONFIG_ARCH_HEAP_VBASE;
+  return OK;
+}
+#endif
+
+/****************************************************************************
  * Name: up_addrenv_heapsize
  *
  * Description:

--- a/arch/risc-v/src/common/riscv_addrenv.c
+++ b/arch/risc-v/src/common/riscv_addrenv.c
@@ -591,6 +591,33 @@ int up_addrenv_vdata(group_addrenv_t *addrenv, uintptr_t textsize,
 }
 
 /****************************************************************************
+ * Name: up_addrenv_vheap
+ *
+ * Description:
+ *   Return the heap virtual address associated with the newly created
+ *   address environment.  This function is used by the binary loaders in
+ *   order get an address that can be used to initialize the new task.
+ *
+ * Input Parameters:
+ *   addrenv - The representation of the task address environment previously
+ *      returned by up_addrenv_create.
+ *   vheap - The location to return the virtual address.
+ *
+ * Returned Value:
+ *   Zero (OK) on success; a negated errno value on failure.
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_BUILD_KERNEL
+int up_addrenv_vheap(const group_addrenv_t *addrenv, void **vheap)
+{
+  DEBUGASSERT(addrenv && vheap);
+  *vheap = (void *)addrenv->heapvbase;
+  return OK;
+}
+#endif
+
+/****************************************************************************
  * Name: up_addrenv_heapsize
  *
  * Description:

--- a/arch/z80/src/z180/z180_mmu.c
+++ b/arch/z80/src/z180/z180_mmu.c
@@ -376,6 +376,33 @@ int up_addrenv_vdata(FAR group_addrenv_t *addrenv, uintptr_t textsize,
 }
 
 /****************************************************************************
+ * Name: up_addrenv_vheap
+ *
+ * Description:
+ *   Return the heap virtual address associated with the newly created
+ *   address environment.  This function is used by the binary loaders in
+ *   order get an address that can be used to initialize the new task.
+ *
+ * Input Parameters:
+ *   addrenv - The representation of the task address environment previously
+ *      returned by up_addrenv_create.
+ *   vheap - The location to return the virtual address.
+ *
+ * Returned Value:
+ *   Zero (OK) on success; a negated errno value on failure.
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_BUILD_KERNEL
+int up_addrenv_vheap(FAR const group_addrenv_t *addrenv, FAR void **vheap)
+{
+  /* Not implemented */
+
+  return -ENOSYS;
+}
+#endif
+
+/****************************************************************************
  * Name: up_addrenv_heapsize
  *
  * Description:

--- a/binfmt/binfmt_execmodule.c
+++ b/binfmt/binfmt_execmodule.c
@@ -118,6 +118,7 @@ int exec_module(FAR const struct binary_s *binp,
   FAR struct task_tcb_s *tcb;
 #if defined(CONFIG_ARCH_ADDRENV) && defined(CONFIG_BUILD_KERNEL)
   save_addrenv_t oldenv;
+  FAR void *vheap;
 #endif
   pid_t pid;
   int ret;
@@ -173,8 +174,15 @@ int exec_module(FAR const struct binary_s *binp,
       goto errout_with_envp;
     }
 
-  binfo("Initialize the user heap (heapsize=%d)\n", binp->addrenv.heapsize);
-  umm_initialize((FAR void *)CONFIG_ARCH_HEAP_VBASE, binp->addrenv.heapsize);
+  ret = up_addrenv_vheap(&binp->addrenv, &vheap);
+  if (ret < 0)
+    {
+      berr("ERROR: up_addrenv_vheap() failed: %d\n", ret);
+      goto errout_with_addrenv;
+    }
+
+  binfo("Initialize the user heap (heapsize=%zu)\n", binp->addrenv.heapsize);
+  umm_initialize(vheap, up_addrenv_heapsize(&binp->addrenv));
 #endif
 
   /* Note that tcb->flags are not modified.  0=normal task */

--- a/include/nuttx/addrenv.h
+++ b/include/nuttx/addrenv.h
@@ -283,6 +283,8 @@ struct addrenv_reserve_s
  *                         address environment
  *   up_addrenv_vdata    - Returns the virtual base address of the .bss/.data
  *                         address environment
+ *   up_addrenv_vheap    - Returns the virtual base address of the heap
+ *                         address environment
  *   up_addrenv_heapsize - Returns the size of the initial heap allocation.
  *   up_addrenv_select   - Instantiate an address environment
  *   up_addrenv_restore  - Restore an address environment

--- a/include/nuttx/arch.h
+++ b/include/nuttx/arch.h
@@ -831,6 +831,8 @@ void up_textheap_free(FAR void *p);
  *                         address environment
  *   up_addrenv_vdata    - Returns the virtual base address of the .bss/.data
  *                         address environment
+ *   up_addrenv_vheap    - Returns the virtual base address of the heap
+ *                         address environment
  *   up_addrenv_heapsize - Returns the size of the initial heap allocation.
  *   up_addrenv_select   - Instantiate an address environment
  *   up_addrenv_restore  - Restore an address environment
@@ -990,6 +992,28 @@ int up_addrenv_vtext(FAR group_addrenv_t *addrenv, FAR void **vtext);
 #ifdef CONFIG_ARCH_ADDRENV
 int up_addrenv_vdata(FAR group_addrenv_t *addrenv, uintptr_t textsize,
                      FAR void **vdata);
+#endif
+
+/****************************************************************************
+ * Name: up_addrenv_vheap
+ *
+ * Description:
+ *   Return the heap virtual address associated with the newly created
+ *   address environment.  This function is used by the binary loaders in
+ *   order get an address that can be used to initialize the new task.
+ *
+ * Input Parameters:
+ *   addrenv - The representation of the task address environment previously
+ *      returned by up_addrenv_create.
+ *   vheap - The location to return the virtual address.
+ *
+ * Returned Value:
+ *   Zero (OK) on success; a negated errno value on failure.
+ *
+ ****************************************************************************/
+
+#if defined(CONFIG_ARCH_ADDRENV) && defined(CONFIG_BUILD_KERNEL)
+int up_addrenv_vheap(FAR const group_addrenv_t *addrenv, FAR void **vheap);
 #endif
 
 /****************************************************************************


### PR DESCRIPTION
Using the Kconfig macro does not work for RISC-V target, as there the
user heap follows .data/.bss and does not obey any Kconfig provided
boundary.

Added stubs for ARM and Z80 also.

## Summary

## Impact

## Testing

