### PR TITLE
armv7-a/r: use cps instruction to change cpu mode

### DIFF
--- a/arch/arm/src/armv7-a/arm_cpuhead.S
+++ b/arch/arm/src/armv7-a/arm_cpuhead.S
@@ -94,8 +94,7 @@
 __cpu1_start:
 	/* Make sure that we are in SYS mode with IRQs and FIQs disabled */
 
-	mov		r0, #(PSR_MODE_SYS | PSR_I_BIT | PSR_F_BIT)
-	msr		cpsr_c, r0
+	cpsid		if, #PSR_MODE_SYS
 
 	/* Set up the stack pointer and the CPU index */
 
@@ -118,8 +117,7 @@ __cpu1_start:
 __cpu2_start:
 	/* Make sure that we are in SYS mode with IRQs and FIQs disabled */
 
-	mov		r0, #(PSR_MODE_SYS | PSR_I_BIT | PSR_F_BIT)
-	msr		cpsr_c, r0
+	cpsid		if, #PSR_MODE_SYS
 
 	/* Set up the stack pointer and the CPU index */
 
@@ -142,8 +140,7 @@ __cpu2_start:
 __cpu3_start:
 	/* Make sure that we are in SYS mode with IRQs and FIQs disabled */
 
-	mov		r0, #(PSR_MODE_SYS | PSR_I_BIT | PSR_F_BIT)
-	msr		cpsr_c, r0
+	cpsid		if, #PSR_MODE_SYS
 
 	/* Set up the stack pointer and the CPU index */
 

--- a/arch/arm/src/armv7-a/arm_head.S
+++ b/arch/arm/src/armv7-a/arm_head.S
@@ -174,8 +174,7 @@
 __start:
 	/* Make sure that we are in SYS mode with IRQs and FIQs disabled */
 
-	mov		r0, #(PSR_MODE_SYS | PSR_I_BIT | PSR_F_BIT)
-	msr		cpsr_c, r0
+	cpsid		if, #PSR_MODE_SYS
 
 	/* The MMU and caches should be disabled */
 

--- a/arch/arm/src/armv7-a/arm_pghead.S
+++ b/arch/arm/src/armv7-a/arm_pghead.S
@@ -203,8 +203,7 @@
 __start:
 	/* Make sure that we are in SYS mode with IRQs and FIQs disabled */
 
-	mov		r0, #(PSR_MODE_SYS | PSR_I_BIT | PSR_F_BIT)
-	msr		cpsr_c, r0
+	cpsid		if, #PSR_MODE_SYS
 
 	/* Clear the 16K level 1 page table */
 

--- a/arch/arm/src/armv7-a/arm_vectors.S
+++ b/arch/arm/src/armv7-a/arm_vectors.S
@@ -171,16 +171,13 @@
 	.type	arm_vectorirq, %function
 
 arm_vectorirq:
-	/* On entry, we are in IRQ mode.  We are free to use the IRQ mode r13
-	 * and r14.
-	 */
+	/* Switch to SYS mode */
 
 #ifdef CONFIG_ARMV7A_DECODEFIQ
-	mov		r13, #(PSR_MODE_SYS | PSR_I_BIT | PSR_F_BIT)
+	cpsid		if, #PSR_MODE_SYS
 #else
-	mov		r13, #(PSR_MODE_SYS | PSR_I_BIT)
+	cpsid		i, #PSR_MODE_SYS
 #endif
-	msr		cpsr_c, r13			/* Switch to SYS mode */
 
 	/* Create a context structure.  First set aside a stack frame
 	 * and store r0-r12 into the frame.
@@ -189,26 +186,14 @@ arm_vectorirq:
 	sub		sp, sp, #XCPTCONTEXT_SIZE
 	stmia		sp, {r0-r12}			/* Save the SYS mode regs */
 
-#ifdef CONFIG_ARMV7A_DECODEFIQ
-	mov		r0, #(PSR_MODE_IRQ | PSR_I_BIT | PSR_F_BIT)
-#else
-	mov		r0, #(PSR_MODE_IRQ | PSR_I_BIT)
-#endif
-	msr		cpsr_c, r0			/* Switch back IRQ mode */
+	cps		#PSR_MODE_IRQ			/* Switch back IRQ mode */
 
 	/* Get the values for r15(pc) and CPSR in r3 and r4 */
 
 	sub		r3, lr, #4
 	mrs		r4, spsr
 
-	/* Then switch back to SYS mode */
-
-#ifdef CONFIG_ARMV7A_DECODEFIQ
-	orr		r0, r0, #(PSR_MODE_SYS | PSR_I_BIT | PSR_F_BIT)
-#else
-	orr		r0, r0, #(PSR_MODE_SYS | PSR_I_BIT)
-#endif
-	msr		cpsr_c, r0
+	cps		#PSR_MODE_SYS			/* Then switch back to SYS mode */
 
 	/* Get the correct values of USR/SYS r13(sp) and r14(lr) in r1 and r2 */
 
@@ -272,12 +257,7 @@ arm_vectorirq:
 
 	/* Switch back IRQ mode and return with shadow SPSR */
 
-#ifdef CONFIG_ARMV7A_DECODEFIQ
-	mov		r4, #(PSR_MODE_IRQ | PSR_I_BIT | PSR_F_BIT)
-#else
-	mov		r4, #(PSR_MODE_IRQ | PSR_I_BIT)
-#endif
-	msr		cpsr_c, r4			/* Switch back IRQ mode */
+	cps		#PSR_MODE_IRQ
 
 	/* Upon return from arm_decodeirq, r0 holds the pointer to the register
 	 * state save area to use to restore the registers.  This may or may not
@@ -319,13 +299,13 @@ arm_vectorirq:
 	.type	arm_vectorsvc, %function
 
 arm_vectorsvc:
+	/* Switch to SYS mode */
 
 #ifdef CONFIG_ARMV7A_DECODEFIQ
-	mov		r13, #(PSR_MODE_SYS | PSR_I_BIT | PSR_F_BIT)
+	cpsid		if, #PSR_MODE_SYS
 #else
-	mov		r13, #(PSR_MODE_SYS | PSR_I_BIT)
+	cpsid		i, #PSR_MODE_SYS
 #endif
-	msr		cpsr_c, r13			/* Switch to SYS mode */
 
 	/* Create a context structure.  First set aside a stack frame
 	 * and store r0-r12 into the frame.
@@ -334,24 +314,14 @@ arm_vectorsvc:
 	sub		sp, sp, #XCPTCONTEXT_SIZE
 	stmia		sp, {r0-r12}			/* Save the SYS mode regs */
 
-#ifdef CONFIG_ARMV7A_DECODEFIQ
-	mov		r0, #(PSR_MODE_SVC | PSR_I_BIT | PSR_F_BIT)
-#else
-	mov		r0, #(PSR_MODE_SVC | PSR_I_BIT)
-#endif
-	msr		cpsr_c, r0			/* Switch back SVC mode */
+	cps		#PSR_MODE_SVC			/* Switch back SVC mode */
 
 	/* Get the values for r15(pc) and CPSR in r3 and r4 */
 
 	mov		r3, r14				/* Save r14 as the PC as well */
 	mrs		r4, spsr			/* Get the saved CPSR */
 
-#ifdef CONFIG_ARMV7A_DECODEFIQ
-	orr		r0, r0, #(PSR_MODE_SYS | PSR_I_BIT | PSR_F_BIT)
-#else
-	orr		r0, r0, #(PSR_MODE_SYS | PSR_I_BIT)
-#endif
-	msr		cpsr_c, r0
+	cps		#PSR_MODE_SYS			/* Then switch back to SYS mode */
 
 	/* Get the correct values of USR/SYS r13(sp) and r14(lr) in r1 and r2 */
 
@@ -417,12 +387,7 @@ arm_vectorsvc:
 
 	/* Switch back SVC mode and return with shadow SPSR */
 
-#ifdef CONFIG_ARMV7A_DECODEFIQ
-	mov		r4, #(PSR_MODE_SVC | PSR_I_BIT | PSR_F_BIT)
-#else
-	mov		r4, #(PSR_MODE_SVC | PSR_I_BIT)
-#endif
-	msr		cpsr_c, r4			/* Switch back SVC mode */
+	cps		#PSR_MODE_SVC
 
 	/* Upon return from arm_syscall, r0 holds the pointer to the register
 	 * state save area to use to restore the registers.  This may or may not
@@ -462,16 +427,13 @@ arm_vectorsvc:
 	.type	arm_vectordata, %function
 
 arm_vectordata:
-	/* On entry we are free to use the ABORT mode registers
-	 * r13 and r14
-	 */
+	/* Switch to SYS mode */
 
 #ifdef CONFIG_ARMV7A_DECODEFIQ
-	mov		r13, #(PSR_MODE_SYS | PSR_I_BIT | PSR_F_BIT)
+	cpsid		if, #PSR_MODE_SYS
 #else
-	mov		r13, #(PSR_MODE_SYS | PSR_I_BIT)
+	cpsid		i, #PSR_MODE_SYS
 #endif
-	msr		cpsr_c, r13			/* Switch to SYS mode */
 
 	/* Create a context structure.  First set aside a stack frame
 	 * and store r0-r12 into the frame.
@@ -480,26 +442,14 @@ arm_vectordata:
 	sub		sp, sp, #XCPTCONTEXT_SIZE
 	stmia		sp, {r0-r12}			/* Save the SYS mode regs */
 
-#ifdef CONFIG_ARMV7A_DECODEFIQ
-	mov		r0, #(PSR_MODE_ABT | PSR_I_BIT | PSR_F_BIT)
-#else
-	mov		r0, #(PSR_MODE_ABT | PSR_I_BIT)
-#endif
-	msr		cpsr_c, r0			/* Switch back ABT mode */
+	cps		#PSR_MODE_ABT			/* Switch back ABT mode */
 
 	/* Get the values for r15(pc) and CPSR in r3 and r4 */
 
 	sub		r3, lr, #8
 	mrs		r4, spsr
 
-	/* Then switch back to SYS mode */
-
-#ifdef CONFIG_ARMV7A_DECODEFIQ
-	mov		r0, #(PSR_MODE_SYS | PSR_I_BIT | PSR_F_BIT)
-#else
-	mov		r0, #(PSR_MODE_SYS | PSR_I_BIT)
-#endif
-	msr		cpsr_c, r0
+	cps		#PSR_MODE_SYS			/* Then switch back to SYS mode */
 
 	/* Get the correct values of USR/SYS r13(sp) and r14(lr) in r1 and r2 */
 
@@ -540,12 +490,7 @@ arm_vectordata:
 
 	/* Switch back ABT mode and return with shadow SPSR */
 
-#ifdef CONFIG_ARMV7A_DECODEFIQ
-	mov		r4, #(PSR_MODE_ABT | PSR_I_BIT | PSR_F_BIT)
-#else
-	mov		r4, #(PSR_MODE_ABT | PSR_I_BIT)
-#endif
-	msr		cpsr_c, r4			/* Switch back ABT mode */
+	cps		#PSR_MODE_ABT
 
 	/* Upon return from arm_dataabort, r0 holds the pointer to the register
 	 * state save area to use to restore the registers.  This may or may not
@@ -585,12 +530,7 @@ arm_vectordata:
 	.type	arm_vectorprefetch, %function
 
 arm_vectorprefetch:
-	/* On entry we are free to use the ABORT mode registers
-	 * r13 and r14
-	 */
-
-	mov		r13, #(PSR_MODE_SYS | PSR_I_BIT | PSR_F_BIT)
-	msr		cpsr_c, r13			/* Switch to SYS mode */
+	cpsid		if, #PSR_MODE_SYS		/* Switch to SYS mode */
 
 	/* Create a context structure.  First set aside a stack frame
 	 * and store r0-r12 into the frame.
@@ -599,18 +539,14 @@ arm_vectorprefetch:
 	sub		sp, sp, #XCPTCONTEXT_SIZE
 	stmia		sp, {r0-r12}			/* Save the SYS mode regs */
 
-	mov		r0, #(PSR_MODE_ABT | PSR_I_BIT | PSR_F_BIT)
-	msr		cpsr_c, r0			/* Switch back ABT mode */
+	cps		#PSR_MODE_ABT			/* Switch back ABT mode */
 
 	/* Get the values for r15(pc) and CPSR in r3 and r4 */
 
 	sub		r3, lr, #4
 	mrs		r4, spsr
 
-	/* Then switch back to SYS mode */
-
-	mov		r0, #(PSR_MODE_SYS | PSR_I_BIT | PSR_F_BIT)
-	msr		cpsr_c, r0
+	cps		#PSR_MODE_SYS			/* Then switch back to SYS mode */
 
 	/* Get the correct values of USR/SYS r13(sp) and r14(lr) in r1 and r2 */
 
@@ -651,12 +587,7 @@ arm_vectorprefetch:
 
 	/* Switch back ABT mode and return with shadow SPSR */
 
-#ifdef CONFIG_ARMV7A_DECODEFIQ
-	mov		r4, #(PSR_MODE_ABT | PSR_I_BIT | PSR_F_BIT)
-#else
-	mov		r4, #(PSR_MODE_ABT | PSR_I_BIT)
-#endif
-	msr		cpsr_c, r4			/* Switch back ABT mode */
+	cps		#PSR_MODE_ABT
 
 	/* Upon return from arm_prefetchabort, r0 holds the pointer to the register
 	 * state save area to use to restore the registers.  This may or may not
@@ -694,12 +625,7 @@ arm_vectorprefetch:
 	.type	arm_vectorundefinsn, %function
 
 arm_vectorundefinsn:
-	/* On entry we are free to use the UND mode registers
-	 * r13 and r14
-	 */
-
-	mov		r13, #(PSR_MODE_SYS | PSR_I_BIT | PSR_F_BIT)
-	msr		cpsr_c, r13			/* Switch to SYS mode */
+	cpsid		if, #PSR_MODE_SYS		/* Switch to SYS mode */
 
 	/* Create a context structure.  First set aside a stack frame
 	 * and store r0-r12 into the frame.
@@ -708,18 +634,14 @@ arm_vectorundefinsn:
 	sub		sp, sp, #XCPTCONTEXT_SIZE
 	stmia		sp, {r0-r12}			/* Save the SYS mode regs */
 
-	mov		r0, #(PSR_MODE_UND | PSR_I_BIT | PSR_F_BIT)
-	msr		cpsr_c, r0			/* Switch back UND mode */
+	cps		#PSR_MODE_UND			/* Switch back UND mode */
 
 	/* Get the values for r15(pc) and CPSR in r3 and r4 */
 
 	mov		r3, lr
 	mrs		r4, spsr
 
-	/* Then switch back to SYS mode */
-
-	mov		r0, #(PSR_MODE_SYS | PSR_I_BIT | PSR_F_BIT)
-	msr		cpsr_c, r0
+	cps		#PSR_MODE_SYS			/* Then switch back to SYS mode */
 
 	/* Get the correct values of USR/SYS r13(sp) and r14(lr) in r1 and r2 */
 
@@ -758,12 +680,7 @@ arm_vectorundefinsn:
 
 	/* Switch back UND mode and return with shadow SPSR */
 
-#ifdef CONFIG_ARMV7A_DECODEFIQ
-	mov		r4, #(PSR_MODE_UND | PSR_I_BIT | PSR_F_BIT)
-#else
-	mov		r4, #(PSR_MODE_UND | PSR_I_BIT)
-#endif
-	msr		cpsr_c, r4			/* Switch back UND mode */
+	cps		#PSR_MODE_UND
 
 	/* Upon return from arm_undefinedinsn, r0 holds the pointer to the register
 	 * state save area to use to restore the registers.  This may or may not
@@ -804,10 +721,7 @@ arm_vectorundefinsn:
 
 arm_vectorfiq:
 #ifdef CONFIG_ARMV7A_DECODEFIQ
-	/* On entry we are free to use the FIQ mode registers r8 through r14 */
-
-	mov		r13, #(PSR_MODE_SYS | PSR_I_BIT | PSR_F_BIT)
-	msr		cpsr_c, r13			/* Switch to SYS mode */
+	cpsid		if, #PSR_MODE_SYS		/* Switch to SYS mode */
 
 	/* Create a context structure.  First set aside a stack frame
 	 * and store r0-r12 into the frame.
@@ -816,18 +730,14 @@ arm_vectorfiq:
 	sub		sp, sp, #XCPTCONTEXT_SIZE
 	stmia		sp, {r0-r12}			/* Save the SYS mode regs */
 
-	mov		r0, #(PSR_MODE_FIQ | PSR_I_BIT | PSR_F_BIT)
-	msr		cpsr_c, r0			/* Switch back FIQ mode */
+	cps		#PSR_MODE_FIQ			/* Switch back FIQ mode */
 
 	/* Get the values for r15(pc) and CPSR in r3 and r4 */
 
 	sub		r3, lr, #4
 	mrs		r4, spsr
 
-	/* Then switch back to SYS mode */
-
-	mov		r0, #(PSR_MODE_SYS | PSR_I_BIT | PSR_F_BIT)
-	msr		cpsr_c, r0
+	cps		#PSR_MODE_SYS			/* Then switch back to SYS mode */
 
 	/* Get the correct values of USR/SYS r13(sp) and r14(lr) in r1 and r2 */
 
@@ -878,12 +788,7 @@ arm_vectorfiq:
 
 	/* Switch back FIQ mode and return with shadow SPSR */
 
-#ifdef CONFIG_ARMV7A_DECODEFIQ
-	mov		r4, #(PSR_MODE_FIQ | PSR_I_BIT | PSR_F_BIT)
-#else
-	mov		r4, #(PSR_MODE_FIQ | PSR_I_BIT)
-#endif
-	msr		cpsr_c, r4			/* Switch back FIQ mode */
+	cps		#PSR_MODE_FIQ
 
 	/* Upon return from arm_decodefiq, r0 holds the pointer to the register
 	 * state save area to use to restore the registers.  This may or may not

--- a/arch/arm/src/armv7-r/arm_head.S
+++ b/arch/arm/src/armv7-r/arm_head.S
@@ -136,8 +136,7 @@
 __start:
 	/* Make sure that we are in SYS mode with IRQs and FIQs disabled */
 
-	mov		r0, #(PSR_MODE_SYS | PSR_I_BIT | PSR_F_BIT)
-	msr		cpsr_c, r0
+	cpsid		if, #PSR_MODE_SYS
 
 	/* Set up the stack pointer and clear the frame pointer. */
 

--- a/arch/arm/src/armv7-r/arm_vectors.S
+++ b/arch/arm/src/armv7-r/arm_vectors.S
@@ -125,16 +125,13 @@
 	.type	arm_vectorirq, %function
 
 arm_vectorirq:
-	/* On entry, we are in IRQ mode.  We are free to use the IRQ mode r13
-	 * and r14.
-	 */
+	/* Switch to SYS mode */
 
 #ifdef CONFIG_ARMV7A_DECODEFIQ
-	mov		r13, #(PSR_MODE_SYS | PSR_I_BIT | PSR_F_BIT)
+	cpsid		if, #PSR_MODE_SYS
 #else
-	mov		r13, #(PSR_MODE_SYS | PSR_I_BIT)
+	cpsid		i, #PSR_MODE_SYS
 #endif
-	msr		cpsr_c, r13			/* Switch to SYS mode */
 
 	/* Create a context structure.  First set aside a stack frame
 	 * and store r0-r12 into the frame.
@@ -143,26 +140,14 @@ arm_vectorirq:
 	sub		sp, sp, #XCPTCONTEXT_SIZE
 	stmia		sp, {r0-r12}			/* Save the SYS mode regs */
 
-#ifdef CONFIG_ARMV7A_DECODEFIQ
-	mov		r0, #(PSR_MODE_IRQ | PSR_I_BIT | PSR_F_BIT)
-#else
-	mov		r0, #(PSR_MODE_IRQ | PSR_I_BIT)
-#endif
-	msr		cpsr_c, r0			/* Switch back IRQ mode */
+	cps		#PSR_MODE_IRQ			/* Switch back IRQ mode */
 
 	/* Get the values for r15(pc) and CPSR in r3 and r4 */
 
 	sub		r3, lr, #4
 	mrs		r4, spsr
 
-	/* Then switch back to SYS mode */
-
-#ifdef CONFIG_ARMV7A_DECODEFIQ
-	orr		r0, r0, #(PSR_MODE_SYS | PSR_I_BIT | PSR_F_BIT)
-#else
-	orr		r0, r0, #(PSR_MODE_SYS | PSR_I_BIT)
-#endif
-	msr		cpsr_c, r0
+	cps		#PSR_MODE_SYS			/* Then switch back to SYS mode */
 
 	/* Get the correct values of USR/SYS r13(sp) and r14(lr) in r1 and r2 */
 
@@ -226,12 +211,7 @@ arm_vectorirq:
 
 	/* Switch back IRQ mode and return with shadow SPSR */
 
-#ifdef CONFIG_ARMV7A_DECODEFIQ
-	mov		r4, #(PSR_MODE_IRQ | PSR_I_BIT | PSR_F_BIT)
-#else
-	mov		r4, #(PSR_MODE_IRQ | PSR_I_BIT)
-#endif
-	msr		cpsr_c, r4			/* Switch back IRQ mode */
+	cps		#PSR_MODE_IRQ
 
 	/* Upon return from arm_decodeirq, r0 holds the pointer to the register
 	 * state save area to use to restore the registers.  This may or may not
@@ -273,13 +253,13 @@ arm_vectorirq:
 	.type	arm_vectorsvc, %function
 
 arm_vectorsvc:
+	/* Switch to SYS mode */
 
 #ifdef CONFIG_ARMV7A_DECODEFIQ
-	mov		r13, #(PSR_MODE_SYS | PSR_I_BIT | PSR_F_BIT)
+	cpsid		if, #PSR_MODE_SYS
 #else
-	mov		r13, #(PSR_MODE_SYS | PSR_I_BIT)
+	cpsid		i, #PSR_MODE_SYS
 #endif
-	msr		cpsr_c, r13			/* Switch to SYS mode */
 
 	/* Create a context structure.  First set aside a stack frame
 	 * and store r0-r12 into the frame.
@@ -288,24 +268,14 @@ arm_vectorsvc:
 	sub		sp, sp, #XCPTCONTEXT_SIZE
 	stmia		sp, {r0-r12}			/* Save the SYS mode regs */
 
-#ifdef CONFIG_ARMV7A_DECODEFIQ
-	mov		r0, #(PSR_MODE_SVC | PSR_I_BIT | PSR_F_BIT)
-#else
-	mov		r0, #(PSR_MODE_SVC | PSR_I_BIT)
-#endif
-	msr		cpsr_c, r0			/* Switch back SVC mode */
+	cps		#PSR_MODE_SVC			/* Switch back SVC mode */
 
 	/* Get the values for r15(pc) and CPSR in r3 and r4 */
 
 	mov		r3, r14				/* Save r14 as the PC as well */
 	mrs		r4, spsr			/* Get the saved CPSR */
 
-#ifdef CONFIG_ARMV7A_DECODEFIQ
-	orr		r0, r0, #(PSR_MODE_SYS | PSR_I_BIT | PSR_F_BIT)
-#else
-	orr		r0, r0, #(PSR_MODE_SYS | PSR_I_BIT)
-#endif
-	msr		cpsr_c, r0
+	cps		#PSR_MODE_SYS			/* Then switch back to SYS mode */
 
 	/* Get the correct values of USR/SYS r13(sp) and r14(lr) in r1 and r2 */
 
@@ -371,12 +341,7 @@ arm_vectorsvc:
 
 	/* Switch back SVC mode and return with shadow SPSR */
 
-#ifdef CONFIG_ARMV7A_DECODEFIQ
-	mov		r4, #(PSR_MODE_SVC | PSR_I_BIT | PSR_F_BIT)
-#else
-	mov		r4, #(PSR_MODE_SVC | PSR_I_BIT)
-#endif
-	msr		cpsr_c, r4			/* Switch back SVC mode */
+	cps		#PSR_MODE_SVC
 
 	/* Upon return from arm_syscall, r0 holds the pointer to the register
 	 * state save area to use to restore the registers.  This may or may not
@@ -416,16 +381,13 @@ arm_vectorsvc:
 	.type	arm_vectordata, %function
 
 arm_vectordata:
-	/* On entry we are free to use the ABORT mode registers
-	 * r13 and r14
-	 */
+	/* Switch to SYS mode */
 
 #ifdef CONFIG_ARMV7A_DECODEFIQ
-	mov		r13, #(PSR_MODE_SYS | PSR_I_BIT | PSR_F_BIT)
+	cpsid		if, #PSR_MODE_SYS
 #else
-	mov		r13, #(PSR_MODE_SYS | PSR_I_BIT)
+	cpsid		i, #PSR_MODE_SYS
 #endif
-	msr		cpsr_c, r13			/* Switch to SYS mode */
 
 	/* Create a context structure.  First set aside a stack frame
 	 * and store r0-r12 into the frame.
@@ -434,26 +396,14 @@ arm_vectordata:
 	sub		sp, sp, #XCPTCONTEXT_SIZE
 	stmia		sp, {r0-r12}			/* Save the SYS mode regs */
 
-#ifdef CONFIG_ARMV7A_DECODEFIQ
-	mov		r0, #(PSR_MODE_ABT | PSR_I_BIT | PSR_F_BIT)
-#else
-	mov		r0, #(PSR_MODE_ABT | PSR_I_BIT)
-#endif
-	msr		cpsr_c, r0			/* Switch back ABT mode */
+	cps		#PSR_MODE_ABT			/* Switch back ABT mode */
 
 	/* Get the values for r15(pc) and CPSR in r3 and r4 */
 
 	sub		r3, lr, #8
 	mrs		r4, spsr
 
-	/* Then switch back to SYS mode */
-
-#ifdef CONFIG_ARMV7A_DECODEFIQ
-	mov		r0, #(PSR_MODE_SYS | PSR_I_BIT | PSR_F_BIT)
-#else
-	mov		r0, #(PSR_MODE_SYS | PSR_I_BIT)
-#endif
-	msr		cpsr_c, r0
+	cps		#PSR_MODE_SYS			/* Then switch back to SYS mode */
 
 	/* Get the correct values of USR/SYS r13(sp) and r14(lr) in r1 and r2 */
 
@@ -494,12 +444,7 @@ arm_vectordata:
 
 	/* Switch back ABT mode and return with shadow SPSR */
 
-#ifdef CONFIG_ARMV7A_DECODEFIQ
-	mov		r4, #(PSR_MODE_ABT | PSR_I_BIT | PSR_F_BIT)
-#else
-	mov		r4, #(PSR_MODE_ABT | PSR_I_BIT)
-#endif
-	msr		cpsr_c, r4			/* Switch back ABT mode */
+	cps		#PSR_MODE_ABT
 
 	/* Upon return from arm_dataabort, r0 holds the pointer to the register
 	 * state save area to use to restore the registers.  This may or may not
@@ -539,12 +484,7 @@ arm_vectordata:
 	.type	arm_vectorprefetch, %function
 
 arm_vectorprefetch:
-	/* On entry we are free to use the ABORT mode registers
-	 * r13 and r14
-	 */
-
-	mov		r13, #(PSR_MODE_SYS | PSR_I_BIT | PSR_F_BIT)
-	msr		cpsr_c, r13			/* Switch to SYS mode */
+	cpsid		if, #PSR_MODE_SYS		/* Switch to SYS mode */
 
 	/* Create a context structure.  First set aside a stack frame
 	 * and store r0-r12 into the frame.
@@ -553,18 +493,14 @@ arm_vectorprefetch:
 	sub		sp, sp, #XCPTCONTEXT_SIZE
 	stmia		sp, {r0-r12}			/* Save the SYS mode regs */
 
-	mov		r0, #(PSR_MODE_ABT | PSR_I_BIT | PSR_F_BIT)
-	msr		cpsr_c, r0			/* Switch back ABT mode */
+	cps		#PSR_MODE_ABT			/* Switch back ABT mode */
 
 	/* Get the values for r15(pc) and CPSR in r3 and r4 */
 
 	sub		r3, lr, #4
 	mrs		r4, spsr
 
-	/* Then switch back to SYS mode */
-
-	mov		r0, #(PSR_MODE_SYS | PSR_I_BIT | PSR_F_BIT)
-	msr		cpsr_c, r0
+	cps		#PSR_MODE_SYS			/* Then switch back to SYS mode */
 
 	/* Get the correct values of USR/SYS r13(sp) and r14(lr) in r1 and r2 */
 
@@ -605,12 +541,7 @@ arm_vectorprefetch:
 
 	/* Switch back ABT mode and return with shadow SPSR */
 
-#ifdef CONFIG_ARMV7A_DECODEFIQ
-	mov		r4, #(PSR_MODE_ABT | PSR_I_BIT | PSR_F_BIT)
-#else
-	mov		r4, #(PSR_MODE_ABT | PSR_I_BIT)
-#endif
-	msr		cpsr_c, r4			/* Switch back ABT mode */
+	cps		#PSR_MODE_ABT
 
 	/* Upon return from arm_prefetchabort, r0 holds the pointer to the register
 	 * state save area to use to restore the registers.  This may or may not
@@ -648,12 +579,7 @@ arm_vectorprefetch:
 	.type	arm_vectorundefinsn, %function
 
 arm_vectorundefinsn:
-	/* On entry we are free to use the UND mode registers
-	 * r13 and r14
-	 */
-
-	mov		r13, #(PSR_MODE_SYS | PSR_I_BIT | PSR_F_BIT)
-	msr		cpsr_c, r13			/* Switch to SYS mode */
+	cpsid		if, #PSR_MODE_SYS		/* Switch to SYS mode */
 
 	/* Create a context structure.  First set aside a stack frame
 	 * and store r0-r12 into the frame.
@@ -662,18 +588,14 @@ arm_vectorundefinsn:
 	sub		sp, sp, #XCPTCONTEXT_SIZE
 	stmia		sp, {r0-r12}			/* Save the SYS mode regs */
 
-	mov		r0, #(PSR_MODE_UND | PSR_I_BIT | PSR_F_BIT)
-	msr		cpsr_c, r0			/* Switch back UND mode */
+	cps		#PSR_MODE_UND			/* Switch back UND mode */
 
 	/* Get the values for r15(pc) and CPSR in r3 and r4 */
 
 	mov		r3, lr
 	mrs		r4, spsr
 
-	/* Then switch back to SYS mode */
-
-	mov		r0, #(PSR_MODE_SYS | PSR_I_BIT | PSR_F_BIT)
-	msr		cpsr_c, r0
+	cps		#PSR_MODE_SYS			/* Then switch back to SYS mode */
 
 	/* Get the correct values of USR/SYS r13(sp) and r14(lr) in r1 and r2 */
 
@@ -712,12 +634,7 @@ arm_vectorundefinsn:
 
 	/* Switch back UND mode and return with shadow SPSR */
 
-#ifdef CONFIG_ARMV7A_DECODEFIQ
-	mov		r4, #(PSR_MODE_UND | PSR_I_BIT | PSR_F_BIT)
-#else
-	mov		r4, #(PSR_MODE_UND | PSR_I_BIT)
-#endif
-	msr		cpsr_c, r4			/* Switch back UND mode */
+	cps		#PSR_MODE_UND
 
 	/* Upon return from arm_undefinedinsn, r0 holds the pointer to the register
 	 * state save area to use to restore the registers.  This may or may not
@@ -758,10 +675,7 @@ arm_vectorundefinsn:
 
 arm_vectorfiq:
 #ifdef CONFIG_ARMV7R_DECODEFIQ
-	/* On entry we are free to use the FIQ mode registers r8 through r14 */
-
-	mov		r13, #(PSR_MODE_SYS | PSR_I_BIT | PSR_F_BIT)
-	msr		cpsr_c, r13			/* Switch to SYS mode */
+	cpsid		if, #PSR_MODE_SYS		/* Switch to SYS mode */
 
 	/* Create a context structure.  First set aside a stack frame
 	 * and store r0-r12 into the frame.
@@ -770,18 +684,14 @@ arm_vectorfiq:
 	sub		sp, sp, #XCPTCONTEXT_SIZE
 	stmia		sp, {r0-r12}			/* Save the SYS mode regs */
 
-	mov		r0, #(PSR_MODE_FIQ | PSR_I_BIT | PSR_F_BIT)
-	msr		cpsr_c, r0			/* Switch back FIQ mode */
+	cps		#PSR_MODE_FIQ			/* Switch back FIQ mode */
 
 	/* Get the values for r15(pc) and CPSR in r3 and r4 */
 
 	sub		r3, lr, #4
 	mrs		r4, spsr
 
-	/* Then switch back to SYS mode */
-
-	mov		r0, #(PSR_MODE_SYS | PSR_I_BIT | PSR_F_BIT)
-	msr		cpsr_c, r0
+	cps		#PSR_MODE_SYS			/* Then switch back to SYS mode */
 
 	/* Get the correct values of USR/SYS r13(sp) and r14(lr) in r1 and r2 */
 
@@ -832,12 +742,7 @@ arm_vectorfiq:
 
 	/* Switch back FIQ mode and return with shadow SPSR */
 
-#ifdef CONFIG_ARMV7A_DECODEFIQ
-	mov		r4, #(PSR_MODE_FIQ | PSR_I_BIT | PSR_F_BIT)
-#else
-	mov		r4, #(PSR_MODE_FIQ | PSR_I_BIT)
-#endif
-	msr		cpsr_c, r4			/* Switch back FIQ mode */
+	cps		#PSR_MODE_FIQ
 
 	/* Upon return from arm_decodefiq, r0 holds the pointer to the register
 	 * state save area to use to restore the registers.  This may or may not


### PR DESCRIPTION
## Summary
- Use CPS instruction to change cpu mode for code simplification
- CPS which changes cpu mode is available in armv6 and above

## Impact
- armv7-a/r

## Testing
- smp and ostest on sabre-6quad:smp w/ qemu
