### PR TITLE
sched/pthread: Should call up_exit in pthread_exit

### DIFF
--- a/sched/pthread/pthread_exit.c
+++ b/sched/pthread/pthread_exit.c
@@ -109,5 +109,5 @@ void nx_pthread_exit(FAR void *exit_value)
    * calling atexit() functions.
    */
 
-  _exit(EXIT_SUCCESS);
+  up_exit(EXIT_SUCCESS);
 }


### PR DESCRIPTION
## Summary
since _exit may kill all sibling thread when
HAVE_GROUP_MEMBERS equal true. Regressed by(#6197):
```
commit 622677d4a1b3a9f20234571fafdceb7b98fe1425
Author: Ville Juven <ville.juven@unikie.com>
Date:   Mon May 2 15:15:06 2022 +0300

    libc: Implement exit, atexit, on_exit and cxa_exit on the user side

    For CONFIG_BUILD_KERNEL using the sched/task/task_exithook implementation
    will just not work. It calls user code with kernel privileges which is
    a bit of a security issue.
```

## Impact
Avoid pthread_exit terminate all thread in the same process

## Testing
ostest
