### PR TITLE
arch: imx6: Enable imx_idle.c to reduce CPU load

### DIFF
--- a/arch/arm/src/imx6/Make.defs
+++ b/arch/arm/src/imx6/Make.defs
@@ -24,7 +24,7 @@ include armv7-a/Make.defs
 
 CHIP_CSRCS  = imx_boot.c imx_memorymap.c imx_clockconfig.c imx_irq.c
 CHIP_CSRCS += imx_timerisr.c imx_gpio.c imx_iomuxc.c
-CHIP_CSRCS += imx_serial.c imx_lowputc.c
+CHIP_CSRCS += imx_serial.c imx_lowputc.c imx_idle.c
 
 ifeq ($(CONFIG_SMP),y)
 CHIP_CSRCS += imx_cpuboot.c


### PR DESCRIPTION
## Summary

- I noticed that QEMU shows a high CPU load.
- This commit re-adds imx_idle.c to avoid this issue.

## Impact

- None

## Testing

- Tested with sabre-6quad:smp with QEMU
