### PR TITLE
Fix broken tiva_gpioirqclear

### DIFF
--- a/arch/arm/src/tiva/common/lmxx_tm4c_gpioirq.c
+++ b/arch/arm/src/tiva/common/lmxx_tm4c_gpioirq.c
@@ -741,7 +741,7 @@ void tiva_gpioirqclear(pinconfig_t pinconfig)
    * logic register. Writing a 0 has no effect."
    */
 
-  putreg32((1 << pin), base + TIVA_GPIO_ICR_OFFSET);
+  putreg32(pin, base + TIVA_GPIO_ICR_OFFSET);
 }
 
 #endif /* CONFIG_TIVA_GPIO_IRQS */


### PR DESCRIPTION
## Summary

`tiva_gpioirqclear` had an extraneous bitshift that resulted (in the best case) the IRQ not being cleared which resulted in an immediate IRQ as soon as `tiva_gpioirqattach` was called.

## Impact

Could affect custom boards that relied on this bug to trigger an interrupt in some obscure way, but unlikely.

## Testing

With custom board based on TM4C123GH6PGE.