### PR TITLE
RISC-V: Fix bug in riscv_addrenv.c

### DIFF
--- a/arch/risc-v/src/common/riscv_addrenv.c
+++ b/arch/risc-v/src/common/riscv_addrenv.c
@@ -385,7 +385,7 @@ int up_addrenv_create(size_t textsize, size_t datasize, size_t heapsize,
 
   /* Allocate 1 extra page for heap, temporary fix for #5811 */
 
-  heapsize = heapsize + MM_NPAGES(1);
+  heapsize = heapsize + MM_PGALIGNUP(1);
 
   /* Map the reserved area */
 


### PR DESCRIPTION
Need 1 full page extra for heap, not 1 byte.

## Summary

## Impact

## Testing

