### PR TITLE
.github/workflows: Add nuttx/source to the safe directory, covering apps

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -155,6 +155,7 @@ jobs:
             mkdir $CCACHE_DIR
             export ARTIFACTDIR=`pwd`/buildartifacts
             git config --global --add safe.directory /github/workspace/sources/nuttx
+            git config --global --add safe.directory /github/workspace/sources/apps
             cd sources/nuttx/tools/ci
             ./cibuild.sh -A -R -c testlist/${{matrix.boards}}.dat
             ccache -s


### PR DESCRIPTION
## Summary
Report here: https://github.com/apache/incubator-nuttx/pull/6460

## Impact
Fix the CI error

## Testing
Pass CI

Signed-off-by: qinwei1 <qinwei1@xiaomi.com>