### PR TITLE
wireless/bcm43xxx: add get country code support

### DIFF
--- a/drivers/wireless/ieee80211/bcm43xxx/bcmf_driver.c
+++ b/drivers/wireless/ieee80211/bcm43xxx/bcmf_driver.c
@@ -1781,3 +1781,33 @@ int bcmf_wl_set_country(FAR struct bcmf_dev_s *priv, FAR struct iwreq *iwr)
 
   return bcmf_wl_set_country_code(priv, interface, iwr->u.data.pointer);
 }
+
+int bcmf_wl_get_country(FAR struct bcmf_dev_s *priv, FAR struct iwreq *iwr)
+{
+  uint8_t country[4] =
+    {
+      0
+    };
+
+  uint32_t out_len;
+  int interface;
+  int ret;
+
+  interface = bcmf_wl_get_interface(priv, iwr);
+
+  if (interface < 0 || iwr->u.data.pointer == NULL)
+    {
+      return -EINVAL;
+    }
+
+  out_len = sizeof(country);
+  ret = bcmf_cdc_iovar_request(priv, interface, false,
+                               IOVAR_STR_COUNTRY, country,
+                               &out_len);
+  if (ret == OK)
+    {
+      memcpy(iwr->u.data.pointer, country, 2);
+    }
+
+  return ret;
+}

--- a/drivers/wireless/ieee80211/bcm43xxx/bcmf_driver.h
+++ b/drivers/wireless/ieee80211/bcm43xxx/bcmf_driver.h
@@ -183,5 +183,6 @@ int bcmf_wl_get_rssi(FAR struct bcmf_dev_s *priv, struct iwreq *iwr);
 int bcmf_wl_get_iwrange(FAR struct bcmf_dev_s *priv, struct iwreq *iwr);
 
 int bcmf_wl_set_country(FAR struct bcmf_dev_s *priv, struct iwreq *iwr);
+int bcmf_wl_get_country(FAR struct bcmf_dev_s *priv, struct iwreq *iwr);
 
 #endif /* __DRIVERS_WIRELESS_IEEE80211_BCM43XXX_BCMF_DRIVER_H */

--- a/drivers/wireless/ieee80211/bcm43xxx/bcmf_netdev.c
+++ b/drivers/wireless/ieee80211/bcm43xxx/bcmf_netdev.c
@@ -1137,6 +1137,10 @@ static int bcmf_ioctl(FAR struct net_driver_s *dev, int cmd,
         ret = bcmf_wl_set_country(priv, (struct iwreq *)arg);
         break;
 
+      case SIOCGIWCOUNTRY:  /* Get country code */
+        ret = bcmf_wl_get_country(priv, (struct iwreq *)arg);
+        break;
+
       default:
         nerr("ERROR: Unrecognized IOCTL command: %x\n", cmd);
         ret = -ENOTTY;  /* Special return value for this case */

--- a/include/nuttx/wireless/wireless.h
+++ b/include/nuttx/wireless/wireless.h
@@ -142,11 +142,13 @@
 
 /* Country code extension */
 
-#define SIOCSIWCOUNTRY      _WLIOC(0x0037)  /* Country code extension */
+#define SIOCSIWCOUNTRY      _WLIOC(0x0037)  /* Set country code */
+#define SIOCGIWCOUNTRY      _WLIOC(0x0038)  /* Get country code */
 
 #define WL_IS80211POINTERCMD(cmd) ((cmd) == SIOCGIWSCAN || \
                                    (cmd) == SIOCSIWSCAN || \
                                    (cmd) == SIOCSIWCOUNTRY || \
+                                   (cmd) == SIOCGIWCOUNTRY || \
                                    (cmd) == SIOCGIWRANGE || \
                                    (cmd) == SIOCSIWENCODEEXT || \
                                    (cmd) == SIOCGIWENCODEEXT || \
@@ -156,7 +158,7 @@
 /* Device-specific network IOCTL commands *******************************************/
 
 #define WL_NETFIRST         0x0000          /* First network command */
-#define WL_NNETCMDS         0x0038          /* Number of network commands */
+#define WL_NNETCMDS         0x0039          /* Number of network commands */
 
 /* Reserved for Bluetooth network devices (see bt_ioctls.h) */
 


### PR DESCRIPTION
## Summary

wireless/bcm43xxx: add get country code support
wireless: add SIOCGIWCOUNTRY (Get country code)

## Impact

N/A

## Testing

Country command with no args to get the ccode:

Get country code:
```
cp> wapi country wlan0
CN
```

Set country code:
```
cp> wapi country wlan0 JP
```

Get country code:
```
cp> wapi country wlan0
JP
```
