### PR TITLE
arch: k210: Add a workaround for clock stabilization

### DIFF
--- a/arch/risc-v/src/k210/k210_clockconfig.c
+++ b/arch/risc-v/src/k210/k210_clockconfig.c
@@ -105,5 +105,9 @@ void k210_clockconfig(void)
 
       g_cpu_clock = OSC_FREQ;
     }
+
+  /* Workaround for stabilization */
+
+  up_udelay(1);
 #endif
 }


### PR DESCRIPTION
## Summary

- I noticed that sometimes uart shows nothing on the maix-bit board.
- This commit adds a workaround to avoid such the issue

## Impact

- k210 only

## Testing

- Tested with maix-bit
