### PR TITLE
arch/xtensa: Initialize the internal heap early with the rest of custom heaps

### DIFF
--- a/arch/xtensa/Kconfig
+++ b/arch/xtensa/Kconfig
@@ -250,6 +250,7 @@ config XTENSA_INTBACKTRACE
 
 config XTENSA_IMEM_USE_SEPARATE_HEAP
 	bool "Use a separate heap for internal memory"
+	select ARCH_HAVE_EXTRA_HEAPS
 	default n
 	---help---
 		This is a separate internal heap that's used by drivers when certain operations

--- a/arch/xtensa/src/common/xtensa_initialize.c
+++ b/arch/xtensa/src/common/xtensa_initialize.c
@@ -104,12 +104,6 @@ void up_initialize(void)
   xtensa_pminitialize();
 #endif
 
-  /* Initialize the internal heap */
-
-#ifdef CONFIG_XTENSA_IMEM_USE_SEPARATE_HEAP
-  xtensa_imm_initialize();
-#endif
-
 #ifdef CONFIG_ARCH_DMA
   /* Initialize the DMA subsystem if the weak function xtensa_dma_initialize
    * has been brought into the build

--- a/arch/xtensa/src/esp32/esp32_extraheaps.c
+++ b/arch/xtensa/src/esp32/esp32_extraheaps.c
@@ -54,6 +54,10 @@
 
 void up_extraheaps_init(void)
 {
+#ifdef CONFIG_XTENSA_IMEM_USE_SEPARATE_HEAP
+  xtensa_imm_initialize();
+#endif
+
 #ifdef CONFIG_ESP32_RTC_HEAP
   esp32_rtcheap_initialize();
 #endif


### PR DESCRIPTION
## Summary
We might have a situation where an allocation will be requested before the call to `up_initialize` is performed. 
For the current code, this situation is the stack for the CPUs in SMP mode.  When the internal heap is enabled, the stack will be allocated from there, however the SMP bring up is before `up_initialize` and this will cause a crash.

Beside this issue, it's natural to have the internal heap initialized with the other heaps.

## Impact
Xtensa chips
## Testing
ESP32
