### PR TITLE
Esp32 lilygo tty t5v2 bugfix

### DIFF
--- a/boards/xtensa/esp32/common/src/esp32_ssd1680.c
+++ b/boards/xtensa/esp32/common/src/esp32_ssd1680.c
@@ -183,7 +183,7 @@ int board_lcd_initialize(void)
        * Must be because setpower(1) function invokes the chip configuration
        */
 
-      g_lcddev->setpower(g_lcddev, CONFIG_LCD_MAXPOWER);
+      ret = g_lcddev->setpower(g_lcddev, CONFIG_LCD_MAXPOWER);
     }
 
   return ret;


### PR DESCRIPTION
E-ink initialization failed because small bug in the code (just 5 missing chars

## Summary
Fixed BSP for Esp32 lilygotty t5v2 board
## Impact
None
## Testing
Yes
