### PR TITLE
wireless/bcm43xxx: discard auth event if netdev down

### DIFF
--- a/drivers/wireless/ieee80211/bcm43xxx/bcmf_driver.c
+++ b/drivers/wireless/ieee80211/bcm43xxx/bcmf_driver.c
@@ -645,6 +645,11 @@ void bcmf_wl_auth_event_handler(FAR struct bcmf_dev_s *priv,
   wlinfo("Got auth event %" PRId32 " status %" PRId32 " from <%s>\n",
          type, status, event->src_name);
 
+  if (!priv->bc_bifup)
+    {
+      return;
+    }
+
   bcmf_hexdump((uint8_t *)event, len, (unsigned long)event);
 
   if (type == WLC_E_SET_SSID && status == WLC_E_STATUS_SUCCESS)

--- a/drivers/wireless/ieee80211/bcm43xxx/bcmf_netdev.c
+++ b/drivers/wireless/ieee80211/bcm43xxx/bcmf_netdev.c
@@ -756,6 +756,10 @@ static int bcmf_ifdown(FAR struct net_driver_s *dev)
 
   if (priv->bc_bifup)
     {
+      /* Mark the device "down" */
+
+      priv->bc_bifup = false;
+
 #ifdef CONFIG_IEEE80211_BROADCOM_LOWPOWER
       if (!work_available(&priv->lp_work))
         {
@@ -765,10 +769,6 @@ static int bcmf_ifdown(FAR struct net_driver_s *dev)
 
       bcmf_wl_enable(priv, false);
       bcmf_wl_active(priv, false);
-
-      /* Mark the device "down" */
-
-      priv->bc_bifup = false;
     }
 
   leave_critical_section(flags);


### PR DESCRIPTION

## Summary

wireless/bcm43xxx: discard auth event if netdev down

Signed-off-by: chao.an <anchao@xiaomi.com>

## Impact

N/A

## Testing

bcm43013