### PR TITLE
sama5: add config SAMA5_SYSTEMRESET in arch/arm/src/sama5/Kconfig

### DIFF
--- a/arch/arm/src/sama5/Kconfig
+++ b/arch/arm/src/sama5/Kconfig
@@ -169,6 +169,10 @@ config SAMA5_HAVE_VDEC
 	bool
 	default n
 
+config SAMA5_HAVE_RSTC_EXTRST
+	bool
+	default n
+
 # Summary configurations
 
 config SAMA5_FLEXCOM
@@ -228,6 +232,7 @@ config ARCH_CHIP_SAMA5D3
 	select SAMA5_HAVE_USART1
 	select SAMA5_HAVE_USART2
 	select SAMA5_HAVE_USART3
+	select SAMA5_HAVE_RSTC_EXTRST
 
 config ARCH_CHIP_SAMA5D4
 	bool
@@ -755,6 +760,28 @@ config SAMA5_VDEC
 	depends on SAMA5_HAVE_VDEC
 
 endmenu # SAMA5 Peripheral Support
+
+config SAMA5_SYSTEMRESET
+	bool "Enable System Reset"
+	select ARCH_HAVE_RESET
+	---help---
+		Enable up_systemreset
+
+if SAMA5_SYSTEMRESET && SAMA5_HAVE_RSTC_EXTRST
+
+config SAMA5_EXTRESET_ERST
+	int "Drive External nRST duration"
+	default 0
+	range 0 16
+	---help---
+		Define if the external reset (nRST) will be generated in up_systemreset
+		and for how long:
+
+		- A value of 0 will not drive the external reset
+		- A value of 1-16 will drive the external reset for 2^SAMA5_EXTRESET_ERST
+		  slow clock cycles.
+
+endif # SAMA5_SYSTEMRESET
 
 config SAMA5_PIO_IRQ
 	bool "PIO pin interrupts"

--- a/boards/arm/sama5/giant-board/Kconfig
+++ b/boards/arm/sama5/giant-board/Kconfig
@@ -119,8 +119,4 @@ config SAMA5_SDMMC1_WIDTH_D1_D4
 	default y
 	depends on SAMA5_SDMMC1
 
-config SAMA5_SYSTEMRESET
-	bool "Enable system reset - this will enable the nsh reboot command"
-	select BOARDCTL_RESET
-
 endif # ARCH_BOARD_GIANT_BOARD

--- a/boards/arm/sama5/sama5d2-xult/Kconfig
+++ b/boards/arm/sama5/sama5d2-xult/Kconfig
@@ -127,8 +127,4 @@ config SAMA5_SDMMC1_WIDTH_D1_D4
 	default y
 	depends on SAMA5_SDMMC1
 
-config SAMA5_SYSTEMRESET
-	bool "Enable system reset - this will enable the nsh reboot command"
-	select BOARDCTL_RESET
-
 endif # ARCH_BOARD_SAMA5D2_XULT


### PR DESCRIPTION
## Summary
Config `SAMA5_SYSTEMRESET` is used in `arch/arm/src/sama5/sam_systemreset.c`, but is not defined in `arch/arm/src/sama5/Kconfig`.
Some SAMA5 board's `Kconfig` contain this item, but it is better in SAMA5's `Kconfig`.
SAMA5D2 and SAMA5D4 does not support external reset.

## Impact

## Testing
SAMA5D26
