### PR TITLE
libc:xtensa:arch_memmove: fix warning

### DIFF
--- a/libs/libc/machine/xtensa/arch_memmove.S
+++ b/libs/libc/machine/xtensa/arch_memmove.S
@@ -396,6 +396,7 @@ memmove:
   _beqz a4, .Lbackdone  # avoid loading anything for zero-length copies
   # copy 16 bytes per iteration for word-aligned dst and unaligned src
   ssa8  a3    # set shift amount from byte offset
+#undef SIM_CHECKS_ALIGNMENT
 #define SIM_CHECKS_ALIGNMENT  1 /* set to 1 when running on ISS with
            * the lint or ferret client, or 0
            * to save a few cycles */


### PR DESCRIPTION
Signed-off-by: zhuyanlin <zhuyanlin1@xiaomi.com>

## Summary

`machine/xtensa/arch_memmove.S:399:11: warning: 'SIM_CHECKS_ALIGNMENT' macro redefined [-Wmacro-redefined]
  #define SIM_CHECKS_ALIGNMENT  1
`
## Impact

No, fix warning.
## Testing

