### PR TITLE
mmcsd/sdio: correct return value of sdio_probe() 

### DIFF
--- a/drivers/mmcsd/sdio.c
+++ b/drivers/mmcsd/sdio.c
@@ -412,7 +412,7 @@ int sdio_probe(FAR struct sdio_dev_s *dev)
 
 err:
   SDIO_GIVELOCK(dev);
-  return OK;
+  return ret;
 }
 
 int sdio_set_blocksize(FAR struct sdio_dev_s *dev, uint8_t function,


### PR DESCRIPTION
## Summary

mmcsd/sdio: correct return value of sdio_probe()

## Impact

N/A

## Testing

bcm43013 iperf test