### PR TITLE
cibuild.sh: Install ESPTOOL V3.0

### DIFF
--- a/tools/ci/cibuild.sh
+++ b/tools/ci/cibuild.sh
@@ -224,7 +224,7 @@ function xtensa-esp32-gcc-toolchain {
     esac
   fi
   xtensa-esp32-elf-gcc --version
-  pip3 install esptool
+  pip3 install esptool==3.3.1
 }
 
 function avr-gcc-toolchain {


### PR DESCRIPTION
## Summary
V4 deprecated python2 which is problematic in macOS.
## Impact
Fix current CI breakage.
## Testing
CI Workflow.
