### PR TITLE
Xtensa: Add missing input operand on sys_call6 inline ASM

### DIFF
--- a/arch/xtensa/include/syscall.h
+++ b/arch/xtensa/include/syscall.h
@@ -395,7 +395,7 @@ static inline uintptr_t sys_call6(unsigned int nbr, uintptr_t parm1,
     "rsync\n"
     : "=r"(reg0)
     : "i"(XCHAL_SWINT_CALL), "r"(reg0), "r"(reg1), "r"(reg2),
-      "r"(reg3), "r"(reg4), "r"(reg5)
+      "r"(reg3), "r"(reg4), "r"(reg5), "r"(reg6)
     : "a9", "memory"
   );
 


### PR DESCRIPTION
## Summary
This PR intends to provide a fix to the `sys_call6` function, where the argument `parm6` is missing from the list of input operands of the inline ASM for the generation of the software interrupt.

## Impact
Fix for the `sys_call6` function call, which is used by some proxies:
- `recvfrom`
- `sendto`
- `mmap`
- `pselect`
- `posix_spawn`
- `task_spawn`

## Testing
Issue caught by visual inspection.
