### PR TITLE
arm/cxd56xx/lc823450: replace arch testset to board implement 

### DIFF
--- a/arch/arm/src/cxd56xx/Make.defs
+++ b/arch/arm/src/cxd56xx/Make.defs
@@ -45,6 +45,7 @@ CHIP_CSRCS += cxd56_cpupause.c
 CHIP_CSRCS += cxd56_cpustart.c
 ifeq ($(CONFIG_CXD56_TESTSET),y)
 CHIP_CSRCS += cxd56_testset.c
+CMN_ASRCS  := $(filter-out arm_testset.S,$(CMN_ASRCS))
 endif
 endif
 

--- a/arch/arm/src/lc823450/Make.defs
+++ b/arch/arm/src/lc823450/Make.defs
@@ -95,6 +95,7 @@ CHIP_CSRCS += lc823450_cpuindex.c
 CHIP_CSRCS += lc823450_cpupause.c
 CHIP_CSRCS += lc823450_cpustart.c
 CHIP_CSRCS += lc823450_testset.c
+CMN_ASRCS  := $(filter-out arm_testset.S,$(CMN_ASRCS))
 endif
 
 ifeq ($(CONFIG_LC823450_SDRAM), y)

--- a/arch/arm/src/rp2040/Make.defs
+++ b/arch/arm/src/rp2040/Make.defs
@@ -38,6 +38,7 @@ CHIP_CSRCS += rp2040_cpustart.c
 CHIP_CSRCS += rp2040_cpupause.c
 CHIP_CSRCS += rp2040_cpuidlestack.c
 CHIP_CSRCS += rp2040_testset.c
+CMN_ASRCS  := $(filter-out arm_testset.S,$(CMN_ASRCS))
 endif
 
 ifeq ($(CONFIG_RP2040_DMAC),y)


### PR DESCRIPTION


## Summary

arm/cxd56xx/lc823450: replace arch testset to board implement

This patch to resolve the regression which leads to the breakage of spresense:smp

Signed-off-by: chao.an <anchao@xiaomi.com>

## Impact

 spresense:smp

## Testing

 spresense:smp board