### PR TITLE
drivers/mtd/smart.c: Modify devname[] size to avoid overflow

### DIFF
--- a/drivers/mtd/smart.c
+++ b/drivers/mtd/smart.c
@@ -1938,7 +1938,7 @@ static int smart_scan(FAR struct smart_struct_s *dev)
 #endif
 #ifdef CONFIG_SMARTFS_MULTI_ROOT_DIRS
   int       x;
-  char      devname[22];
+  char      devname[32];
   FAR struct smart_multiroot_device_s *rootdirdev;
 #endif
   static const uint16_t sizetbl[8] =


### PR DESCRIPTION
## Summary
snprintf output to devname[] may cause overflow.
![image](https://user-images.githubusercontent.com/50488882/170478466-72d2b46c-9ad8-4f96-9b74-c2777aac0518.png)

## Impact
MTD SMART

## Testing
N/A
