### PR TITLE
arch: Remvoe the error message when toolchain can't find

### DIFF
--- a/arch/avr/src/avr/Toolchain.defs
+++ b/arch/avr/src/avr/Toolchain.defs
@@ -80,8 +80,6 @@ else ifeq ($(CONFIG_ARCH_CHIP_AT90USB1287),y)
 else ifeq ($(CONFIG_ARCH_CHIP_ATMEGA2560),y)
   ARCHCPUFLAGS += -mmcu=atmega2560
   LDFLAGS += -mavr6
-else
-  $(error "No valid CONFIG_ARCH_CHIP_ set in the configuration")
 endif
 
 ifeq ($(CONFIG_DEBUG_CUSTOMOPT),y)

--- a/arch/sparc/src/sparc_v8/Toolchain.defs
+++ b/arch/sparc/src/sparc_v8/Toolchain.defs
@@ -52,8 +52,6 @@ ifeq ($(CONFIG_ARCH_CHIP_BM3803),y)
   ARCHCPUFLAGS += -mcpu=leon
 else ifeq ($(CONFIG_ARCH_CHIP_BM3823),y)
   ARCHCPUFLAGS += -mcpu=leon -mflat
-else
-  $(error "No valid CONFIG_ARCH_CHIP_ set in the configuration")
 endif
 
 ifeq ($(CONFIG_DEBUG_CUSTOMOPT),y)


### PR DESCRIPTION
## Summary
to avoid blocking the basic ci check

## Impact
avr/sparc

## Testing
Pass CI
