### PR TITLE
fix sd can't usage when mult-block receive errro

### DIFF
--- a/drivers/mmcsd/mmcsd_spi.c
+++ b/drivers/mmcsd/mmcsd_spi.c
@@ -1280,6 +1280,8 @@ static ssize_t mmcsd_read(FAR struct inode *inode, unsigned char *buffer,
           if (mmcsd_recvblock(slot, buffer, SECTORSIZE(slot)) != 0)
             {
               ferr("ERROR: Failed: to receive the block\n");
+              /* Send CMD12: Stops transmission */
+              response = mmcsd_sendcmd(slot, &g_cmd12, 0);
               goto errout_with_eio;
             }
 


### PR DESCRIPTION
## Summary
sd status will wrong when mult-block read error
## Impact
sd will can't used when mult-block read error
## Testing
bes m0 board test done
