### PR TITLE
sched/semaphore: Fix priority restoration

### DIFF
--- a/include/nuttx/sched.h
+++ b/include/nuttx/sched.h
@@ -558,8 +558,10 @@ struct tcb_s
 
 #ifdef CONFIG_PRIORITY_INHERITANCE
 #if CONFIG_SEM_NNESTPRIO > 0
-  uint8_t  npend_reprio;             /* Number of nested reprioritizations  */
-  uint8_t  pend_reprios[CONFIG_SEM_NNESTPRIO];
+  uint8_t  nsem_boosts;                  /* Number of semaphores that are
+                                          *  currently causing thread to be
+                                          *  boosted  */
+  struct semboost_s sem_boosts[CONFIG_SEM_NNESTPRIO];
 #endif
   uint8_t  base_priority;                /* "Normal" priority of the thread */
   FAR struct semholder_s *holdsem;       /* List of held semaphores         */

--- a/include/semaphore.h
+++ b/include/semaphore.h
@@ -131,6 +131,14 @@ typedef struct sem_s sem_t;
     {(c)}                        /* semcount */
 #endif
 
+#ifdef CONFIG_PRIORITY_INHERITANCE
+struct semboost_s
+{
+  FAR sem_t *sem;
+  uint8_t priority;
+};
+#endif
+
 /****************************************************************************
  * Public Data
  ****************************************************************************/

--- a/sched/task/task_restart.c
+++ b/sched/task/task_restart.c
@@ -166,7 +166,7 @@ int nxtask_restart(pid_t pid)
 #ifdef CONFIG_PRIORITY_INHERITANCE
   tcb->cmn.base_priority = tcb->cmn.init_priority;
 #  if CONFIG_SEM_NNESTPRIO > 0
-  tcb->cmn.npend_reprio = 0;
+  tcb->cmn.nsem_boosts = 0;
 #  endif
 #endif
 

--- a/sched/wqueue/kwork_inherit.c
+++ b/sched/wqueue/kwork_inherit.c
@@ -37,6 +37,8 @@
 #if defined(CONFIG_SCHED_WORKQUEUE) && defined(CONFIG_SCHED_LPWORK) && \
     defined(CONFIG_PRIORITY_INHERITANCE)
 
+static sem_t g_kwork_dummy_sem;
+
 /****************************************************************************
  * Private Functions
  ****************************************************************************/
@@ -67,73 +69,39 @@ static void lpwork_boostworker(pid_t wpid, uint8_t reqprio)
   DEBUGASSERT(wtcb);
 
 #if CONFIG_SEM_NNESTPRIO > 0
-  /* If the priority of the client thread that is greater than the base
-   * priority of the worker thread, then we may need to adjust the worker
-   * thread's priority now or later to that priority.
+  /* If the priority of the thread that is waiting for a count is greater
+   * than the base priority of the thread holding a count, then we add this
+   * priority for the semaphore to the list of boosting semaphores
    */
 
   if (reqprio > wtcb->base_priority)
     {
-      /* If the new priority is greater than the current, possibly already
-       * boosted priority of the worker thread, then we will have to raise
-       * the worker thread's priority now.
-       */
-
-      if (reqprio > wtcb->sched_priority)
+      if (wtcb->nsem_boosts < CONFIG_SEM_NNESTPRIO)
         {
-          /* If the current priority of worker thread has already been
-           * boosted, then add the boost priority to the list of restoration
-           * priorities.  When the higher priority waiter thread gets its
-           * count, then we need to revert the worker thread to this saved
-           * priority (not to its base priority).
+          /* Store this boost in the list of active boosts */
+
+          struct semboost_s *boost = &wtcb->sem_boosts[wtcb->nsem_boosts];
+          wtcb->nsem_boosts++;
+
+          /* Store reference to dummy semaphore to record boost */
+
+          boost->sem = &g_kwork_dummy_sem;
+          boost->priority = reqprio;
+          /* If the boost we just received is a new maximum. We need to boost
+           * ourselves
            */
 
-          if (wtcb->sched_priority > wtcb->base_priority)
+          if (boost->priority > wtcb->sched_priority)
             {
-              /* Save the current, boosted priority of the worker thread. */
-
-              if (wtcb->npend_reprio < CONFIG_SEM_NNESTPRIO)
-                {
-                  wtcb->pend_reprios[wtcb->npend_reprio] =
-                    wtcb->sched_priority;
-                  wtcb->npend_reprio++;
-                }
-              else
-                {
-                  serr("ERROR: CONFIG_SEM_NNESTPRIO exceeded\n");
-                  DEBUGASSERT(wtcb->npend_reprio < CONFIG_SEM_NNESTPRIO);
-                }
+              nxsched_set_priority(wtcb, boost->priority);
             }
-
-          /* Raise the priority of the worker.  This cannot cause a context
-           * switch because we have preemption disabled.  The worker thread
-           * may be marked "pending" and the switch may occur during
-           * sched_unblock() processing.
-           */
-
-          nxsched_set_priority(wtcb, reqprio);
         }
       else
         {
-          /* The new priority is above the base priority of the worker,
-           * but not as high as its current working priority.  Just put it
-           * in the list of pending restoration priorities so that when the
-           * higher priority thread gets its count, we can revert to this
-           * saved priority and not to the base priority.
-           */
-
-          if (wtcb->npend_reprio < CONFIG_SEM_NNESTPRIO)
-            {
-              wtcb->pend_reprios[wtcb->npend_reprio] = reqprio;
-              wtcb->npend_reprio++;
-            }
-          else
-            {
-              serr("ERROR: CONFIG_SEM_NNESTPRIO exceeded\n");
-              DEBUGASSERT(wtcb->npend_reprio < CONFIG_SEM_NNESTPRIO);
-            }
+          serr("ERROR: TCB %p out of priority boost slots.", wtcb);
         }
     }
+
 #else
   /* If the priority of the client thread that is less than of equal to the
    * priority of the worker thread, then do nothing because the thread is
@@ -174,11 +142,6 @@ static void lpwork_boostworker(pid_t wpid, uint8_t reqprio)
 static void lpwork_restoreworker(pid_t wpid, uint8_t reqprio)
 {
   FAR struct tcb_s *wtcb;
-#if CONFIG_SEM_NNESTPRIO > 0
-  uint8_t wpriority;
-  int index;
-  int selected;
-#endif
 
   /* Get the TCB of the low priority worker thread from the process ID. */
 
@@ -192,100 +155,50 @@ static void lpwork_restoreworker(pid_t wpid, uint8_t reqprio)
   if (wtcb->sched_priority != wtcb->base_priority)
     {
 #if CONFIG_SEM_NNESTPRIO > 0
-      /* Are there other, pending priority levels to revert to? */
-
-      if (wtcb->npend_reprio < 1)
-        {
-          /* No... the worker thread has only been boosted once.
-           * npend_reprio should be 0 and the boosted priority should be the
-           * priority of the client task (reqprio)
-           *
-           * That latter assumption may not be true if the client's priority
-           * was also boosted so that it no longer matches the wtcb's
-           * sched_priority.  Or if CONFIG_SEM_NNESTPRIO is too small (so
-           * that we do not have a proper record of the reprioritizations).
-           */
-
-          DEBUGASSERT(/* wtcb->sched_priority == reqprio && */
-                      wtcb->npend_reprio == 0);
-
-          /* Reset the worker's priority back to the base priority. */
-
-          nxsched_reprioritize(wtcb, wtcb->base_priority);
-        }
-
-      /* There are multiple pending priority levels. The worker thread's
-       * "boosted" priority could greater than or equal to "reqprio" (it
-       * could be greater if its priority we boosted because it also holds
-       * some semaphore).
+      /* Priority is supposed to go back to what it was before.
+       * We can remove the highest boost for kwork boosts from our
+       * list of boosts, and re-evaluate what is the now the highest
+       * priority still waiting
        */
 
-      else if (wtcb->sched_priority <= reqprio)
+      int max_boost_index = -1;
+      uint8_t max_boost_priority = 0;
+      for (int i = 0; i < wtcb->nsem_boosts; i++)
         {
-          /* The worker thread has been boosted to the same priority as the
-           * waiter thread that just received the count.  We will simply
-           * reprioritize to the next highest pending priority.
-           */
-
-          /* Find the highest pending priority and remove it from the list */
-
-          for (index = 1, selected = 0; index < wtcb->npend_reprio; index++)
+          if (wtcb->sem_boosts[i].sem == &g_kwork_dummy_sem)
             {
-              if (wtcb->pend_reprios[index] > wtcb->pend_reprios[selected])
+              if (max_boost_priority < wtcb->sem_boosts[i].priority)
                 {
-                  selected = index;
+                  max_boost_priority = wtcb->sem_boosts[i].priority;
+                  max_boost_index = i;
                 }
             }
-
-          /* Remove the highest priority pending priority from the list */
-
-          wpriority = wtcb->pend_reprios[selected];
-          index = wtcb->npend_reprio - 1;
-          if (index > 0)
-            {
-              wtcb->pend_reprios[selected] = wtcb->pend_reprios[index];
-            }
-
-          wtcb->npend_reprio = index;
-
-          /* And apply that priority to the thread (while retaining the
-           * base_priority)
-           */
-
-          nxsched_set_priority(wtcb, wpriority);
         }
-      else
+
+      if (max_boost_index >= 0)
         {
-          /* The worker thread has been boosted to a higher priority than the
-           * waiter task.  The pending priority should be in the list (unless
-           * it was lost because of list overflow or because the worker was
-           * reprioritized again unbeknownst to the priority inheritance
-           * logic).
-           *
-           * Search the list for the matching priority.
+          /* We found the maximum boost for kwork boost on this task.
+           * Remove this, as this is no longer required
+           * remove (replace max with last, decrease count)
            */
 
-          for (index = 0; index < wtcb->npend_reprio; index++)
-            {
-              /* Does this pending priority match the priority of the thread
-               * that just received the count?
-               */
+          wtcb->sem_boosts[max_boost_index] =
+            wtcb->sem_boosts[wtcb->nsem_boosts - 1];
+          wtcb->nsem_boosts--;
+        }
 
-              if (wtcb->pend_reprios[index] == reqprio)
-                {
-                  /* Yes, remove it from the list */
+      /* Find new max priority by going through the boosts still present */
 
-                  selected = wtcb->npend_reprio - 1;
-                  if (selected > 0)
-                    {
-                      wtcb->pend_reprios[index] =
-                        wtcb->pend_reprios[selected];
-                    }
+      uint8_t new_priority = wtcb->base_priority;
+      for (int i = 0; i < wtcb->nsem_boosts; i++)
+        {
+          new_priority = (wtcb->sem_boosts[i].priority > new_priority) ?
+              wtcb->sem_boosts[i].priority : new_priority;
+        }
 
-                  wtcb->npend_reprio = selected;
-                  break;
-                }
-            }
+      if (new_priority != wtcb->sched_priority)
+        {
+          nxsched_set_priority(wtcb, new_priority);
         }
 #else
       /* There is no alternative restore priorities, drop the priority


### PR DESCRIPTION
## Summary

Another attempt at fixing https://github.com/apache/incubator-nuttx/issues/6310
Difference to https://github.com/apache/incubator-nuttx/pull/6318 is that in this attempt, the reason for the boost (the address of the semaphore causing the boost) gets stored in the list of boosts in the tcb. 

Main idea: Instead of just storing an array of priorities but forgetting to what tasks they belong to, we store the address of the semaphore as well.
Then, on every boost we put a (semaphore, new_priority) tuple in the array, on every release, we remove the one that corresponds to the released semphore with the highest priority, iff we still hold a count on that semaphore, otherwise we remove all that correspond to the semaphore.
At the end, we just set as the priority the maximum value of all boosts on all semaphores that are in the array

## Impact
This should generally fix the priority inheritance issues seen in https://github.com/apache/incubator-nuttx/issues/6310. It passes some hand-crafted adverse tests. 

After this patch, memory footprint increases by `n_tasks * CONFIG_SEM_NNESTPRIO * 4` bytes more memory. This could potentially be mitigated by using a linked list with preallocated holders instead of the array in the tcb, (like with the semaphore holders list).

## Testing

