### PR TITLE
pthread/spinlock: Call up_testsest directly in the flat build 

### DIFF
--- a/libs/libc/pthread/Kconfig
+++ b/libs/libc/pthread/Kconfig
@@ -9,8 +9,8 @@ menu "pthread support"
 config PTHREAD_SPINLOCKS
 	bool "pthread spinlock support"
 	default n
-	depends on SPINLOCK && BOARDCTL
-	select BOARDCTL_TESTSET
+	depends on SPINLOCK && (BUILD_FLAT || BOARDCTL)
+	select BOARDCTL_TESTSET if !BUILD_FLAT
 	---help---
 		Enable support for pthread spinlocks.
 

--- a/libs/libc/pthread/pthread_spinlock.c
+++ b/libs/libc/pthread/pthread_spinlock.c
@@ -26,6 +26,7 @@
 
 #include <sys/types.h>
 #include <sys/boardctl.h>
+#include <nuttx/spinlock.h>
 
 #include <assert.h>
 #include <errno.h>
@@ -184,7 +185,11 @@ int pthread_spin_lock(pthread_spinlock_t *lock)
 
   do
     {
+#ifdef CONFIG_BUILD_FLAT
+      ret = up_testset(&lock->sp_lock) == SP_LOCKED ? 1 : 0;
+#else
       ret = boardctl(BOARDIOC_TESTSET, (uintptr_t)&lock->sp_lock);
+#endif
     }
   while (ret == 1);
 


### PR DESCRIPTION
## Summary

- libc: Move the common implementation of up_testset to libc/machine 

## Impact
spinlock

## Testing
Pass CI
