### PR TITLE
Fix in default syslog date format.

### DIFF
--- a/drivers/syslog/Kconfig
+++ b/drivers/syslog/Kconfig
@@ -130,7 +130,7 @@ config SYSLOG_TIMESTAMP_LOCALTIME
 
 config SYSLOG_TIMESTAMP_FORMAT
 	string "Time format"
-	default "%e/%m/%y %H:%M:%S"
+	default "%d/%m/%y %H:%M:%S"
 	depends on SYSLOG_TIMESTAMP_FORMATTED
 	---help---
 		Formatter string for syslog timestamp printing.
@@ -139,7 +139,7 @@ config SYSLOG_TIMESTAMP_FORMAT
 config SYSLOG_TIMESTAMP_FORMAT_MICROSECOND
 	bool "Append microseconds after seconds"
 	default y
-	depends on SYSLOG_TIMESTAMP_FORMAT = "%e/%m/%y %H:%M:%S"
+	depends on SYSLOG_TIMESTAMP_FORMAT = "%d/%m/%y %H:%M:%S"
 
 config SYSLOG_TIMESTAMP_BUFFER
 	int "Formatted timestamp buffer size"


### PR DESCRIPTION
## Summary

When `SYSLOG_TIMESTAMP_FORMATTED` is selected, `SYSLOG_TIMESTAMP_FORMAT` is used to format the date that syslog will print.

Although the formatting is configurable by the user, I believe that the default setting is not optimal.

It is inconsistent, as all numbers printed are zero-padded *except* the day.  
This PR changes the default format, making the day of the month also zero-padded.

This is a more sane and consistent default.


## Impact

The default syslog date format is more consistent.  
This default change should not harm any system, or cause any side effect, and can be configured by the user back to what it was before.


## Testing

Tested on a custom STM32F4 target on a serial logger.

Example logs:

Before:
```
[ 5/06/22 12:07:01] [ 4] [  INFO] Bootloader status: [NO ACTION - 0x0000]
[ 5/06/22 12:07:01] [ 4] [  INFO] SD card mounted.
[ 5/06/22 12:07:01] [ 5] [  INFO] Loading settings...
```

After:

```
[05/06/22 12:05:22] [ 4] [  INFO] Bootloader status: [NO ACTION - 0x0000]
[05/06/22 12:05:22] [ 4] [  INFO] SD card mounted.
[05/06/22 12:05:22] [ 5] [  INFO] Loading settings...
```
