### PR TITLE
open-amp:fix memory leak

### DIFF
--- a/openamp/0010-open-amp-use-strlcpy-inside-of-strncpy.patch
+++ b/openamp/0010-open-amp-use-strlcpy-inside-of-strncpy.patch
@@ -1,0 +1,41 @@
+From 5dce061e7d5cc922aa1a15649cc937cfeb5f14b8 Mon Sep 17 00:00:00 2001
+From: anjiahao <anjiahao@xiaomi.com>
+Date: Thu, 5 May 2022 19:55:38 +0800
+Subject: [PATCH 2/2] open-amp:use strlcpy inside of strncpy
+
+Signed-off-by: anjiahao <anjiahao@xiaomi.com>
+Change-Id: I796edd3d697e2cd59d20f40a140179cd968765e7
+---
+ lib/rpmsg/rpmsg.c          | 2 +-
+ lib/rpmsg/rpmsg_internal.h | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/lib/rpmsg/rpmsg.c b/lib/rpmsg/rpmsg.c
+index e52144b..3842454 100644
+--- a/lib/rpmsg/rpmsg.c
++++ b/lib/rpmsg/rpmsg.c
+@@ -134,7 +134,7 @@ int rpmsg_send_ns_message(struct rpmsg_endpoint *ept, unsigned long flags)
+ 
+ 	ns_msg.flags = flags;
+ 	ns_msg.addr = ept->addr;
+-	strncpy(ns_msg.name, ept->name, sizeof(ns_msg.name));
++	strlcpy(ns_msg.name, ept->name, sizeof(ns_msg.name));
+ 	ret = rpmsg_send_offchannel_raw(ept, ept->addr,
+ 					RPMSG_NS_EPT_ADDR,
+ 					&ns_msg, sizeof(ns_msg), true);
+diff --git a/lib/rpmsg/rpmsg_internal.h b/lib/rpmsg/rpmsg_internal.h
+index e64aeff..a1fbe90 100644
+--- a/lib/rpmsg/rpmsg_internal.h
++++ b/lib/rpmsg/rpmsg_internal.h
+@@ -105,7 +105,7 @@ static inline void rpmsg_initialize_ept(struct rpmsg_endpoint *ept,
+ 					rpmsg_ept_cb cb,
+ 					rpmsg_ns_unbind_cb ns_unbind_cb)
+ {
+-	strncpy(ept->name, name ? name : "", sizeof(ept->name));
++	strlcpy(ept->name, name ? name : "", sizeof(ept->name));
+ 	ept->addr = src;
+ 	ept->dest_addr = dest;
+ 	ept->cb = cb;
+-- 
+2.25.1
+

--- a/openamp/009-open-amp-fix-memory-leak.patch
+++ b/openamp/009-open-amp-fix-memory-leak.patch
@@ -1,0 +1,43 @@
+From aaa28e7ab36bf3b1f76225614377d59b85a07bc1 Mon Sep 17 00:00:00 2001
+From: anjiahao <anjiahao@xiaomi.com>
+Date: Thu, 5 May 2022 15:31:09 +0800
+Subject: [PATCH 1/2] open-amp:fix memory leak
+
+Signed-off-by: anjiahao <anjiahao@xiaomi.com>
+Change-Id: Id379ed376a2b4e1c2d792f6e314809c1ef5be06b
+---
+ lib/remoteproc/remoteproc.c | 9 +++------
+ 1 file changed, 3 insertions(+), 6 deletions(-)
+
+diff --git a/lib/remoteproc/remoteproc.c b/lib/remoteproc/remoteproc.c
+index ec808c9..56b29f1 100644
+--- a/lib/remoteproc/remoteproc.c
++++ b/lib/remoteproc/remoteproc.c
+@@ -120,21 +120,18 @@ static void *remoteproc_get_rsc_table(struct remoteproc *rproc,
+ 	if (ret < 0 || ret < (int)len || !img_data) {
+ 		metal_log(METAL_LOG_ERROR,
+ 			  "get rsc failed: 0x%llx, 0x%llx\r\n", offset, len);
++		metal_free_memory(rsc_table);
+ 		rsc_table = RPROC_ERR_PTR(-RPROC_EINVAL);
+-		goto error;
++		return rsc_table;
+ 	}
+ 	memcpy(rsc_table, img_data, len);
+ 
+ 	ret = handle_rsc_table(rproc, rsc_table, len, NULL);
+ 	if (ret < 0) {
++		metal_free_memory(rsc_table);
+ 		rsc_table = RPROC_ERR_PTR(ret);
+-		goto error;
+ 	}
+ 	return rsc_table;
+-
+-error:
+-	metal_free_memory(rsc_table);
+-	return rsc_table;
+ }
+ 
+ static int remoteproc_parse_rsc_table(struct remoteproc *rproc,
+-- 
+2.25.1
+

--- a/openamp/open-amp.defs
+++ b/openamp/open-amp.defs
@@ -41,6 +41,8 @@ open-amp.zip:
 	$(Q) patch -p0 < 0006-openamp-fix-scenario-case.patch
 	$(Q) patch -p0 < 0007-openamp-divide-shram-to-TX-shram-RX-shram.patch
 	$(Q) patch -p0 < 0008-rpmsg_virtio-don-t-need-check-status-when-get_tx_pay.patch
+	$(Q) patch -p0 < 009-open-amp-fix-memory-leak.patch
+	$(Q) patch -p0 < 0010-open-amp-use-strlcpy-inside-of-strncpy.patch
 
 .openamp_headers: open-amp.zip
 	$(eval headers := $(wildcard open-amp/lib/include/openamp/*.h))


### PR DESCRIPTION
fix memory leak and use strlcpy inside of strncpy
Signed-off-by: anjiahao <anjiahao@xiaomi.com>

## Summary

## Impact

## Testing

