### PR TITLE
getrandom: fix comment contradicting code

### DIFF
--- a/include/sys/random.h
+++ b/include/sys/random.h
@@ -50,12 +50,10 @@
  * Name: getrandom
  *
  * Description:
- *   Fill a buffer of arbitrary length with randomness. This is the
- *   preferred interface for getting random numbers. The traditional
- *   /dev/random approach is susceptible for things like the attacker
- *   exhausting file descriptors on purpose.
- *
- *   Note that this function cannot fail, other than by asserting.
+ *   Fill a buffer of arbitrary length with randomness. This uses
+ *   either /dev/random (if GRND_RANDOM flag) or /dev/urandom device and
+ *   is therefore susceptible for things like the attacker exhausting file
+ *   descriptors on purpose.
  *
  * Input Parameters:
  *   bytes  - Buffer for returned random bytes

--- a/libs/libc/misc/lib_getrandom.c
+++ b/libs/libc/misc/lib_getrandom.c
@@ -36,12 +36,10 @@
  * Name: getrandom
  *
  * Description:
- *   Fill a buffer of arbitrary length with randomness. This is the
- *   preferred interface for getting random numbers. The traditional
- *   /dev/random approach is susceptible for things like the attacker
- *   exhausting file descriptors on purpose.
- *
- *   Note that this function cannot fail, other than by asserting.
+ *   Fill a buffer of arbitrary length with randomness. This uses
+ *   either /dev/random (if GRND_RANDOM flag) or /dev/urandom device and
+ *   is therefore susceptible for things like the attacker exhausting file
+ *   descriptors on purpose.
  *
  * Input Parameters:
  *   bytes  - Buffer for returned random bytes


### PR DESCRIPTION
## Summary
Commit c8ea7a95 changed getrandom() to be more like in Linux, but function's comment was not fully updated. This patch changes erroneous comment to match current implementation.

## Impact
N/A

## Testing
N/A
