### PR TITLE
arch: Define WCHAR_[MIN|MAX] in arch/include/limits.h 

### DIFF
--- a/arch/arm/include/limits.h
+++ b/arch/arm/include/limits.h
@@ -37,11 +37,11 @@
 /* These could be different on machines where char is unsigned */
 
 #ifdef __CHAR_UNSIGNED__
-#define CHAR_MIN    0
-#define CHAR_MAX    UCHAR_MAX
+#  define CHAR_MIN  0
+#  define CHAR_MAX  UCHAR_MAX
 #else
-#define CHAR_MIN    SCHAR_MIN
-#define CHAR_MAX    SCHAR_MAX
+#  define CHAR_MIN  SCHAR_MIN
+#  define CHAR_MAX  SCHAR_MAX
 #endif
 
 #define SHRT_MIN    (-SHRT_MAX - 1)
@@ -67,5 +67,16 @@
 #define PTR_MIN     (-PTR_MAX - 1)
 #define PTR_MAX     2147483647
 #define UPTR_MAX    4294967295U
+
+#if !defined(__WCHAR_TYPE__)
+#  define WCHAR_MIN INT_MIN
+#  define WCHAR_MAX INT_MAX
+#elif defined(__WCHAR_UNSIGNED__)
+#  define WCHAR_MIN 0
+#  define WCHAR_MAX __WCHAR_MAX__
+#else
+#  define WCHAR_MIN (-__WCHAR_MAX__ - 1)
+#  define WCHAR_MAX __WCHAR_MAX__
+#endif
 
 #endif /* __ARCH_ARM_INCLUDE_LIMITS_H */

--- a/arch/avr/include/avr/limits.h
+++ b/arch/avr/include/avr/limits.h
@@ -37,11 +37,11 @@
 /* These could be different on machines where char is unsigned */
 
 #ifdef __CHAR_UNSIGNED__
-#define CHAR_MIN    0
-#define CHAR_MAX    UCHAR_MAX
+#  define CHAR_MIN  0
+#  define CHAR_MAX  UCHAR_MAX
 #else
-#define CHAR_MIN    SCHAR_MIN
-#define CHAR_MAX    SCHAR_MAX
+#  define CHAR_MIN  SCHAR_MIN
+#  define CHAR_MAX  SCHAR_MAX
 #endif
 
 #define SHRT_MIN    (-SHRT_MAX - 1)
@@ -69,5 +69,16 @@
 #define PTR_MIN     (-PTR_MAX - 1)
 #define PTR_MAX     32767
 #define UPTR_MAX    65535U
+
+#if !defined(__WCHAR_TYPE__)
+#  define WCHAR_MIN INT_MIN
+#  define WCHAR_MAX INT_MAX
+#elif defined(__WCHAR_UNSIGNED__)
+#  define WCHAR_MIN 0
+#  define WCHAR_MAX __WCHAR_MAX__
+#else
+#  define WCHAR_MIN (-__WCHAR_MAX__ - 1)
+#  define WCHAR_MAX __WCHAR_MAX__
+#endif
 
 #endif /* __ARCH_AVR_INCLUDE_AVR_LIMITS_H */

--- a/arch/avr/include/avr32/limits.h
+++ b/arch/avr/include/avr32/limits.h
@@ -37,11 +37,11 @@
 /* These could be different on machines where char is unsigned */
 
 #ifdef __CHAR_UNSIGNED__
-#define CHAR_MIN    0
-#define CHAR_MAX    UCHAR_MAX
+#  define CHAR_MIN  0
+#  define CHAR_MAX  UCHAR_MAX
 #else
-#define CHAR_MIN    SCHAR_MIN
-#define CHAR_MAX    SCHAR_MAX
+#  define CHAR_MIN  SCHAR_MIN
+#  define CHAR_MAX  SCHAR_MAX
 #endif
 
 #define SHRT_MIN    (-SHRT_MAX - 1)
@@ -69,5 +69,16 @@
 #define PTR_MIN     (-PTR_MAX - 1)
 #define PTR_MAX     2147483647
 #define UPTR_MAX    4294967295U
+
+#if !defined(__WCHAR_TYPE__)
+#  define WCHAR_MIN INT_MIN
+#  define WCHAR_MAX INT_MAX
+#elif defined(__WCHAR_UNSIGNED__)
+#  define WCHAR_MIN 0
+#  define WCHAR_MAX __WCHAR_MAX__
+#else
+#  define WCHAR_MIN (-__WCHAR_MAX__ - 1)
+#  define WCHAR_MAX __WCHAR_MAX__
+#endif
 
 #endif /* __ARCH_AVR_INCLUDE_AVR32_LIMITS_H */

--- a/arch/ceva/include/limits.h
+++ b/arch/ceva/include/limits.h
@@ -37,4 +37,15 @@
 #define PTR_MAX     LONG_MAX
 #define UPTR_MAX    ULONG_MAX
 
+#if !defined(__WCHAR_TYPE__)
+#  define WCHAR_MIN INT_MIN
+#  define WCHAR_MAX INT_MAX
+#elif defined(__WCHAR_UNSIGNED__)
+#  define WCHAR_MIN 0
+#  define WCHAR_MAX __WCHAR_MAX__
+#else
+#  define WCHAR_MIN (-__WCHAR_MAX__ - 1)
+#  define WCHAR_MAX __WCHAR_MAX__
+#endif
+
 #endif /* __ARCH_CEVA_INCLUDE_LIMITS_H */

--- a/arch/hc/include/hc12/limits.h
+++ b/arch/hc/include/hc12/limits.h
@@ -37,11 +37,11 @@
 /* These could be different on machines where char is unsigned */
 
 #ifdef __CHAR_UNSIGNED__
-#define CHAR_MIN    0
-#define CHAR_MAX    UCHAR_MAX
+#  define CHAR_MIN  0
+#  define CHAR_MAX  UCHAR_MAX
 #else
-#define CHAR_MIN    SCHAR_MIN
-#define CHAR_MAX    SCHAR_MAX
+#  define CHAR_MIN  SCHAR_MIN
+#  define CHAR_MAX  SCHAR_MAX
 #endif
 
 #define SHRT_MIN    (-SHRT_MAX - 1)
@@ -77,5 +77,16 @@
 #define PTR_MIN     (-PTR_MAX - 1)
 #define PTR_MAX     32767
 #define UPTR_MAX    65535U
+
+#if !defined(__WCHAR_TYPE__)
+#  define WCHAR_MIN INT_MIN
+#  define WCHAR_MAX INT_MAX
+#elif defined(__WCHAR_UNSIGNED__)
+#  define WCHAR_MIN 0
+#  define WCHAR_MAX __WCHAR_MAX__
+#else
+#  define WCHAR_MIN (-__WCHAR_MAX__ - 1)
+#  define WCHAR_MAX __WCHAR_MAX__
+#endif
 
 #endif /* __ARCH_HC_INCLUDE_HC12_LIMITS_H */

--- a/arch/hc/include/hcs12/limits.h
+++ b/arch/hc/include/hcs12/limits.h
@@ -37,11 +37,11 @@
 /* These could be different on machines where char is unsigned */
 
 #ifdef __CHAR_UNSIGNED__
-#define CHAR_MIN    0
-#define CHAR_MAX    UCHAR_MAX
+#  define CHAR_MIN  0
+#  define CHAR_MAX  UCHAR_MAX
 #else
-#define CHAR_MIN    SCHAR_MIN
-#define CHAR_MAX    SCHAR_MAX
+#  define CHAR_MIN  SCHAR_MIN
+#  define CHAR_MAX  SCHAR_MAX
 #endif
 
 #define SHRT_MIN    (-SHRT_MAX - 1)
@@ -77,5 +77,16 @@
 #define PTR_MIN     (-PTR_MAX - 1)
 #define PTR_MAX     32767
 #define UPTR_MAX    65535U
+
+#if !defined(__WCHAR_TYPE__)
+#  define WCHAR_MIN INT_MIN
+#  define WCHAR_MAX INT_MAX
+#elif defined(__WCHAR_UNSIGNED__)
+#  define WCHAR_MIN 0
+#  define WCHAR_MAX __WCHAR_MAX__
+#else
+#  define WCHAR_MIN (-__WCHAR_MAX__ - 1)
+#  define WCHAR_MAX __WCHAR_MAX__
+#endif
 
 #endif /* __ARCH_HC_INCLUDE_HCS12_LIMITS_H */

--- a/arch/mips/include/limits.h
+++ b/arch/mips/include/limits.h
@@ -37,11 +37,11 @@
 /* These could be different on machines where char is unsigned */
 
 #ifdef __CHAR_UNSIGNED__
-#define CHAR_MIN    0
-#define CHAR_MAX    UCHAR_MAX
+#  define CHAR_MIN  0
+#  define CHAR_MAX  UCHAR_MAX
 #else
-#define CHAR_MIN    SCHAR_MIN
-#define CHAR_MAX    SCHAR_MAX
+#  define CHAR_MIN  SCHAR_MIN
+#  define CHAR_MAX  SCHAR_MAX
 #endif
 
 #define SHRT_MIN    (-SHRT_MAX - 1)
@@ -67,5 +67,16 @@
 #define PTR_MIN     (-PTR_MAX - 1)
 #define PTR_MAX     2147483647
 #define UPTR_MAX    4294967295U
+
+#if !defined(__WCHAR_TYPE__)
+#  define WCHAR_MIN INT_MIN
+#  define WCHAR_MAX INT_MAX
+#elif defined(__WCHAR_UNSIGNED__)
+#  define WCHAR_MIN 0
+#  define WCHAR_MAX __WCHAR_MAX__
+#else
+#  define WCHAR_MIN (-__WCHAR_MAX__ - 1)
+#  define WCHAR_MAX __WCHAR_MAX__
+#endif
 
 #endif /* __ARCH_MIPS_INCLUDE_LIMITS_H */

--- a/arch/misoc/include/limits.h
+++ b/arch/misoc/include/limits.h
@@ -37,11 +37,11 @@
 /* These could be different on machines where char is unsigned */
 
 #ifdef __CHAR_UNSIGNED__
-#define CHAR_MIN    0
-#define CHAR_MAX    UCHAR_MAX
+#  define CHAR_MIN  0
+#  define CHAR_MAX  UCHAR_MAX
 #else
-#define CHAR_MIN    SCHAR_MIN
-#define CHAR_MAX    SCHAR_MAX
+#  define CHAR_MIN  SCHAR_MIN
+#  define CHAR_MAX  SCHAR_MAX
 #endif
 
 #define SHRT_MIN    (-SHRT_MAX - 1)
@@ -69,5 +69,16 @@
 #define PTR_MIN     (-PTR_MAX - 1)
 #define PTR_MAX     2147483647
 #define UPTR_MAX    4294967295U
+
+#if !defined(__WCHAR_TYPE__)
+#  define WCHAR_MIN INT_MIN
+#  define WCHAR_MAX INT_MAX
+#elif defined(__WCHAR_UNSIGNED__)
+#  define WCHAR_MIN 0
+#  define WCHAR_MAX __WCHAR_MAX__
+#else
+#  define WCHAR_MIN (-__WCHAR_MAX__ - 1)
+#  define WCHAR_MAX __WCHAR_MAX__
+#endif
 
 #endif /* __ARCH_MISOC_INCLUDE_LIMITS_H */

--- a/arch/or1k/include/limits.h
+++ b/arch/or1k/include/limits.h
@@ -37,11 +37,11 @@
 /* These could be different on machines where char is unsigned */
 
 #ifdef __CHAR_UNSIGNED__
-#define CHAR_MIN    0
-#define CHAR_MAX    UCHAR_MAX
+#  define CHAR_MIN  0
+#  define CHAR_MAX  UCHAR_MAX
 #else
-#define CHAR_MIN    SCHAR_MIN
-#define CHAR_MAX    SCHAR_MAX
+#  define CHAR_MIN  SCHAR_MIN
+#  define CHAR_MAX  SCHAR_MAX
 #endif
 
 #define SHRT_MIN    (-SHRT_MAX - 1)
@@ -67,5 +67,16 @@
 #define PTR_MIN     (-PTR_MAX - 1)
 #define PTR_MAX     2147483647
 #define UPTR_MAX    4294967295U
+
+#if !defined(__WCHAR_TYPE__)
+#  define WCHAR_MIN INT_MIN
+#  define WCHAR_MAX INT_MAX
+#elif defined(__WCHAR_UNSIGNED__)
+#  define WCHAR_MIN 0
+#  define WCHAR_MAX __WCHAR_MAX__
+#else
+#  define WCHAR_MIN (-__WCHAR_MAX__ - 1)
+#  define WCHAR_MAX __WCHAR_MAX__
+#endif
 
 #endif /* __ARCH_OR1K_INCLUDE_LIMITS_H */

--- a/arch/renesas/include/m16c/limits.h
+++ b/arch/renesas/include/m16c/limits.h
@@ -37,11 +37,11 @@
 /* These could be different on machines where char is unsigned */
 
 #ifdef __CHAR_UNSIGNED__
-#define CHAR_MIN    0
-#define CHAR_MAX    UCHAR_MAX
+#  define CHAR_MIN  0
+#  define CHAR_MAX  UCHAR_MAX
 #else
-#define CHAR_MIN    SCHAR_MIN
-#define CHAR_MAX    SCHAR_MAX
+#  define CHAR_MIN  SCHAR_MIN
+#  define CHAR_MAX  SCHAR_MAX
 #endif
 
 #define SHRT_MIN    (-SHRT_MAX - 1)
@@ -69,5 +69,16 @@
 #define PTR_MIN     (-PTR_MAX - 1)
 #define PTR_MAX     32767
 #define UPTR_MAX    65535U
+
+#if !defined(__WCHAR_TYPE__)
+#  define WCHAR_MIN INT_MIN
+#  define WCHAR_MAX INT_MAX
+#elif defined(__WCHAR_UNSIGNED__)
+#  define WCHAR_MIN 0
+#  define WCHAR_MAX __WCHAR_MAX__
+#else
+#  define WCHAR_MIN (-__WCHAR_MAX__ - 1)
+#  define WCHAR_MAX __WCHAR_MAX__
+#endif
 
 #endif /* __ARCH_RENESAS_INCLUDE_M16C_LIMITS_H */

--- a/arch/renesas/include/rx65n/limits.h
+++ b/arch/renesas/include/rx65n/limits.h
@@ -33,11 +33,11 @@
 /* These could be different on machines where char is unsigned */
 
 #ifdef __CHAR_UNSIGNED__
-#define CHAR_MIN    0
-#define CHAR_MAX    UCHAR_MAX
+#  define CHAR_MIN  0
+#  define CHAR_MAX  UCHAR_MAX
 #else
-#define CHAR_MIN    SCHAR_MIN
-#define CHAR_MAX    SCHAR_MAX
+#  define CHAR_MIN  SCHAR_MIN
+#  define CHAR_MAX  SCHAR_MAX
 #endif
 
 #define SHRT_MIN    (-SHRT_MAX - 1)
@@ -65,5 +65,16 @@
 #define PTR_MIN     (-PTR_MAX - 1)
 #define PTR_MAX     2147483647
 #define UPTR_MAX    4294967295U
+
+#if !defined(__WCHAR_TYPE__)
+#  define WCHAR_MIN INT_MIN
+#  define WCHAR_MAX INT_MAX
+#elif defined(__WCHAR_UNSIGNED__)
+#  define WCHAR_MIN 0
+#  define WCHAR_MAX __WCHAR_MAX__
+#else
+#  define WCHAR_MIN (-__WCHAR_MAX__ - 1)
+#  define WCHAR_MAX __WCHAR_MAX__
+#endif
 
 #endif /* __ARCH_RENESAS_INCLUDE_RX65N_LIMITS_H */

--- a/arch/renesas/include/sh1/limits.h
+++ b/arch/renesas/include/sh1/limits.h
@@ -37,11 +37,11 @@
 /* These could be different on machines where char is unsigned */
 
 #ifdef __CHAR_UNSIGNED__
-#define CHAR_MIN    0
-#define CHAR_MAX    UCHAR_MAX
+#  define CHAR_MIN  0
+#  define CHAR_MAX  UCHAR_MAX
 #else
-#define CHAR_MIN    SCHAR_MIN
-#define CHAR_MAX    SCHAR_MAX
+#  define CHAR_MIN  SCHAR_MIN
+#  define CHAR_MAX  SCHAR_MAX
 #endif
 
 #define SHRT_MIN    (-SHRT_MAX - 1)
@@ -69,5 +69,16 @@
 #define PTR_MIN     (-PTR_MAX - 1)
 #define PTR_MAX     2147483647
 #define UPTR_MAX    4294967295U
+
+#if !defined(__WCHAR_TYPE__)
+#  define WCHAR_MIN INT_MIN
+#  define WCHAR_MAX INT_MAX
+#elif defined(__WCHAR_UNSIGNED__)
+#  define WCHAR_MIN 0
+#  define WCHAR_MAX __WCHAR_MAX__
+#else
+#  define WCHAR_MIN (-__WCHAR_MAX__ - 1)
+#  define WCHAR_MAX __WCHAR_MAX__
+#endif
 
 #endif /* __ARCH_RENESAS_INCLUDE_SH1_LIMITS_H */

--- a/arch/renesas/include/sh1Plimits.h
+++ b/arch/renesas/include/sh1Plimits.h
@@ -37,11 +37,11 @@
 /* These could be different on machines where char is unsigned */
 
 #ifdef __CHAR_UNSIGNED__
-#define CHAR_MIN    0
-#define CHAR_MAX    UCHAR_MAX
+#  define CHAR_MIN  0
+#  define CHAR_MAX  UCHAR_MAX
 #else
-#define CHAR_MIN    SCHAR_MIN
-#define CHAR_MAX    SCHAR_MAX
+#  define CHAR_MIN  SCHAR_MIN
+#  define CHAR_MAX  SCHAR_MAX
 #endif
 
 #define SHRT_MIN    (-SHRT_MAX - 1)
@@ -69,5 +69,16 @@
 #define PTR_MIN     (-PTR_MAX - 1)
 #define PTR_MAX     2147483647
 #define UPTR_MAX    4294967295U
+
+#if !defined(__WCHAR_TYPE__)
+#  define WCHAR_MIN INT_MIN
+#  define WCHAR_MAX INT_MAX
+#elif defined(__WCHAR_UNSIGNED__)
+#  define WCHAR_MIN 0
+#  define WCHAR_MAX __WCHAR_MAX__
+#else
+#  define WCHAR_MIN (-__WCHAR_MAX__ - 1)
+#  define WCHAR_MAX __WCHAR_MAX__
+#endif
 
 #endif /* __ARCH_RENESAS_INCLUDE_SH1_PLIMITS_H */

--- a/arch/risc-v/include/limits.h
+++ b/arch/risc-v/include/limits.h
@@ -37,11 +37,11 @@
 /* These could be different on machines where char is unsigned */
 
 #ifdef __CHAR_UNSIGNED__
-#define CHAR_MIN    0
-#define CHAR_MAX    UCHAR_MAX
+#  define CHAR_MIN  0
+#  define CHAR_MAX  UCHAR_MAX
 #else
-#define CHAR_MIN    SCHAR_MIN
-#define CHAR_MAX    SCHAR_MAX
+#  define CHAR_MIN  SCHAR_MIN
+#  define CHAR_MAX  SCHAR_MAX
 #endif
 
 #define SHRT_MIN    (-SHRT_MAX - 1)
@@ -54,38 +54,43 @@
 
 /* These change on 32-bit and 64-bit platforms */
 
-#if defined(CONFIG_ARCH_RV32)
+#ifdef CONFIG_ARCH_RV32
+#  define LONG_MIN  (-LONG_MAX - 1)
+#  define LONG_MAX  2147483647L
+#  define ULONG_MAX 4294967295UL
 
-#define LONG_MIN    (-LONG_MAX - 1)
-#define LONG_MAX    2147483647L
-#define ULONG_MAX   4294967295UL
-
-#define LLONG_MIN   (-LLONG_MAX - 1)
-#define LLONG_MAX   9223372036854775807LL
-#define ULLONG_MAX  18446744073709551615ULL
+#  define LLONG_MIN  (-LLONG_MAX - 1)
+#  define LLONG_MAX  9223372036854775807LL
+#  define ULLONG_MAX 18446744073709551615ULL
 
 /* A pointer is 4 bytes */
 
-#define PTR_MIN     (-PTR_MAX - 1)
-#define PTR_MAX     2147483647
-#define UPTR_MAX    4294967295U
+#  define PTR_MIN   (-PTR_MAX - 1)
+#  define PTR_MAX   2147483647
+#  define UPTR_MAX  4294967295U
+#else /* CONFIG_ARCH_RV32 */
+#  define LONG_MIN  (-LONG_MAX - 1)
+#  define LONG_MAX  9223372036854775807L
+#  define ULONG_MAX 18446744073709551615UL
 
-#endif /* defined(CONFIG_ARCH_RV32) */
+#  define LLONG_MIN  (-LLONG_MAX - 1)
+#  define LLONG_MAX  9223372036854775807LL
+#  define ULLONG_MAX 18446744073709551615ULL
 
-#if defined(CONFIG_ARCH_RV64)
+#  define PTR_MIN   (-PTR_MAX - 1)
+#  define PTR_MAX   9223372036854775807
+#  define UPTR_MAX  18446744073709551615U
+#endif
 
-#define LONG_MIN    (-LONG_MAX - 1)
-#define LONG_MAX    9223372036854775807L
-#define ULONG_MAX   18446744073709551615UL
-
-#define LLONG_MIN   (-LLONG_MAX - 1)
-#define LLONG_MAX   9223372036854775807LL
-#define ULLONG_MAX  18446744073709551615ULL
-
-#define PTR_MIN     (-PTR_MAX - 1)
-#define PTR_MAX     9223372036854775807
-#define UPTR_MAX    18446744073709551615U
-
+#if !defined(__WCHAR_TYPE__)
+#  define WCHAR_MIN INT_MIN
+#  define WCHAR_MAX INT_MAX
+#elif defined(__WCHAR_UNSIGNED__)
+#  define WCHAR_MIN 0
+#  define WCHAR_MAX __WCHAR_MAX__
+#else
+#  define WCHAR_MIN (-__WCHAR_MAX__ - 1)
+#  define WCHAR_MAX __WCHAR_MAX__
 #endif
 
 #endif /* __ARCH_RISCV_INCLUDE_LIMITS_H */

--- a/arch/sim/include/limits.h
+++ b/arch/sim/include/limits.h
@@ -37,11 +37,11 @@
 /* These could be different on machines where char is unsigned */
 
 #ifdef __CHAR_UNSIGNED__
-#define CHAR_MIN     0
-#define CHAR_MAX     UCHAR_MAX
+#  define CHAR_MIN   0
+#d  efine CHAR_MAX   UCHAR_MAX
 #else
-#define CHAR_MIN     SCHAR_MIN
-#define CHAR_MAX     SCHAR_MAX
+#  define CHAR_MIN   SCHAR_MIN
+#  define CHAR_MAX   SCHAR_MAX
 #endif
 
 #define SHRT_MIN     (-SHRT_MAX - 1)
@@ -79,6 +79,17 @@
 #else
 #  define PTR_MAX    2147483647
 #  define UPTR_MAX   4294967295U
+#endif
+
+#if !defined(__WCHAR_TYPE__)
+#  define WCHAR_MIN INT_MIN
+#  define WCHAR_MAX INT_MAX
+#elif defined(__WCHAR_UNSIGNED__)
+#  define WCHAR_MIN 0
+#  define WCHAR_MAX __WCHAR_MAX__
+#else
+#  define WCHAR_MIN (-__WCHAR_MAX__ - 1)
+#  define WCHAR_MAX __WCHAR_MAX__
 #endif
 
 #endif /* __ARCH_SIM_INCLUDE_LIMITS_H  */

--- a/arch/sparc/include/limits.h
+++ b/arch/sparc/include/limits.h
@@ -37,11 +37,11 @@
 /* These could be different on machines where char is unsigned */
 
 #ifdef __CHAR_UNSIGNED__
-#define CHAR_MIN    0
-#define CHAR_MAX    UCHAR_MAX
+#  define CHAR_MIN  0
+#  define CHAR_MAX  UCHAR_MAX
 #else
-#define CHAR_MIN    SCHAR_MIN
-#define CHAR_MAX    SCHAR_MAX
+#  define CHAR_MIN  SCHAR_MIN
+#  define CHAR_MAX  SCHAR_MAX
 #endif
 
 #define SHRT_MIN    (-SHRT_MAX - 1)
@@ -67,6 +67,17 @@
 #define PTR_MIN     (-PTR_MAX - 1)
 #define PTR_MAX     2147483647
 #define UPTR_MAX    4294967295U
+
+#if !defined(__WCHAR_TYPE__)
+#  define WCHAR_MIN INT_MIN
+#  define WCHAR_MAX INT_MAX
+#elif defined(__WCHAR_UNSIGNED__)
+#  define WCHAR_MIN 0
+#  define WCHAR_MAX __WCHAR_MAX__
+#else
+#  define WCHAR_MIN (-__WCHAR_MAX__ - 1)
+#  define WCHAR_MAX __WCHAR_MAX__
+#endif
 
 #endif /* __ARCH_SPARC_INCLUDE_LIMITS_H */
 

--- a/arch/x86/include/i486/limits.h
+++ b/arch/x86/include/i486/limits.h
@@ -37,11 +37,11 @@
 /* These could be different on machines where char is unsigned */
 
 #ifdef __CHAR_UNSIGNED__
-#define CHAR_MIN    0
-#define CHAR_MAX    UCHAR_MAX
+#  define CHAR_MIN  0
+#  define CHAR_MAX  UCHAR_MAX
 #else
-#define CHAR_MIN    SCHAR_MIN
-#define CHAR_MAX    SCHAR_MAX
+#  define CHAR_MIN  SCHAR_MIN
+#  define CHAR_MAX  SCHAR_MAX
 #endif
 
 #define SHRT_MIN    (-SHRT_MAX - 1)
@@ -67,5 +67,16 @@
 #define PTR_MIN     (-PTR_MAX - 1)
 #define PTR_MAX     2147483647
 #define UPTR_MAX    4294967295U
+
+#if !defined(__WCHAR_TYPE__)
+#  define WCHAR_MIN INT_MIN
+#  define WCHAR_MAX INT_MAX
+#elif defined(__WCHAR_UNSIGNED__)
+#  define WCHAR_MIN 0
+#  define WCHAR_MAX __WCHAR_MAX__
+#else
+#  define WCHAR_MIN (-__WCHAR_MAX__ - 1)
+#  define WCHAR_MAX __WCHAR_MAX__
+#endif
 
 #endif /* __ARCH_X86_INCLUDE_I486_LIMITS_H  */

--- a/arch/x86_64/include/intel64/limits.h
+++ b/arch/x86_64/include/intel64/limits.h
@@ -37,11 +37,11 @@
 /* These could be different on machines where char is unsigned */
 
 #ifdef __CHAR_UNSIGNED__
-#define CHAR_MIN    0
-#define CHAR_MAX    UCHAR_MAX
+#  define CHAR_MIN  0
+#  define CHAR_MAX  UCHAR_MAX
 #else
-#define CHAR_MIN    SCHAR_MIN
-#define CHAR_MAX    SCHAR_MAX
+#  define CHAR_MIN  SCHAR_MIN
+#  define CHAR_MAX  SCHAR_MAX
 #endif
 
 #define SHRT_MIN    (-SHRT_MAX - 1)
@@ -67,5 +67,16 @@
 #define PTR_MIN     (-PTR_MAX - 1)
 #define PTR_MAX     LLONG_MAX
 #define UPTR_MAX    ULLONG_MAX
+
+#if !defined(__WCHAR_TYPE__)
+#  define WCHAR_MIN INT_MIN
+#  define WCHAR_MAX INT_MAX
+#elif defined(__WCHAR_UNSIGNED__)
+#  define WCHAR_MIN 0
+#  define WCHAR_MAX __WCHAR_MAX__
+#else
+#  define WCHAR_MIN (-__WCHAR_MAX__ - 1)
+#  define WCHAR_MAX __WCHAR_MAX__
+#endif
 
 #endif /* __ARCH_X86_64_INCLUDE_INTEL64_LIMITS_H  */

--- a/arch/xtensa/include/limits.h
+++ b/arch/xtensa/include/limits.h
@@ -37,11 +37,11 @@
 /* These could be different on machines where char is unsigned */
 
 #ifdef __CHAR_UNSIGNED__
-#define CHAR_MIN    0
-#define CHAR_MAX    UCHAR_MAX
+#  define CHAR_MIN  0
+#  define CHAR_MAX  UCHAR_MAX
 #else
-#define CHAR_MIN    SCHAR_MIN
-#define CHAR_MAX    SCHAR_MAX
+#  define CHAR_MIN  SCHAR_MIN
+#  define CHAR_MAX  SCHAR_MAX
 #endif
 
 #define SHRT_MIN    (-SHRT_MAX - 1)
@@ -67,5 +67,16 @@
 #define PTR_MIN     (-PTR_MAX - 1)
 #define PTR_MAX     2147483647
 #define UPTR_MAX    4294967295U
+
+#if !defined(__WCHAR_TYPE__)
+#  define WCHAR_MIN INT_MIN
+#  define WCHAR_MAX INT_MAX
+#elif defined(__WCHAR_UNSIGNED__)
+#  define WCHAR_MIN 0
+#  define WCHAR_MAX __WCHAR_MAX__
+#else
+#  define WCHAR_MIN (-__WCHAR_MAX__ - 1)
+#  define WCHAR_MAX __WCHAR_MAX__
+#endif
 
 #endif /* __ARCH_XTENSA_INCLUDE_LIMITS_H */

--- a/arch/z16/include/limits.h
+++ b/arch/z16/include/limits.h
@@ -37,11 +37,11 @@
 /* These could be different on machines where char is unsigned */
 
 #ifdef __CHAR_UNSIGNED__
-#define CHAR_MIN    0
-#define CHAR_MAX    UCHAR_MAX
+#  define CHAR_MIN  0
+#  define CHAR_MAX  UCHAR_MAX
 #else
-#define CHAR_MIN    SCHAR_MIN
-#define CHAR_MAX    SCHAR_MAX
+#  define CHAR_MIN  SCHAR_MIN
+#  define CHAR_MAX  SCHAR_MAX
 #endif
 
 #define SHRT_MIN    (-SHRT_MAX - 1)
@@ -65,5 +65,16 @@
 #define PTR_MIN     (-PTR_MAX - 1)
 #define PTR_MAX     2147483647
 #define UPTR_MAX    4294967295U
+
+#if !defined(__WCHAR_TYPE__)
+#  define WCHAR_MIN INT_MIN
+#  define WCHAR_MAX INT_MAX
+#elif defined(__WCHAR_UNSIGNED__)
+#  define WCHAR_MIN 0
+#  define WCHAR_MAX __WCHAR_MAX__
+#else
+#  define WCHAR_MIN (-__WCHAR_MAX__ - 1)
+#  define WCHAR_MAX __WCHAR_MAX__
+#endif
 
 #endif /* __ARCH_Z16_INCLUDE_LIMITS_H  */

--- a/arch/z80/include/ez80/limits.h
+++ b/arch/z80/include/ez80/limits.h
@@ -37,11 +37,11 @@
 /* These could be different on machines where char is unsigned */
 
 #ifdef __CHAR_UNSIGNED__
-#define CHAR_MIN    0
-#define CHAR_MAX    UCHAR_MAX
+#  define CHAR_MIN  0
+#  define CHAR_MAX  UCHAR_MAX
 #else
-#define CHAR_MIN    SCHAR_MIN
-#define CHAR_MAX    SCHAR_MAX
+#  define CHAR_MIN  SCHAR_MIN
+#  define CHAR_MAX  SCHAR_MAX
 #endif
 
 #define SHRT_MIN    (-SHRT_MAX - 1)
@@ -67,17 +67,28 @@
 
 #define PTR_MIN     (-PTR_MAX - 1)
 #ifdef CONFIG_EZ80_Z80MODE
-#define PTR_MAX     32767
-#define UPTR_MAX    65535U
+#  define PTR_MAX   32767
+#  define UPTR_MAX  65535U
 #else
-#define PTR_MAX     8388607
-#define UPTR_MAX    16777215U
+#  define PTR_MAX   8388607
+#  define UPTR_MAX  16777215U
 #endif
 
 #ifdef __clang__
-#define LLONG_MIN       (-LLONG_MAX - 1)
-#define LLONG_MAX       9223372036854775807LL
-#define ULLONG_MAX      18446744073709551615ULL
+#  define LLONG_MIN  (-LLONG_MAX - 1)
+#  define LLONG_MAX  9223372036854775807LL
+#  define ULLONG_MAX 18446744073709551615ULL
+#endif
+
+#if !defined(__WCHAR_TYPE__)
+#  define WCHAR_MIN INT_MIN
+#  define WCHAR_MAX INT_MAX
+#elif defined(__WCHAR_UNSIGNED__)
+#  define WCHAR_MIN 0
+#  define WCHAR_MAX __WCHAR_MAX__
+#else
+#  define WCHAR_MIN (-__WCHAR_MAX__ - 1)
+#  define WCHAR_MAX __WCHAR_MAX__
 #endif
 
 #endif /* __ARCH_Z80_INCLUDE_EZ80_LIMITS_H */

--- a/arch/z80/include/z180/limits.h
+++ b/arch/z80/include/z180/limits.h
@@ -37,11 +37,11 @@
 /* These could be different on machines where char is unsigned */
 
 #ifdef __CHAR_UNSIGNED__
-#define CHAR_MIN    0
-#define CHAR_MAX    UCHAR_MAX
+#  define CHAR_MIN  0
+#  define CHAR_MAX  UCHAR_MAX
 #else
-#define CHAR_MIN    SCHAR_MIN
-#define CHAR_MAX    SCHAR_MAX
+#  define CHAR_MIN  SCHAR_MIN
+#  define CHAR_MAX  SCHAR_MAX
 #endif
 
 #define SHRT_MIN    (-SHRT_MAX - 1)
@@ -67,5 +67,16 @@
 #define PTR_MIN     (-PTR_MAX - 1)
 #define PTR_MAX     32767
 #define UPTR_MAX    65535U
+
+#if !defined(__WCHAR_TYPE__)
+#  define WCHAR_MIN INT_MIN
+#  define WCHAR_MAX INT_MAX
+#elif defined(__WCHAR_UNSIGNED__)
+#  define WCHAR_MIN 0
+#  define WCHAR_MAX __WCHAR_MAX__
+#else
+#  define WCHAR_MIN (-__WCHAR_MAX__ - 1)
+#  define WCHAR_MAX __WCHAR_MAX__
+#endif
 
 #endif /* __ARCH_Z80_INCLUDE_Z180_LIMITS_H  */

--- a/arch/z80/include/z8/limits.h
+++ b/arch/z80/include/z8/limits.h
@@ -37,11 +37,11 @@
 /* These could be different on machines where char is unsigned */
 
 #ifdef __CHAR_UNSIGNED__
-#define CHAR_MIN    0
-#define CHAR_MAX    UCHAR_MAX
+#  define CHAR_MIN  0
+#  define CHAR_MAX  UCHAR_MAX
 #else
-#define CHAR_MIN    SCHAR_MIN
-#define CHAR_MAX    SCHAR_MAX
+#  define CHAR_MIN  SCHAR_MIN
+#  define CHAR_MAX  SCHAR_MAX
 #endif
 
 #define SHRT_MIN    (-SHRT_MAX - 1)
@@ -63,5 +63,16 @@
 #define PTR_MIN     (-PTR_MAX - 1)
 #define PTR_MAX     32767
 #define UPTR_MAX    65535U
+
+#if !defined(__WCHAR_TYPE__)
+#  define WCHAR_MIN INT_MIN
+#  define WCHAR_MAX INT_MAX
+#elif defined(__WCHAR_UNSIGNED__)
+#  define WCHAR_MIN 0
+#  define WCHAR_MAX __WCHAR_MAX__
+#else
+#  define WCHAR_MIN (-__WCHAR_MAX__ - 1)
+#  define WCHAR_MAX __WCHAR_MAX__
+#endif
 
 #endif /* __ARCH_Z80_INCLUDE_Z8_LIMITS_H  */

--- a/arch/z80/include/z80/limits.h
+++ b/arch/z80/include/z80/limits.h
@@ -37,11 +37,11 @@
 /* These could be different on machines where char is unsigned */
 
 #ifdef __CHAR_UNSIGNED__
-#define CHAR_MIN    0
-#define CHAR_MAX    UCHAR_MAX
+#  define CHAR_MIN  0
+#  define CHAR_MAX  UCHAR_MAX
 #else
-#define CHAR_MIN    SCHAR_MIN
-#define CHAR_MAX    SCHAR_MAX
+#  define CHAR_MIN  SCHAR_MIN
+#  define CHAR_MAX  SCHAR_MAX
 #endif
 
 #define SHRT_MIN    (-SHRT_MAX - 1)
@@ -67,5 +67,16 @@
 #define PTR_MIN     (-PTR_MAX - 1)
 #define PTR_MAX     32767
 #define UPTR_MAX    65535U
+
+#if !defined(__WCHAR_TYPE__)
+#  define WCHAR_MIN INT_MIN
+#  define WCHAR_MAX INT_MAX
+#elif defined(__WCHAR_UNSIGNED__)
+#  define WCHAR_MIN 0
+#  define WCHAR_MAX __WCHAR_MAX__
+#else
+#  define WCHAR_MIN (-__WCHAR_MAX__ - 1)
+#  define WCHAR_MAX __WCHAR_MAX__
+#endif
 
 #endif /* __ARCH_Z80_INCLUDE_Z80_LIMITS_H  */

--- a/include/stdint.h
+++ b/include/stdint.h
@@ -145,21 +145,6 @@
 #  define UINTMAX_C(x)      UINT32_C(x)
 #endif
 
-/* Limits of Other Integer Types */
-
-#if 0
-#  define                   PTRDIFF_MIN
-#  define                   PTRDIFF_MAX
-#endif
-
-#if 0
-#  define                   WCHAR_MIN
-#  define                   WCHAR_MAX
-
-#  define                   WINT_MIN
-#  define                   WINT_MAX
-#endif
-
 /****************************************************************************
  * Public Types
  ****************************************************************************/

--- a/include/wchar.h
+++ b/include/wchar.h
@@ -57,9 +57,7 @@
  * Reference: Opengroup.org
  */
 
-#define WCHAR_MAX 0xffff
-#define WCHAR_MIN 0x0000
-#define WEOF      ((wint_t)-1)
+#define WEOF ((wint_t)-1)
 
 #define wcsftime_l(s, m, f, t, l)   wcsftime(s, m, f, t)
 #define wcscasecmp_l(s1, s2, l)     wcscasecmp(s1, s2)

--- a/include/wchar.h
+++ b/include/wchar.h
@@ -61,10 +61,6 @@
 #define WCHAR_MIN 0x0000
 #define WEOF      ((wint_t)-1)
 
-#ifndef NULL
-#  define NULL ((FAR void *)0)
-#endif
-
 #define wcsftime_l(s, m, f, t, l)   wcsftime(s, m, f, t)
 #define wcscasecmp_l(s1, s2, l)     wcscasecmp(s1, s2)
 #define wcsncasecmp_l(s1, s2, n, l) wcsncasecmp(s1, s2, n)

--- a/libs/libc/wchar/lib_btowc.c
+++ b/libs/libc/wchar/lib_btowc.c
@@ -66,13 +66,13 @@ wint_t btowc(int c)
 
   b = (char)c;
 
-  retval = mbtowc(&pwc, (FAR const char *)&b, 1);
+  retval = mbtowc(&pwc, &b, 1);
 
   if (retval != 0 && retval != 1)
     {
       return WEOF;
     }
 
-  return (wint_t)pwc;
+  return pwc;
 }
 #endif

--- a/libs/libc/wchar/lib_mbrtowc.c
+++ b/libs/libc/wchar/lib_mbrtowc.c
@@ -57,15 +57,19 @@
 size_t mbrtowc(FAR wchar_t *pwc, FAR const char *s,
                size_t n, FAR mbstate_t *ps)
 {
-  int retval = 0;
+  FAR const char *e = s;
+  size_t retval = 0;
 
   if (s == NULL)
     {
-      retval = mbtowc(NULL, "", 1);
+      s = e = "";
+      n = 1;
     }
-  else
+
+  retval = mbsnrtowcs(pwc, &e, 1, n, ps);
+  if (retval == 1)
     {
-      retval = mbtowc(pwc, s, n);
+      retval = e - s;
     }
 
   return retval;

--- a/libs/libc/wchar/lib_mbrtowc.c
+++ b/libs/libc/wchar/lib_mbrtowc.c
@@ -68,13 +68,6 @@ size_t mbrtowc(FAR wchar_t *pwc, FAR const char *s,
       retval = mbtowc(pwc, s, n);
     }
 
-  if (retval == -1)
-    {
-      return (size_t)(-1);
-    }
-  else
-    {
-      return (size_t)retval;
-    }
+  return retval;
 }
 #endif

--- a/libs/libc/wchar/lib_wcrtomb.c
+++ b/libs/libc/wchar/lib_wcrtomb.c
@@ -69,13 +69,6 @@ size_t wcrtomb(FAR char *s, wchar_t wc, FAR mbstate_t *ps)
       retval = wctomb(s, wc);
     }
 
-  if (retval == -1)
-    {
-      return (size_t)(-1);
-    }
-  else
-    {
-      return (size_t)retval;
-    }
+  return retval;
 }
 #endif

--- a/libs/libc/wchar/lib_wcscmp.c
+++ b/libs/libc/wchar/lib_wcscmp.c
@@ -63,10 +63,10 @@ int wcscmp(FAR const wchar_t *s1, FAR const wchar_t *s2)
     {
       if (*s1++ == 0)
         {
-          return (0);
+          return 0;
         }
     }
 
-  return (*s1 - *--s2);
+  return *s1 - *--s2;
 }
 #endif

--- a/libs/libc/wchar/lib_wctob.c
+++ b/libs/libc/wchar/lib_wctob.c
@@ -57,6 +57,6 @@ int wctob(wint_t wc)
       return EOF;
     }
 
-  return wctomb(pmb, wc) == 1 ? (int)pmb[0] : EOF;
+  return wctomb(pmb, wc) == 1 ? pmb[0] : EOF;
 }
 #endif

--- a/libs/libc/wchar/lib_wmemcpy.c
+++ b/libs/libc/wchar/lib_wmemcpy.c
@@ -55,6 +55,6 @@
 
 FAR wchar_t *wmemcpy(FAR wchar_t *d, FAR const wchar_t *s, size_t n)
 {
-  return (FAR wchar_t *)memcpy(d, s, n * sizeof(wchar_t));
+  return memcpy(d, s, n * sizeof(wchar_t));
 }
 #endif

--- a/libs/libc/wchar/lib_wmemmove.c
+++ b/libs/libc/wchar/lib_wmemmove.c
@@ -54,6 +54,6 @@
 
 FAR wchar_t *wmemmove(FAR wchar_t *d, FAR const wchar_t *s, size_t n)
 {
-  return (FAR wchar_t *)memmove(d, s, n * sizeof(wchar_t));
+  return memmove(d, s, n * sizeof(wchar_t));
 }
 #endif

--- a/libs/libc/wchar/lib_wmemset.c
+++ b/libs/libc/wchar/lib_wmemset.c
@@ -57,7 +57,7 @@ FAR wchar_t *wmemset(FAR wchar_t *s, wchar_t c, size_t n)
   FAR wchar_t *p;
   size_t i;
 
-  p = (FAR wchar_t *)s;
+  p = s;
   for (i = 0; i < n; i++)
     {
       *p = c;


### PR DESCRIPTION
## Summary
follow up the below change(https://github.com/apache/incubator-nuttx/pull/4754):
```
commit https://github.com/apache/incubator-nuttx/commit/635752389226ad005f52524a933acf864c1a1f8d
Author: Xiang Xiao <xiaoxiang@xiaomi.com>
Date:   Mon Nov 1 12:40:51 2021 +0800

    arch: Add _wchar_t typedef like other basic types
```

## Impact
Ensure WCHAR_MIN and WCHAR_MAX get the corrected value

## Testing
Pass CI
