### PR TITLE
wireless/bcm43xxx: sort scan result by rssi

### DIFF
--- a/drivers/wireless/ieee80211/bcm43xxx/Kconfig
+++ b/drivers/wireless/ieee80211/bcm43xxx/Kconfig
@@ -125,11 +125,11 @@ config IEEE80211_BROADCOM_SCHED_PRIORITY
 		This parameter should be set the bcmf daemon thread
 		schedule priority
 
-config IEEE80211_BROADCOM_SCAN_RESULT_SIZE
-	int "Broadcom BCMF escan result size"
-	default 1024
+config IEEE80211_BROADCOM_SCAN_RESULT_ENTRIES
+	int "Broadcom BCMF escan result entries"
+	default 10
 	---help---
-		This parameter should be set the bcmf escan result buffer size
+		This parameter should be set the bcmf escan result buffer entries
 
 if IEEE80211_BROADCOM_FULLMAC
 

--- a/drivers/wireless/ieee80211/bcm43xxx/bcmf_driver.h
+++ b/drivers/wireless/ieee80211/bcm43xxx/bcmf_driver.h
@@ -89,8 +89,8 @@ struct bcmf_dev_s
 
   int scan_status;                     /* Current scan status */
   struct wdog_s scan_timeout;          /* Scan timeout timer */
-  FAR uint8_t *scan_result;            /* Temp buffer that holds results */
-  unsigned int scan_result_size;       /* Current size of temp buffer */
+  FAR wl_bss_info_t *scan_result;      /* Temp buffer that holds results */
+  unsigned int scan_result_entries;    /* Current entries of temp buffer */
 
   sem_t auth_signal; /* Authentication notification signal */
   int   auth_status; /* Authentication status */


### PR DESCRIPTION
## Summary

wireless/bcm43xxx: sort scan result by rssi
  
1. Replace SCAN_RESULT_SIZE to SCAN_RESULT_ENTRIES
2. filter scan result with better rssi
3. Sort scan result by rssi

## Impact

N/A

## Testing

bcm43013 scan