### PR TITLE
usbdev/usbmsc: introduce USBMSC_WRMULTIPLE for faster writes

### DIFF
--- a/drivers/usbdev/Kconfig
+++ b/drivers/usbdev/Kconfig
@@ -799,6 +799,20 @@ config USBMSC_NRDREQS
 	---help---
 		The number of write/read requests that can be in flight
 
+config USBMSC_WRMULTIPLE
+	bool "Write multiple blocks at once if possible"
+	default n
+	---help---
+		Store multiple blocks and write them in a single request.  This
+		speeds up the writing significantly with eMMC devices, for example,
+		because writing 512 bytes may be as fast as writing the complete
+		SUPER_PAGE_SIZE (see extended CSD [225] bits 0-3), which may be up
+		to 64Kb.  Real-life example with different block sizes, using the
+		dd command with argument bs=512, bs=8k (USBMSC_NWRREQS = 4, and 16):
+		512b: 470 kb/s, 8k: 5.3 Mb/s.  This is more than a tenfold increase
+		in the throughput.  Without this option enabled, the block driver's
+		block size is always used, which is usually 512 bytes.
+
 config USBMSC_BULKINREQLEN
 	int "Bulk IN request size"
 	default 512 if USBDEV_DUALSPEED

--- a/drivers/usbdev/usbmsc.c
+++ b/drivers/usbdev/usbmsc.c
@@ -1514,7 +1514,12 @@ int usbmsc_bindlun(FAR void *handle, FAR const char *drvrpath,
 
   if (!priv->iobuffer)
     {
+#ifdef CONFIG_USBMSC_WRMULTIPLE
+      priv->iobuffer = (FAR uint8_t *)kmm_malloc(geo.geo_sectorsize *
+                                                 CONFIG_USBMSC_NWRREQS);
+#else
       priv->iobuffer = (FAR uint8_t *)kmm_malloc(geo.geo_sectorsize);
+#endif
       if (!priv->iobuffer)
         {
           usbtrace(TRACE_CLSERROR(USBMSC_TRACEERR_ALLOCIOBUFFER),
@@ -1522,7 +1527,11 @@ int usbmsc_bindlun(FAR void *handle, FAR const char *drvrpath,
           return -ENOMEM;
         }
 
+#ifdef CONFIG_USBMSC_WRMULTIPLE
+      priv->iosize = geo.geo_sectorsize * CONFIG_USBMSC_NWRREQS;
+#else
       priv->iosize = geo.geo_sectorsize;
+#endif
     }
   else if (priv->iosize < geo.geo_sectorsize)
     {


### PR DESCRIPTION
This patch introduces a configuration option USBMSC_WRMULTIPLE,
which is used to store multiple blocks into a larger chunk that
then gets written via the mmcsd_writemultiple() (in case mmcsd
is used).

The bottleneck with the current implementation is the poor
performance due to short block writes.  USBMSC_DRVR_WRITE()
always writes only one sector (with eMMC that's usually 512 bytes).
eMMC devices usually erase much larger regions with near constant
time (see Jedec JESD84-B51, Extended CSD register byte [225],
SUPER_PAGE_SIZE): 'This register defines one or multiple of
programmable boundary unit that is programmed at the same time.'

If USBMSC_WRMULTIPLE is defined, then USBMSC_NWRREQS is used to
allocate the write buffer size.  We don't want this to be the
default behavior yet as this may reveal unseen bugs in usb drivers
due to the faster overall performance.

Sample configurations with measured performance:

  - Without USBMSC_WRMULTIPLE: 470 Kb/s
  - With USBMSC_WRMULTIPLE, CONFIG_USBMSC_NWRREQS=4: 1.1 Mb/s
    (dd with bs=2k)
  - With USBMSC_WRMULTIPLE, CONFIG_USBMSC_NWRREQS=16: 5.2 Mb/s
    (dd with bs=8k)

No doubt, this feature alone may make the mass storage work 10
times faster than before with eMMC cards.

Signed-off-by: Eero Nurkkala <eero.nurkkala@offcode.fi>

## Summary

This speeds up the mass storage emmcsd write operations significantly.

## Impact

Due to the high risk, the behavior is behind #ifdefs.  Enabling this feature
is likely to reveal USB driver issues, like it did with risc-v/mpfs as well.

## Testing

Sending  1.9 Gb image on Polarfire MPFS kit with varying bs options:

dd if=core-image-minimal-dev-icicle-kit-es-amp-20211208101259.rootfs.wic of=/dev/sdb bs=2k status=progress

dd if=core-image-minimal-dev-icicle-kit-es-amp-20211208101259.rootfs.wic of=/dev/sdb bs=8k status=progress
