### PR TITLE
armv7-a: smp: fix stack coloration

### DIFF
--- a/arch/arm/src/armv7-a/arm_cpuhead.S
+++ b/arch/arm/src/armv7-a/arm_cpuhead.S
@@ -441,7 +441,7 @@ __cpu3_start:
 #ifdef CONFIG_STACK_COLORATION
 	.type	.Lstkinit, %object
 .Lstkinit:
-	.long	SMP_STACK_WORDS
+	.long	SMP_STACK_WORDS - (XCPTCONTEXT_SIZE / 4)
 	.long	STACK_COLOR				/* Stack coloration word */
 	.size	.Lstkinit, . -.Lstkinit
 #endif


### PR DESCRIPTION
## Summary
- The stack pointer is subtracted to alloc xcptcontext area in the `__cpu?_start:` block
- Fix the stack coloration overrun to the previous cpu's xcpt area

## Impact
- armv7-a's smp configuration

## Testing
- smp and ostest on sabre-6quad:smp w/ qemu