### PR TITLE
libs: risc-v: Add R_RISCV_JAL support to arch_elf.c

### DIFF
--- a/libs/libc/machine/risc-v/common/arch_elf.c
+++ b/libs/libc/machine/risc-v/common/arch_elf.c
@@ -82,6 +82,7 @@ static struct rname_code_s _rname_table[] =
   {"CALL", R_RISCV_CALL},
   {"CALL_PLT", R_RISCV_CALL_PLT},
   {"BRANCH", R_RISCV_BRANCH},
+  {"JAL", R_RISCV_JAL},
   {"RVC_JUMP", R_RISCV_RVC_JUMP},
   {"RVC_BRANCH", R_RISCV_RVC_BRANCH},
 };
@@ -394,6 +395,29 @@ int up_relocateadd(FAR const Elf_Rela *rel, FAR const Elf_Sym *sym,
           ASSERT(offset && val);
 
           binfo("offset for Bx=%ld (0x%lx) (val=0x%08" PRIx32 ") "
+                "already set!\n",
+                offset, offset, val);
+        }
+        break;
+
+      case R_RISCV_JAL:
+        {
+          binfo("%s at %08" PRIxPTR " [%08" PRIx32 "] "
+                "to sym=%p st_value=%08lx\n",
+                _get_rname(relotype),
+                addr, _get_val((uint16_t *)addr),
+                sym, sym->st_value);
+
+          /* P.21 Unconditinal Jumps : UJ type (imm=20bit) */
+
+          offset = (long)sym->st_value + (long)rel->r_addend - (long)addr;
+          uint32_t val = _get_val((uint16_t *)addr) & 0xfffff000;
+
+          ASSERT(offset && val);
+
+          /* NOTE: we assume that a compiler adds an immediate value */
+
+          binfo("offset for JAL=%ld (0x%lx) (val=0x%08" PRIx32 ") "
                 "already set!\n",
                 offset, offset, val);
         }


### PR DESCRIPTION
## Summary

- This commit adds R_RISCV_JAL support to arch_elf.c
- The code only checks the immediate value but does not relocate it
  because it is done by the compiler.

## Impact

- None

## Testing

- Tested with rv-virt:knsh64 (not merged yet)
