### PR TITLE
arm/tlsr82: gpio driver bug fix and optimize.

### DIFF
--- a/arch/arm/src/tlsr82/Kconfig
+++ b/arch/arm/src/tlsr82/Kconfig
@@ -209,6 +209,14 @@ config TLSR82_GPIO_VALIDATION
 		gpio can be configured be this multiplex function. But this function
 		need more flash space.
 
+config TLSR82_GPIO_DUMPREGS
+	bool "Tlsr82 gpio dump registers enable"
+	default n
+	depends on DEBUG_GPIO_INFO
+	---help---
+		If enable this config, developer can call tlsr82_gpio_dumpregs() to
+		dump all the gpio registers.
+
 endif
 
 menuconfig TLSR82_I2C

--- a/arch/arm/src/tlsr82/hardware/tlsr82_gpio.h
+++ b/arch/arm/src/tlsr82/hardware/tlsr82_gpio.h
@@ -90,7 +90,7 @@
 #define GPIO_IRQ_NORMAL_ALL_REG        REG_ADDR8(0x5b5)
 #define GPIO_IRQ_RISC_EN_REG           REG_ADDR8(0x642)
 
-#define GPIO_IRQ_NORMAL_REG(group)     REG_ADDR8(0x587 + (group))
+#define GPIO_IRQ_NORMAL_REG(group)     REG_ADDR8(0x587 + ((group) << 3))
 #define GPIO_IRQ_M0_REG(group)         REG_ADDR8(0x5b8 + (group))
 #define GPIO_IRQ_M1_REG(group)         REG_ADDR8(0x5c0 + (group))
 #define GPIO_IRQ_M2_REG(group)         REG_ADDR8(0x5c8 + (group))

--- a/arch/arm/src/tlsr82/tlsr82_gpio.h
+++ b/arch/arm/src/tlsr82/tlsr82_gpio.h
@@ -144,7 +144,7 @@
 #define GPIO_POL_SHIFT                 23
 #define GPIO_POL_MASK                  (0x1 << GPIO_POL_SHIFT)
 #define GPIO_POL_RISE                  (0 << GPIO_POL_SHIFT)
-#define GPIO_POL_FAIL                  (1 << GPIO_POL_SHIFT)
+#define GPIO_POL_FALL                  (1 << GPIO_POL_SHIFT)
 
 /* GPIO specific pin definitions */
 


### PR DESCRIPTION
## Summary
1. follow telink sdk handbook, adjust register configuration order；
2. add more debug information output;
3. gpio irq bug fix and optimize;
4. typo fix; 

## Impact
tlsr82 gpio

## Testing
local test with gpio example, input, output, irq(normal mode, risc mode)
