### PR TITLE
arm/cortex-m/toolchain: try print runtime library only in clang 

### DIFF
--- a/arch/arm/src/armv6-m/Toolchain.defs
+++ b/arch/arm/src/armv6-m/Toolchain.defs
@@ -185,10 +185,12 @@ endif
 # Add the builtin library
 
 COMPILER_RT_LIB = $(shell $(CC) $(ARCHCPUFLAGS) --print-libgcc-file-name)
-ifeq ($(wildcard $(COMPILER_RT_LIB)),)
-  # if "--print-libgcc-file-name" unable to find the correct libgcc PATH
-  # then go ahead and try "--print-file-name"
-  COMPILER_RT_LIB := $(wildcard $(shell $(CC) $(ARCHCPUFLAGS) --print-file-name $(notdir $(COMPILER_RT_LIB))))
+ifeq ($(CONFIG_ARMV6M_TOOLCHAIN),CLANG)
+  ifeq ($(wildcard $(COMPILER_RT_LIB)),)
+    # if "--print-libgcc-file-name" unable to find the correct libgcc PATH
+    # then go ahead and try "--print-file-name"
+    COMPILER_RT_LIB := $(wildcard $(shell $(CC) $(ARCHCPUFLAGS) --print-file-name $(notdir $(COMPILER_RT_LIB))))
+  endif
 endif
 
 EXTRA_LIBS += $(COMPILER_RT_LIB)

--- a/arch/arm/src/armv7-m/Toolchain.defs
+++ b/arch/arm/src/armv7-m/Toolchain.defs
@@ -257,10 +257,12 @@ endif
 # Add the builtin library
 
 COMPILER_RT_LIB = $(shell $(CC) $(ARCHCPUFLAGS) --print-libgcc-file-name)
-ifeq ($(wildcard $(COMPILER_RT_LIB)),)
-  # if "--print-libgcc-file-name" unable to find the correct libgcc PATH
-  # then go ahead and try "--print-file-name"
-  COMPILER_RT_LIB := $(wildcard $(shell $(CC) $(ARCHCPUFLAGS) --print-file-name $(notdir $(COMPILER_RT_LIB))))
+ifeq ($(CONFIG_ARMV7M_TOOLCHAIN),CLANG)
+  ifeq ($(wildcard $(COMPILER_RT_LIB)),)
+    # if "--print-libgcc-file-name" unable to find the correct libgcc PATH
+    # then go ahead and try "--print-file-name"
+    COMPILER_RT_LIB := -$(wildcard $(shell $(CC) $(ARCHCPUFLAGS) --print-file-name $(notdir $(COMPILER_RT_LIB))))
+  endif
 endif
 
 EXTRA_LIBS += $(COMPILER_RT_LIB)

--- a/arch/arm/src/armv8-m/Toolchain.defs
+++ b/arch/arm/src/armv8-m/Toolchain.defs
@@ -266,10 +266,12 @@ endif
 # Add the builtin library
 
 COMPILER_RT_LIB = $(shell $(CC) $(ARCHCPUFLAGS) --print-libgcc-file-name)
-ifeq ($(wildcard $(COMPILER_RT_LIB)),)
-  # if "--print-libgcc-file-name" unable to find the correct libgcc PATH
-  # then go ahead and try "--print-file-name"
-  COMPILER_RT_LIB := $(wildcard $(shell $(CC) $(ARCHCPUFLAGS) --print-file-name $(notdir $(COMPILER_RT_LIB))))
+ifeq ($(CONFIG_ARMV8M_TOOLCHAIN),CLANG)
+  ifeq ($(wildcard $(COMPILER_RT_LIB)),)
+    # if "--print-libgcc-file-name" unable to find the correct libgcc PATH
+    # then go ahead and try "--print-file-name"
+    COMPILER_RT_LIB := $(wildcard $(shell $(CC) $(ARCHCPUFLAGS) --print-file-name $(notdir $(COMPILER_RT_LIB))))
+  endif
 endif
 
 EXTRA_LIBS += $(COMPILER_RT_LIB)


### PR DESCRIPTION


## Summary

arm/cortex-m/toolchain: try print runtime library only in clang

fix compile warning:

make: arm-nuttx-elf-gcc: Command not found

Signed-off-by: chao.an <anchao@xiaomi.com>

## Impact

N/A

## Testing

ci-check