### PR TITLE
Revert "net/tcp: discard connect reference before free"

### DIFF
--- a/net/tcp/tcp_close.c
+++ b/net/tcp/tcp_close.c
@@ -58,10 +58,6 @@ static void tcp_close_work(FAR void *param)
   /* Stop the network monitor for all sockets */
 
   tcp_stop_monitor(conn, TCP_CLOSE);
-
-  /* Discard our reference to the connection */
-
-  conn->crefs = 0;
   tcp_free(conn);
 
   net_unlock();
@@ -360,6 +356,7 @@ int tcp_close(FAR struct socket *psock)
   /* Perform the disconnection now */
 
   tcp_unlisten(conn); /* No longer accepting connections */
+  conn->crefs = 0;    /* Discard our reference to the connection */
 
   /* Break any current connections and close the socket */
 

--- a/net/tcp/tcp_conn.c
+++ b/net/tcp/tcp_conn.c
@@ -696,7 +696,6 @@ FAR struct tcp_conn_s *tcp_alloc(uint8_t domain)
            * waiting for it.
            */
 
-          conn->crefs = 0;
           tcp_free(conn);
 
           /* Now there is guaranteed to be one free connection.  Get it! */


### PR DESCRIPTION
## Summary

This reverts commit b88a1fd7fdf713f7c653453f40094e3e98b2ff6c. [1]

Because:

* It casues assertion failures like [2].

* I don't understand what it attempted to fix.

[1]
```
commit b88a1fd7fdf713f7c653453f40094e3e98b2ff6c
Author: chao.an <anchao@xiaomi.com>
Date:   Sat Jul 2 13:17:41 2022 +0800

    net/tcp: discard connect reference before free

    connect reference should be set to 0 before free

    Signed-off-by: chao.an <anchao@xiaomi.com>
```

[2]
```
    #0  up_assert (filename=0x5516d0 "tcp/tcp_conn.c", lineno=771) at sim/up_assert.c:75
    #1  0x000000000040a4bb in _assert (filename=0x5516d0 "tcp/tcp_conn.c", linenum=771) at assert/lib_assert.c:36
    #2  0x000000000042a2ad in tcp_free (conn=0x597fe0 <g_tcp_connections+384>) at tcp/tcp_conn.c:771
    #3  0x000000000053bdc2 in tcp_close_disconnect (psock=0x7f58d1abbd80) at tcp/tcp_close.c:331
    #4  0x000000000053bc69 in tcp_close (psock=0x7f58d1abbd80) at tcp/tcp_close.c:366
    #5  0x000000000052eefe in inet_close (psock=0x7f58d1abbd80) at inet/inet_sockif.c:1689
    #6  0x000000000052eb9b in psock_close (psock=0x7f58d1abbd80) at socket/net_close.c:102
    #7  0x0000000000440495 in sock_file_close (filep=0x7f58d1b35f40) at socket/socket.c:115
    #8  0x000000000043b8b6 in file_close (filep=0x7f58d1b35f40) at vfs/fs_close.c:74
    #9  0x000000000043ab22 in nx_close (fd=9) at inode/fs_files.c:544
    #10 0x000000000043ab7f in close (fd=9) at inode/fs_files.c:578
```

## Impact

## Testing

