### PR TITLE
SSD1306: Added option to force reconfigure display after power off

### DIFF
--- a/drivers/lcd/Kconfig
+++ b/drivers/lcd/Kconfig
@@ -416,6 +416,12 @@ config SSD1306_I2CFREQ
 
 endif # LCD_SSD1306_I2C
 
+config SSD1306_POWEROFF_RECONFIGURE
+	bool "Reconfigure SSD1306 after power off"
+	default n
+	---help---
+		Forces a (re)configuration of the SSD1306 after calling power off.
+
 config LCD_SSD1351
 	bool "SSD1351 OLED Display Module"
 	default n

--- a/drivers/lcd/ssd1306_base.c
+++ b/drivers/lcd/ssd1306_base.c
@@ -755,6 +755,13 @@ static int ssd1306_setpower(FAR struct lcd_dev_s *dev, int power)
 
       priv->on = false;
 
+#ifdef CONFIG_SSD1306_POWEROFF_RECONFIGURE
+
+      /* Display is not configured anymore. */
+
+      priv->is_conf = false;
+#else
+
       /* Try turn off power completely */
 
       if (priv->board_priv && priv->board_priv->set_vcc)
@@ -768,6 +775,7 @@ static int ssd1306_setpower(FAR struct lcd_dev_s *dev, int power)
               priv->is_conf = false;
             }
         }
+#endif
     }
   else
     {


### PR DESCRIPTION
## Summary
Added option to force reconfigure the display after power off.
This is useful if for example the voltage domain of the display is not active during NuttX initialization.

## Impact
Extended the current kconfig options.

## Testing
Tested on custom S32K1xx board.
