### PR TITLE
wireless/bcm43xxx: configurable schedule priority of daemon thread 

### DIFF
--- a/drivers/wireless/ieee80211/bcm43xxx/Kconfig
+++ b/drivers/wireless/ieee80211/bcm43xxx/Kconfig
@@ -118,6 +118,13 @@ config IEEE80211_BROADCOM_FULLMAC_SDIO
 		This selection enables support for broadcom
 		FullMAC-compliant devices using SDIO bus.
 
+config IEEE80211_BROADCOM_SCHED_PRIORITY
+	int "Broadcom BCMF daemon thread schedule priority"
+	default 255
+	---help---
+		This parameter should be set the bcmf daemon thread
+		schedule priority
+
 if IEEE80211_BROADCOM_FULLMAC
 
 config IEEE80211_BROADCOM_NINTERFACES

--- a/drivers/wireless/ieee80211/bcm43xxx/bcmf_sdio.c
+++ b/drivers/wireless/ieee80211/bcm43xxx/bcmf_sdio.c
@@ -773,7 +773,8 @@ int bcmf_bus_sdio_initialize(FAR struct bcmf_dev_s *priv,
 
   /* Spawn bcmf daemon thread */
 
-  ret = kthread_create(BCMF_THREAD_NAME, SCHED_PRIORITY_MAX,
+  ret = kthread_create(BCMF_THREAD_NAME,
+                       CONFIG_IEEE80211_BROADCOM_SCHED_PRIORITY,
                        BCMF_THREAD_STACK_SIZE, bcmf_sdio_thread,
                        (FAR char * const *)NULL);
 


### PR DESCRIPTION
## Summary

wireless/bcm43xxx: configurable schedule priority of daemon thread

## Impact

N/A

## Testing

bcm43013 test