### PR TITLE
risc-v/vfork: Fix saved register set and add FPU registers

### DIFF
--- a/arch/risc-v/include/irq.h
+++ b/arch/risc-v/include/irq.h
@@ -458,6 +458,26 @@
 #define REG_T5              REG_X30
 #define REG_T6              REG_X31
 
+#ifdef CONFIG_ARCH_FPU
+/* $0-$1 = fs0-fs1: Callee saved registers */
+
+#  define REG_FS0           REG_F8
+#  define REG_FS1           REG_F9
+
+/* $18-$27 = fs2-fs11: Callee saved registers */
+
+#  define REG_FS2           REG_F18
+#  define REG_FS3           REG_F19
+#  define REG_FS4           REG_F20
+#  define REG_FS5           REG_F21
+#  define REG_FS6           REG_F22
+#  define REG_FS7           REG_F23
+#  define REG_FS8           REG_F24
+#  define REG_FS9           REG_F25
+#  define REG_FS10          REG_F26
+#  define REG_FS11          REG_F27
+#endif
+
 /****************************************************************************
  * Public Types
  ****************************************************************************/

--- a/arch/risc-v/src/common/riscv_vfork.c
+++ b/arch/risc-v/src/common/riscv_vfork.c
@@ -206,25 +206,39 @@ pid_t up_vfork(const struct vfork_s *context)
    * indication to the newly started child thread.
    */
 
-  child->cmn.xcp.regs[REG_S1]  = context->s1;  /* Saved register s1 */
-  child->cmn.xcp.regs[REG_S2]  = context->s2;  /* Saved register s2 */
-  child->cmn.xcp.regs[REG_S3]  = context->s3;  /* Saved register s3 */
-  child->cmn.xcp.regs[REG_S4]  = context->s4;  /* Saved register s4 */
-  child->cmn.xcp.regs[REG_S5]  = context->s5;  /* Saved register s5 */
-  child->cmn.xcp.regs[REG_S6]  = context->s6;  /* Saved register s6 */
-  child->cmn.xcp.regs[REG_S7]  = context->s7;  /* Saved register s7 */
-  child->cmn.xcp.regs[REG_S8]  = context->s8;  /* Saved register s8 */
-  child->cmn.xcp.regs[REG_S9]  = context->s9;  /* Saved register s9 */
-  child->cmn.xcp.regs[REG_S10] = context->s10; /* Saved register s10 */
-  child->cmn.xcp.regs[REG_S11] = context->s11; /* Saved register s11 */
+  child->cmn.xcp.regs[REG_S1]   = context->s1;  /* Saved register s1 */
+  child->cmn.xcp.regs[REG_S2]   = context->s2;  /* Saved register s2 */
+  child->cmn.xcp.regs[REG_S3]   = context->s3;  /* Saved register s3 */
+  child->cmn.xcp.regs[REG_S4]   = context->s4;  /* Saved register s4 */
+  child->cmn.xcp.regs[REG_S5]   = context->s5;  /* Saved register s5 */
+  child->cmn.xcp.regs[REG_S6]   = context->s6;  /* Saved register s6 */
+  child->cmn.xcp.regs[REG_S7]   = context->s7;  /* Saved register s7 */
+  child->cmn.xcp.regs[REG_S8]   = context->s8;  /* Saved register s8 */
+  child->cmn.xcp.regs[REG_S9]   = context->s9;  /* Saved register s9 */
+  child->cmn.xcp.regs[REG_S10]  = context->s10; /* Saved register s10 */
+  child->cmn.xcp.regs[REG_S11]  = context->s11; /* Saved register s11 */
 #ifdef CONFIG_RISCV_FRAMEPOINTER
-  child->cmn.xcp.regs[REG_FP]  = newfp;        /* Frame pointer */
+  child->cmn.xcp.regs[REG_FP]   = newfp;        /* Frame pointer */
 #else
-  child->cmn.xcp.regs[REG_S0]  = context->s0;  /* Saved register s0 */
+  child->cmn.xcp.regs[REG_S0]   = context->s0;  /* Saved register s0 */
 #endif
-  child->cmn.xcp.regs[REG_SP]  = newsp;        /* Stack pointer */
+  child->cmn.xcp.regs[REG_SP]   = newsp;        /* Stack pointer */
 #ifdef RISCV_SAVE_GP
-  child->cmn.xcp.regs[REG_GP]  = newsp;        /* Global pointer */
+  child->cmn.xcp.regs[REG_GP]   = newsp;        /* Global pointer */
+#endif
+#ifdef CONFIG_ARCH_FPU
+  child->cmn.xcp.regs[REG_FS0]  = context->fs0;  /* Saved register fs1 */
+  child->cmn.xcp.regs[REG_FS1]  = context->fs1;  /* Saved register fs1 */
+  child->cmn.xcp.regs[REG_FS2]  = context->fs2;  /* Saved register fs2 */
+  child->cmn.xcp.regs[REG_FS3]  = context->fs3;  /* Saved register fs3 */
+  child->cmn.xcp.regs[REG_FS4]  = context->fs4;  /* Saved register fs4 */
+  child->cmn.xcp.regs[REG_FS5]  = context->fs5;  /* Saved register fs5 */
+  child->cmn.xcp.regs[REG_FS6]  = context->fs6;  /* Saved register fs6 */
+  child->cmn.xcp.regs[REG_FS7]  = context->fs7;  /* Saved register fs7 */
+  child->cmn.xcp.regs[REG_FS8]  = context->fs8;  /* Saved register fs8 */
+  child->cmn.xcp.regs[REG_FS9]  = context->fs9;  /* Saved register fs9 */
+  child->cmn.xcp.regs[REG_FS10] = context->fs10; /* Saved register fs10 */
+  child->cmn.xcp.regs[REG_FS11] = context->fs11; /* Saved register fs11 */
 #endif
 
 #ifdef CONFIG_LIB_SYSCALL

--- a/arch/risc-v/src/common/riscv_vfork.c
+++ b/arch/risc-v/src/common/riscv_vfork.c
@@ -206,18 +206,21 @@ pid_t up_vfork(const struct vfork_s *context)
    * indication to the newly started child thread.
    */
 
-  child->cmn.xcp.regs[REG_S0]  = context->s0;  /* Saved register s0 */
   child->cmn.xcp.regs[REG_S1]  = context->s1;  /* Saved register s1 */
   child->cmn.xcp.regs[REG_S2]  = context->s2;  /* Saved register s2 */
-  child->cmn.xcp.regs[REG_S3]  = context->s3;  /* Volatile register s3 */
-  child->cmn.xcp.regs[REG_S4]  = context->s4;  /* Volatile register s4 */
-  child->cmn.xcp.regs[REG_S5]  = context->s5;  /* Volatile register s5 */
-  child->cmn.xcp.regs[REG_S6]  = context->s6;  /* Volatile register s6 */
-  child->cmn.xcp.regs[REG_S7]  = context->s7;  /* Volatile register s7 */
+  child->cmn.xcp.regs[REG_S3]  = context->s3;  /* Saved register s3 */
+  child->cmn.xcp.regs[REG_S4]  = context->s4;  /* Saved register s4 */
+  child->cmn.xcp.regs[REG_S5]  = context->s5;  /* Saved register s5 */
+  child->cmn.xcp.regs[REG_S6]  = context->s6;  /* Saved register s6 */
+  child->cmn.xcp.regs[REG_S7]  = context->s7;  /* Saved register s7 */
+  child->cmn.xcp.regs[REG_S8]  = context->s8;  /* Saved register s8 */
+  child->cmn.xcp.regs[REG_S9]  = context->s9;  /* Saved register s9 */
+  child->cmn.xcp.regs[REG_S10] = context->s10; /* Saved register s10 */
+  child->cmn.xcp.regs[REG_S11] = context->s11; /* Saved register s11 */
 #ifdef CONFIG_RISCV_FRAMEPOINTER
   child->cmn.xcp.regs[REG_FP]  = newfp;        /* Frame pointer */
 #else
-  child->cmn.xcp.regs[REG_S8]  = context->s8;  /* Volatile register s8 */
+  child->cmn.xcp.regs[REG_S0]  = context->s0;  /* Saved register s0 */
 #endif
   child->cmn.xcp.regs[REG_SP]  = newsp;        /* Stack pointer */
 #ifdef RISCV_SAVE_GP

--- a/arch/risc-v/src/common/riscv_vfork.h
+++ b/arch/risc-v/src/common/riscv_vfork.h
@@ -118,7 +118,22 @@ struct vfork_s
   uintptr_t gp;   /* Global pointer */
 #endif
 
-  /* Floating point registers (not yet) */
+  /* Floating point registers */
+
+#ifdef CONFIG_ARCH_FPU
+  uintptr_t fs0;   /* Saved register fs0 */
+  uintptr_t fs1;   /* Saved register fs1 */
+  uintptr_t fs2;   /* Saved register fs2 */
+  uintptr_t fs3;   /* Saved register fs3 */
+  uintptr_t fs4;   /* Saved register fs4 */
+  uintptr_t fs5;   /* Saved register fs5 */
+  uintptr_t fs6;   /* Saved register fs6 */
+  uintptr_t fs7;   /* Saved register fs7 */
+  uintptr_t fs8;   /* Saved register fs8 */
+  uintptr_t fs9;   /* Saved register fs9 */
+  uintptr_t fs10;  /* Saved register fs10 */
+  uintptr_t fs11;  /* Saved register fs11 */
+#endif
 };
 #endif
 

--- a/arch/risc-v/src/common/riscv_vfork.h
+++ b/arch/risc-v/src/common/riscv_vfork.h
@@ -32,35 +32,34 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-/* Register r30 may be a frame pointer in some ABIs.  Or may just be saved
- * register s8.  It makes a difference for vfork handling.
+/* Register x8 may be a frame pointer in some ABIs.  Or may just be saved
+ * register s0.  It makes a difference for vfork handling.
  */
 
 #undef VFORK_HAVE_FP
 
-/* r0      zero   Always has the value 0.
- * r1      at     Temporary generally used by assembler.
- * r2-r3   v0-v1  Used for expression evaluations and to hold the integer and
- *                pointer type function return values.
- * r4-r7   a0-a3  Used for passing arguments to functions; values are not
- *                preserved across function calls.
- * r8-r15  t0-t7  Temporary registers used for expression evaluation; values
- *                are not preserved across function calls.
- * r16-r23 s0-s7  Saved registers; values are preserved across function
- *                calls.
- * r24-r25 t8-t9  Temporary registers used for expression evaluations; values
- *                are not preserved across function calls. When calling
- *                position independent functions r25 must contain the address
- *                of the called function.
- * r26-r27 k0-k1  Used only by the operating system.
- * r28     gp     Global pointer and context pointer.
- * r29     sp     Stack pointer.
- * r30     s8     Saved register (like s0-s7).  If a frame pointer is used,
- *                then this is the frame pointer.
- * r31     ra     Return address.
+/* Register ABI Name Description                        Saver
+ *
+ * x0       zero     Hard-wired zero                    —
+ * x1       ra       Return address                     Caller
+ * x2       sp       Stack pointer                      Callee
+ * x3       gp       Global pointer                     —
+ * x4       tp       Thread pointer                     —
+ * x5–7     t0–2     Temporaries                        Caller
+ * x8       s0/fp    Saved register/frame pointer       Callee
+ * x9       s1       Saved register                     Callee
+ * x10–11   a0–1     Function arguments/return values   Caller
+ * x12–17   a2–7     Function arguments                 Caller
+ * x18–27   s2–11    Saved registers                    Callee
+ * x28–31   t3–6     Temporaries                        Caller
+ * f0–7     ft0–7    FP temporaries                     Caller
+ * f8–9     fs0–1    FP saved registers                 Callee
+ * f10–11   fa0–1    FP arguments/return values         Caller
+ * f12–17   fa2–7    FP arguments                       Caller
+ * f18–27   fs2–11   FP saved registers                 Callee
+ * f28–31   ft8–11   FP temporaries                     Caller
  */
 
-#define VFORK_S0_OFFSET   (0*INT_REG_SIZE)   /* Saved register s0 */
 #define VFORK_S1_OFFSET   (1*INT_REG_SIZE)   /* Saved register s1 */
 #define VFORK_S2_OFFSET   (2*INT_REG_SIZE)   /* Saved register s2 */
 #define VFORK_S3_OFFSET   (3*INT_REG_SIZE)   /* Saved register s3 */
@@ -68,20 +67,24 @@
 #define VFORK_S5_OFFSET   (5*INT_REG_SIZE)   /* Saved register s5 */
 #define VFORK_S6_OFFSET   (6*INT_REG_SIZE)   /* Saved register s6 */
 #define VFORK_S7_OFFSET   (7*INT_REG_SIZE)   /* Saved register s7 */
+#define VFORK_S8_OFFSET   (8*INT_REG_SIZE)   /* Saved register s8 */
+#define VFORK_S9_OFFSET   (9*INT_REG_SIZE)   /* Saved register s9 */
+#define VFORK_S10_OFFSET  (10*INT_REG_SIZE)  /* Saved register s10 */
+#define VFORK_S11_OFFSET  (11*INT_REG_SIZE)  /* Saved register s11 */
 
 #ifdef CONFIG_RISCV_FRAMEPOINTER
-#  define VFORK_FP_OFFSET (8*INT_REG_SIZE)   /* Frame pointer */
+#  define VFORK_FP_OFFSET (0*INT_REG_SIZE)   /* Frame pointer */
 #else
-#  define VFORK_S8_OFFSET (8*INT_REG_SIZE)   /* Saved register s8 */
+#  define VFORK_S0_OFFSET (0*INT_REG_SIZE)   /* Saved register s0 */
 #endif
 
-#define VFORK_SP_OFFSET   (9*INT_REG_SIZE)   /* Stack pointer*/
-#define VFORK_RA_OFFSET   (10*INT_REG_SIZE)  /* Return address*/
+#define VFORK_SP_OFFSET   (12*INT_REG_SIZE)  /* Stack pointer*/
+#define VFORK_RA_OFFSET   (13*INT_REG_SIZE)  /* Return address*/
 #ifdef RISCV_SAVE_GP
-#  define VFORK_GP_OFFSET (11*INT_REG_SIZE)  /* Global pointer */
-#  define VFORK_SIZEOF    (12*INT_REG_SIZE)
+#  define VFORK_GP_OFFSET (14*INT_REG_SIZE)  /* Global pointer */
+#  define VFORK_SIZEOF    (15*INT_REG_SIZE)
 #else
-#  define VFORK_SIZEOF    (11*INT_REG_SIZE)
+#  define VFORK_SIZEOF    (13*INT_REG_SIZE)
 #endif
 
 /****************************************************************************
@@ -93,7 +96,6 @@ struct vfork_s
 {
   /* CPU registers */
 
-  uintptr_t s0;   /* Saved register s0 */
   uintptr_t s1;   /* Saved register s1 */
   uintptr_t s2;   /* Saved register s2 */
   uintptr_t s3;   /* Saved register s3 */
@@ -101,10 +103,14 @@ struct vfork_s
   uintptr_t s5;   /* Saved register s5 */
   uintptr_t s6;   /* Saved register s6 */
   uintptr_t s7;   /* Saved register s7 */
+  uintptr_t s8;   /* Saved register s8 */
+  uintptr_t s9;   /* Saved register s9 */
+  uintptr_t s10;  /* Saved register s10 */
+  uintptr_t s11;  /* Saved register s11 */
 #ifdef CONFIG_RISCV_FRAMEPOINTER
   uintptr_t fp;   /* Frame pointer */
 #else
-  uintptr_t s8;   /* Saved register s8 */
+  uintptr_t s0;   /* Saved register s0 */
 #endif
   uintptr_t sp;   /* Stack pointer */
   uintptr_t ra;   /* Return address */


### PR DESCRIPTION
## Summary
Like the title says
## Impact
RISC-V vfork only
## Testing
user_main: vfork() test
vfork_test: Child 79 ran successfully
