### PR TITLE
Restore lost flash define for stm32.

### DIFF
--- a/arch/arm/src/stm32/hardware/stm32_flash.h
+++ b/arch/arm/src/stm32/hardware/stm32_flash.h
@@ -592,6 +592,7 @@
 #    define FLASH_OPTCR_WDG_SW      (1 << 5)                        /* Bit 5: WDG_SW */
 #  define FLASH_OPTCR_RDP_SHIFT     (8)                             /* Bits 8-15: Read protect */
 #  define FLASH_OPTCR_RDP_MASK      (0xff << FLASH_OPTCR_RDP_SHIFT)
+#  define FLASH_OPTCR_RDP(n)        ((uint32_t)(n) << FLASH_OPTCR_RDP_SHIFT)
 #  define FLASH_OPTCR_NWRP_SHIFT    (16)                            /* Bits 16-27: Not write protect */
 #  define FLASH_OPTCR_NWRP_MASK     (0xfff << FLASH_OPTCR_NWRP_SHIFT)
 #endif


### PR DESCRIPTION
It was used in the previous nuttx versions, but then it was removed for unknown reasons.
It's still in use in some projects and I really don't want to include it in project files.
What's more, the same define you can see at file: arch/arm/src/stm32f7/hardware/stm32f72xx73xx_flash.h

https://github.com/apache/incubator-nuttx/blob/248b738f255374c1e9a99f1e3f69d3c0f615f727/arch/arm/src/stm32f7/hardware/stm32f72xx73xx_flash.h#L186

