### PR TITLE
Added -fPIC option when building jlink-nuttx.so.

### DIFF
--- a/tools/Makefile.host
+++ b/tools/Makefile.host
@@ -228,7 +228,7 @@ endif
 # jlink-nuttx - Create jlink GDBServer nuttx plugin
 
 jlink-nuttx$(HOSTDYNEXT): jlink-nuttx.c
-	$(Q) $(HOSTCC) $(HOSTCFLAGS) -shared jlink-nuttx.c -o jlink-nuttx$(HOSTDYNEXT)
+	$(Q) $(HOSTCC) $(HOSTCFLAGS) -shared -fPIC jlink-nuttx.c -o jlink-nuttx$(HOSTDYNEXT)
 
 ifdef HOSTDYNEXT
 jlink-nuttx: jlink-nuttx$(HOSTDYNEXT)


### PR DESCRIPTION
## Summary

The NuttX-aware JLink plug-in cannot be built successfully in some distros.
At least in my case, the compiler was requesting for the option `-fPIC` to be enabled.

## Impact

The plug-in builds and runs correctly.

## Testing

Built successfully, and tested on an actual target.  
It works correctly.
