### PR TITLE
drvers/mmcsd/sdio: function enable should wait for CCCR_IORDY 

### DIFF
--- a/drivers/mmcsd/sdio.c
+++ b/drivers/mmcsd/sdio.c
@@ -30,6 +30,7 @@
 #include <nuttx/compiler.h>
 #include <nuttx/arch.h>
 #include <nuttx/sdio.h>
+#include <nuttx/signal.h>
 
 /****************************************************************************
  * Pre-processor Definitions
@@ -460,15 +461,15 @@ int sdio_enable_function(FAR struct sdio_dev_s *dev, uint8_t function)
       return ret;
     }
 
-  /* Wait 10ms for function to be enabled */
+  /* Wait 1s for function to be enabled */
 
-  int loops = 10;
+  int loops = 100;
 
   while (loops-- > 0)
     {
-      up_mdelay(1);
+      nxsig_usleep(10 * 1000);
 
-      ret = sdio_io_rw_direct(dev, false, 0, SDIO_CCCR_IOEN, 0, &value);
+      ret = sdio_io_rw_direct(dev, false, 0, SDIO_CCCR_IORDY, 0, &value);
       if (ret != OK)
         {
           return ret;


### PR DESCRIPTION
## Summary

drvers/mmcsd/sdio: function enable should wait for CCCR_IORDY

1. function enable should wait for CCCR_IORDY
2. enlarge wait timeout from 10ms to 1s

Signed-off-by: chao.an <anchao@xiaomi.com>

## Impact

function enable

## Testing

bcm43013 wireless chip via SDIO interface