### PR TITLE
fs/mqueue: skip nxmq_pollnotify() if no poll waiters

### DIFF
--- a/fs/mqueue/mq_open.c
+++ b/fs/mqueue/mq_open.c
@@ -370,6 +370,7 @@ static mqd_t nxmq_vopen(FAR const char *mq_name, int oflags, va_list ap)
  * Public Functions
  ****************************************************************************/
 
+#if CONFIG_FS_MQUEUE_NPOLLWAITERS > 0
 void nxmq_pollnotify(FAR struct mqueue_inode_s *msgq, pollevent_t eventset)
 {
   int i;
@@ -395,6 +396,7 @@ void nxmq_pollnotify(FAR struct mqueue_inode_s *msgq, pollevent_t eventset)
         }
     }
 }
+#endif
 
 /****************************************************************************
  * Name: file_mq_open

--- a/include/nuttx/mqueue.h
+++ b/include/nuttx/mqueue.h
@@ -417,7 +417,11 @@ int nxmq_alloc_msgq(FAR struct mq_attr *attr,
  *
  ****************************************************************************/
 
+#if CONFIG_FS_MQUEUE_NPOLLWAITERS > 0
 void nxmq_pollnotify(FAR struct mqueue_inode_s *msgq, pollevent_t eventset);
+#else
+# define nxmq_pollnotify(msgq, eventset)
+#endif
 
 /****************************************************************************
  * Name: file_mq_open


### PR DESCRIPTION
## Summary

fs/mqueue: skip nxmq_pollnotify() if no poll waiters

## Impact


## Testing


mq_send performance test (cycle count)

```
434 (origin)
425 (fs/mqueue: skip nxmq_pollnotify() if no poll waiters)
```