### PR TITLE
libc: Rename lib_Exit lib__Exit

### DIFF
--- a/libs/libc/stdlib/Make.defs
+++ b/libs/libc/stdlib/Make.defs
@@ -21,7 +21,7 @@
 # Add the stdlib C files to the build
 
 CSRCS += lib_abs.c lib_abort.c lib_atof.c lib_atoi.c lib_getprogname.c
-CSRCS += lib_atol.c lib_atoll.c lib_div.c lib_ldiv.c lib_lldiv.c lib_Exit.c
+CSRCS += lib_atol.c lib_atoll.c lib_div.c lib_ldiv.c lib_lldiv.c lib__Exit.c
 CSRCS += lib_itoa.c lib_labs.c lib_llabs.c lib_realpath.c lib_bsearch.c
 CSRCS += lib_rand.c lib_qsort.c lib_srand.c lib_strtol.c
 CSRCS += lib_strtoll.c lib_strtoul.c lib_strtoull.c lib_strtod.c lib_strtof.c

--- a/libs/libc/stdlib/lib__Exit.c
+++ b/libs/libc/stdlib/lib__Exit.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * libs/libc/stdlib/lib_Exit.c
+ * libs/libc/stdlib/lib__Exit.c
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with


### PR DESCRIPTION
Naming collision with lib_exit on some systems

## Summary

## Impact

## Testing

