### PR TITLE
xtensa/xtensa_coproc.S: Use the first allocated memory to save A0.

### DIFF
--- a/arch/xtensa/include/xtensa/xtensa_abi.h
+++ b/arch/xtensa/include/xtensa/xtensa_abi.h
@@ -159,9 +159,12 @@
 
 #endif
 
-/* Index into stack frame (skipping over saved A0) */
+/* Index into stack frame.
+ * For CALL0 ABI the argument "n" should be greater than 0 to avoid
+ * corrupting the saved A0 if ENTRY was used.
+ */
 
-#define LOCAL_OFFSET(n) ((n) << 2)  /* n = 1 .. ((size >> 2) - 1) */
+#define LOCAL_OFFSET(n) ((n) << 2)  /* n = 0/1 .. ((size >> 2) - 1) */
 
 #endif /* __ASSEMBLY_ */
 

--- a/arch/xtensa/src/common/xtensa_coproc.S
+++ b/arch/xtensa/src/common/xtensa_coproc.S
@@ -252,7 +252,7 @@ xtensa_coproc_savestate:
 	 */
 
 	ENTRY(24)
-	s32i	a0,  sp, LOCAL_OFFSET(1)		/* Save return address */
+	s32i	a0,  sp, LOCAL_OFFSET(0)		/* Save return address */
 
 	/* Call _xtensa_coproc_savestate() with A2=address of co-processor
 	 * save area.
@@ -262,7 +262,7 @@ xtensa_coproc_savestate:
 
 	/* Restore a0 and return */
 
-	l32i	a0,  sp, LOCAL_OFFSET(1)		/* Recover return address */
+	l32i	a0,  sp, LOCAL_OFFSET(0)		/* Recover return address */
 	RET(24)
 
 #endif
@@ -451,7 +451,7 @@ xtensa_coproc_restorestate:
 	 */
 
 	ENTRY(24)
-	s32i	a0,  sp, LOCAL_OFFSET(1)		/* Save return address */
+	s32i	a0,  sp, LOCAL_OFFSET(0)		/* Save return address */
 
 	/* Call _xtensa_coproc_restorestate() with A2=address of co-processor
 	 * save area.   Registers a0, a2-a7, a13-a15 have been trashed.
@@ -461,7 +461,7 @@ xtensa_coproc_restorestate:
 
 	/* Restore a0 and return */
 
-	l32i	a0,  sp, LOCAL_OFFSET(1)		/* Recover return address */
+	l32i	a0,  sp, LOCAL_OFFSET(0)		/* Recover return address */
 	RET(24)
 
 #endif


### PR DESCRIPTION
## Summary
In Windowed ABI, we don't need to skip over any memory as we are only saving A0.  
The old code was working just because `ENTRY` works with multiples of 8, so we were already (and still) allocating two words and using the second one.
## Impact
Code should work as before, just slightly less confusing.
## Testing

All ESP32xx defconfigs build and run successfully.