### PR TITLE
include/nuttx/crypto: include sys/types.h insted of stdint.h

### DIFF
--- a/include/nuttx/crypto/crypto.h
+++ b/include/nuttx/crypto/crypto.h
@@ -27,7 +27,7 @@
 
 #include <nuttx/config.h>
 
-#include <stdint.h>
+#include <sys/types.h>
 
 /****************************************************************************
  * Pre-processor Definitions


### PR DESCRIPTION
## Summary
It is better to include `sys/types.h` since header does not contain types from `stdint.h` and  `sys/types.h` is `__ASSEMBLY__` friendly.

## Impact
None

## Testing
Pass CI