### PR TITLE
Mpfs fix ddr training failures

### DIFF
--- a/arch/risc-v/src/mpfs/mpfs_start.c
+++ b/arch/risc-v/src/mpfs/mpfs_start.c
@@ -167,7 +167,19 @@ void __mpfs_start(uint64_t mhartid)
 #endif
 
 #ifdef CONFIG_MPFS_DDR_INIT
-  mpfs_ddr_init();
+  if (mpfs_ddr_init() != 0)
+    {
+      /* We don't allow booting, ddr training failure will cause random
+       * behaviour
+       */
+
+      showprogress('X');
+
+      /* Reset, but let the progress come out of the uart first */
+
+      up_udelay(1000);
+      up_systemreset();
+    }
 #endif
 
   showprogress('B');


### PR DESCRIPTION
## Summary

This fixes silently ignoring DDR training failure for MPFS target. If the training fails, it is better to reset the whole system and try again.

## Impact

Silently ignoring the training failure caused random behaviour if the training failed. This is a very rare case, if all the parameters are set correctly, but could have caused disastrous errors. Also, on the new hardware where all the parameters may not be initially correct, it is easier to catch the errors here than crashing randomly later.

## Testing

Tested on Aries m100pfsevp SOM
