### PR TITLE
wireless/bcm43xxx: country code should terminating with null

### DIFF
--- a/drivers/wireless/ieee80211/bcm43xxx/bcmf_driver.c
+++ b/drivers/wireless/ieee80211/bcm43xxx/bcmf_driver.c
@@ -1807,6 +1807,7 @@ int bcmf_wl_get_country(FAR struct bcmf_dev_s *priv, FAR struct iwreq *iwr)
   if (ret == OK)
     {
       memcpy(iwr->u.data.pointer, country, 2);
+      ((uint8_t *)iwr->u.data.pointer)[2] = '\0';
     }
 
   return ret;


### PR DESCRIPTION
## Summary

wireless/bcm43xxx: country code should terminating with null

## Impact

N/A

## Testing

bcm43013