### PR TITLE
xtensa: Remove old references to co-processors.

### DIFF
--- a/arch/xtensa/src/common/xtensa_cpupause.c
+++ b/arch/xtensa/src/common/xtensa_cpupause.c
@@ -109,8 +109,8 @@ int up_cpu_paused(int cpu)
   sched_note_cpu_paused(tcb);
 #endif
 
-  /* Copy the CURRENT_REGS into the OLD TCB (otcb).  The co-processor state
-   * will be saved as part of the return from xtensa_irq_dispatch().
+  /* Save the current context at CURRENT_REGS into the TCB at the head
+   * of the assigned task list for this CPU.
    */
 
   xtensa_savestate(tcb->xcp.regs);

--- a/arch/xtensa/src/common/xtensa_irqdispatch.c
+++ b/arch/xtensa/src/common/xtensa_irqdispatch.c
@@ -62,12 +62,7 @@ uint32_t *xtensa_irq_dispatch(int irq, uint32_t *regs)
 
   CURRENT_REGS = regs;
 
-  /* Deliver the IRQ
-   *
-   * NOTE: Co-process state has not been saved yet (see below).  As a
-   * consequence, no interrupt level logic may perform co-processor
-   * operations.  This includes use of the FPU.
-   */
+  /* Deliver the IRQ */
 
   irq_dispatch(irq, regs);
 

--- a/arch/xtensa/src/common/xtensa_sigdeliver.c
+++ b/arch/xtensa/src/common/xtensa_sigdeliver.c
@@ -140,7 +140,6 @@ void xtensa_sig_deliver(void)
   rtcb->xcp.sigdeliver = NULL;  /* Allows next handler to be scheduled */
 
   /* Then restore the correct state for this thread of execution.
-   * NOTE: The co-processor state should already be correct.
    */
 
   board_autoled_off(LED_SIGNAL);


### PR DESCRIPTION
## Summary
These comments are wrong now.
## Impact
N/A
## Testing
N/A
