### PR TITLE
framebuffer for e-ink display. Added callback function to redraw.

### DIFF
--- a/include/nuttx/lcd/lcd.h
+++ b/include/nuttx/lcd/lcd.h
@@ -123,6 +123,21 @@ struct lcd_planeinfo_s
                  fb_coord_t row_end, fb_coord_t col_start,
                  fb_coord_t col_end, FAR uint8_t *buffer);
 
+  /* This method can be used to redraw display's content.
+   *
+   *  dev       - LCD interface to redraw its memory content
+   *
+   * NOTE: In case of non e-ink dispalys redrawing is cheap and can be done
+   * after each memory modification. Redrawing e-ink display is time and
+   * energy consuming.
+   * In order to avoid such operation (time and energy consumption) we can
+   * implement callback function putrun without redrawing the screen.
+   * Function putrun is called many times unless the function putarea is
+   * implemented.
+   */
+
+  int (*redraw)(FAR struct lcd_dev_s *dev);
+
   /* Plane color characteristics ********************************************/
 
   /* This is working memory allocated by the LCD driver for each LCD device


### PR DESCRIPTION
Kconfig changes
SSD1680 driver changes
ioctl(..., FBIO_REDRAW, ...) added

## Summary
It is possible to ask E-ink driver to redraw. In case of frame buffer modification, the screen is not updated. We want to reduce number of redraw operation. It is time and energy consuming without obligatory implementation of callback function **putarea** (struct lcd_planeinfo_s).

## Impact
New callback function **redraw** in struct lcd_planeinfo_s (lsd.h file). Implementation of this function is optional.

## Testing
Yes on ssd1680 e-ink display.

