### PR TITLE
riscv/pmp: fix bug: PMP_CFG_FLAG_MASK makes pmp cfg fail.

### DIFF
--- a/arch/risc-v/src/common/riscv_pmp.c
+++ b/arch/risc-v/src/common/riscv_pmp.c
@@ -58,7 +58,7 @@
 #define BLOCK_ALIGN_MASK        (MIN_BLOCK_SIZE - 1)
 
 #define PMP_CFG_BITS_CNT        (8)
-#define PMP_CFG_FLAG_MASK       (0xFF)
+#define PMP_CFG_FLAG_MASK       ((uintptr_t)0xFF)
 
 #define PMP_CFG_CNT_IN_REG      (PMP_XLEN / PMP_CFG_BITS_CNT)
 


### PR DESCRIPTION
## Summary
On RV64, when PMP entry >= 4, the current code generates unexpected instructions "sllw":
    5300050c:   3a202773                csrr    a4,pmpcfg2
        PMP_MASK_SET_ONE_REGION(region, attr, cfg);
    53000510:   8b9d                    andi    a5,a5,7
    53000512:   00379513                slli    a0,a5,0x3
    53000516:   0ff00793                li      a5,255
    5300051a:   00a797bb                sllw    a5,a5,a0
    5300051e:   fff7c793                not     a5,a5
    53000522:   2781                    sext.w  a5,a5
    53000524:   8ff9                    and     a5,a5,a4
    53000526:   00a59533                sll     a0,a1,a0
    5300052a:   8d5d                    or      a0,a0,a5
        WRITE_CSR(pmpcfg2, cfg);
    5300052c:   3a251073                csrw    pmpcfg2,a0
Which leads to the wrong PMPCFG settings: pmpcfg0[7:0] gets cleared when PMP entry=4.

## Impact
All RISC-V builds utilize the PMP.

## Testing
Verified. 
