### PR TITLE
clock/settime: minor fix compile warning

### DIFF
--- a/sched/clock/clock_timekeeping.c
+++ b/sched/clock/clock_timekeeping.c
@@ -115,7 +115,7 @@ int clock_timekeeping_get_wall_time(FAR struct timespec *ts)
  * Name: clock_timekeeping_set_wall_time
  ****************************************************************************/
 
-int clock_timekeeping_set_wall_time(FAR struct timespec *ts)
+int clock_timekeeping_set_wall_time(FAR const struct timespec *ts)
 {
   irqstate_t flags;
   uint64_t counter;

--- a/sched/clock/clock_timekeeping.h
+++ b/sched/clock/clock_timekeeping.h
@@ -37,7 +37,7 @@
  ****************************************************************************/
 
 int clock_timekeeping_get_wall_time(FAR struct timespec *ts);
-int clock_timekeeping_set_wall_time(FAR struct timespec *ts);
+int clock_timekeeping_set_wall_time(FAR const struct timespec *ts);
 
 void clock_update_wall_time(void);
 


### PR DESCRIPTION
## Summary

clock/settime: minor fix compile warning

clock/clock_settime.c: In function ‘clock_settime’:
clock/clock_settime.c:120:45: warning: passing argument 1 of ‘clock_timekeeping_set_wall_time’
                              discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
  120 |       ret = clock_timekeeping_set_wall_time(tp);
      |                                             ^~
In file included from clock/clock_settime.c:37:
sched/clock/clock_timekeeping.h:40:58: note: expected ‘struct timespec *’
                                       but argument is of type ‘const struct timespec *’
   40 | int clock_timekeeping_set_wall_time(FAR struct timespec *ts);
      |

Signed-off-by: chao.an <anchao@xiaomi.com>

## Impact

N/A

## Testing

enable CONFIG_CLOCK_TIMEKEEPING