### PR TITLE
sched/mqueue: do sanity check if DEBUG_FEATURES is enabled

### DIFF
--- a/sched/mqueue/mq_rcvinternal.c
+++ b/sched/mqueue/mq_rcvinternal.c
@@ -54,7 +54,6 @@
  *
  * Input Parameters:
  *   msgq   - Message queue descriptor
- *   oflags - flags from user set
  *   msg    - Buffer to receive the message
  *   msglen - Size of the buffer in bytes
  *
@@ -69,9 +68,19 @@
  *
  ****************************************************************************/
 
-int nxmq_verify_receive(FAR struct mqueue_inode_s *msgq,
-                        int oflags, FAR char *msg, size_t msglen)
+#ifdef CONFIG_DEBUG_FEATURES
+int nxmq_verify_receive(FAR struct file *mq, FAR char *msg, size_t msglen)
 {
+  FAR struct inode *inode = mq->f_inode;
+  FAR struct mqueue_inode_s *msgq;
+
+  if (inode == NULL)
+    {
+      return -EBADF;
+    }
+
+  msgq = inode->i_private;
+
   /* Verify the input parameters */
 
   if (!msg || !msgq)
@@ -79,7 +88,7 @@ int nxmq_verify_receive(FAR struct mqueue_inode_s *msgq,
       return -EINVAL;
     }
 
-  if ((oflags & O_RDOK) == 0)
+  if ((mq->f_oflags & O_RDOK) == 0)
     {
       return -EPERM;
     }
@@ -91,6 +100,7 @@ int nxmq_verify_receive(FAR struct mqueue_inode_s *msgq,
 
   return OK;
 }
+#endif
 
 /****************************************************************************
  * Name: nxmq_wait_receive

--- a/sched/mqueue/mq_send.c
+++ b/sched/mqueue/mq_send.c
@@ -70,28 +70,22 @@
 int file_mq_send(FAR struct file *mq, FAR const char *msg, size_t msglen,
                  unsigned int prio)
 {
-  FAR struct inode *inode = mq->f_inode;
   FAR struct mqueue_inode_s *msgq;
   FAR struct mqueue_msg_s *mqmsg;
   irqstate_t flags;
   int ret;
 
-  if (!inode)
-    {
-      return -EBADF;
-    }
-
-  msgq = inode->i_private;
-
   /* Verify the input parameters -- setting errno appropriately
    * on any failures to verify.
    */
 
-  ret = nxmq_verify_send(msgq, mq->f_oflags, msg, msglen, prio);
+  ret = nxmq_verify_send(mq, msg, msglen, prio);
   if (ret < 0)
     {
       return ret;
     }
+
+  msgq = mq->f_inode->i_private;
 
   /* Allocate a message structure:
    * - Immediately if we are called from an interrupt handler.

--- a/sched/mqueue/mq_sndinternal.c
+++ b/sched/mqueue/mq_sndinternal.c
@@ -57,7 +57,6 @@
  *
  * Input Parameters:
  *   msgq   - Message queue descriptor
- *   oflags - flags from user set
  *   msg    - Message to send
  *   msglen - The length of the message in bytes
  *   prio   - The priority of the message
@@ -73,9 +72,20 @@
  *
  ****************************************************************************/
 
-int nxmq_verify_send(FAR struct mqueue_inode_s *msgq, int oflags,
-                     FAR const char *msg, size_t msglen, unsigned int prio)
+#ifdef CONFIG_DEBUG_FEATURES
+int nxmq_verify_send(FAR FAR struct file *mq, FAR const char *msg,
+                     size_t msglen, unsigned int prio)
 {
+  FAR struct inode *inode = mq->f_inode;
+  FAR struct mqueue_inode_s *msgq;
+
+  if (inode == NULL)
+    {
+      return -EBADF;
+    }
+
+  msgq = inode->i_private;
+
   /* Verify the input parameters */
 
   if (msg == NULL || msgq == NULL || prio > MQ_PRIO_MAX)
@@ -83,7 +93,7 @@ int nxmq_verify_send(FAR struct mqueue_inode_s *msgq, int oflags,
       return -EINVAL;
     }
 
-  if ((oflags & O_WROK) == 0)
+  if ((mq->f_oflags & O_WROK) == 0)
     {
       return -EPERM;
     }
@@ -95,6 +105,7 @@ int nxmq_verify_send(FAR struct mqueue_inode_s *msgq, int oflags,
 
   return OK;
 }
+#endif
 
 /****************************************************************************
  * Name: nxmq_alloc_msg

--- a/sched/mqueue/mq_timedreceive.c
+++ b/sched/mqueue/mq_timedreceive.c
@@ -138,19 +138,11 @@ ssize_t file_mq_timedreceive(FAR struct file *mq, FAR char *msg,
                              size_t msglen, FAR unsigned int *prio,
                              FAR const struct timespec *abstime)
 {
-  FAR struct inode *inode = mq->f_inode;
   FAR struct tcb_s *rtcb = this_task();
   FAR struct mqueue_inode_s *msgq;
   FAR struct mqueue_msg_s *mqmsg;
   irqstate_t flags;
   int ret;
-
-  if (!inode)
-    {
-      return -EBADF;
-    }
-
-  msgq = inode->i_private;
 
   DEBUGASSERT(up_interrupt_context() == false);
 
@@ -158,7 +150,7 @@ ssize_t file_mq_timedreceive(FAR struct file *mq, FAR char *msg,
    * errno appropriately.
    */
 
-  ret = nxmq_verify_receive(msgq, mq->f_oflags, msg, msglen);
+  ret = nxmq_verify_receive(mq, msg, msglen);
   if (ret < 0)
     {
       return ret;
@@ -168,6 +160,8 @@ ssize_t file_mq_timedreceive(FAR struct file *mq, FAR char *msg,
     {
       return -EINVAL;
     }
+
+  msgq = mq->f_inode->i_private;
 
   /* Furthermore, nxmq_wait_receive() expects to have interrupts disabled
    * because messages can be sent from interrupt level.

--- a/sched/mqueue/mq_timedsend.c
+++ b/sched/mqueue/mq_timedsend.c
@@ -146,7 +146,6 @@ int file_mq_timedsend(FAR struct file *mq, FAR const char *msg,
                       size_t msglen, unsigned int prio,
                       FAR const struct timespec *abstime)
 {
-  FAR struct inode *inode = mq->f_inode;
   FAR struct tcb_s *rtcb = this_task();
   FAR struct mqueue_inode_s *msgq;
   FAR struct mqueue_msg_s *mqmsg;
@@ -154,22 +153,17 @@ int file_mq_timedsend(FAR struct file *mq, FAR const char *msg,
   sclock_t ticks;
   int ret;
 
-  if (!inode)
-    {
-      return -EBADF;
-    }
-
-  msgq = inode->i_private;
-
   DEBUGASSERT(up_interrupt_context() == false);
 
   /* Verify the input parameters on any failures to verify. */
 
-  ret = nxmq_verify_send(msgq, mq->f_oflags, msg, msglen, prio);
+  ret = nxmq_verify_send(mq, msg, msglen, prio);
   if (ret < 0)
     {
       return ret;
     }
+
+  msgq = mq->f_inode->i_private;
 
   /* Disable interruption */
 

--- a/sched/mqueue/mqueue.h
+++ b/sched/mqueue/mqueue.h
@@ -115,8 +115,11 @@ void nxmq_wait_irq(FAR struct tcb_s *wtcb, int errcode);
 
 /* mq_rcvinternal.c *************************************************************/
 
-int nxmq_verify_receive(FAR struct mqueue_inode_s *msgq,
-                        int oflags, FAR char *msg, size_t msglen);
+#ifdef CONFIG_DEBUG_FEATURES
+int nxmq_verify_receive(FAR struct file *mq, FAR char *msg, size_t msglen);
+#else
+# define nxmq_verify_receive(msgq, msg, msglen) OK
+#endif
 int nxmq_wait_receive(FAR struct mqueue_inode_s *msgq,
                       int oflags, FAR struct mqueue_msg_s **rcvmsg);
 ssize_t nxmq_do_receive(FAR struct mqueue_inode_s *msgq,
@@ -125,8 +128,12 @@ ssize_t nxmq_do_receive(FAR struct mqueue_inode_s *msgq,
 
 /* mq_sndinternal.c *************************************************************/
 
-int nxmq_verify_send(FAR struct mqueue_inode_s *msgq, int oflags,
-                     FAR const char *msg, size_t msglen, unsigned int prio);
+#ifdef CONFIG_DEBUG_FEATURES
+int nxmq_verify_send(FAR struct file *mq, FAR const char *msg,
+                     size_t msglen, unsigned int prio);
+#else
+# define nxmq_verify_send(mq, msg, msglen, prio) OK
+#endif
 FAR struct mqueue_msg_s *nxmq_alloc_msg(void);
 int nxmq_wait_send(FAR struct mqueue_inode_s *msgq, int oflags);
 int nxmq_do_send(FAR struct mqueue_inode_s *msgq,


### PR DESCRIPTION
## Summary

sched/mqueue: do sanity check if DEBUG_FEATURES is enabled

## Impact

## Testing

mq_send test (cycle count)

```
393 origin
361 (sched/mqueue: do sanity check if DEBUG_FEATURES is enabled)
```