### PR TITLE
arch/risc-v/litex: fix typo

### DIFF
--- a/arch/risc-v/src/litex/litex_cache.S
+++ b/arch/risc-v/src/litex/litex_cache.S
@@ -72,7 +72,7 @@ up_invalidate_dcache_all:
   .globl  up_invalidate_icache_all
   .type   up_invalidate_icache_all, function
 
-up_invalidate_dcaup_invalidate_icache_allhe_all:
+up_invalidate_icache_all:
   .word 0x100F
   nop
   nop


### PR DESCRIPTION
## Summary
Fix typo in icache invalidate all function

## Impact

## Testing

