### PR TITLE
add docs for stm32wl5 chip and nucleo-wl55jc board

### DIFF
--- a/Documentation/platforms/arm/stm32wl5/boards/nucleo-wl55jc/index.rst
+++ b/Documentation/platforms/arm/stm32wl5/boards/nucleo-wl55jc/index.rst
@@ -1,0 +1,109 @@
+=============
+Nucleo-WL55JC
+=============
+
+The `Nucleo-WL55JC <https://www.st.com/en/evaluation-tools/nucleo-wl55jc.html>`_
+is a development board for the STM32WL55 SoC from ST. It features 64 I/O,
+3 onboard LEDs and buttons, integrated stlink for easy debug and flashing
+and on-board LoRa receiver with external antenna. NSH can be easily access
+via virtual serial port from usb.
+
+Features
+========
+
+  - STM32WL55JC MCU, 256K FLASH, 64K SRAM
+  - 32768 Hz LSE crystal
+  - 32 MHz HSE crystal
+  - Embedded stlink-v3 debugger (debug/flash and virtual serial port)
+  - Reset button
+  - 3 user programmable LEDs
+  - 3 user programmable buttons
+  - Power indicator LED
+  - LoRa radio with antenna
+  - 64 Nucleo I/O
+  - Arduino compatible pinout
+
+Pin Mapping
+===========
+
+Pin mapping can be altered by (de)soldering bridges, by default board
+uses following mapping:
+
+===== ========== ============================
+Pin   Signal     Notes
+===== ========== ============================
+PA2   LPUART1 TX Virtual serial port over usb
+PA3   LPUART2 RX Virtual serial port over usb
+PB6   USART1 TX  D1 on Arduino pinout
+PB7   USART1 RX  R0 on Arduino pinout
+PA0   Button 1
+PA1   Button 2
+PC6   Button 3
+PB15  Blue LED   Active HIGH
+PB11  Red LED    Active HIGH
+PB9   Green LED  Active HIGH
+===== ========== ============================
+
+Default Peripherals Configuration
+=================================
+
+LED
+---
+
+Green and Red LEDs are used by the system at boot to show system state.
+Once system is booted these LEDs are for user to control. When
+CONFIG_ARCH_LEDS is set, Blue LED is reserved by OS for reporting system
+status. When CONFIG_ARCH_LEDS is not set, OS state won't be reported on
+any of the LEDs and all 3 LEDs are available for user right from the start.
+
+Serial Console
+--------------
+
+There are 2 serial ports - USART1 and LPUART1.
+
+USART1 is connected to arduino D0/D1 pin and LPUART is connected to
+stlink that provides virtual serial port.
+
+NSH is configured to use LPUART and virtual serial port. After flashing
+you can open /dev/ttyACM0 (may change depending on your system) and nsh
+prompt will be waiting for you there. Serial device does not disapear
+when flashing and reseting board - it can be left opened and flashing
+will work without problems.
+
+Configurations
+==============
+
+nsh
+---
+
+Basic NuttShell configuration (console enabled in LPUART1, exposed via USB
+connection, at 115200 bps 8n1).
+
+Flash & Debug
+=============
+
+Both flashing and debugging are done using the embedded stlink-v3 debugger.
+OpenOCD can be invoked in the following way to flash::
+
+    openocd -f interface/stlink.cfg -f target/stm32wlx.cfg \
+        -c "program nuttx.bin exit 0x08000000"
+
+To debug attach openocd to stlink with command::
+
+    openocd -f interface/stlink.cfg -f target/stm32wlx.cfg
+
+start gdb::
+
+    arm-none-eabi-gdb ./nuttx --tui
+
+attach to gdb server::
+
+    target remote localhost:3333
+
+(optionally) reset program and start from the very beginning::
+
+    monitor reset halt
+
+Remember to generate debug symbol by setting CONFIG_DEBUG_SYMBOLS
+and optionally (for more natural flow in gdb step) suppress optimization
+by setting CONFIG_DEBUG_NOOPT.

--- a/Documentation/platforms/arm/stm32wl5/index.rst
+++ b/Documentation/platforms/arm/stm32wl5/index.rst
@@ -1,0 +1,134 @@
+========
+STM32WL5
+========
+
+The STM32WL5 is a dual CPU (not core!) chip based on ARM Cortex-M4 and
+Cortex-M0 with integrated sub-GHz radio for LoRa (G)FSK, (G)MSK and BPSK
+modulations.
+
+Only Cortex-M0 has access to radio peripheral. Pipe between CPUs exists
+so that radio packets can be exchanged between CPUs. Chip was designed
+so that Cortex-M0 cpu handles radio traffic while Cortex-M4 cpu handles
+actions based on traffic received. All other peripherals are shared
+(like uart, spi, i2c) and both CPUs can initiate them, but it's required
+to be done only by one of them.
+
+Supported MCUs
+=============
+
+STM32WL5 has only two chips in family. STM32WL55 and STM32WL54. Only
+difference between them is that STM32WL55 has support for LoRa while
+Stm32WL54 does not.
+
+Peripheral Support
+==================
+
+The following list indicates peripherals supported in NuttX:
+
+==========  =======  =====
+Peripheral  Support  Notes
+==========  =======  =====
+IRQs        Yes
+GPIO        Yes
+EXTI        No
+HSE         Yes
+PLL         Yes      Tested @ 48MHz
+HSI         Yes      Not tested
+MSI         Yes      Not tested
+LSE         Yes      Not tested
+RCC         Yes      All registers defined, not all peripherals enabled
+SYSCFG      Yes      All registers defined, remapping not tested
+USART       Yes
+LPUART      Yes      full speed with HSE works, low power mode with LSE not implemented
+DMA         No
+SRAM2       No
+SPI         No
+I2C         No
+RTC         No
+Timers      No
+PM          No
+AES         No
+RNG         No
+CRC         No
+WWDG        No
+IWDG        No
+ADC         No
+DAC         No
+IPCC        No
+Radio@CPU0  No
+==========  =======  =====
+
+PLL
+---
+
+PLL is a module that allows MCU to generate higher (or lower) clocks than
+provided by the source. For example it can be used to drive system clock
+with 48MHz when 8MHz HSE crystal is installed.
+
+LSE
+---
+
+Low speed external crystal. Can be used to clock RTC and/or independent
+watchdog (IWDG). LSE is usually 32768Hz high precision crystal.
+
+HSI
+---
+
+High speed internal clock. Can be used as a source for sysclk and
+internal buses (APB, AHB). This clock source is not as precise or
+as stable as HSE, but it cuts down costs by avoiding external
+hardware (crystal and capacitors) and is usually good enough if
+operating temperatures are stable. It's clock is fixed at 16MHz.
+
+MSI
+---
+
+Adjustable internal clock. Can be adjusted by software, but it's
+accuracy and stability is even lower than HSI.
+
+HSE
+---
+
+High speed external crystal. Can be used to clock sysclk and internal
+buses (APB, AHB). External crystal is more precise and more stable
+than HSI.
+
+RCC
+---
+
+Reset and clock control. Enables or disables specific peripherals.
+
+SYSCFG
+------
+
+System configuration controller. Can be used to remap memory or
+manage external interrupts.
+
+GPIO
+----
+
+Pins can be configured using :c:func:`stm32wl5_configgpio` function. Writing
+to pins is done by :c:func:`stm32wl5_gpiowrite` function and reading is done
+by :c:func:`stm32wl5_gpioread`.
+
+UART
+----
+
+Universal Asynchronous Receiver/Transmitter module. UART is initialized
+automatically during MCU boot.
+
+IPCC
+----
+
+Inter-processor communication controller. IPCC is used to exchange data
+between Cortex-M4 and Cortex-M0 CPUs.
+
+Supported Boards
+================
+
+.. toctree::
+   :glob:
+   :maxdepth: 1
+
+   boards/*/*
+


### PR DESCRIPTION
This patch adds documentation for both stm32wl5 chip family and
nucleo-wl55jc board. I've kept the same directory structure for
arm/stm32 as in arch/ and boards/ directories.

Signed-off-by: Michał Łyszczek <michal.lyszczek@bofc.pl>

## Summary
Add docs

## Impact
None, it's just a doc

## Testing
Validated if 'make html' generate proper html files.
