### PR TITLE
xtensa: move fpu register to XCPTCONTEXT_REGS

### DIFF
--- a/arch/xtensa/include/irq.h
+++ b/arch/xtensa/include/irq.h
@@ -118,12 +118,25 @@
 /* Storage for overlay state */
 
 #  error Overlays not supported
-#  define XCPTCONTEXT_REGS  _REG_OVLY_START
+#  define _REG_CP_START  _REG_OVLY_START
 #else
-#  define XCPTCONTEXT_REGS  _REG_OVLY_START
+#  define _REG_CP_START  _REG_OVLY_START
 #endif
 
-#define XCPTCONTEXT_SIZE    ((4 * XCPTCONTEXT_REGS) + 0x20)
+#if XCHAL_CP_NUM > 0
+#  if (XCHAL_TOTAL_SA_ALIGN == 8) && ((_REG_CP_START & 1) == 1)
+  /* Fpu first address must align to cp align size. */
+
+#    define REG_CP_DUMMY      (_REG_CP_START + 0)
+#    define XCPTCONTEXT_REGS  (_REG_CP_START + 1)
+#  else
+#    define XCPTCONTEXT_REGS  _REG_CP_START
+#  endif
+#  define XCPTCONTEXT_SIZE    ((4 * XCPTCONTEXT_REGS) + XTENSA_CP_SA_SIZE + 0x20)
+#else
+#  define XCPTCONTEXT_REGS    _REG_CP_START
+#  define XCPTCONTEXT_SIZE    ((4 * XCPTCONTEXT_REGS) + 0x20)
+#endif
 
 /****************************************************************************
  * Public Types
@@ -154,12 +167,6 @@ struct xcptcontext
   /* Register save area */
 
   uint32_t *regs;
-
-#if XCHAL_CP_NUM > 0
-  /* Co-processor save area */
-
-  struct xtensa_cpstate_s cpstate;
-#endif
 
 #ifdef CONFIG_LIB_SYSCALL
   /* The following array holds the return address and the exc_return value

--- a/arch/xtensa/include/syscall.h
+++ b/arch/xtensa/include/syscall.h
@@ -107,7 +107,7 @@
 
 /* SYS call 1:
  *
- * void xtensa_context_restore(uint32_t **restoreregs) noreturn_function;
+ * void xtensa_context_restore(uint32_t *restoreregs) noreturn_function;
  */
 
 #define SYS_restore_context       (1)

--- a/arch/xtensa/include/xtensa/xtensa_coproc.h
+++ b/arch/xtensa/include/xtensa/xtensa_coproc.h
@@ -140,6 +140,12 @@
 
 #ifndef __ASSEMBLY__
 
+#if 0
+
+/* This struct is not used as CP context switch was implement in interrupt
+ * handler. Will be reused when lazy context switch is implemented.
+ */
+
 struct xtensa_cpstate_s
 {
   uint16_t cpenable;                                 /* (2 bytes) Co-processors active for this thread */
@@ -149,6 +155,7 @@ struct xtensa_cpstate_s
 
 static_assert(offsetof(struct xtensa_cpstate_s, cpasa) == XTENSA_CPASA,
               "CP save area address alignment violation.");
+#endif
 
 /****************************************************************************
  * Inline Functions

--- a/arch/xtensa/src/common/xtensa.h
+++ b/arch/xtensa/src/common/xtensa.h
@@ -285,11 +285,6 @@ int xtensa_intercpu_interrupt(int tocpu, int intcode);
 void xtensa_pause_handler(void);
 #endif
 
-#if XCHAL_CP_NUM > 0
-void xtensa_coproc_savestate(struct xtensa_cpstate_s *cpstate);
-void xtensa_coproc_restorestate(struct xtensa_cpstate_s *cpstate);
-#endif
-
 /* Signals */
 
 void _xtensa_sig_trampoline(void);

--- a/arch/xtensa/src/common/xtensa.h
+++ b/arch/xtensa/src/common/xtensa.h
@@ -254,9 +254,8 @@ void xtensa_dumpstate(void);
 /* Initialization */
 
 #if XCHAL_CP_NUM > 0
-struct xtensa_cpstate_s;
-void xtensa_coproc_enable(struct xtensa_cpstate_s *cpstate, int cpset);
-void xtensa_coproc_disable(struct xtensa_cpstate_s *cpstate, int cpset);
+void xtensa_coproc_enable(int cpset);
+void xtensa_coproc_disable(int cpset);
 #endif
 
 /* Window Spill */

--- a/arch/xtensa/src/common/xtensa_context.S
+++ b/arch/xtensa/src/common/xtensa_context.S
@@ -85,7 +85,7 @@
  *   This function saves Xtensa processor state.
  *   It is called directly by interrupt handling logic with interrupts
  *   disabled.  Registers PC, PS, A0, A1 (SP), A2 and A3 are saved before
- *   calling this function. 
+ *   calling this function.
  *
  *   The counterpart to this function is _xtensa_context_restore().
  *
@@ -196,8 +196,17 @@ _xtensa_context_save:
 	wsr     a2, PS                     /* Restore PS to the value at entry */
 	wsr     a0, EPC1                   /* Restore EPC1 to the value at entry */
 	rsync
-	l32i  a0, sp, (4 * REG_TMP0)       /* Restore return address */
+	l32i	a0, sp, (4 * REG_TMP0)       /* Restore return address */
 
+#endif
+
+#if XCHAL_CP_NUM > 0
+	s32i    a0, sp, (4 * REG_TMP0)     /* Save return address */
+
+	mov	a2, sp
+	call0	_xtensa_coproc_savestate
+
+	l32i	a0, sp, (4 * REG_TMP0)       /* Restore return address */
 #endif
 
 	ret
@@ -238,6 +247,14 @@ _xtensa_context_save:
 	.align  4
 
 _xtensa_context_restore:
+
+#if XCHAL_CP_NUM > 0
+	s32i    a0, a2, (4 * REG_TMP0)	     /* Save return address */
+
+	call0	_xtensa_coproc_restorestate
+
+	l32i	a0, a2, (4 * REG_TMP0)       /* Restore return address */
+#endif
 
 #if XCHAL_HAVE_LOOPS != 0
 	l32i	a3, a2, (4 * REG_LBEG)

--- a/arch/xtensa/src/common/xtensa_coproc.S
+++ b/arch/xtensa/src/common/xtensa_coproc.S
@@ -39,6 +39,7 @@
 
 #include <nuttx/config.h>
 
+#include <arch/irq.h>
 #include <arch/xtensa/core.h>
 #include <arch/xtensa/xtensa_abi.h>
 #include <arch/xtensa/xtensa_coproc.h>
@@ -58,7 +59,7 @@
   /* Offset to CP n save area in thread's CP save area. */
 
   .global	_xtensa_coproc_saoffsets
-  .type	_xtensa_coproc_saoffsets, @object
+  .type		_xtensa_coproc_saoffsets, @object
   .align	16                      /* Minimize crossing cache boundaries */
 
 _xtensa_coproc_saoffsets:
@@ -88,9 +89,7 @@ _xtensa_coproc_saoffsets:
  *   around the assembly language call to _xtensa_coproc_savestate.
  *
  * Entry Conditions:
- *   - A2 holds the address of the co-processor state save area
- *   - The thread being switched out is still the current thread.
- *   - CPENABLE state reflects which coprocessors are active.
+ *   - A2 holds the address of current interrupt stack pointer.
  *   - Registers have been saved/spilled already.
  *
  * Exit conditions:
@@ -112,78 +111,88 @@ _xtensa_coproc_savestate:
 
 	/* Move the address of the thread state save area to R15 */
 
-	mov		a15, a2							/* A15 is now the address of the save area */
+	mov		a3, a2					/* A3 is now the address of the save area */
+
+	/* The stack when interrupt happened (the register a2)
+	* ----------------------------------------------------
+	* | Reserve area (0x20)                              |
+	* ----------------------------------------------------
+	* | Coproc context                                   |
+	* ----------------------------------------------------
+	* | Xtensa common regs                               |
+	* ---------------------------------------------------| <- SP
+	*/
+
+	addi		a3, a3, (4 * XCPTCONTEXT_REGS)
 
 	/* CPENABLE should show which CPs are enabled. */
 
-	rsr		a2, CPENABLE					/* a2 = which CPs are enabled */
-	beqz	a2, .Ldone1						/* Quick exit if none */
+	rsr		a2, CPENABLE				/* a2 = which CPs are enabled */
+	beqz		a2, .Ldone1				/* Quick exit if none */
 
-	s16i	a2, a15, XTENSA_CPSTORED		/* Save mask of CPs being stored */
-	movi	a13, _xtensa_coproc_saoffsets	/* Array of CP save offsets */
-	addi	a15, a15, XTENSA_CPASA			/* a15 = base of aligned save area */
+	movi		a13, _xtensa_coproc_saoffsets		/* Array of CP save offsets */
 
 #if XCHAL_CP0_SA_SIZE > 0
-	bbci.l	a2, 0, 2f						/* CP 0 not enabled */
-	l32i	a14, a13, 0						/* a14 = _xtensa_coproc_saoffsets[0] */
-	add		a3, a14, a15					/* a3 = save area for CP 0 */
-	xchal_cp0_store	a3, a4, a5, a6, a7 continue=0 ofs=-1 select=XTHAL_SAS_TIE|XTHAL_SAS_NOCC|XTHAL_SAS_CALE alloc=XTHAL_SAS_ALL
+	bbci.l		a2,  0,   2f				/* CP 0 not enabled */
+	l32i		a14, a13, 0				/* a14 = _xtensa_coproc_saoffsets[0] */
+	add		a3,  a14, a3				/* a3 = save area for CP 0 */
+	xchal_cp0_store	a3,  a4,  a5, a6, a7 continue=0 ofs=-1 select=XTHAL_SAS_TIE|XTHAL_SAS_NOCC|XTHAL_SAS_CALE alloc=XTHAL_SAS_ALL
 2:
 #endif
 
 #if XCHAL_CP1_SA_SIZE > 0
-	bbci.l	a2, 1, 2f						/* CP 1 not enabled */
-	l32i	a14, a13, 4						/* a14 = _xtensa_coproc_saoffsets[1] */
-	add		a3, a14, a15					/* a3 = save area for CP 1 */
-	xchal_cp1_store	a3, a4, a5, a6, a7 continue=0 ofs=-1 select=XTHAL_SAS_TIE|XTHAL_SAS_NOCC|XTHAL_SAS_CALE alloc=XTHAL_SAS_ALL
+	bbci.l		a2,  1,   2f				/* CP 1 not enabled */
+	l32i		a14, a13, 4				/* a14 = _xtensa_coproc_saoffsets[1] */
+	add		a3,  a14, a3				/* a3 = save area for CP 1 */
+	xchal_cp1_store	a3,  a4,  a5, a6, a7 continue=0 ofs=-1 select=XTHAL_SAS_TIE|XTHAL_SAS_NOCC|XTHAL_SAS_CALE alloc=XTHAL_SAS_ALL
 2:
 #endif
 
 #if XCHAL_CP2_SA_SIZE > 0
-	bbci.l	a2, 2, 2f
-	l32i	a14, a13, 8
-	add		a3, a14, a15
-	xchal_cp2_store	a3, a4, a5, a6, a7 continue=0 ofs=-1 select=XTHAL_SAS_TIE|XTHAL_SAS_NOCC|XTHAL_SAS_CALE alloc=XTHAL_SAS_ALL
+	bbci.l		a2,  2,   2f
+	l32i		a14, a13, 8
+	add		a3,  a14, a3
+	xchal_cp2_store	a3,  a4,  a5, a6, a7 continue=0 ofs=-1 select=XTHAL_SAS_TIE|XTHAL_SAS_NOCC|XTHAL_SAS_CALE alloc=XTHAL_SAS_ALL
 2:
 #endif
 
 #if XCHAL_CP3_SA_SIZE > 0
-	bbci.l	a2, 3, 2f
-	l32i	a14, a13, 12
-	add		a3, a14, a15
-	xchal_cp3_store	a3, a4, a5, a6, a7 continue=0 ofs=-1 select=XTHAL_SAS_TIE|XTHAL_SAS_NOCC|XTHAL_SAS_CALE alloc=XTHAL_SAS_ALL
+	bbci.l		a2,  3,   2f
+	l32i		a14, a13, 12
+	add		a3,  a14, a3
+	xchal_cp3_store	a3,  a4,  a5, a6, a7 continue=0 ofs=-1 select=XTHAL_SAS_TIE|XTHAL_SAS_NOCC|XTHAL_SAS_CALE alloc=XTHAL_SAS_ALL
 2:
 #endif
 
 #if XCHAL_CP4_SA_SIZE > 0
-	bbci.l	a2, 4, 2f
-	l32i	a14, a13, 16
-	add		a3, a14, a15
-	xchal_cp4_store	a3, a4, a5, a6, a7 continue=0 ofs=-1 select=XTHAL_SAS_TIE|XTHAL_SAS_NOCC|XTHAL_SAS_CALE alloc=XTHAL_SAS_ALL
+	bbci.l		a2,  4,   2f
+	l32i		a14, a13, 16
+	add		a3,  a14, a3
+	xchal_cp4_store	a3,  a4,  a5, a6, a7 continue=0 ofs=-1 select=XTHAL_SAS_TIE|XTHAL_SAS_NOCC|XTHAL_SAS_CALE alloc=XTHAL_SAS_ALL
 2:
 #endif
 
 #if XCHAL_CP5_SA_SIZE > 0
-	bbci.l	a2, 5, 2f
-	l32i	a14, a13, 20
-	add		a3, a14, a15
-	xchal_cp5_store	a3, a4, a5, a6, a7 continue=0 ofs=-1 select=XTHAL_SAS_TIE|XTHAL_SAS_NOCC|XTHAL_SAS_CALE alloc=XTHAL_SAS_ALL
+	bbci.l		a2,  5,   2f
+	l32i		a14, a13, 20
+	add		a3,  a14, a3
+	xchal_cp5_store	a3,  a4,  a5, a6, a7 continue=0 ofs=-1 select=XTHAL_SAS_TIE|XTHAL_SAS_NOCC|XTHAL_SAS_CALE alloc=XTHAL_SAS_ALL
 2:
 #endif
 
 #if XCHAL_CP6_SA_SIZE > 0
-	bbci.l	a2, 6, 2f
-	l32i	a14, a13, 24
-	add		a3, a14, a15
-	xchal_cp6_store	a3, a4, a5, a6, a7 continue=0 ofs=-1 select=XTHAL_SAS_TIE|XTHAL_SAS_NOCC|XTHAL_SAS_CALE alloc=XTHAL_SAS_ALL
+	bbci.l		a2,  6,   2f
+	l32i		a14, a13, 24
+	add		a3,  a14, a3
+	xchal_cp6_store	a3,  a4,  a5, a6, a7 continue=0 ofs=-1 select=XTHAL_SAS_TIE|XTHAL_SAS_NOCC|XTHAL_SAS_CALE alloc=XTHAL_SAS_ALL
 2:
 #endif
 
 #if XCHAL_CP7_SA_SIZE > 0
-	bbci.l	a2, 7, 2f
-	l32i	a14, a13, 28
-	add		a3, a14, a15
-	xchal_cp7_store	a3, a4, a5, a6, a7 continue=0 ofs=-1 select=XTHAL_SAS_TIE|XTHAL_SAS_NOCC|XTHAL_SAS_CALE alloc=XTHAL_SAS_ALL
+	bbci.l		a2,  7,   2f
+	l32i		a14, a13, 28
+	add		a3,  a14, a3
+	xchal_cp7_store	a3,  a4,  a5, a6, a7 continue=0 ofs=-1 select=XTHAL_SAS_TIE|XTHAL_SAS_NOCC|XTHAL_SAS_CALE alloc=XTHAL_SAS_ALL
 2:
 #endif
 
@@ -191,83 +200,6 @@ _xtensa_coproc_savestate:
 	ret
 
 	.size	_xtensa_coproc_savestate, . - _xtensa_coproc_savestate
-
-/****************************************************************************
- * Name: xtensa_coproc_savestate
- *
- * Description:
- *   If there is a current thread and it has a coprocessor state save area,
- *   then save all callee-saved state into this area. xtensa_coproc_savestate()
- *   is simply a C wrapper around the assembly language call to
- *   _xtensa_coproc_savestate.
- *
- * Input Parameters:
- *   A2 - Address of co-processor save area
- *
- * Returned Value:
- *   None
- *
- * Assumptions:
- *   Called with interrupts disabled.
- *
- ****************************************************************************/
-
-	.global	xtensa_coproc_savestate
-	.type	xtensa_coproc_savestate, @function
-
-	.align	4
-	.literal_position
-	.align	4
-
-xtensa_coproc_savestate:
-
-#ifdef __XTENSA_CALL0_ABI__
-	/* Need to preserve a8-11.  _xtensa_coproc_savestate modifies a2-a7,
-	 * a13-a15. a12-a15 are callee saved registers so a13-a14 must be
-	 * preserved.
-	 */
-
-	ENTRY(16)
-	s32i	a13, sp, LOCAL_OFFSET(1)		/* Save clobbered registers */
-	s32i	a14, sp, LOCAL_OFFSET(2)
-	s32i	a15, sp, LOCAL_OFFSET(3)
-
-	/* Call _xtensa_coproc_savestate() with A2=address of co-processor
-	 * save area.
-	 */
-
-	call0 _xtensa_coproc_savestate
-
-	/* Restore a13-15 and return */
-
-	l32i	a13, sp, LOCAL_OFFSET(1)		/* Restore clobbered registers */
-	l32i	a14, sp, LOCAL_OFFSET(2)
-	l32i	a15, sp, LOCAL_OFFSET(3)
-	RET(16)
-
-#else
-	/* Allocate the stack frame.  This function needs to allocate the usual 16
-	 * byte for the base save area + space for one variable.
-	 * NOTE: entry works in multiples of 8 bytes.
-	 */
-
-	ENTRY(24)
-	s32i	a0,  sp, LOCAL_OFFSET(0)		/* Save return address */
-
-	/* Call _xtensa_coproc_savestate() with A2=address of co-processor
-	 * save area.
-	 */
-
-	call0 _xtensa_coproc_savestate
-
-	/* Restore a0 and return */
-
-	l32i	a0,  sp, LOCAL_OFFSET(0)		/* Recover return address */
-	RET(24)
-
-#endif
-
-	.size	xtensa_coproc_savestate, . - xtensa_coproc_savestate
 
 /****************************************************************************
  * Name: _xtensa_coproc_restorestate
@@ -284,12 +216,10 @@ xtensa_coproc_savestate:
  *   around the assembly language call to _xtensa_coproc_restorestate.
  *
  * Entry Conditions:
- *   - A2 holds the address of the co-processor state save area
- *   - The incoming thread is set as the current thread.
+ *   - A2 holds the address of the current interrupt stack pointer.
  *
  * Exit conditions:
  *   - All necessary CP callee-saved state has been restored.
- *   - CPENABLE - Set up correctly for the current thread.
  *   - Registers a2-a7, a13-a15 have been trashed.
  *
  * Must be called from assembly code only, using CALL0.
@@ -307,82 +237,86 @@ _xtensa_coproc_restorestate:
 
 	/* Move the address of the thread state save area to R15 */
 
-	mov		a15, a2							/* A15 is now the address of the save area */
+	mov		a3, a2				/* A3 is now the address of the save area */
 
-#ifdef CONFIG_XTENSA_CP_LAZY
-	movi	a2, 0							/* a2 = Will disable all coprocessors */
-#else
-	l16ui	a2, a15, XTENSA_CPENABLE		/* a2 = Which CPs have been enable for this thread? */
-#endif
-	wsr		a2, CPENABLE					/* Set CPENABLE correctly for this thread */
-	l16ui	a2, a15, XTENSA_CPSTORED		/* a2 = Which CPs have been saved for this thread? */
-	movi	a3, 0							/* Clear the ones being restored (all of them) */
-	s16i	a3, a15, XTENSA_CPSTORED		/* Clear saved CP mask */
+	/* The stack when interrupt happened (the register A2)
+	* ----------------------------------------------------
+	* | Reserve area (0x20)                              |
+	* ----------------------------------------------------
+	* | Coproc context                                   |
+	* ----------------------------------------------------
+	* | Xtensa common regs                               |
+	* ---------------------------------------------------| <- SP
+	*/
 
-	movi	a13, _xtensa_coproc_saoffsets	/* Array of CP save offsets */
-	addi	a15, a15, XTENSA_CPASA			/* a15 = base of aligned save area */
+	addi		a3, a3, (4 * XCPTCONTEXT_REGS)
+
+	rsr		a8, CPENABLE			/* Set CPENABLE correctly for this thread */
+	beqz		a8, .Ldone1			/* Quick exit if none */
+
+	movi		a13, _xtensa_coproc_saoffsets	/* Array of CP save offsets */
 
 #if XCHAL_CP0_SA_SIZE
-	bbci.l	a2, 0, 2f						/* CP 0 not enabled */
-	l32i	a14, a13, 0						/* a14 = _xtensa_coproc_saoffsets[0] */
-	add		a3, a14, a15					/* a3 = save area for CP 0 */
-	xchal_cp0_load	a3, a4, a5, a6, a7 continue=0 ofs=-1 select=XTHAL_SAS_TIE|XTHAL_SAS_NOCC|XTHAL_SAS_CALE alloc=XTHAL_SAS_ALL
+	bbci.l		a8,  0,   2f			/* CP 0 not enabled */
+	l32i		a14, a13, 0			/* a14 = _xtensa_coproc_saoffsets[0] */
+	add		a3,  a14, a3			/* a3 = save area for CP 0 */
+	xchal_cp0_load	a3,  a4,  a5, a6, a7 continue=0 ofs=-1 select=XTHAL_SAS_TIE|XTHAL_SAS_NOCC|XTHAL_SAS_CALE alloc=XTHAL_SAS_ALL
 2:
 #endif
 
 #if XCHAL_CP1_SA_SIZE
-	bbci.l	a2, 1, 2f						/* CP 1 not enabled */
-	l32i	a14, a13, 4						/* a14 = _xtensa_coproc_saoffsets[1] */
-	add		a3, a14, a15					/* a3 = save area for CP 1 */
-	xchal_cp1_load	a3, a4, a5, a6, a7 continue=0 ofs=-1 select=XTHAL_SAS_TIE|XTHAL_SAS_NOCC|XTHAL_SAS_CALE alloc=XTHAL_SAS_ALL
+	bbci.l		a8,  1,   2f			/* CP 1 not enabled */
+	l32i		a14, a13, 4			/* a14 = _xtensa_coproc_saoffsets[1] */
+	add		a3,  a14, a3			/* a3 = save area for CP 1 */
+	xchal_cp1_load	a3,  a4,  a5, a6, a7 continue=0 ofs=-1 select=XTHAL_SAS_TIE|XTHAL_SAS_NOCC|XTHAL_SAS_CALE alloc=XTHAL_SAS_ALL
 2:
 #endif
 
 #if XCHAL_CP2_SA_SIZE
-	bbci.l	a2, 2, 2f
-	l32i	a14, a13, 8
-	add		a3, a14, a15
-	xchal_cp2_load	a3, a4, a5, a6, a7 continue=0 ofs=-1 select=XTHAL_SAS_TIE|XTHAL_SAS_NOCC|XTHAL_SAS_CALE alloc=XTHAL_SAS_ALL
+	bbci.l		a8,  2,   2f
+	l32i		a14, a13, 8
+	add		a3,  a14, a3
+	xchal_cp2_load	a3,  a4,  a5, a6, a7 continue=0 ofs=-1 select=XTHAL_SAS_TIE|XTHAL_SAS_NOCC|XTHAL_SAS_CALE alloc=XTHAL_SAS_ALL
 2:
 #endif
 
 #if XCHAL_CP3_SA_SIZE
-	bbci.l	a2, 3, 2f
-	l32i	a14, a13, 12
-	add		a3, a14, a15
-	xchal_cp3_load	a3, a4, a5, a6, a7 continue=0 ofs=-1 select=XTHAL_SAS_TIE|XTHAL_SAS_NOCC|XTHAL_SAS_CALE alloc=XTHAL_SAS_ALL
+	bbci.l		a8,  3,   2f
+	l32i		a14, a13, 12
+	add		a3,  a14, a3
+	xchal_cp3_load	a3,  a4,  a5, a6, a7 continue=0 ofs=-1 select=XTHAL_SAS_TIE|XTHAL_SAS_NOCC|XTHAL_SAS_CALE alloc=XTHAL_SAS_ALL
 2:
 #endif
 
 #if XCHAL_CP4_SA_SIZE
-	bbci.l	a2, 4, 2f
-	l32i	a14, a13, 16
-	add		a3, a14, a15
-	xchal_cp4_load	a3, a4, a5, a6, a7 continue=0 ofs=-1 select=XTHAL_SAS_TIE|XTHAL_SAS_NOCC|XTHAL_SAS_CALE alloc=XTHAL_SAS_ALL
+	bbci.l		a8,  4,   2f
+	l32i		a14, a13, 16
+	add		a3,  a14, a3
+	xchal_cp4_load	a3,  a4,  a5, a6, a7 continue=0 ofs=-1 select=XTHAL_SAS_TIE|XTHAL_SAS_NOCC|XTHAL_SAS_CALE alloc=XTHAL_SAS_ALL
 2:
 #endif
 
 #if XCHAL_CP5_SA_SIZE
-	bbci.l	a2, 5, 2f
-	l32i	a14, a13, 20
-	add		a3, a14, a15
-	xchal_cp5_load	a3, a4, a5, a6, a7 continue=0 ofs=-1 select=XTHAL_SAS_TIE|XTHAL_SAS_NOCC|XTHAL_SAS_CALE alloc=XTHAL_SAS_ALL
+	bbci.l		a8,  5,   2f
+	l32i		a14, a13, 20
+	add		a3,  a14, a3
+	xchal_cp5_load	a3,  a4,  a5, a6, a7 continue=0 ofs=-1 select=XTHAL_SAS_TIE|XTHAL_SAS_NOCC|XTHAL_SAS_CALE alloc=XTHAL_SAS_ALL
 2:
 #endif
 
 #if XCHAL_CP6_SA_SIZE
-	bbci.l	a2, 6, 2f
-	l32i	a14, a13, 24
-	add		a3, a14, a15
-	xchal_cp6_load	a3, a4, a5, a6, a7 continue=0 ofs=-1 select=XTHAL_SAS_TIE|XTHAL_SAS_NOCC|XTHAL_SAS_CALE alloc=XTHAL_SAS_ALL
+	bbci.l		a8,  6,   2f
+	l32i		a14, a13, 24
+	add		a3,  a14, a3
+	xchal_cp6_load	a3,  a4,  a5, a6, a7 continue=0 ofs=-1 select=XTHAL_SAS_TIE|XTHAL_SAS_NOCC|XTHAL_SAS_CALE alloc=XTHAL_SAS_ALL
 2:
 #endif
 
 #if XCHAL_CP7_SA_SIZE
-	bbci.l	a2, 7, 2f
-	l32i	a14, a13, 28
-	add		a3, a14, a15
-	xchal_cp7_load	a3, a4, a5, a6, a7 continue=0 ofs=-1 select=XTHAL_SAS_TIE|XTHAL_SAS_NOCC|XTHAL_SAS_CALE alloc=XTHAL_SAS_ALL
+	bbci.l		a8,  7,   2f
+	l32i		a14, a13, 28
+	add		a3,  a14, a3
+	xchal_cp7_load	a3,  a4,  a5, a6, a7 continue=0 ofs=-1 select=XTHAL_SAS_TIE|XTHAL_SAS_NOCC|XTHAL_SAS_CALE alloc=XTHAL_SAS_ALL
 2:
 #endif
 	/* Ensure wsr.CPENABLE has completed. */
@@ -391,81 +325,5 @@ _xtensa_coproc_restorestate:
 	ret
 
 	.size	_xtensa_coproc_restorestate, . - _xtensa_coproc_restorestate
-
-/****************************************************************************
- * Name: xtensa_coproc_restorestate
- *
- * Description:
- *   Restore any callee-saved coprocessor state for the incoming thread.
- *   xtensa_coproc_restorestate() is simply a C wrapper around the assembly
- *   language call to _xtensa_coproc_restorestate.
- *
- * Input Parameters:
- *   - A2 holds the address of the threads state save area
- *
- * Returned Value:
- *   None
- *
- * Assumptions:
- *   Called with interrupts disabled.
- *
- ****************************************************************************/
-
-	.global	xtensa_coproc_restorestate
-	.type	xtensa_coproc_restorestate, @function
-
-	.align	4
-	.literal_position
-	.align	4
-
-xtensa_coproc_restorestate:
-
-#ifdef __XTENSA_CALL0_ABI__
-	/* Need to preserve a8-11.  _xtensa_coproc_restorestate modifies a2-a7,
-	 * a13-a15. a12-a15 are callee saved registers so a13-a14 must be
-	 * preserved.
-	 */
-
-	ENTRY(16)
-	s32i	a13, sp, LOCAL_OFFSET(1)		/* Save clobbered values */
-	s32i	a14, sp, LOCAL_OFFSET(2)
-	s32i	a15, sp, LOCAL_OFFSET(3)
-
-	/* Call _xtensa_coproc_restorestate() with A2=address of co-processor
-	 * save area.   Registers a0, a2-a7, a13-a15 have been trashed.
-	 */
-
-	call0 _xtensa_coproc_restorestate
-
-	/* Restore a13-a15 and return */
-
-	l32i	a13, sp, LOCAL_OFFSET(1)		/* Restore clobbered registers */
-	l32i	a14, sp, LOCAL_OFFSET(2)
-	l32i	a15, sp, LOCAL_OFFSET(3)
-	RET(16)
-
-#else
-	/* Allocate the stack frame.  This function needs to allocate the usual 16
-	 * byte for the base save area + space for one variable.
-	 * NOTE: entry works in multiples of 8 bytes.
-	 */
-
-	ENTRY(24)
-	s32i	a0,  sp, LOCAL_OFFSET(0)		/* Save return address */
-
-	/* Call _xtensa_coproc_restorestate() with A2=address of co-processor
-	 * save area.   Registers a0, a2-a7, a13-a15 have been trashed.
-	 */
-
-	call0 _xtensa_coproc_restorestate
-
-	/* Restore a0 and return */
-
-	l32i	a0,  sp, LOCAL_OFFSET(0)		/* Recover return address */
-	RET(24)
-
-#endif
-
-  .size	xtensa_coproc_restorestate, . - xtensa_coproc_restorestate
 
 #endif /* XCHAL_CP_NUM > 0 */

--- a/arch/xtensa/src/common/xtensa_cpenable.c
+++ b/arch/xtensa/src/common/xtensa_cpenable.c
@@ -45,7 +45,6 @@
  *   Enable a set of co-processors.
  *
  * Input Parameters:
- *   cpstate - A pointer to the Co-processor state save structure.
  *   cpset   - A bit set of co-processors to be enabled.  Matches bit layout
  *             of the CPENABLE register.  Bit 0-XCHAL_CP_NUM:  0 = no change
  *             1 = enable
@@ -55,7 +54,7 @@
  *
  ****************************************************************************/
 
-void xtensa_coproc_enable(struct xtensa_cpstate_s *cpstate, int cpset)
+void xtensa_coproc_enable(int cpset)
 {
   irqstate_t flags;
   uint32_t cpenable;
@@ -64,16 +63,6 @@ void xtensa_coproc_enable(struct xtensa_cpstate_s *cpstate, int cpset)
 
   flags = enter_critical_section();
 
-  /* Don't enable co-processors that may already be enabled
-   *
-   *          cpenable
-   *            0   1
-   *          --- ---
-   *  cpset 0 | 0   0
-   *        1 | 1   0
-   */
-
-  cpset ^= (cpset & cpstate->cpenable);
   if (cpset != 0)
     {
       /* Enable the co-processors */
@@ -81,9 +70,6 @@ void xtensa_coproc_enable(struct xtensa_cpstate_s *cpstate, int cpset)
       cpenable = xtensa_get_cpenable();
       cpenable |= cpset;
       xtensa_set_cpenable(cpenable);
-
-      cpstate->cpenable  = cpenable;
-      cpstate->cpstored &= ~cpset;
     }
 
   leave_critical_section(flags);
@@ -96,7 +82,6 @@ void xtensa_coproc_enable(struct xtensa_cpstate_s *cpstate, int cpset)
  *   Enable a set of co-processors.
  *
  * Input Parameters:
- *   cpstate - A pointer to the Co-processor state save structure.
  *   cpset   - A bit set of co-processors to be enabled.  Matches bit layout
  *             of the CPENABLE register.  Bit 0-XCHAL_CP_NUM:  0 = no change
  *             1 = disable
@@ -106,7 +91,7 @@ void xtensa_coproc_enable(struct xtensa_cpstate_s *cpstate, int cpset)
  *
  ****************************************************************************/
 
-void xtensa_coproc_disable(struct xtensa_cpstate_s *cpstate, int cpset)
+void xtensa_coproc_disable(int cpset)
 {
   irqstate_t flags;
   uint32_t cpenable;
@@ -115,16 +100,6 @@ void xtensa_coproc_disable(struct xtensa_cpstate_s *cpstate, int cpset)
 
   flags = enter_critical_section();
 
-  /* Don't disable co-processors that are already be disabled.
-   *
-   *          cpenable
-   *            0   1
-   *          --- ---
-   *  cpset 0 | 0   0
-   *        1 | 0   1
-   */
-
-  cpset &= cpstate->cpenable;
   if (cpset != 0)
     {
       /* Disable the co-processors */
@@ -132,9 +107,6 @@ void xtensa_coproc_disable(struct xtensa_cpstate_s *cpstate, int cpset)
       cpenable = xtensa_get_cpenable();
       cpenable &= ~cpset;
       xtensa_set_cpenable(cpenable);
-
-      cpstate->cpenable  = cpenable;
-      cpstate->cpstored &= ~cpset;
     }
 
   leave_critical_section(flags);

--- a/arch/xtensa/src/common/xtensa_dumpstate.c
+++ b/arch/xtensa/src/common/xtensa_dumpstate.c
@@ -299,7 +299,7 @@ void xtensa_dumpstate(void)
     }
   else
     {
-      up_saveusercontext(&rtcb->xcp.regs);
+      up_saveusercontext(rtcb->xcp.regs);
     }
 
   /* Dump the registers (if available) */

--- a/arch/xtensa/src/common/xtensa_exit.c
+++ b/arch/xtensa/src/common/xtensa_exit.c
@@ -139,7 +139,7 @@ void up_exit(int status)
 
   /* Then switch contexts */
 
-  xtensa_context_restore(&tcb->xcp.regs);
+  xtensa_context_restore(tcb->xcp.regs);
 
   /* xtensa_context_restore() should not return but could if the
    * software interrupts are disabled.

--- a/arch/xtensa/src/common/xtensa_exit.c
+++ b/arch/xtensa/src/common/xtensa_exit.c
@@ -116,12 +116,6 @@ void up_exit(int status)
 
   sinfo("TCB=%p exiting\n", tcb);
 
-#if XCHAL_CP_NUM > 0
-  /* Disable co-processor support for the task that is exit-ing. */
-
-  xtensa_coproc_disable(&tcb->xcp.cpstate, XTENSA_CP_ALLSET);
-#endif
-
   /* Destroy the task at the head of the ready to run list. */
 
   nxtask_exit();

--- a/arch/xtensa/src/common/xtensa_initialize.c
+++ b/arch/xtensa/src/common/xtensa_initialize.c
@@ -84,6 +84,10 @@ static inline void xtensa_color_intstack(void)
 
 void up_initialize(void)
 {
+#if XCHAL_CP_NUM > 0
+  xtensa_set_cpenable(CONFIG_XTENSA_CP_INITSET);
+#endif
+
   xtensa_color_intstack();
 
   /* Add any extra memory fragments to the memory manager */

--- a/arch/xtensa/src/common/xtensa_initialstate.c
+++ b/arch/xtensa/src/common/xtensa_initialstate.c
@@ -108,18 +108,4 @@ void up_initial_state(struct tcb_s *tcb)
 
   xcp->regs[REG_PS]   = PS_UM | PS_WOE | PS_CALLINC(1);
 #endif
-
-#if XCHAL_CP_NUM > 0
-  /* Set up the co-processors that will be enabled initially when the thread
-   * starts (see xtensa_coproc.h).  If the lazy co-processor state restore
-   * logic is selected, that would be the empty set.
-   */
-
-#ifdef CONFIG_XTENSA_CP_LAZY
-  xcp->cpstate.cpenable = 0;  /* No co-processors are enabled */
-#else
-  xcp->cpstate.cpenable = (CONFIG_XTENSA_CP_INITSET & XTENSA_CP_ALLSET);
-#endif
-  xcp->cpstate.cpstored = 0;  /* No co-processors haved state saved */
-#endif
 }

--- a/arch/xtensa/src/common/xtensa_sigdeliver.c
+++ b/arch/xtensa/src/common/xtensa_sigdeliver.c
@@ -178,5 +178,5 @@ void xtensa_sig_deliver(void)
    */
 
   board_autoled_off(LED_SIGNAL);
-  xtensa_context_restore(&regs);
+  xtensa_context_restore(regs);
 }

--- a/arch/xtensa/src/common/xtensa_swint.c
+++ b/arch/xtensa/src/common/xtensa_swint.c
@@ -96,7 +96,7 @@ int xtensa_swint(int irq, void *context, void *arg)
       case SYS_save_context:
         {
           DEBUGASSERT(regs[REG_A3] != 0);
-          memcpy(*(uint32_t **)regs[REG_A3], regs, XCPTCONTEXT_SIZE);
+          memcpy((uint32_t *)regs[REG_A3], regs, XCPTCONTEXT_SIZE);
         }
 
         break;
@@ -121,7 +121,7 @@ int xtensa_swint(int irq, void *context, void *arg)
       case SYS_restore_context:
         {
           DEBUGASSERT(regs[REG_A3] != 0);
-          CURRENT_REGS = *(uint32_t **)regs[REG_A3];
+          CURRENT_REGS = (uint32_t *)regs[REG_A3];
         }
 
         break;

--- a/arch/xtensa/src/common/xtensa_swint.c
+++ b/arch/xtensa/src/common/xtensa_swint.c
@@ -51,13 +51,6 @@ int xtensa_swint(int irq, void *context, void *arg)
 {
   uint32_t *regs = (uint32_t *)context;
   uint32_t cmd;
-#if XCHAL_CP_NUM > 0
-  uintptr_t cpstate;
-  uint32_t cpstate_off;
-
-  cpstate_off = offsetof(struct xcptcontext, cpstate) -
-                offsetof(struct xcptcontext, regs);
-#endif
 
   DEBUGASSERT(regs && regs == CURRENT_REGS);
   cmd = regs[REG_A2];
@@ -104,10 +97,6 @@ int xtensa_swint(int irq, void *context, void *arg)
         {
           DEBUGASSERT(regs[REG_A3] != 0);
           memcpy(*(uint32_t **)regs[REG_A3], regs, XCPTCONTEXT_SIZE);
-#if XCHAL_CP_NUM > 0
-          cpstate = (uintptr_t)regs[REG_A3] + cpstate_off;
-          xtensa_coproc_savestate((struct xtensa_cpstate_s *)cpstate);
-#endif
         }
 
         break;
@@ -133,10 +122,6 @@ int xtensa_swint(int irq, void *context, void *arg)
         {
           DEBUGASSERT(regs[REG_A3] != 0);
           CURRENT_REGS = *(uint32_t **)regs[REG_A3];
-#if XCHAL_CP_NUM > 0
-          cpstate = (uintptr_t)regs[REG_A3] + cpstate_off;
-          xtensa_coproc_restorestate((struct xtensa_cpstate_s *)cpstate);
-#endif
         }
 
         break;

--- a/arch/xtensa/src/esp32/esp32_cpustart.c
+++ b/arch/xtensa/src/esp32/esp32_cpustart.c
@@ -209,7 +209,7 @@ void IRAM_ATTR xtensa_appcpu_start(void)
    * be the CPUs NULL task.
    */
 
-  xtensa_context_restore(&tcb->xcp.regs);
+  xtensa_context_restore(tcb->xcp.regs);
 }
 
 /****************************************************************************

--- a/arch/xtensa/src/esp32/esp32_cpustart.c
+++ b/arch/xtensa/src/esp32/esp32_cpustart.c
@@ -180,14 +180,6 @@ void IRAM_ATTR xtensa_appcpu_start(void)
 
   up_enable_irq(XTENSA_IRQ_SWINT);
 
-#if 0 /* Does it make since to have co-processors enabled on the IDLE thread? */
-#if XTENSA_CP_ALLSET != 0
-  /* Set initial co-processor state */
-
-  xtensa_coproc_enable(struct xtensa_cpstate_s *cpstate, int cpset);
-#endif
-#endif
-
   /* Dump registers so that we can see what is going to happen on return */
 
   xtensa_registerdump(tcb);

--- a/arch/xtensa/src/esp32s3/esp32s3_cpustart.c
+++ b/arch/xtensa/src/esp32s3/esp32s3_cpustart.c
@@ -169,7 +169,7 @@ void xtensa_appcpu_start(void)
    * be the CPUs NULL task.
    */
 
-  xtensa_context_restore(&tcb->xcp.regs);
+  xtensa_context_restore(tcb->xcp.regs);
 }
 
 /****************************************************************************


### PR DESCRIPTION
1 move fpu register to XCP_REGS
2 move save & restore fpu register to context_save/restore

Consistency with other archs.

Signed-off-by: zhuyanlin <zhuyanlin1@xiaomi.com>

## Summary

This PR move fpu register to XCP, in Consistency with other archs

## Impact

No

## Testing

1) Test in xtensa board, with fpu coprocosser 

#define XCHAL_CP_NUM                    1       /* number of coprocessors */
#define XCHAL_CP_MAX                    2       /* max CP ID + 1 (0 if none) */
#define XCHAL_CP_MASK                   0x02    /* bitmask of all CPs by ID */

ostest test OK

2) Qemu Esp32. ostest OK