### PR TITLE
arch/riscv/mpfs: Add a config flag to select SD mux state

### DIFF
--- a/arch/risc-v/src/mpfs/Kconfig
+++ b/arch/risc-v/src/mpfs/Kconfig
@@ -132,6 +132,17 @@ config MPFS_EMMCSD_MUX_GPIO
 	---help---
 		External mux GPIO between e.MMC and SD-card
 
+choice MPFS_EMMCSD_MUX
+	prompt "Configure SD/eMMC mux"
+
+config MPFS_EMMCSD_MUX_SDCARD
+	bool "SD card"
+
+config MPFS_EMMCSD_MUX_EMMC
+	bool "eMMC"
+
+endchoice
+
 config MPFS_ROMFS_MOUNT
 	bool "Mount the ROMFS file system"
 	depends on FS_ROMFS

--- a/arch/risc-v/src/mpfs/mpfs_emmcsd.c
+++ b/arch/risc-v/src/mpfs/mpfs_emmcsd.c
@@ -442,7 +442,11 @@ struct mpfs_dev_s g_emmcsd_dev =
   },
   .hw_base           = MPFS_EMMC_SD_BASE,
   .plic_irq          = MPFS_IRQ_MMC_MAIN,
-  .emmc              = false,               /* Set true for emmc operation */
+#ifdef CONFIG_MPFS_EMMCSD_MUX_EMMC
+  .emmc              = true,
+#else
+  .emmc              = false,
+#endif
   .blocksize         = 512,
   .onebit            = false,
   .polltransfer      = true,


### PR DESCRIPTION
This has been previously hard-coded to SD-card. Make it build time configurable.

Signed-off-by: Jukka Laitinen <jukkax@ssrc.tii.ae>

