### PR TITLE
sched/mqueue: minor code tuning of message queue

### DIFF
--- a/sched/mqueue/mq_msgfree.c
+++ b/sched/mqueue/mq_msgfree.c
@@ -55,8 +55,6 @@
 
 void nxmq_free_msg(FAR struct mqueue_msg_s *mqmsg)
 {
-  irqstate_t flags;
-
   /* If this is a generally available pre-allocated message,
    * then just put it back in the free list.
    */
@@ -67,9 +65,7 @@ void nxmq_free_msg(FAR struct mqueue_msg_s *mqmsg)
        * list from interrupt handlers.
        */
 
-      flags = enter_critical_section();
       sq_addlast((FAR sq_entry_t *)mqmsg, &g_msgfree);
-      leave_critical_section(flags);
     }
 
   /* If this is a message pre-allocated for interrupts,
@@ -82,9 +78,7 @@ void nxmq_free_msg(FAR struct mqueue_msg_s *mqmsg)
        * list from interrupt handlers.
        */
 
-      flags = enter_critical_section();
       sq_addlast((FAR sq_entry_t *)mqmsg, &g_msgfreeirq);
-      leave_critical_section(flags);
     }
 
   /* Otherwise, deallocate it.  Note:  interrupt handlers

--- a/sched/mqueue/mq_receive.c
+++ b/sched/mqueue/mq_receive.c
@@ -79,7 +79,6 @@ ssize_t file_mq_receive(FAR struct file *mq, FAR char *msg, size_t msglen,
   irqstate_t flags;
   ssize_t ret;
 
-  inode = mq->f_inode;
   if (!inode)
     {
       return -EBADF;
@@ -108,7 +107,6 @@ ssize_t file_mq_receive(FAR struct file *mq, FAR char *msg, size_t msglen,
   /* Get the message from the message queue */
 
   ret = nxmq_wait_receive(msgq, mq->f_oflags, &mqmsg);
-  leave_critical_section(flags);
 
   /* Check if we got a message from the message queue.  We might
    * not have a message if:
@@ -117,11 +115,12 @@ ssize_t file_mq_receive(FAR struct file *mq, FAR char *msg, size_t msglen,
    * - The wait was interrupted by a signal
    */
 
-  if (ret >= 0)
+  if (ret == OK)
     {
-      DEBUGASSERT(mqmsg != NULL);
       ret = nxmq_do_receive(msgq, mqmsg, msg, prio);
     }
+
+  leave_critical_section(flags);
 
   return ret;
 }

--- a/sched/mqueue/mq_sndinternal.c
+++ b/sched/mqueue/mq_sndinternal.c
@@ -126,7 +126,6 @@ int nxmq_verify_send(FAR struct mqueue_inode_s *msgq, int oflags,
 FAR struct mqueue_msg_s *nxmq_alloc_msg(void)
 {
   FAR struct mqueue_msg_s *mqmsg;
-  irqstate_t flags;
 
   /* If we were called from an interrupt handler, then try to get the message
    * from generally available list of messages. If this fails, then try the
@@ -154,9 +153,7 @@ FAR struct mqueue_msg_s *nxmq_alloc_msg(void)
        * Disable interrupts -- we might be called from an interrupt handler.
        */
 
-      flags = enter_critical_section();
       mqmsg = (FAR struct mqueue_msg_s *)sq_remfirst(&g_msgfree);
-      leave_critical_section(flags);
 
       /* If we cannot a message from the free list, then we will have to
        * allocate one.
@@ -214,7 +211,6 @@ FAR struct mqueue_msg_s *nxmq_alloc_msg(void)
 int nxmq_wait_send(FAR struct mqueue_inode_s *msgq, int oflags)
 {
   FAR struct tcb_s *rtcb;
-  int ret;
 
 #ifdef CONFIG_CANCELLATION_POINTS
   /* nxmq_wait_send() is not a cancellation point, but may be called via
@@ -233,7 +229,11 @@ int nxmq_wait_send(FAR struct mqueue_inode_s *msgq, int oflags)
 
   /* Verify that the queue is indeed full as the caller thinks */
 
-  if (msgq->nmsgs >= msgq->maxmsgs)
+  /* Loop until there are fewer than max allowable messages in the
+   * receiving message queue
+   */
+
+  while (msgq->nmsgs >= msgq->maxmsgs)
     {
       /* Should we block until there is sufficient space in the
        * message queue?
@@ -246,51 +246,36 @@ int nxmq_wait_send(FAR struct mqueue_inode_s *msgq, int oflags)
           return -EAGAIN;
         }
 
-      /* Yes... We will not return control until the message queue is
-       * available or we receive a signal or at timeout occurs.
+      /* Block until the message queue is no longer full.
+       * When we are unblocked, we will try again
        */
 
-      else
+      rtcb           = this_task();
+      rtcb->msgwaitq = msgq;
+      msgq->nwaitnotfull++;
+
+      /* Initialize the errcode used to communication wake-up error
+       * conditions.
+       */
+
+      rtcb->errcode = OK;
+
+      /* Make sure this is not the idle task, descheduling that
+       * isn't going to end well.
+       */
+
+      DEBUGASSERT(NULL != rtcb->flink);
+      up_block_task(rtcb, TSTATE_WAIT_MQNOTFULL);
+
+      /* When we resume at this point, either (1) the message queue
+       * is no longer empty, or (2) the wait has been interrupted by
+       * a signal.  We can detect the latter case be examining the
+       * per-task errno value (should be EINTR or ETIMEOUT).
+       */
+
+      if (rtcb->errcode != OK)
         {
-          /* Loop until there are fewer than max allowable messages in the
-           * receiving message queue
-           */
-
-          while (msgq->nmsgs >= msgq->maxmsgs)
-            {
-              /* Block until the message queue is no longer full.
-               * When we are unblocked, we will try again
-               */
-
-              rtcb           = this_task();
-              rtcb->msgwaitq = msgq;
-              msgq->nwaitnotfull++;
-
-              /* Initialize the errcode used to communication wake-up error
-               * conditions.
-               */
-
-              rtcb->errcode = OK;
-
-              /* Make sure this is not the idle task, descheduling that
-               * isn't going to end well.
-               */
-
-              DEBUGASSERT(NULL != rtcb->flink);
-              up_block_task(rtcb, TSTATE_WAIT_MQNOTFULL);
-
-              /* When we resume at this point, either (1) the message queue
-               * is no longer empty, or (2) the wait has been interrupted by
-               * a signal.  We can detect the latter case be examining the
-               * per-task errno value (should be EINTR or ETIMEOUT).
-               */
-
-              ret = rtcb->errcode;
-              if (ret != OK)
-                {
-                  return -ret;
-                }
-            }
+          return -rtcb->errcode;
         }
     }
 
@@ -325,7 +310,6 @@ int nxmq_do_send(FAR struct mqueue_inode_s *msgq,
   FAR struct tcb_s *btcb;
   FAR struct mqueue_msg_s *next;
   FAR struct mqueue_msg_s *prev;
-  irqstate_t flags;
 
   /* Construct the message header info */
 
@@ -336,11 +320,8 @@ int nxmq_do_send(FAR struct mqueue_inode_s *msgq,
 
   memcpy((FAR void *)mqmsg->mail, (FAR const void *)msg, msglen);
 
-  /* Insert the new message in the message queue */
-
-  flags = enter_critical_section();
-
-  /* Search the message list to find the location to insert the new
+  /* Insert the new message in the message queue
+   * Search the message list to find the location to insert the new
    * message. Each is list is maintained in ascending priority order.
    */
 
@@ -366,8 +347,6 @@ int nxmq_do_send(FAR struct mqueue_inode_s *msgq,
     {
       nxmq_pollnotify(msgq, POLLIN);
     }
-
-  leave_critical_section(flags);
 
   /* Check if we need to notify any tasks that are attached to the
    * message queue
@@ -396,7 +375,6 @@ int nxmq_do_send(FAR struct mqueue_inode_s *msgq,
 
   /* Check if any tasks are waiting for the MQ not empty event. */
 
-  flags = enter_critical_section();
   if (msgq->nwaitnotempty > 0)
     {
       /* Find the highest priority task that is waiting for
@@ -421,6 +399,5 @@ int nxmq_do_send(FAR struct mqueue_inode_s *msgq,
       up_unblock_task(btcb);
     }
 
-  leave_critical_section(flags);
   return OK;
 }

--- a/sched/mqueue/mq_timedreceive.c
+++ b/sched/mqueue/mq_timedreceive.c
@@ -145,7 +145,6 @@ ssize_t file_mq_timedreceive(FAR struct file *mq, FAR char *msg,
   irqstate_t flags;
   int ret;
 
-  inode = mq->f_inode;
   if (!inode)
     {
       return -EBADF;
@@ -188,23 +187,23 @@ ssize_t file_mq_timedreceive(FAR struct file *mq, FAR char *msg,
        * disabled here so that this time stays valid until the wait begins.
        */
 
-      int result = clock_abstime2ticks(CLOCK_REALTIME, abstime, &ticks);
+      ret = clock_abstime2ticks(CLOCK_REALTIME, abstime, &ticks);
 
       /* If the time has already expired and the message queue is empty,
        * return immediately.
        */
 
-      if (result == OK && ticks <= 0)
+      if (ret == OK && ticks <= 0)
         {
-          result = ETIMEDOUT;
+          ret = ETIMEDOUT;
         }
 
       /* Handle any time-related errors */
 
-      if (result != OK)
+      if (ret != OK)
         {
-          leave_critical_section(flags);
-          return -result;
+          ret = -ret;
+          goto errout_in_critical_section;
         }
 
       /* Start the watchdog */
@@ -222,10 +221,6 @@ ssize_t file_mq_timedreceive(FAR struct file *mq, FAR char *msg,
 
   wd_cancel(&rtcb->waitdog);
 
-  /* We can now restore interrupts */
-
-  leave_critical_section(flags);
-
   /* Check if we got a message from the message queue.  We might
    * not have a message if:
    *
@@ -234,11 +229,16 @@ ssize_t file_mq_timedreceive(FAR struct file *mq, FAR char *msg,
    * - The watchdog timeout expired
    */
 
-  if (ret >= 0)
+  if (ret == OK)
     {
       DEBUGASSERT(mqmsg != NULL);
       ret = nxmq_do_receive(msgq, mqmsg, msg, prio);
     }
+
+  /* We can now restore interrupts */
+
+errout_in_critical_section:
+  leave_critical_section(flags);
 
   return ret;
 }


### PR DESCRIPTION
## Summary

sched/mqueue: minor code tuning of message queue
```
remove unnecessary temporary variables
adjust the protection scope of the critical section
```

## Impact

## Testing


mq_send performance test (cycle count)

```
434 (origin)
425 (fs/mqueue: skip nxmq_pollnotify() if no poll waiters)
415 (sched/mqueue: minor code tuning of message queue)
```