### PR TITLE
sched: Move the call of pthread_mutex_inconsistent to nxtask_recover

### DIFF
--- a/sched/pthread/pthread_cancel.c
+++ b/sched/pthread/pthread_cancel.c
@@ -99,12 +99,6 @@ int pthread_cancel(pthread_t thread)
 
   pthread_completejoin((pid_t)thread, PTHREAD_CANCELED);
 
-#ifndef CONFIG_PTHREAD_MUTEX_UNSAFE
-  /* Recover any mutexes still held by the canceled thread */
-
-  pthread_mutex_inconsistent(tcb);
-#endif
-
   /* Then let nxtask_terminate do the real work */
 
   return nxtask_terminate((pid_t)thread, false);

--- a/sched/pthread/pthread_exit.c
+++ b/sched/pthread/pthread_exit.c
@@ -90,12 +90,6 @@ void nx_pthread_exit(FAR void *exit_value)
       exit(EXIT_FAILURE);
     }
 
-#ifndef CONFIG_PTHREAD_MUTEX_UNSAFE
-  /* Recover any mutexes still held by the canceled thread */
-
-  pthread_mutex_inconsistent(tcb);
-#endif
-
   /* Perform common task termination logic.  This will get called again later
    * through logic kicked off by _exit().  However, we need to call it before
    * calling _exit() in order certain operations if this is the last thread

--- a/sched/task/exit.c
+++ b/sched/task/exit.c
@@ -34,7 +34,6 @@
 #include "task/task.h"
 #include "group/group.h"
 #include "sched/sched.h"
-#include "pthread/pthread.h"
 
 /****************************************************************************
  * Public Functions
@@ -66,12 +65,6 @@ void _exit(int status)
    */
 
   group_kill_children(tcb);
-#endif
-
-#if !defined(CONFIG_DISABLE_PTHREAD) && !defined(CONFIG_PTHREAD_MUTEX_UNSAFE)
-  /* Recover any mutexes still held by the canceled thread */
-
-  pthread_mutex_inconsistent(tcb);
 #endif
 
   /* Perform common task termination logic.  This will get called again later

--- a/sched/task/task_recover.c
+++ b/sched/task/task_recover.c
@@ -33,6 +33,7 @@
 #include "semaphore/semaphore.h"
 #include "wdog/wdog.h"
 #include "mqueue/mqueue.h"
+#include "pthread/pthread.h"
 #include "sched/sched.h"
 #include "task/task.h"
 
@@ -61,6 +62,12 @@
 
 void nxtask_recover(FAR struct tcb_s *tcb)
 {
+#if !defined(CONFIG_DISABLE_PTHREAD) && !defined(CONFIG_PTHREAD_MUTEX_UNSAFE)
+  /* Recover any mutexes still held by the canceled thread */
+
+  pthread_mutex_inconsistent(tcb);
+#endif
+
   /* The task is being deleted.  Cancel in pending timeout events. */
 
   wd_recover(tcb);


### PR DESCRIPTION
## Summary
to avoid it spread around all possible exit path

## Impact
task_restart/task_delete/task_exit can restore the mutex too.

## Testing
ostest
