### PR TITLE
risc-v/opensbi: Generalize the SBI variable handling in makefile

### DIFF
--- a/arch/risc-v/src/Makefile
+++ b/arch/risc-v/src/Makefile
@@ -35,9 +35,6 @@ ARCH_SRCDIR = $(TOPDIR)$(DELIM)arch$(DELIM)$(CONFIG_ARCH)$(DELIM)src
 INCLUDES += ${shell $(INCDIR) "$(CC)" $(ARCH_SRCDIR)$(DELIM)chip}
 INCLUDES += ${shell $(INCDIR) "$(CC)" $(ARCH_SRCDIR)$(DELIM)common}
 INCLUDES += ${shell $(INCDIR) "$(CC)" $(TOPDIR)$(DELIM)sched}
-ifeq ($(CONFIG_OPENSBI),y)
-INCLUDES += $(shell $(INCDIR) "$(CC)" $(ARCH_SRCDIR)$(DELIM)opensbi$(DELIM)opensbi-3rdparty$(DELIM)include)
-endif
 
 CPPFLAGS += $(INCLUDES)
 CFLAGS += $(INCLUDES)
@@ -59,16 +56,10 @@ STARTUP_OBJS ?= $(HEAD_OBJ)
 
 # Flat build or kernel-mode objects
 
-ASRCS = $(CHIP_ASRCS) $(CMN_ASRCS)
-ifeq ($(CONFIG_OPENSBI),y)
-ASRCS += $(OPENSBI_ASRCS)
-endif
+ASRCS = $(CHIP_ASRCS) $(CMN_ASRCS) $(SBI_ASRCS)
 AOBJS = $(ASRCS:.S=$(OBJEXT))
 
-CSRCS = $(CHIP_CSRCS) $(CMN_CSRCS)
-ifeq ($(CONFIG_OPENSBI),y)
-CSRCS += $(OPENSBI_CSRCS)
-endif
+CSRCS = $(CHIP_CSRCS) $(CMN_CSRCS) $(SBI_CSRCS)
 COBJS = $(CSRCS:.c=$(OBJEXT))
 
 SRCS = $(ASRCS) $(CSRCS)
@@ -114,9 +105,7 @@ endif
 
 VPATH += chip
 VPATH += common
-ifeq ($(CONFIG_OPENSBI),y)
-VPATH += opensbi
-endif
+VPATH += $(SBI_DIR)
 VPATH += $(ARCH_SUBDIR)
 VPATH += $(CHIP_DIR)
 

--- a/arch/risc-v/src/opensbi/Make.defs
+++ b/arch/risc-v/src/opensbi/Make.defs
@@ -23,14 +23,18 @@ ifeq ($(CONFIG_OPENSBI),y)
 DEPPATH += --dep-path opensbi/opensbi-3rdparty
 VPATH += :opensbi/opensbi-3rdparty
 
-OPENSBI_CSRCS = $(wildcard opensbi/opensbi-3rdparty/lib/sbi/*.c)
-OPENSBI_CSRCS += opensbi/opensbi-3rdparty/lib/utils/ipi/aclint_mswi.c
-OPENSBI_CSRCS += opensbi/opensbi-3rdparty/lib/utils/irqchip/plic.c
-OPENSBI_CSRCS += opensbi/opensbi-3rdparty/lib/utils/timer/aclint_mtimer.c
+SBI_CSRCS  = $(wildcard opensbi/opensbi-3rdparty/lib/sbi/*.c)
+SBI_CSRCS += opensbi/opensbi-3rdparty/lib/utils/ipi/aclint_mswi.c
+SBI_CSRCS += opensbi/opensbi-3rdparty/lib/utils/irqchip/plic.c
+SBI_CSRCS += opensbi/opensbi-3rdparty/lib/utils/timer/aclint_mtimer.c
 
-OPENSBI_ASRCS += opensbi/opensbi-3rdparty/lib/sbi/sbi_expected_trap.S
-OPENSBI_ASRCS += opensbi/opensbi-3rdparty/lib/sbi/sbi_hfence.S
-OPENSBI_ASRCS += opensbi/opensbi-3rdparty/lib/sbi/riscv_hardfp.S
+SBI_ASRCS += opensbi/opensbi-3rdparty/lib/sbi/sbi_expected_trap.S
+SBI_ASRCS += opensbi/opensbi-3rdparty/lib/sbi/sbi_hfence.S
+SBI_ASRCS += opensbi/opensbi-3rdparty/lib/sbi/riscv_hardfp.S
+
+INCLUDES  += $(shell $(INCDIR) "$(CC)" $(ARCH_SRCDIR)$(DELIM)opensbi$(DELIM)opensbi-3rdparty$(DELIM)include)
+
+SBI_DIR   := opensbi
 
 OPENSBI_UNPACK  = opensbi-3rdparty
 OPENSBI_COMMIT  = 4998a712b2ab504eff306110879ee05af6050177


### PR DESCRIPTION
- Remove most of the ifeq-conditions and replace them with variables.
- Move the -I flag for 3rd party headers to opensbi/Make.defs

This clean-up / generalization makes it much simpler to add a new SBI
implementation, without the need to add a bunch of ifeq / elif conditions
to the makefile.

## Summary
A bit of clean up for risc-v/src/Makefile
## Impact
None
## Testing
icicle:knsh and build icicle:opensbi
