### PR TITLE
MCAN_INT_ACKE must be on the list of MCAN_TXERR_INTS to be properly h…

### DIFF
--- a/arch/arm/src/samv7/sam_mcan.c
+++ b/arch/arm/src/samv7/sam_mcan.c
@@ -777,7 +777,8 @@
                             MCAN_INT_TEFL)
 #define MCAN_TXDEDBUF_INTS MCAN_TXCOMMON_INTS
 
-#define MCAN_TXERR_INTS    (MCAN_INT_TEFL | MCAN_INT_PEA | MCAN_INT_PED)
+#define MCAN_TXERR_INTS    (MCAN_INT_TEFL | MCAN_INT_PEA | MCAN_INT_PED | \
+                            MCAN_INT_ACKE)
 
 /* Common-, TX- and RX-Error-Mask */
 


### PR DESCRIPTION
…andeled

## Summary

## Impact

## Testing

