### PR TITLE
xtensa_sigtramp.S: Remove unnecessary entry instruction

### DIFF
--- a/arch/xtensa/src/common/xtensa_schedsigaction.c
+++ b/arch/xtensa/src/common/xtensa_schedsigaction.c
@@ -87,11 +87,11 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 
   if (!tcb->xcp.sigdeliver)
     {
+      sinfo("rtcb=0x%p CURRENT_REGS=0x%p\n", this_task(), CURRENT_REGS);
+
       /* First, handle some special cases when the signal is being delivered
        * to the currently executing task.
        */
-
-      sinfo("rtcb=0x%p CURRENT_REGS=0x%p\n", this_task(), CURRENT_REGS);
 
       if (tcb == this_task())
         {

--- a/arch/xtensa/src/common/xtensa_sigdeliver.c
+++ b/arch/xtensa/src/common/xtensa_sigdeliver.c
@@ -46,7 +46,7 @@
  *
  * Description:
  *   This is the a signal handling trampoline.  When a signal action was
- *   posted.  The task context was mucked with and forced to branch to this
+ *   posted, the task context was mucked with and forced to branch to this
  *   location with interrupts disabled.
  *
  ****************************************************************************/

--- a/arch/xtensa/src/common/xtensa_sigtramp.S
+++ b/arch/xtensa/src/common/xtensa_sigtramp.S
@@ -56,7 +56,7 @@ _xtensa_sig_trampoline:
 	ENTRY(16)						/* REVISIT: This should not be here */
 
 #ifdef __XTENSA_CALL0_ABI__
-	cali0	xtensa_sig_deliver		/* Call xtensa_sig_deliver */
+	call0	xtensa_sig_deliver		/* Call xtensa_sig_deliver */
 #else
 	call4	xtensa_sig_deliver		/* Call xtensa_sig_deliver */
 #endif

--- a/arch/xtensa/src/common/xtensa_sigtramp.S
+++ b/arch/xtensa/src/common/xtensa_sigtramp.S
@@ -26,8 +26,6 @@
 
 #include <nuttx/config.h>
 
-#include <arch/xtensa/xtensa_abi.h>
-
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
@@ -53,8 +51,6 @@
 	.align	4
 
 _xtensa_sig_trampoline:
-	ENTRY(16)						/* REVISIT: This should not be here */
-
 #ifdef __XTENSA_CALL0_ABI__
 	call0	xtensa_sig_deliver		/* Call xtensa_sig_deliver */
 #else


### PR DESCRIPTION
## Summary
`_xtensa_sig_trampoline` is not called the usual way with window calls (call4, call8 and call12), we get there from a context switch after modifying the task's PC.  The `entry` instruction here is not required, besides it creates a frame that confuses the backtrace at that point.
## Impact
Xtensas chips.
## Testing
ESP32, ESP32-S2 and ESP32-S3.
