### PR TITLE
net: Ensure sendmsg and sendfile return -EAGAIN in case of timeout

### DIFF
--- a/net/icmp/icmp_sendmsg.c
+++ b/net/icmp/icmp_sendmsg.c
@@ -439,6 +439,10 @@ ssize_t icmp_sendmsg(FAR struct socket *psock, FAR struct msghdr *msg,
 
                   ret = -ENETUNREACH;
                 }
+              else
+                {
+                  ret = -EAGAIN;
+                }
             }
 
           state.snd_result = ret;

--- a/net/icmpv6/icmpv6_sendmsg.c
+++ b/net/icmpv6/icmpv6_sendmsg.c
@@ -430,6 +430,10 @@ ssize_t icmpv6_sendmsg(FAR struct socket *psock, FAR struct msghdr *msg,
 
                   ret = -ENETUNREACH;
                 }
+              else
+                {
+                  ret = -EAGAIN;
+                }
             }
 
           state.snd_result = ret;

--- a/net/sixlowpan/sixlowpan_send.c
+++ b/net/sixlowpan/sixlowpan_send.c
@@ -258,6 +258,7 @@ int sixlowpan_send(FAR struct net_driver_s *dev,
             {
               if (ret == -ETIMEDOUT)
                 {
+                  ret = -EAGAIN;
                   neighbor_notreachable(dev);
                 }
 

--- a/net/sixlowpan/sixlowpan_tcpsend.c
+++ b/net/sixlowpan/sixlowpan_tcpsend.c
@@ -660,6 +660,11 @@ static int sixlowpan_send_packet(FAR struct socket *psock,
               ret = net_timedwait(&sinfo.s_waitsem, timeout);
               if (ret != -ETIMEDOUT || acked == sinfo.s_acked)
                 {
+                  if (ret == -ETIMEDOUT)
+                    {
+                      ret = -EAGAIN;
+                    }
+
                   break; /* Timeout without any progress */
                 }
             }

--- a/net/tcp/tcp_send_unbuffered.c
+++ b/net/tcp/tcp_send_unbuffered.c
@@ -680,6 +680,11 @@ ssize_t psock_tcp_send(FAR struct socket *psock,
                                   _SO_TIMEOUT(conn->sconn.s_sndtimeo));
               if (ret != -ETIMEDOUT || acked == state.snd_acked)
                 {
+                  if (ret == -ETIMEDOUT)
+                    {
+                      ret = -EAGAIN;
+                    }
+
                   break; /* Timeout without any progress */
                 }
             }

--- a/net/tcp/tcp_sendfile.c
+++ b/net/tcp/tcp_sendfile.c
@@ -583,6 +583,11 @@ ssize_t tcp_sendfile(FAR struct socket *psock, FAR struct file *infile,
               &state.snd_sem, _SO_TIMEOUT(conn->sconn.s_sndtimeo));
       if (ret != -ETIMEDOUT || acked == state.snd_acked)
         {
+          if (ret == -ETIMEDOUT)
+            {
+              ret = -EAGAIN;
+            }
+
           break; /* Successful completion or timeout without any progress */
         }
     }

--- a/sched/mqueue/mq_send.c
+++ b/sched/mqueue/mq_send.c
@@ -91,7 +91,7 @@ int file_mq_send(FAR struct file *mq, FAR const char *msg, size_t msglen,
    * - Immediately if we are called from an interrupt handler.
    * - Immediately if the message queue is not full, or
    * - After successfully waiting for the message queue to become
-   *   non-FULL.  This would fail with EAGAIN, EINTR, or ETIMEOUT.
+   *   non-FULL.  This would fail with EAGAIN, EINTR, or ETIMEDOUT.
    */
 
   flags = enter_critical_section();

--- a/sched/mqueue/mq_sndinternal.c
+++ b/sched/mqueue/mq_sndinternal.c
@@ -198,11 +198,11 @@ FAR struct mqueue_msg_s *nxmq_alloc_msg(void)
  *   On success, nxmq_wait_send() returns 0 (OK); a negated errno value is
  *   returned on any failure:
  *
- *   EAGAIN   The queue was full and the O_NONBLOCK flag was set for the
- *            message queue description referred to by msgq.
- *   EINTR    The call was interrupted by a signal handler.
- *   ETIMEOUT A timeout expired before the message queue became non-full
- *            (mq_timedsend only).
+ *   EAGAIN    The queue was full and the O_NONBLOCK flag was set for the
+ *             message queue description referred to by msgq.
+ *   EINTR     The call was interrupted by a signal handler.
+ *   ETIMEDOUT A timeout expired before the message queue became non-full
+ *             (mq_timedsend only).
  *
  * Assumptions/restrictions:
  * - The caller has verified the input parameters using nxmq_verify_send().
@@ -272,7 +272,7 @@ int nxmq_wait_send(FAR struct mqueue_inode_s *msgq, int oflags)
       /* When we resume at this point, either (1) the message queue
        * is no longer empty, or (2) the wait has been interrupted by
        * a signal.  We can detect the latter case be examining the
-       * per-task errno value (should be EINTR or ETIMEOUT).
+       * per-task errno value (should be EINTR or ETIMEDOUT).
        */
 
       if (rtcb->errcode != OK)

--- a/sched/mqueue/mq_timedsend.c
+++ b/sched/mqueue/mq_timedsend.c
@@ -251,7 +251,7 @@ int file_mq_timedsend(FAR struct file *mq, FAR const char *msg,
   ret = nxmq_wait_send(msgq, mq->f_oflags);
 
   /* This may return with an error and errno set to either EINTR
-   * or ETIMEOUT.  Cancel the watchdog timer in any event.
+   * or ETIMEDOUT.  Cancel the watchdog timer in any event.
    */
 
   wd_cancel(&rtcb->waitdog);


### PR DESCRIPTION
## Summary
instead of -ETIMEDOUT, as specify here:
https://pubs.opengroup.org/onlinepubs/009604599/functions/sendmsg.html
https://man7.org/linux/man-pages/man2/sendfile.2.html

## Impact
More compatible to standard

## Testing
Pass CI
