### PR TITLE
Separate a few debug stuff from CONFIG_DEBUG_MM

### DIFF
--- a/fs/procfs/fs_procfsmeminfo.c
+++ b/fs/procfs/fs_procfsmeminfo.c
@@ -415,7 +415,7 @@ static ssize_t memdump_read(FAR struct file *filep, FAR char *buffer,
   procfile = (FAR struct meminfo_file_s *)filep->f_priv;
   DEBUGASSERT(procfile);
 
-#ifdef CONFIG_DEBUG_MM
+#ifdef CONFIG_MM_BACKTRACE
   linesize  = procfs_snprintf(procfile->line, MEMINFO_LINELEN,
                               "usage: <pid/used/free/on/off>\n"
                               "on/off backtrace\n"
@@ -460,7 +460,7 @@ static ssize_t memdump_write(FAR struct file *filep, FAR const char *buffer,
   procfile = filep->f_priv;
   DEBUGASSERT(procfile);
 
-#ifdef CONFIG_DEBUG_MM
+#ifdef CONFIG_MM_BACKTRACE
   if (strcmp(buffer, "on") == 0)
     {
       for (entry = g_procfs_meminfo; entry != NULL; entry = entry->next)
@@ -490,7 +490,7 @@ static ssize_t memdump_write(FAR struct file *filep, FAR const char *buffer,
       case 'f':
         pid = (pid_t)-2;
         break;
-#ifdef CONFIG_DEBUG_MM
+#ifdef CONFIG_MM_BACKTRACE
       default:
         pid = atoi(buffer);
 #endif

--- a/fs/procfs/fs_procfsproc.c
+++ b/fs/procfs/fs_procfsproc.c
@@ -178,7 +178,7 @@ static ssize_t proc_critmon(FAR struct proc_file_s *procfile,
                  FAR struct tcb_s *tcb, FAR char *buffer, size_t buflen,
                  off_t offset);
 #endif
-#ifdef CONFIG_DEBUG_MM
+#ifdef CONFIG_MM_BACKTRACE
 static ssize_t proc_heap(FAR struct proc_file_s *procfile,
                          FAR struct tcb_s *tcb, FAR char *buffer,
                          size_t buflen, off_t offset);
@@ -904,7 +904,7 @@ static ssize_t proc_critmon(FAR struct proc_file_s *procfile,
  * Name: proc_heap
  ****************************************************************************/
 
-#ifdef CONFIG_DEBUG_MM
+#ifdef CONFIG_MM_BACKTRACE
 static ssize_t proc_heap(FAR struct proc_file_s *procfile,
                          FAR struct tcb_s *tcb, FAR char *buffer,
                          size_t buflen, off_t offset)
@@ -1575,7 +1575,7 @@ static ssize_t proc_read(FAR struct file *filep, FAR char *buffer,
       ret = proc_critmon(procfile, tcb, buffer, buflen, filep->f_pos);
       break;
 #endif
-#ifdef CONFIG_DEBUG_MM
+#ifdef CONFIG_MM_BACKTRACE
     case PROC_HEAP: /* Task heap info */
       ret = proc_heap(procfile, tcb, buffer, buflen, filep->f_pos);
       break;

--- a/include/nuttx/mm/mm.h
+++ b/include/nuttx/mm/mm.h
@@ -296,7 +296,7 @@ void kmm_extend(FAR void *mem, size_t size, int region);
 
 struct mallinfo; /* Forward reference */
 int mm_mallinfo(FAR struct mm_heap_s *heap, FAR struct mallinfo *info);
-#ifdef CONFIG_DEBUG_MM
+#ifdef CONFIG_MM_BACKTRACE
 struct mallinfo_task; /* Forward reference */
 int mm_mallinfo_task(FAR struct mm_heap_s *heap,
                      FAR struct mallinfo_task *info);
@@ -306,7 +306,7 @@ int mm_mallinfo_task(FAR struct mm_heap_s *heap,
 
 #ifdef CONFIG_MM_KERNEL_HEAP
 struct mallinfo kmm_mallinfo(void);
-#  ifdef CONFIG_DEBUG_MM
+#  ifdef CONFIG_MM_BACKTRACE
 struct mallinfo_task kmm_mallinfo_task(pid_t pid);
 #  endif
 #endif

--- a/mm/Kconfig
+++ b/mm/Kconfig
@@ -191,4 +191,9 @@ config MM_BACKTRACE_DEFAULT
 	default n
 	depends on DEBUG_MM
 
+config MM_DUMP_ON_FAILURE
+	bool "Dump heap info on allocation failure"
+	default n
+	depends on DEBUG_MM
+
 source "mm/iob/Kconfig"

--- a/mm/Kconfig
+++ b/mm/Kconfig
@@ -186,10 +186,15 @@ config MM_KASAN
 		bugs in native code. After turn on this option, Please
 		add -fsanitize=kernel-address to CFLAGS/CXXFLAGS too.
 
+config MM_BACKTRACE
+	bool "Owner tracking and backtrace"
+	default n
+	depends on DEBUG_MM
+
 config MM_BACKTRACE_DEFAULT
 	bool "Enable the backtrace record by default"
 	default n
-	depends on DEBUG_MM
+	depends on MM_BACKTRACE
 
 config MM_DUMP_ON_FAILURE
 	bool "Dump heap info on allocation failure"

--- a/mm/Kconfig
+++ b/mm/Kconfig
@@ -201,4 +201,9 @@ config MM_DUMP_ON_FAILURE
 	default n
 	depends on DEBUG_MM
 
+config MM_PANIC_ON_FAILURE
+	bool "Panic on allocation failure"
+	default n
+	depends on DEBUG_MM
+
 source "mm/iob/Kconfig"

--- a/mm/kmm_heap/kmm_mallinfo.c
+++ b/mm/kmm_heap/kmm_mallinfo.c
@@ -59,7 +59,7 @@ struct mallinfo kmm_mallinfo(void)
  *
  ****************************************************************************/
 
-#ifdef CONFIG_DEBUG_MM
+#ifdef CONFIG_MM_BACKTRACE
 struct mallinfo_task kmm_mallinfo_task(pid_t pid)
 {
   struct mallinfo_task info;

--- a/mm/mm_heap/mm.h
+++ b/mm/mm_heap/mm.h
@@ -90,7 +90,7 @@
 #  define MM_MAX_SHIFT    (22)  /*  4 Mb */
 #endif
 
-#ifdef CONFIG_DEBUG_MM
+#ifdef CONFIG_MM_BACKTRACE
 #  define MM_MIN_SHIFT       (MM_MIN_SHIFT_ + 2)
 #  define MM_BACKTRACE_DEPTH 8
 #  define MM_ADD_BACKTRACE(heap, ptr) \
@@ -165,7 +165,7 @@ typedef uint32_t mmsize_t;
 
 struct mm_allocnode_s
 {
-#ifdef CONFIG_DEBUG_MM
+#ifdef CONFIG_MM_BACKTRACE
   pid_t pid;                               /* The pid for caller */
   FAR void *backtrace[MM_BACKTRACE_DEPTH]; /* The backtrace buffer for caller */
 #endif
@@ -180,7 +180,7 @@ static_assert(SIZEOF_MM_ALLOCNODE <= MM_MIN_CHUNK,
 
 struct mm_freenode_s
 {
-#ifdef CONFIG_DEBUG_MM
+#ifdef CONFIG_MM_BACKTRACE
   pid_t pid;                               /* The pid for caller */
   FAR void *backtrace[MM_BACKTRACE_DEPTH]; /* The backtrace buffer for caller */
 #endif

--- a/mm/mm_heap/mm_mallinfo.c
+++ b/mm/mm_heap/mm_mallinfo.c
@@ -75,7 +75,7 @@ static void mallinfo_handler(FAR struct mm_allocnode_s *node, FAR void *arg)
     }
 }
 
-#ifdef CONFIG_DEBUG_MM
+#ifdef CONFIG_MM_BACKTRACE
 static void mallinfo_task_handler(FAR struct mm_allocnode_s *node,
                                   FAR void *arg)
 {
@@ -137,7 +137,7 @@ int mm_mallinfo(FAR struct mm_heap_s *heap, FAR struct mallinfo *info)
  *
  ****************************************************************************/
 
-#ifdef CONFIG_DEBUG_MM
+#ifdef CONFIG_MM_BACKTRACE
 int mm_mallinfo_task(FAR struct mm_heap_s *heap,
                      FAR struct mallinfo_task *info)
 {

--- a/mm/mm_heap/mm_malloc.c
+++ b/mm/mm_heap/mm_malloc.c
@@ -256,6 +256,9 @@ FAR void *mm_malloc(FAR struct mm_heap_s *heap, size_t size)
             minfo.mxordblk, minfo.aordblks, minfo.ordblks);
       mm_memdump(heap, -1);
 #endif
+#ifdef CONFIG_MM_PANIC_ON_FAILURE
+      PANIC();
+#endif
     }
 #endif
 

--- a/mm/mm_heap/mm_malloc.c
+++ b/mm/mm_heap/mm_malloc.c
@@ -244,15 +244,18 @@ FAR void *mm_malloc(FAR struct mm_heap_s *heap, size_t size)
 #ifdef CONFIG_DEBUG_MM
   else
     {
+#ifdef CONFIG_MM_DUMP_ON_FAILURE
       struct mallinfo minfo;
+#endif
 
       mwarn("WARNING: Allocation failed, size %zu\n", alignsize);
+#ifdef CONFIG_MM_DUMP_ON_FAILURE
       mm_mallinfo(heap, &minfo);
       mwarn("Total:%d, used:%d, free:%d, largest:%d, nused:%d, nfree:%d\n",
             minfo.arena, minfo.uordblks, minfo.fordblks,
             minfo.mxordblk, minfo.aordblks, minfo.ordblks);
       mm_memdump(heap, -1);
-      DEBUGASSERT(false);
+#endif
     }
 #endif
 

--- a/mm/mm_heap/mm_memdump.c
+++ b/mm/mm_heap/mm_memdump.c
@@ -65,13 +65,13 @@ static void memdump_handler(FAR struct mm_allocnode_s *node, FAR void *arg)
   if ((node->preceding & MM_ALLOC_BIT) != 0)
     {
       DEBUGASSERT(node->size >= SIZEOF_MM_ALLOCNODE);
-#ifndef CONFIG_DEBUG_MM
+#ifndef CONFIG_MM_BACKTRACE
       if (info->pid == -1)
 #else
       if (info->pid == -1 || node->pid == info->pid)
 #endif
         {
-#ifndef CONFIG_DEBUG_MM
+#ifndef CONFIG_MM_BACKTRACE
           syslog(LOG_INFO, "%12zu%*p\n",
                  (size_t)node->size, MM_PTR_FMT_WIDTH,
                  ((FAR char *)node + SIZEOF_MM_ALLOCNODE));
@@ -141,7 +141,7 @@ void mm_memdump(FAR struct mm_heap_s *heap, pid_t pid)
   if (pid >= -1)
     {
       syslog(LOG_INFO, "Dump all used memory node info:\n");
-#ifndef CONFIG_DEBUG_MM
+#ifndef CONFIG_MM_BACKTRACE
       syslog(LOG_INFO, "%12s%*s\n", "Size", MM_PTR_FMT_WIDTH, "Address");
 #else
       syslog(LOG_INFO, "%6s%12s%*s %s\n", "PID", "Size", MM_PTR_FMT_WIDTH,

--- a/mm/umm_heap/umm_mallinfo.c
+++ b/mm/umm_heap/umm_mallinfo.c
@@ -59,7 +59,7 @@ struct mallinfo mallinfo(void)
  *
  ****************************************************************************/
 
-#ifdef CONFIG_DEBUG_MM
+#ifdef CONFIG_MM_BACKTRACE
 struct mallinfo_task mallinfo_task(pid_t pid)
 {
   struct mallinfo_task info;


### PR DESCRIPTION
## Summary
Separate a few debug stuff from CONFIG_DEBUG_MM.

* backtrace
* dump and abort on failure

## Impact

## Testing
compile tested a few combinations
tested on esp32 with these new options disabled