### PR TITLE
risc-v/mpfs: Move the entry point to .start section

### DIFF
--- a/arch/risc-v/src/mpfs/mpfs_head.S
+++ b/arch/risc-v/src/mpfs/mpfs_head.S
@@ -38,7 +38,7 @@
 
   .extern __trap_vec
 
-  .section .text
+  .section .start
   .global __start
 
 __start:

--- a/arch/risc-v/src/mpfs/mpfs_shead.S
+++ b/arch/risc-v/src/mpfs/mpfs_shead.S
@@ -38,7 +38,7 @@
 
   .extern __trap_vec
 
-  .section .text
+  .section .start
   .global __start
 
 /****************************************************************************

--- a/boards/risc-v/mpfs/icicle/scripts/kernel-space.ld
+++ b/boards/risc-v/mpfs/icicle/scripts/kernel-space.ld
@@ -40,12 +40,12 @@ __ksram_size = LENGTH(ksram);
 __ksram_end = ORIGIN(ksram) + LENGTH(ksram);
 
 ENTRY(_stext)
-EXTERN(_vectors)
+EXTERN(__start)
 SECTIONS
 {
     .text : {
         _stext = ABSOLUTE(.);
-        *(.vectors)
+        *(.start .start.*)
         *(.text .text.*)
         *(.fixup)
         *(.gnu.warning)

--- a/boards/risc-v/mpfs/icicle/scripts/ld-envm-opensbi.script
+++ b/boards/risc-v/mpfs/icicle/scripts/ld-envm-opensbi.script
@@ -29,7 +29,7 @@ MEMORY
 OUTPUT_ARCH("riscv")
 
 ENTRY(_stext)
-EXTERN(_vectors)
+EXTERN(__start)
 SECTIONS
 {
     .text.sbi : {
@@ -59,7 +59,7 @@ SECTIONS
 
     .text : {
         _stext = ABSOLUTE(.);
-        mpfs_head.o
+        *(.start .start.*)
         *(.text .text.*)
         *(.f-ixup)
         *(.gnu.warning)

--- a/boards/risc-v/mpfs/icicle/scripts/ld-envm.script
+++ b/boards/risc-v/mpfs/icicle/scripts/ld-envm.script
@@ -32,12 +32,12 @@ __ksram_size = LENGTH(lim);
 __ksram_end = ORIGIN(lim) + LENGTH(lim);
 
 ENTRY(_stext)
-EXTERN(_vectors)
+EXTERN(__start)
 SECTIONS
 {
     .text : {
         _stext = ABSOLUTE(.);
-        mpfs_head.o
+        *(.start .start.*)
         *(.text .text.*)
         *(.fixup)
         *(.gnu.warning)

--- a/boards/risc-v/mpfs/icicle/scripts/ld-ihc.script
+++ b/boards/risc-v/mpfs/icicle/scripts/ld-ihc.script
@@ -33,7 +33,7 @@ __ksram_size = LENGTH(sram);
 __ksram_end = ORIGIN(sram) + LENGTH(sram);
 
 ENTRY(_stext)
-EXTERN(_vectors)
+EXTERN(__start)
 SECTIONS
 {
     .filler_area : ALIGN(0x1000)
@@ -61,7 +61,7 @@ SECTIONS
 
     .text : {
         _stext = ABSOLUTE(.);
-        mpfs_head.o
+        *(.start .start.*)
         *(.text .text.*)
         *(.fixup)
         *(.gnu.warning)

--- a/boards/risc-v/mpfs/icicle/scripts/ld-kernel.script
+++ b/boards/risc-v/mpfs/icicle/scripts/ld-kernel.script
@@ -46,12 +46,12 @@ __pgheap_start = ORIGIN(pgram);
 __pgheap_size = LENGTH(pgram);
 
 ENTRY(_stext)
-EXTERN(_vectors)
+EXTERN(__start)
 SECTIONS
 {
     .text : {
         _stext = ABSOLUTE(.);
-        *(.vectors)
+        *(.start .start.*)
         *(.text .text.*)
         *(.fixup)
         *(.gnu.warning)

--- a/boards/risc-v/mpfs/icicle/scripts/ld.script
+++ b/boards/risc-v/mpfs/icicle/scripts/ld.script
@@ -31,12 +31,12 @@ __ksram_size = LENGTH(sram);
 __ksram_end = ORIGIN(sram) + LENGTH(sram);
 
 ENTRY(_stext)
-EXTERN(_vectors)
+EXTERN(__start)
 SECTIONS
 {
     .text : {
         _stext = ABSOLUTE(.);
-        mpfs_head.o
+        *(.start .start.*)
         *(.text .text.*)
         *(.fixup)
         *(.gnu.warning)

--- a/boards/risc-v/mpfs/m100pfsevp/scripts/ld-envm.script
+++ b/boards/risc-v/mpfs/m100pfsevp/scripts/ld-envm.script
@@ -28,12 +28,12 @@ MEMORY
 OUTPUT_ARCH("riscv")
 
 ENTRY(_stext)
-EXTERN(_vectors)
+EXTERN(__start)
 SECTIONS
 {
     .text : {
         _stext = ABSOLUTE(.);
-        mpfs_head.o
+        *(.start .start.*)
         *(.text .text.*)
         *(.fixup)
         *(.gnu.warning)

--- a/boards/risc-v/mpfs/m100pfsevp/scripts/ld.script
+++ b/boards/risc-v/mpfs/m100pfsevp/scripts/ld.script
@@ -27,12 +27,12 @@ MEMORY
 OUTPUT_ARCH("riscv")
 
 ENTRY(_stext)
-EXTERN(_vectors)
+EXTERN(__start)
 SECTIONS
 {
     .text : {
         _stext = ABSOLUTE(.);
-        mpfs_head.o
+        *(.start .start.*)
         *(.text .text.*)
         *(.fixup)
         *(.gnu.warning)


### PR DESCRIPTION
Remove the object linkage and use an explicit .start section

## Summary
Define an explicit .start section where the entry point is placed. Also, remove _vectors (which is copy&paste from ARM).
## Impact
Ensures the entry point goes to the correct place when using external build tools. NuttX build works because it defines --entry=__start but other build tools might not define this.
## Testing
icicle:nsh
