### PR TITLE
wireless/bcm43xxx: Don't call bcmf_board_setup_oob_irq in bcmf_sdio_thread

### DIFF
--- a/drivers/wireless/ieee80211/bcm43xxx/bcmf_sdio.c
+++ b/drivers/wireless/ieee80211/bcm43xxx/bcmf_sdio.c
@@ -953,10 +953,6 @@ int bcmf_sdio_thread(int argc, char **argv)
           continue;
         }
 
-      /* Re-configure the board GPIO interrupt pin */
-
-      bcmf_board_setup_oob_irq(sbus->minor, bcmf_oob_irq, (void *)sbus);
-
       /* If we're done for now, turn off clock request. */
 
 #if 0


### PR DESCRIPTION
## Summary
since oob irq is already setup in bcmf_bus_setup_interrupts, it waste
time and energy to do the same thing repeatly in the work thread.

## Impact
Minor

## Testing
internal device
