### PR TITLE
risc-v/mpfs: emmcsd: fix two issues

### DIFF
--- a/arch/risc-v/src/mpfs/hardware/mpfs_emmcsd.h
+++ b/arch/risc-v/src/mpfs/hardware/mpfs_emmcsd.h
@@ -145,7 +145,7 @@
 
 #define MPFS_EMMCSD_HRS06_ETR           (1 << 15)
 #define MPFS_EMMCSD_HRS06_ETV           (0x3f << 8)
-#define MPFS_EMMCSD_HRS06_EMM           (0x3 << 0)
+#define MPFS_EMMCSD_HRS06_EMM           (0x7 << 0)
 
 /* HRS07 register */
 

--- a/arch/risc-v/src/mpfs/mpfs_emmcsd.c
+++ b/arch/risc-v/src/mpfs/mpfs_emmcsd.c
@@ -996,8 +996,8 @@ static void mpfs_endtransfer(struct mpfs_dev_s *priv,
 
   /* Clear Buffer Read Ready (BRR), BWR and DMA statuses */
 
-  putreg32(MPFS_EMMCSD_SRS12, MPFS_EMMCSD_SRS12_BRR |
-           MPFS_EMMCSD_SRS12_BWR | MPFS_EMMCSD_SRS12_DMAINT);
+  putreg32(MPFS_EMMCSD_SRS12_BRR | MPFS_EMMCSD_SRS12_BWR |
+           MPFS_EMMCSD_SRS12_DMAINT, MPFS_EMMCSD_SRS12);
 
   /* Mark the transfer finished */
 


### PR DESCRIPTION
This patch fixes the following issues:
  1. MPFS_EMMCSD_HRS06_EMM bitmask had to be 0x7, not 0x03
  2. putreg32() caused outright memory corruption as the
     arguments were in wrong order

Signed-off-by: Eero Nurkkala <eero.nurkkala@offcode.fi>

## Summary

The driver caused memory corruption

## Impact

mpfs / emmcsd

## Testing

MPFS Polarfire Icicle board on hart0, emmc mounted with FAT32 file system. File copies etc.
