### PR TITLE
Minor fix for atexit series function

### DIFF
--- a/libs/libc/machine/arm/aeabi_atexit.c
+++ b/libs/libc/machine/arm/aeabi_atexit.c
@@ -42,9 +42,7 @@
  *
  ****************************************************************************/
 
-int weak_function __aeabi_atexit(void *object,
-                                 void (*func)(void *),
-                                 void *dso_handle)
+int __aeabi_atexit(void *object, void (*func)(void *), void *dso_handle)
 {
   return atexit_register(ATTYPE_CXA, (void (*)(void))func, object,
                          dso_handle);

--- a/libs/libc/stdlib/Make.defs
+++ b/libs/libc/stdlib/Make.defs
@@ -28,8 +28,9 @@ CSRCS += lib_strtoll.c lib_strtoul.c lib_strtoull.c lib_strtod.c lib_strtof.c
 CSRCS += lib_strtold.c lib_checkbase.c lib_mktemp.c lib_mkstemp.c lib_mkdtemp.c
 CSRCS += lib_aligned_alloc.c lib_posix_memalign.c lib_valloc.c
 
+CSRCS += lib_cxa_atexit.c
 ifneq ($(CONFIG_LIBC_MAX_EXITFUNS),0)
-CSRCS += lib_atexit.c lib_cxa_atexit.c lib_onexit.c
+CSRCS += lib_atexit.c lib_onexit.c
 endif
 
 ifeq ($(CONFIG_LIBC_WCHAR),y)


### PR DESCRIPTION
## Summary

- libc: Remove weak_function from __aeabi_atexit 
- libc: Always compile ___cxa_atexit 

## Impact
Minor

## Testing
Pass CI
