### PR TITLE
arch/stm32_capture fix SMC register offset address and completion slave mode selection

### DIFF
--- a/arch/arm/src/stm32/stm32_capture.c
+++ b/arch/arm/src/stm32/stm32_capture.c
@@ -661,7 +661,7 @@ static int stm32_cap_setclock(struct stm32_cap_dev_s *dev,
         return ERROR;
     }
 
-  stm32_modifyreg16(priv, STM32_BTIM_EGR_OFFSET, GTIM_SMCR_SMS_MASK, regval);
+  stm32_modifyreg16(priv, STM32_GTIM_SMCR_OFFSET, GTIM_SMCR_SMS_MASK, regval);
 
   /* Set Maximum */
 

--- a/arch/arm/src/stm32/stm32_capture.c
+++ b/arch/arm/src/stm32/stm32_capture.c
@@ -651,17 +651,40 @@ static int stm32_cap_setclock(struct stm32_cap_dev_s *dev,
           regval = GTIM_SMCR_DISAB;
           break;
 
+      case STM32_CAP_CLK_ENC1:
+          regval = GTIM_SMCR_ENCMD1;
+          break;
+
+      case STM32_CAP_CLK_ENC2:
+          regval = GTIM_SMCR_ENCMD2;
+          break;
+
+      case STM32_CAP_CLK_ENC3:
+          regval = GTIM_SMCR_ENCMD3;
+          break;
+
+      case STM32_CAP_CLK_RST:
+          regval = GTIM_SMCR_RESET;
+          break;
+
+      case STM32_CAP_CLK_GAT:
+          regval = GTIM_SMCR_GATED;
+          break;
+
+      case STM32_CAP_CLK_TRG:
+          regval = GTIM_SMCR_TRIGGER;
+          break;
+
       case STM32_CAP_CLK_EXT:
           regval = GTIM_SMCR_EXTCLK1;
           break;
-
-      /* TODO: Add other case */
 
       default:
         return ERROR;
     }
 
-  stm32_modifyreg16(priv, STM32_GTIM_SMCR_OFFSET, GTIM_SMCR_SMS_MASK, regval);
+  stm32_modifyreg16(priv, STM32_GTIM_SMCR_OFFSET,
+                    GTIM_SMCR_SMS_MASK, regval);
 
   /* Set Maximum */
 

--- a/arch/arm/src/stm32/stm32_capture.h
+++ b/arch/arm/src/stm32/stm32_capture.h
@@ -127,9 +127,13 @@ typedef enum
 typedef enum
 {
   STM32_CAP_CLK_INT = 0,
+  STM32_CAP_CLK_ENC1,
+  STM32_CAP_CLK_ENC2,
+  STM32_CAP_CLK_ENC3,
+  STM32_CAP_CLK_RST,
+  STM32_CAP_CLK_GAT,
+  STM32_CAP_CLK_TRG,
   STM32_CAP_CLK_EXT,
-
-  /* TODO: Add other clock */
 } stm32_cap_clk_t;
 
 /* Capture flags */


### PR DESCRIPTION
## Summary
1、the SMC register offset address is error , it should be fixed;
2、there just two slave mode can be set at present, it can be completed.
## Impact
nothing
## Testing
ci
