### PR TITLE
xtensa/esp32_rtc_lowerhalf.c: Initialize ret variable.

### DIFF
--- a/arch/xtensa/src/esp32/esp32_rtc_lowerhalf.c
+++ b/arch/xtensa/src/esp32/esp32_rtc_lowerhalf.c
@@ -538,7 +538,7 @@ struct rtc_lowerhalf_s *esp32_rtc_lowerhalf(void)
 
 int esp32_rtc_driverinit(void)
 {
-  int ret;
+  int ret = ERROR;
   struct rtc_lowerhalf_s *lower;
 
   /* Instantiate the ESP32 lower-half RTC driver */


### PR DESCRIPTION
## Summary
 Initialize ret variable to avoid a warning.
## Impact
Eliminate a warning.
## Testing
ESP32
