### PR TITLE
sched/mqueue: replace inline linklist to improve performance 

### DIFF
--- a/include/nuttx/mqueue.h
+++ b/include/nuttx/mqueue.h
@@ -29,6 +29,7 @@
 #include <nuttx/compiler.h>
 #include <nuttx/fs/fs.h>
 #include <nuttx/signal.h>
+#include <nuttx/list.h>
 
 #include <sys/types.h>
 #include <stdint.h>
@@ -87,7 +88,7 @@
 struct mqueue_inode_s
 {
   FAR struct inode *inode;    /* Containing inode */
-  sq_queue_t msglist;         /* Prioritized message list */
+  struct list_node msglist;   /* Prioritized message list */
   int16_t maxmsgs;            /* Maximum number of messages in the queue */
   int16_t nmsgs;              /* Number of message in the queue */
   int16_t nwaitnotfull;       /* Number tasks waiting for not full */

--- a/sched/mqueue/mq_msgfree.c
+++ b/sched/mqueue/mq_msgfree.c
@@ -25,7 +25,6 @@
 #include <nuttx/config.h>
 
 #include <assert.h>
-#include <queue.h>
 
 #include <nuttx/irq.h>
 #include <nuttx/arch.h>
@@ -65,7 +64,7 @@ void nxmq_free_msg(FAR struct mqueue_msg_s *mqmsg)
        * list from interrupt handlers.
        */
 
-      sq_addlast((FAR sq_entry_t *)mqmsg, &g_msgfree);
+      list_add_tail(&g_msgfree, &mqmsg->node);
     }
 
   /* If this is a message pre-allocated for interrupts,
@@ -78,7 +77,7 @@ void nxmq_free_msg(FAR struct mqueue_msg_s *mqmsg)
        * list from interrupt handlers.
        */
 
-      sq_addlast((FAR sq_entry_t *)mqmsg, &g_msgfreeirq);
+      list_add_tail(&g_msgfreeirq, &mqmsg->node);
     }
 
   /* Otherwise, deallocate it.  Note:  interrupt handlers

--- a/sched/mqueue/mq_msgqalloc.c
+++ b/sched/mqueue/mq_msgqalloc.c
@@ -86,7 +86,7 @@ int nxmq_alloc_msgq(FAR struct mq_attr *attr,
     {
       /* Initialize the new named message queue */
 
-      sq_init(&msgq->msglist);
+      list_initialize(&msgq->msglist);
       if (attr)
         {
           msgq->maxmsgs    = (int16_t)attr->mq_maxmsg;

--- a/sched/mqueue/mq_msgqfree.c
+++ b/sched/mqueue/mq_msgqfree.c
@@ -52,19 +52,18 @@
 
 void nxmq_free_msgq(FAR struct mqueue_inode_s *msgq)
 {
-  FAR struct mqueue_msg_s *curr;
-  FAR struct mqueue_msg_s *next;
+  FAR struct mqueue_msg_s *entry;
+  FAR struct mqueue_msg_s *tmp;
 
   /* Deallocate any stranded messages in the message queue. */
 
-  curr = (FAR struct mqueue_msg_s *)msgq->msglist.head;
-  while (curr)
+  list_for_every_entry_safe(&msgq->msglist, entry,
+                            tmp, struct mqueue_msg_s, node)
     {
       /* Deallocate the message structure. */
 
-      next = curr->next;
-      nxmq_free_msg(curr);
-      curr = next;
+      list_delete(&entry->node);
+      nxmq_free_msg(entry);
     }
 
   /* Then deallocate the message queue itself */

--- a/sched/mqueue/mq_rcvinternal.c
+++ b/sched/mqueue/mq_rcvinternal.c
@@ -145,8 +145,8 @@ int nxmq_wait_receive(FAR struct mqueue_inode_s *msgq,
 
   /* Get the message from the head of the queue */
 
-  while ((newmsg = (FAR struct mqueue_msg_s *)sq_remfirst(&msgq->msglist))
-          == NULL)
+  while ((newmsg = (FAR struct mqueue_msg_s *)
+                   list_remove_head(&msgq->msglist)) == NULL)
     {
       /* The queue is empty!  Should we block until there the above condition
        * has been satisfied?

--- a/sched/mqueue/mq_timedreceive.c
+++ b/sched/mqueue/mq_timedreceive.c
@@ -179,7 +179,7 @@ ssize_t file_mq_timedreceive(FAR struct file *mq, FAR char *msg,
    * will not need to start timer.
    */
 
-  if (msgq->msglist.head == NULL)
+  if (list_is_empty(&msgq->msglist))
     {
       sclock_t ticks;
 

--- a/sched/mqueue/mqueue.h
+++ b/sched/mqueue/mqueue.h
@@ -62,15 +62,15 @@ enum mqalloc_e
 
 struct mqueue_msg_s
 {
-  FAR struct mqueue_msg_s *next;  /* Forward link to next message */
-  uint8_t type;                   /* (Used to manage allocations) */
-  uint8_t priority;               /* priority of message */
+  struct list_node node;   /* Link node to message */
+  uint8_t type;            /* (Used to manage allocations) */
+  uint8_t priority;        /* Priority of message */
 #if MQ_MAX_BYTES < 256
-  uint8_t msglen;                 /* Message data length */
+  uint8_t msglen;          /* Message data length */
 #else
-  uint16_t msglen;                /* Message data length */
+  uint16_t msglen;         /* Message data length */
 #endif
-  char mail[MQ_MAX_BYTES];        /* Message data */
+  char mail[MQ_MAX_BYTES]; /* Message data */
 };
 
 /********************************************************************************
@@ -89,13 +89,13 @@ extern "C"
  * The number of messages in this list is a system configuration item.
  */
 
-EXTERN sq_queue_t  g_msgfree;
+EXTERN struct list_node g_msgfree;
 
-/* The g_msgfreeInt is a list of messages that are reserved for use by
+/* The g_msgfreeirq is a list of messages that are reserved for use by
  * interrupt handlers.
  */
 
-EXTERN sq_queue_t  g_msgfreeirq;
+EXTERN struct list_node g_msgfreeirq;
 
 /********************************************************************************
  * Public Function Prototypes


### PR DESCRIPTION
## Summary

sched/mqueue: replace inline linklist to improve performance

## Impact

N/A

## Testing


mq_send test (cycle count)

```
434 (origin)
425 (fs/mqueue: skip nxmq_pollnotify() if no poll waiters)
415 (sched/mqueue: minor code tuning of message queue)
393 (sched/mqueue: replace inline linklist to improve performance)
361 (sched/mqueue: do sanity check if DEBUG_FEATURES is enabled)
```