### PR TITLE
sched/group: addrenv: allocate current group for each cpu

### DIFF
--- a/sched/group/group.h
+++ b/sched/group/group.h
@@ -52,14 +52,14 @@ extern FAR struct task_group_s *g_grouphead;
 #endif
 
 #ifdef CONFIG_ARCH_ADDRENV
-/* This variable holds the PID of the current task group.  This ID is
- * zero if the current task is a kernel thread that has no address
- * environment (other than the kernel context).
+/* This variable holds the current task group.  This pointer is NULL
+ * if the current task is a kernel thread that has no address environment
+ * (other than the kernel context).
  *
  * This must only be accessed with interrupts disabled.
  */
 
-extern pid_t g_pid_current;
+extern FAR struct task_group_s *g_group_current[CONFIG_SMP_NCPUS];
 #endif
 
 /****************************************************************************

--- a/sched/group/group_leave.c
+++ b/sched/group/group_leave.c
@@ -130,6 +130,7 @@ static inline void group_release(FAR struct task_group_s *group)
 {
 #ifdef CONFIG_ARCH_ADDRENV
   save_addrenv_t oldenv;
+  int i;
 #endif
 
 #if CONFIG_TLS_TASK_NELEM > 0
@@ -248,7 +249,13 @@ static inline void group_release(FAR struct task_group_s *group)
 
   /* Mark no address environment */
 
-  g_pid_current = INVALID_PROCESS_ID;
+  for (i = 0; i < CONFIG_SMP_NCPUS; i++)
+    {
+      if (group == g_group_current[i])
+        {
+          g_group_current[i] = NULL;
+        }
+    }
 
   /* Restore the previous addrenv */
 


### PR DESCRIPTION
## Summary:
- In case of SMP and ADDRENV, allocate current group for each cpu
  - g_pid_current holds pid of the group and uses for addrenv switching
  - allocate g_group_current for each cpu in stead of g_pid_current
  - g_group_current is the array that pointed to the current task_group_s struct

## Impact:
- `ADDRENV=y` and `SMP=y`

## Testing:
- sabre-6quad:smp w/ qemu
- sabre-6quad:knsh w/ qemu
- sabre-6quad:knsh_smp w/ qemu (WIP)