### PR TITLE
Tcp nowrbuf

### DIFF
--- a/arch/arm/src/stm32h7/stm32h7x3xx_rcc.c
+++ b/arch/arm/src/stm32h7/stm32h7x3xx_rcc.c
@@ -98,6 +98,12 @@
 #  define USE_PLL3
 #endif
 
+#ifdef STM32_BOARD_USEHSI
+#ifndef STM32_BOARD_HSIDIV
+#error When HSI is used, you have to define STM32_BOARD_HSIDIV in board/include/board.h
+#endif
+#endif
+
 /****************************************************************************
  * Private Data
  ****************************************************************************/
@@ -143,10 +149,6 @@ static inline void rcc_reset(void)
               RCC_CR_CSION | RCC_CR_PLL1ON |
               RCC_CR_PLL2ON | RCC_CR_PLL3ON |
               RCC_CR_HSIDIV_MASK);
-
-  /* Set HSI predivider to default (4, 16MHz) */
-
-  regval |= RCC_CR_HSIDIV_4;
 
   putreg32(regval, STM32_RCC_CR);
 
@@ -600,6 +602,11 @@ void stm32_stdclockconfig(void)
 
   regval  = getreg32(STM32_RCC_CR);
   regval |= RCC_CR_HSION;           /* Enable HSI */
+
+  /* Set HSI predivider to board specific value */
+
+  regval |= STM32_BOARD_HSIDIV;
+
   putreg32(regval, STM32_RCC_CR);
 
   /* Wait until the HSI is ready (or until a timeout elapsed) */

--- a/net/tcp/Make.defs
+++ b/net/tcp/Make.defs
@@ -59,9 +59,12 @@ NET_CSRCS += tcp_recvwindow.c tcp_netpoll.c tcp_ioctl.c
 
 ifeq ($(CONFIG_NET_TCP_WRITE_BUFFERS),y)
 NET_CSRCS += tcp_wrbuffer.c
+endif
+
+# TCP debug
+
 ifeq ($(CONFIG_DEBUG_FEATURES),y)
 NET_CSRCS += tcp_dump.c
-endif
 endif
 
 # Include TCP build support

--- a/net/tcp/tcp_dump.c
+++ b/net/tcp/tcp_dump.c
@@ -52,10 +52,11 @@ void tcp_event_handler_dump(FAR struct net_driver_s *dev,
                             uint16_t flags,
                             FAR struct tcp_conn_s *conn)
 {
+#ifdef CONFIG_NET_TCP_WRITE_BUFFERS
   nerr("ERROR: conn->dev == NULL or pvconn != conn:"
        " dev=%p pvconn=%p pvpriv=%p flags=0x%04x"
        " conn->dev=%p conn->flags=0x%04x tcpstateflags=0x%02x crefs=%d"
-       " isn=%" PRIu32 " sndseq=%" PRIu32
+       " sndseq=%" PRIu32
        " tx_unacked=%" PRId32 " sent=%" PRId32
        " conn=%p s_flags=0x%02x\n",
        dev, pvconn, pvpriv, flags,
@@ -63,6 +64,19 @@ void tcp_event_handler_dump(FAR struct net_driver_s *dev,
        conn->isn, tcp_getsequence(conn->sndseq),
        (uint32_t)conn->tx_unacked, conn->sent,
        conn, conn->sconn.s_flags);
+#else
+  nerr("ERROR: conn->dev == NULL or pvconn != conn:"
+       " dev=%p pvconn=%p pvpriv=%p flags=0x%04x"
+       " conn->dev=%p conn->flags=0x%04x tcpstateflags=0x%02x crefs=%d"
+       " isn=%" PRIu32 " sndseq=%" PRIu32
+       " tx_unacked=%" PRId32
+       " conn=%p s_flags=0x%02x\n",
+       dev, pvconn, pvpriv, flags,
+       conn->dev, conn->flags, conn->tcpstateflags, conn->crefs,
+       tcp_getsequence(conn->sndseq),
+       (uint32_t)conn->tx_unacked,
+       conn, conn->sconn.s_flags);
+#endif
 }
 
 /****************************************************************************


### PR DESCRIPTION
## Summary
The TCP stack cannot be built if CONFIG_NET_TCP_WRITE_BUFFERS is not enabled.

## Impact
Allows the build of the tcp stack without defining CONFIG_NET_TCP_WRITE_BUFFERS.

## Testing
Build any NuttX with networking enabled and CONFIG_NET_TCP_WRITE_BUFFERS disabled: it fails without this fix.