### PR TITLE
Make sensor mpu60x0 more configurable in menuconfig

### DIFF
--- a/drivers/sensors/Kconfig
+++ b/drivers/sensors/Kconfig
@@ -738,6 +738,52 @@ config MPU60X0_EXTI
 		to the sampling rate chosen during operation.
 		Default:  No interrupts or blocking, i.e. user-driven sampling.
 
+config MPU60X0_EXT_SYNC_SET
+	int "MPU60x0 frame sync bit position"
+	default 0
+	---help---
+		EXT_SYNC_SET[2..0]
+		EXT_SYNC_SET: frame sync bit position
+		(see datasheet, it's ... complicated)
+
+config MPU60X0_DLPF_CFG
+	int "MPU60x0 digital low-pass filter bandwidth"
+	default 1
+	---help---
+		DLPF_CFG[2..0]
+		DLPF_CFG: digital low-pass filter bandwidth
+		(see datasheet, it's ... complicated)
+
+config MPU60X0_GYRO_FS_SEL
+	int "MPU60x0 Gyro FS_SEL"
+	default 2
+	---help---
+		Sets the @fs_sel bit in GYRO_CONFIG to the value provided. Per 
+		the	datasheet, the meaning of @fs_sel is as follows:
+		GYRO_CONFIG(0x1b) :   XG_ST YG_ST ZG_ST FS_SEL1 FS_SEL0 x  x  x
+		XG_ST, YG_ST, ZG_ST  :  self-test (unsupported in this driver)
+				1 -> activate self-test on X, Y, and/or Z gyros
+		FS_SEL[10] : full-scale range select
+				0 -> ±  250 deg/sec
+				1 -> ±  500 deg/sec
+				2 -> ± 1000 deg/sec
+				3 -> ± 2000 deg/sec
+
+config MPU60X0_ACCEL_AFS_SEL
+	int "MPU60x0 Accelerometer AFS_SEL"
+	default 2
+	---help---
+		Sets the @afs_sel bit in ACCEL_CONFIG to the value provided. Per
+		the datasheet, the meaning of @afs_sel is as follows:
+		ACCEL_CONFIG(0x1c) :   XA_ST YA_ST ZA_ST AFS_SEL1 AFS_SEL0 x  x  x
+		XA_ST, YA_ST, ZA_ST  :  self-test (unsupported in this driver)
+				1 -> activate self-test on X, Y, and/or Z accelerometers
+		AFS_SEL[10] : full-scale range select
+				0 -> ±  2 g
+				1 -> ±  4 g
+				2 -> ±  8 g
+				3 -> ± 16 g
+
 endif # SENSORS_MPU60X0
 
 config SENSORS_MAX44009

--- a/drivers/sensors/mpu60x0.c
+++ b/drivers/sensors/mpu60x0.c
@@ -731,17 +731,20 @@ static int mpu_reset(FAR struct mpu_dev_s *dev)
 
   __mpu_write_pwr_mgmt_2(dev, 0);
 
-  /* No FSYNC, set accel LPF at 184 Hz, gyro LPF at 188 Hz */
+  /* default No FSYNC, set accel LPF at 184 Hz, gyro LPF at 188 Hz in
+   * menuconfig
+   */
 
-  __mpu_write_config(dev, 0, 1);
+  __mpu_write_config(dev, CONFIG_MPU60X0_EXT_SYNC_SET,
+                     CONFIG_MPU60X0_DLPF_CFG);
 
-  /* ± 1000 deg/sec */
+  /* default ± 1000 deg/sec in menuconfig */
 
-  __mpu_write_gyro_config(dev, 2);
+  __mpu_write_gyro_config(dev, CONFIG_MPU60X0_GYRO_FS_SEL);
 
-  /* ± 8g */
+  /* default ± 8g in menuconfig */
 
-  __mpu_write_accel_config(dev, 2);
+  __mpu_write_accel_config(dev, CONFIG_MPU60X0_ACCEL_AFS_SEL);
 
   /* clear INT on any read (we aren't using that pin right now) */
 


### PR DESCRIPTION
## Summary
add configs in menuconfig for mpu60x0 sensor

## Testing
passed with ESP32C3 and MPU6050
