### PR TITLE
libc/stdio: Generate the dummy atexit and on_exit

### DIFF
--- a/libs/libc/stdlib/Make.defs
+++ b/libs/libc/stdlib/Make.defs
@@ -27,11 +27,7 @@ CSRCS += lib_rand.c lib_qsort.c lib_srand.c lib_strtol.c
 CSRCS += lib_strtoll.c lib_strtoul.c lib_strtoull.c lib_strtod.c lib_strtof.c
 CSRCS += lib_strtold.c lib_checkbase.c lib_mktemp.c lib_mkstemp.c lib_mkdtemp.c
 CSRCS += lib_aligned_alloc.c lib_posix_memalign.c lib_valloc.c
-
-CSRCS += lib_cxa_atexit.c
-ifneq ($(CONFIG_LIBC_MAX_EXITFUNS),0)
-CSRCS += lib_atexit.c lib_onexit.c
-endif
+CSRCS += lib_atexit.c lib_cxa_atexit.c lib_onexit.c
 
 ifeq ($(CONFIG_LIBC_WCHAR),y)
 CSRCS += lib_mblen.c lib_mbtowc.c lib_wctomb.c

--- a/libs/libc/stdlib/lib_atexit.c
+++ b/libs/libc/stdlib/lib_atexit.c
@@ -30,9 +30,7 @@
 #include <nuttx/semaphore.h>
 #include <nuttx/tls.h>
 
-/****************************************************************************
- * Pre-processor Definitions
- ****************************************************************************/
+#if CONFIG_LIBC_MAX_EXITFUNS > 0
 
 /****************************************************************************
  * Private Functions
@@ -102,35 +100,6 @@ static void exitfunc_unlock(void)
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
-
-/****************************************************************************
- * Name: atexit
- *
- * Description:
- *    Registers a function to be called at program exit.
- *    The atexit() function registers the given function to be called
- *    at normal process termination, whether via exit or via return from
- *    the program's main().
- *
- *    Limitations in the current implementation:
- *
- *      1. Only a single atexit function can be registered unless
- *         CONFIG_LIBC_MAX_EXITFUNS defines a larger number.
- *      2. atexit functions are not inherited when a new task is
- *         created.
- *
- * Input Parameters:
- *   func - A pointer to the function to be called when the task exits.
- *
- * Returned Value:
- *   Zero on success. Non-zero on failure.
- *
- ****************************************************************************/
-
-int atexit(CODE void (*func)(void))
-{
-  return atexit_register(ATTYPE_ATEXIT, func, NULL, NULL);
-}
 
 int atexit_register(int type, CODE void (*func)(void), FAR void *arg,
                     FAR void *dso)
@@ -218,4 +187,35 @@ void atexit_call_exitfuncs(int status)
           (*((CODE void (*)(FAR void *))func))(arg);
         }
     }
+}
+
+#endif
+
+/****************************************************************************
+ * Name: atexit
+ *
+ * Description:
+ *    Registers a function to be called at program exit.
+ *    The atexit() function registers the given function to be called
+ *    at normal process termination, whether via exit or via return from
+ *    the program's main().
+ *
+ *    Limitations in the current implementation:
+ *
+ *      1. Only a single atexit function can be registered unless
+ *         CONFIG_LIBC_MAX_EXITFUNS defines a larger number.
+ *      2. atexit functions are not inherited when a new task is
+ *         created.
+ *
+ * Input Parameters:
+ *   func - A pointer to the function to be called when the task exits.
+ *
+ * Returned Value:
+ *   Zero on success. Non-zero on failure.
+ *
+ ****************************************************************************/
+
+int atexit(CODE void (*func)(void))
+{
+  return atexit_register(ATTYPE_ATEXIT, func, NULL, NULL);
 }


### PR DESCRIPTION
## Summary
since the compiler may generate the code call atexit automatically

## Impact

## Testing
pass ci