### PR TITLE
net/tcp: Zero keeptimer in case caller set keepalive to false

### DIFF
--- a/net/tcp/tcp_setsockopt.c
+++ b/net/tcp/tcp_setsockopt.c
@@ -129,11 +129,8 @@ int tcp_setsockopt(FAR struct socket *psock, int option,
 
                 /* Reset timer */
 
-                if (conn->keepalive)
-                  {
-                    conn->keeptimer   = conn->keepidle;
-                    conn->keepretries = 0;
-                  }
+                conn->keeptimer   = keepalive ? conn->keepidle : 0;
+                conn->keepretries = 0;
               }
           }
         break;


### PR DESCRIPTION
## Summary
Make the logic in https://github.com/apache/incubator-nuttx/pull/6290 more correct.

## Impact
Shouldn't since nobody use keeptimer and keepretries when keepalive is false.

## Testing

