### PR TITLE
net/tcp: fix regression of invalid update the rexmit_seq in buffer mode

### DIFF
--- a/net/tcp/tcp.h
+++ b/net/tcp/tcp.h
@@ -175,7 +175,10 @@ struct tcp_conn_s
   uint8_t  rcvseq[4];     /* The sequence number that we expect to
                            * receive next */
   uint8_t  sndseq[4];     /* The sequence number that was last sent by us */
+#if !defined(CONFIG_NET_TCP_WRITE_BUFFERS) || \
+    defined(CONFIG_NET_SENDFILE)
   uint32_t rexmit_seq;    /* The sequence number to be retrasmitted */
+#endif
   uint8_t  crefs;         /* Reference counts on this instance */
 #if defined(CONFIG_NET_IPv4) && defined(CONFIG_NET_IPv6)
   uint8_t  domain;        /* IP domain: PF_INET or PF_INET6 */

--- a/net/tcp/tcp_send_buffered.c
+++ b/net/tcp/tcp_send_buffered.c
@@ -594,8 +594,6 @@ static uint16_t psock_send_eventhandler(FAR struct net_driver_s *dev,
               continue;
             }
 
-          conn->rexmit_seq = rexmitno;
-
           /* Reconstruct the length of the earliest segment to be
            * retransmitted.
            */
@@ -612,7 +610,6 @@ static uint16_t psock_send_eventhandler(FAR struct net_driver_s *dev,
            */
 
           DEBUGASSERT(TCP_WBSEQNO(wrb) != (unsigned)-1);
-          conn->rexmit_seq = TCP_WBSEQNO(wrb);
 
 #ifdef NEED_IPDOMAIN_SUPPORT
           /* If both IPv4 and IPv6 support are enabled, then we will need to


### PR DESCRIPTION
## Summary

net/tcp: fix regression of invalid update the rexmit_seq in buffer mode

fix regression of invalid update the rexmit_seq in buffer mode
rexmit_seq should not be used instead of sndseq in fast retransmission,
sndseq of retransmission in the packet does not need to be re-updated

Signed-off-by: chao.an <anchao@xiaomi.com>

## Impact

N/A

## Testing

bcm43013 iperf test