### PR TITLE
board: nucleo-l432kc: Add missing nucleo 432kc spi driver setting

### DIFF
--- a/arch/arm/src/stm32l4/stm32l4_pwm.c
+++ b/arch/arm/src/stm32l4/stm32l4_pwm.c
@@ -437,8 +437,8 @@ static struct stm32l4_pwmchan_s g_pwm1channels[] =
     .out1 =
     {
       .in_use  = 1,
-      .pol     = CONFIG_STM32L4L4_TIM1_CH4POL,
-      .idle    = CONFIG_STM32L4L4_TIM1_CH4IDLE,
+      .pol     = CONFIG_STM32L4_TIM1_CH4POL,
+      .idle    = CONFIG_STM32L4_TIM1_CH4IDLE,
       .pincfg  = PWM_TIM1_CH4CFG,
     }
 #endif

--- a/boards/arm/stm32l4/nucleo-l432kc/include/board.h
+++ b/boards/arm/stm32l4/nucleo-l432kc/include/board.h
@@ -227,14 +227,20 @@
 /* PWM output for full bridge, uses config 1, because port E is N/A on QFP64
  * CH1     | 1(A8) 2(E9)
  * CH2     | 1(A9) 2(E11)
+ * CH3     | 1(A10) 2(E10)
+ * CH4     | 1(A11) 2(E14)
  * CHN1    | 1(A7) 2(B13) 3(E8)
  * CHN2    | 1(B0) 2(B14) 3(E10)
+ * CHN3    | 1(B1) 2(B15) 3(E12)
  */
 
 #define GPIO_TIM1_CH1OUT  GPIO_TIM1_CH1OUT_1
 #define GPIO_TIM1_CH1NOUT GPIO_TIM1_CH1N_1
 #define GPIO_TIM1_CH2OUT  GPIO_TIM1_CH2OUT_1
 #define GPIO_TIM1_CH2NOUT GPIO_TIM1_CH2N_1
+#define GPIO_TIM1_CH3OUT GPIO_TIM1_CH3OUT_1
+#define GPIO_TIM1_CH3NOUT GPIO_TIM1_CH3OUT_1
+#define GPIO_TIM1_CH4OUT GPIO_TIM1_CH4OUT_1
 
 /* LPTIM2 PWM output
  * REVISIT : Add support for the other clock sources, LSE, LSI and HSI

--- a/boards/arm/stm32l4/nucleo-l432kc/src/nucleo-l432kc.h
+++ b/boards/arm/stm32l4/nucleo-l432kc/src/nucleo-l432kc.h
@@ -133,7 +133,8 @@ int stm32l4_gpio_initialize(void);
  * Name: stm32l4_spiregister
  *
  * Description:
- *   Called to register spi character driver of initialized spi device for the Nucleo-L432KC board.
+ *   Called to register spi character driver of initialized
+ *   spi device for the Nucleo-L432KC board.
  *
  ****************************************************************************/
 

--- a/boards/arm/stm32l4/nucleo-l432kc/src/nucleo-l432kc.h
+++ b/boards/arm/stm32l4/nucleo-l432kc/src/nucleo-l432kc.h
@@ -130,6 +130,16 @@ int stm32l4_gpio_initialize(void);
 #endif
 
 /****************************************************************************
+ * Name: stm32l4_spiregister
+ *
+ * Description:
+ *   Called to register spi character driver of initialized spi device for the Nucleo-L432KC board.
+ *
+ ****************************************************************************/
+
+void stm32l4_spiregister(void);
+
+/****************************************************************************
  * Name: stm32l4_spiinitialize
  *
  * Description:

--- a/boards/arm/stm32l4/nucleo-l432kc/src/stm32_appinit.c
+++ b/boards/arm/stm32l4/nucleo-l432kc/src/stm32_appinit.c
@@ -217,6 +217,12 @@ int board_app_initialize(uintptr_t arg)
     }
 #endif
 
+#ifdef CONFIG_SPI_DRIVER
+  stm32l4_spiregister(); 
+  // driver registering must be processed in appinit. 
+  //If called it during board_init, registering failed due to heap doesn't be initialized yet.
+#endif
+
 #ifdef HAVE_AT45DB
   /* Initialize and register the ATDB FLASH file system. */
 

--- a/boards/arm/stm32l4/nucleo-l432kc/src/stm32_appinit.c
+++ b/boards/arm/stm32l4/nucleo-l432kc/src/stm32_appinit.c
@@ -218,9 +218,11 @@ int board_app_initialize(uintptr_t arg)
 #endif
 
 #ifdef CONFIG_SPI_DRIVER
-  stm32l4_spiregister(); 
-  // driver registering must be processed in appinit. 
-  //If called it during board_init, registering failed due to heap doesn't be initialized yet.
+  stm32l4_spiregister();
+  /* driver registering must be processed in appinit.
+   * If called it during board_init,
+   * registering failed due to heap doesn't be initialized yet.
+   */
 #endif
 
 #ifdef HAVE_AT45DB

--- a/boards/arm/stm32l4/nucleo-l432kc/src/stm32_spi.c
+++ b/boards/arm/stm32l4/nucleo-l432kc/src/stm32_spi.c
@@ -30,6 +30,7 @@
 #include <errno.h>
 
 #include <nuttx/spi/spi.h>
+#include <nuttx/spi/spi_transfer.h>
 #include <arch/board/board.h>
 
 #include "chip.h"
@@ -78,6 +79,13 @@ void stm32l4_spiinitialize(void)
   else
     {
       spiinfo("INFO: SPI port 1 initialized\n");
+#ifdef CONFIG_SPI_DRIVER
+      ret = spi_register(g_spi1, 1);
+      if (ret < 0)
+      {
+        spierr("ERROR: FAILED to register driver of SPI port 1\n");
+      }
+#endif
     }
 
   /* Setup CS, EN & IRQ line IOs */
@@ -98,6 +106,13 @@ void stm32l4_spiinitialize(void)
   else
     {
       spiinfo("INFO: SPI port 2 initialized\n");
+#ifdef CONFIG_SPI_DRIVER
+      ret = spi_register(g_spi2, 2);
+      if (ret < 0)
+      {
+        spierr("ERROR: FAILED to register driver of SPI port 2\n");
+      }
+#endif
     }
 
   /* Setup CS, EN & IRQ line IOs */

--- a/boards/arm/stm32l4/nucleo-l432kc/src/stm32_spi.c
+++ b/boards/arm/stm32l4/nucleo-l432kc/src/stm32_spi.c
@@ -61,7 +61,8 @@ struct spi_dev_s *g_spi2;
  * Name: stm32l4_spiregister
  *
  * Description:
- *   Called to register spi character driver of initialized spi device for the Nucleo-L432KC board.
+ *   Called to register spi character driver of
+ *   initialized spi device for the Nucleo-L432KC board.
  *
  ****************************************************************************/
 
@@ -70,16 +71,17 @@ void stm32l4_spiregister(void)
 #ifdef CONFIG_STM32L4_SPI1
       int ret = spi_register(g_spi1, 1);
       if (ret < 0)
-      {
-        spierr("ERROR: FAILED to register driver of SPI port 1\n");
-      }
+        {
+          spierr("ERROR: FAILED to register driver of SPI port 1\n");
+        }
 #endif
+
 #ifdef CONFIG_STM32L4_SPI2
       int ret = spi_register(g_spi2, 2);
       if (ret < 0)
-      {
-        spierr("ERROR: FAILED to register driver of SPI port 2\n");
-      }
+        {
+          spierr("ERROR: FAILED to register driver of SPI port 2\n");
+        }
 #endif
 }
 

--- a/boards/arm/stm32l4/nucleo-l432kc/src/stm32_spi.c
+++ b/boards/arm/stm32l4/nucleo-l432kc/src/stm32_spi.c
@@ -58,6 +58,32 @@ struct spi_dev_s *g_spi2;
  ****************************************************************************/
 
 /****************************************************************************
+ * Name: stm32l4_spiregister
+ *
+ * Description:
+ *   Called to register spi character driver of initialized spi device for the Nucleo-L432KC board.
+ *
+ ****************************************************************************/
+
+void stm32l4_spiregister(void)
+{
+#ifdef CONFIG_STM32L4_SPI1
+      int ret = spi_register(g_spi1, 1);
+      if (ret < 0)
+      {
+        spierr("ERROR: FAILED to register driver of SPI port 1\n");
+      }
+#endif
+#ifdef CONFIG_STM32L4_SPI2
+      int ret = spi_register(g_spi2, 2);
+      if (ret < 0)
+      {
+        spierr("ERROR: FAILED to register driver of SPI port 2\n");
+      }
+#endif
+}
+
+/****************************************************************************
  * Name: stm32l4_spiinitialize
  *
  * Description:
@@ -79,13 +105,6 @@ void stm32l4_spiinitialize(void)
   else
     {
       spiinfo("INFO: SPI port 1 initialized\n");
-#ifdef CONFIG_SPI_DRIVER
-      ret = spi_register(g_spi1, 1);
-      if (ret < 0)
-      {
-        spierr("ERROR: FAILED to register driver of SPI port 1\n");
-      }
-#endif
     }
 
   /* Setup CS, EN & IRQ line IOs */
@@ -106,13 +125,6 @@ void stm32l4_spiinitialize(void)
   else
     {
       spiinfo("INFO: SPI port 2 initialized\n");
-#ifdef CONFIG_SPI_DRIVER
-      ret = spi_register(g_spi2, 2);
-      if (ret < 0)
-      {
-        spierr("ERROR: FAILED to register driver of SPI port 2\n");
-      }
-#endif
     }
 
   /* Setup CS, EN & IRQ line IOs */


### PR DESCRIPTION
## Summary
- chip: stm32l4: Correct config mistype
- board: nucleo-l432kc: Add missing TIM1 CH3, CH4 pin definition
- chip: stm32l4: Register spi character driver when both spi port and driver available
- board: nucleo-l432kc: Add spi driver registering function and Make it is called on appinit.

## Impact
Before this PR, SPI character driver doesn't be registered unlike other driver like I2C and etc.
Even there is no method to enable character driver on config and code in app to.
This PR makes to that SPI character driver is registered on board init when peripheral and driver is enabled.

## Testing
Tested on real board and Communication is tested with MPU9250 IMU.