### PR TITLE
.github/workflows: Add nuttx/source to the safe directory

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -154,6 +154,7 @@ jobs:
             export CCACHE_DIR=`pwd`/ccache
             mkdir $CCACHE_DIR
             export ARTIFACTDIR=`pwd`/buildartifacts
+            git config --global --add safe.directory /github/workspace/sources/nuttx
             cd sources/nuttx/tools/ci
             ./cibuild.sh -A -R -c testlist/${{matrix.boards}}.dat
             ccache -s


### PR DESCRIPTION
## Summary
Report here: https://github.com/apache/incubator-nuttx/pull/6460

## Impact
Fix the CI error

## Testing
Pass CI
