### PR TITLE
arch/backtrace: correct the skip counter

### DIFF
--- a/arch/arm/src/common/arm_backtrace_fp.c
+++ b/arch/arm/src/common/arm_backtrace_fp.c
@@ -55,7 +55,7 @@ static int backtrace(uintptr_t *base, uintptr_t *limit,
   if (pc)
     {
       i++;
-      if (*skip-- <= 0)
+      if ((*skip)-- <= 0)
         {
           *buffer++ = pc;
         }
@@ -68,7 +68,7 @@ static int backtrace(uintptr_t *base, uintptr_t *limit,
           break;
         }
 
-      if (*skip-- <= 0)
+      if ((*skip)-- <= 0)
         {
           *buffer++ = (void *)*fp;
         }


### PR DESCRIPTION
## Summary

arch/backtrace: correct the skip counter

arm_backtrace_fp.c was missing from the previous PR:

https://github.com/apache/incubator-nuttx/pull/5122

## Impact

N/A

## Testing

cortex-a backtrace