### PR TITLE
wireless/bcm43xxx: add status print on bcmf_wl_auth_event_handler() 

### DIFF
--- a/drivers/wireless/ieee80211/bcm43xxx/bcmf_driver.c
+++ b/drivers/wireless/ieee80211/bcm43xxx/bcmf_driver.c
@@ -577,7 +577,8 @@ void bcmf_wl_auth_event_handler(FAR struct bcmf_dev_s *priv,
   type = bcmf_getle32(&event->type);
   status = bcmf_getle32(&event->status);
 
-  wlinfo("Got auth event %" PRId32 " from <%s>\n", type, event->src_name);
+  wlinfo("Got auth event %" PRId32 " status %" PRId32 " from <%s>\n",
+         type, status, event->src_name);
 
   bcmf_hexdump((uint8_t *)event, len, (unsigned long)event);
 


### PR DESCRIPTION
## Summary

wireless/bcm43xxx: add status print on bcmf_wl_auth_event_handler()

## Impact

N/A

## Testing

bcm43013 scan