### PR TITLE
[syslog] Fixed separation of log sessions.

### DIFF
--- a/drivers/syslog/syslog_filechannel.c
+++ b/drivers/syslog/syslog_filechannel.c
@@ -58,7 +58,7 @@ static void log_separate(FAR const char *log_file)
 {
   struct file fp;
 
-  if (file_open(&fp, log_file, O_WRONLY) < 0)
+  if (file_open(&fp, log_file, (O_WRONLY | O_APPEND)) < 0)
     {
       return;
     }


### PR DESCRIPTION
## Summary

The option `CONFIG_SYSLOG_FILE_SEPARATE` allows for a separator (a few blank lines) to be print between two successive log sessions.

Due to `O_APPEND` flag missing, the separator was not correctly printed to the file, so this functionality was broken.

## Impact

Log separation in file logs now works correctly.

## Testing

Tested in a custom STM32F4 target, logging in an SD card.  
The logs are now properly separated.

