### PR TITLE
net: fix the build when CONFIG_NET_TCP_WRITE_BUFFERS is not enabled

### DIFF
--- a/net/tcp/Make.defs
+++ b/net/tcp/Make.defs
@@ -59,9 +59,12 @@ NET_CSRCS += tcp_recvwindow.c tcp_netpoll.c tcp_ioctl.c
 
 ifeq ($(CONFIG_NET_TCP_WRITE_BUFFERS),y)
 NET_CSRCS += tcp_wrbuffer.c
+endif
+
+# TCP debug
+
 ifeq ($(CONFIG_DEBUG_FEATURES),y)
 NET_CSRCS += tcp_dump.c
-endif
 endif
 
 # Include TCP build support

--- a/net/tcp/tcp_dump.c
+++ b/net/tcp/tcp_dump.c
@@ -52,6 +52,7 @@ void tcp_event_handler_dump(FAR struct net_driver_s *dev,
                             uint16_t flags,
                             FAR struct tcp_conn_s *conn)
 {
+#ifdef CONFIG_NET_TCP_WRITE_BUFFERS
   nerr("ERROR: conn->dev == NULL or pvconn != conn:"
        " dev=%p pvconn=%p pvpriv=%p flags=0x%04x"
        " conn->dev=%p conn->flags=0x%04x tcpstateflags=0x%02x crefs=%d"
@@ -63,6 +64,19 @@ void tcp_event_handler_dump(FAR struct net_driver_s *dev,
        conn->isn, tcp_getsequence(conn->sndseq),
        (uint32_t)conn->tx_unacked, conn->sent,
        conn, conn->sconn.s_flags);
+#else
+  nerr("ERROR: conn->dev == NULL or pvconn != conn:"
+       " dev=%p pvconn=%p pvpriv=%p flags=0x%04x"
+       " conn->dev=%p conn->flags=0x%04x tcpstateflags=0x%02x crefs=%d"
+       " sndseq=%" PRIu32
+       " tx_unacked=%" PRId32
+       " conn=%p s_flags=0x%02x\n",
+       dev, pvconn, pvpriv, flags,
+       conn->dev, conn->flags, conn->tcpstateflags, conn->crefs,
+       tcp_getsequence(conn->sndseq),
+       (uint32_t)conn->tx_unacked,
+       conn, conn->sconn.s_flags);
+#endif
 }
 
 /****************************************************************************


### PR DESCRIPTION
## Summary
The build is currently broken if CONFIG_NET_TCP_WRITE_BUFFERS is not enabled

## Impact
None (this fixes a broken build)

## Testing
1.build any nuttx with tcp network enabled
2.make sure CONFIG_NET_TCP_WRITE_BUFFERS is enabled
=>build is ok
3.disable CONFIG_NET_TCP_WRITE_BUFFERS
=>build is broken
3.apply this fix
=> now it builds again