### PR TITLE
wireless/bcm43xxx: enable power saving on netdev up/down

### DIFF
--- a/drivers/wireless/ieee80211/bcm43xxx/bcmf_driver.h
+++ b/drivers/wireless/ieee80211/bcm43xxx/bcmf_driver.h
@@ -169,4 +169,6 @@ int bcmf_wl_get_rssi(FAR struct bcmf_dev_s *priv, struct iwreq *iwr);
 
 int bcmf_wl_get_iwrange(FAR struct bcmf_dev_s *priv, struct iwreq *iwr);
 
+int bcmf_wl_active(FAR struct bcmf_dev_s *priv, bool active);
+
 #endif /* __DRIVERS_WIRELESS_IEEE80211_BCM43XXX_BCMF_DRIVER_H */

--- a/drivers/wireless/ieee80211/bcm43xxx/bcmf_sdio.h
+++ b/drivers/wireless/ieee80211/bcm43xxx/bcmf_sdio.h
@@ -141,6 +141,8 @@ struct bcmf_sdio_frame
 int bcmf_bus_sdio_initialize(FAR struct bcmf_dev_s *priv,
           int minor, FAR struct sdio_dev_s *dev);
 
+int bcmf_bus_sdio_active(FAR struct bcmf_dev_s *priv, bool active);
+
 /* FIXME: Low level bus data transfer function
  * To avoid bus error, len will be aligned to:
  * - upper power of 2 iflen is lesser than 64


### PR DESCRIPTION
## Summary

 wireless/bcm43xxx: enable power saving on netdev up/down
 
 Move sdio/firmware de/initialize to ifup/down
 
 Signed-off-by: chao.an <anchao@xiaomi.com>


## Impact

N/A

## Testing

bcm43013 ifup/ifdown