### PR TITLE
driver/rc: add IR configuration information

### DIFF
--- a/include/nuttx/rc/lirc_dev.h
+++ b/include/nuttx/rc/lirc_dev.h
@@ -146,6 +146,7 @@ struct lirc_lowerhalf_s
 {
   FAR const struct lirc_ops_s  *ops;
   FAR void                     *priv;
+  FAR void                     *conf;
   unsigned int                  timeout;
   unsigned int                  min_timeout;
   unsigned int                  max_timeout;


### PR DESCRIPTION
Signed-off-by: chenwen@espressif.com <chenwen@espressif.com>

## Summary
It is hard to distiguish different lirc devices, since "struct lirc_lowerhalf_s" has no member for underlying private drivers. 

For example, if there are two lirc devices A and B, and we want to open(or to close), we have no information to tell A from B when we are faced with "struct lirc_lowerhalf". Although there is a priv member in "struct lirc_lowerhalf_s", it is the pointer to lirc upperhalf handle, not  the underlying private driver we need.

Although I can build different drivers for A and B to make a difference, this is not a good path to go. The lirc devices are identical and should share the same driver code, with only their channel/pin being different.

So here is a proposed solution,  a new member of conf is added, which contains underlying devicde information like channel and pin.
 
## Impact

## Testing

