### PR TITLE
wireless/bcm43xxx: set listen interval on lowpower

### DIFF
--- a/drivers/wireless/ieee80211/bcm43xxx/Kconfig
+++ b/drivers/wireless/ieee80211/bcm43xxx/Kconfig
@@ -146,11 +146,23 @@ config IEEE80211_BROADCOM_DEFAULT_COUNTRY
 
 if IEEE80211_BROADCOM_LOWPOWER
 
-config IEEE80211_BROADCOM_LOWPOWER_TIMEOUT
+config IEEE80211_BROADCOM_LP_DTIM_TIMEOUT
 	int "Broadcom BCMF lower power timeout(second)"
 	default 10
 	---help---
 		This parameter should be enable the bcmf lower power timeout
+
+config IEEE80211_BROADCOM_LP_DTIM_INTERVAL
+	int "Broadcom BCMF listen interval dtim(millisecond)"
+	default 500
+	---help---
+		This parameter should be set the listen interval dtim in milliseconds
+
+config IEEE80211_BROADCOM_LP_IFDOWN_TIMEOUT
+	int "Broadcom BCMF lower power if down timeout(second)"
+	default 600
+	---help---
+		This parameter should be enable the bcmf lower power if down timeout
 
 endif # IEEE80211_BROADCOM_LOWPOWER
 

--- a/drivers/wireless/ieee80211/bcm43xxx/bcmf_driver.h
+++ b/drivers/wireless/ieee80211/bcm43xxx/bcmf_driver.h
@@ -96,9 +96,10 @@ struct bcmf_dev_s
   int   auth_status; /* Authentication status */
 
 #ifdef CONFIG_IEEE80211_BROADCOM_LOWPOWER
-  struct work_s lp_work;    /* Low power work to work queue */
-  int           lp_mode;    /* Low power mode */
-  sclock_t      lp_ticks;   /* Ticks of last tx time */
+  struct work_s lp_work_ifdown; /* Ifdown work to work queue */
+  struct work_s lp_work_dtim;   /* Low power work to work queue */
+  int           lp_dtim;        /* Listen interval Delivery Traffic Indication Message */
+  sclock_t      lp_ticks;       /* Ticks of last tx time */
 #endif
 };
 
@@ -146,7 +147,9 @@ int bcmf_wl_enable(FAR struct bcmf_dev_s *priv, bool enable);
 
 int bcmf_wl_active(FAR struct bcmf_dev_s *priv, bool active);
 
-int bcmf_wl_set_pm(FAR struct bcmf_dev_s *priv, int mode);
+#ifdef CONFIG_IEEE80211_BROADCOM_LOWPOWER
+int bcmf_wl_set_dtim(FAR struct bcmf_dev_s *priv, uint32_t interval_ms);
+#endif
 
 int bcmf_wl_set_country_code(FAR struct bcmf_dev_s *priv,
                              int interface, FAR void *code);

--- a/include/nuttx/net/netdev.h
+++ b/include/nuttx/net/netdev.h
@@ -593,6 +593,17 @@ void neighbor_out(FAR struct net_driver_s *dev);
 int devif_loopback(FAR struct net_driver_s *dev);
 
 /****************************************************************************
+ * Name: netdev_ifup / netdev_ifdown
+ *
+ * Description:
+ *   Bring the interface up/down
+ *
+ ****************************************************************************/
+
+void netdev_ifup(FAR struct net_driver_s *dev);
+void netdev_ifdown(FAR struct net_driver_s *dev);
+
+/****************************************************************************
  * Carrier detection
  *
  * Call netdev_carrier_on when the carrier has become available and the

--- a/net/netdev/netdev.h
+++ b/net/netdev/netdev.h
@@ -91,17 +91,6 @@ typedef int (*netdev_callback_t)(FAR struct net_driver_s *dev,
  ****************************************************************************/
 
 /****************************************************************************
- * Name: netdev_ifup / netdev_ifdown
- *
- * Description:
- *   Bring the interface up/down
- *
- ****************************************************************************/
-
-void netdev_ifup(FAR struct net_driver_s *dev);
-void netdev_ifdown(FAR struct net_driver_s *dev);
-
-/****************************************************************************
  * Name: netdev_verify
  *
  * Description:


### PR DESCRIPTION
## Summary

wireless/bcm43xxx: set listen interval on lowpower

set listen interval dtim(Delivery Traffic Indication Message) on lowpower mode

Signed-off-by: chao.an <anchao@xiaomi.com>

## Impact

N/A

## Testing

bcm43013