### PR TITLE
Armv6-m LTO fix

### DIFF
--- a/arch/arm/src/armv6-m/Toolchain.defs
+++ b/arch/arm/src/armv6-m/Toolchain.defs
@@ -100,6 +100,9 @@ ifeq ($(CONFIG_LTO_THIN),y)
   ARCHOPTIMIZATION += -flto=thin
 else ifeq ($(CONFIG_LTO_FULL),y)
   ARCHOPTIMIZATION += -flto
+  ifeq ($(CONFIG_ARMV6M_TOOLCHAIN),GNU_EABI)
+    ARCHOPTIMIZATION += -fuse-linker-plugin
+  endif
 endif
 
 # NuttX buildroot under Linux or Cygwin
@@ -143,12 +146,21 @@ else
   CC      = $(CROSSDEV)gcc
   CXX     = $(CROSSDEV)g++
   CPP     = $(CROSSDEV)gcc -E -P -x c
-  LD      = $(CROSSDEV)ld
   STRIP   = $(CROSSDEV)strip --strip-unneeded
-  AR      = $(CROSSDEV)ar rcs
-  NM      = $(CROSSDEV)nm
   OBJCOPY = $(CROSSDEV)objcopy
   OBJDUMP = $(CROSSDEV)objdump
+  LD      = $(CROSSDEV)ld
+  AR      = $(CROSSDEV)ar rcs
+  NM      = $(CROSSDEV)nm
+
+  ifeq ($(CONFIG_LTO_FULL),y)
+    ifeq ($(CONFIG_ARMV6M_TOOLCHAIN),GNU_EABI)
+      LD := $(CROSSDEV)gcc
+      AR := $(CROSSDEV)gcc-ar rcs
+      NM := $(CROSSDEV)gcc-nm
+      ARCHOPTIMIZATION += -fno-builtin
+    endif
+  endif
 endif
 
 # Architecture flags
@@ -170,6 +182,8 @@ endif
 ifneq ($(CONFIG_CXX_RTTI),y)
   ARCHCXXFLAGS += -fno-rtti
 endif
+
+LDFLAGS += -nostdlib
 
 # Optimization of unused sections
 

--- a/boards/arm/kl/freedom-kl25z/scripts/freedom-kl25z.ld
+++ b/boards/arm/kl/freedom-kl25z/scripts/freedom-kl25z.ld
@@ -43,7 +43,7 @@ SECTIONS
     } > vectflash
 
     .cfmprotect : {
-        *(.cfmconfig)
+        KEEP(*(.cfmconfig))
     } > cfmprotect
 
     .text : {

--- a/boards/arm/kl/freedom-kl26z/scripts/freedom-kl26z.ld
+++ b/boards/arm/kl/freedom-kl26z/scripts/freedom-kl26z.ld
@@ -43,7 +43,7 @@ SECTIONS
     } > vectflash
 
     .cfmprotect : {
-        *(.cfmconfig)
+        KEEP(*(.cfmconfig))
     } > cfmprotect
 
     .text : {

--- a/boards/arm/kl/teensy-lc/scripts/teensy-lc.ld
+++ b/boards/arm/kl/teensy-lc/scripts/teensy-lc.ld
@@ -43,7 +43,7 @@ SECTIONS
     } > vectflash
 
     .cfmprotect : {
-        *(.cfmconfig)
+        KEEP(*(.cfmconfig))
     } > cfmprotect
 
     .text : {


### PR DESCRIPTION
## Summary
The previous commits added support for LTO to both GCC and Clang but the Armv6-m build wasn't producing the correct result. Technically it procured an empty file or reported missing functions (depending on the linker script). This only takes changes that were in armv7-m architecture and applies them to armv6-m as well.

## Impact
It is possible now to use LTO on amrv6-m.

## Testing
I only tested that it compiles and that the resulting binary contains some code. It wasn't run tested on either of these Kinetis L boards (I do not have them). It was tested only on Freedom-KL81Z that wasn't submitted to the upstream yet.