### PR TITLE
drivers/lcd: getplaneinfo fix for ST7789,ST7565 and skeleton driver

### DIFF
--- a/drivers/lcd/skeleton.c
+++ b/drivers/lcd/skeleton.c
@@ -301,6 +301,7 @@ static int skel_getplaneinfo(FAR struct lcd_dev_s *dev,
   DEBUGASSERT(dev && pinfo && planeno == 0);
   ginfo("planeno: %d bpp: %d\n", planeno, g_planeinfo.bpp);
   memcpy(pinfo, &g_planeinfo, sizeof(struct lcd_planeinfo_s));
+  pinfo->dev = dev;
   return OK;
 }
 

--- a/drivers/lcd/st7565.c
+++ b/drivers/lcd/st7565.c
@@ -723,6 +723,7 @@ static int st7565_getplaneinfo(FAR struct lcd_dev_s *dev,
   DEBUGASSERT(dev && pinfo && planeno == 0);
   ginfo("planeno: %d bpp: %d\n", planeno, g_planeinfo.bpp);
   memcpy(pinfo, &g_planeinfo, sizeof(struct lcd_planeinfo_s));
+  pinfo->dev = dev;
   return OK;
 }
 

--- a/drivers/lcd/st7789.c
+++ b/drivers/lcd/st7789.c
@@ -646,6 +646,7 @@ static int st7789_getplaneinfo(FAR struct lcd_dev_s *dev,
 #endif
   pinfo->buffer = (FAR uint8_t *)priv->runbuffer; /* Run scratch buffer */
   pinfo->bpp    = priv->bpp;                      /* Bits-per-pixel */
+  pinfo->dev    = dev;                            /* The lcd device */
   return OK;
 }
 


### PR DESCRIPTION
## Summary
In #6465, the new member `struct lcd_dev_s *dev` is added to `struct lcd_planeinfo_s`.
The member must be initialized in getplaneinfo method. But ST7789, ST7768 and skeleton LCD drivers lacks it.

The `raspberrypi-pico:displaypack` configuration crashes because of this problem.
This PR fixes it.

## Impact
Every target using ST7789 and ST7567 LCD controllers.

## Testing
`raspberrypi-pico:displaypack` works.