### PR TITLE
arch/addrenv: Add missing FAR qualifier to addrenv_mprot

### DIFF
--- a/include/nuttx/arch.h
+++ b/include/nuttx/arch.h
@@ -1203,8 +1203,8 @@ int up_addrenv_detach(FAR struct task_group_s *group, FAR struct tcb_s *tcb);
  ****************************************************************************/
 
 #ifdef CONFIG_ARCH_ADDRENV
-int up_addrenv_mprot(group_addrenv_t *addrenv, uintptr_t addr, size_t len,
-                     int prot);
+int up_addrenv_mprot(FAR group_addrenv_t *addrenv, uintptr_t addr,
+                     size_t len, int prot);
 #endif
 
 /****************************************************************************


### PR DESCRIPTION
## Summary

## Impact

## Testing

