### PR TITLE
sched/env: Fix the return value of unsetenv()

### DIFF
--- a/sched/environ/env_unsetenv.c
+++ b/sched/environ/env_unsetenv.c
@@ -61,23 +61,22 @@ int unsetenv(FAR const char *name)
 {
   FAR struct tcb_s *rtcb = this_task();
   FAR struct task_group_s *group = rtcb->group;
-  int ret = OK;
+  int idx;
 
   DEBUGASSERT(name && group);
 
   /* Check if the variable exists */
 
   sched_lock();
-  if (group && (ret = env_findvar(group, name)) >= 0)
+  if (group && (idx = env_findvar(group, name)) >= 0)
     {
       /* It does!  Remove the name=value pair from the environment. */
 
-      env_removevar(group, ret);
-      ret = OK;
+      env_removevar(group, idx);
     }
 
   sched_unlock();
-  return ret;
+  return OK;
 }
 
 #endif /* CONFIG_DISABLE_ENVIRON */

--- a/sched/environ/env_unsetenv.c
+++ b/sched/environ/env_unsetenv.c
@@ -63,7 +63,15 @@ int unsetenv(FAR const char *name)
   FAR struct task_group_s *group = rtcb->group;
   int idx;
 
-  DEBUGASSERT(name && group);
+  DEBUGASSERT(group);
+
+  /* Check the incoming parameter */
+
+  if (name == NULL || *name == '\0' || strchr(name, '=') != NULL)
+    {
+      set_errno(EINVAL);
+      return ERROR;
+    }
 
   /* Check if the variable exists */
 


### PR DESCRIPTION
If the environment variable does not exist, the function succeeds, as
defined by POSIX.

>    The unsetenv() function deletes the variable name from the
       environment.  If name does not exist in the environment, then the
       function succeeds, and the environment is unchanged.


## Summary
Fixes return value of unsetenv, value was accidentally broken in #6083
## Impact

## Testing

