### PR TITLE
sched/semaphore: fix priority boost restoration for priority inheritance

### DIFF
--- a/Documentation/reference/user/05_counting_semaphore.rst
+++ b/Documentation/reference/user/05_counting_semaphore.rst
@@ -77,23 +77,6 @@ implementation:
      slightly increased code size and around 6-12 bytes times the value of
      ``CONFIG_SEM_PREALLOCHOLDERS``.
 
-  -  ``CONFIG_SEM_NNESTPRIO``: In addition, there may be multiple
-     threads of various priorities that need to wait for a count from the
-     semaphore. These, the lower priority thread holding the semaphore may
-     have to be boosted numerous times and, to make things more complex,
-     will have to keep track of all of the boost priorities values in
-     order to correctly restore the priorities after a count has been
-     handed out to the higher priority thread. The
-     ``CONFIG_SEM_NNESTPRIO`` defines the size of an array, one array per
-     active thread. This setting is the maximum number of higher priority
-     threads (minus 1) than can be waiting for another thread to release a
-     count on a semaphore. This value may be set to zero if no more than
-     one thread is expected to wait for a semaphore.
-
-     The cost associated with setting ``CONFIG_SEM_NNESTPRIO`` is slightly
-     increased code size and (``CONFIG_SEM_PREALLOCHOLDERS`` + 1) times
-     the maximum number of active threads.
-
   -  **Increased Susceptibility to Bad Thread Behavior**. These various
      structures tie the semaphore implementation more tightly to the
      behavior of the implementation. For examples, if a thread executes

--- a/include/nuttx/sched.h
+++ b/include/nuttx/sched.h
@@ -559,10 +559,7 @@ struct tcb_s
   uint8_t  task_state;                   /* Current state of the thread     */
 
 #ifdef CONFIG_PRIORITY_INHERITANCE
-#if CONFIG_SEM_NNESTPRIO > 0
-  uint8_t  npend_reprio;             /* Number of nested reprioritizations  */
-  uint8_t  pend_reprios[CONFIG_SEM_NNESTPRIO];
-#endif
+  uint8_t  boost_priority;               /* "Boosted" priority of the thread */
   uint8_t  base_priority;                /* "Normal" priority of the thread */
   FAR struct semholder_s *holdsem;       /* List of held semaphores         */
 #endif
@@ -635,12 +632,12 @@ struct tcb_s
   /* Pre-emption monitor support ********************************************/
 
 #ifdef CONFIG_SCHED_CRITMONITOR
-  uint32_t premp_start;                  /* Time when preemption disabled       */
-  uint32_t premp_max;                    /* Max time preemption disabled        */
-  uint32_t crit_start;                   /* Time critical section entered       */
-  uint32_t crit_max;                     /* Max time in critical section        */
-  uint32_t run_start;                    /* Time when thread begin run          */
-  uint32_t run_max;                      /* Max time thread run                 */
+  uint32_t premp_start;                  /* Time when preemption disabled   */
+  uint32_t premp_max;                    /* Max time preemption disabled    */
+  uint32_t crit_start;                   /* Time critical section entered   */
+  uint32_t crit_max;                     /* Max time in critical section    */
+  uint32_t run_start;                    /* Time when thread begin run      */
+  uint32_t run_max;                      /* Max time thread run             */
 #endif
 
   /* State save areas *******************************************************/
@@ -670,7 +667,7 @@ struct task_tcb_s
 {
   /* Common TCB fields ******************************************************/
 
-  struct tcb_s cmn;                      /* Common TCB fields                   */
+  struct tcb_s cmn;                      /* Common TCB fields               */
 
   /* Task Management Fields *************************************************/
 

--- a/sched/Kconfig
+++ b/sched/Kconfig
@@ -1172,16 +1172,6 @@ config SEM_PREALLOCHOLDERS
 		are only using semaphores as mutexes (only one holder) OR if no more
 		than two threads participate using a counting semaphore.
 
-config SEM_NNESTPRIO
-	int "Maximum number of higher priority threads"
-	default 16
-	---help---
-		If priority inheritance is enabled, then this setting is the
-		maximum number of higher priority threads (minus 1) than can be
-		waiting for another thread to release a count on a semaphore.
-		This value may be set to zero if no more than one thread is
-		expected to wait for a semaphore.
-
 endif # PRIORITY_INHERITANCE
 
 menu "RTOS hooks"

--- a/sched/sched/sched_reprioritize.c
+++ b/sched/sched/sched_reprioritize.c
@@ -79,11 +79,9 @@ int nxsched_reprioritize(FAR struct tcb_s *tcb, int sched_priority)
 
       tcb->base_priority  = (uint8_t)sched_priority;
 
-      /* Discard any pending reprioritizations as well */
+      /* Discard priority boost as well */
 
-#if CONFIG_SEM_NNESTPRIO > 0
-      tcb->npend_reprio   = 0;
-#endif
+      tcb->boost_priority = 0;
     }
 
   return ret;

--- a/sched/semaphore/sem_post.c
+++ b/sched/semaphore/sem_post.c
@@ -134,7 +134,7 @@ int nxsem_post(FAR sem_t *sem)
       if (sem_count <= 0)
         {
           /* Check if there are any tasks in the waiting for semaphore
-           * task list that are waiting for this semaphore. This is a
+           * task list that are waiting for this semaphore.  This is a
            * prioritized list so the first one we encounter is the one
            * that we want.
            */

--- a/sched/task/task_restart.c
+++ b/sched/task/task_restart.c
@@ -165,9 +165,7 @@ int nxtask_restart(pid_t pid)
 
 #ifdef CONFIG_PRIORITY_INHERITANCE
   tcb->cmn.base_priority = tcb->cmn.init_priority;
-#  if CONFIG_SEM_NNESTPRIO > 0
-  tcb->cmn.npend_reprio = 0;
-#  endif
+  tcb->cmn.boost_priority = 0;
 #endif
 
   /* Re-initialize the processor-specific portion of the TCB.  This will


### PR DESCRIPTION
## Summary
Fix priority boost restoration in case of priority inheritance
Details in https://github.com/apache/incubator-nuttx/issues/6310

## Impact
Improve priority inheritance. Reduce size of TCB in case is priority inheritance is enabled

## Testing
Priority inheritance ostest pass on SAMe70-QMTECH and STM32F4Discovery boards
