### PR TITLE
fs/mount: "df -h" fixes regarding datatype sizes

### DIFF
--- a/fs/mount/fs_procfs_mount.c
+++ b/fs/mount/fs_procfs_mount.c
@@ -101,6 +101,7 @@ struct mount_info_s
 
 /* Helpers */
 
+printflike(2, 3)
 static void    mount_sprintf(FAR struct mount_info_s *info,
                  FAR const char *fmt, ...);
 #ifndef CONFIG_FS_PROCFS_EXCLUDE_MOUNT

--- a/fs/mount/fs_procfs_mount.c
+++ b/fs/mount/fs_procfs_mount.c
@@ -268,6 +268,26 @@ static int blocks_entry(FAR const char *mountpoint,
                 statbuf->f_blocks - statbuf->f_bavail, statbuf->f_bavail,
                 mountpoint);
 #else
+#  if defined(CONFIG_FS_LARGEFILE) && defined(CONFIG_HAVE_LONG_LONG)
+  if (statbuf->f_blocks > ULONG_MAX)
+    {
+      fwarn("Detected unsigned overflow in 'Blocks', upper word = %lu\n",
+            (uint32_t)(statbuf->f_blocks >> 32));
+    }
+
+  if ((statbuf->f_blocks - statbuf->f_bavail) > ULONG_MAX)
+    {
+      fwarn("Detected unsigned overflow in 'Used', upper word = %lu\n",
+            (uint32_t)((statbuf->f_blocks - statbuf->f_bavail) >> 32));
+    }
+
+  if (statbuf->f_bavail > ULONG_MAX)
+    {
+      fwarn("Detected unsigned overflow in 'Avail', upper word = %lu\n",
+            (uint32_t)(statbuf->f_bavail >> 32));
+    }
+
+#  endif
   mount_sprintf(info, "%6zu %10" PRIu32 " %10" PRIu32
                 "  %10" PRIu32 " %s\n",
                 statbuf->f_bsize, (uint32_t)statbuf->f_blocks,

--- a/fs/mount/fs_procfs_mount.c
+++ b/fs/mount/fs_procfs_mount.c
@@ -248,6 +248,10 @@ static int blocks_entry(FAR const char *mountpoint,
 
   if (!info->header)
     {
+#if defined(CONFIG_HAVE_LONG_LONG) && !defined(CONFIG_LIBC_LONG_LONG)
+      finfo("long long is enabled, but libc does not support it;\n"
+            "blockcounts may be truncated\n");
+#endif
       mount_sprintf(info,
                     "  Block    Number\n");
       mount_sprintf(info,
@@ -257,11 +261,19 @@ static int blocks_entry(FAR const char *mountpoint,
 
   /* Generate blocks list one line at a time */
 
+#ifdef CONFIG_LIBC_LONG_LONG
   mount_sprintf(info, "%6zu %10" PRIuOFF " %10" PRIuOFF
                 "  %10" PRIuOFF " %s\n",
                 statbuf->f_bsize, statbuf->f_blocks,
                 statbuf->f_blocks - statbuf->f_bavail, statbuf->f_bavail,
                 mountpoint);
+#else
+  mount_sprintf(info, "%6zu %10" PRIu32 " %10" PRIu32
+                "  %10" PRIu32 " %s\n",
+                statbuf->f_bsize, (uint32_t)statbuf->f_blocks,
+                (uint32_t)(statbuf->f_blocks - statbuf->f_bavail),
+                (uint32_t)statbuf->f_bavail, mountpoint);
+#endif /* CONFIG_LIBC_LONG_LONG */
 
   return (info->totalsize >= info->buflen) ? 1 : 0;
 }

--- a/fs/mount/fs_procfs_mount.c
+++ b/fs/mount/fs_procfs_mount.c
@@ -257,7 +257,7 @@ static int blocks_entry(FAR const char *mountpoint,
 
   /* Generate blocks list one line at a time */
 
-  mount_sprintf(info, "%6lu %10" PRIuOFF " %10" PRIuOFF
+  mount_sprintf(info, "%6zu %10" PRIuOFF " %10" PRIuOFF
                 "  %10" PRIuOFF " %s\n",
                 statbuf->f_bsize, statbuf->f_blocks,
                 statbuf->f_blocks - statbuf->f_bavail, statbuf->f_bavail,

--- a/fs/mount/fs_procfs_mount.c
+++ b/fs/mount/fs_procfs_mount.c
@@ -362,14 +362,14 @@ static int usage_entry(FAR const char *mountpoint,
 
   /* Generate usage list one line at a time */
 
-#ifdef CONFIG_HAVE_LONG_LONG
+#ifdef CONFIG_LIBC_LONG_LONG
   mount_sprintf(info, "  %-10s %6llu%c %8llu%c  %8llu%c %s\n", fstype,
                 size, sizelabel, used, usedlabel, free, freelabel,
                 mountpoint);
 #else
-  mount_sprintf(info, "  %-10s %6ld%c %8ld%c  %8ld%c %s\n", fstype,
-                size, sizelabel, used, usedlabel, free, freelabel,
-                mountpoint);
+  mount_sprintf(info, "  %-10s %6lu%c %8lu%c  %8lu%c %s\n", fstype,
+                (uint32_t)size, sizelabel, (uint32_t)used, usedlabel,
+                (uint32_t)free, freelabel, mountpoint);
 #endif
 
   return (info->totalsize >= info->buflen) ? 1 : 0;


### PR DESCRIPTION
## Summary
This PR intends to correct `df` and `df -h` nshlib command output.
Refer to #5253 for details.
## Impact
32-bit arches with HAVE_LONG_LONG (and FS_LARGEFILE) but with disabled LIBC_LONG_LONG.
## Testing
builds on ARMv7-M `nucleo-h743zi2:jumbo` with config tweaks -LIBC_LONG_LONG, +DEBUG_FS_WARN
builds and runs on ARMv6-M `stm32f072b-disco:nsh` with config tweaks; on Milandr MDR32F1QI; 
only procfs tested, but now there's no garbage on stdout.