### PR TITLE
wireless/bcm43xxx: enable tx flow control to improve performance

### DIFF
--- a/drivers/wireless/ieee80211/bcm43xxx/bcmf_sdio.c
+++ b/drivers/wireless/ieee80211/bcm43xxx/bcmf_sdio.c
@@ -1065,11 +1065,9 @@ struct bcmf_sdio_frame *bcmf_sdio_allocate_frame(FAR struct bcmf_dev_s *priv,
           DEBUGPANIC();
         }
 
-#if 0
       if (!tx ||
           sbus->tx_queue_count <
-            CONFIG_IEEE80211_BROADCOM_FRAME_POOL_SIZE - 1)
-#endif
+            CONFIG_IEEE80211_BROADCOM_FRAME_POOL_SIZE / 2)
         {
           if ((entry = bcmf_dqueue_pop_tail(&sbus->free_queue)) != NULL)
             {

--- a/drivers/wireless/ieee80211/bcm43xxx/bcmf_sdio.h
+++ b/drivers/wireless/ieee80211/bcm43xxx/bcmf_sdio.h
@@ -106,6 +106,7 @@ struct bcmf_sdio_dev_s
   dq_queue_t free_queue;           /* Queue of available frames */
   dq_queue_t tx_queue;             /* Queue of frames to transmit */
   dq_queue_t rx_queue;             /* Queue of frames used to receive */
+  volatile int tx_queue_count;     /* Count of items in TX queue */
 };
 
 /* Structure used to manage SDIO frames */


### PR DESCRIPTION
## Summary

1. wireless/bcm43xxx: enable tx flow control to improve performance

RX/TX shared free queue on bcmf implementation, if TX occupies the
free queue completely, RX will trigger read abort because it cannot
successfully alloc buffer for the shared free queue. This commit will
limit the sending entries of tx and prevent rx triggering abort

2. Revert "wireless/bcm43xxx: remove unused tx_queue_count"


## Impact

N/A

## Testing

bcm43013 iperf test