### PR TITLE
net/tcp: Hold the net lock in tcp_timer_expiry

### DIFF
--- a/include/nuttx/net/netdev.h
+++ b/include/nuttx/net/netdev.h
@@ -496,10 +496,8 @@ int sixlowpan_input(FAR struct radio_driver_s *ieee,
  * Polling of connections
  *
  * These functions will traverse each active network connection structure
- * and perform appropriate operations:  devif_timer() will perform TCP timer
- * operations (and UDP polling operations); devif_poll() will perform TCP
- * and UDP polling operations. The CAN driver MUST implement logic to
- * periodically call devif_timer(); devif_poll() may be called asynchronously
+ * and perform appropriate operations:  devif_poll() will perform TCP
+ * and UDP polling operations. devif_poll() may be called asynchronously
  * from the network driver can accept another outgoing packet.
  *
  * In both cases, these functions will call the provided callback function

--- a/include/nuttx/net/radiodev.h
+++ b/include/nuttx/net/radiodev.h
@@ -68,11 +68,11 @@ struct radiodev_properties_s
  *     field of the IOB.
  *
  *     Outgoing frames are generated when the radio network driver calls
- *     the devif_poll(), devif_timer(), sixlowpan_input(), or
- *     ieee802154_input() interfaces.  In each case, the radio driver must
- *     provide a working buffer in the d_buf pointer.  A special form of
- *     the packet buffer must be used, struct sixlowpan_reassbuf_s.  This
- *     special for includes appended data for managing reassembly of packets.
+ *     the devif_poll(), sixlowpan_input(), or ieee802154_input()
+ *     interfaces.  In each case, the radio driver must provide a working
+ *     buffer in the d_buf pointer.  A special form of the packet buffer
+ *     must be used, struct sixlowpan_reassbuf_s.  This special for
+ *     includes appended data for managing reassembly of packets.
  *
  *   - Received frames are provided by radio network driver to the network
  *     via an IOB parameter in the sixlowpan_input() pr ieee802154_input()

--- a/net/arp/arp.h
+++ b/net/arp/arp.h
@@ -215,7 +215,7 @@ int arp_send(in_addr_t ipaddr);
  *
  * Assumptions:
  *   This function is called from the MAC device driver indirectly through
- *   devif_poll() and devif_timer().  The network must be locked.
+ *   devif_poll().  The network must be locked.
  *
  ****************************************************************************/
 

--- a/net/arp/arp_poll.c
+++ b/net/arp/arp_poll.c
@@ -45,8 +45,8 @@
  *
  * Assumptions:
  *   This function is called from the MAC device driver indirectly through
- *   devif_poll() and devif_timer() and may be called from the timer
- *   interrupt/watchdog handler level.
+ *   devif_poll() and may be called from the timer  interrupt/watchdog
+ *   handler level.
  *
  ****************************************************************************/
 

--- a/net/ipforward/ipforward.h
+++ b/net/ipforward/ipforward.h
@@ -234,7 +234,7 @@ int ipfwd_forward(FAR struct forward_s *fwd);
  *
  * Assumptions:
  *   This function is called from the MAC device driver indirectly through
- *   devif_poll() and devif_timer().
+ *   devif_poll().
  *
  ****************************************************************************/
 

--- a/net/ipforward/ipfwd_poll.c
+++ b/net/ipforward/ipfwd_poll.c
@@ -153,7 +153,7 @@ static void ipfwd_packet_conversion(FAR struct net_driver_s *dev, int proto)
  *
  * Assumptions:
  *   This function is called from the MAC device driver indirectly through
- *   devif_poll() and devif_timer().
+ *   devif_poll().
  *
  ****************************************************************************/
 

--- a/net/sixlowpan/sixlowpan.h
+++ b/net/sixlowpan/sixlowpan.h
@@ -106,7 +106,7 @@ ssize_t psock_6lowpan_tcp_send(FAR struct socket *psock, FAR const void *buf,
  *   3. TCP output resulting from TX or timer polling
  *
  *   Cases 2 and 3 will be handled here.  Logic in ipv6_tcp_input(),
- *   devif_poll(), and devif_timer() detect if (1) an attempt to return with
+ *   and devif_poll() detect if (1) an attempt to return with
  *   d_len > 0 and (2) that the device is an IEEE802.15.4 MAC network
  *   driver. Under those conditions, this function will be called to create
  *   the IEEE80215.4 frames.

--- a/net/sixlowpan/sixlowpan_tcpsend.c
+++ b/net/sixlowpan/sixlowpan_tcpsend.c
@@ -823,7 +823,7 @@ ssize_t psock_6lowpan_tcp_send(FAR struct socket *psock, FAR const void *buf,
  *   3. TCP output resulting from TX or timer polling
  *
  *   Cases 2 and 3 will be handled here.  Logic in ipv6_tcp_input(),
- *   devif_poll(), and devif_timer() detect if (1) an attempt to return with
+ *   and devif_poll() detect if (1) an attempt to return with
  *   d_len > 0 and (2) that the device is an IEEE802.15.4 MAC network
  *   driver. Under those conditions, this function will be called to create
  *   the IEEE80215.4 frames.

--- a/net/tcp/tcp_timer.c
+++ b/net/tcp/tcp_timer.c
@@ -138,11 +138,20 @@ static int tcp_get_timeout(FAR struct tcp_conn_s *conn)
 
 static void tcp_timer_expiry(FAR void *arg)
 {
-  FAR struct tcp_conn_s *conn = arg;
+  FAR struct tcp_conn_s *conn = NULL;
 
   net_lock();
-  conn->timeout = true;
-  netdev_txnotify_dev(conn->dev);
+
+  while ((conn = tcp_nextconn(conn)) != NULL)
+    {
+      if (conn == arg)
+        {
+          conn->timeout = true;
+          netdev_txnotify_dev(conn->dev);
+          break;
+        }
+    }
+
   net_unlock();
 }
 

--- a/net/tcp/tcp_timer.c
+++ b/net/tcp/tcp_timer.c
@@ -58,6 +58,7 @@
 #include <nuttx/net/netstats.h>
 #include <nuttx/net/tcp.h>
 
+#include "netdev/netdev.h"
 #include "devif/devif.h"
 #include "socket/socket.h"
 #include "tcp/tcp.h"
@@ -139,8 +140,10 @@ static void tcp_timer_expiry(FAR void *arg)
 {
   FAR struct tcp_conn_s *conn = arg;
 
+  net_lock();
   conn->timeout = true;
-  conn->dev->d_txavail(conn->dev);
+  netdev_txnotify_dev(conn->dev);
+  net_unlock();
 }
 
 /****************************************************************************

--- a/wireless/ieee802154/mac802154_loopback.c
+++ b/wireless/ieee802154/mac802154_loopback.c
@@ -284,8 +284,8 @@ static inline void lo_netmask(FAR struct net_driver_s *dev)
  *
  * Description:
  *   Check if the network has any outgoing packets ready to send.  This is
- *   a callback from devif_poll() or devif_timer().  devif_poll() will be
- *   called only during normal TX polling.
+ *   a callback from devif_poll().  devif_poll() will be called only during
+ *   normal TX polling.
  *
  * Input Parameters:
  *   dev - Reference to the NuttX driver state structure

--- a/wireless/pktradio/pktradio_loopback.c
+++ b/wireless/pktradio/pktradio_loopback.c
@@ -273,8 +273,8 @@ static inline void lo_netmask(FAR struct net_driver_s *dev)
  *
  * Description:
  *   Check if the network has any outgoing packets ready to send.  This is
- *   a callback from devif_poll() or devif_timer().  devif_poll() will be
- *   called only during normal TX polling.
+ *   a callback from devif_poll().  devif_poll() will be called only during
+ *   normal TX polling.
  *
  * Input Parameters:
  *   dev - Reference to the NuttX driver state structure


### PR DESCRIPTION
## Summary
to follow the call convention for d_txavail.
This patch try to fix the inconsistent made by https://github.com/apache/incubator-nuttx/pull/6330.

## Impact
tcp timer process

## Testing

