### PR TITLE
libc/assert: let CONFIG_NDEBUG default to !CONFIG_DEBUG_ASSERTIONS

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -559,7 +559,7 @@ menu "Debug Options"
 
 config NDEBUG
 	bool "Define NDEBUG globally"
-	default y
+	default !DEBUG_ASSERTIONS
 
 config DEBUG_ALERT
 	bool

--- a/boards/risc-v/mpfs/icicle/configs/network/defconfig
+++ b/boards/risc-v/mpfs/icicle/configs/network/defconfig
@@ -6,7 +6,6 @@
 # modifications.
 #
 # CONFIG_DISABLE_OS_API is not set
-# CONFIG_NDEBUG is not set
 # CONFIG_NSH_DISABLE_LOSMART is not set
 CONFIG_ARCH="risc-v"
 CONFIG_ARCH_BOARD="icicle"


### PR DESCRIPTION
## Summary
so the user could just change CONFIG_DEBUG_ASSERTIONS in most case

## Impact
NDEBUG default setting

## Testing
local
