### PR TITLE
Fix wrong path in README for RISC-V

### DIFF
--- a/boards/risc-v/fe310/hifive1-revb/README-qemu.txt
+++ b/boards/risc-v/fe310/hifive1-revb/README-qemu.txt
@@ -28,8 +28,8 @@ index c449421741..5a76600785 100644
 4. Configure and build NuttX
 
   $ mkdir ./nuttx; cd ./nuttx
-  $ git clone https://github.com/apache/incubator-nuttx.git
-  $ git clone https://github.com/apache/incubator-nuttx-apps.git
+  $ git clone https://github.com/apache/incubator-nuttx.git nuttx
+  $ git clone https://github.com/apache/incubator-nuttx-apps.git apps
   $ cd nuttx
   $ make distclean
   $ ./tools/configure.sh hifive1-revb:nsh

--- a/boards/risc-v/fe310/hifive1-revb/README.txt
+++ b/boards/risc-v/fe310/hifive1-revb/README.txt
@@ -11,8 +11,8 @@
 3. Configure and build NuttX
 
   $ mkdir ./nuttx; cd ./nuttx
-  $ git clone https://github.com/apache/incubator-nuttx.git
-  $ git clone https://github.com/apache/incubator-nuttx-apps.git
+  $ git clone https://github.com/apache/incubator-nuttx.git nuttx
+  $ git clone https://github.com/apache/incubator-nuttx-apps.git apps
   $ cd nuttx
   $ make distclean
   $ ./tools/configure.sh hifive1-revb:nsh

--- a/boards/risc-v/k210/maix-bit/README-qemu.txt
+++ b/boards/risc-v/k210/maix-bit/README-qemu.txt
@@ -25,8 +25,8 @@
 4. Configure and build NuttX
 
   $ mkdir ./nuttx; cd ./nuttx
-  $ git clone https://github.com/apache/incubator-nuttx.git
-  $ git clone https://github.com/apache/incubator-nuttx-apps.git
+  $ git clone https://github.com/apache/incubator-nuttx.git nuttx
+  $ git clone https://github.com/apache/incubator-nuttx-apps.git apps
   $ cd nuttx
   $ make distclean
   $ ./tools/configure.sh maix-bit:nsh

--- a/boards/risc-v/litex/arty_a7/README.txt
+++ b/boards/risc-v/litex/arty_a7/README.txt
@@ -11,8 +11,8 @@
 3. Configure and build NuttX
 
   $ mkdir ./nuttx; cd ./nuttx
-  $ git clone https://github.com/apache/incubator-nuttx.git
-  $ git clone https://github.com/apache/incubator-nuttx-apps.git
+  $ git clone https://github.com/apache/incubator-nuttx.git nuttx
+  $ git clone https://github.com/apache/incubator-nuttx-apps.git apps
   $ cd nuttx
   $ make distclean
   $ ./tools/configure.sh arty_a7:nsh

--- a/boards/risc-v/qemu-rv/rv-virt/README.txt
+++ b/boards/risc-v/qemu-rv/rv-virt/README.txt
@@ -13,8 +13,8 @@
 3. Configure and build NuttX
 
   $ mkdir ./nuttx; cd ./nuttx
-  $ git clone https://github.com/apache/incubator-nuttx.git
-  $ git clone https://github.com/apache/incubator-nuttx-apps.git
+  $ git clone https://github.com/apache/incubator-nuttx.git nuttx
+  $ git clone https://github.com/apache/incubator-nuttx-apps.git apps
   $ cd nuttx
   $ make distclean
   $ ./tools/configure.sh rv-virt:nsh


### PR DESCRIPTION
Signed-off-by: Hidenori Matsubayashi <hidenori.matsubayashi@gmail.com>

## Summary
Update README to fix the wrong path. Also, I checked other READMEs, but they are fine.

## Impact
None

## Testing
None
