### PR TITLE
Replace all sem_wait with nxsem_wait

### DIFF
--- a/arch/arm/src/phy62xx/uart.c
+++ b/arch/arm/src/phy62xx/uart.c
@@ -1156,7 +1156,7 @@ void h4uart_rx_irq(void *arg)
         }
 
       circbuf_write(param->pcirc_h2c, buf, len);
-      sem_post(param->psem_h2c);
+      nxsem_post(param->psem_h2c);
     }
 }
 

--- a/arch/arm/src/rtl8720c/amebaz_depend.c
+++ b/arch/arm/src/rtl8720c/amebaz_depend.c
@@ -186,7 +186,7 @@ void rtw_free_sema(void **sema)
 
 void rtw_up_sema(void **sema)
 {
-  sem_post(*sema);
+  nxsem_post(*sema);
 }
 
 void rtw_up_sema_from_isr(void **sema)

--- a/arch/arm/src/stm32/stm32_foc.c
+++ b/arch/arm/src/stm32/stm32_foc.c
@@ -1570,7 +1570,7 @@ static int stm32_foc_adc_calibration_handler(struct foc_dev_s *dev)
 
       /* Post semaphore that calibration is done */
 
-      sem_post(&priv->cal_done_sem);
+      nxsem_post(&priv->cal_done_sem);
     }
   else
     {

--- a/arch/arm/src/tlsr82/tlsr82_adc.c
+++ b/arch/arm/src/tlsr82/tlsr82_adc.c
@@ -647,7 +647,7 @@ static void adc_read_work(struct adc_dev_s *dev)
   int32_t adc;
   struct adc_chan_s *priv = (struct adc_chan_s *)dev->ad_priv;
 
-  ret = sem_wait(&g_sem_excl);
+  ret = nxsem_wait(&g_sem_excl);
   if (ret < 0)
     {
       aerr("Failed to wait sem ret=%d\n", ret);
@@ -676,7 +676,7 @@ static void adc_read_work(struct adc_dev_s *dev)
   ainfo("channel: %" PRIu8 ", voltage: %" PRIu32 " mV\n", priv->channel,
         adc);
 
-  sem_post(&g_sem_excl);
+  nxsem_post(&g_sem_excl);
 }
 
 /****************************************************************************

--- a/arch/mips/src/pic32mz/pic32mz_spi.c
+++ b/arch/mips/src/pic32mz/pic32mz_spi.c
@@ -1747,7 +1747,7 @@ static void spi_exchange(struct spi_dev_s *dev, const void *txbuffer,
   spi_txdma_sample(priv, DMA_AFTER_START);
 
   /* Wait for DMA completion. This is done in a loop because there may be
-   * false alarm semaphore counts that cause sem_wait() not fail to wait
+   * false alarm semaphore counts that cause nxsem_wait() not fail to wait
    * or to wake-up prematurely (for example due to the receipt of a signal).
    * We know that the DMA has completed when the result is anything other
    * that -EBUSY.

--- a/arch/risc-v/src/bl602/bl602_netdev.c
+++ b/arch/risc-v/src/bl602/bl602_netdev.c
@@ -32,7 +32,7 @@
 #include <assert.h>
 #include <debug.h>
 #include <sched.h>
-#include <semaphore.h>
+#include <nuttx/semaphore.h>
 #include <nuttx/nuttx.h>
 #include <nuttx/kmalloc.h>
 #include <nuttx/list.h>
@@ -1509,7 +1509,7 @@ static int bl602_ioctl_wifi_start(struct bl602_net_driver_s *priv,
           return -EPIPE;
         }
 
-      sem_wait(&g_wifi_connect_sem);
+      nxsem_wait(&g_wifi_connect_sem);
 
       /* check connect state */
 
@@ -1639,7 +1639,7 @@ bl602_net_ioctl(struct net_driver_s *dev, int cmd, unsigned long arg)
               para->flags = 0;
             }
 
-          if (sem_trywait(&g_wifi_scan_sem) == 0)
+          if (nxsem_trywait(&g_wifi_scan_sem) == 0)
             {
               if (priv->channel != 0)
                 {
@@ -1672,24 +1672,24 @@ bl602_net_ioctl(struct net_driver_s *dev, int cmd, unsigned long arg)
         {
           struct iwreq *req = (struct iwreq *)arg;
 
-          sem_wait(&g_wifi_scan_sem);
+          nxsem_wait(&g_wifi_scan_sem);
 
           if (g_state.scan_result_status != 0)
             {
               wlwarn("scan failed\n");
-              sem_post(&g_wifi_scan_sem);
+              nxsem_post(&g_wifi_scan_sem);
               return -EIO;
             }
 
           if (g_state.scan_result_len == 0)
             {
               req->u.data.length = 0;
-              sem_post(&g_wifi_scan_sem);
+              nxsem_post(&g_wifi_scan_sem);
               return OK;
             }
 
           ret = format_scan_result_to_wapi(req, g_state.scan_result_len);
-          sem_post(&g_wifi_scan_sem);
+          nxsem_post(&g_wifi_scan_sem);
           return ret;
         }
       while (0);
@@ -2114,7 +2114,7 @@ void bl602_net_event(int evt, int val)
           netdev_carrier_on(&priv->net_dev);
 
           wifi_mgmr_sta_autoconnect_disable();
-          sem_post(&g_wifi_connect_sem);
+          nxsem_post(&g_wifi_connect_sem);
         }
       while (0);
       break;
@@ -2147,7 +2147,7 @@ void bl602_net_event(int evt, int val)
                   wifi_mgmr_sta_autoconnect_disable();
                   wifi_mgmr_api_idle();
 
-                  sem_post(&g_wifi_connect_sem);
+                  nxsem_post(&g_wifi_connect_sem);
                 }
             }
         }
@@ -2158,7 +2158,7 @@ void bl602_net_event(int evt, int val)
       do
         {
           g_state.scan_result_status = val;
-          sem_post(&g_wifi_scan_sem);
+          nxsem_post(&g_wifi_scan_sem);
         }
       while (0);
 

--- a/arch/risc-v/src/esp32c3/esp32c3_adc.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_adc.c
@@ -573,7 +573,7 @@ static void adc_read_work(struct adc_dev_s *dev)
   int32_t adc;
   struct adc_chan_s *priv = (struct adc_chan_s *)dev->ad_priv;
 
-  ret = sem_wait(&g_sem_excl);
+  ret = nxsem_wait(&g_sem_excl);
   if (ret < 0)
     {
       aerr("Failed to wait sem ret=%d\n", ret);
@@ -591,7 +591,7 @@ static void adc_read_work(struct adc_dev_s *dev)
   ainfo("channel: %" PRIu8 ", voltage: %" PRIu32 " mV\n", priv->channel,
         adc);
 
-  sem_post(&g_sem_excl);
+  nxsem_post(&g_sem_excl);
 }
 
 /****************************************************************************
@@ -706,7 +706,7 @@ static int adc_setup(struct adc_dev_s *dev)
 
   /* Start calibration only once  */
 
-  ret = sem_wait(&g_sem_excl);
+  ret = nxsem_wait(&g_sem_excl);
   if (ret < 0)
     {
       adc_disable_clk();
@@ -720,7 +720,7 @@ static int adc_setup(struct adc_dev_s *dev)
       g_calibrated = true;
     }
 
-  sem_post(&g_sem_excl);
+  nxsem_post(&g_sem_excl);
 
   /* The ADC device is ready */
 

--- a/arch/risc-v/src/esp32c3/esp32c3_ble_adapter.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_ble_adapter.c
@@ -920,7 +920,7 @@ static int semphr_take_wrapper(void *semphr, uint32_t block_time_ms)
 
   if (block_time_ms == OSI_FUNCS_TIME_BLOCKING)
     {
-      ret = sem_wait(&bt_sem->sem);
+      ret = nxsem_wait(&bt_sem->sem);
       if (ret)
         {
           wlerr("Failed to wait sem\n");
@@ -967,7 +967,7 @@ static int semphr_give_wrapper(void *semphr)
   int ret;
   struct bt_sem_s *bt_sem = (struct bt_sem_s *)semphr;
 
-  ret = sem_post(&bt_sem->sem);
+  ret = nxsem_post(&bt_sem->sem);
   if (ret)
     {
       wlerr("Failed to post sem error=%d\n", ret);

--- a/arch/xtensa/src/esp32/esp32_ble_adapter.c
+++ b/arch/xtensa/src/esp32/esp32_ble_adapter.c
@@ -1191,7 +1191,7 @@ static void semphr_delete_wrapper(void *semphr)
 
 static int IRAM_ATTR semphr_take_from_isr_wrapper(void *semphr, void *hptw)
 {
-  return esp_errno_trans(sem_trywait(semphr));
+  return esp_errno_trans(nxsem_trywait(semphr));
 }
 
 /****************************************************************************
@@ -1266,7 +1266,7 @@ static int semphr_take_wrapper(void *semphr, uint32_t block_time_ms)
 
   if (block_time_ms == OSI_FUNCS_TIME_BLOCKING)
     {
-      ret = sem_wait(sem);
+      ret = nxsem_wait(sem);
       if (ret)
         {
           wlerr("Failed to wait sem %d\n", ret);
@@ -1311,7 +1311,7 @@ static int semphr_give_wrapper(void *semphr)
   int ret;
   sem_t *sem = (sem_t *)semphr;
 
-  ret = sem_post(sem);
+  ret = nxsem_post(sem);
   if (ret)
     {
       wlerr("Failed to post sem error=%d\n", ret);


### PR DESCRIPTION
## Summary
kernel shouldn't call the userspace api if nx version is provided.

## Impact
Minor

## Testing
Pass CI
