### PR TITLE
libc/stdio: Support 'e'(O_CLOEXEC) in lib_mode2oflags 

### DIFF
--- a/arch/arm/src/common/arm_hostfs.c
+++ b/arch/arm/src/common/arm_hostfs.c
@@ -78,18 +78,18 @@ static int host_flags_to_mode(int flags)
 {
   static const int modeflags[] =
   {
+    O_RDONLY | O_TEXT,
     O_RDONLY,
-    O_RDONLY | O_BINARY,
+    O_RDWR | O_TEXT,
     O_RDWR,
-    O_RDWR | O_BINARY,
+    O_WRONLY | O_CREAT | O_TRUNC | O_TEXT,
     O_WRONLY | O_CREAT | O_TRUNC,
-    O_WRONLY | O_CREAT | O_TRUNC | O_BINARY,
+    O_RDWR | O_CREAT | O_TRUNC | O_TEXT,
     O_RDWR | O_CREAT | O_TRUNC,
-    O_RDWR | O_CREAT | O_TRUNC | O_BINARY,
+    O_WRONLY | O_CREAT | O_APPEND | O_TEXT,
     O_WRONLY | O_CREAT | O_APPEND,
-    O_WRONLY | O_CREAT | O_APPEND | O_BINARY,
+    O_RDWR | O_CREAT | O_APPEND | O_TEXT,
     O_RDWR | O_CREAT | O_APPEND,
-    O_RDWR | O_CREAT | O_APPEND | O_BINARY,
     0,
   };
 

--- a/arch/arm/src/rtl8720c/ameba_hci.c
+++ b/arch/arm/src/rtl8720c/ameba_hci.c
@@ -389,7 +389,7 @@ static int hci_open(struct file *filep)
   hci_dev_t *dev = inode->i_private;
   int ret;
   ret = file_open(&dev->filep,
-                  CONFIG_AMEBA_HCI_DEV_NAME, O_RDWR | O_BINARY);
+                  CONFIG_AMEBA_HCI_DEV_NAME, O_RDWR);
   if (ret < 0)
     {
       return ret;

--- a/arch/risc-v/src/common/riscv_hostfs.c
+++ b/arch/risc-v/src/common/riscv_hostfs.c
@@ -78,18 +78,18 @@ static int host_flags_to_mode(int flags)
 {
   static const int modeflags[] =
   {
+    O_RDONLY | O_TEXT,
     O_RDONLY,
-    O_RDONLY | O_BINARY,
+    O_RDWR | O_TEXT,
     O_RDWR,
-    O_RDWR | O_BINARY,
+    O_WRONLY | O_CREAT | O_TRUNC | O_TEXT,
     O_WRONLY | O_CREAT | O_TRUNC,
-    O_WRONLY | O_CREAT | O_TRUNC | O_BINARY,
+    O_RDWR | O_CREAT | O_TRUNC | O_TEXT,
     O_RDWR | O_CREAT | O_TRUNC,
-    O_RDWR | O_CREAT | O_TRUNC | O_BINARY,
+    O_WRONLY | O_CREAT | O_APPEND | O_TEXT,
     O_WRONLY | O_CREAT | O_APPEND,
-    O_WRONLY | O_CREAT | O_APPEND | O_BINARY,
+    O_RDWR | O_CREAT | O_APPEND | O_TEXT,
     O_RDWR | O_CREAT | O_APPEND,
-    O_RDWR | O_CREAT | O_APPEND | O_BINARY,
     0,
   };
 

--- a/drivers/wireless/bluetooth/bt_uart_shim.c
+++ b/drivers/wireless/bluetooth/bt_uart_shim.c
@@ -401,7 +401,7 @@ FAR struct btuart_lowerhalf_s *btuart_shim_getdevice(FAR const char *path)
 
   s = &n->state;
 
-  ret = file_open(&s->f, path, O_RDWR | O_BINARY);
+  ret = file_open(&s->f, path, O_RDWR);
   if (ret < 0)
     {
       kmm_free(n);

--- a/drivers/wireless/ieee80211/bcm43xxx/bcmf_core.c
+++ b/drivers/wireless/ieee80211/bcm43xxx/bcmf_core.c
@@ -248,7 +248,7 @@ int bcmf_upload_file(FAR struct bcmf_sdio_dev_s *sbus, uint32_t address,
 
   /* Open the file in the detached state */
 
-  ret = file_open(&finfo, path, O_RDONLY | O_BINARY);
+  ret = file_open(&finfo, path, O_RDONLY);
   if (ret < 0)
     {
       wlerr("ERROR: Failed to open the FILE MTD file %s: %d\n", path, ret);

--- a/drivers/wireless/ieee80211/bcm43xxx/bcmf_driver.c
+++ b/drivers/wireless/ieee80211/bcm43xxx/bcmf_driver.c
@@ -259,7 +259,7 @@ int bcmf_driver_download_clm(FAR struct bcmf_dev_s *priv)
   wlinfo("Download %d bytes\n", datalen);
 
   ret = file_open(&finfo, CONFIG_IEEE80211_BROADCOM_FWCLMNAME,
-                  O_RDONLY | O_BINARY);
+                  O_RDONLY);
   if (ret < 0)
     {
       wlerr("ERROR: Failed to open the FILE MTD file\n", ret);

--- a/include/fcntl.h
+++ b/include/fcntl.h
@@ -49,7 +49,7 @@
 #define O_NDELAY    O_NONBLOCK      /* Synonym for O_NONBLOCK */
 #define O_SYNC      (1 << 7)        /* Synchronize output on write */
 #define O_DSYNC     O_SYNC          /* Equivalent to OSYNC in NuttX */
-#define O_BINARY    (1 << 8)        /* Open the file in binary (untranslated) mode. */
+#define O_TEXT      (1 << 8)        /* Open the file in text (translated) mode. */
 #define O_DIRECT    (1 << 9)        /* Avoid caching, write directly to hardware */
 #define O_CLOEXEC   (1 << 10)       /* Close on execute */
 
@@ -58,7 +58,7 @@
 #define O_RSYNC     0               /* Synchronize input on read */
 #define O_ACCMODE   O_RDWR          /* Mask for access mode */
 #define O_NOCTTY    0               /* Required by POSIX */
-#define O_TEXT      0               /* Open the file in text (translated) mode. */
+#define O_BINARY    0               /* Open the file in binary (untranslated) mode. */
 
 /* This is the highest bit number used in the open flags bitset.  Bits above
  * this bit number may be used within NuttX for other, internal purposes.

--- a/include/sys/eventfd.h
+++ b/include/sys/eventfd.h
@@ -33,7 +33,7 @@
  ****************************************************************************/
 
 #define EFD_NONBLOCK  O_NONBLOCK
-#define EFD_SEMAPHORE O_BINARY
+#define EFD_SEMAPHORE O_SYNC
 #define EFD_CLOEXEC   O_CLOEXEC
 
 /****************************************************************************

--- a/libs/libc/misc/lib_ncompress.c
+++ b/libs/libc/misc/lib_ncompress.c
@@ -174,10 +174,6 @@
 #  define NOALLIGN 1
 #endif                                 /* DOS */
 
-#ifndef O_BINARY
-#  define O_BINARY 0            /* System has no binary mode */
-#endif
-
 #ifdef M_XENIX                  /* Stupid compiler can't handle arrays with */
 #  if BITS == 16                /* more than 65535 bytes - so we fake it */
 #    define MAXSEG_64K

--- a/libs/libc/stdio/lib_fopen.c
+++ b/libs/libc/stdio/lib_fopen.c
@@ -49,6 +49,8 @@
 #define MODE_NONE 0        /* No access mode determined */
 #define MODE_MASK (MODE_R | MODE_W | MODE_A)
 
+#define FLAG_KEEP (O_BINARY | O_EXCL)
+
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
@@ -204,7 +206,7 @@ int lib_mode2oflags(FAR const char *mode)
                   {
                     /* Retain any binary and exclusive mode selections */
 
-                    oflags &= (O_BINARY | O_EXCL);
+                    oflags &= FLAG_KEEP;
 
                     /* Open for read/write access */
 
@@ -216,7 +218,7 @@ int lib_mode2oflags(FAR const char *mode)
                   {
                     /* Retain any binary and exclusive mode selections */
 
-                    oflags &= (O_BINARY | O_EXCL);
+                    oflags &= FLAG_KEEP;
 
                     /* Open for write read/access, truncating any existing
                      * file.
@@ -230,7 +232,7 @@ int lib_mode2oflags(FAR const char *mode)
                   {
                     /* Retain any binary and exclusive mode selections */
 
-                    oflags &= (O_BINARY | O_EXCL);
+                    oflags &= FLAG_KEEP;
 
                     /* Read from the beginning of the file; write to the
                      * end,

--- a/libs/libc/stdio/lib_fopen.c
+++ b/libs/libc/stdio/lib_fopen.c
@@ -49,7 +49,7 @@
 #define MODE_NONE 0        /* No access mode determined */
 #define MODE_MASK (MODE_R | MODE_W | MODE_A)
 
-#define FLAG_KEEP (O_BINARY | O_EXCL)
+#define FLAG_KEEP (O_BINARY | O_CLOEXEC | O_EXCL)
 
 /****************************************************************************
  * Public Functions
@@ -256,6 +256,21 @@ int lib_mode2oflags(FAR const char *mode)
                 /* The file is opened in binary mode */
 
                 oflags |= O_BINARY;
+              }
+            else
+              {
+                goto errout;
+              }
+            break;
+
+          /* Open for close on execute */
+
+          case 'e' :
+            if ((state & MODE_MASK) != MODE_NONE)
+              {
+                /* The file will be closed on execute */
+
+                oflags |= O_CLOEXEC;
               }
             else
               {

--- a/libs/libc/stdio/lib_fopen.c
+++ b/libs/libc/stdio/lib_fopen.c
@@ -49,7 +49,7 @@
 #define MODE_NONE 0        /* No access mode determined */
 #define MODE_MASK (MODE_R | MODE_W | MODE_A)
 
-#define FLAG_KEEP (O_BINARY | O_CLOEXEC | O_EXCL)
+#define FLAG_KEEP (O_TEXT | O_CLOEXEC | O_EXCL)
 
 /****************************************************************************
  * Public Functions
@@ -156,7 +156,7 @@ int lib_mode2oflags(FAR const char *mode)
               {
                 /* Open for read access */
 
-                oflags = O_RDOK;
+                oflags = O_RDOK | O_TEXT;
                 state  = MODE_R;
               }
             else
@@ -172,7 +172,7 @@ int lib_mode2oflags(FAR const char *mode)
               {
                 /* Open for write access, truncating any existing file */
 
-                oflags = (O_WROK | O_CREAT | O_TRUNC);
+                oflags = O_WROK | O_CREAT | O_TRUNC | O_TEXT;
                 state  = MODE_W;
               }
             else
@@ -188,7 +188,7 @@ int lib_mode2oflags(FAR const char *mode)
               {
                 /* Write to the end of the file */
 
-                oflags = O_WROK | O_CREAT | O_APPEND;
+                oflags = O_WROK | O_CREAT | O_APPEND | O_TEXT;
                 state  = MODE_A;
               }
             else
@@ -224,7 +224,7 @@ int lib_mode2oflags(FAR const char *mode)
                      * file.
                      */
 
-                    oflags |= (O_RDWR | O_CREAT | O_TRUNC);
+                    oflags |= O_RDWR | O_CREAT | O_TRUNC;
                   }
                   break;
 
@@ -238,7 +238,7 @@ int lib_mode2oflags(FAR const char *mode)
                      * end,
                      */
 
-                    oflags |= (O_RDWR | O_CREAT | O_APPEND);
+                    oflags |= O_RDWR | O_CREAT | O_APPEND;
                   }
                   break;
 
@@ -255,7 +255,7 @@ int lib_mode2oflags(FAR const char *mode)
               {
                 /* The file is opened in binary mode */
 
-                oflags |= O_BINARY;
+                oflags &= ~O_TEXT;
               }
             else
               {

--- a/libs/libc/stdio/lib_fopen.c
+++ b/libs/libc/stdio/lib_fopen.c
@@ -263,7 +263,7 @@ int lib_mode2oflags(FAR const char *mode)
 
           /* Open for exclusive access ("{r|w|a|b|+}x") */
 
-          case 'X' :
+          case 'x' :
             if ((state & MODE_MASK) != MODE_NONE)
               {
                 /* The file is opened in exclusive mode */

--- a/libs/libc/stdio/lib_fopen.c
+++ b/libs/libc/stdio/lib_fopen.c
@@ -45,11 +45,6 @@
                             * or creating file */
 #define MODE_A    (1 << 2) /* Bit 2: "a{b|x|+}" open for writing, appending
                             * the to file */
-#define MODE_PLUS (1 << 3) /* Bit 3: "{r|w|a|b|x}+" open for update (reading
-                            * and writing) */
-#define MODE_B    (1 << 4) /* Bit 4: "{r|w|a|x|+}b" Binary mode */
-#define MODE_X    (1 << 5) /* Bit 5: "{r|w|a|b|+}x" Open exclusive mode */
-#define MODE_T    (1 << 6) /* Bit 6: "{r|w|a|+}t" Text mode */
 
 #define MODE_NONE 0        /* No access mode determined */
 #define MODE_MASK (MODE_R | MODE_W | MODE_A)
@@ -214,7 +209,6 @@ int lib_mode2oflags(FAR const char *mode)
                     /* Open for read/write access */
 
                     oflags |= O_RDWR;
-                    state  |= MODE_PLUS;
                  }
                  break;
 
@@ -229,7 +223,6 @@ int lib_mode2oflags(FAR const char *mode)
                      */
 
                     oflags |= (O_RDWR | O_CREAT | O_TRUNC);
-                    state  |= MODE_PLUS;
                   }
                   break;
 
@@ -244,7 +237,6 @@ int lib_mode2oflags(FAR const char *mode)
                      */
 
                     oflags |= (O_RDWR | O_CREAT | O_APPEND);
-                    state  |= MODE_PLUS;
                   }
                   break;
 
@@ -262,7 +254,6 @@ int lib_mode2oflags(FAR const char *mode)
                 /* The file is opened in binary mode */
 
                 oflags |= O_BINARY;
-                state  |= MODE_B;
               }
             else
               {
@@ -278,7 +269,6 @@ int lib_mode2oflags(FAR const char *mode)
                 /* The file is opened in exclusive mode */
 
                 oflags |= O_EXCL;
-                state  |= MODE_X;
               }
             else
               {
@@ -294,7 +284,6 @@ int lib_mode2oflags(FAR const char *mode)
                 /* The file is opened in text mode */
 
                 oflags |= O_TEXT;
-                state  |= MODE_T;
               }
             else
               {

--- a/libs/libc/stream/lib_stdoutstream.c
+++ b/libs/libc/stream/lib_stdoutstream.c
@@ -115,7 +115,7 @@ void lib_stdoutstream(FAR struct lib_stdoutstream_s *outstream,
    */
 
 #ifndef CONFIG_STDIO_DISABLE_BUFFERING
-  if (stream->fs_bufstart != NULL && (stream->fs_oflags & O_BINARY) == 0)
+  if (stream->fs_bufstart != NULL && (stream->fs_oflags & O_TEXT) != 0)
     {
       outstream->public.flush = stdoutstream_flush;
     }

--- a/libs/libc/stream/lib_stdsostream.c
+++ b/libs/libc/stream/lib_stdsostream.c
@@ -126,7 +126,7 @@ void lib_stdsostream(FAR struct lib_stdsostream_s *outstream,
    */
 
 #ifndef CONFIG_STDIO_DISABLE_BUFFERING
-  if (stream->fs_bufstart != NULL && (stream->fs_oflags & O_BINARY) == 0)
+  if (stream->fs_bufstart != NULL && (stream->fs_oflags & O_TEXT) != 0)
     {
       outstream->public.flush = stdsostream_flush;
     }

--- a/libs/libc/time/lib_localtime.c
+++ b/libs/libc/time/lib_localtime.c
@@ -625,7 +625,7 @@ static int tzload(FAR const char *name,
       goto oops;
     }
 
-  fid = _NX_OPEN(name, O_RDONLY | O_BINARY);
+  fid = _NX_OPEN(name, O_RDONLY);
   if (fid < 0)
     {
       goto oops;


### PR DESCRIPTION
## Summary
and make the binary(no process) mode as the default 

## Impact
Can add O_CLOEXEC flags in fopen

## Testing
Pass CI
