### PR TITLE
Add up_textheap_heapmember

### DIFF
--- a/arch/arm/src/cxd56xx/cxd56_textheap.c
+++ b/arch/arm/src/cxd56xx/cxd56_textheap.c
@@ -95,3 +95,21 @@ void up_textheap_free(void *p)
 
   kmm_free(p);
 }
+
+/****************************************************************************
+ * Name: up_textheap_heapmember()
+ ****************************************************************************/
+
+bool up_textheap_heapmember(void *p)
+{
+  if (p == NULL)
+    {
+      return false;
+    }
+
+#ifdef CONFIG_CXD56_USE_SYSBUS
+  p += SYSBUS_ADDRESS_OFFSET;
+#endif
+
+  return kmm_heapmember(p);
+}

--- a/arch/risc-v/src/esp32c3/esp32c3_textheap.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_textheap.c
@@ -110,3 +110,29 @@ void up_textheap_free(void *p)
         }
     }
 }
+
+/****************************************************************************
+ * Name: up_textheap_heapmember()
+ *
+ * Description:
+ *   Test if memory is from text heap.
+ *
+ ****************************************************************************/
+
+bool up_textheap_heapmember(void *p)
+{
+  if (p == NULL)
+    {
+      return false;
+    }
+
+#ifdef CONFIG_ESP32C3_RTC_HEAP
+  if (esp32c3_ptr_rtc(p))
+    {
+      return esp32c3_rtcheap_heapmember(p);
+    }
+#endif
+
+  p -= D_I_BUS_OFFSET;
+  return kmm_heapmember(p);
+}

--- a/arch/xtensa/src/esp32/esp32_textheap.c
+++ b/arch/xtensa/src/esp32/esp32_textheap.c
@@ -104,3 +104,28 @@ void up_textheap_free(void *p)
         }
     }
 }
+
+/****************************************************************************
+ * Name: up_textheap_heapmember
+ *
+ * Description:
+ *   Test if memory is from text heap.
+ *
+ ****************************************************************************/
+
+bool up_textheap_heapmember(void *p)
+{
+  if (p == NULL)
+    {
+      return false;
+    }
+
+#ifdef CONFIG_ESP32_RTC_HEAP
+  if (esp32_ptr_rtcslow(p))
+    {
+      return esp32_rtcheap_heapmember(p);
+    }
+#endif
+
+  return esp32_iramheap_heapmember(p);
+}

--- a/include/nuttx/arch.h
+++ b/include/nuttx/arch.h
@@ -802,6 +802,18 @@ void up_textheap_free(FAR void *p);
 #endif
 
 /****************************************************************************
+ * Name: up_textheap_heapmember
+ *
+ * Description:
+ *   Test if memory is from text heap.
+ *
+ ****************************************************************************/
+
+#if defined(CONFIG_ARCH_USE_TEXT_HEAP)
+bool up_textheap_heapmember(FAR void *p);
+#endif
+
+/****************************************************************************
  * Name: up_setpicbase and up_getpicbase
  *
  * Description:

--- a/include/nuttx/kmalloc.h
+++ b/include/nuttx/kmalloc.h
@@ -99,6 +99,7 @@ extern "C"
 #  define kmm_memalign(a,s)      memalign(a,s)
 #  define kmm_free(p)            free(p)
 #  define kmm_mallinfo()         mallinfo()
+#  define kmm_heapmember(p)      umm_heapmember(p)
 
 #else
 /* Otherwise, the kernel-space allocators are declared in


### PR DESCRIPTION
## Summary
intended usage: https://github.com/bytecodealliance/wasm-micro-runtime/pull/1181

## Impact

## Testing
a wamr aot module tested on esp32. (with various other patches)
cxd56xx and esp32c3 are not tested.