### PR TITLE
icmp: Fixed replies to broadcasts.

### DIFF
--- a/net/icmp/icmp_reply.c
+++ b/net/icmp/icmp_reply.c
@@ -103,6 +103,8 @@ void icmp_reply(FAR struct net_driver_s *dev, int type, int code)
   if (net_ipv4addr_hdrcmp(ipv4->destipaddr, &any)
 #  ifdef CONFIG_NET_BROADCAST
       || net_ipv4addr_hdrcmp(ipv4->destipaddr, &bcast)
+      || net_ipv4addr_broadcast(net_ip4addr_conv32(ipv4->destipaddr),
+                                dev->d_netmask)
 #  endif /* CONFIG_NET_BROADCAST */
      )
     {


### PR DESCRIPTION
## Summary

ICMP must not reply to broadcasts.

Currently, it is improperly checking whether the destination is a broadcast, by a pure equality check with INADDR_BROADCAST.  
The broadcast address, as defined by the subnet mask, is not checked. This results in ICMP replying to broadcasts that it shouldn't.

The fix also takes into account the subnet mast, and checks against the calculated broadcast address, ensuring that only valid responses are sent.

## Impact

There are no more ICMP responses to broadcasts.

## Testing
Tested on a custom target, based on the STM32F427, using the LAN8720A.

Traffic was examined with Wireshark, with and without the fix, validating the fix.
