### PR TITLE
sched: Remove task_restart in case of CONFIG_BUILD_KERNEL

### DIFF
--- a/include/sys/syscall_lookup.h
+++ b/include/sys/syscall_lookup.h
@@ -93,11 +93,11 @@ SYSCALL_LOOKUP(sem_wait,                   1)
   SYSCALL_LOOKUP(task_create,              5)
   SYSCALL_LOOKUP(task_spawn,               6)
   SYSCALL_LOOKUP(task_delete,              1)
+  SYSCALL_LOOKUP(task_restart,             1)
 #else
   SYSCALL_LOOKUP(pgalloc,                  2)
 #endif
 
-SYSCALL_LOOKUP(task_restart,               1)
 SYSCALL_LOOKUP(task_setcancelstate,        2)
 SYSCALL_LOOKUP(up_assert,                  2)
 

--- a/syscall/syscall.csv
+++ b/syscall/syscall.csv
@@ -173,7 +173,7 @@
 "sysinfo","sys/sysinfo.h","","int","FAR struct sysinfo *"
 "task_create","sched.h","!defined(CONFIG_BUILD_KERNEL)", "int","FAR const char *","int","int","main_t","FAR char * const []|FAR char * const *"
 "task_delete","sched.h","!defined(CONFIG_BUILD_KERNEL)","int","pid_t"
-"task_restart","sched.h","","int","pid_t"
+"task_restart","sched.h","!defined(CONFIG_BUILD_KERNEL)","int","pid_t"
 "task_setcancelstate","sched.h","","int","int","FAR int *"
 "task_setcanceltype","sched.h","defined(CONFIG_CANCELLATION_POINTS)","int","int","FAR int *"
 "task_spawn","nuttx/spawn.h","!defined(CONFIG_BUILD_KERNEL)","int","FAR const char *","main_t","FAR const posix_spawn_file_actions_t *","FAR const posix_spawnattr_t *","FAR char * const []|FAR char * const *","FAR char * const []|FAR char * const *"


### PR DESCRIPTION
Same treatment as task_delete, this is not usable in kernel build
either.

## Summary

## Impact

## Testing

