### PR TITLE
wireless/bcm43xxx: filter out the bssi with same ssid name

### DIFF
--- a/drivers/wireless/ieee80211/bcm43xxx/bcmf_driver.c
+++ b/drivers/wireless/ieee80211/bcm43xxx/bcmf_driver.c
@@ -749,7 +749,9 @@ void bcmf_wl_scan_event_handler(FAR struct bcmf_dev_s *priv,
           /* Check if current bss AP is not already detected */
 
           if (memcmp(&curr->BSSID, &bss[i].BSSID,
-                     sizeof(curr->BSSID)) == 0)
+                     sizeof(curr->BSSID)) == 0 ||
+              memcmp(&curr->SSID, &bss[i].SSID,
+                     sizeof(curr->SSID)) == 0)
             {
               /* Replace the duplicate entry if rssi is
                * better than before


### PR DESCRIPTION
## Summary

wireless/bcm43xxx: filter out the bssi with same ssid name

## Impact

N/A

## Testing

bcm43013