### PR TITLE
RISC-V: Fix crt0 file compilation

### DIFF
--- a/arch/risc-v/src/common/crt0.c
+++ b/arch/risc-v/src/common/crt0.c
@@ -32,6 +32,8 @@
 #include <sys/types.h>
 #include <stdlib.h>
 
+#include "riscv_internal.h"
+
 #ifdef CONFIG_BUILD_KERNEL
 
 /****************************************************************************


### PR DESCRIPTION
Definition of STACK_FRAME_SIZE was moved

## Summary

## Impact

## Testing

