### PR TITLE
littlefs_stat: Fix directory size

### DIFF
--- a/fs/littlefs/lfs_vfs.c
+++ b/fs/littlefs/lfs_vfs.c
@@ -1430,13 +1430,14 @@ static int littlefs_stat(FAR struct inode *mountpt, FAR const char *relpath,
       if (info.type == LFS_TYPE_REG)
         {
           buf->st_mode |= S_IFREG;
+          buf->st_size = info.size;
         }
       else
         {
           buf->st_mode |= S_IFDIR;
+          buf->st_size = 0;
         }
 
-      buf->st_size    = info.size;
       buf->st_blksize = fs->cfg.block_size;
       buf->st_blocks  = (buf->st_size + buf->st_blksize - 1) /
                         buf->st_blksize;


### PR DESCRIPTION
## Summary
lfs_info.size is only valid for LFS_TYPE_REG.
For directory, use 0 instead of stack garbage.

## Impact

## Testing
tested on esp32
