### PR TITLE
sched/wqueue: Add work_timeleft macro to get the left time to start

### DIFF
--- a/drivers/power/activity_governor.c
+++ b/drivers/power/activity_governor.c
@@ -569,8 +569,10 @@ static void governor_timer(int domain)
 
   if (state < PM_SLEEP && !pdom->stay[pdom->state])
     {
-      int delay = pmtick[state] + pdomstate->btime - clock_systime_ticks();
-      int left  = wd_gettime(&pdomstate->wdog);
+      sclock_t delay = pmtick[state] +
+                       pdomstate->btime -
+                       clock_systime_ticks();
+      sclock_t left  = wd_gettime(&pdomstate->wdog);
 
       if (delay <= 0)
         {

--- a/include/nuttx/wdog.h
+++ b/include/nuttx/wdog.h
@@ -160,7 +160,7 @@ int wd_cancel(FAR struct wdog_s *wdog);
  *
  ****************************************************************************/
 
-int wd_gettime(FAR struct wdog_s *wdog);
+sclock_t wd_gettime(FAR struct wdog_s *wdog);
 
 #undef EXTERN
 #ifdef __cplusplus

--- a/include/nuttx/wqueue.h
+++ b/include/nuttx/wqueue.h
@@ -422,6 +422,29 @@ void work_foreach(int qid, work_foreach_t handler, FAR void *arg);
 #define work_available(work) ((work)->worker == NULL)
 
 /****************************************************************************
+ * Name: work_timeleft
+ *
+ * Description:
+ *   This function returns the time remaining before the specified work
+ *   start.
+ *
+ * Input Parameters:
+ *   work - The work queue structure to check.
+ *
+ * Returned Value:
+ *   The time in system ticks remaining until the work start.
+ *   Zero means either that work is not valid or that work has already
+ *   started.
+ *
+ ****************************************************************************/
+
+#ifdef __KERNEL__
+#  define work_timeleft(work) wd_gettime(&((work)->u.timer))
+#else
+#  define work_timeleft(work) ((sclock_t)((work)->u.s.qtime - clock()))
+#endif
+
+/****************************************************************************
  * Name: lpwork_boostpriority
  *
  * Description:

--- a/sched/wdog/wd_gettime.c
+++ b/sched/wdog/wd_gettime.c
@@ -50,7 +50,7 @@
  *
  ****************************************************************************/
 
-int wd_gettime(FAR struct wdog_s *wdog)
+sclock_t wd_gettime(FAR struct wdog_s *wdog)
 {
   irqstate_t flags;
 
@@ -64,7 +64,7 @@ int wd_gettime(FAR struct wdog_s *wdog)
        */
 
       FAR struct wdog_s *curr;
-      int delay = 0;
+      sclock_t delay = 0;
 
       for (curr = (FAR struct wdog_s *)g_wdactivelist.head;
            curr != NULL;


### PR DESCRIPTION
## Summary

- sched/wdog: Change the return type of wd_gettime from int to sclock_t

## Impact
new API

## Testing
Pass CI
