### PR TITLE
ci/arm-13.dat: do not check board tlsr8278adk80d

### DIFF
--- a/tools/ci/testlist/arm-13.dat
+++ b/tools/ci/testlist/arm-13.dat
@@ -9,3 +9,4 @@
 -launchxl-tms57004:nsh
 -lm3s6965-ek:qemu-nxflat
 -tms570ls31x-usb-kit:nsh
+-tlsr8278adk80d


### PR DESCRIPTION
## Summary
Telink toolchain is special and not added to the CI yet.

## Impact
Telink boards CI.

## Testing
CI.
