### PR TITLE
nuttx/lib: remove dependency on BUILD_FLAT for library memory allocation interface

### DIFF
--- a/include/nuttx/lib/lib.h
+++ b/include/nuttx/lib/lib.h
@@ -41,7 +41,7 @@
  * then only the first mode is supported.
  */
 
-#if !defined(CONFIG_BUILD_FLAT) && defined(__KERNEL__)
+#if defined(__KERNEL__)
 
   /* Domain-specific allocations */
 


### PR DESCRIPTION
## Summary
Library memory allocation interface should not depend on `BUILD_FLAT` option because in case of `BUILD_FLAT` the `kmm_` and `kumm_` are anyway redirected to the same allocation function calls

## Impact
None. Just clean-up the code

## Testing
Pass CI