### PR TITLE
sched/note: fix build break

### DIFF
--- a/sched/sched/sched_note.c
+++ b/sched/sched/sched_note.c
@@ -431,8 +431,8 @@ static void note_spincommon(FAR struct tcb_s *tcb,
 
   note_common(tcb, &note.nsp_cmn, sizeof(struct note_spinlock_s), type);
 
-  sched_note_flatten(note.nsp_spinlock, &spinlock, sizeof(spilock));
-  note.nsp_value = (uint8_t)*spinlock;
+  sched_note_flatten(note.nsp_spinlock, &spinlock, sizeof(spinlock));
+  note.nsp_value = *(uint8_t *)spinlock;
 
   /* Add the note to circular buffer */
 


### PR DESCRIPTION


## Summary
sched/note: fix build break

1. fix typo spilock -> spinlock
2. fix build break

sched/sched_note.c: In function ‘note_spincommon’:
sched/sched_note.c:435:3: error: aggregate value used where an integer was expected
  435 |   note.nsp_value = (uint8_t)*spinlock;
      |   ^~~~

Signed-off-by: chao.an <anchao@xiaomi.com>

## Impact

sched/note

## Testing

ci-check