### PR TITLE
arch/arm/armv7-m: Fix error link argument for compiler-rt

### DIFF
--- a/arch/arm/src/armv7-m/Toolchain.defs
+++ b/arch/arm/src/armv7-m/Toolchain.defs
@@ -268,7 +268,7 @@ ifeq ($(CONFIG_ARMV7M_TOOLCHAIN),CLANG)
   ifeq ($(wildcard $(COMPILER_RT_LIB)),)
     # if "--print-libgcc-file-name" unable to find the correct libgcc PATH
     # then go ahead and try "--print-file-name"
-    COMPILER_RT_LIB := -$(wildcard $(shell $(CC) $(ARCHCPUFLAGS) --print-file-name $(notdir $(COMPILER_RT_LIB))))
+    COMPILER_RT_LIB := $(wildcard $(shell $(CC) $(ARCHCPUFLAGS) --print-file-name $(notdir $(COMPILER_RT_LIB))))
   endif
 endif
 


### PR DESCRIPTION
## Summary
Fix:
```
ld.lld: error: unknown argument '-/home/huang/Work/vwear/prebuilts/clang/linux/arm/bin/../lib/clang-runtimes/armv7em_hard_fpv4_sp_d16/lib/libclang_rt.builtins-armv7em.a'
```
## Impact
None
## Testing
stm32f429i-disco
