### PR TITLE
net/tcp: discard connect reference before free

### DIFF
--- a/net/tcp/tcp_close.c
+++ b/net/tcp/tcp_close.c
@@ -58,6 +58,10 @@ static void tcp_close_work(FAR void *param)
   /* Stop the network monitor for all sockets */
 
   tcp_stop_monitor(conn, TCP_CLOSE);
+
+  /* Discard our reference to the connection */
+
+  conn->crefs = 0;
   tcp_free(conn);
 
   net_unlock();
@@ -356,7 +360,6 @@ int tcp_close(FAR struct socket *psock)
   /* Perform the disconnection now */
 
   tcp_unlisten(conn); /* No longer accepting connections */
-  conn->crefs = 0;    /* Discard our reference to the connection */
 
   /* Break any current connections and close the socket */
 

--- a/net/tcp/tcp_conn.c
+++ b/net/tcp/tcp_conn.c
@@ -696,6 +696,7 @@ FAR struct tcp_conn_s *tcp_alloc(uint8_t domain)
            * waiting for it.
            */
 
+          conn->crefs = 0;
           tcp_free(conn);
 
           /* Now there is guaranteed to be one free connection.  Get it! */


### PR DESCRIPTION
## Summary

net/tcp: discard connect reference before free

connect reference should be set to 0 before free

## Impact

N/A

## Testing

bcm43013 iperf test