### PR TITLE
wireless/bcm43xx: replace sem_wait to uninterruptible version

### DIFF
--- a/drivers/wireless/ieee80211/bcm43xxx/bcmf_cdc.c
+++ b/drivers/wireless/ieee80211/bcm43xxx/bcmf_cdc.c
@@ -166,7 +166,7 @@ int bcmf_cdc_control_request(FAR struct bcmf_dev_s *priv,
 
   /* Take device control mutex */
 
-  if ((ret = nxsem_wait(&priv->control_mutex)) < 0)
+  if ((ret = nxsem_wait_uninterruptible(&priv->control_mutex)) < 0)
     {
       return ret;
     }

--- a/drivers/wireless/ieee80211/bcm43xxx/bcmf_driver.c
+++ b/drivers/wireless/ieee80211/bcm43xxx/bcmf_driver.c
@@ -1094,7 +1094,7 @@ int bcmf_wl_start_scan(FAR struct bcmf_dev_s *priv, struct iwreq *iwr)
 
   /* Lock control_mutex semaphore */
 
-  if ((ret = nxsem_wait(&priv->control_mutex)) < 0)
+  if ((ret = nxsem_wait_uninterruptible(&priv->control_mutex)) < 0)
     {
       goto exit_failed;
     }
@@ -1161,7 +1161,7 @@ int bcmf_wl_get_scan_results(FAR struct bcmf_dev_s *priv, struct iwreq *iwr)
 
   /* Lock control_mutex semaphore to avoid race condition */
 
-  if ((ret = nxsem_wait(&priv->control_mutex)) < 0)
+  if ((ret = nxsem_wait_uninterruptible(&priv->control_mutex)) < 0)
     {
       goto exit_failed;
     }

--- a/drivers/wireless/ieee80211/bcm43xxx/bcmf_sdio.c
+++ b/drivers/wireless/ieee80211/bcm43xxx/bcmf_sdio.c
@@ -880,7 +880,7 @@ int bcmf_sdio_thread(int argc, char **argv)
     {
       /* Wait for event (device interrupt, user request or waitdog timer) */
 
-      ret = nxsem_wait(&sbus->thread_signal);
+      ret = nxsem_wait_uninterruptible(&sbus->thread_signal);
       if (ret < 0)
         {
           wlerr("Error while waiting for semaphore\n");
@@ -977,7 +977,7 @@ struct bcmf_sdio_frame *bcmf_sdio_allocate_frame(FAR struct bcmf_dev_s *priv,
 
   while (1)
     {
-      if (nxsem_wait(&sbus->queue_mutex) < 0)
+      if (nxsem_wait_uninterruptible(&sbus->queue_mutex) < 0)
         {
           DEBUGPANIC();
         }
@@ -1030,7 +1030,7 @@ void bcmf_sdio_free_frame(FAR struct bcmf_dev_s *priv,
 {
   FAR struct bcmf_sdio_dev_s *sbus = (FAR struct bcmf_sdio_dev_s *)priv->bus;
 
-  if (nxsem_wait(&sbus->queue_mutex) < 0)
+  if (nxsem_wait_uninterruptible(&sbus->queue_mutex) < 0)
     {
       DEBUGPANIC();
     }

--- a/drivers/wireless/ieee80211/bcm43xxx/bcmf_sdpcm.c
+++ b/drivers/wireless/ieee80211/bcm43xxx/bcmf_sdpcm.c
@@ -312,7 +312,7 @@ int bcmf_sdpcm_readframe(FAR struct bcmf_dev_s *priv)
 
         /* Queue frame and notify network layer frame is available */
 
-        if (nxsem_wait(&sbus->queue_mutex) < 0)
+        if (nxsem_wait_uninterruptible(&sbus->queue_mutex) < 0)
           {
             DEBUGPANIC();
           }
@@ -371,7 +371,7 @@ int bcmf_sdpcm_sendframe(FAR struct bcmf_dev_s *priv)
       return -EAGAIN;
     }
 
-  if (nxsem_wait(&sbus->queue_mutex) < 0)
+  if (nxsem_wait_uninterruptible(&sbus->queue_mutex) < 0)
     {
       DEBUGPANIC();
     }
@@ -473,7 +473,7 @@ int bcmf_sdpcm_queue_frame(FAR struct bcmf_dev_s *priv,
 
   /* Add frame in tx queue */
 
-  if (nxsem_wait(&sbus->queue_mutex) < 0)
+  if (nxsem_wait_uninterruptible(&sbus->queue_mutex) < 0)
     {
       DEBUGPANIC();
     }
@@ -533,7 +533,7 @@ struct bcmf_frame_s *bcmf_sdpcm_get_rx_frame(FAR struct bcmf_dev_s *priv)
   struct bcmf_sdio_frame *sframe;
   FAR struct bcmf_sdio_dev_s *sbus = (FAR struct bcmf_sdio_dev_s *)priv->bus;
 
-  if (nxsem_wait(&sbus->queue_mutex) < 0)
+  if (nxsem_wait_uninterruptible(&sbus->queue_mutex) < 0)
     {
       DEBUGPANIC();
     }

--- a/drivers/wireless/ieee80211/bcm43xxx/bcmf_utils.c
+++ b/drivers/wireless/ieee80211/bcm43xxx/bcmf_utils.c
@@ -85,7 +85,7 @@ void bcmf_hexdump(uint8_t *data, unsigned int len, unsigned long offset)
 
 int bcmf_sem_wait(sem_t *sem, unsigned int timeout_ms)
 {
-  return nxsem_tickwait(sem, MSEC2TICK(timeout_ms));
+  return nxsem_tickwait_uninterruptible(sem, MSEC2TICK(timeout_ms));
 }
 
 void bcmf_dqueue_push(dq_queue_t *queue, dq_entry_t *entry)


### PR DESCRIPTION
## Summary

wireless/bcm43xx: replace sem_wait to uninterruptible version

## Impact

N/A

## Testing

bcm43013 iperf test