### PR TITLE
libc/time: rearrange itimerspec struct elements

### DIFF
--- a/include/time.h
+++ b/include/time.h
@@ -140,8 +140,8 @@ struct tm
 
 struct itimerspec
 {
+  struct timespec it_interval; /* Thereafter */
   struct timespec it_value;    /* First time */
-  struct timespec it_interval; /* and thereafter */
 };
 
 /* forward reference (defined in signal.h) */


### PR DESCRIPTION
## Summary

Reorder the elements of itimerspec to match Linux `include/uapi/linux/time.h`.

When creating cross platform (NuttX/Linux) applications that use itimerspec, and when compiling as C++, the difference in this order creates an incompatibility. 

In C++, if initialising an itimerspec structure with designated initialisers, the order must match the declaration.

## Impact

Anyone currently initialising an itimerspec structure with designated initialisers and compiling with C++.
This patch means they will have to reorder.

## Testing

