### PR TITLE
LCD: Added existing FBIO_SETPOWER support to lcd_framebuffer.c

### DIFF
--- a/drivers/lcd/lcd_framebuffer.c
+++ b/drivers/lcd/lcd_framebuffer.c
@@ -105,6 +105,8 @@ static int lcdfb_setcursor(FAR struct fb_vtable_s *vtable,
              FAR struct fb_setcursor_s *settings);
 #endif
 
+static int lcdfb_setpower(FAR struct fb_vtable_s *vtable, FAR int power);
+
 /****************************************************************************
  * Private Data
  ****************************************************************************/
@@ -437,6 +439,35 @@ static int lcdfb_setcursor(FAR struct fb_vtable_s *vtable,
 #endif
 
 /****************************************************************************
+ * Name: lcdfb_setpower
+ ****************************************************************************/
+
+static int lcdfb_setpower(FAR struct fb_vtable_s *vtable, FAR int power)
+{
+  int ret = -EINVAL;
+  FAR struct lcdfb_dev_s *priv;
+  FAR struct lcd_dev_s *lcd;
+
+  DEBUGASSERT(vtable != NULL);
+
+  priv = (FAR struct lcdfb_dev_s *)vtable;
+
+  if (priv != NULL)
+    {
+      lcd = priv->lcd;
+      DEBUGASSERT(lcd->setpower != NULL);
+
+      ret = lcd->setpower(lcd, power);
+      if (ret < 0)
+        {
+          lcderr("ERROR: LCD setpower() failed: %d\n", ret);
+        }
+    }
+
+  return ret;
+}
+
+/****************************************************************************
  * Public Functions
  ****************************************************************************/
 
@@ -491,6 +522,7 @@ int up_fbinitialize(int display)
   priv->vtable.setcursor    = lcdfb_setcursor,
 #endif
   priv->vtable.updatearea   = lcdfb_updateearea,
+  priv->vtable.setpower     = lcdfb_setpower,
 
 #ifdef CONFIG_LCD_EXTERNINIT
   /* Use external graphics driver initialization */


### PR DESCRIPTION
## Summary
In nuttx/drivers/video/fb.c there is a FBIOSET_POWER IOCTL. 
To use this, fb->vtable->setpower needs to be connected to the correct function.
This function is now added in lcd_framebuffer.c

## Impact
Extending existing interface.

## Testing
Tested with an SSD1306 display on custom S32K1xx board.
