### PR TITLE
sched/tls: Shouldn't get tls info directly from sp in kernel space

### DIFF
--- a/include/nuttx/tls.h
+++ b/include/nuttx/tls.h
@@ -304,7 +304,7 @@ uintptr_t task_tls_get_value(int tlsindex);
 
 #if defined(up_tls_info)
 #  define tls_get_info() up_tls_info()
-#elif defined(CONFIG_TLS_ALIGNED)
+#elif defined(CONFIG_TLS_ALIGNED) && !defined(__KERNEL__)
 #  define tls_get_info() TLS_INFO(up_getsp())
 #else
 FAR struct tls_info_s *tls_get_info(void);

--- a/libs/libc/tls/tls_getinfo.c
+++ b/libs/libc/tls/tls_getinfo.c
@@ -30,7 +30,7 @@
 #include <nuttx/arch.h>
 #include <nuttx/tls.h>
 
-#if !defined(up_tls_info) && !defined(CONFIG_TLS_ALIGNED)
+#if !defined(up_tls_info) && (defined(__KERNEL__) || !defined(CONFIG_TLS_ALIGNED))
 
 /****************************************************************************
  * Public Functions
@@ -72,4 +72,4 @@ FAR struct tls_info_s *tls_get_info(void)
   return info;
 }
 
-#endif /* !defined(up_tls_info) && !defined(CONFIG_TLS_ALIGNED) */
+#endif /* !defined(up_tls_info) && (defined(__KERNEL__) || !defined(CONFIG_TLS_ALIGNED)) */


### PR DESCRIPTION
## Summary
since the stack may switch to the kernel or interrupt stack. Report here: https://github.com/apache/incubator-nuttx/pull/6337.

## Impact
fail to get the tls info in case of CONFIG_TLS_ALIGNED = y

## Testing
rv-virt:knsh64
