### PR TITLE
Fixes to imxRT and SAM E70 PWM drivers

### DIFF
--- a/arch/arm/src/imxrt/imxrt_flexpwm.c
+++ b/arch/arm/src/imxrt/imxrt_flexpwm.c
@@ -220,7 +220,7 @@ static struct imxrt_flexpwm_s g_pwm1 =
 {
   .ops = &g_pwmops,
   .modules = g_pwm1_modules,
-  .modules_num = 4,
+  .modules_num = FLEXPWM1_NMODULES,
   .frequency = 0,
   .base = IMXRT_FLEXPWM1_BASE,
 };
@@ -322,7 +322,7 @@ static struct imxrt_flexpwm_s g_pwm2 =
 {
   .ops = &g_pwmops,
   .modules = g_pwm2_modules,
-  .modules_num = 4,
+  .modules_num = FLEXPWM2_NMODULES,
   .frequency = 0,
   .base = IMXRT_FLEXPWM2_BASE,
 };
@@ -424,7 +424,7 @@ static struct imxrt_flexpwm_s g_pwm3 =
 {
   .ops = &g_pwmops,
   .modules = g_pwm3_modules,
-  .modules_num = 4,
+  .modules_num = FLEXPWM3_NMODULES,
   .frequency = 0,
   .base = IMXRT_FLEXPWM3_BASE,
 };
@@ -526,7 +526,7 @@ static struct imxrt_flexpwm_s g_pwm4 =
 {
   .ops = &g_pwmops,
   .modules = g_pwm4_modules,
-  .modules_num = 4,
+  .modules_num = FLEXPWM4_NMODULES,
   .frequency = 0,
   .base = IMXRT_FLEXPWM4_BASE,
 };

--- a/arch/arm/src/imxrt/imxrt_flexpwm.h
+++ b/arch/arm/src/imxrt/imxrt_flexpwm.h
@@ -36,6 +36,114 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
+#ifdef CONFIG_IMXRT_FLEXPWM1_MOD1
+#define FLEXPWM1_MOD1 1
+#else
+#define FLEXPWM1_MOD1 0
+#endif
+
+#ifdef CONFIG_IMXRT_FLEXPWM1_MOD2
+#define FLEXPWM1_MOD2 1
+#else
+#define FLEXPWM1_MOD2 0
+#endif
+
+#ifdef CONFIG_IMXRT_FLEXPWM1_MOD3
+#define FLEXPWM1_MOD3 1
+#else
+#define FLEXPWM1_MOD3 0
+#endif
+
+#ifdef CONFIG_IMXRT_FLEXPWM1_MOD4
+#define FLEXPWM1_MOD4 1
+#else
+#define FLEXPWM1_MOD4 0
+#endif
+
+#define FLEXPWM1_NMODULES (FLEXPWM1_MOD1 + FLEXPWM1_MOD2 + \
+                           FLEXPWM1_MOD3 + FLEXPWM1_MOD4)
+
+#ifdef CONFIG_IMXRT_FLEXPWM2_MOD1
+#define FLEXPWM2_MOD1 1
+#else
+#define FLEXPWM2_MOD1 0
+#endif
+
+#ifdef CONFIG_IMXRT_FLEXPWM2_MOD2
+#define FLEXPWM2_MOD2 1
+#else
+#define FLEXPWM2_MOD2 0
+#endif
+
+#ifdef CONFIG_IMXRT_FLEXPWM2_MOD3
+#define FLEXPWM2_MOD3 1
+#else
+#define FLEXPWM2_MOD3 0
+#endif
+
+#ifdef CONFIG_IMXRT_FLEXPWM2_MOD4
+#define FLEXPWM2_MOD4 1
+#else
+#define FLEXPWM2_MOD4 0
+#endif
+
+#define FLEXPWM2_NMODULES (FLEXPWM2_MOD1 + FLEXPWM2_MOD2 + \
+                           FLEXPWM2_MOD3 + FLEXPWM2_MOD4)
+
+#ifdef CONFIG_IMXRT_FLEXPWM3_MOD1
+#define FLEXPWM3_MOD1 1
+#else
+#define FLEXPWM3_MOD1 0
+#endif
+
+#ifdef CONFIG_IMXRT_FLEXPWM3_MOD2
+#define FLEXPWM3_MOD2 1
+#else
+#define FLEXPWM3_MOD2 0
+#endif
+
+#ifdef CONFIG_IMXRT_FLEXPWM3_MOD3
+#define FLEXPWM3_MOD3 1
+#else
+#define FLEXPWM3_MOD3 0
+#endif
+
+#ifdef CONFIG_IMXRT_FLEXPWM3_MOD4
+#define FLEXPWM3_MOD4 1
+#else
+#define FLEXPWM3_MOD4 0
+#endif
+
+#define FLEXPWM3_NMODULES (FLEXPWM3_MOD1 + FLEXPWM3_MOD2 + \
+                           FLEXPWM3_MOD3 + FLEXPWM3_MOD4)
+
+#ifdef CONFIG_IMXRT_FLEXPWM4_MOD1
+#define FLEXPWM4_MOD1 1
+#else
+#define FLEXPWM4_MOD1 0
+#endif
+
+#ifdef CONFIG_IMXRT_FLEXPWM4_MOD2
+#define FLEXPWM4_MOD2 1
+#else
+#define FLEXPWM4_MOD2 0
+#endif
+
+#ifdef CONFIG_IMXRT_FLEXPWM4_MOD3
+#define FLEXPWM4_MOD3 1
+#else
+#define FLEXPWM4_MOD3 0
+#endif
+
+#ifdef CONFIG_IMXRT_FLEXPWM4_MOD4
+#define FLEXPWM4_MOD4 1
+#else
+#define FLEXPWM4_MOD4 0
+#endif
+
+#define FLEXPWM4_NMODULES (FLEXPWM4_MOD1 + FLEXPWM4_MOD2 + \
+                           FLEXPWM4_MOD3 + FLEXPWM4_MOD4)
+
 /****************************************************************************
  * Public Function Prototypes
  ****************************************************************************/

--- a/arch/arm/src/samv7/sam_pwm.c
+++ b/arch/arm/src/samv7/sam_pwm.c
@@ -147,7 +147,7 @@ static struct sam_pwm_s g_pwm0 =
 {
   .ops = &g_pwmops,
   .channels = g_pwm0_channels,
-  .channels_num = 4,
+  .channels_num = PWM0_NCHANNELS,
   .frequency = 0,
   .base = SAM_PWM0_BASE,
 };
@@ -191,7 +191,7 @@ static struct sam_pwm_s g_pwm1 =
 {
   .ops = &g_pwmops,
   .channels = g_pwm1_channels,
-  .channels_num = 4,
+  .channels_num = PWM1_NCHANNELS,
   .frequency = 0,
   .base = SAM_PWM1_BASE,
 };

--- a/arch/arm/src/samv7/sam_pwm.h
+++ b/arch/arm/src/samv7/sam_pwm.h
@@ -36,6 +36,60 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
+#ifdef CONFIG_SAMV7_PWM0_CH0
+#define PWM0_CH0 1
+#else
+#define PWM0_CH0 0
+#endif
+
+#ifdef CONFIG_SAMV7_PWM0_CH1
+#define PWM0_CH1 1
+#else
+#define PWM0_CH1 0
+#endif
+
+#ifdef CONFIG_SAMV7_PWM0_CH2
+#define PWM0_CH2 1
+#else
+#define PWM0_CH2 0
+#endif
+
+#ifdef CONFIG_SAMV7_PWM0_CH3
+#define PWM0_CH3 1
+#else
+#define PWM0_CH3 0
+#endif
+
+#define PWM0_NCHANNELS (PWM0_CH0 + PWM0_CH1 + \
+                        PWM0_CH2 + PWM0_CH3)
+
+#ifdef CONFIG_SAMV7_PWM1_CH0
+#define PWM1_CH0 1
+#else
+#define PWM1_CH0 0
+#endif
+
+#ifdef CONFIG_SAMV7_PWM1_CH1
+#define PWM1_CH1 1
+#else
+#define PWM1_CH1 0
+#endif
+
+#ifdef CONFIG_SAMV7_PWM1_CH2
+#define PWM1_CH2 1
+#else
+#define PWM1_CH2 0
+#endif
+
+#ifdef CONFIG_SAMV7_PWM1_CH3
+#define PWM1_CH3 1
+#else
+#define PWM1_CH3 0
+#endif
+
+#define PWM1_NCHANNELS (PWM1_CH0 + PWM1_CH1 + \
+                        PWM1_CH2 + PWM1_CH3)
+
 /****************************************************************************
  * Public Function Prototypes
  ****************************************************************************/


### PR DESCRIPTION
## Summary
Use configuration options to set number of channels/modules in imxRT and SAM E70 PWM drivers. Old option could read to undefined behavior and hard faults.

## Impact
imxRT and SAM E70 MCUs only, both related just to PWM driver.

## Testing

Tested on SAM E70 Xplained and Teensy 4.1 boards.

