### PR TITLE
armv7-a: smp: allocate page table for each cpu

### DIFF
--- a/arch/arm/src/armv7-a/arm_cpuhead.S
+++ b/arch/arm/src/armv7-a/arm_cpuhead.S
@@ -223,6 +223,10 @@ __cpu3_start:
 	 */
 
 	ldr		r1, .LCppgtable		/* r1=phys. page table */
+#ifdef CONFIG_ARCH_ADDRENV
+	mov		r2, #PGTABLE_SIZE
+	mla		r1, r2, r5, r1		/* page table of cpu1,2,3 */
+#endif
 	orr		r1, r1, #(TTBR0_RGN_WBWA | TTBR0_IRGN0)	/* Select cache properties */
 	mcr		CP15_TTBR0(r1)
 	mcr		CP15_TTBR1(r1)

--- a/arch/arm/src/armv7-a/arm_mmu.c
+++ b/arch/arm/src/armv7-a/arm_mmu.c
@@ -52,7 +52,7 @@
 #ifndef CONFIG_ARCH_ROMPGTABLE
 void mmu_l1_setentry(uint32_t paddr, uint32_t vaddr, uint32_t mmuflags)
 {
-  uint32_t *l1table = (uint32_t *)PGTABLE_BASE_VADDR;
+  uint32_t *l1table = mmu_l1_pgtable();
   uint32_t  index   = vaddr >> 20;
 
   /* Save the page table entry */
@@ -87,7 +87,7 @@ void mmu_l1_setentry(uint32_t paddr, uint32_t vaddr, uint32_t mmuflags)
 #if !defined(CONFIG_ARCH_ROMPGTABLE) && defined(CONFIG_ARCH_ADDRENV)
 void mmu_l1_restore(uintptr_t vaddr, uint32_t l1entry)
 {
-  uint32_t *l1table = (uint32_t *)PGTABLE_BASE_VADDR;
+  uint32_t *l1table = mmu_l1_pgtable();
   uint32_t  index   = vaddr >> 20;
 
   /* Set the encoded page table entry */


### PR DESCRIPTION
## Summary
- In case of SMP and ADDRENV, allocate the page table for each cpu
- Each cpu holds separated addrenv and MMU setting

## Impact
- armv7-a

## Testing
- sabre-6quad:smp w/ qemu
- sabre-6quad:knsh w/ qemu
- sabre-6quad:knsh_smp w/ qemu (WIP)