### PR TITLE
Documentation: fix multiple errors and warnings

### DIFF
--- a/Documentation/components/drivers/special/syslog.rst
+++ b/Documentation/components/drivers/special/syslog.rst
@@ -391,7 +391,7 @@ mounting of the file systems.
 The interface ``syslog_file_channel()`` is used to configure the
 SYSLOG file channel:
 
-.. c:function:: FAR struct syslog_channel_s *
+.. c:function:: FAR struct syslog_channel_s * \
                     syslog_file_channel(FAR const char *devpath);
 
   Configure to use a file in a mounted file system

--- a/Documentation/faq/index.rst
+++ b/Documentation/faq/index.rst
@@ -12,18 +12,18 @@ How to increase the command line length?
 ----------------------------------------
 
 You can increase the Max command line length from 64 to other value,
-this way:
+this way::
 
-Application Configuration  --->
-        NSH Library  --->
-            Command Line Configuration  --->
-                (64) Max command line length
+    Application Configuration  --->
+            NSH Library  --->
+                Command Line Configuration  --->
+                    (64) Max command line length
 
 How do I enable editing support on the command line?
 ----------------------------------------------------
 
 You need to change Command Line Editor from "Minimal readline" to
-"Command Line Editor", this way:
+"Command Line Editor", this way::
 
     Application Configuration  --->
         NSH Library  --->
@@ -33,7 +33,7 @@ You need to change Command Line Editor from "Minimal readline" to
 How to enable command line history?
 -----------------------------------
 
-You need to enable these options in the menuconfig:
+You need to enable these options in the menuconfig::
 
     Application Configuration  --->
         System Libraries and NSH Add-Ons  --->
@@ -43,19 +43,19 @@ You need to enable these options in the menuconfig:
                 (16)      Command line history records
 
 Note: If you are using the "Command Line Editor" instead of the "readline"
-then you need to use this other option:
+then you need to use this other option::
 
     Application Configuration  --->
         System Libraries and NSH Add-Ons  --->
             -*- EMACS-like Command Line Editor  --->
-                	[*]   Command line history
-                	(80)    Command line history length
-                	(16)    Command line history records
+                [*]   Command line history
+                (80)    Command line history length
+                (16)    Command line history records
 
 How to enable autocomplete on the command line?
 -----------------------------------------------
 
-You need to enable these options in the menuconfig:
+You need to enable these options in the menuconfig::
 
     Application Configuration  --->
         System Libraries and NSH Add-Ons  --->
@@ -70,7 +70,7 @@ Note: autocomplete is not enabled when "Command Line Editor" instead of the
 How to interrupt an NSH Application using Ctrl^C ?
 --------------------------------------------------
 
-You need to enable these options in the menuconfig:
+You need to enable these options in the menuconfig::
 
     RTOS Features --->
         Signal Configuration --->
@@ -90,7 +90,7 @@ How to start directly my application instead starting NSH?
 
 You can start you application directly instead of starting the default
 NSH terminal. Lets support your application is called "hello", then you
-will modify the ENTRYPOINT to call "hello_main" instead of "nsh_main":
+will modify the ENTRYPOINT to call "hello_main" instead of "nsh_main"::
 
     RTOS Features --->
         Tasks and Scheduling  --->
@@ -105,13 +105,13 @@ executed anymore and so some drivers initialiation that are called from
 it also stops to work.
 
 You can fix it enabling the Board Late Initialization that will replace the
-NSH_ARCHINIT to call those drivers initialization. Just enable it:
+NSH_ARCHINIT to call those drivers initialization. Just enable it::
 
     RTOS Features --->
         RTOS hooks --->
             [*] Custom board late initialization
 
-Also you need to disable the architecture-specific initialization:
+Also you need to disable the architecture-specific initialization::
 
     Application Configuration --->
         NSH Library --->
@@ -123,7 +123,7 @@ Why isn't /dev/ttySx created when using USB Console even when UART is enabled?
 If you don't use serial console then /dev/ttyS0 will not be created,
 even if you enable the UART peripheral at "System Type".
 
-You can fix it enabling the Serial Upper-Half Driver:
+You can fix it enabling the Serial Upper-Half Driver::
 
     Device Drivers --->
         Serial Driver Support --->

--- a/Documentation/platforms/arm/imxrt/index.rst
+++ b/Documentation/platforms/arm/imxrt/index.rst
@@ -6,7 +6,7 @@ The i.MX RT series of chips from NXP Semiconductors is based around an ARM Corte
 at 500 MHz, 600 MHz or 1 GHz based on particular MCUs
 
 Supported MCUs
-=============
+==============
 
 The following list includes MCUs from i.MX RT series and indicates whether they are supported in NuttX
 

--- a/Documentation/platforms/risc-v/esp32c3/index.rst
+++ b/Documentation/platforms/risc-v/esp32c3/index.rst
@@ -123,7 +123,7 @@ LED_PWM      Yes
 SHA          Yes
 RSA          Yes
 CDC Console  Yes    Rev.3
-========== ======= =====
+=========== ======= =====
 
 Supported Boards
 ================

--- a/Documentation/platforms/xtensa/esp32/index.rst
+++ b/Documentation/platforms/xtensa/esp32/index.rst
@@ -68,7 +68,7 @@ Bootloader and partitions
 -------------------------
 
 ESP32 requires a bootloader to be flashed as well as a set of FLASH partitions. This is only needed the first time
-(or any time you which to modify either of these). An easy way is to use prebuilt binaries for NuttX from `here <https://github.com/espressif/esp-nuttx-bootloader>`_. In there you will find instructions to rebuild these if necessary. 
+(or any time you which to modify either of these). An easy way is to use prebuilt binaries for NuttX `from here <https://github.com/espressif/esp-nuttx-bootloader>`_. In there you will find instructions to rebuild these if necessary. 
 Once you downloaded both binaries, you can flash them by adding an ``ESPTOOL_BINDIR`` parameter, pointing to the directory where these binaries were downloaded:
 
 .. code-block:: console
@@ -155,8 +155,8 @@ Data        0x3ffae000 0x3ffdffff Internal SRAM 2 DMA
 Data        0x3ffe0000 0x3fffffff Internal SRAM 1 DMA
 =========== ========== ========== =============== ===============
 
-Boundary Address
----------------
+Boundary Address (Embedded)
+---------------------------
 
 ====================== ========== ========== =============== ===============
 BUS TYPE               START      LAST       DESCRIPTION     NOTES
@@ -184,8 +184,8 @@ Data        0x3f400000 0x3f7fffff External Flash  Read
 Data        0x3f800000 0x3fbfffff External SRAM   Read and Write
 =========== ========== ========== =============== ===============
 
-Boundary Address
-----------------
+Boundary Address (External)
+---------------------------
 
 Instruction 0x400c2000 0x40bfffff 11512 KB External Flash Read
 
@@ -271,7 +271,7 @@ following in ``scripts/esp32.cfg``::
   #set ESP32_ONLYCPU 2
 
 Wi-Fi
-====
+=====
 
 A standard network interface will be configured and can be initialized such as::
 
@@ -287,7 +287,7 @@ the result by running ``ifconfig`` afterwards.
 .. tip:: Boards usually expose a ``wapi`` defconfig which enables Wi-Fi
 
 Wi-Fi SoftAP
-===========
+============
 
 It is possible to use ESP32 as an Access Point (SoftAP). Actually there are some
 boards with a ``sta_softap`` which enables this support.

--- a/Documentation/reference/os/arch.rst
+++ b/Documentation/reference/os/arch.rst
@@ -123,21 +123,21 @@ APIs Exported by Architecture-Specific Logic to NuttX
   -  ``stack_base_ptr``: Adjusted stack base pointer after the TLS Data
      and Arguments has been removed from the stack allocation.
 
-  Here is the diagram after some allocation(tls, arg):
+  Here is the diagram after some allocation(tls, arg)::
 
-                   +-------------+ <-stack_alloc_ptr(lowest)
-                   |  TLS Data   |
-                   +-------------+
-                   |  Arguments  |
-  stack_base_ptr-> +-------------+\
-                   |  Available  | +
-                   |    Stack    | |
-                |  |             | |
-                |  |             | +->adj_stack_size
-                v  |             | |
-                   |             | |
-                   |             | +
-                   +-------------+/
+                     +-------------+ <-stack_alloc_ptr(lowest)
+                     |  TLS Data   |
+                     +-------------+
+                     |  Arguments  |
+    stack_base_ptr-> +-------------+\
+                     |  Available  | +
+                     |    Stack    | |
+                  |  |             | |
+                  |  |             | +->adj_stack_size
+                  v  |             | |
+                     |             | |
+                     |             | +
+                     +-------------+/
 
   :param tcb: The TCB of new task.
   :param frame_size: The size of the stack frame to allocate.

--- a/Documentation/reference/user/02_task_scheduling.rst
+++ b/Documentation/reference/user/02_task_scheduling.rst
@@ -55,7 +55,7 @@ Functions
   name. Differences from the full POSIX implementation include:
 
     -  The range of priority values for the POSIX call is 0 to 255. The
-      priority 0 is the lowest priority and 255 is the highest priority.
+       priority 0 is the lowest priority and 255 is the highest priority.
 
   .. note:: Setting a task's priority to the same value has the similar effect
     to ``sched_yield()``: The task will be moved to after all other tasks

--- a/Documentation/reference/user/13_boardctl.rst
+++ b/Documentation/reference/user/13_boardctl.rst
@@ -184,7 +184,7 @@ USB
    
    :configuration: CONFIG_BOARDCTL && CONFIG_BOARDCTL_USBDEVCTRL
    
-   :dependencies: Board logic must provide ``board_<usbdev>_initialize()`.
+   :dependencies: Board logic must provide `board_<usbdev>_initialize()`.
    
 Graphics
 --------


### PR DESCRIPTION
Multiple files were badly formatted, which resulted in many
warnings. This made it harder to check for errors in newly
written documentation.

What's worse, badly formatted text resulted in butchered
output in generated html.

This patch fixes most of the errors, but alas, not all of
the errors can be fixed. Anyway, this should be way easier
to spot errors in newly written docs now.

Signed-off-by: Michał Łyszczek <michal.lyszczek@bofc.pl>

## Summary
Fix coding errors in documentation
## Impact
None
## Testing
Visual verification of resulting htmls
