### PR TITLE
vncserver: Correct rfb_keyevent_s definition

### DIFF
--- a/drivers/video/vnc/vnc_receiver.c
+++ b/drivers/video/vnc/vnc_receiver.c
@@ -321,7 +321,7 @@ int vnc_receiver(FAR struct vnc_session_s *session)
                   /* Inject the key press/release event into NX */
 
                   keyevent = (FAR struct rfb_keyevent_s *)session->inbuf;
-                  vnc_key_map(session, rfb_getbe16(keyevent->key),
+                  vnc_key_map(session, rfb_getbe32(keyevent->key),
                               (bool)keyevent->down);
                 }
             }

--- a/include/nuttx/video/rfb.h
+++ b/include/nuttx/video/rfb.h
@@ -411,7 +411,7 @@ struct rfb_keyevent_s
   uint8_t msgtype;               /* U8  Message type */
   uint8_t down;                  /* U8  Down flag */
   uint8_t padding[2];
-  uint8_t key[2];                /* U16 Key */
+  uint8_t key[4];                /* U16 Key */
 };
 
 /* "The interpretation of keysyms is a complex area. In order to be as


### PR DESCRIPTION


## Summary
Refer to https://datatracker.ietf.org/doc/html/rfc6143,
size of key is 4 byte.
## Impact
vncserver
## Testing
sim
