### PR TITLE
wireless/bcm43xxx: only break out the send loop if no data

### DIFF
--- a/drivers/wireless/ieee80211/bcm43xxx/bcmf_netdev.c
+++ b/drivers/wireless/ieee80211/bcm43xxx/bcmf_netdev.c
@@ -518,13 +518,11 @@ static void bcmf_tx_poll_work(FAR void *arg)
 
           devif_poll(&priv->bc_dev, bcmf_txpoll);
 
-          /* Break out the continuous send if :
-           * 1. IP stack has no data to send.
-           * 2. RX worker ready.
+          /* Break out the continuous send if IP stack has
+           * no data to send.
            */
 
-          if (priv->cur_tx_frame != NULL ||
-              !work_available(&priv->bc_rxwork))
+          if (priv->cur_tx_frame != NULL)
             {
               break;
             }


### PR DESCRIPTION
## Summary

wireless/bcm43xxx: only break out the send loop if no data

only break out the continuous send if IP stack has no data to send to avoid
tx being constantly interrupted by RX

Signed-off-by: chao.an <anchao@xiaomi.com>

## Impact

N/A

## Testing

bcm43013