### PR TITLE
risc-v/mpfs: IHC: allow hart configuration

### DIFF
--- a/arch/risc-v/src/mpfs/Kconfig
+++ b/arch/risc-v/src/mpfs/Kconfig
@@ -246,6 +246,70 @@ config MPFS_IHC
 	---help---
 		Selects and enables the Inter-Hart-Communication (IHC) slave driver.
 
+config MPFS_IHC_LINUX_ON_HART1
+	int "Linux on hart1"
+	depends on MPFS_IHC
+	default 0
+	range 0 1
+	---help---
+		Set this to 1 if U-boot / Linux is running on hart1
+
+config MPFS_IHC_LINUX_ON_HART2
+	int "Linux on hart2"
+	depends on MPFS_IHC
+	default 0
+	range 0 1
+	---help---
+		Set this to 1 if U-boot / Linux is running on hart2
+
+config MPFS_IHC_LINUX_ON_HART3
+	int "Linux on hart3"
+	depends on MPFS_IHC
+	default 1
+	range 0 1
+	---help---
+		Set this to 1 if U-boot / Linux is running on hart3
+
+config MPFS_IHC_LINUX_ON_HART4
+	int "Linux on hart4"
+	depends on MPFS_IHC
+	default 1
+	range 0 1
+	---help---
+		Set this to 1 if U-boot / Linux is running on hart4
+
+config MPFS_IHC_NUTTX_ON_HART1
+	int "NuttX on hart1"
+	depends on MPFS_IHC
+	default 0
+	range 0 1
+	---help---
+		Set this to 1 if NuttX is running on hart1
+
+config MPFS_IHC_NUTTX_ON_HART2
+	int "NuttX on hart2"
+	depends on MPFS_IHC
+	default 1
+	range 0 1
+	---help---
+		Set this to 1 if NuttX is running on hart2
+
+config MPFS_IHC_NUTTX_ON_HART3
+        int "NuttX on hart3"
+        depends on MPFS_IHC
+        default 0
+	range 0 1
+	---help---
+		Set this to 1 if NuttX is running on hart3
+
+config MPFS_IHC_NUTTX_ON_HART4
+        int "NuttX on hart4"
+        depends on MPFS_IHC
+        default 0
+	range 0 1
+	---help---
+		Set this to 1 if NuttX is running on hart4
+
 config MPFS_ETHMAC
 	bool
 	default n


### PR DESCRIPTION
Let the user pick what runs on the harts. For example, the
default configuration now supports NuttX on hart2 and Linux
kernel on harts 3 and 4. Also fix a few issues in the code.

Signed-off-by: Eero Nurkkala <eero.nurkkala@offcode.fi>

## Summary

Former sample had fixed NuttX on hart4 and Linux on harts 1,2,3

## Impact

Better IHC usage

## Testing

Polarfire MPFS
