### PR TITLE
mm: Log name of the Heap to which the new region is being added

### DIFF
--- a/mm/mm_heap/mm_initialize.c
+++ b/mm/mm_heap/mm_initialize.c
@@ -105,7 +105,14 @@ void mm_addregion(FAR struct mm_heap_s *heap, FAR void *heapstart,
   heapend  = MM_ALIGN_DOWN((uintptr_t)heapstart + (uintptr_t)heapsize);
   heapsize = heapend - heapbase;
 
+#if defined(CONFIG_FS_PROCFS) && \
+    !defined(CONFIG_FS_PROCFS_EXCLUDE_MEMINFO) && \
+    (defined(CONFIG_BUILD_FLAT) || defined(__KERNEL__))
+  minfo("[%s] Region %d: base=%p size=%zu\n",
+        heap->mm_procfs.name, IDX + 1, heapstart, heapsize);
+#else
   minfo("Region %d: base=%p size=%zu\n", IDX + 1, heapstart, heapsize);
+#endif
 
   /* Add the size of this region to the total size of the heap */
 
@@ -209,10 +216,6 @@ FAR struct mm_heap_s *mm_initialize(FAR const char *name,
 
   mm_seminitialize(heap);
 
-  /* Add the initial region of memory to the heap */
-
-  mm_addregion(heap, heapstart, heapsize);
-
 #if defined(CONFIG_FS_PROCFS) && !defined(CONFIG_FS_PROCFS_EXCLUDE_MEMINFO)
 #if defined(CONFIG_BUILD_FLAT) || defined(__KERNEL__)
   heap->mm_procfs.name = name;
@@ -220,6 +223,15 @@ FAR struct mm_heap_s *mm_initialize(FAR const char *name,
 #if defined (CONFIG_DEBUG_MM) && defined(CONFIG_MM_BACKTRACE_DEFAULT)
   heap->mm_procfs.backtrace = true;
 #endif
+#endif
+#endif
+
+  /* Add the initial region of memory to the heap */
+
+  mm_addregion(heap, heapstart, heapsize);
+
+#if defined(CONFIG_FS_PROCFS) && !defined(CONFIG_FS_PROCFS_EXCLUDE_MEMINFO)
+#if defined(CONFIG_BUILD_FLAT) || defined(__KERNEL__)
   procfs_register_meminfo(&heap->mm_procfs);
 #endif
 #endif


### PR DESCRIPTION
## Summary
This PR intends to improve the logging of `mm_addregion` function by informing the name of the Heap to which the new region is being added.

## Impact
Increase in debug information, should not have any real impact.

## Testing
`esp32c3-devkit:knsh`

### Before
```
mm_initialize: Heap: name=Umem, start=0x3fc905ac size=322228
mm_addregion: Region 1: base=0x3fc90704 size=321872
up_allocate_kheap: Heap: start=3fc83068 end=3fc90000 size=53144
mm_initialize: Heap: name=Kmem, start=0x3fc83068 size=53144
mm_addregion: Region 1: base=0x3fc831c4 size=52784
```
###After
```
mm_initialize: Heap: name=Umem, start=0x3fc905ac size=322228
mm_addregion: [Umem] Region 1: base=0x3fc90704 size=321872
up_allocate_kheap: Heap: start=3fc83068 end=3fc90000 size=53144
mm_initialize: Heap: name=Kmem, start=0x3fc83068 size=53144
mm_addregion: [Kmem] Region 1: base=0x3fc831c4 size=52784
```

