### PR TITLE
driver/syslog:sched lock in syslog to prevent garbled print from multi-thread

### DIFF
--- a/drivers/syslog/Kconfig
+++ b/drivers/syslog/Kconfig
@@ -374,7 +374,7 @@ config SYSLOG_CHARDEV
 		supported.
 
 config SYSLOG_SCHEDLOCK
-	bool "SYSLOG schedlock"
+	bool "SYSLOG schedlock (DANGER: may degrade NuttX Realtime Performance)"
 	default n
 	---help---
 		Use schedlock to make sure syslogs from multiple threads are not garbled.

--- a/drivers/syslog/Kconfig
+++ b/drivers/syslog/Kconfig
@@ -373,4 +373,13 @@ config SYSLOG_CHARDEV
 		byte output with no time-stamping or any other SYSLOG features
 		supported.
 
+config SYSLOG_SCHEDLOCK
+	bool "SYSLOG schedlock"
+	default n
+	---help---
+		Use schedlock to make sure syslogs from multiple threads are not garbled.
+
+		NOTE that this may influence scheduler behavior. Scheduler will be locked
+		when a thread enters syslog, and unlocked when syslog returns.
+
 endmenu # System logging

--- a/drivers/syslog/vsyslog.c
+++ b/drivers/syslog/vsyslog.c
@@ -79,6 +79,10 @@ int nx_vsyslog(int priority, FAR const IPTR char *fmt, FAR va_list *ap)
 #endif
 #endif
 
+#ifdef CONFIG_SYSLOG_SCHEDLOCK
+  sched_lock();
+#endif
+
   /* Wrap the low-level output in a stream object and let lib_vsprintf
    * do the work.
    */
@@ -225,6 +229,10 @@ int nx_vsyslog(int priority, FAR const IPTR char *fmt, FAR va_list *ap)
   /* Flush and destroy the syslog stream buffer */
 
   syslogstream_destroy(&stream);
+#endif
+
+#ifdef CONFIG_SYSLOG_SCHEDLOCK
+  sched_unlock();
 #endif
 
   return ret;


### PR DESCRIPTION
driver/syslog:sched lock in syslog to prevent garbled print from multi-thread

Change-Id: I7e08763790f226ed3ebca5567ed77d698c258ca4
Signed-off-by: 田昕 <tianxin7@xiaomi.com>

## Summary
In our application,  a long input string (approximately 1000bytes)  will be read and printed.  I need to figure out a way to make sure the prints are not garbled.
Since the input is long, I don't want to use CONFIG_SYSLOG_BUFFER and increase syslog buffer size to 1000+ bytes.
After some thought,  sched_lock is my solution. 
FYI, we chose Round-Robin schedule.

This pr also relates to https://github.com/apache/incubator-nuttx/issues/3599. I can't get answer from the discussion, but it is interesting and helpful to read it.

## Impact
Scheduler behavior when sysloging is influenced.

## Testing
Tested on Vela
