### PR TITLE
drivers/lcd: Fix regression on ILI9341 introduced after #6465

### DIFF
--- a/drivers/lcd/ili9341.c
+++ b/drivers/lcd/ili9341.c
@@ -578,7 +578,7 @@ static int ili9341_putrun(FAR struct lcd_dev_s *lcd_dev, fb_coord_t row,
                           fb_coord_t col,
                           FAR const uint8_t * buffer, size_t npixels)
 {
-  FAR struct ili9341_dev_s *dev = (FAR struct ili9341_dev_s *)dev;
+  FAR struct ili9341_dev_s *dev = (FAR struct ili9341_dev_s *)lcd_dev;
   FAR struct ili9341_lcd_s *lcd = dev->lcd;
   FAR const uint16_t *src = (FAR const uint16_t *)buffer;
 


### PR DESCRIPTION
## Summary
This PR intends to provide a fix to a regression on the ILI9341 LCD Controller driver after #6465.

It made the **lvgldemo** application crash at startup.

## Impact
Every target using the ILI9341 LCD Controller.

## Testing
`esp32-wrover-kit:lvgl` once again executes the `lvgldemo` application.

