### PR TITLE
Fix compiler warnings (-Wunused-parameter) in various functions

### DIFF
--- a/drivers/misc/dev_null.c
+++ b/drivers/misc/dev_null.c
@@ -74,6 +74,10 @@ static const struct file_operations devnull_fops =
 static ssize_t devnull_read(FAR struct file *filep, FAR char *buffer,
                             size_t len)
 {
+  UNUSED(filep);
+  UNUSED(buffer);
+  UNUSED(len);
+
   return 0; /* Return EOF */
 }
 
@@ -84,6 +88,9 @@ static ssize_t devnull_read(FAR struct file *filep, FAR char *buffer,
 static ssize_t devnull_write(FAR struct file *filep, FAR const char *buffer,
                              size_t len)
 {
+  UNUSED(filep);
+  UNUSED(buffer);
+
   return len; /* Say that everything was written */
 }
 
@@ -94,6 +101,8 @@ static ssize_t devnull_write(FAR struct file *filep, FAR const char *buffer,
 static int devnull_poll(FAR struct file *filep, FAR struct pollfd *fds,
                         bool setup)
 {
+  UNUSED(filep);
+
   if (setup)
     {
       fds->revents |= (fds->events & (POLLIN | POLLOUT));

--- a/drivers/misc/dev_zero.c
+++ b/drivers/misc/dev_zero.c
@@ -74,6 +74,8 @@ static const struct file_operations devzero_fops =
 static ssize_t devzero_read(FAR struct file *filep, FAR char *buffer,
                             size_t len)
 {
+  UNUSED(filep);
+
   memset(buffer, 0, len);
   return len;
 }
@@ -85,6 +87,9 @@ static ssize_t devzero_read(FAR struct file *filep, FAR char *buffer,
 static ssize_t devzero_write(FAR struct file *filep, FAR const char *buffer,
                              size_t len)
 {
+  UNUSED(filep);
+  UNUSED(buffer);
+
   return len;
 }
 
@@ -95,6 +100,8 @@ static ssize_t devzero_write(FAR struct file *filep, FAR const char *buffer,
 static int devzero_poll(FAR struct file *filep, FAR struct pollfd *fds,
                         bool setup)
 {
+  UNUSED(filep);
+
   if (setup)
     {
       fds->revents |= (fds->events & (POLLIN | POLLOUT));

--- a/drivers/syslog/syslog_channel.c
+++ b/drivers/syslog/syslog_channel.c
@@ -229,6 +229,7 @@ static ssize_t syslog_default_write(FAR struct syslog_channel_s *channel,
   nxsem_post(&sem);
 #endif
 
+  UNUSED(channel);
   return buflen;
 }
 #endif

--- a/drivers/syslog/syslog_device.c
+++ b/drivers/syslog/syslog_device.c
@@ -658,6 +658,8 @@ static int syslog_dev_flush(FAR struct syslog_channel_s *channel)
    */
 
   file_fsync(&syslog_dev->sl_file);
+#else
+  UNUSED(channel);
 #endif
 
   return OK;

--- a/libs/libc/grp/lib_initgroups.c
+++ b/libs/libc/grp/lib_initgroups.c
@@ -55,5 +55,7 @@ int initgroups(FAR const char *user, gid_t group)
    * Thus, just ignore this request silently and report success.
    */
 
+  UNUSED(user);
+  UNUSED(group);
   return 0;
 }

--- a/libs/libc/misc/lib_glob.c
+++ b/libs/libc/misc/lib_glob.c
@@ -366,6 +366,9 @@ static int do_glob(FAR char *buf, size_t pos, int type, FAR char *pat,
 
 static int ignore_err(FAR const char *path, int err)
 {
+  UNUSED(path);
+  UNUSED(err);
+
   return 0;
 }
 

--- a/libs/libc/misc/lib_mknod.c
+++ b/libs/libc/misc/lib_mknod.c
@@ -55,7 +55,8 @@
  *
  * Input Parameters:
  *   pathname - The full path to node.
- *   mode     - File type and permission
+ *   mode     - File type and permission.
+ *   dev      - Ignored.
  *
  * Returned Value:
  *   0 is returned on success; otherwise, -1 is returned with errno set
@@ -66,6 +67,8 @@
 int mknod(FAR const char *path, mode_t mode, dev_t dev)
 {
   int ret = -1;
+
+  UNUSED(dev);
 
   switch (mode & S_IFMT)
     {

--- a/libs/libc/pthread/pthread_atfork.c
+++ b/libs/libc/pthread/pthread_atfork.c
@@ -34,5 +34,9 @@ int pthread_atfork(CODE void (*prepare)(void),
 {
   /* fork isn't supported yet, so the dummy implementation is enough. */
 
+  UNUSED(prepare);
+  UNUSED(parent);
+  UNUSED(child);
+
   return 0;
 }

--- a/libs/libc/pthread/pthread_barrierinit.c
+++ b/libs/libc/pthread/pthread_barrierinit.c
@@ -75,6 +75,8 @@ int pthread_barrier_init(FAR pthread_barrier_t *barrier,
 {
   int ret = OK;
 
+  UNUSED(attr);
+
   if (!barrier || count == 0)
     {
       ret = EINVAL;

--- a/libs/libc/semaphore/sem_init.c
+++ b/libs/libc/semaphore/sem_init.c
@@ -61,6 +61,8 @@
 
 int nxsem_init(FAR sem_t *sem, int pshared, unsigned int value)
 {
+  UNUSED(pshared);
+
   /* Verify that a semaphore was provided and the count is within the valid
    * range.
    */

--- a/libs/libc/stream/lib_libnoflush.c
+++ b/libs/libc/stream/lib_libnoflush.c
@@ -52,5 +52,6 @@
 
 int lib_noflush(FAR struct lib_outstream_s *this)
 {
+  UNUSED(this);
   return OK;
 }

--- a/libs/libc/stream/lib_libsnoflush.c
+++ b/libs/libc/stream/lib_libsnoflush.c
@@ -51,5 +51,6 @@
 
 int lib_snoflush(FAR struct lib_sostream_s *this)
 {
+  UNUSED(this);
   return OK;
 }

--- a/libs/libc/stream/lib_nullinstream.c
+++ b/libs/libc/stream/lib_nullinstream.c
@@ -33,6 +33,7 @@
 
 static int nullinstream_getc(FAR struct lib_instream_s *this)
 {
+  UNUSED(this);
   return EOF;
 }
 

--- a/libs/libc/stream/lib_nulloutstream.c
+++ b/libs/libc/stream/lib_nulloutstream.c
@@ -34,6 +34,7 @@
 
 static void nulloutstream_putc(FAR struct lib_outstream_s *this, int ch)
 {
+  UNUSED(ch);
   DEBUGASSERT(this);
   this->nput++;
 }

--- a/libs/libc/string/lib_strerror.c
+++ b/libs/libc/string/lib_strerror.c
@@ -365,6 +365,8 @@ FAR char *strerror(int errnum)
         }
     }
   while (ndxlow <= ndxhi);
+#else
+  UNUSED(errnum);
 #endif
   return "Unknown error";
 }

--- a/libs/libc/time/lib_gettimeofday.c
+++ b/libs/libc/time/lib_gettimeofday.c
@@ -60,6 +60,8 @@ int gettimeofday(FAR struct timeval *tv, FAR struct timezone *tz)
   struct timespec ts;
   int ret;
 
+  UNUSED(tz);
+
 #ifdef CONFIG_DEBUG_FEATURES
   if (!tv)
     {

--- a/libs/libc/time/lib_settimeofday.c
+++ b/libs/libc/time/lib_settimeofday.c
@@ -58,6 +58,8 @@ int settimeofday(FAR const struct timeval *tv, FAR struct timezone *tz)
 {
   struct timespec ts;
 
+  UNUSED(tz);
+
 #ifdef CONFIG_DEBUG_FEATURES
   if (!tv || tv->tv_usec >= USEC_PER_SEC)
     {

--- a/libs/libc/unistd/lib_getrlimit.c
+++ b/libs/libc/unistd/lib_getrlimit.c
@@ -44,6 +44,8 @@
 
 int getrlimit(int resource, FAR struct rlimit *rlp)
 {
+  UNUSED(resource);
+
   if (rlp == NULL)
     {
       set_errno(EINVAL);

--- a/libs/libc/unistd/lib_getrusage.c
+++ b/libs/libc/unistd/lib_getrusage.c
@@ -48,10 +48,15 @@
  *   information for the child process is discarded and not included in the
  *   resource information provided by getrusage().
  *
+ *   Note: This is currently a dummy implementation and as such does not
+ *   honor the 'who' parameter.
+ *
  ****************************************************************************/
 
 int getrusage(int who, FAR struct rusage *r_usage)
 {
+  UNUSED(who);
+
   if (r_usage == NULL)
     {
       set_errno(EINVAL);

--- a/libs/libc/unistd/lib_pathconf.c
+++ b/libs/libc/unistd/lib_pathconf.c
@@ -112,6 +112,8 @@ long fpathconf(int fildes, int name)
    * necessary.
    */
 
+  UNUSED(fildes);
+
   switch (name)
     {
       case _PC_PATH_MAX:
@@ -143,5 +145,7 @@ long fpathconf(int fildes, int name)
 
 long pathconf(FAR const char *path, int name)
 {
+  UNUSED(path);
+
   return fpathconf(-1, name);
 }

--- a/libs/libc/unistd/lib_setpriority.c
+++ b/libs/libc/unistd/lib_setpriority.c
@@ -58,6 +58,8 @@ int setpriority(int which, id_t who, int value)
   struct sched_param param;
   int ret;
 
+  UNUSED(which);
+
   if (who == 0)
     {
       who = getpid();

--- a/libs/libc/unistd/lib_setrlimit.c
+++ b/libs/libc/unistd/lib_setrlimit.c
@@ -46,5 +46,8 @@ int setrlimit(int resource, FAR const struct rlimit *rlp)
 {
   /* This is a dummy realization to make the compiler happy */
 
+  UNUSED(resource);
+  UNUSED(rlp);
+
   return OK;
 }

--- a/sched/group/group_signal.c
+++ b/sched/group/group_signal.c
@@ -270,6 +270,8 @@ errout:
 
 #else
 
+  UNUSED(group);
+  UNUSED(siginfo);
   return -ENOSYS;
 
 #endif

--- a/sched/irq/irq_unexpectedisr.c
+++ b/sched/irq/irq_unexpectedisr.c
@@ -46,6 +46,9 @@
 
 int irq_unexpected_isr(int irq, FAR void *context, FAR void *arg)
 {
+  UNUSED(context);
+  UNUSED(arg);
+
   up_irq_save();
   _err("ERROR irq: %d\n", irq);
   PANIC();

--- a/sched/sched/sched_resumescheduler.c
+++ b/sched/sched/sched_resumescheduler.c
@@ -90,7 +90,7 @@ void nxsched_resume_scheduler(FAR struct tcb_s *tcb)
 
   if (tcb->irqcount > 0)
     {
-      /* Do notihing here
+      /* Do nothing here
        * NOTE: spin_setbit() is done in nxsched_add_readytorun()
        * and nxsched_remove_readytorun()
        */

--- a/sched/task/task_spawn.c
+++ b/sched/task/task_spawn.c
@@ -182,7 +182,8 @@ errout:
  *      task_restart() would still be an issue.
  *
  * Input Parameters:
- *   Standard task start-up parameters
+ *   argc, argv - Ignored. The task's start-up parameters are passed via the
+ *     semaphore-protected global structure g_spawn_parms.
  *
  * Returned Value:
  *   Standard task return value.
@@ -197,6 +198,9 @@ static int nxtask_spawn_proxy(int argc, FAR char *argv[])
    * if the file_actions parameter to task_spawn[p] was non-NULL and/or the
    * option to change the signal mask was selected.
    */
+
+  UNUSED(argc);
+  UNUSED(argv);
 
   DEBUGASSERT(g_spawn_parms.file_actions ||
               (g_spawn_parms.attr &&

--- a/sched/timer/timer_getoverrun.c
+++ b/sched/timer/timer_getoverrun.c
@@ -75,6 +75,7 @@
 
 int timer_getoverrun(timer_t timerid)
 {
+  UNUSED(timerid);
   set_errno(ENOSYS);
   return ERROR;
 }


### PR DESCRIPTION
## Summary

Fix the `-Wunused-parameter` warning in:
- group/group_signal.c: group_signal()
- irq/irq_unexpectedisr.c: irq_unexpected_isr()
- task/task_spawn.c: nxtask_spawn_proxy()
- timer/timer_getoverrun.c: timer_getoverrun()
- misc/dev_null.c: devnull_read(), devnull_write(), devnull_poll()
- misc/dev_zero.c: devzero_read(), devzero_write(), devzero_poll()
- syslog/syslog_channel.c: syslog_default_write()
- syslog/syslog_device.c: syslog_dev_flush()
- grp/lib_initgroups.c: initgroups()
- misc/lib_mknod.c: mknod()
- misc/lib_glob.c: ignore_err()
- pthread/pthread_barrierinit.c: pthread_barrier_init()
- pthread/pthread_atfork.c: pthread_atfork()
- semaphore/sem_init.c: nxsem_init()
- stream/lib_nullinstream.c: nullinstream_getc()
- stream/lib_nulloutstream.c: nulloutstream_putc()
- stream/lib_libnoflush.c: lib_noflush()
- stream/lib_libsnoflush.c: lib_snoflush()
- string/lib_strerror.c: strerror()
- time/lib_gettimeofday.c: gettimeofday()
- time/lib_settimeofday.c: settimeofday()
- unistd/lib_pathconf.c: fpathconf(), pathconf()
- unistd/lib_getrusage.c: getrusage()
- unistd/lib_setrlimit.c: setrlimit()
- unistd/lib_getrlimit.c: getrlimit()
- unistd/lib_setpriority.c: setpriority()

## Impact

Clears many compiler warnings when building with, e.g., `-Wextra`, etc.

## Testing

- build testing
- nxstyle
