### PR TITLE
LCD SSD1306: Added custom configuration option

### DIFF
--- a/drivers/lcd/Kconfig
+++ b/drivers/lcd/Kconfig
@@ -323,6 +323,38 @@ config LCD_HILETGO
 		LCD_MAXCONTRAST should be 255, but any value >0 and <=255 will be accepted.
 		LCD_MAXPOWER should be 1:  0=off, 1=on
 
+config LCD_SSD1306_CUSTOM
+	bool "Custom SSD1306-controlled OLED Display Module"
+	default n
+	select LCD_SSD1306
+	---help---
+		Custom OLED Display Module,
+		controlled by the Solomon Tech SSD1306 LCD controller.
+
+if LCD_SSD1306_CUSTOM
+
+config LCD_SSD1306_CUSTOM_DEV_NATIVE_XRES 
+	int "Custom LCD native X-resolution"
+	default 128
+
+config LCD_SSD1306_CUSTOM_DEV_NATIVE_YRES 
+	int "Custom LCD native Y-resolution"
+	default 32
+
+config LCD_SSD1306_CUSTOM_DEV_XOFFSET 
+	int "Custom LCD X-offset"
+	default 0
+
+config LCD_SSD1306_CUSTOM_DEV_PAGES 
+	int "Custom LCD number of pages"
+	default 4
+
+config LCD_SSD1306_CUSTOM_DEV_CMNPAD 
+	int "Custom LCD COM configuration (cmnpad)"
+	default 2
+
+endif # LCD_SSD1306_CUSTOM
+
 config LCD_SSD1306
 	bool
 

--- a/drivers/lcd/ssd1306.h
+++ b/drivers/lcd/ssd1306.h
@@ -45,7 +45,8 @@
     !defined(CONFIG_LCD_UG2864HSWEG01) && \
     !defined(CONFIG_LCD_UG2832HSWEG04) && \
     !defined(CONFIG_LCD_DD12864WO4A) && \
-    !defined(CONFIG_LCD_HILETGO)
+    !defined(CONFIG_LCD_HILETGO) && \
+    !defined(CONFIG_LCD_SSD1306_CUSTOM)
 #  error "Unknown and unsupported SSD1306 LCD"
 #endif
 
@@ -167,6 +168,13 @@
 #  define SSD1306_DEV_PAGES       8    /* 8 pages */
 #  define SSD1306_DEV_CMNPAD      0x10 /* COM configuration */
 #  define IS_SSD1309              1    /* SSD1309 based LCD. */
+#elif defined(CONFIG_LCD_SSD1306_CUSTOM)
+#  define SSD1306_DEV_NATIVE_XRES CONFIG_LCD_SSD1306_CUSTOM_DEV_NATIVE_XRES /* Only 128 of 131 columns used */
+#  define SSD1306_DEV_NATIVE_YRES CONFIG_LCD_SSD1306_CUSTOM_DEV_NATIVE_YRES /* 4 pages each 8 rows */
+#  define SSD1306_DEV_XOFFSET     CONFIG_LCD_SSD1306_CUSTOM_DEV_XOFFSET     /* Offset to logical column 0 */
+#  define SSD1306_DEV_PAGES       CONFIG_LCD_SSD1306_CUSTOM_DEV_PAGES       /* 4 pages */
+#  define SSD1306_DEV_CMNPAD      CONFIG_LCD_SSD1306_CUSTOM_DEV_CMNPAD      /* COM configuration */
+#  undef IS_SSD1309
 #endif
 
 #if defined(CONFIG_LCD_LANDSCAPE) || defined(CONFIG_LCD_RLANDSCAPE)
@@ -235,6 +243,14 @@
 #    undef  SSD1306_DEV_REVERSEY
 #  endif
 #elif defined(CONFIG_LCD_DD12864WO4A)
+#  if defined(CONFIG_LCD_LANDSCAPE)
+#    define SSD1306_DEV_REVERSEX  1
+#    undef  SSD1306_DEV_REVERSEY
+#  elif defined(CONFIG_LCD_RLANDSCAPE)
+#    undef  SSD1306_DEV_REVERSEX
+#    define SSD1306_DEV_REVERSEY  1
+#  endif
+#elif defined(CONFIG_LCD_SSD1306_CUSTOM)
 #  if defined(CONFIG_LCD_LANDSCAPE)
 #    define SSD1306_DEV_REVERSEX  1
 #    undef  SSD1306_DEV_REVERSEY


### PR DESCRIPTION
## Summary
Added option in menuconfig for custom SSD1306 configuration. 
This is useful for usage of off-brand displays.

## Impact
little, extended existing configurations.

## Testing
Tested on custom s32k1xx board with SSD1306 display.
