### PR TITLE
build: Fix dependencies of kernel targets.

### DIFF
--- a/libs/libc/Makefile
+++ b/libs/libc/Makefile
@@ -144,8 +144,8 @@ endif
 # C library for the kernel phase of the two-pass kernel build
 
 ifneq ($(BIN),$(KBIN))
-$(KBIN):
-	$(Q) $(MAKE) $(KBIN) BIN=$(KBIN) BINDIR=kbin EXTRAFLAGS="$(EXTRAFLAGS)"
+$(KBIN): $(OBJS)
+	$(Q) $(MAKE) $(KBIN) BIN=$(KBIN) EXTRAFLAGS="$(EXTRAFLAGS)"
 endif
 
 # Context

--- a/libs/libnx/Makefile
+++ b/libs/libnx/Makefile
@@ -214,8 +214,8 @@ $(BIN): $(OBJS)
 # NX library for the kernel phase of the two-pass kernel build
 
 ifneq ($(BIN),$(KBIN))
-$(KBIN):
-	$(Q) $(MAKE) $(KBIN) BIN=$(KBIN) BINDIR=kbin EXTRAFLAGS="$(EXTRAFLAGS)"
+$(KBIN): $(OBJS)
+	$(Q) $(MAKE) $(KBIN) BIN=$(KBIN) EXTRAFLAGS="$(EXTRAFLAGS)"
 endif
 
 # Dependencies

--- a/mm/Makefile
+++ b/mm/Makefile
@@ -62,8 +62,8 @@ $(BIN):	$(OBJS)
 # Memory manager for the kernel phase of the two-pass kernel build
 
 ifneq ($(BIN),$(KBIN))
-$(KBIN):
-	$(Q) $(MAKE) $(KBIN) BIN=$(KBIN) BINDIR=kbin EXTRAFLAGS="$(EXTRAFLAGS)"
+$(KBIN): $(OBJS)
+	$(Q) $(MAKE) $(KBIN) BIN=$(KBIN) EXTRAFLAGS="$(EXTRAFLAGS)"
 endif
 
 # Dependencies

--- a/tools/LibTargets.mk
+++ b/tools/LibTargets.mk
@@ -26,19 +26,19 @@
 # Possible kernel-mode builds
 
 libs$(DELIM)libc$(DELIM)libkc$(LIBEXT): pass2dep
-	$(Q) $(MAKE) -C libs$(DELIM)libc libkc$(LIBEXT) EXTRAFLAGS="$(KDEFINE) $(EXTRAFLAGS)"
+	$(Q) $(MAKE) -C libs$(DELIM)libc libkc$(LIBEXT) BINDIR=kbin EXTRAFLAGS="$(KDEFINE) $(EXTRAFLAGS)"
 
 staging$(DELIM)libkc$(LIBEXT): libs$(DELIM)libc$(DELIM)libkc$(LIBEXT)
 	$(Q) $(call INSTALL_LIB,$<,$@)
 
 libs$(DELIM)libnx$(DELIM)libknx$(LIBEXT): pass2dep
-	$(Q) $(MAKE) -C libs$(DELIM)libnx libknx$(LIBEXT) EXTRAFLAGS="$(KDEFINE) $(EXTRAFLAGS)"
+	$(Q) $(MAKE) -C libs$(DELIM)libnx libknx$(LIBEXT) BINDIR=kbin EXTRAFLAGS="$(KDEFINE) $(EXTRAFLAGS)"
 
 staging$(DELIM)libknx$(LIBEXT): libs$(DELIM)libnx$(DELIM)libknx$(LIBEXT)
 	$(Q) $(call INSTALL_LIB,$<,$@)
 
 mm$(DELIM)libkmm$(LIBEXT): pass2dep
-	$(Q) $(MAKE) -C mm libkmm$(LIBEXT) EXTRAFLAGS="$(KDEFINE) $(EXTRAFLAGS)"
+	$(Q) $(MAKE) -C mm libkmm$(LIBEXT) BINDIR=kbin EXTRAFLAGS="$(KDEFINE) $(EXTRAFLAGS)"
 
 staging$(DELIM)libkmm$(LIBEXT): mm$(DELIM)libkmm$(LIBEXT)
 	$(Q) $(call INSTALL_LIB,$<,$@)


### PR DESCRIPTION
## Summary

Targets build during the kernel phase did not have their dependencies
specified and thus they were not rebuilt after their dependencies have
changed, for example by changing options in menuconfig.

The second change in `LibTarget.mk` is required so that `BINDIR` will expand to its correct value when making `OBJS`.

## Impact
Fix rebuilding targets in protected mode.
## Testing
esp32.
