### PR TITLE
Revert "tools/testbuild.sh: Don't skip configure and distclean"

### DIFF
--- a/tools/testbuild.sh
+++ b/tools/testbuild.sh
@@ -257,10 +257,6 @@ function build {
     xargs -I "{}" cp "{}" $artifactconfigdir < $nuttx/nuttx.manifest
   fi
 
-  return $fail
-}
-
-function refresh {
   # Ensure defconfig in the canonical form
 
   if ! ./tools/refresh.sh --silent $config; then
@@ -304,11 +300,10 @@ function dotest {
   config=`echo $1 | cut -d',' -f1`
   check=${HOST},${config/\//:}
 
-  skip=0
   for re in $blacklist; do
     if [[ "${check}" =~ ${re:1}$ ]]; then
       echo "Skipping: $1"
-      skip=1
+      return
     fi
   done
 
@@ -351,11 +346,8 @@ function dotest {
   echo "------------------------------------------------------------------------------------"
   distclean
   configure
-  if [ ${skip} -ne 1 ]; then
-    build
-    run
-  fi
-  refresh
+  build
+  run
 }
 
 # Perform the build test for each entry in the test list file


### PR DESCRIPTION


## Summary
This reverts commit 05ff19d17bed7ff8a9ac8d38ae7ad81cf84ee70d because now we are having a bunch of `make: arm-nuttx-eabi-gcc: Command not found` for some configs.

I've seen it first in #6197 but every PR has the same errors/messages.
## Impact
Remove build error
## Testing
CI will do the testing.
