### PR TITLE
LCD / SSD1306 added (re)configure IOCTL

### DIFF
--- a/drivers/lcd/lcd_framebuffer.c
+++ b/drivers/lcd/lcd_framebuffer.c
@@ -106,6 +106,7 @@ static int lcdfb_setcursor(FAR struct fb_vtable_s *vtable,
 #endif
 
 static int lcdfb_setpower(FAR struct fb_vtable_s *vtable, FAR int power);
+static int lcdfb_configure(FAR struct fb_vtable_s *vtable);
 
 /****************************************************************************
  * Private Data
@@ -468,6 +469,35 @@ static int lcdfb_setpower(FAR struct fb_vtable_s *vtable, FAR int power)
 }
 
 /****************************************************************************
+ * Name: lcdfb_configure
+ ****************************************************************************/
+
+static int lcdfb_configure(FAR struct fb_vtable_s *vtable)
+{
+  int ret = -EINVAL;
+  FAR struct lcdfb_dev_s *priv;
+  FAR struct lcd_dev_s *lcd;
+
+  DEBUGASSERT(vtable != NULL);
+
+  priv = (FAR struct lcdfb_dev_s *)vtable;
+
+  if (priv != NULL)
+    {
+      lcd = priv->lcd;
+      DEBUGASSERT(lcd->configure != NULL);
+
+      ret = lcd->configure(lcd);
+      if (ret < 0)
+        {
+          lcderr("ERROR: LCD configure() failed: %d\n", ret);
+        }
+    }
+
+  return ret;
+}
+
+/****************************************************************************
  * Public Functions
  ****************************************************************************/
 
@@ -523,6 +553,7 @@ int up_fbinitialize(int display)
 #endif
   priv->vtable.updatearea   = lcdfb_updateearea,
   priv->vtable.setpower     = lcdfb_setpower,
+  priv->vtable.configure    = lcdfb_configure,
 
 #ifdef CONFIG_LCD_EXTERNINIT
   /* Use external graphics driver initialization */

--- a/drivers/lcd/ssd1306_base.c
+++ b/drivers/lcd/ssd1306_base.c
@@ -171,9 +171,9 @@ static int  ssd1306_setpower(struct lcd_dev_s *dev, int power);
 static int  ssd1306_getcontrast(struct lcd_dev_s *dev);
 static int  ssd1306_setcontrast(struct lcd_dev_s *dev,
                                 unsigned int contrast);
+static int  ssd1306_configuredisplay(struct lcd_dev_s *dev);
 
 static int  ssd1306_do_disponoff(struct ssd1306_dev_s *priv, bool on);
-static int  ssd1306_configuredisplay(struct ssd1306_dev_s *priv);
 static int  ssd1306_redrawfb(struct ssd1306_dev_s *priv);
 
 /****************************************************************************
@@ -232,6 +232,7 @@ static const struct lcd_dev_s g_oleddev_dev =
   .setpower     = ssd1306_setpower,
   .getcontrast  = ssd1306_getcontrast,
   .setcontrast  = ssd1306_setcontrast,
+  .configure    = ssd1306_configuredisplay,
 };
 
 /* This is the OLED driver instance. Only a single device is supported
@@ -782,7 +783,7 @@ static int ssd1306_setpower(FAR struct lcd_dev_s *dev, int power)
         {
           /* Configure display and turn the display on */
 
-          ret = ssd1306_configuredisplay(priv);
+          ret = ssd1306_configuredisplay(dev);
           if (ret < 0)
             {
               return ret;
@@ -901,9 +902,12 @@ static int ssd1306_setcontrast(struct lcd_dev_s *dev, unsigned int contrast)
  *
  ****************************************************************************/
 
-static int ssd1306_configuredisplay(struct ssd1306_dev_s *priv)
+static int ssd1306_configuredisplay(struct lcd_dev_s *dev)
 {
+  struct ssd1306_dev_s *priv = (struct ssd1306_dev_s *)dev;
   int ret;
+
+  DEBUGASSERT(priv);
 
   /* Lock and select device */
 

--- a/drivers/video/fb.c
+++ b/drivers/video/fb.c
@@ -535,6 +535,14 @@ static int fb_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
         }
         break;
 
+      case FBIOCONFIGURE_DISPLAY:
+        {
+          DEBUGASSERT(fb->vtable != NULL &&
+                      fb->vtable->configure != NULL);
+          ret = fb->vtable->configure(fb->vtable);
+        }
+        break;
+
       default:
         gerr("ERROR: Unsupported IOCTL command: %d\n", cmd);
         ret = -ENOTTY;

--- a/include/nuttx/lcd/lcd.h
+++ b/include/nuttx/lcd/lcd.h
@@ -212,6 +212,10 @@ struct lcd_dev_s
   /* Get LCD panel frame rate (0: disable refresh) */
 
   int (*getframerate)(struct lcd_dev_s *dev);
+
+  /* Configure the display */
+
+  int (*configure)(struct lcd_dev_s *dev);
 };
 
 /****************************************************************************

--- a/include/nuttx/video/fb.h
+++ b/include/nuttx/video/fb.h
@@ -285,6 +285,8 @@
 #define FBIOPAN_DISPLAY       _FBIOC(0x0016)  /* Pan display
                                                * Argument: read-only struct
                                                *           fb_planeinfo_s* */
+#define FBIOCONFIGURE_DISPLAY _FBIOC(0x0017)  /* Configure display
+                                               * Argument:            none */
 
 /****************************************************************************
  * Public Types
@@ -613,6 +615,10 @@ struct fb_vtable_s
   /* Enable/disable panel power (0: full off). */
 
   int (*setpower)(FAR struct fb_vtable_s *vtable, int power);
+
+  /* configure */
+
+  int (*configure)(FAR struct fb_vtable_s *vtable);
 };
 
 /****************************************************************************


### PR DESCRIPTION
## Summary
Added IOCTL to (re)configure the display.
This is needed if for example the voltage domain of the display is not active during NuttX initialization.

## Impact
Extended current implementation with an extra IOCTL.

## Testing
Tested on a custom S32K1xx board.
