### PR TITLE
arm/tlsr82: optimize the adc driver.

### DIFF
--- a/arch/arm/src/tlsr82/Kconfig
+++ b/arch/arm/src/tlsr82/Kconfig
@@ -314,6 +314,50 @@ menuconfig TLSR82_ADC
 	bool "ADC Configuration"
 	default n
 
+if TLSR82_ADC
+
+config TLSR82_ADC_CALI
+	bool "TLSR82 Adc calibration enable"
+	default n
+	---help---
+		When enable the adc calibration, adc driver will read the calibration
+		parameters stored in the falsh during initialization and use these
+		parameters to calibrate the sample value.
+
+config TLSR82_ADC_CALI_PARA_ADDR
+	hex
+	default 0x3fff8 if TLSR82_ADC_CALI
+	---help---
+		This is the adc calibration parameters address, this address must be
+		equal to the address defined in production tools.
+
+config TLSR82_ADC_CHAN0
+  bool "TLSR82 Adc channel 0 enable"
+  default n
+
+config TLSR82_ADC_CHAN1
+  bool "TLSR82 Adc channel 1 enable"
+  default n
+
+config TLSR82_ADC_CHAN2
+  bool "TLSR82 Adc channel 2 enable"
+  default n
+
+config TLSR82_ADC_VBAT
+  bool "TLSR82 Adc channel Vbat enable"
+  default n
+
+config TLSR82_ADC_FILT_NUM
+	int "TLSR82 Adc filter average number"
+	default 4
+	---help---
+		This number determines the average number during sampling, driver will
+		remove max and min sample values and calculate the average of the
+		remaining values as the last sample value.
+		Note: This number must be multiple of 4.
+
+endif
+
 menuconfig TLSR82_LPCOMP
 	bool "LPCOMP Configuration"
 	default n

--- a/arch/arm/src/tlsr82/hardware/tlsr82_adc.h
+++ b/arch/arm/src/tlsr82/hardware/tlsr82_adc.h
@@ -62,6 +62,46 @@
 #define ADC_VREF_1P2V                      (0x2 << ADC_VREF_SHIFT)
 #define ADC_VREF_RSVD2                     (0x3 << ADC_VREF_SHIFT)
 
+/* ADC analog input positive and negative channel definition */
+
+#define ADC_CHAN_POS_SHIFT                 4
+#define ADC_CHAN_POS_MASK                  (0xf << ADC_CHAN_POS_SHIFT)
+#define ADC_CHAN_POS_NOINPUT               (0  << ADC_CHAN_POS_SHIFT)
+#define ADC_CHAN_POS_B0                    (1  << ADC_CHAN_POS_SHIFT)
+#define ADC_CHAN_POS_B1                    (2  << ADC_CHAN_POS_SHIFT)
+#define ADC_CHAN_POS_B2                    (3  << ADC_CHAN_POS_SHIFT)
+#define ADC_CHAN_POS_B3                    (4  << ADC_CHAN_POS_SHIFT)
+#define ADC_CHAN_POS_B4                    (5  << ADC_CHAN_POS_SHIFT)
+#define ADC_CHAN_POS_B5                    (6  << ADC_CHAN_POS_SHIFT)
+#define ADC_CHAN_POS_B6                    (7  << ADC_CHAN_POS_SHIFT)
+#define ADC_CHAN_POS_B7                    (8  << ADC_CHAN_POS_SHIFT)
+#define ADC_CHAN_POS_C4                    (9  << ADC_CHAN_POS_SHIFT)
+#define ADC_CHAN_POS_C5                    (10 << ADC_CHAN_POS_SHIFT)
+#define ADC_CHAN_POS_PGA0                  (11 << ADC_CHAN_POS_SHIFT)
+#define ADC_CHAN_POS_PGA1                  (12 << ADC_CHAN_POS_SHIFT)
+#define ADC_CHAN_POS_TEMSENSOR             (13 << ADC_CHAN_POS_SHIFT)
+#define ADC_CHAN_POS_TEMSENSOR_EE          (14 << ADC_CHAN_POS_SHIFT)
+#define ADC_CHAN_POS_VBAT                  (15 << ADC_CHAN_POS_SHIFT)
+
+#define ADC_CHAN_NEG_SHIFT                 0
+#define ADC_CHAN_NEG_MASK                  (0xf << ADC_CHAN_NEG_SHIFT)
+#define ADC_CHAN_NEG_NOINPUT               (0  << ADC_CHAN_NEG_SHIFT)
+#define ADC_CHAN_NEG_B0                    (1  << ADC_CHAN_NEG_SHIFT)
+#define ADC_CHAN_NEG_B1                    (2  << ADC_CHAN_NEG_SHIFT)
+#define ADC_CHAN_NEG_B2                    (3  << ADC_CHAN_NEG_SHIFT)
+#define ADC_CHAN_NEG_B3                    (4  << ADC_CHAN_NEG_SHIFT)
+#define ADC_CHAN_NEG_B4                    (5  << ADC_CHAN_NEG_SHIFT)
+#define ADC_CHAN_NEG_B5                    (6  << ADC_CHAN_NEG_SHIFT)
+#define ADC_CHAN_NEG_B6                    (7  << ADC_CHAN_NEG_SHIFT)
+#define ADC_CHAN_NEG_B7                    (8  << ADC_CHAN_NEG_SHIFT)
+#define ADC_CHAN_NEG_C4                    (9  << ADC_CHAN_NEG_SHIFT)
+#define ADC_CHAN_NEG_C5                    (10 << ADC_CHAN_NEG_SHIFT)
+#define ADC_CHAN_NEG_PGA0                  (11 << ADC_CHAN_NEG_SHIFT)
+#define ADC_CHAN_NEG_PGA1                  (12 << ADC_CHAN_NEG_SHIFT)
+#define ADC_CHAN_NEG_TEMSENSOR             (13 << ADC_CHAN_NEG_SHIFT)
+#define ADC_CHAN_NEG_TEMSENSOR_EE          (14 << ADC_CHAN_NEG_SHIFT)
+#define ADC_CHAN_NEG_GND                   (15 << ADC_CHAN_NEG_SHIFT)
+
 /* ADC Mode, Resolution definition */
 
 #define ADC_MODE_RES_SHIFT                 0

--- a/arch/arm/src/tlsr82/hardware/tlsr82_dfifo.h
+++ b/arch/arm/src/tlsr82/hardware/tlsr82_dfifo.h
@@ -1,0 +1,83 @@
+/****************************************************************************
+ * arch/arm/src/tlsr82/hardware/tlsr82_dfifo.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __ARCH_ARM_SRC_TLSR82_HARDWARE_TLSR82_DFIFO_H
+#define __ARCH_ARM_SRC_TLSR82_HARDWARE_TLSR82_DFIFO_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+#include <arch/tlsr82/chip.h>
+
+#include "hardware/tlsr82_register.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/* DFIFO = DMA FIFO */
+
+/* DFIFO0 ~ DFIFO2 address and size register definition */
+
+#define DFIFO0_ADDR_REG            REG_ADDR16(0xb00)
+#define DFIFO0_SIZE_REG            REG_ADDR8(0xb02)
+#define DFIFO0_ADDRHI_REG          REG_ADDR8(0xb03)
+
+#define DFIFO1_ADDR_REG            REG_ADDR16(0xb04)
+#define DFIFO1_SIZE_REG            REG_ADDR8(0xb06)
+#define DFIFO1_ADDRHI_REG          REG_ADDR8(0xb07)
+
+#define DFIFO2_ADDR_REG            REG_ADDR16(0xb08)
+#define DFIFO2_SIZE_REG            REG_ADDR8(0xb0a)
+#define DFIFO2_ADDRHI_REG          REG_ADDR8(0xb0b)
+
+#define DFIFO_ADC_ADDR_REG         DFIFO2_ADDR_REG
+#define DFIFO_ADC_SIZE_REG         DFIFO2_SIZE_REG
+#define DFIFO_ADC_ADDRHI_REG       DFIFO0_ADDRHI_REG
+
+/* DFIFO mode register definition */
+
+#define DFIFO_MODE_REG             REG_ADDR8(0xb10)
+
+/* DFIFO read and write buffer register definition */
+
+#define DFIFO0_RPTR_REG            REG_ADDR16(0xb14)
+#define DFIFO0_WPTR_REG            REG_ADDR16(0xb16)
+
+#define DFIFO1_RPTR_REG            REG_ADDR16(0xb18)
+#define DFIFO1_WPTR_REG            REG_ADDR16(0xb1a)
+
+#define DFIFO2_RPTR_REG            REG_ADDR16(0xb1c)
+#define DFIFO2_WPTR_REG            REG_ADDR16(0xb1e)
+
+/* DFIFO mode bit definition */
+
+#define DFIFO_MODE_DFIFO0_IN       BIT(0)
+#define DFIFO_MODE_DFIFO1_IN       BIT(1)
+#define DFIFO_MODE_DFIFO2_IN       BIT(2)
+#define DFIFO_MODE_DFIFO0_OUT      BIT(3)
+#define DFIFO_MODE_DFIFO0_L_INT    BIT(4)
+#define DFIFO_MODE_DFIFO0_H_INT    BIT(5)
+#define DFIFO_MODE_DFIFO1_H_INT    BIT(6)
+#define DFIFO_MODE_DFIFO2_H_INT    BIT(7)
+
+#endif /* __ARCH_ARM_SRC_TLSR82_HARDWARE_TLSR82_DFIFO_H */

--- a/arch/arm/src/tlsr82/tlsr82_adc.h
+++ b/arch/arm/src/tlsr82/tlsr82_adc.h
@@ -30,6 +30,22 @@
 #include "hardware/tlsr82_adc.h"
 
 /****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define ADC_CHAN_0               0
+#define ADC_CHAN_1               1
+#define ADC_CHAN_2               2
+#define ADC_CHAN_3               3
+#define ADC_CHAN_4               4
+#define ADC_CHAN_5               5
+#define ADC_CHAN_6               6
+#define ADC_CHAN_7               7
+#define ADC_CHAN_TEMP            253
+#define ADC_CHAN_VBAT            254
+#define ADC_CHAN_NONE            255
+
+/****************************************************************************
  * Public Function Prototypes
  ****************************************************************************/
 

--- a/arch/arm/src/tlsr82/tlsr82_timer.h
+++ b/arch/arm/src/tlsr82/tlsr82_timer.h
@@ -121,6 +121,20 @@ struct tlsr82_timer_ops_s
 };
 
 /****************************************************************************
+ * Inline Functions
+ ****************************************************************************/
+
+static inline uint32_t tlsr82_time(void)
+{
+  return SYSTIMER_TICK_REG;
+}
+
+static inline bool tlsr82_time_exceed(uint32_t start, uint32_t us)
+{
+  return ((uint32_t)(tlsr82_time() - start) > us * 16);
+}
+
+/****************************************************************************
  * Public Function Prototypes
  ****************************************************************************/
 

--- a/boards/arm/tlsr82/tlsr8278adk80d/src/tlsr8278_bringup.c
+++ b/boards/arm/tlsr82/tlsr8278adk80d/src/tlsr8278_bringup.c
@@ -134,7 +134,9 @@ int tlsr8278_bringup(void)
 #endif /* CONFIG_TLSR82_PWM */
 
 #ifdef CONFIG_TLSR82_ADC
-  ret = tlsr82_adc_init("/dev/adc0", 0);
+
+#ifdef CONFIG_TLSR82_ADC_CHAN0
+  ret = tlsr82_adc_init("/dev/adc0", ADC_CHAN_0);
   if (ret < 0)
     {
       syslog(LOG_ERR,
@@ -142,6 +144,41 @@ int tlsr8278_bringup(void)
              ret);
       return ret;
     }
+#endif
+
+#ifdef CONFIG_TLSR82_ADC_CHAN1
+  ret = tlsr82_adc_init("/dev/adc1", ADC_CHAN_1);
+  if (ret < 0)
+    {
+      syslog(LOG_ERR,
+             "ERROR: Failed to initialize adc1 driver: %d\n",
+             ret);
+      return ret;
+    }
+#endif
+
+#ifdef CONFIG_TLSR82_ADC_CHAN2
+  ret = tlsr82_adc_init("/dev/adc2", ADC_CHAN_2);
+  if (ret < 0)
+    {
+      syslog(LOG_ERR,
+             "ERROR: Failed to initialize adc2 driver: %d\n",
+             ret);
+      return ret;
+    }
+#endif
+
+#ifdef CONFIG_TLSR82_ADC_VBAT
+  ret = tlsr82_adc_init("/dev/adcvbat", ADC_CHAN_VBAT);
+  if (ret < 0)
+    {
+      syslog(LOG_ERR,
+             "ERROR: Failed to initialize adcbat driver: %d\n",
+             ret);
+      return ret;
+    }
+#endif
+
 #endif /* CONFIG_TLSR82_ADC */
 
 #ifdef CONFIG_TLSR82_FLASH


### PR DESCRIPTION
## Summary
1. Add vbat mode for chip internal voltage sample;
2. Add adc channel config;
3. Using DFIFO2 to get the sample value, follow telink sdk.
4. Add calibration function and config;

## Impact
tlsr82 chip

## Testing
local test with adc example
1. vbat mode sample voltage 3.253mV (actual voltage is 3.3V);
2. base mode sample error (no calibration) < 50mV in range 0~3.5V;
