### PR TITLE
stm32h7: allow definition of HSI divider in board config

### DIFF
--- a/arch/arm/src/stm32h7/stm32h7x3xx_rcc.c
+++ b/arch/arm/src/stm32h7/stm32h7x3xx_rcc.c
@@ -98,6 +98,10 @@
 #  define USE_PLL3
 #endif
 
+#if defined(STM32_BOARD_USEHSI) && !defined(STM32_BOARD_HSIDIV)
+#error When HSI is used, you have to define STM32_BOARD_HSIDIV in board/include/board.h
+#endif
+
 /****************************************************************************
  * Private Data
  ****************************************************************************/
@@ -600,6 +604,11 @@ void stm32_stdclockconfig(void)
 
   regval  = getreg32(STM32_RCC_CR);
   regval |= RCC_CR_HSION;           /* Enable HSI */
+
+  /* Set HSI predivider to board specific value */
+
+  regval |= STM32_BOARD_HSIDIV;
+
   putreg32(regval, STM32_RCC_CR);
 
   /* Wait until the HSI is ready (or until a timeout elapsed) */


### PR DESCRIPTION
## Summary
nucleo-h743zi is the only instanciation of stm32h7, and this board uses the HSE oscillator provided by the stlink interface.
If the integrated stlink debugger is disabled (this can happen in certain power configurations) then the CPU has no more clock reference. The HSI can be used instead, but definitions to do so easily are currently lacking.

When the HSI is used, the HSI divider is hardwired to 4, which results in a 16 MHz reference clock, and this requires a full recomputation of all PLL constants to match the complex clock tree speeds.

This commit adds the ability to choose the HSI divider, which must be indicated in board.h .
This is useful to match the HSI frequency to the existing HSE config, eg 8 MHz.
This allows to use the exact same PLL configuration and minimizes code changes.

## Impact
None expected if projects based on STM32H7 continue to use HSE.
This is new code that only applies to users of STM32H7 that want to use the HSI oscillator. To my knowledge there is none but you never know.

## Testing
In theory, all projects using STM32H7 should be retested. No regression is expected.
