### PR TITLE
drivers/segger: Support the customize SEGGER_RTT_[BUFFER_]SECTION

### DIFF
--- a/drivers/segger/Kconfig
+++ b/drivers/segger/Kconfig
@@ -12,6 +12,19 @@ config SEGGER_RTT
 
 if SEGGER_RTT
 
+config SEGGER_RTT_SECTION
+	string "Segger RTT Control Block Section"
+	default ""
+	---help---
+		Declare _SEGGER_RTT global variable in the specific data section.
+
+config SEGGER_RTT_BUFFER_SECTION
+	string "Segger RTT Buffer Block Section"
+	default SEGGER_RTT_SECTION
+	---help---
+		Declare _acUpBuffer/_acDownBuffer global variables in the specific
+		data section.
+
 config SEGGER_RTT_CPU_CACHE_LINE_SIZE
 	int "Segger RTT Cache Line Size"
 	default 0

--- a/drivers/segger/Make.defs
+++ b/drivers/segger/Make.defs
@@ -26,6 +26,14 @@ ifeq ($(CONFIG_SEGGER_RTT),y)
 
   CFLAGS += -Wno-shadow -Wno-array-bounds
 
+  ifneq ($(CONFIG_SEGGER_RTT_SECTION),"")
+    CFLAGS += ${shell $(DEFINE) "$(CC)" SEGGER_RTT_SECTION=CONFIG_SEGGER_RTT_SECTION}
+  endif
+
+  ifneq ($(CONFIG_SEGGER_RTT_BUFFER_SECTION),"")
+    CFLAGS += ${shell $(DEFINE) "$(CC)" SEGGER_RTT_BUFFER_SECTION=CONFIG_SEGGER_RTT_BUFFER_SECTION}
+  endif
+
   CFLAGS += ${shell $(INCDIR) "$(CC)" segger$(DELIM)config}
   CFLAGS += ${shell $(INCDIR) "$(CC)" segger$(DELIM)RTT$(DELIM)RTT}
 


### PR DESCRIPTION
## Summary
User could put the variable to the special region(e.g. uncacheable)

## Impact
new feature

## Testing
Pass CI
