### PR TITLE
arm/tlsr82: fix kconfig warning 

### DIFF
--- a/arch/arm/src/tlsr82/Kconfig
+++ b/arch/arm/src/tlsr82/Kconfig
@@ -269,7 +269,7 @@ config TLSR82_PWM0_PULSECOUNT
 # PWM1 configuration
 
 config TLSR82_PWM1
-	bool " TLSR82 PWM1 Enable"
+	bool "TLSR82 PWM1 Enable"
 	default n
 
 # PWM2 configuration


### PR DESCRIPTION


## Summary

arm/tlsr82: fix kconfig warning

`arch/arm/src/tlsr82/Kconfig:272:warning: leading whitespace ignored`

Signed-off-by: chao.an <anchao@xiaomi.com>

## Impact

N/A

## Testing

ci-check