### PR TITLE
xtensa: Fix argument passing for sys_call5 and sys_call6 functions

### DIFF
--- a/arch/xtensa/include/syscall.h
+++ b/arch/xtensa/include/syscall.h
@@ -350,7 +350,7 @@ static inline uintptr_t sys_call5(unsigned int nbr, uintptr_t parm1,
                                   uintptr_t parm4, uintptr_t parm5)
 {
   register long reg0 __asm__("a2") = (long)(nbr);
-  register long reg5 __asm__("a7") = (long)(parm4);
+  register long reg5 __asm__("a7") = (long)(parm5);
   register long reg4 __asm__("a6") = (long)(parm4);
   register long reg3 __asm__("a5") = (long)(parm3);
   register long reg2 __asm__("a4") = (long)(parm2);
@@ -384,8 +384,8 @@ static inline uintptr_t sys_call6(unsigned int nbr, uintptr_t parm1,
                                   uintptr_t parm6)
 {
   register long reg0 __asm__("a2") = (long)(nbr);
-  register long reg6 __asm__("a8") = (long)(parm4);
-  register long reg5 __asm__("a7") = (long)(parm4);
+  register long reg6 __asm__("a8") = (long)(parm6);
+  register long reg5 __asm__("a7") = (long)(parm5);
   register long reg4 __asm__("a6") = (long)(parm4);
   register long reg3 __asm__("a5") = (long)(parm3);
   register long reg2 __asm__("a4") = (long)(parm2);


### PR DESCRIPTION
## Summary
This PR intends to provide a fix to the `sys_call5` and `sys_call6` functions, where the argument `parm4` is mistakenly passed instead of the remaining arguments.

## Impact
Fix for system calls passing 5 or 6 arguments.

## Testing
Issue caught by visual inspection.

