### PR TITLE
Remove "0x" prefix preceding "%p" specifier on format string

### DIFF
--- a/arch/arm/src/arm/arm_schedulesigaction.c
+++ b/arch/arm/src/arm/arm_schedulesigaction.c
@@ -77,7 +77,7 @@
 
 void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 {
-  sinfo("tcb=0x%p sigdeliver=0x%p\n", tcb, sigdeliver);
+  sinfo("tcb=%p sigdeliver=%p\n", tcb, sigdeliver);
 
   /* Refuse to handle nested signal actions */
 
@@ -87,7 +87,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
        * being delivered to the currently executing task.
        */
 
-      sinfo("rtcb=0x%p CURRENT_REGS=0x%p\n", this_task(), CURRENT_REGS);
+      sinfo("rtcb=%p CURRENT_REGS=%p\n", this_task(), CURRENT_REGS);
 
       if (tcb == this_task())
         {

--- a/arch/arm/src/armv6-m/arm_schedulesigaction.c
+++ b/arch/arm/src/armv6-m/arm_schedulesigaction.c
@@ -81,7 +81,7 @@
 #ifndef CONFIG_SMP
 void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 {
-  sinfo("tcb=0x%p sigdeliver=0x%p\n", tcb, sigdeliver);
+  sinfo("tcb=%p sigdeliver=%p\n", tcb, sigdeliver);
   DEBUGASSERT(tcb != NULL && sigdeliver != NULL);
 
   /* Refuse to handle nested signal actions */
@@ -92,7 +92,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
        * to the currently executing task.
        */
 
-      sinfo("rtcb=0x%p CURRENT_REGS=0x%p\n", this_task(), CURRENT_REGS);
+      sinfo("rtcb=%p CURRENT_REGS=%p\n", this_task(), CURRENT_REGS);
 
       if (tcb == this_task())
         {
@@ -213,7 +213,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
   int cpu;
   int me;
 
-  sinfo("tcb=0x%p sigdeliver=0x%p\n", tcb, sigdeliver);
+  sinfo("tcb=%p sigdeliver=%p\n", tcb, sigdeliver);
 
   /* Refuse to handle nested signal actions */
 
@@ -223,7 +223,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
        * to task that is currently executing on any CPU.
        */
 
-      sinfo("rtcb=0x%p CURRENT_REGS=0x%p\n", this_task(), CURRENT_REGS);
+      sinfo("rtcb=%p CURRENT_REGS=%p\n", this_task(), CURRENT_REGS);
 
       if (tcb->task_state == TSTATE_TASK_RUNNING)
         {

--- a/arch/arm/src/armv7-a/arm_schedulesigaction.c
+++ b/arch/arm/src/armv7-a/arm_schedulesigaction.c
@@ -80,7 +80,7 @@
 #ifndef CONFIG_SMP
 void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 {
-  sinfo("tcb=0x%p sigdeliver=0x%p\n", tcb, sigdeliver);
+  sinfo("tcb=%p sigdeliver=%p\n", tcb, sigdeliver);
 
   /* Refuse to handle nested signal actions */
 
@@ -90,7 +90,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
        * to task that is currently executing on this CPU.
        */
 
-      sinfo("rtcb=0x%p CURRENT_REGS=0x%p\n", this_task(), CURRENT_REGS);
+      sinfo("rtcb=%p CURRENT_REGS=%p\n", this_task(), CURRENT_REGS);
 
       if (tcb == this_task())
         {
@@ -212,7 +212,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
   int cpu;
   int me;
 
-  sinfo("tcb=0x%p sigdeliver=0x%p\n", tcb, sigdeliver);
+  sinfo("tcb=%p sigdeliver=%p\n", tcb, sigdeliver);
 
   /* Refuse to handle nested signal actions */
 
@@ -222,7 +222,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
        * to task that is currently executing on any CPU.
        */
 
-      sinfo("rtcb=0x%p CURRENT_REGS=0x%p\n", this_task(), CURRENT_REGS);
+      sinfo("rtcb=%p CURRENT_REGS=%p\n", this_task(), CURRENT_REGS);
 
       if (tcb->task_state == TSTATE_TASK_RUNNING)
         {

--- a/arch/arm/src/armv7-m/arm_schedulesigaction.c
+++ b/arch/arm/src/armv7-m/arm_schedulesigaction.c
@@ -82,7 +82,7 @@
 #ifndef CONFIG_SMP
 void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 {
-  sinfo("tcb=0x%p sigdeliver=0x%p\n", tcb, sigdeliver);
+  sinfo("tcb=%p sigdeliver=%p\n", tcb, sigdeliver);
   DEBUGASSERT(tcb != NULL && sigdeliver != NULL);
 
   /* Refuse to handle nested signal actions */
@@ -93,7 +93,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
        * to the currently executing task.
        */
 
-      sinfo("rtcb=0x%p CURRENT_REGS=0x%p\n", this_task(), CURRENT_REGS);
+      sinfo("rtcb=%p CURRENT_REGS=%p\n", this_task(), CURRENT_REGS);
 
       if (tcb == this_task())
         {
@@ -222,7 +222,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
   int cpu;
   int me;
 
-  sinfo("tcb=0x%p sigdeliver=0x%p\n", tcb, sigdeliver);
+  sinfo("tcb=%p sigdeliver=%p\n", tcb, sigdeliver);
 
   /* Refuse to handle nested signal actions */
 
@@ -232,7 +232,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
        * to task that is currently executing on any CPU.
        */
 
-      sinfo("rtcb=0x%p CURRENT_REGS=0x%p\n", this_task(), CURRENT_REGS);
+      sinfo("rtcb=%p CURRENT_REGS=%p\n", this_task(), CURRENT_REGS);
 
       if (tcb->task_state == TSTATE_TASK_RUNNING)
         {

--- a/arch/arm/src/armv7-r/arm_schedulesigaction.c
+++ b/arch/arm/src/armv7-r/arm_schedulesigaction.c
@@ -77,7 +77,7 @@
 
 void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 {
-  sinfo("tcb=0x%p sigdeliver=0x%p\n", tcb, sigdeliver);
+  sinfo("tcb=%p sigdeliver=%p\n", tcb, sigdeliver);
 
   /* Refuse to handle nested signal actions */
 
@@ -87,7 +87,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
        * to the currently executing task.
        */
 
-      sinfo("rtcb=0x%p CURRENT_REGS=0x%p\n", this_task(), CURRENT_REGS);
+      sinfo("rtcb=%p CURRENT_REGS=%p\n", this_task(), CURRENT_REGS);
 
       if (tcb == this_task())
         {

--- a/arch/arm/src/armv8-m/arm_schedulesigaction.c
+++ b/arch/arm/src/armv8-m/arm_schedulesigaction.c
@@ -82,7 +82,7 @@
 #ifndef CONFIG_SMP
 void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 {
-  sinfo("tcb=0x%p sigdeliver=0x%p\n", tcb, sigdeliver);
+  sinfo("tcb=%p sigdeliver=%p\n", tcb, sigdeliver);
   DEBUGASSERT(tcb != NULL && sigdeliver != NULL);
 
   /* Refuse to handle nested signal actions */
@@ -93,7 +93,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
        * to the currently executing task.
        */
 
-      sinfo("rtcb=0x%p CURRENT_REGS=0x%p\n", this_task(), CURRENT_REGS);
+      sinfo("rtcb=%p CURRENT_REGS=%p\n", this_task(), CURRENT_REGS);
 
       if (tcb == this_task())
         {
@@ -222,7 +222,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
   int cpu;
   int me;
 
-  sinfo("tcb=0x%p sigdeliver=0x%p\n", tcb, sigdeliver);
+  sinfo("tcb=%p sigdeliver=%p\n", tcb, sigdeliver);
 
   /* Refuse to handle nested signal actions */
 
@@ -232,7 +232,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
        * to task that is currently executing on any CPU.
        */
 
-      sinfo("rtcb=0x%p CURRENT_REGS=0x%p\n", this_task(), CURRENT_REGS);
+      sinfo("rtcb=%p CURRENT_REGS=%p\n", this_task(), CURRENT_REGS);
 
       if (tcb->task_state == TSTATE_TASK_RUNNING)
         {

--- a/arch/arm/src/lc823450/lc823450_usbdev.c
+++ b/arch/arm/src/lc823450/lc823450_usbdev.c
@@ -401,7 +401,7 @@ static int lc823450_epconfigure(struct usbdev_ep_s *ep,
       priv->eplist[epnum].ep.maxpacket = GETUINT16(desc->mxpacketsize);
     }
 
-  DPRINTF("epnum = %d, ep = 0x%p, max = %d, speed = 0x%x, in = 0x%x\n",
+  DPRINTF("epnum = %d, ep = %p, max = %d, speed = 0x%x, in = 0x%x\n",
           epnum, ep, priv->eplist[epnum].ep.maxpacket,
           priv->usbdev.speed, priv->eplist[epnum].in);
 

--- a/arch/arm/src/samd5e5/sam_tc.c
+++ b/arch/arm/src/samd5e5/sam_tc.c
@@ -729,7 +729,7 @@ TC_HANDLE sam_tc_allocate(int tc, int frequency)
 
   /* Return an opaque reference to the tc */
 
-  tmrinfo("Returning 0x%p\n", priv);
+  tmrinfo("Returning %p\n", priv);
   return (TC_HANDLE)priv;
 }
 

--- a/arch/arm/src/samd5e5/sam_usb.c
+++ b/arch/arm/src/samd5e5/sam_usb.c
@@ -7613,7 +7613,7 @@ static ssize_t sam_transfer(struct usbhost_driver_s *drvr,
   unsigned int idx = (unsigned int)ep;
   ssize_t nbytes;
 
-  uwarn("pipe%d buffer:0x%p buflen:%d\n",  idx, buffer, buflen);
+  uwarn("pipe%d buffer:%p buflen:%d\n",  idx, buffer, buflen);
 
   DEBUGASSERT(priv && buffer && idx < SAM_USB_NENDPOINTS && buflen > 0);
   pipe = &priv->pipelist[idx];

--- a/arch/arm/src/tiva/common/tiva_adclib.c
+++ b/arch/arm/src/tiva/common/tiva_adclib.c
@@ -397,7 +397,7 @@ void tiva_adc_irq_attach(uint8_t adc, uint8_t sse, xcpt_t isr)
   int irq = sse2irq[SSE_IDX(adc, sse)];
 
 #ifdef CONFIG_DEBUG_ANALOG
-  ainfo("assigning ISR=0x%p to ADC%d SSE%d IRQ=0x%02x...\n",
+  ainfo("assigning ISR=%p to ADC%d SSE%d IRQ=0x%02x...\n",
         isr, adc, sse, irq);
 #endif
 

--- a/arch/arm/src/tlsr82/tc32/tc32_schedulesigaction.c
+++ b/arch/arm/src/tlsr82/tc32/tc32_schedulesigaction.c
@@ -77,7 +77,7 @@
 
 void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 {
-  sinfo("tcb=0x%p sigdeliver=0x%p\n", tcb, sigdeliver);
+  sinfo("tcb=%p sigdeliver=%p\n", tcb, sigdeliver);
 
   /* Refuse to handle nested signal actions */
 
@@ -87,7 +87,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
        * being delivered to the currently executing task.
        */
 
-      sinfo("rtcb=0x%p CURRENT_REGS=0x%p\n", this_task(), CURRENT_REGS);
+      sinfo("rtcb=%p CURRENT_REGS=%p\n", this_task(), CURRENT_REGS);
 
       if (tcb == this_task())
         {

--- a/arch/arm/src/tlsr82/tlsr82_pwm.c
+++ b/arch/arm/src/tlsr82/tlsr82_pwm.c
@@ -300,7 +300,7 @@ static int pwm_config(struct tlsr82_pwmtimer_s *priv,
 
   if (priv == NULL || info == NULL)
     {
-      pwmerr("priv or info is null, priv=0x%p info=0x%p\n", priv, info);
+      pwmerr("priv or info is null, priv=%p info=%p\n", priv, info);
       return -EINVAL;
     }
 

--- a/arch/avr/src/avr/up_schedulesigaction.c
+++ b/arch/avr/src/avr/up_schedulesigaction.c
@@ -79,7 +79,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 {
   uintptr_t reg_ptr = (uintptr_t)up_sigdeliver;
 
-  sinfo("tcb=0x%p sigdeliver=0x%p\n", tcb, sigdeliver);
+  sinfo("tcb=%p sigdeliver=%p\n", tcb, sigdeliver);
 
   /* Refuse to handle nested signal actions */
 
@@ -89,7 +89,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
        * being delivered to the currently executing task.
        */
 
-      sinfo("rtcb=0x%p g_current_regs=0x%p\n",
+      sinfo("rtcb=%p g_current_regs=%p\n",
             this_task(), g_current_regs);
 
       if (tcb == this_task())

--- a/arch/avr/src/avr32/up_schedulesigaction.c
+++ b/arch/avr/src/avr32/up_schedulesigaction.c
@@ -77,7 +77,7 @@
 
 void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 {
-  sinfo("tcb=0x%p sigdeliver=0x%p\n", tcb, sigdeliver);
+  sinfo("tcb=%p sigdeliver=%p\n", tcb, sigdeliver);
 
   /* Refuse to handle nested signal actions */
 
@@ -87,7 +87,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
        * being delivered to the currently executing task.
        */
 
-      sinfo("rtcb=0x%p g_current_regs=0x%p\n",
+      sinfo("rtcb=%p g_current_regs=%p\n",
             this_task(), g_current_regs);
 
       if (tcb == this_task())

--- a/arch/ceva/src/common/up_schedulesigaction.c
+++ b/arch/ceva/src/common/up_schedulesigaction.c
@@ -74,7 +74,7 @@
 
 void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 {
-  sinfo("tcb=0x%p sigdeliver=0x%p\n", tcb, sigdeliver);
+  sinfo("tcb=%p sigdeliver=%p\n", tcb, sigdeliver);
   DEBUGASSERT(tcb != NULL && sigdeliver != NULL);
 
   /* Refuse to handle nested signal actions */
@@ -85,7 +85,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
        * to task that is currently executing on any CPU.
        */
 
-      sinfo("rtcb=0x%p CURRENT_REGS=0x%p\n", this_task(), CURRENT_REGS);
+      sinfo("rtcb=%p CURRENT_REGS=%p\n", this_task(), CURRENT_REGS);
 
       if (tcb->task_state == TSTATE_TASK_RUNNING)
         {

--- a/arch/mips/src/mips32/mips_schedulesigaction.c
+++ b/arch/mips/src/mips32/mips_schedulesigaction.c
@@ -80,7 +80,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 {
   uint32_t status;
 
-  sinfo("tcb=0x%p sigdeliver=0x%p\n", tcb, sigdeliver);
+  sinfo("tcb=%p sigdeliver=%p\n", tcb, sigdeliver);
 
   /* Refuse to handle nested signal actions */
 
@@ -90,7 +90,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
        * being delivered to the currently executing task.
        */
 
-      sinfo("rtcb=0x%p CURRENT_REGS=0x%p\n",
+      sinfo("rtcb=%p CURRENT_REGS=%p\n",
             this_task(), CURRENT_REGS);
 
       if (tcb == this_task())

--- a/arch/misoc/src/lm32/lm32_schedulesigaction.c
+++ b/arch/misoc/src/lm32/lm32_schedulesigaction.c
@@ -77,7 +77,7 @@
 
 void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 {
-  sinfo("tcb=0x%p sigdeliver=0x%p\n", tcb, sigdeliver);
+  sinfo("tcb=%p sigdeliver=%p\n", tcb, sigdeliver);
 
   /* Refuse to handle nested signal actions */
 
@@ -87,7 +87,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
        * being delivered to the currently executing task.
        */
 
-      sinfo("rtcb=0x%p g_current_regs=0x%p\n",
+      sinfo("rtcb=%p g_current_regs=%p\n",
             this_task(), g_current_regs);
 
       if (tcb == this_task())

--- a/arch/misoc/src/minerva/minerva_schedulesigaction.c
+++ b/arch/misoc/src/minerva/minerva_schedulesigaction.c
@@ -78,7 +78,7 @@
 
 void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 {
-  sinfo("tcb=0x%p sigdeliver=0x%p\n", tcb, sigdeliver);
+  sinfo("tcb=%p sigdeliver=%p\n", tcb, sigdeliver);
 
   /* Refuse to handle nested signal actions */
 
@@ -88,7 +88,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
        * to the currently executing task.
        */
 
-      sinfo("rtcb=0x%p g_current_regs=0x%p\n", this_task(), g_current_regs);
+      sinfo("rtcb=%p g_current_regs=%p\n", this_task(), g_current_regs);
 
       if (tcb == this_task())
         {

--- a/arch/or1k/src/common/up_schedulesigaction.c
+++ b/arch/or1k/src/common/up_schedulesigaction.c
@@ -76,7 +76,7 @@
 
 void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 {
-  sinfo("tcb=0x%p sigdeliver=0x%p\n", tcb, sigdeliver);
+  sinfo("tcb=%p sigdeliver=%p\n", tcb, sigdeliver);
 
   /* Refuse to handle nested signal actions */
 
@@ -86,7 +86,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
        * being delivered to the currently executing task.
        */
 
-      sinfo("rtcb=0x%p CURRENT_REGS=0x%p\n", this_task(), CURRENT_REGS);
+      sinfo("rtcb=%p CURRENT_REGS=%p\n", this_task(), CURRENT_REGS);
 
       if (tcb == this_task())
         {

--- a/arch/renesas/src/m16c/m16c_schedulesigaction.c
+++ b/arch/renesas/src/m16c/m16c_schedulesigaction.c
@@ -76,7 +76,7 @@
 
 void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 {
-  sinfo("tcb=0x%p sigdeliver=0x%p\n", tcb, sigdeliver);
+  sinfo("tcb=%p sigdeliver=%p\n", tcb, sigdeliver);
 
   /* Refuse to handle nested signal actions */
 
@@ -86,7 +86,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
        * being delivered to the currently executing task.
        */
 
-      sinfo("rtcb=0x%p g_current_regs=0x%p\n", this_task(), g_current_regs);
+      sinfo("rtcb=%p g_current_regs=%p\n", this_task(), g_current_regs);
 
       if (tcb == this_task())
         {

--- a/arch/renesas/src/rx65n/rx65n_schedulesigaction.c
+++ b/arch/renesas/src/rx65n/rx65n_schedulesigaction.c
@@ -76,7 +76,7 @@
 
 void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 {
-  sinfo("tcb=0x%p sigdeliver=0x%p\n", tcb, sigdeliver);
+  sinfo("tcb=%p sigdeliver=%p\n", tcb, sigdeliver);
 
   /* Refuse to handle nested signal actions */
 
@@ -86,7 +86,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
        * being delivered to the currently executing task.
        */
 
-      sinfo("rtcb=0x%p g_current_regs=0x%p\n", this_task(), g_current_regs);
+      sinfo("rtcb=%p g_current_regs=%p\n", this_task(), g_current_regs);
 
       if (tcb == this_task())
         {

--- a/arch/renesas/src/sh1/sh1_schedulesigaction.c
+++ b/arch/renesas/src/sh1/sh1_schedulesigaction.c
@@ -76,7 +76,7 @@
 
 void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 {
-  sinfo("tcb=0x%p sigdeliver=0x%p\n", tcb, sigdeliver);
+  sinfo("tcb=%p sigdeliver=%p\n", tcb, sigdeliver);
 
   /* Refuse to handle nested signal actions */
 
@@ -86,7 +86,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
        * being delivered to the currently executing task.
        */
 
-      sinfo("rtcb=0x%p g_current_regs=0x%p\n", this_task(), g_current_regs);
+      sinfo("rtcb=%p g_current_regs=%p\n", this_task(), g_current_regs);
 
       if (tcb == this_task())
         {

--- a/arch/risc-v/src/common/riscv_schedulesigaction.c
+++ b/arch/risc-v/src/common/riscv_schedulesigaction.c
@@ -81,7 +81,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 {
   uintptr_t int_ctx;
 
-  sinfo("tcb=0x%p sigdeliver=0x%p\n", tcb, sigdeliver);
+  sinfo("tcb=%p sigdeliver=%p\n", tcb, sigdeliver);
 
   /* Refuse to handle nested signal actions */
 
@@ -91,7 +91,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
        * being delivered to the currently executing task.
        */
 
-      sinfo("rtcb=0x%p CURRENT_REGS=0x%p\n",
+      sinfo("rtcb=%p CURRENT_REGS=%p\n",
             this_task(), CURRENT_REGS);
 
       if (tcb == this_task())
@@ -221,7 +221,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
   int cpu;
   int me;
 
-  sinfo("tcb=0x%p sigdeliver=0x%p\n", tcb, sigdeliver);
+  sinfo("tcb=%p sigdeliver=%p\n", tcb, sigdeliver);
 
   /* Refuse to handle nested signal actions */
 
@@ -231,7 +231,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
        * to task that is currently executing on any CPU.
        */
 
-      sinfo("rtcb=0x%p CURRENT_REGS=0x%p\n", this_task(), CURRENT_REGS);
+      sinfo("rtcb=%p CURRENT_REGS=%p\n", this_task(), CURRENT_REGS);
 
       if (tcb->task_state == TSTATE_TASK_RUNNING)
         {

--- a/arch/sim/src/sim/up_schedulesigaction.c
+++ b/arch/sim/src/sim/up_schedulesigaction.c
@@ -77,7 +77,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 
   /* We don't have to anything complex for the simulated target */
 
-  sinfo("tcb=0x%p sigdeliver=0x%p\n", tcb, sigdeliver);
+  sinfo("tcb=%p sigdeliver=%p\n", tcb, sigdeliver);
 
   /* Make sure that interrupts are disabled */
 

--- a/arch/sparc/src/sparc_v8/up_schedulesigaction.c
+++ b/arch/sparc/src/sparc_v8/up_schedulesigaction.c
@@ -75,7 +75,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 {
   irqstate_t flags;
 
-  sinfo("tcb=0x%p sigdeliver=0x%p\n", tcb, sigdeliver);
+  sinfo("tcb=%p sigdeliver=%p\n", tcb, sigdeliver);
 
   /* Make sure that interrupts are disabled */
 
@@ -89,7 +89,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
        * being delivered to the currently executing task.
        */
 
-      sinfo("rtcb=0x%p g_current_regs=0x%p\n",
+      sinfo("rtcb=%p g_current_regs=%p\n",
             this_task(), g_current_regs);
 
       if (tcb == this_task())

--- a/arch/x86/src/i486/up_schedulesigaction.c
+++ b/arch/x86/src/i486/up_schedulesigaction.c
@@ -72,7 +72,7 @@
 
 void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 {
-  sinfo("tcb=0x%p sigdeliver=0x%p\n", tcb, sigdeliver);
+  sinfo("tcb=%p sigdeliver=%p\n", tcb, sigdeliver);
 
   /* Refuse to handle nested signal actions */
 
@@ -82,7 +82,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
        * to the currently executing task.
        */
 
-      sinfo("rtcb=0x%p g_current_regs=0x%p\n", this_task(), g_current_regs);
+      sinfo("rtcb=%p g_current_regs=%p\n", this_task(), g_current_regs);
 
       if (tcb == this_task())
         {

--- a/arch/x86_64/src/intel64/up_schedulesigaction.c
+++ b/arch/x86_64/src/intel64/up_schedulesigaction.c
@@ -72,8 +72,8 @@
 
 void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 {
-  sinfo("tcb=0x%p sigdeliver=0x%p\n", tcb, sigdeliver);
-  sinfo("rtcb=0x%p g_current_regs=0x%p\n", this_task(), g_current_regs);
+  sinfo("tcb=%p sigdeliver=%p\n", tcb, sigdeliver);
+  sinfo("rtcb=%p g_current_regs=%p\n", this_task(), g_current_regs);
 
   /* Refuse to handle nested signal actions */
 

--- a/arch/xtensa/src/common/xtensa_schedsigaction.c
+++ b/arch/xtensa/src/common/xtensa_schedsigaction.c
@@ -80,14 +80,14 @@
 #ifndef CONFIG_SMP
 void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
 {
-  sinfo("tcb=0x%p sigdeliver=0x%p\n", tcb, sigdeliver);
+  sinfo("tcb=%p sigdeliver=%p\n", tcb, sigdeliver);
   DEBUGASSERT(tcb != NULL && sigdeliver != NULL);
 
   /* Refuse to handle nested signal actions */
 
   if (!tcb->xcp.sigdeliver)
     {
-      sinfo("rtcb=0x%p CURRENT_REGS=0x%p\n", this_task(), CURRENT_REGS);
+      sinfo("rtcb=%p CURRENT_REGS=%p\n", this_task(), CURRENT_REGS);
 
       /* First, handle some special cases when the signal is being delivered
        * to the currently executing task.
@@ -212,7 +212,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
   int cpu;
   int me;
 
-  sinfo("tcb=0x%p sigdeliver=0x%p\n", tcb, sigdeliver);
+  sinfo("tcb=%p sigdeliver=%p\n", tcb, sigdeliver);
 
   /* Refuse to handle nested signal actions */
 
@@ -222,7 +222,7 @@ void up_schedule_sigaction(struct tcb_s *tcb, sig_deliver_t sigdeliver)
        * to task that is currently executing on any CPU.
        */
 
-      sinfo("rtcb=0x%p CURRENT_REGS=0x%p\n", this_task(), CURRENT_REGS);
+      sinfo("rtcb=%p CURRENT_REGS=%p\n", this_task(), CURRENT_REGS);
 
       if (tcb->task_state == TSTATE_TASK_RUNNING)
         {

--- a/arch/z16/src/common/z16_schedulesigaction.c
+++ b/arch/z16/src/common/z16_schedulesigaction.c
@@ -76,7 +76,7 @@
 
 void up_schedule_sigaction(FAR struct tcb_s *tcb, sig_deliver_t sigdeliver)
 {
-  sinfo("tcb=0x%p sigdeliver=0x%06x\n", tcb, (uint32_t)sigdeliver);
+  sinfo("tcb=%p sigdeliver=0x%06x\n", tcb, (uint32_t)sigdeliver);
 
   /* Refuse to handle nested signal actions */
 
@@ -86,7 +86,7 @@ void up_schedule_sigaction(FAR struct tcb_s *tcb, sig_deliver_t sigdeliver)
        * being delivered to the currently executing task.
        */
 
-      sinfo("rtcb=0x%p g_current_regs=0x%p\n", this_task(), g_current_regs);
+      sinfo("rtcb=%p g_current_regs=%p\n", this_task(), g_current_regs);
 
       if (tcb == this_task())
         {

--- a/arch/z80/src/ez80/ez80_schedulesigaction.c
+++ b/arch/z80/src/ez80/ez80_schedulesigaction.c
@@ -102,7 +102,7 @@ static void ez80_sigsetup(FAR struct tcb_s *tcb, sig_deliver_t sigdeliver,
 
 void up_schedule_sigaction(FAR struct tcb_s *tcb, sig_deliver_t sigdeliver)
 {
-  sinfo("tcb=0x%p sigdeliver=0x%06" PRIx32 "\n", tcb, (uint32_t)sigdeliver);
+  sinfo("tcb=%p sigdeliver=0x%06" PRIx32 "\n", tcb, (uint32_t)sigdeliver);
 
   /* Refuse to handle nested signal actions */
 

--- a/arch/z80/src/z180/z180_schedulesigaction.c
+++ b/arch/z80/src/z180/z180_schedulesigaction.c
@@ -105,7 +105,7 @@ static void z180_sigsetup(FAR struct tcb_s *tcb, sig_deliver_t sigdeliver,
 
 void up_schedule_sigaction(FAR struct tcb_s *tcb, sig_deliver_t sigdeliver)
 {
-  _info("tcb=0x%p sigdeliver=0x%04x\n", tcb, (uint16_t)sigdeliver);
+  _info("tcb=%p sigdeliver=0x%04x\n", tcb, (uint16_t)sigdeliver);
 
   /* Refuse to handle nested signal actions */
 

--- a/arch/z80/src/z8/z8_schedulesigaction.c
+++ b/arch/z80/src/z8/z8_schedulesigaction.c
@@ -102,7 +102,7 @@ static void z8_sigsetup(FAR struct tcb_s *tcb, sig_deliver_t sigdeliver,
 
 void up_schedule_sigaction(FAR struct tcb_s *tcb, sig_deliver_t sigdeliver)
 {
-  sinfo("tcb=0x%p sigdeliver=0x%04x\n", tcb, (uint16_t)sigdeliver);
+  sinfo("tcb=%p sigdeliver=0x%04x\n", tcb, (uint16_t)sigdeliver);
 
   /* Refuse to handle nested signal actions */
 

--- a/arch/z80/src/z80/z80_schedulesigaction.c
+++ b/arch/z80/src/z80/z80_schedulesigaction.c
@@ -103,7 +103,7 @@ static void z80_sigsetup(FAR struct tcb_s *tcb, sig_deliver_t sigdeliver,
 
 void up_schedule_sigaction(FAR struct tcb_s *tcb, sig_deliver_t sigdeliver)
 {
-  _info("tcb=0x%p sigdeliver=0x%04x\n", tcb, (uint16_t)sigdeliver);
+  _info("tcb=%p sigdeliver=0x%04x\n", tcb, (uint16_t)sigdeliver);
 
   /* Refuse to handle nested signal actions */
 

--- a/libs/libc/pthread/pthread_attr_destroy.c
+++ b/libs/libc/pthread/pthread_attr_destroy.c
@@ -53,7 +53,7 @@ int pthread_attr_destroy(FAR pthread_attr_t *attr)
 {
   int ret;
 
-  linfo("attr=0x%p\n", attr);
+  linfo("attr=%p\n", attr);
 
   if (!attr)
     {

--- a/libs/libc/pthread/pthread_attr_getaffinity.c
+++ b/libs/libc/pthread/pthread_attr_getaffinity.c
@@ -51,7 +51,7 @@
 int pthread_attr_getaffinity_np(FAR const pthread_attr_t *attr,
                                 size_t cpusetsize, cpu_set_t *cpuset)
 {
-  linfo("attr=0x%p cpusetsize=%d cpuset=0x%p\n",
+  linfo("attr=%p cpusetsize=%d cpuset=%p\n",
          attr, (int)cpusetsize, cpuset);
 
   DEBUGASSERT(attr != NULL && cpusetsize == sizeof(cpu_set_t) &&

--- a/libs/libc/pthread/pthread_attr_getinheritsched.c
+++ b/libs/libc/pthread/pthread_attr_getinheritsched.c
@@ -57,7 +57,7 @@ int pthread_attr_getinheritsched(FAR const pthread_attr_t *attr,
 {
   int ret;
 
-  linfo("attr=0x%p inheritsched=0x%p\n", attr, inheritsched);
+  linfo("attr=%p inheritsched=%p\n", attr, inheritsched);
 
   if (!attr || !inheritsched)
     {

--- a/libs/libc/pthread/pthread_attr_getschedparam.c
+++ b/libs/libc/pthread/pthread_attr_getschedparam.c
@@ -55,7 +55,7 @@ int pthread_attr_getschedparam(FAR const pthread_attr_t *attr,
 {
   int ret;
 
-  linfo("attr=0x%p param=0x%p\n", attr, param);
+  linfo("attr=%p param=%p\n", attr, param);
 
   if (!attr || !param)
     {

--- a/libs/libc/pthread/pthread_attr_getschedpolicy.c
+++ b/libs/libc/pthread/pthread_attr_getschedpolicy.c
@@ -54,7 +54,7 @@ int pthread_attr_getschedpolicy(FAR const pthread_attr_t *attr,
 {
   int ret;
 
-  linfo("attr=0x%p policy=0x%p\n", attr, policy);
+  linfo("attr=%p policy=%p\n", attr, policy);
 
   if (!attr || !policy)
     {

--- a/libs/libc/pthread/pthread_attr_getstack.c
+++ b/libs/libc/pthread/pthread_attr_getstack.c
@@ -53,7 +53,7 @@ int pthread_attr_getstack(FAR pthread_attr_t *attr,
 {
   int ret;
 
-  linfo("attr=0x%p stackaddr=0x%p stacksize=0x%p\n",
+  linfo("attr=%p stackaddr=%p stacksize=%p\n",
         attr, stackaddr, stacksize);
 
   if (!attr || !stackaddr || !stacksize)

--- a/libs/libc/pthread/pthread_attr_getstacksize.c
+++ b/libs/libc/pthread/pthread_attr_getstacksize.c
@@ -53,7 +53,7 @@ int pthread_attr_getstacksize(FAR const pthread_attr_t *attr,
 {
   int ret;
 
-  linfo("attr=0x%p stacksize=0x%p\n", attr, stacksize);
+  linfo("attr=%p stacksize=%p\n", attr, stacksize);
 
   if (!stacksize)
     {

--- a/libs/libc/pthread/pthread_attr_init.c
+++ b/libs/libc/pthread/pthread_attr_init.c
@@ -71,7 +71,7 @@ int pthread_attr_init(FAR pthread_attr_t *attr)
 {
   int ret = OK;
 
-  linfo("attr=0x%p\n", attr);
+  linfo("attr=%p\n", attr);
   if (!attr)
     {
       ret = ENOMEM;

--- a/libs/libc/pthread/pthread_attr_setaffinity.c
+++ b/libs/libc/pthread/pthread_attr_setaffinity.c
@@ -53,7 +53,7 @@ int pthread_attr_setaffinity_np(FAR pthread_attr_t *attr,
                                 size_t cpusetsize,
                                 FAR const cpu_set_t *cpuset)
 {
-  linfo("attr=0x%p cpusetsize=%d cpuset=0x%p\n",
+  linfo("attr=%p cpusetsize=%d cpuset=%p\n",
          attr, (int)cpusetsize, cpuset);
 
   DEBUGASSERT(attr != NULL && cpusetsize == sizeof(cpu_set_t) &&

--- a/libs/libc/pthread/pthread_attr_setschedparam.c
+++ b/libs/libc/pthread/pthread_attr_setschedparam.c
@@ -55,7 +55,7 @@ int pthread_attr_setschedparam(FAR pthread_attr_t *attr,
 {
   int ret;
 
-  linfo("attr=0x%p param=0x%p\n", attr, param);
+  linfo("attr=%p param=%p\n", attr, param);
 
   if (!attr || !param)
     {

--- a/libs/libc/pthread/pthread_attr_setschedpolicy.c
+++ b/libs/libc/pthread/pthread_attr_setschedpolicy.c
@@ -55,7 +55,7 @@ int pthread_attr_setschedpolicy(FAR pthread_attr_t *attr, int policy)
 {
   int ret;
 
-  linfo("attr=0x%p policy=%d\n", attr, policy);
+  linfo("attr=%p policy=%d\n", attr, policy);
 
   if (!attr ||
       (policy != SCHED_FIFO

--- a/libs/libc/pthread/pthread_attr_setstack.c
+++ b/libs/libc/pthread/pthread_attr_setstack.c
@@ -55,7 +55,7 @@ int pthread_attr_setstack(FAR pthread_attr_t *attr,
 {
   int ret;
 
-  linfo("attr=0x%p stackaddr=0x%p stacksize=%ld\n",
+  linfo("attr=%p stackaddr=%p stacksize=%ld\n",
         attr, stackaddr, stacksize);
 
   if (!attr || !stackaddr || stacksize < PTHREAD_STACK_MIN)

--- a/libs/libc/pthread/pthread_attr_setstacksize.c
+++ b/libs/libc/pthread/pthread_attr_setstacksize.c
@@ -53,7 +53,7 @@ int pthread_attr_setstacksize(FAR pthread_attr_t *attr, size_t stacksize)
 {
   int ret;
 
-  linfo("attr=0x%p stacksize=%zu\n", attr, stacksize);
+  linfo("attr=%p stacksize=%zu\n", attr, stacksize);
 
   if (!attr || stacksize < PTHREAD_STACK_MIN)
     {

--- a/libs/libc/pthread/pthread_condattr_destroy.c
+++ b/libs/libc/pthread/pthread_condattr_destroy.c
@@ -52,7 +52,7 @@ int pthread_condattr_destroy(FAR pthread_condattr_t *attr)
 {
   int ret = OK;
 
-  linfo("attr=0x%p\n", attr);
+  linfo("attr=%p\n", attr);
 
   if (!attr)
     {

--- a/libs/libc/pthread/pthread_condattr_init.c
+++ b/libs/libc/pthread/pthread_condattr_init.c
@@ -52,7 +52,7 @@ int pthread_condattr_init(FAR pthread_condattr_t *attr)
 {
   int ret = OK;
 
-  linfo("attr=0x%p\n", attr);
+  linfo("attr=%p\n", attr);
 
   if (!attr)
     {

--- a/libs/libc/pthread/pthread_conddestroy.c
+++ b/libs/libc/pthread/pthread_conddestroy.c
@@ -56,7 +56,7 @@ int pthread_cond_destroy(FAR pthread_cond_t *cond)
   int ret = OK;
   int sval = 0;
 
-  sinfo("cond=0x%p\n", cond);
+  sinfo("cond=%p\n", cond);
 
   if (!cond)
     {

--- a/libs/libc/pthread/pthread_condinit.c
+++ b/libs/libc/pthread/pthread_condinit.c
@@ -54,7 +54,7 @@ int pthread_cond_init(FAR pthread_cond_t *cond,
 {
   int ret = OK;
 
-  sinfo("cond=0x%p attr=0x%p\n", cond, attr);
+  sinfo("cond=%p attr=%p\n", cond, attr);
 
   if (cond == NULL)
     {

--- a/libs/libc/pthread/pthread_mutexattr_destroy.c
+++ b/libs/libc/pthread/pthread_mutexattr_destroy.c
@@ -52,7 +52,7 @@ int pthread_mutexattr_destroy(FAR pthread_mutexattr_t *attr)
 {
   int ret = OK;
 
-  linfo("attr=0x%p\n", attr);
+  linfo("attr=%p\n", attr);
 
   if (!attr)
     {

--- a/libs/libc/pthread/pthread_mutexattr_getpshared.c
+++ b/libs/libc/pthread/pthread_mutexattr_getpshared.c
@@ -54,7 +54,7 @@ int pthread_mutexattr_getpshared(FAR const pthread_mutexattr_t *attr,
 {
   int ret = OK;
 
-  linfo("attr=0x%p pshared=0x%p\n", attr, pshared);
+  linfo("attr=%p pshared=%p\n", attr, pshared);
 
   if (!attr || !pshared)
     {

--- a/libs/libc/pthread/pthread_mutexattr_init.c
+++ b/libs/libc/pthread/pthread_mutexattr_init.c
@@ -52,7 +52,7 @@ int pthread_mutexattr_init(FAR pthread_mutexattr_t *attr)
 {
   int ret = OK;
 
-  linfo("attr=0x%p\n", attr);
+  linfo("attr=%p\n", attr);
 
   if (!attr)
     {

--- a/libs/libc/pthread/pthread_mutexattr_setprotocol.c
+++ b/libs/libc/pthread/pthread_mutexattr_setprotocol.c
@@ -51,7 +51,7 @@
 int pthread_mutexattr_setprotocol(FAR pthread_mutexattr_t *attr,
                                   int protocol)
 {
-  linfo("attr=0x%p protocol=%d\n", attr, protocol);
+  linfo("attr=%p protocol=%d\n", attr, protocol);
   DEBUGASSERT(attr != NULL);
 
   if (protocol >= PTHREAD_PRIO_NONE && protocol <= PTHREAD_PRIO_PROTECT)

--- a/libs/libc/pthread/pthread_mutexattr_setpshared.c
+++ b/libs/libc/pthread/pthread_mutexattr_setpshared.c
@@ -53,7 +53,7 @@ int pthread_mutexattr_setpshared(FAR pthread_mutexattr_t *attr, int pshared)
 {
   int ret = OK;
 
-  linfo("attr=0x%p pshared=%d\n", attr, pshared);
+  linfo("attr=%p pshared=%d\n", attr, pshared);
 
   if (!attr || (pshared != 0 && pshared != 1))
     {

--- a/libs/libc/stdio/lib_libvscanf.c
+++ b/libs/libc/stdio/lib_libvscanf.c
@@ -864,17 +864,17 @@ int lib_vscanf(FAR struct lib_instream_s *obj, FAR int *lastc,
                       switch (modifier)
                         {
                         case HH_MOD:
-                          linfo("Return %ld to 0x%p\n", tmplong, pchar);
+                          linfo("Return %ld to %p\n", tmplong, pchar);
                           *pchar = (unsigned char)tmplong;
                           break;
 
                         case H_MOD:
-                          linfo("Return %ld to 0x%p\n", tmplong, pshort);
+                          linfo("Return %ld to %p\n", tmplong, pshort);
                           *pshort = (unsigned short)tmplong;
                           break;
 
                         case NO_MOD:
-                          linfo("Return %ld to 0x%p\n", tmplong, pint);
+                          linfo("Return %ld to %p\n", tmplong, pint);
                           *pint = (unsigned int)tmplong;
                           break;
 
@@ -882,13 +882,13 @@ int lib_vscanf(FAR struct lib_instream_s *obj, FAR int *lastc,
                         case L_MOD:
 #endif
                         default:
-                          linfo("Return %ld to 0x%p\n", tmplong, plong);
+                          linfo("Return %ld to %p\n", tmplong, plong);
                           *plong = tmplong;
                           break;
 
 #ifdef CONFIG_LIBC_LONG_LONG
                         case LL_MOD:
-                          linfo("Return %lld to 0x%p\n", tmplonglong,
+                          linfo("Return %lld to %p\n", tmplonglong,
                                 plonglong);
                           *plonglong = tmplonglong;
                           break;

--- a/sched/pthread/pthread_completejoin.c
+++ b/sched/pthread/pthread_completejoin.c
@@ -54,7 +54,7 @@ static bool pthread_notifywaiters(FAR struct join_s *pjoin)
   int ntasks_waiting;
   int status;
 
-  sinfo("pjoin=0x%p\n", pjoin);
+  sinfo("pjoin=%p\n", pjoin);
 
   /* Are any tasks waiting for our exit value? */
 
@@ -257,7 +257,7 @@ int pthread_completejoin(pid_t pid, FAR void *exit_value)
 void pthread_destroyjoin(FAR struct task_group_s *group,
                          FAR struct join_s *pjoin)
 {
-  sinfo("pjoin=0x%p\n", pjoin);
+  sinfo("pjoin=%p\n", pjoin);
 
   /* Remove the join info from the set of joins */
 

--- a/sched/pthread/pthread_condbroadcast.c
+++ b/sched/pthread/pthread_condbroadcast.c
@@ -56,7 +56,7 @@ int pthread_cond_broadcast(FAR pthread_cond_t *cond)
   int ret = OK;
   int sval;
 
-  sinfo("cond=0x%p\n", cond);
+  sinfo("cond=%p\n", cond);
 
   if (!cond)
     {

--- a/sched/pthread/pthread_condclockwait.c
+++ b/sched/pthread/pthread_condclockwait.c
@@ -78,7 +78,7 @@ int pthread_cond_clockwait(FAR pthread_cond_t *cond,
   int ret = OK;
   int status;
 
-  sinfo("cond=0x%p mutex=0x%p abstime=0x%p\n", cond, mutex, abstime);
+  sinfo("cond=%p mutex=%p abstime=%p\n", cond, mutex, abstime);
 
   /* pthread_cond_clockwait() is a cancellation point */
 

--- a/sched/pthread/pthread_condsignal.c
+++ b/sched/pthread/pthread_condsignal.c
@@ -55,7 +55,7 @@ int pthread_cond_signal(FAR pthread_cond_t *cond)
   int ret = OK;
   int sval;
 
-  sinfo("cond=0x%p\n", cond);
+  sinfo("cond=%p\n", cond);
 
   if (!cond)
     {

--- a/sched/pthread/pthread_condwait.c
+++ b/sched/pthread/pthread_condwait.c
@@ -59,7 +59,7 @@ int pthread_cond_wait(FAR pthread_cond_t *cond, FAR pthread_mutex_t *mutex)
   int status;
   int ret;
 
-  sinfo("cond=0x%p mutex=0x%p\n", cond, mutex);
+  sinfo("cond=%p mutex=%p\n", cond, mutex);
 
   /* pthread_cond_wait() is a cancellation point */
 

--- a/sched/pthread/pthread_getschedparam.c
+++ b/sched/pthread/pthread_getschedparam.c
@@ -78,7 +78,7 @@ int pthread_getschedparam(pthread_t thread, FAR int *policy,
 {
   int ret;
 
-  sinfo("Thread ID=%d policy=0x%p param=0x%p\n", thread, policy, param);
+  sinfo("Thread ID=%d policy=%p param=%p\n", thread, policy, param);
 
   if (policy == NULL || param == NULL)
     {

--- a/sched/pthread/pthread_join.c
+++ b/sched/pthread/pthread_join.c
@@ -176,7 +176,7 @@ int pthread_join(pthread_t thread, FAR pthread_addr_t *pexit_value)
 
           if (pexit_value)
             {
-              sinfo("exit_value=0x%p\n", pjoin->exit_value);
+              sinfo("exit_value=%p\n", pjoin->exit_value);
               *pexit_value = pjoin->exit_value;
             }
         }
@@ -206,7 +206,7 @@ int pthread_join(pthread_t thread, FAR pthread_addr_t *pexit_value)
           if (pexit_value)
             {
               *pexit_value = pjoin->exit_value;
-              sinfo("exit_value=0x%p\n", pjoin->exit_value);
+              sinfo("exit_value=%p\n", pjoin->exit_value);
             }
 
           /* Post the thread's data semaphore so that the exiting thread

--- a/sched/pthread/pthread_mutexconsistent.c
+++ b/sched/pthread/pthread_mutexconsistent.c
@@ -76,7 +76,7 @@ int pthread_mutex_consistent(FAR pthread_mutex_t *mutex)
   int ret = EINVAL;
   int status;
 
-  sinfo("mutex=0x%p\n", mutex);
+  sinfo("mutex=%p\n", mutex);
   DEBUGASSERT(mutex != NULL);
 
   if (mutex != NULL)

--- a/sched/pthread/pthread_mutexdestroy.c
+++ b/sched/pthread/pthread_mutexdestroy.c
@@ -60,7 +60,7 @@ int pthread_mutex_destroy(FAR pthread_mutex_t *mutex)
   int ret = EINVAL;
   int status;
 
-  sinfo("mutex=0x%p\n", mutex);
+  sinfo("mutex=%p\n", mutex);
   DEBUGASSERT(mutex != NULL);
 
   if (mutex != NULL)

--- a/sched/pthread/pthread_mutexinit.c
+++ b/sched/pthread/pthread_mutexinit.c
@@ -77,7 +77,7 @@ int pthread_mutex_init(FAR pthread_mutex_t *mutex,
   int ret = OK;
   int status;
 
-  sinfo("mutex=0x%p attr=0x%p\n", mutex, attr);
+  sinfo("mutex=%p attr=%p\n", mutex, attr);
 
   if (!mutex)
     {

--- a/sched/pthread/pthread_mutextimedlock.c
+++ b/sched/pthread/pthread_mutextimedlock.c
@@ -81,7 +81,7 @@ int pthread_mutex_timedlock(FAR pthread_mutex_t *mutex,
   pid_t mypid = getpid();
   int ret = EINVAL;
 
-  sinfo("mutex=0x%p\n", mutex);
+  sinfo("mutex=%p\n", mutex);
   DEBUGASSERT(mutex != NULL);
 
   if (mutex != NULL)

--- a/sched/pthread/pthread_mutextrylock.c
+++ b/sched/pthread/pthread_mutextrylock.c
@@ -71,7 +71,7 @@ int pthread_mutex_trylock(FAR pthread_mutex_t *mutex)
   int status;
   int ret = EINVAL;
 
-  sinfo("mutex=0x%p\n", mutex);
+  sinfo("mutex=%p\n", mutex);
   DEBUGASSERT(mutex != NULL);
 
   if (mutex != NULL)

--- a/sched/pthread/pthread_mutexunlock.c
+++ b/sched/pthread/pthread_mutexunlock.c
@@ -102,7 +102,7 @@ int pthread_mutex_unlock(FAR pthread_mutex_t *mutex)
 {
   int ret = EPERM;
 
-  sinfo("mutex=0x%p\n", mutex);
+  sinfo("mutex=%p\n", mutex);
   DEBUGASSERT(mutex != NULL);
   if (mutex == NULL)
     {

--- a/sched/pthread/pthread_setschedparam.c
+++ b/sched/pthread/pthread_setschedparam.c
@@ -91,7 +91,7 @@ int pthread_setschedparam(pthread_t thread, int policy,
 {
   int ret;
 
-  sinfo("thread ID=%d policy=%d param=0x%p\n", thread, policy, param);
+  sinfo("thread ID=%d policy=%d param=%p\n", thread, policy, param);
 
   /* Let nxsched_set_scheduler do all of the work */
 


### PR DESCRIPTION
## Summary
This PR intends to fix some Syslog message strings when %p is passed as the format specifier.

The "p" format specifier already prepends the pointer address with "0x" when printing:
```
up_schedule_sigaction: tcb=0x0x3ffaeff0 sigdeliver=0x0x400d2024
up_schedule_sigaction: rtcb=0x0x3ffaeff0 CURRENT_REGS=0x0x3ffce014
```

## Impact
Should bring no relevant impact, changes just to format strings.

## Testing
CI Build pass.
