### PR TITLE
arch/arm/Kconfig: Add description for ARM_THUMB to make it configurable

### DIFF
--- a/arch/arm/Kconfig
+++ b/arch/arm/Kconfig
@@ -917,7 +917,7 @@ config ARCH_TRUSTZONE_BOTH
 endchoice # TrustZone Configuration
 
 config ARM_THUMB
-	bool
+	bool "Thumb Mode"
 	default n
 
 config ARM_HAVE_WFE_SEV


### PR DESCRIPTION
## Summary
Add description for ARM_THUMB to make it configurable by defconfig, it's useful for cortex-a based chips.
## Impact
No
## Testing
Custom boards
