### PR TITLE
Fix ENOENT errors when polling on Netlink socket

### DIFF
--- a/drivers/usbhost/usbhost_storage.c
+++ b/drivers/usbhost/usbhost_storage.c
@@ -2435,16 +2435,15 @@ int usbhost_msc_notifier_setup(worker_t worker, uint8_t event, char sdchar,
  *         usbhost_msc_notifier_setup().
  *
  * Returned Value:
- *   Zero (OK) is returned on success; a negated errno value is returned on
- *   any failure.
+ *   None.
  *
  ****************************************************************************/
 
-int usbhost_msc_notifier_teardown(int key)
+void usbhost_msc_notifier_teardown(int key)
 {
   /* This is just a simple wrapper around work_notifier_teardown(). */
 
-  return work_notifier_teardown(key);
+  work_notifier_teardown(key);
 }
 
 /****************************************************************************

--- a/include/nuttx/mm/iob.h
+++ b/include/nuttx/mm/iob.h
@@ -349,13 +349,12 @@ int iob_notifier_setup(int qid, worker_t worker, FAR void *arg);
  *         iob_notifier_setup().
  *
  * Returned Value:
- *   Zero (OK) is returned on success; a negated errno value is returned on
- *   any failure.
+ *   None.
  *
  ****************************************************************************/
 
 #ifdef CONFIG_IOB_NOTIFIER
-int iob_notifier_teardown(int key);
+void iob_notifier_teardown(int key);
 #endif
 
 /****************************************************************************

--- a/include/nuttx/usb/usbhost.h
+++ b/include/nuttx/usb/usbhost.h
@@ -1093,12 +1093,11 @@ int usbhost_msc_notifier_setup(worker_t worker, uint8_t event, char sdchar,
  *         usbhost_msc_notifier_setup().
  *
  * Returned Value:
- *   Zero (OK) is returned on success; a negated errno value is returned on
- *   any failure.
+ *   None.
  *
  ****************************************************************************/
 
-int usbhost_msc_notifier_teardown(int key);
+void usbhost_msc_notifier_teardown(int key);
 
 /****************************************************************************
  * Name: usbhost_msc_notifier_signal

--- a/include/nuttx/wqueue.h
+++ b/include/nuttx/wqueue.h
@@ -500,13 +500,12 @@ int work_notifier_setup(FAR struct work_notifier_s *info);
  *         work_notifier_setup().
  *
  * Returned Value:
- *   Zero (OK) is returned on success; a negated errno value is returned on
- *   any failure.
+ *   None.
  *
  ****************************************************************************/
 
 #ifdef CONFIG_WQUEUE_NOTIFIER
-int work_notifier_teardown(int key);
+void work_notifier_teardown(int key);
 #endif
 
 /****************************************************************************

--- a/mm/iob/iob_notifier.c
+++ b/mm/iob/iob_notifier.c
@@ -92,16 +92,15 @@ int iob_notifier_setup(int qid, worker_t worker, FAR void *arg)
  *         iob_notifier_setup().
  *
  * Returned Value:
- *   Zero (OK) is returned on success; a negated errno value is returned on
- *   any failure.
+ *   None.
  *
  ****************************************************************************/
 
-int iob_notifier_teardown(int key)
+void iob_notifier_teardown(int key)
 {
   /* This is just a simple wrapper around work_notifier_teardown(). */
 
-  return work_notifier_teardown(key);
+  work_notifier_teardown(key);
 }
 
 /****************************************************************************

--- a/net/netdev/netdev.h
+++ b/net/netdev/netdev.h
@@ -478,13 +478,12 @@ int netdown_notifier_setup(worker_t worker, FAR struct net_driver_s *dev,
  *         netdown_notifier_setup().
  *
  * Returned Value:
- *   Zero (OK) is returned on success; a negated errno value is returned on
- *   any failure.
+ *   None.
  *
  ****************************************************************************/
 
 #ifdef CONFIG_NETDOWN_NOTIFIER
-int netdown_notifier_teardown(int key);
+void netdown_notifier_teardown(int key);
 #endif
 
 /****************************************************************************

--- a/net/netdev/netdown_notifier.c
+++ b/net/netdev/netdown_notifier.c
@@ -105,16 +105,15 @@ int netdown_notifier_setup(worker_t worker, FAR struct net_driver_s *dev,
  *         netdown_notifier_setup().
  *
  * Returned Value:
- *   Zero (OK) is returned on success; a negated errno value is returned on
- *   any failure.
+ *   None.
  *
  ****************************************************************************/
 
-int netdown_notifier_teardown(int key)
+void netdown_notifier_teardown(int key)
 {
   /* This is just a simple wrapper around work_notifier_teardown(). */
 
-  return work_notifier_teardown(key);
+  work_notifier_teardown(key);
 }
 
 /****************************************************************************

--- a/net/netlink/netlink.h
+++ b/net/netlink/netlink.h
@@ -178,13 +178,9 @@ int netlink_notifier_setup(worker_t worker, FAR struct netlink_conn_s *conn,
  * Input Parameters:
  *   conn - Teardown the notification for this Netlink connection.
  *
- * Returned Value:
- *   Zero (OK) is returned on success; a negated errno value is returned on
- *   any failure.
- *
  ****************************************************************************/
 
-int netlink_notifier_teardown(FAR struct netlink_conn_s *conn);
+void netlink_notifier_teardown(FAR struct netlink_conn_s *conn);
 
 /****************************************************************************
  * Name: netlink_notifier_signal

--- a/net/netlink/netlink_notifier.c
+++ b/net/netlink/netlink_notifier.c
@@ -93,26 +93,19 @@ int netlink_notifier_setup(worker_t worker, FAR struct netlink_conn_s *conn,
  * Input Parameters:
  *   conn - Teardown the notification for this Netlink connection.
  *
- * Returned Value:
- *   Zero (OK) is returned on success; a negated errno value is returned on
- *   any failure.
- *
  ****************************************************************************/
 
-int netlink_notifier_teardown(FAR struct netlink_conn_s *conn)
+void netlink_notifier_teardown(FAR struct netlink_conn_s *conn)
 {
   DEBUGASSERT(conn != NULL);
-  int ret = OK;
 
   /* This is just a simple wrapper around work_notifier_teardown(). */
 
   if (conn->key > 0)
     {
-      ret = work_notifier_teardown(conn->key);
+      work_notifier_teardown(conn->key);
       conn->key = 0;
     }
-
-  return ret;
 }
 
 /****************************************************************************

--- a/net/netlink/netlink_sockif.c
+++ b/net/netlink/netlink_sockif.c
@@ -638,7 +638,7 @@ static int netlink_poll(FAR struct socket *psock, FAR struct pollfd *fds,
     {
       /* Cancel any response notifications */
 
-      ret = netlink_notifier_teardown(conn);
+      netlink_notifier_teardown(conn);
       conn->pollsem   = NULL;
       conn->pollevent = NULL;
     }

--- a/net/tcp/tcp.h
+++ b/net/tcp/tcp.h
@@ -1830,13 +1830,12 @@ int tcp_disconnect_notifier_setup(worker_t worker,
  *         tcp_readahead_notifier_setup().
  *
  * Returned Value:
- *   Zero (OK) is returned on success; a negated errno value is returned on
- *   any failure.
+ *   None.
  *
  ****************************************************************************/
 
 #ifdef CONFIG_NET_TCP_NOTIFIER
-int tcp_notifier_teardown(int key);
+void tcp_notifier_teardown(int key);
 #endif
 
 /****************************************************************************

--- a/net/tcp/tcp_notifier.c
+++ b/net/tcp/tcp_notifier.c
@@ -217,16 +217,15 @@ int tcp_disconnect_notifier_setup(worker_t worker,
  *         tcp_readahead_notifier_setup().
  *
  * Returned Value:
- *   Zero (OK) is returned on success; a negated errno value is returned on
- *   any failure.
+ *   None.
  *
  ****************************************************************************/
 
-int tcp_notifier_teardown(int key)
+void tcp_notifier_teardown(int key)
 {
   /* This is just a simple wrapper around work_notifier_teardown(). */
 
-  return work_notifier_teardown(key);
+  work_notifier_teardown(key);
 }
 
 /****************************************************************************

--- a/net/udp/udp.h
+++ b/net/udp/udp.h
@@ -832,13 +832,12 @@ int udp_writebuffer_notifier_setup(worker_t worker,
  *         udp_readahead_notifier_setup().
  *
  * Returned Value:
- *   Zero (OK) is returned on success; a negated errno value is returned on
- *   any failure.
+ *   None.
  *
  ****************************************************************************/
 
 #ifdef CONFIG_NET_UDP_NOTIFIER
-int udp_notifier_teardown(int key);
+void udp_notifier_teardown(int key);
 #endif
 
 /****************************************************************************

--- a/net/udp/udp_notifier.c
+++ b/net/udp/udp_notifier.c
@@ -164,16 +164,15 @@ int udp_writebuffer_notifier_setup(worker_t worker,
  *         udp_readahead_notifier_setup().
  *
  * Returned Value:
- *   Zero (OK) is returned on success; a negated errno value is returned on
- *   any failure.
+ *   None.
  *
  ****************************************************************************/
 
-int udp_notifier_teardown(int key)
+void udp_notifier_teardown(int key)
 {
   /* This is just a simple wrapper around work_notifier_teardown(). */
 
-  return work_notifier_teardown(key);
+  work_notifier_teardown(key);
 }
 
 /****************************************************************************

--- a/sched/wqueue/kwork_notifier.c
+++ b/sched/wqueue/kwork_notifier.c
@@ -276,16 +276,14 @@ int work_notifier_setup(FAR struct work_notifier_s *info)
  *         work_notifier_setup().
  *
  * Returned Value:
- *   Zero (OK) is returned on success; a negated errno value is returned on
- *   any failure.
+ *   None.
  *
  ****************************************************************************/
 
-int work_notifier_teardown(int key)
+void work_notifier_teardown(int key)
 {
   FAR struct work_notifier_entry_s *notifier;
   irqstate_t flags;
-  int ret = OK;
 
   /* Disable interrupts very briefly. */
 
@@ -296,13 +294,7 @@ int work_notifier_teardown(int key)
    */
 
   notifier = work_notifier_find(key);
-  if (notifier == NULL)
-    {
-      /* There is no notification with this key in the pending list */
-
-      ret = -ENOENT;
-    }
-  else
+  if (notifier != NULL)
     {
       /* Found it!  Remove the notification from the pending list */
 
@@ -314,7 +306,6 @@ int work_notifier_teardown(int key)
     }
 
   leave_critical_section(flags);
-  return ret;
 }
 
 /****************************************************************************


### PR DESCRIPTION
## Summary

When a Netlink response is issued, which a task is currently polling for
on the corresponding AF_NETLINK socket, then the poll call will return
with a ENOENT error.  This is due to the fact that the Netlink response
notifier is automatically torn down after the notification.  Thus, this
change fixes up the ENOENT return value to OK.

## Impact

None

## Testing

Tested on an STMicroelectronics B-U585I-IOT02A board.