### PR TITLE
tiva: Add UART CTS/RTS support

### DIFF
--- a/arch/arm/src/tiva/common/tiva_lowputc.c
+++ b/arch/arm/src/tiva/common/tiva_lowputc.c
@@ -261,6 +261,13 @@ void tiva_lowsetup(void)
 
   tiva_configgpio(GPIO_UART0_RX);
   tiva_configgpio(GPIO_UART0_TX);
+
+#if defined(CONFIG_SERIAL_IFLOWCONTROL) && defined(CONFIG_UART0_IFLOWCONTROL)
+  tiva_configgpio(GPIO_UART0_RTS);
+#endif
+#if defined(CONFIG_SERIAL_OFLOWCONTROL) && defined(CONFIG_UART0_OFLOWCONTROL)
+  tiva_configgpio(GPIO_UART0_CTS);
+#endif
 #endif
 
 #ifdef CONFIG_TIVA_UART1
@@ -269,6 +276,13 @@ void tiva_lowsetup(void)
 
   tiva_configgpio(GPIO_UART1_RX);
   tiva_configgpio(GPIO_UART1_TX);
+
+#if defined(CONFIG_SERIAL_IFLOWCONTROL) && defined(CONFIG_UART1_IFLOWCONTROL)
+  tiva_configgpio(GPIO_UART1_RTS);
+#endif
+#if defined(CONFIG_SERIAL_OFLOWCONTROL) && defined(CONFIG_UART1_OFLOWCONTROL)
+  tiva_configgpio(GPIO_UART1_CTS);
+#endif
 #endif
 
 #ifdef CONFIG_TIVA_UART2
@@ -277,6 +291,13 @@ void tiva_lowsetup(void)
 
   tiva_configgpio(GPIO_UART2_RX);
   tiva_configgpio(GPIO_UART2_TX);
+
+#if defined(CONFIG_SERIAL_IFLOWCONTROL) && defined(CONFIG_UART2_IFLOWCONTROL)
+  tiva_configgpio(GPIO_UART2_RTS);
+#endif
+#if defined(CONFIG_SERIAL_OFLOWCONTROL) && defined(CONFIG_UART2_OFLOWCONTROL)
+  tiva_configgpio(GPIO_UART2_CTS);
+#endif
 #endif
 
 #ifdef CONFIG_TIVA_UART3
@@ -285,6 +306,13 @@ void tiva_lowsetup(void)
 
   tiva_configgpio(GPIO_UART3_RX);
   tiva_configgpio(GPIO_UART3_TX);
+
+#if defined(CONFIG_SERIAL_IFLOWCONTROL) && defined(CONFIG_UART3_IFLOWCONTROL)
+  tiva_configgpio(GPIO_UART3_RTS);
+#endif
+#if defined(CONFIG_SERIAL_OFLOWCONTROL) && defined(CONFIG_UART3_OFLOWCONTROL)
+  tiva_configgpio(GPIO_UART3_CTS);
+#endif
 #endif
 
 #ifdef CONFIG_TIVA_UART4
@@ -293,6 +321,13 @@ void tiva_lowsetup(void)
 
   tiva_configgpio(GPIO_UART4_RX);
   tiva_configgpio(GPIO_UART4_TX);
+
+#if defined(CONFIG_SERIAL_IFLOWCONTROL) && defined(CONFIG_UART4_IFLOWCONTROL)
+  tiva_configgpio(GPIO_UART4_RTS);
+#endif
+#if defined(CONFIG_SERIAL_OFLOWCONTROL) && defined(CONFIG_UART4_OFLOWCONTROL)
+  tiva_configgpio(GPIO_UART4_CTS);
+#endif
 #endif
 
 #ifdef CONFIG_TIVA_UART5
@@ -301,6 +336,13 @@ void tiva_lowsetup(void)
 
   tiva_configgpio(GPIO_UART5_RX);
   tiva_configgpio(GPIO_UART5_TX);
+
+#if defined(CONFIG_SERIAL_IFLOWCONTROL) && defined(CONFIG_UART5_IFLOWCONTROL)
+  tiva_configgpio(GPIO_UART5_RTS);
+#endif
+#if defined(CONFIG_SERIAL_OFLOWCONTROL) && defined(CONFIG_UART5_OFLOWCONTROL)
+  tiva_configgpio(GPIO_UART5_CTS);
+#endif
 #endif
 
 #ifdef CONFIG_TIVA_UART6
@@ -309,6 +351,13 @@ void tiva_lowsetup(void)
 
   tiva_configgpio(GPIO_UART6_RX);
   tiva_configgpio(GPIO_UART6_TX);
+
+#if defined(CONFIG_SERIAL_IFLOWCONTROL) && defined(CONFIG_UART6_IFLOWCONTROL)
+  tiva_configgpio(GPIO_UART6_RTS);
+#endif
+#if defined(CONFIG_SERIAL_OFLOWCONTROL) && defined(CONFIG_UART6_OFLOWCONTROL)
+  tiva_configgpio(GPIO_UART6_CTS);
+#endif
 #endif
 
 #ifdef CONFIG_TIVA_UART7
@@ -317,6 +366,13 @@ void tiva_lowsetup(void)
 
   tiva_configgpio(GPIO_UART7_RX);
   tiva_configgpio(GPIO_UART7_TX);
+
+#if defined(CONFIG_SERIAL_IFLOWCONTROL) && defined(CONFIG_UART7_IFLOWCONTROL)
+  tiva_configgpio(GPIO_UART7_RTS);
+#endif
+#if defined(CONFIG_SERIAL_OFLOWCONTROL) && defined(CONFIG_UART7_OFLOWCONTROL)
+  tiva_configgpio(GPIO_UART7_CTS);
+#endif
 #endif
 
   /* Enable the selected console device */

--- a/arch/arm/src/tiva/common/tiva_serial.c
+++ b/arch/arm/src/tiva/common/tiva_serial.c
@@ -295,6 +295,12 @@ struct up_dev_s
   uint8_t  parity;    /* 0=none, 1=odd, 2=even */
   uint8_t  bits;      /* Number of bits (7 or 8) */
   bool     stopbits2; /* true: Configure with 2 stop bits instead of 1 */
+#ifdef CONFIG_SERIAL_IFLOWCONTROL
+  bool     iflow;     /* input flow control (RTS) enabled */
+#endif
+#ifdef CONFIG_SERIAL_OFLOWCONTROL
+  bool     oflow;     /* output flow control (CTS) enabled */
+#endif
 };
 
 /****************************************************************************
@@ -384,6 +390,12 @@ static struct up_dev_s g_uart0priv =
   .parity         = CONFIG_UART0_PARITY,
   .bits           = CONFIG_UART0_BITS,
   .stopbits2      = CONFIG_UART0_2STOP,
+#if defined(CONFIG_SERIAL_IFLOWCONTROL) && defined(CONFIG_UART0_IFLOWCONTROL)
+  .iflow          = true,
+#endif
+#if defined(CONFIG_SERIAL_OFLOWCONTROL) && defined(CONFIG_UART0_OFLOWCONTROL)
+  .oflow          = true,
+#endif
 };
 
 static uart_dev_t g_uart0port =
@@ -414,6 +426,12 @@ static struct up_dev_s g_uart1priv =
   .parity         = CONFIG_UART1_PARITY,
   .bits           = CONFIG_UART1_BITS,
   .stopbits2      = CONFIG_UART1_2STOP,
+#if defined(CONFIG_SERIAL_IFLOWCONTROL) && defined(CONFIG_UART1_IFLOWCONTROL)
+  .iflow          = true,
+#endif
+#if defined(CONFIG_SERIAL_OFLOWCONTROL) && defined(CONFIG_UART1_OFLOWCONTROL)
+  .oflow          = true,
+#endif
 };
 
 static uart_dev_t g_uart1port =
@@ -444,6 +462,12 @@ static struct up_dev_s g_uart2priv =
   .parity         = CONFIG_UART2_PARITY,
   .bits           = CONFIG_UART2_BITS,
   .stopbits2      = CONFIG_UART2_2STOP,
+#if defined(CONFIG_SERIAL_IFLOWCONTROL) && defined(CONFIG_UART2_IFLOWCONTROL)
+  .iflow          = true,
+#endif
+#if defined(CONFIG_SERIAL_OFLOWCONTROL) && defined(CONFIG_UART2_OFLOWCONTROL)
+  .oflow          = true,
+#endif
 };
 
 static uart_dev_t g_uart2port =
@@ -474,6 +498,12 @@ static struct up_dev_s g_uart3priv =
   .parity         = CONFIG_UART3_PARITY,
   .bits           = CONFIG_UART3_BITS,
   .stopbits2      = CONFIG_UART3_2STOP,
+#if defined(CONFIG_SERIAL_IFLOWCONTROL) && defined(CONFIG_UART3_IFLOWCONTROL)
+  .iflow          = true,
+#endif
+#if defined(CONFIG_SERIAL_OFLOWCONTROL) && defined(CONFIG_UART3_OFLOWCONTROL)
+  .oflow          = true,
+#endif
 };
 
 static uart_dev_t g_uart3port =
@@ -504,6 +534,12 @@ static struct up_dev_s g_uart4priv =
   .parity         = CONFIG_UART4_PARITY,
   .bits           = CONFIG_UART4_BITS,
   .stopbits2      = CONFIG_UART4_2STOP,
+#if defined(CONFIG_SERIAL_IFLOWCONTROL) && defined(CONFIG_UART4_IFLOWCONTROL)
+  .iflow          = true,
+#endif
+#if defined(CONFIG_SERIAL_OFLOWCONTROL) && defined(CONFIG_UART4_OFLOWCONTROL)
+  .oflow          = true,
+#endif
 };
 
 static uart_dev_t g_uart4port =
@@ -534,6 +570,12 @@ static struct up_dev_s g_uart5priv =
   .parity         = CONFIG_UART5_PARITY,
   .bits           = CONFIG_UART5_BITS,
   .stopbits2      = CONFIG_UART5_2STOP,
+#if defined(CONFIG_SERIAL_IFLOWCONTROL) && defined(CONFIG_UART5_IFLOWCONTROL)
+  .iflow          = true,
+#endif
+#if defined(CONFIG_SERIAL_OFLOWCONTROL) && defined(CONFIG_UART5_OFLOWCONTROL)
+  .oflow          = true,
+#endif
 };
 
 static uart_dev_t g_uart5port =
@@ -564,6 +606,12 @@ static struct up_dev_s g_uart6priv =
   .parity         = CONFIG_UART6_PARITY,
   .bits           = CONFIG_UART6_BITS,
   .stopbits2      = CONFIG_UART6_2STOP,
+#if defined(CONFIG_SERIAL_IFLOWCONTROL) && defined(CONFIG_UART6_IFLOWCONTROL)
+  .iflow          = true,
+#endif
+#if defined(CONFIG_SERIAL_OFLOWCONTROL) && defined(CONFIG_UART6_OFLOWCONTROL)
+  .oflow          = true,
+#endif
 };
 
 static uart_dev_t g_uart6port =
@@ -594,6 +642,12 @@ static struct up_dev_s g_uart7priv =
   .parity         = CONFIG_UART7_PARITY,
   .bits           = CONFIG_UART7_BITS,
   .stopbits2      = CONFIG_UART7_2STOP,
+#if defined(CONFIG_SERIAL_IFLOWCONTROL) && defined(CONFIG_UART7_IFLOWCONTROL)
+  .iflow          = true,
+#endif
+#if defined(CONFIG_SERIAL_OFLOWCONTROL) && defined(CONFIG_UART7_OFLOWCONTROL)
+  .oflow          = true,
+#endif
 };
 
 static uart_dev_t g_uart7port =
@@ -869,10 +923,33 @@ static int up_setup(struct uart_dev_s *dev)
   lcrh |= UART_LCRH_FEN;
   up_serialout(priv, TIVA_UART_LCRH_OFFSET, lcrh);
 
-  /* Enable Rx, Tx, and the UART */
+  /* Enable Rx, Tx, CTS/RTS (if requested), and the UART */
 
   ctl = up_serialin(priv, TIVA_UART_CTL_OFFSET);
   ctl |= (UART_CTL_UARTEN | UART_CTL_TXE | UART_CTL_RXE);
+
+#if defined(CONFIG_SERIAL_IFLOWCONTROL)
+  if (priv->iflow)
+    {
+      ctl |= UART_CTL_RTSEN;
+    }
+  else
+    {
+      ctl &= ~(UART_CTL_RTSEN);
+    }
+#endif
+
+#if defined(CONFIG_SERIAL_OFLOWCONTROL)
+  if (priv->oflow)
+    {
+      ctl |= UART_CTL_CTSEN;
+    }
+  else
+    {
+      ctl &= ~(UART_CTL_CTSEN);
+    }
+#endif
+
   up_serialout(priv, TIVA_UART_CTL_OFFSET, ctl);
 
   /* Set up the cache IM value */


### PR DESCRIPTION
## Summary

In Tiva architecture's lower-half serial (UART) driver, the Kconfigs to enable RTS and/or CTS were not being honored. This PR adds this support.

## Impact

When selected in Kconfig, the UART's RTS and/or CTS will be configured when the port is first opened.

## Testing

Serial communication is working on a custom board. Communication is between UART2 of a TM4C129ENCZAD microcontroller and a peripheral IC that requires RX, TX, CTS, and RTS.