### PR TITLE
wireless/bcm43xxx: merge frame send to once to improve the performance

### DIFF
--- a/drivers/wireless/ieee80211/bcm43xxx/bcmf_sdpcm.c
+++ b/drivers/wireless/ieee80211/bcm43xxx/bcmf_sdpcm.c
@@ -391,25 +391,11 @@ int bcmf_sdpcm_sendframe(FAR struct bcmf_dev_s *priv)
                (unsigned long)sframe->header.base);
 #endif
 
-  /* Write the first 4 bytes of sdpcm header */
+  /* Write the frame data (the buffer is DMA aligned here) */
 
   ret = bcmf_transfer_bytes(sbus, true, 2, 0,
                             sframe->header.base,
-                            FIRST_WORD_SIZE);
-  if (ret != OK)
-    {
-      /* TODO handle retry count and remove frame from queue + abort TX */
-
-      wlinfo("fail send frame %d\n", ret);
-      ret = -EIO;
-      goto exit_abort;
-    }
-
-  /* Write the remaining frame data (the buffer is DMA aligned here) */
-
-  ret = bcmf_transfer_bytes(sbus, true, 2, 0,
-                            sframe->header.base + FIRST_WORD_SIZE,
-                            sframe->header.len - FIRST_WORD_SIZE);
+                            sframe->header.len);
   if (ret != OK)
     {
       /* TODO handle retry count and remove frame from queue + abort TX */


### PR DESCRIPTION
## Summary

wireless/bcm43xxx: merge frame send to once to improve the performance

## Impact

N/A

## Testing

bcm43013 iperf test:

before:
```
cp> iperf -c 192.168.1.111 -i 1
   0.00-   1.01 sec    1900544 Bytes   15.08 Mbits/sec
   1.01-   2.01 sec    3817472 Bytes   15.30 Mbits/sec
   2.01-   3.02 sec    5619712 Bytes   14.35 Mbits/sec
   3.02-   4.02 sec    7536640 Bytes   15.27 Mbits/sec
```

after:
```
cp> iperf -c 192.168.1.111 -i 1
   0.00-   1.00 sec    1998848 Bytes   15.91 Mbits/sec
   1.00-   2.01 sec    4079616 Bytes   16.57 Mbits/sec
   2.01-   3.02 sec    6160384 Bytes   16.51 Mbits/sec
   3.02-   4.02 sec    8208384 Bytes   16.30 Mbits/sec
```