### PR TITLE
Fix stm32 pwm HAVE_ADVTIM

### DIFF
--- a/arch/arm/src/stm32/stm32_pwm.c
+++ b/arch/arm/src/stm32/stm32_pwm.c
@@ -529,7 +529,9 @@ static const struct stm32_pwm_ops_s g_llpwmops =
   .ccr_get         = pwm_ccr_get,
   .arr_update      = pwm_arr_update,
   .arr_get         = pwm_arr_get,
+#ifdef HAVE_ADVTIM
   .rcr_update      = pwm_rcr_update,
+#endif
   .rcr_get         = pwm_rcr_get,
 #ifdef HAVE_TRGO
   .trgo_set        = pwm_trgo_configure,


### PR DESCRIPTION
## Summary

Architecture: STM32/stm32f103

If used PWM on general timers, it will call the exception in https://github.com/apache/incubator-nuttx/blob/master/arch/arm/src/stm32/stm32_pwm.c#L532.

Because the function ''pwm_rcr_update" exists only for Advanced Timer.

