### PR TITLE
arch/xtensa: Don't build xtensa_coproc.S

### DIFF
--- a/arch/xtensa/src/esp32/Make.defs
+++ b/arch/xtensa/src/esp32/Make.defs
@@ -28,7 +28,7 @@ HEAD_CSRC  = esp32_start.c esp32_wdt.c
 
 # Common XTENSA files (arch/xtensa/src/common)
 
-CMN_ASRCS  = xtensa_context.S xtensa_coproc.S xtensa_cpuint.S xtensa_panic.S
+CMN_ASRCS  = xtensa_context.S xtensa_cpuint.S xtensa_panic.S
 
 CMN_CSRCS  = xtensa_assert.c xtensa_blocktask.c
 CMN_CSRCS += xtensa_cpenable.c xtensa_createstack.c xtensa_exit.c

--- a/arch/xtensa/src/esp32s2/Make.defs
+++ b/arch/xtensa/src/esp32s2/Make.defs
@@ -28,7 +28,7 @@ HEAD_CSRC  = esp32s2_start.c esp32s2_wdt.c
 
 # Common XTENSA files (arch/xtensa/src/common)
 
-CMN_ASRCS  = xtensa_context.S xtensa_coproc.S xtensa_cpuint.S xtensa_panic.S
+CMN_ASRCS  = xtensa_context.S xtensa_cpuint.S xtensa_panic.S
 
 CMN_CSRCS  = xtensa_assert.c xtensa_blocktask.c
 CMN_CSRCS += xtensa_cpenable.c xtensa_createstack.c xtensa_exit.c

--- a/arch/xtensa/src/esp32s3/Make.defs
+++ b/arch/xtensa/src/esp32s3/Make.defs
@@ -28,7 +28,7 @@ HEAD_CSRC  = esp32s3_start.c
 
 # Common XTENSA files (arch/xtensa/src/common)
 
-CMN_ASRCS  = xtensa_context.S xtensa_coproc.S xtensa_cpuint.S xtensa_panic.S
+CMN_ASRCS  = xtensa_context.S xtensa_cpuint.S xtensa_panic.S
 
 CMN_CSRCS  = xtensa_assert.c xtensa_blocktask.c
 CMN_CSRCS += xtensa_cpenable.c xtensa_createstack.c xtensa_exit.c


### PR DESCRIPTION
## Summary
Don't build xtensa_coproc.S, it has only macros and is included when needed.
## Impact
N/A
## Testing
ESP32, ESP32-S2, ESP32-S3
