### PR TITLE
arch/xtensa/xtensa_coproc.S: Fix the condition to save the coprocessors state.

### DIFF
--- a/arch/xtensa/src/common/xtensa_coproc.S
+++ b/arch/xtensa/src/common/xtensa_coproc.S
@@ -118,7 +118,7 @@ _xtensa_coproc_saoffsets:
 	bbci.l		a2,  0,   2f				/* CP 0 not enabled */
 	l32i		a14, a13, 0				/* a14 = _xtensa_coproc_saoffsets[0] */
 	add		a3,  a14, a3				/* a3 = save area for CP 0 */
-	xchal_cp0_store	a3,  a4,  a5, a6, a7 continue=0 ofs=-1 select=XTHAL_SAS_TIE|XTHAL_SAS_NOCC|XTHAL_SAS_CALE alloc=XTHAL_SAS_ALL
+	xchal_cp0_store	a3,  a4,  a5, a6, a7
 2:
 #endif
 
@@ -126,7 +126,7 @@ _xtensa_coproc_saoffsets:
 	bbci.l		a2,  1,   2f				/* CP 1 not enabled */
 	l32i		a14, a13, 4				/* a14 = _xtensa_coproc_saoffsets[1] */
 	add		a3,  a14, a3				/* a3 = save area for CP 1 */
-	xchal_cp1_store	a3,  a4,  a5, a6, a7 continue=0 ofs=-1 select=XTHAL_SAS_TIE|XTHAL_SAS_NOCC|XTHAL_SAS_CALE alloc=XTHAL_SAS_ALL
+	xchal_cp1_store	a3,  a4,  a5, a6, a7
 2:
 #endif
 
@@ -134,7 +134,7 @@ _xtensa_coproc_saoffsets:
 	bbci.l		a2,  2,   2f
 	l32i		a14, a13, 8
 	add		a3,  a14, a3
-	xchal_cp2_store	a3,  a4,  a5, a6, a7 continue=0 ofs=-1 select=XTHAL_SAS_TIE|XTHAL_SAS_NOCC|XTHAL_SAS_CALE alloc=XTHAL_SAS_ALL
+	xchal_cp2_store	a3,  a4,  a5, a6, a7
 2:
 #endif
 
@@ -142,7 +142,7 @@ _xtensa_coproc_saoffsets:
 	bbci.l		a2,  3,   2f
 	l32i		a14, a13, 12
 	add		a3,  a14, a3
-	xchal_cp3_store	a3,  a4,  a5, a6, a7 continue=0 ofs=-1 select=XTHAL_SAS_TIE|XTHAL_SAS_NOCC|XTHAL_SAS_CALE alloc=XTHAL_SAS_ALL
+	xchal_cp3_store	a3,  a4,  a5, a6, a7
 2:
 #endif
 
@@ -150,7 +150,7 @@ _xtensa_coproc_saoffsets:
 	bbci.l		a2,  4,   2f
 	l32i		a14, a13, 16
 	add		a3,  a14, a3
-	xchal_cp4_store	a3,  a4,  a5, a6, a7 continue=0 ofs=-1 select=XTHAL_SAS_TIE|XTHAL_SAS_NOCC|XTHAL_SAS_CALE alloc=XTHAL_SAS_ALL
+	xchal_cp4_store	a3,  a4,  a5, a6, a7
 2:
 #endif
 
@@ -158,7 +158,7 @@ _xtensa_coproc_saoffsets:
 	bbci.l		a2,  5,   2f
 	l32i		a14, a13, 20
 	add		a3,  a14, a3
-	xchal_cp5_store	a3,  a4,  a5, a6, a7 continue=0 ofs=-1 select=XTHAL_SAS_TIE|XTHAL_SAS_NOCC|XTHAL_SAS_CALE alloc=XTHAL_SAS_ALL
+	xchal_cp5_store	a3,  a4,  a5, a6, a7
 2:
 #endif
 
@@ -166,7 +166,7 @@ _xtensa_coproc_saoffsets:
 	bbci.l		a2,  6,   2f
 	l32i		a14, a13, 24
 	add		a3,  a14, a3
-	xchal_cp6_store	a3,  a4,  a5, a6, a7 continue=0 ofs=-1 select=XTHAL_SAS_TIE|XTHAL_SAS_NOCC|XTHAL_SAS_CALE alloc=XTHAL_SAS_ALL
+	xchal_cp6_store	a3,  a4,  a5, a6, a7
 2:
 #endif
 
@@ -174,7 +174,7 @@ _xtensa_coproc_saoffsets:
 	bbci.l		a2,  7,   2f
 	l32i		a14, a13, 28
 	add		a3,  a14, a3
-	xchal_cp7_store	a3,  a4,  a5, a6, a7 continue=0 ofs=-1 select=XTHAL_SAS_TIE|XTHAL_SAS_NOCC|XTHAL_SAS_CALE alloc=XTHAL_SAS_ALL
+	xchal_cp7_store	a3,  a4,  a5, a6, a7
 2:
 #endif
 
@@ -227,7 +227,7 @@ Ldone1:
 	bbci.l		a8,  0,   2f			/* CP 0 not enabled */
 	l32i		a14, a13, 0			/* a14 = _xtensa_coproc_saoffsets[0] */
 	add		a3,  a14, a3			/* a3 = save area for CP 0 */
-	xchal_cp0_load	a3,  a4,  a5, a6, a7 continue=0 ofs=-1 select=XTHAL_SAS_TIE|XTHAL_SAS_NOCC|XTHAL_SAS_CALE alloc=XTHAL_SAS_ALL
+	xchal_cp0_load	a3,  a4,  a5, a6, a7
 2:
 #endif
 
@@ -235,7 +235,7 @@ Ldone1:
 	bbci.l		a8,  1,   2f			/* CP 1 not enabled */
 	l32i		a14, a13, 4			/* a14 = _xtensa_coproc_saoffsets[1] */
 	add		a3,  a14, a3			/* a3 = save area for CP 1 */
-	xchal_cp1_load	a3,  a4,  a5, a6, a7 continue=0 ofs=-1 select=XTHAL_SAS_TIE|XTHAL_SAS_NOCC|XTHAL_SAS_CALE alloc=XTHAL_SAS_ALL
+	xchal_cp1_load	a3,  a4,  a5, a6, a7
 2:
 #endif
 
@@ -243,7 +243,7 @@ Ldone1:
 	bbci.l		a8,  2,   2f
 	l32i		a14, a13, 8
 	add		a3,  a14, a3
-	xchal_cp2_load	a3,  a4,  a5, a6, a7 continue=0 ofs=-1 select=XTHAL_SAS_TIE|XTHAL_SAS_NOCC|XTHAL_SAS_CALE alloc=XTHAL_SAS_ALL
+	xchal_cp2_load	a3,  a4,  a5, a6, a7
 2:
 #endif
 
@@ -251,7 +251,7 @@ Ldone1:
 	bbci.l		a8,  3,   2f
 	l32i		a14, a13, 12
 	add		a3,  a14, a3
-	xchal_cp3_load	a3,  a4,  a5, a6, a7 continue=0 ofs=-1 select=XTHAL_SAS_TIE|XTHAL_SAS_NOCC|XTHAL_SAS_CALE alloc=XTHAL_SAS_ALL
+	xchal_cp3_load	a3,  a4,  a5, a6, a7
 2:
 #endif
 
@@ -259,7 +259,7 @@ Ldone1:
 	bbci.l		a8,  4,   2f
 	l32i		a14, a13, 16
 	add		a3,  a14, a3
-	xchal_cp4_load	a3,  a4,  a5, a6, a7 continue=0 ofs=-1 select=XTHAL_SAS_TIE|XTHAL_SAS_NOCC|XTHAL_SAS_CALE alloc=XTHAL_SAS_ALL
+	xchal_cp4_load	a3,  a4,  a5, a6, a7
 2:
 #endif
 
@@ -267,7 +267,7 @@ Ldone1:
 	bbci.l		a8,  5,   2f
 	l32i		a14, a13, 20
 	add		a3,  a14, a3
-	xchal_cp5_load	a3,  a4,  a5, a6, a7 continue=0 ofs=-1 select=XTHAL_SAS_TIE|XTHAL_SAS_NOCC|XTHAL_SAS_CALE alloc=XTHAL_SAS_ALL
+	xchal_cp5_load	a3,  a4,  a5, a6, a7
 2:
 #endif
 
@@ -275,7 +275,7 @@ Ldone1:
 	bbci.l		a8,  6,   2f
 	l32i		a14, a13, 24
 	add		a3,  a14, a3
-	xchal_cp6_load	a3,  a4,  a5, a6, a7 continue=0 ofs=-1 select=XTHAL_SAS_TIE|XTHAL_SAS_NOCC|XTHAL_SAS_CALE alloc=XTHAL_SAS_ALL
+	xchal_cp6_load	a3,  a4,  a5, a6, a7
 2:
 #endif
 
@@ -283,7 +283,7 @@ Ldone1:
 	bbci.l		a8,  7,   2f
 	l32i		a14, a13, 28
 	add		a3,  a14, a3
-	xchal_cp7_load	a3,  a4,  a5, a6, a7 continue=0 ofs=-1 select=XTHAL_SAS_TIE|XTHAL_SAS_NOCC|XTHAL_SAS_CALE alloc=XTHAL_SAS_ALL
+	xchal_cp7_load	a3,  a4,  a5, a6, a7
 2:
 #endif
 	/* Ensure wsr.CPENABLE has completed. */


### PR DESCRIPTION
## Summary
The parameters that were passed to the save/restore macros were making them being a NOP.

## Impact
Xtensa chips
## Testing
ESP32, ESP32-S2, ESP32-S3.
