### PR TITLE
binfmt/libelf: Fix function description field

### DIFF
--- a/binfmt/libelf/libelf_addrenv.c
+++ b/binfmt/libelf/libelf_addrenv.c
@@ -146,10 +146,10 @@ int elf_addrenv_alloc(FAR struct elf_loadinfo_s *loadinfo, size_t textsize,
 }
 
 /****************************************************************************
- * Name: elf_addrenv_restore
+ * Name: elf_addrenv_select
  *
  * Description:
- *   Restore the address environment before elf_addrenv_select() was called..
+ *   Temporarily select the task's address environment.
  *
  * Input Parameters:
  *   loadinfo - Load state information
@@ -187,20 +187,16 @@ int elf_addrenv_select(FAR struct elf_loadinfo_s *loadinfo)
 #endif
 
 /****************************************************************************
- * Name: elf_addrenv_free
+ * Name: elf_addrenv_restore
  *
  * Description:
- *   Release the address environment previously created by
- *   elf_addrenv_alloc().  This function  is called only under certain error
- *   conditions after the module has been loaded but not yet started.
- *   After the module has been started, the address environment will
- *   automatically be freed when the module exits.
+ *   Restore the address environment before elf_addrenv_select() was called..
  *
  * Input Parameters:
  *   loadinfo - Load state information
  *
  * Returned Value:
- *   None.
+ *   Zero (OK) on success; a negated errno value on failure.
  *
  ****************************************************************************/
 


### PR DESCRIPTION
Copy&paste error, wrong description field used

## Summary

## Impact

## Testing

