### PR TITLE
wireless/bcm43xxx: add more ioctl command support

### DIFF
--- a/drivers/wireless/ieee80211/bcm43xxx/bcmf_driver.h
+++ b/drivers/wireless/ieee80211/bcm43xxx/bcmf_driver.h
@@ -151,7 +151,22 @@ int bcmf_wl_set_auth_param(FAR struct bcmf_dev_s *priv, struct iwreq *iwr);
 int bcmf_wl_set_encode_ext(FAR struct bcmf_dev_s *priv, struct iwreq *iwr);
 
 int bcmf_wl_set_mode(FAR struct bcmf_dev_s *priv, struct iwreq *iwr);
+int bcmf_wl_get_mode(FAR struct bcmf_dev_s *priv, struct iwreq *iwr);
 
 int bcmf_wl_set_ssid(FAR struct bcmf_dev_s *priv, struct iwreq *iwr);
+int bcmf_wl_get_ssid(FAR struct bcmf_dev_s *priv, struct iwreq *iwr);
+
+int bcmf_wl_set_bssid(FAR struct bcmf_dev_s *priv, struct iwreq *iwr);
+int bcmf_wl_get_bssid(FAR struct bcmf_dev_s *priv, struct iwreq *iwr);
+
+int bcmf_wl_get_channel(FAR struct bcmf_dev_s *priv, struct iwreq *iwr);
+
+int bcmf_wl_get_rate(FAR struct bcmf_dev_s *priv, struct iwreq *iwr);
+
+int bcmf_wl_get_txpower(FAR struct bcmf_dev_s *priv, struct iwreq *iwr);
+
+int bcmf_wl_get_rssi(FAR struct bcmf_dev_s *priv, struct iwreq *iwr);
+
+int bcmf_wl_get_iwrange(FAR struct bcmf_dev_s *priv, struct iwreq *iwr);
 
 #endif /* __DRIVERS_WIRELESS_IEEE80211_BCM43XXX_BCMF_DRIVER_H */

--- a/drivers/wireless/ieee80211/bcm43xxx/bcmf_ioctl.h
+++ b/drivers/wireless/ieee80211/bcm43xxx/bcmf_ioctl.h
@@ -2712,6 +2712,13 @@ typedef struct wl_rssi_event
   int8_t rssi_levels[MAX_RSSI_LEVELS];
 } wl_rssi_event_t;
 
+typedef struct wl_sta_rssi
+{
+  uint32_t          rssi;
+  struct ether_addr sta_addr;
+  uint16_t          foo;
+} wl_sta_rssi_t;
+
 #define WLFEATURE_DISABLE_11N          0x00000001
 #define WLFEATURE_DISABLE_11N_STBC_TX  0x00000002
 #define WLFEATURE_DISABLE_11N_STBC_RX  0x00000004

--- a/drivers/wireless/ieee80211/bcm43xxx/bcmf_netdev.c
+++ b/drivers/wireless/ieee80211/bcm43xxx/bcmf_netdev.c
@@ -915,8 +915,7 @@ static int bcmf_ioctl(FAR struct net_driver_s *dev, int cmd,
         break;
 
       case SIOCGIWFREQ:     /* Get channel/frequency (Hz) */
-        wlwarn("WARNING: SIOCGIWFREQ not implemented\n");
-        ret = -ENOSYS;
+        ret = bcmf_wl_get_channel(priv, (struct iwreq *)arg);
         break;
 
       case SIOCSIWMODE:     /* Set operation mode */
@@ -924,18 +923,15 @@ static int bcmf_ioctl(FAR struct net_driver_s *dev, int cmd,
         break;
 
       case SIOCGIWMODE:     /* Get operation mode */
-        wlwarn("WARNING: SIOCGIWMODE not implemented\n");
-        ret = -ENOSYS;
+        ret = bcmf_wl_get_mode(priv, (struct iwreq *)arg);
         break;
 
       case SIOCSIWAP:       /* Set access point MAC addresses */
-        wlwarn("WARNING: SIOCSIWAP not implemented\n");
-        ret = -ENOSYS;
+        ret = bcmf_wl_set_bssid(priv, (struct iwreq *)arg);
         break;
 
       case SIOCGIWAP:       /* Get access point MAC addresses */
-        wlwarn("WARNING: SIOCGIWAP not implemented\n");
-        ret = -ENOSYS;
+        ret = bcmf_wl_get_bssid(priv, (struct iwreq *)arg);
         break;
 
       case SIOCSIWESSID:    /* Set ESSID (network name) */
@@ -943,8 +939,7 @@ static int bcmf_ioctl(FAR struct net_driver_s *dev, int cmd,
         break;
 
       case SIOCGIWESSID:    /* Get ESSID */
-        wlwarn("WARNING: SIOCGIWESSID not implemented\n");
-        ret = -ENOSYS;
+        ret = bcmf_wl_get_ssid(priv, (struct iwreq *)arg);
         break;
 
       case SIOCSIWRATE:     /* Set default bit rate (bps) */
@@ -953,8 +948,7 @@ static int bcmf_ioctl(FAR struct net_driver_s *dev, int cmd,
         break;
 
       case SIOCGIWRATE:     /* Get default bit rate (bps) */
-        wlwarn("WARNING: SIOCGIWRATE not implemented\n");
-        ret = -ENOSYS;
+        ret = bcmf_wl_get_rate(priv, (struct iwreq *)arg);
         break;
 
       case SIOCSIWTXPOW:    /* Set transmit power (dBm) */
@@ -963,8 +957,15 @@ static int bcmf_ioctl(FAR struct net_driver_s *dev, int cmd,
         break;
 
       case SIOCGIWTXPOW:    /* Get transmit power (dBm) */
-        wlwarn("WARNING: SIOCGIWTXPOW not implemented\n");
-        ret = -ENOSYS;
+        ret = bcmf_wl_get_txpower(priv, (struct iwreq *)arg);
+        break;
+
+      case SIOCGIWSENS:     /* Get transmit power (dBm) */
+        ret = bcmf_wl_get_rssi(priv, (struct iwreq *)arg);
+        break;
+
+      case SIOCGIWRANGE:    /* Get range of parameters */
+        ret = bcmf_wl_get_iwrange(priv, (struct iwreq *)arg);
         break;
 
       default:


### PR DESCRIPTION
## Summary

wireless/bcm43xxx: add more ioctl command support

 Support command:
   SIOCGIWFREQ
   SIOCGIWMODE
   SIOCSIWAP
   SIOCGIWAP
   SIOCGIWESSID
   SIOCGIWRATE
   SIOCGIWTXPOW
   SIOCGIWSENS
   SIOCGIWRANGE
 
 Signed-off-by: chao.an <anchao@xiaomi.com>

## Impact

N/A

## Testing


```
Before:                                    After:
 cp> wapi show wlan0                          cp> wapi show wlan0
 wlan0 Configuration:                         wlan0 Configuration:
        IP: 192.168.31.202                           IP: 192.168.31.202
   NetMask: 255.255.255.0                       NetMask: 255.255.255.0
 ioctl(SIOCGIWFREQ): 88                       Frequency: 5785
 ERROR: wapi_get_freq() failed: -88                Flag: WAPI_FREQ_AUTO
 ioctl(SIOCGIWESSID): 88                        Channel: 157
 ERROR: wapi_get_essid() failed: -88          Frequency: 5785
 ioctl(SIOCGIWMODE): 88                           ESSID: archer5
 ERROR: wapi_get_mode() failed: -88                Flag: WAPI_ESSID_ON
 ioctl(SIOCGIWAP): 88                              Mode: WAPI_MODE_MANAGED
 ERROR: wapi_get_ap() failed: -88                    AP: ec:41:18:e0:76:7f
 ioctl(SIOCGIWRATE): 88                         BitRate: 58500
 ERROR: wapi_get_bitrate() failed: -88             Flag: WAPI_BITRATE_FIXED
 ioctl(SIOCGIWTXPOW): 88                        TxPower: 31
 ERROR: wapi_get_txpower() failed: -88             Flag: WAPI_TXPOWER_DBM
 ioctl(SIOCGIWSENS): 25                           Sense: -17

```

