### PR TITLE
Convert DEBUGASSERT(false) into more intuitive DEBUGPANIC()

### DIFF
--- a/arch/arm/src/cxd56xx/cxd56_gpioint.c
+++ b/arch/arm/src/cxd56xx/cxd56_gpioint.c
@@ -291,7 +291,7 @@ static int set_gpioint_config(int slot, uint32_t gpiocfg)
       val |= (INT_ROUTE_PMU_LATCH << shift);
       break;
     default:
-      DEBUGASSERT(0);
+      DEBUGPANIC();
       break;
     }
 

--- a/arch/arm/src/efm32/efm32_flash.c
+++ b/arch/arm/src/efm32/efm32_flash.c
@@ -433,7 +433,7 @@ int __ramfunc__ msc_load_write_data(uint32_t *data, uint32_t num_words,
 
           /* Gecko does not have auto-increment of ADDR. */
 
-          DEBUGASSERT(0);
+          DEBUGPANIC();
 #else
 
           /* Requires a system core clock at 14MHz or higher */

--- a/arch/arm/src/efm32/efm32_pwm.c
+++ b/arch/arm/src/efm32/efm32_pwm.c
@@ -396,7 +396,7 @@ static int pwm_timer(struct efm32_pwmtimer_s *priv,
       break;
 
     default:
-      DEBUGASSERT(false);
+      DEBUGPANIC();
     }
 
   pwm_putreg(priv, EFM32_TIMER_ROUTE_OFFSET, regval);
@@ -618,7 +618,7 @@ static int pwm_setup(struct pwm_lowerhalf_s *dev)
       break;
 
     default:
-      DEBUGASSERT(false);
+      DEBUGPANIC();
       break;
     }
 

--- a/arch/arm/src/efm32/efm32_usbhost.c
+++ b/arch/arm/src/efm32/efm32_usbhost.c
@@ -1645,7 +1645,7 @@ static void efm32_transfer_start(struct efm32_usbhost_s *priv, int chidx)
           break;
 
         default:
-          DEBUGASSERT(false);
+          DEBUGPANIC();
           return;
         }
 

--- a/arch/arm/src/lc823450/lc823450_clockconfig.c
+++ b/arch/arm/src/lc823450/lc823450_clockconfig.c
@@ -152,7 +152,7 @@ void lc823450_clockconfig()
     }
   else
     {
-      DEBUGASSERT(false);
+      DEBUGPANIC();
     }
 #endif
 

--- a/arch/arm/src/lc823450/lc823450_gpio.c
+++ b/arch/arm/src/lc823450/lc823450_gpio.c
@@ -325,7 +325,7 @@ int lc823450_gpio_config(uint16_t gpiocfg)
                 pupd = IOEX_PUPD_PULLDOWN;
                 break;
               default:
-                DEBUGASSERT(0);
+                DEBUGPANIC();
                 return -EINVAL;
             }
         }
@@ -467,7 +467,7 @@ bool lc823450_gpio_read(uint16_t gpiocfg)
 #endif /* CONFIG_IOEX */
   else
     {
-      DEBUGASSERT(0);
+      DEBUGPANIC();
     }
 
   return value;

--- a/arch/arm/src/lc823450/lc823450_i2c.c
+++ b/arch/arm/src/lc823450/lc823450_i2c.c
@@ -1108,7 +1108,7 @@ struct i2c_master_s *lc823450_i2cbus_initialize(int port)
         break;
 #endif
     default:
-      DEBUGASSERT(false);
+      DEBUGPANIC();
       return NULL;
     }
 
@@ -1180,7 +1180,7 @@ int lc823450_i2cbus_uninitialize(struct i2c_master_s *dev)
 
   if (-1 == port)
     {
-      DEBUGASSERT(0);
+      DEBUGPANIC();
       return -EFAULT;
     }
 

--- a/arch/arm/src/lc823450/lc823450_i2s.c
+++ b/arch/arm/src/lc823450/lc823450_i2s.c
@@ -275,7 +275,7 @@ static void _setup_audio_pll(uint32_t freq)
         break;
 
       default:
-        DEBUGASSERT(false);
+        DEBUGPANIC();
     }
 
   /* Set divider */
@@ -369,7 +369,7 @@ static void lc823450_i2s_setchannel(char id, uint8_t ch)
         break;
 
       default:
-        DEBUGASSERT(false);
+        DEBUGPANIC();
         break;
     }
 

--- a/arch/arm/src/lc823450/lc823450_irq.c
+++ b/arch/arm/src/lc823450/lc823450_irq.c
@@ -719,7 +719,7 @@ void arm_ack_irq(int irq)
     {
       /* IRQ should be handled on CPU0 */
 
-      DEBUGASSERT(false);
+      DEBUGPANIC();
     }
 #endif
 }

--- a/arch/arm/src/lc823450/lc823450_mtd.c
+++ b/arch/arm/src/lc823450/lc823450_mtd.c
@@ -697,7 +697,7 @@ int lc823450_mtd_initialize(uint32_t devno)
                 PRIuOFF " nblocks=%" PRIuOFF "\n", __func__,
                 partinfo[i].startblock, partinfo[i].nblocks);
           mtd_semgive(&g_sem);
-          DEBUGASSERT(0);
+          DEBUGPANIC();
           return -EIO;
         }
 
@@ -707,7 +707,7 @@ int lc823450_mtd_initialize(uint32_t devno)
           finfo("%s(): mmcl_initialize part%d failed: %d\n",
                 __func__, partno, ret);
           mtd_semgive(&g_sem);
-          DEBUGASSERT(0);
+          DEBUGPANIC();
           return ret;
         }
     }

--- a/arch/arm/src/lc823450/lc823450_sdc.c
+++ b/arch/arm/src/lc823450/lc823450_sdc.c
@@ -272,7 +272,7 @@ int lc823450_sdc_initialize(uint32_t ch)
 #endif
 
       default:
-        DEBUGASSERT(false);
+        DEBUGPANIC();
     }
 
   mcinfo("++++ start\n");

--- a/arch/arm/src/lc823450/lc823450_sddrv_dep.c
+++ b/arch/arm/src/lc823450/lc823450_sddrv_dep.c
@@ -110,7 +110,7 @@ static int _get_ch_from_cfg(struct sddrcfg_s *cfg)
         break;
 
       default:
-        DEBUGASSERT(false);
+        DEBUGPANIC();
     }
 
   return ch;

--- a/arch/arm/src/lc823450/lc823450_spi.c
+++ b/arch/arm/src/lc823450/lc823450_spi.c
@@ -236,7 +236,7 @@ static void spi_setmode(struct spi_dev_s *dev, enum spi_mode_e mode)
   switch (mode)
     {
       case SPIDEV_MODE0: /* CPOL=0; CPHA=0 */
-        DEBUGASSERT(0);
+        DEBUGPANIC();
         break;
 
       case SPIDEV_MODE1: /* CPOL=0; CPHA=1 */
@@ -244,7 +244,7 @@ static void spi_setmode(struct spi_dev_s *dev, enum spi_mode_e mode)
         break;
 
       case SPIDEV_MODE2: /* CPOL=1; CPHA=0 */
-        DEBUGASSERT(0);
+        DEBUGPANIC();
         break;
 
       case SPIDEV_MODE3: /* CPOL=1; CPHA=1 */

--- a/arch/arm/src/lpc43xx/lpc43_timer.c
+++ b/arch/arm/src/lpc43xx/lpc43_timer.c
@@ -743,7 +743,7 @@ void lpc43_tmrinitialize(const char *devpath, int irq)
 #endif
 
     default:
-      DEBUGASSERT(0);
+      DEBUGPANIC();
     }
 
   priv->ops = &g_tmrops;

--- a/arch/arm/src/nrf52/nrf52_i2c.c
+++ b/arch/arm/src/nrf52/nrf52_i2c.c
@@ -354,7 +354,7 @@ static int nrf52_i2c_transfer(struct i2c_master_s *dev,
                 {
                   /* Not supported */
 
-                  DEBUGASSERT(0);
+                  DEBUGPANIC();
                 }
             }
 #endif

--- a/arch/arm/src/nrf52/nrf52_lowputc.c
+++ b/arch/arm/src/nrf52/nrf52_lowputc.c
@@ -212,7 +212,7 @@ static void nrf52_setbaud(uintptr_t base, const struct uart_config_s *config)
 
       default:
         {
-          DEBUGASSERT(0);
+          DEBUGPANIC();
           break;
         }
     }

--- a/arch/arm/src/nrf52/nrf52_spi.c
+++ b/arch/arm/src/nrf52/nrf52_spi.c
@@ -850,7 +850,7 @@ static void nrf52_spi_setmode(struct spi_dev_s *dev,
 
           default:
             {
-              DEBUGASSERT(0);
+              DEBUGPANIC();
               return;
             }
         }

--- a/arch/arm/src/rp2040/rp2040_usbdev.c
+++ b/arch/arm/src/rp2040/rp2040_usbdev.c
@@ -825,7 +825,7 @@ static void rp2040_handle_zlp(struct rp2040_usbdev_s *priv)
         break;
 
       default:
-        DEBUGASSERT(0);
+        DEBUGPANIC();
     }
 
   usbtrace(TRACE_INTDECODE(RP2040_TRACEINTID_HANDLEZLP), privep->ep.eplog);

--- a/arch/arm/src/s32k1xx/s32k1xx_clockconfig.c
+++ b/arch/arm/src/s32k1xx/s32k1xx_clockconfig.c
@@ -1881,7 +1881,7 @@ static void up_pm_notify(struct pm_callback_s *cb, int domain,
             {
               /* error */
 
-              DEBUGASSERT(false);
+              DEBUGPANIC();
             }
           }
 
@@ -1891,7 +1891,7 @@ static void up_pm_notify(struct pm_callback_s *cb, int domain,
           {
             /* error */
 
-            DEBUGASSERT(false);
+            DEBUGPANIC();
           }
 
           /* calculate the new clock ticks */
@@ -2020,7 +2020,7 @@ static void up_pm_notify(struct pm_callback_s *cb, int domain,
             {
               /* error */
 
-              DEBUGASSERT(false);
+              DEBUGPANIC();
             }
           }
 
@@ -2030,7 +2030,7 @@ static void up_pm_notify(struct pm_callback_s *cb, int domain,
           {
             /* error */
 
-            DEBUGASSERT(false);
+            DEBUGPANIC();
           }
 
 #endif /* CONFIG_RUN_STANDBY */
@@ -2218,7 +2218,7 @@ static void up_pm_notify(struct pm_callback_s *cb, int domain,
             {
               /* error */
 
-              DEBUGASSERT(false);
+              DEBUGPANIC();
             }
           }
 
@@ -2228,7 +2228,7 @@ static void up_pm_notify(struct pm_callback_s *cb, int domain,
           {
             /* error */
 
-            DEBUGASSERT(false);
+            DEBUGPANIC();
           }
 
 #endif /* CONFIG_RUN_SLEEP */

--- a/arch/arm/src/sam34/sam_tc.c
+++ b/arch/arm/src/sam34/sam_tc.c
@@ -634,7 +634,7 @@ void sam_tcinitialize(const char *devpath, int irq)
 #endif
 
     default:
-      DEBUGASSERT(0);
+      DEBUGPANIC();
     }
 
   priv->ops = &g_tcops;

--- a/arch/arm/src/sam34/sam_wdt.c
+++ b/arch/arm/src/sam34/sam_wdt.c
@@ -564,7 +564,7 @@ static xcpt_t sam34_capture(struct watchdog_lowerhalf_s *lower,
   return oldhandler;
 
 #endif
-  DEBUGASSERT(0);
+  DEBUGPANIC();
   return NULL;
 }
 

--- a/arch/arm/src/stm32/stm32_can_sock.c
+++ b/arch/arm/src/stm32/stm32_can_sock.c
@@ -1294,7 +1294,7 @@ errout:
     }
   else
     {
-      DEBUGASSERT(0);
+      DEBUGPANIC();
     }
 
   return ret;
@@ -1361,7 +1361,7 @@ static int stm32can_rxinterrupt(struct stm32_can_s *priv, int rxmb)
     }
   else
     {
-      DEBUGASSERT(0);
+      DEBUGPANIC();
     }
 
   return OK;

--- a/arch/arm/src/stm32/stm32_foc.c
+++ b/arch/arm/src/stm32/stm32_foc.c
@@ -1660,7 +1660,7 @@ static int stm32_foc_adc_handler(int irq, void *context, void *arg)
               ret = foc_dev->adc_isr(dev);
               if (ret < 0)
                 {
-                  DEBUGASSERT(0);
+                  DEBUGPANIC();
                 }
             }
 

--- a/arch/arm/src/stm32/stm32_i2c_v2.c
+++ b/arch/arm/src/stm32/stm32_i2c_v2.c
@@ -2708,7 +2708,7 @@ static int stm32_i2c_pm_prepare(struct pm_callback_s *cb, int domain,
 
       if (nxsem_get_value(&priv->sem_excl, &sval) < 0)
         {
-          DEBUGASSERT(false);
+          DEBUGPANIC();
           return -EINVAL;
         }
 

--- a/arch/arm/src/stm32/stm32_otgfshost.c
+++ b/arch/arm/src/stm32/stm32_otgfshost.c
@@ -1567,7 +1567,7 @@ static void stm32_transfer_start(struct stm32_usbhost_s *priv, int chidx)
           break;
 
         default:
-          DEBUGASSERT(false);
+          DEBUGPANIC();
           return;
         }
 

--- a/arch/arm/src/stm32/stm32_otghshost.c
+++ b/arch/arm/src/stm32/stm32_otghshost.c
@@ -1568,7 +1568,7 @@ static void stm32_transfer_start(struct stm32_usbhost_s *priv, int chidx)
           break;
 
         default:
-          DEBUGASSERT(false);
+          DEBUGPANIC();
           return;
         }
 

--- a/arch/arm/src/stm32/stm32_tickless.c
+++ b/arch/arm/src/stm32/stm32_tickless.c
@@ -441,7 +441,7 @@ void up_timer_initialize(void)
 
         /* Basic timers not supported by this implementation */
 
-        DEBUGASSERT(0);
+        DEBUGPANIC();
         break;
 #endif
 
@@ -450,7 +450,7 @@ void up_timer_initialize(void)
 
         /* Basic timers not supported by this implementation */
 
-        DEBUGASSERT(0);
+        DEBUGPANIC();
         break;
 #endif
 
@@ -511,7 +511,7 @@ void up_timer_initialize(void)
 #endif
 
       default:
-        DEBUGASSERT(0);
+        DEBUGPANIC();
     }
 
   /* Get the TC frequency that corresponds to the requested resolution */
@@ -530,7 +530,7 @@ void up_timer_initialize(void)
   if (!g_tickless.tch)
     {
       tmrerr("ERROR: Failed to allocate TIM%d\n", g_tickless.timer);
-      DEBUGASSERT(0);
+      DEBUGPANIC();
     }
 
   STM32_TIM_SETCLOCK(g_tickless.tch, g_tickless.frequency);

--- a/arch/arm/src/stm32f0l0g0/stm32_i2c.c
+++ b/arch/arm/src/stm32f0l0g0/stm32_i2c.c
@@ -2719,7 +2719,7 @@ static int stm32_i2c_pm_prepare(struct pm_callback_s *cb, int domain,
 
       if (nxsem_get_value(&priv->sem_excl, &sval) < 0)
         {
-          DEBUGASSERT(false);
+          DEBUGPANIC();
           return -EINVAL;
         }
 

--- a/arch/arm/src/stm32f0l0g0/stm32_spi.c
+++ b/arch/arm/src/stm32f0l0g0/stm32_spi.c
@@ -1619,7 +1619,7 @@ static int spi_pm_prepare(struct pm_callback_s *cb, int domain,
 
       if (nxsem_get_value(&priv->exclsem, &sval) < 0)
         {
-          DEBUGASSERT(false);
+          DEBUGPANIC();
           return -EINVAL;
         }
 

--- a/arch/arm/src/stm32f7/stm32_i2c.c
+++ b/arch/arm/src/stm32f7/stm32_i2c.c
@@ -2745,7 +2745,7 @@ static int stm32_i2c_pm_prepare(struct pm_callback_s *cb, int domain,
 
       if (nxsem_get_value(&priv->sem_excl, &sval) < 0)
         {
-          DEBUGASSERT(false);
+          DEBUGPANIC();
           return -EINVAL;
         }
 

--- a/arch/arm/src/stm32f7/stm32_otghost.c
+++ b/arch/arm/src/stm32f7/stm32_otghost.c
@@ -1553,7 +1553,7 @@ static void stm32_transfer_start(struct stm32_usbhost_s *priv, int chidx)
           break;
 
         default:
-          DEBUGASSERT(false);
+          DEBUGPANIC();
           return;
         }
 

--- a/arch/arm/src/stm32f7/stm32_spi.c
+++ b/arch/arm/src/stm32f7/stm32_spi.c
@@ -2078,7 +2078,7 @@ static int spi_pm_prepare(struct pm_callback_s *cb, int domain,
 
       if (nxsem_get_value(&priv->exclsem, &sval) < 0)
         {
-          DEBUGASSERT(false);
+          DEBUGPANIC();
           return -EINVAL;
         }
 

--- a/arch/arm/src/stm32f7/stm32_tickless.c
+++ b/arch/arm/src/stm32f7/stm32_tickless.c
@@ -474,7 +474,7 @@ void up_timer_initialize(void)
 
         /* Basic timers not supported by this implementation */
 
-        DEBUGASSERT(0);
+        DEBUGPANIC();
         break;
 #endif
 
@@ -483,7 +483,7 @@ void up_timer_initialize(void)
 
         /* Basic timers not supported by this implementation */
 
-        DEBUGASSERT(0);
+        DEBUGPANIC();
         break;
 #endif
 
@@ -560,7 +560,7 @@ void up_timer_initialize(void)
 #endif
 
       default:
-        DEBUGASSERT(0);
+        DEBUGPANIC();
     }
 
   /* Get the TC frequency that corresponds to the requested resolution */
@@ -579,7 +579,7 @@ void up_timer_initialize(void)
   if (!g_tickless.tch)
     {
       tmrerr("ERROR: Failed to allocate TIM%d\n", g_tickless.timer);
-      DEBUGASSERT(0);
+      DEBUGPANIC();
     }
 
   STM32_TIM_SETCLOCK(g_tickless.tch, g_tickless.frequency);

--- a/arch/arm/src/stm32h7/stm32_i2c.c
+++ b/arch/arm/src/stm32h7/stm32_i2c.c
@@ -2709,7 +2709,7 @@ static int stm32_i2c_pm_prepare(struct pm_callback_s *cb, int domain,
 
       if (nxsem_get_value(&priv->sem_excl, &sval) < 0)
         {
-          DEBUGASSERT(false);
+          DEBUGPANIC();
           return -EINVAL;
         }
 

--- a/arch/arm/src/stm32h7/stm32_otghost.c
+++ b/arch/arm/src/stm32h7/stm32_otghost.c
@@ -1556,7 +1556,7 @@ static void stm32_transfer_start(struct stm32_usbhost_s *priv, int chidx)
           break;
 
         default:
-          DEBUGASSERT(false);
+          DEBUGPANIC();
           return;
         }
 

--- a/arch/arm/src/stm32h7/stm32_spi.c
+++ b/arch/arm/src/stm32h7/stm32_spi.c
@@ -2395,7 +2395,7 @@ static int spi_pm_prepare(struct pm_callback_s *cb, int domain,
 
       if (nxsem_get_value(&priv->exclsem, &sval) < 0)
         {
-          DEBUGASSERT(false);
+          DEBUGPANIC();
           return -EINVAL;
         }
 

--- a/arch/arm/src/stm32h7/stm32_spi_slave.c
+++ b/arch/arm/src/stm32h7/stm32_spi_slave.c
@@ -1568,7 +1568,7 @@ static int spi_pm_prepare(struct pm_callback_s *cb, int domain,
 
       if (nxsem_getvalue(&priv->exclsem, &sval) < 0)
         {
-          DEBUGASSERT(false);
+          DEBUGPANIC();
           return -EINVAL;
         }
 

--- a/arch/arm/src/stm32h7/stm32_tickless.c
+++ b/arch/arm/src/stm32h7/stm32_tickless.c
@@ -528,7 +528,7 @@ void up_timer_initialize(void)
 #endif
 
       default:
-        DEBUGASSERT(0);
+        DEBUGPANIC();
     }
 
   /* Get the TC frequency that corresponds to the requested resolution */
@@ -547,7 +547,7 @@ void up_timer_initialize(void)
   if (g_tickless.tch == NULL)
     {
       tmrerr("ERROR: Failed to allocate TIM%d\n", g_tickless.timer);
-      DEBUGASSERT(0);
+      DEBUGPANIC();
     }
 
   STM32_TIM_SETCLOCK(g_tickless.tch, g_tickless.frequency);

--- a/arch/arm/src/stm32l4/stm32l4_1wire.c
+++ b/arch/arm/src/stm32l4/stm32l4_1wire.c
@@ -1155,7 +1155,7 @@ static int stm32_1wire_pm_prepare(struct pm_callback_s *cb, int domain,
 
       if (nxsem_get_value(&priv->sem_excl, &sval) < 0)
         {
-          DEBUGASSERT(false);
+          DEBUGPANIC();
           return -EINVAL;
         }
 

--- a/arch/arm/src/stm32l4/stm32l4_i2c.c
+++ b/arch/arm/src/stm32l4/stm32l4_i2c.c
@@ -2919,7 +2919,7 @@ static int stm32l4_i2c_pm_prepare(struct pm_callback_s *cb, int domain,
 
       if (nxsem_get_value(&priv->sem_excl, &sval) < 0)
         {
-          DEBUGASSERT(false);
+          DEBUGPANIC();
           return -EINVAL;
         }
 

--- a/arch/arm/src/stm32l4/stm32l4_otgfshost.c
+++ b/arch/arm/src/stm32l4/stm32l4_otgfshost.c
@@ -1570,7 +1570,7 @@ static void stm32l4_transfer_start(struct stm32l4_usbhost_s *priv,
           break;
 
         default:
-          DEBUGASSERT(false);
+          DEBUGPANIC();
           return;
         }
 

--- a/arch/arm/src/stm32l4/stm32l4_spi.c
+++ b/arch/arm/src/stm32l4/stm32l4_spi.c
@@ -1670,7 +1670,7 @@ static int spi_pm_prepare(struct pm_callback_s *cb, int domain,
 
       if (nxsem_get_value(&priv->exclsem, &sval) < 0)
         {
-          DEBUGASSERT(false);
+          DEBUGPANIC();
           return -EINVAL;
         }
 

--- a/arch/arm/src/stm32l5/stm32l5_spi.c
+++ b/arch/arm/src/stm32l5/stm32l5_spi.c
@@ -1673,7 +1673,7 @@ static int spi_pm_prepare(struct pm_callback_s *cb, int domain,
 
       if (nxsem_getvalue(&priv->exclsem, &sval) < 0)
         {
-          DEBUGASSERT(false);
+          DEBUGPANIC();
           return -EINVAL;
         }
 

--- a/arch/arm/src/stm32u5/stm32_spi.c
+++ b/arch/arm/src/stm32u5/stm32_spi.c
@@ -2137,7 +2137,7 @@ static int spi_pm_prepare(struct pm_callback_s *cb, int domain,
 
       if (nxsem_get_value(&priv->exclsem, &sval) < 0)
         {
-          DEBUGASSERT(false);
+          DEBUGPANIC();
           return -EINVAL;
         }
 

--- a/arch/arm/src/stm32wb/stm32wb_serial.c
+++ b/arch/arm/src/stm32wb/stm32wb_serial.c
@@ -2556,7 +2556,7 @@ static void stm32wb_serial_pmnotify(struct pm_callback_s *cb, int domain,
         break;
 
       default:
-        DEBUGASSERT(0);
+        DEBUGPANIC();
         break;
     }
 }
@@ -2657,7 +2657,7 @@ static int stm32wb_serial_pmprepare(struct pm_callback_s *cb, int domain,
         break;
 
       default:
-        DEBUGASSERT(0);
+        DEBUGPANIC();
         break;
     }
 

--- a/arch/arm/src/stm32wb/stm32wb_spi.c
+++ b/arch/arm/src/stm32wb/stm32wb_spi.c
@@ -1607,7 +1607,7 @@ static int spi_pm_prepare(struct pm_callback_s *cb, int domain,
 
         if (nxsem_get_value(&priv->exclsem, &sval) < 0)
           {
-            DEBUGASSERT(false);
+            DEBUGPANIC();
             return -EINVAL;
           }
 
@@ -1623,7 +1623,7 @@ static int spi_pm_prepare(struct pm_callback_s *cb, int domain,
         break;
 
       default:
-        DEBUGASSERT(0);
+        DEBUGPANIC();
         break;
     }
 

--- a/arch/arm/src/stm32wb/stm32wb_tickless.c
+++ b/arch/arm/src/stm32wb/stm32wb_tickless.c
@@ -385,7 +385,7 @@ void up_timer_initialize(void)
 #endif
 
       default:
-        DEBUGASSERT(0);
+        DEBUGPANIC();
     }
 
   /* Get the TC frequency that corresponds to the requested resolution */
@@ -404,7 +404,7 @@ void up_timer_initialize(void)
   if (!g_tickless.tch)
     {
       tmrerr("ERROR: Failed to allocate TIM%d\n", g_tickless.timer);
-      DEBUGASSERT(0);
+      DEBUGPANIC();
     }
 
   STM32WB_TIM_SETCLOCK(g_tickless.tch, g_tickless.frequency);

--- a/arch/arm/src/tlsr82/tlsr82_serial.c
+++ b/arch/arm/src/tlsr82/tlsr82_serial.c
@@ -665,7 +665,7 @@ static void uart_dma_send(uart_priv_t *priv, char *buf, size_t len)
 
   if (len + DMA_HEAD_LEN > priv->txdmasize)
     {
-      DEBUGASSERT(false);
+      DEBUGPANIC();
       return;
     }
 

--- a/arch/risc-v/src/bl602/bl602_os_hal.c
+++ b/arch/risc-v/src/bl602/bl602_os_hal.c
@@ -1218,7 +1218,7 @@ void bl_os_irq_attach(int32_t n, void *f, void *arg)
 
   if (!adapter)
     {
-      DEBUGASSERT(0);
+      DEBUGPANIC();
     }
 
   adapter->func = f;
@@ -1228,7 +1228,7 @@ void bl_os_irq_attach(int32_t n, void *f, void *arg)
 
   if (ret != OK)
     {
-      DEBUGASSERT(0);
+      DEBUGPANIC();
     }
 }
 

--- a/arch/risc-v/src/esp32c3/esp32c3_ble_adapter.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_ble_adapter.c
@@ -827,7 +827,7 @@ static void semphr_delete_wrapper(void *semphr)
 
 static int semphr_take_from_isr_wrapper(void *semphr, void *hptw)
 {
-  DEBUGASSERT(0);
+  DEBUGPANIC();
   return false;
 }
 
@@ -1183,7 +1183,7 @@ static int IRAM_ATTR queue_send_from_isr_wrapper(void *queue,
 
 static int queue_recv_from_isr_wrapper(void *queue, void *item, void *hptw)
 {
-  DEBUGASSERT(0);
+  DEBUGPANIC();
   return false;
 }
 
@@ -1537,7 +1537,7 @@ static void btdm_sleep_enter_phase1_wrapper(uint32_t lpcycles)
   else
     {
       wlerr("timer start failed");
-      DEBUGASSERT(0);
+      DEBUGPANIC();
     }
 }
 
@@ -1566,7 +1566,7 @@ static void btdm_sleep_enter_phase2_wrapper(void)
         }
       else
         {
-          DEBUGASSERT(0);
+          DEBUGPANIC();
         }
 
       if (g_lp_stat.pm_lock_released == false)
@@ -1602,7 +1602,7 @@ static void btdm_sleep_exit_phase3_wrapper(void)
   if (btdm_sleep_clock_sync())
     {
       wlerr("sleep eco state err\n");
-      DEBUGASSERT(0);
+      DEBUGPANIC();
     }
 
   if (btdm_controller_get_sleep_mode() == ESP_BT_SLEEP_MODE_1)
@@ -2154,7 +2154,7 @@ int esp32c3_bt_controller_deinit(void)
     }
   else
     {
-      DEBUGASSERT(0);
+      DEBUGPANIC();
     }
 
 #ifdef CONFIG_PM
@@ -2230,7 +2230,7 @@ int esp32c3_bt_controller_disable(void)
     }
   else
     {
-      DEBUGASSERT(0);
+      DEBUGPANIC();
     }
 #endif
 

--- a/arch/risc-v/src/esp32c3/esp32c3_spi.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_spi.c
@@ -643,7 +643,7 @@ static void esp32c3_spi_setmode(struct spi_dev_s *dev,
 
           default:
             spierr("Invalid mode: %d\n", mode);
-            DEBUGASSERT(false);
+            DEBUGPANIC();
             return;
         }
 
@@ -1185,7 +1185,7 @@ void esp32c3_spi_dma_init(struct spi_dev_s *dev)
     {
       spierr("Failed to allocate GDMA channel\n");
 
-      DEBUGASSERT(false);
+      DEBUGPANIC();
     }
 
   /* Disable segment transaction mode for SPI Master */

--- a/arch/risc-v/src/esp32c3/esp32c3_spi_slave.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_spi_slave.c
@@ -462,7 +462,7 @@ static void spislave_setmode(struct spi_slave_ctrlr_s *ctrlr,
 
           default:
             spierr("Invalid mode: %d\n", mode);
-            DEBUGASSERT(false);
+            DEBUGPANIC();
             return;
         }
 
@@ -933,7 +933,7 @@ void spislave_dma_init(struct spislave_priv_s *priv)
     {
       spierr("Failed to allocate GDMA channel\n");
 
-      DEBUGASSERT(false);
+      DEBUGPANIC();
     }
 
   /* Disable segment transaction mode for SPI Slave */

--- a/arch/risc-v/src/esp32c3/esp32c3_tickless.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_tickless.c
@@ -597,7 +597,7 @@ void IRAM_ATTR up_step_idletime(uint32_t us)
   step_counter = USEC_2_CTICK((uint64_t)us) + up_tmr_getcounter();
   if (step_counter > alarm_value)
     {
-      DEBUGASSERT(0);
+      DEBUGPANIC();
     }
 
   up_tmr_counter_advance(step_counter);

--- a/arch/risc-v/src/esp32c3/esp32c3_wifi_adapter.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_wifi_adapter.c
@@ -945,7 +945,7 @@ static void esp_set_isr(int32_t n, void *f, void *arg)
   adapter = kmm_malloc(sizeof(struct irq_adpt));
   if (!adapter)
     {
-      DEBUGASSERT(0);
+      DEBUGPANIC();
     }
 
   adapter->func = f;
@@ -954,7 +954,7 @@ static void esp_set_isr(int32_t n, void *f, void *arg)
   ret = irq_attach(n + ESP32C3_IRQ_FIRSTPERIPH, esp_int_adpt_cb, adapter);
   if (ret != OK)
     {
-      DEBUGASSERT(0);
+      DEBUGPANIC();
     }
 
   g_wifi_irq_bind = true;
@@ -1870,7 +1870,7 @@ static uint32_t esp_queue_msg_waiting(void *queue)
 
 static void *esp_event_group_create(void)
 {
-  DEBUGASSERT(0);
+  DEBUGPANIC();
 
   return NULL;
 }
@@ -1885,7 +1885,7 @@ static void *esp_event_group_create(void)
 
 static void esp_event_group_delete(void *event)
 {
-  DEBUGASSERT(0);
+  DEBUGPANIC();
 }
 
 /****************************************************************************
@@ -1898,7 +1898,7 @@ static void esp_event_group_delete(void *event)
 
 static uint32_t esp_event_group_set_bits(void *event, uint32_t bits)
 {
-  DEBUGASSERT(0);
+  DEBUGPANIC();
 
   return false;
 }
@@ -1913,7 +1913,7 @@ static uint32_t esp_event_group_set_bits(void *event, uint32_t bits)
 
 static uint32_t esp_event_group_clear_bits(void *event, uint32_t bits)
 {
-  DEBUGASSERT(0);
+  DEBUGPANIC();
 
   return false;
 }
@@ -1932,7 +1932,7 @@ static uint32_t esp_event_group_wait_bits(void *event,
                                           int wait_for_all_bits,
                                           uint32_t block_time_tick)
 {
-  DEBUGASSERT(0);
+  DEBUGPANIC();
 
   return false;
 }
@@ -2945,7 +2945,7 @@ static int esp_nvs_set_i8(uint32_t handle,
 #ifdef CONFIG_ESP32C3_WIFI_SAVE_PARAM
   return esp_nvs_set_blob(handle, key, &value, sizeof(int8_t));
 #else
-  DEBUGASSERT(0);
+  DEBUGPANIC();
 
   return -1;
 #endif
@@ -2976,7 +2976,7 @@ static int esp_nvs_get_i8(uint32_t handle,
 
   return esp_nvs_get_blob(handle, key, out_value, &len);
 #else
-  DEBUGASSERT(0);
+  DEBUGPANIC();
 
   return -1;
 #endif
@@ -3005,7 +3005,7 @@ static int esp_nvs_set_u8(uint32_t handle,
 #ifdef CONFIG_ESP32C3_WIFI_SAVE_PARAM
   return esp_nvs_set_blob(handle, key, &value, sizeof(uint8_t));
 #else
-  DEBUGASSERT(0);
+  DEBUGPANIC();
 
   return -1;
 #endif
@@ -3036,7 +3036,7 @@ static int esp_nvs_get_u8(uint32_t handle,
 
   return esp_nvs_get_blob(handle, key, out_value, &len);
 #else
-  DEBUGASSERT(0);
+  DEBUGPANIC();
 
   return -1;
 #endif
@@ -3065,7 +3065,7 @@ static int esp_nvs_set_u16(uint32_t handle,
 #ifdef CONFIG_ESP32C3_WIFI_SAVE_PARAM
   return esp_nvs_set_blob(handle, key, &value, sizeof(uint16_t));
 #else
-  DEBUGASSERT(0);
+  DEBUGPANIC();
 
   return -1;
 #endif
@@ -3096,7 +3096,7 @@ static int esp_nvs_get_u16(uint32_t handle,
 
   return esp_nvs_get_blob(handle, key, out_value, &len);
 #else
-  DEBUGASSERT(0);
+  DEBUGPANIC();
 
   return -1;
 #endif
@@ -3149,7 +3149,7 @@ static int esp_nvs_open(const char *name,
 
   return 0;
 #else
-  DEBUGASSERT(0);
+  DEBUGPANIC();
 
   return -1;
 #endif
@@ -3177,7 +3177,7 @@ static void esp_nvs_close(uint32_t handle)
   kmm_free(nvs_adpt->index_name);
   kmm_free(nvs_adpt);
 #else
-  DEBUGASSERT(0);
+  DEBUGPANIC();
 #endif
 }
 
@@ -3263,7 +3263,7 @@ static int esp_nvs_set_blob(uint32_t handle,
 
   return 0;
 #else
-  DEBUGASSERT(0);
+  DEBUGPANIC();
 
   return -1;
 #endif
@@ -3337,7 +3337,7 @@ static int esp_nvs_get_blob(uint32_t handle,
 
   return 0;
 #else
-  DEBUGASSERT(0);
+  DEBUGPANIC();
 
   return -1;
 #endif
@@ -3385,7 +3385,7 @@ static int esp_nvs_erase_key(uint32_t handle, const char *key)
 
   return 0;
 #else
-  DEBUGASSERT(0);
+  DEBUGPANIC();
 
   return -1;
 #endif

--- a/arch/risc-v/src/esp32c3/esp32c3_wireless.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_wireless.c
@@ -335,7 +335,7 @@ void esp32c3_phy_enable(void)
   if (!cal_data)
     {
       wlerr("ERROR: Failed to kmm_zalloc");
-      DEBUGASSERT(0);
+      DEBUGPANIC();
     }
 
   flags = enter_critical_section();

--- a/arch/sparc/src/bm3803/bm3803_tickless.c
+++ b/arch/sparc/src/bm3803/bm3803_tickless.c
@@ -189,7 +189,7 @@ void up_timer_initialize(void)
   if (ret < 0)
     {
       tmrerr("ERROR: bm3803_oneshot_initialize failed\n");
-      DEBUGASSERT(0);
+      DEBUGPANIC();
     }
 
 #ifdef CONFIG_SCHED_TICKLESS_LIMIT_MAX_SLEEP
@@ -199,7 +199,7 @@ void up_timer_initialize(void)
   if (ret < 0)
     {
       tmrerr("ERROR: bm3803_oneshot_max_delay failed\n");
-      DEBUGASSERT(0);
+      DEBUGPANIC();
     }
 
   /* Convert this to configured clock ticks for use by the OS timer logic */
@@ -223,7 +223,7 @@ void up_timer_initialize(void)
   if (ret < 0)
     {
       tmrerr("ERROR: bm3803_freerun_initialize failed\n");
-      DEBUGASSERT(0);
+      DEBUGPANIC();
     }
 }
 

--- a/arch/sparc/src/sparc_v8/up_reprioritizertr.c
+++ b/arch/sparc/src/sparc_v8/up_reprioritizertr.c
@@ -74,7 +74,7 @@ void up_reprioritize_rtr(struct tcb_s *tcb, uint8_t priority)
 #endif
     )
     {
-       DEBUGASSERT(0);
+       DEBUGPANIC();
     }
   else
     {

--- a/arch/xtensa/src/esp32/esp32_ble_adapter.c
+++ b/arch/xtensa/src/esp32/esp32_ble_adapter.c
@@ -1923,7 +1923,7 @@ static void btdm_sleep_enter_phase1_wrapper(uint32_t lpcycles)
   else
     {
       wlerr("timer start failed");
-      DEBUGASSERT(0);
+      DEBUGPANIC();
     }
 }
 
@@ -1952,7 +1952,7 @@ static void btdm_sleep_enter_phase2_wrapper(void)
         }
       else
         {
-          DEBUGASSERT(0);
+          DEBUGPANIC();
         }
 
       if (g_lp_stat.pm_lock_released == false)
@@ -1988,7 +1988,7 @@ static void btdm_sleep_exit_phase3_wrapper(void)
   if (btdm_sleep_clock_sync())
     {
       wlerr("sleep eco state err\n");
-      DEBUGASSERT(0);
+      DEBUGPANIC();
     }
 
   if (btdm_controller_get_sleep_mode() == ESP_BT_SLEEP_MODE_1)
@@ -2464,7 +2464,7 @@ int esp32_bt_controller_deinit(void)
     }
   else
     {
-      DEBUGASSERT(0);
+      DEBUGPANIC();
     }
 
 #ifdef CONFIG_PM
@@ -2540,7 +2540,7 @@ int esp32_bt_controller_disable(void)
     }
   else
     {
-      DEBUGASSERT(0);
+      DEBUGPANIC();
     }
 #endif
 

--- a/arch/xtensa/src/esp32/esp32_rtc.c
+++ b/arch/xtensa/src/esp32/esp32_rtc.c
@@ -1548,7 +1548,7 @@ int IRAM_ATTR esp_rtc_clk_get_cpu_freq(void)
             }
           else
             {
-              DEBUGASSERT(0);
+              DEBUGPANIC();
             }
         }
         break;
@@ -1561,7 +1561,7 @@ int IRAM_ATTR esp_rtc_clk_get_cpu_freq(void)
 
       case RTC_CNTL_SOC_CLK_SEL_APLL:
         default:
-          DEBUGASSERT(0);
+          DEBUGPANIC();
     }
 
   return freq_mhz;

--- a/arch/xtensa/src/esp32/esp32_wifi_adapter.c
+++ b/arch/xtensa/src/esp32/esp32_wifi_adapter.c
@@ -939,7 +939,7 @@ static void *esp_spin_lock_create(void)
   if (!lock)
     {
       wlerr("Failed to alloc %d memory\n", tmp);
-      DEBUGASSERT(0);
+      DEBUGPANIC();
     }
 
   spin_initialize(lock, SP_UNLOCKED);
@@ -1787,7 +1787,7 @@ static uint32_t esp_queue_msg_waiting(void *queue)
 
 static void *esp_event_group_create(void)
 {
-  DEBUGASSERT(0);
+  DEBUGPANIC();
 
   return NULL;
 }
@@ -1802,7 +1802,7 @@ static void *esp_event_group_create(void)
 
 static void esp_event_group_delete(void *event)
 {
-  DEBUGASSERT(0);
+  DEBUGPANIC();
 }
 
 /****************************************************************************
@@ -1815,7 +1815,7 @@ static void esp_event_group_delete(void *event)
 
 static uint32_t esp_event_group_set_bits(void *event, uint32_t bits)
 {
-  DEBUGASSERT(0);
+  DEBUGPANIC();
 
   return false;
 }
@@ -1830,7 +1830,7 @@ static uint32_t esp_event_group_set_bits(void *event, uint32_t bits)
 
 static uint32_t esp_event_group_clear_bits(void *event, uint32_t bits)
 {
-  DEBUGASSERT(0);
+  DEBUGPANIC();
 
   return false;
 }
@@ -1849,7 +1849,7 @@ static uint32_t esp_event_group_wait_bits(void *event,
                                           int32_t wait_for_all_bits,
                                           uint32_t block_time_tick)
 {
-  DEBUGASSERT(0);
+  DEBUGPANIC();
 
   return false;
 }
@@ -2396,7 +2396,7 @@ uint32_t esp_get_free_heap_size(void)
 static void esp_dport_access_stall_other_cpu_start(void)
 {
 #ifdef CONFIG_SMP
-  DEBUGASSERT(0);
+  DEBUGPANIC();
 #endif
 }
 
@@ -2411,7 +2411,7 @@ static void esp_dport_access_stall_other_cpu_start(void)
 static void esp_dport_access_stall_other_cpu_end(void)
 {
 #ifdef CONFIG_SMP
-  DEBUGASSERT(0);
+  DEBUGPANIC();
 #endif
 }
 
@@ -2852,7 +2852,7 @@ static int32_t esp_nvs_set_i8(uint32_t handle,
 #ifdef CONFIG_ESP32_WIFI_SAVE_PARAM
   return esp_nvs_set_blob(handle, key, &value, sizeof(int8_t));
 #else
-  DEBUGASSERT(0);
+  DEBUGPANIC();
 
   return -1;
 #endif
@@ -2883,7 +2883,7 @@ static int32_t esp_nvs_get_i8(uint32_t handle,
 
   return esp_nvs_get_blob(handle, key, out_value, &len);
 #else
-  DEBUGASSERT(0);
+  DEBUGPANIC();
 
   return -1;
 #endif
@@ -2912,7 +2912,7 @@ static int32_t esp_nvs_set_u8(uint32_t handle,
 #ifdef CONFIG_ESP32_WIFI_SAVE_PARAM
   return esp_nvs_set_blob(handle, key, &value, sizeof(uint8_t));
 #else
-  DEBUGASSERT(0);
+  DEBUGPANIC();
 
   return -1;
 #endif
@@ -2943,7 +2943,7 @@ static int32_t esp_nvs_get_u8(uint32_t handle,
 
   return esp_nvs_get_blob(handle, key, out_value, &len);
 #else
-  DEBUGASSERT(0);
+  DEBUGPANIC();
 
   return -1;
 #endif
@@ -2972,7 +2972,7 @@ static int32_t esp_nvs_set_u16(uint32_t handle,
 #ifdef CONFIG_ESP32_WIFI_SAVE_PARAM
   return esp_nvs_set_blob(handle, key, &value, sizeof(uint16_t));
 #else
-  DEBUGASSERT(0);
+  DEBUGPANIC();
 
   return -1;
 #endif
@@ -3003,7 +3003,7 @@ static int32_t esp_nvs_get_u16(uint32_t handle,
 
   return esp_nvs_get_blob(handle, key, out_value, &len);
 #else
-  DEBUGASSERT(0);
+  DEBUGPANIC();
 
   return -1;
 #endif
@@ -3056,7 +3056,7 @@ static int32_t esp_nvs_open(const char *name,
 
   return 0;
 #else
-  DEBUGASSERT(0);
+  DEBUGPANIC();
 
   return -1;
 #endif
@@ -3084,7 +3084,7 @@ static void esp_nvs_close(uint32_t handle)
   kmm_free(nvs_adpt->index_name);
   kmm_free(nvs_adpt);
 #else
-  DEBUGASSERT(0);
+  DEBUGPANIC();
 #endif
 }
 
@@ -3170,7 +3170,7 @@ static int32_t esp_nvs_set_blob(uint32_t handle,
 
   return 0;
 #else
-  DEBUGASSERT(0);
+  DEBUGPANIC();
 
   return -1;
 #endif
@@ -3244,7 +3244,7 @@ static int32_t esp_nvs_get_blob(uint32_t handle,
 
   return 0;
 #else
-  DEBUGASSERT(0);
+  DEBUGPANIC();
 
   return -1;
 #endif
@@ -3292,7 +3292,7 @@ static int32_t esp_nvs_erase_key(uint32_t handle, const char *key)
 
   return 0;
 #else
-  DEBUGASSERT(0);
+  DEBUGPANIC();
 
   return -1;
 #endif

--- a/arch/xtensa/src/esp32s3/esp32s3_spi.c
+++ b/arch/xtensa/src/esp32s3/esp32s3_spi.c
@@ -740,7 +740,7 @@ static void esp32s3_spi_setmode(struct spi_dev_s *dev,
 
           default:
             spierr("Invalid mode: %d\n", mode);
-            DEBUGASSERT(false);
+            DEBUGPANIC();
             return;
         }
 
@@ -1300,7 +1300,7 @@ void esp32s3_spi_dma_init(struct spi_dev_s *dev)
     {
       spierr("Failed to allocate GDMA channel\n");
 
-      DEBUGASSERT(false);
+      DEBUGPANIC();
     }
 
   /* Disable segment transaction mode for SPI Master */

--- a/arch/z16/src/z16f/z16f_espi.c
+++ b/arch/z16/src/z16f/z16f_espi.c
@@ -493,7 +493,7 @@ static void spi_setmode(FAR struct spi_dev_s *dev, enum spi_mode_e mode)
           break;
 
         default:
-          DEBUGASSERT(false);
+          DEBUGPANIC();
           return;
         }
 

--- a/boards/arm/nrf52/nrf52840-dk/src/nrf52_highpri.c
+++ b/boards/arm/nrf52/nrf52840-dk/src/nrf52_highpri.c
@@ -115,7 +115,7 @@ void timer_handler(void)
   ret = NRF52_TIM_CHECKINT(g_highpri.dev, NRF52_TIM_CC0);
   if (ret != 1)
     {
-      DEBUGASSERT(0);
+      DEBUGPANIC();
     }
 
   /* Increment the count associated with the current basepri */

--- a/boards/arm/stm32/common/src/stm32_ihm07m1.c
+++ b/boards/arm/stm32/common/src/stm32_ihm07m1.c
@@ -337,7 +337,7 @@ static void board_foc_trace(struct foc_dev_s *dev, int type, bool state)
       default:
         {
           mtrerr("board_foc_trace type=%d not supported!\n", type);
-          DEBUGASSERT(0);
+          DEBUGPANIC();
         }
     }
 }

--- a/boards/arm/stm32/common/src/stm32_ihm08m1.c
+++ b/boards/arm/stm32/common/src/stm32_ihm08m1.c
@@ -327,7 +327,7 @@ static void board_foc_trace(struct foc_dev_s *dev, int type, bool state)
       default:
         {
           mtrerr("board_foc_trace type=%d not supported!\n", type);
-          DEBUGASSERT(0);
+          DEBUGPANIC();
         }
     }
 }

--- a/boards/arm/stm32/common/src/stm32_ihm16m1.c
+++ b/boards/arm/stm32/common/src/stm32_ihm16m1.c
@@ -335,7 +335,7 @@ static void board_foc_trace(struct foc_dev_s *dev, int type, bool state)
       default:
         {
           mtrerr("board_foc_trace type=%d not supported!\n", type);
-          DEBUGASSERT(0);
+          DEBUGPANIC();
         }
     }
 }

--- a/drivers/1wire/1wire.c
+++ b/drivers/1wire/1wire.c
@@ -155,7 +155,7 @@ static int onewire_pm_prepare(FAR struct pm_callback_s *cb, int domain,
 
       if (nxsem_get_value(&master->devsem.sem, &sval) < 0)
         {
-          DEBUGASSERT(false);
+          DEBUGPANIC();
           return -EINVAL;
         }
 

--- a/drivers/can/can.c
+++ b/drivers/can/can.c
@@ -1165,7 +1165,7 @@ static int can_poll(FAR struct file *filep, FAR struct pollfd *fds,
 
       if (ret < 0)
         {
-          DEBUGASSERT(false);
+          DEBUGPANIC();
           goto return_with_irqdisabled;
         }
       else if (sval > 0)
@@ -1406,7 +1406,7 @@ int can_receive(FAR struct can_dev_s *dev, FAR struct can_hdr_s *hdr,
           sval = 0;
           if (nxsem_get_value(&fifo->rx_sem, &sval) < 0)
             {
-              DEBUGASSERT(false);
+              DEBUGPANIC();
 #ifdef CONFIG_CAN_ERRORS
               /* Report unspecified error */
 

--- a/drivers/motor/foc/foc_dev.c
+++ b/drivers/motor/foc/foc_dev.c
@@ -760,7 +760,7 @@ static int foc_notifier(FAR struct foc_dev_s *dev,
         {
           /* This is a critical fault */
 
-          DEBUGASSERT(0);
+          DEBUGPANIC();
 
           /* Set timeout fault if not in debug mode */
 

--- a/drivers/net/encx24j600.c
+++ b/drivers/net/encx24j600.c
@@ -1760,7 +1760,7 @@ static void enc_rxabtif(FAR struct enc_driver_s *priv)
       descr = (FAR struct enc_descr_s *)sq_next(descr);
     }
 
-  DEBUGASSERT(false);
+  DEBUGPANIC();
 #endif
 
   descr = (FAR struct enc_descr_s *)sq_peek(&priv->rxqueue);

--- a/drivers/net/lan91c111.c
+++ b/drivers/net/lan91c111.c
@@ -785,7 +785,7 @@ static void lan91c111_txdone(FAR struct net_driver_s *dev)
     }
   else
     {
-      DEBUGASSERT(0);
+      DEBUGPANIC();
     }
 }
 

--- a/drivers/power/bq2429x.c
+++ b/drivers/power/bq2429x.c
@@ -744,7 +744,7 @@ static int bq2429x_health(FAR struct battery_charger_dev_s *dev,
         break; /* No return, check for other faults */
 
       default:
-        DEBUGASSERT(false);
+        DEBUGPANIC();
         *health = BATTERY_HEALTH_UNKNOWN;
         return OK;
     }

--- a/drivers/usbdev/cdcecm.c
+++ b/drivers/usbdev/cdcecm.c
@@ -1408,7 +1408,7 @@ static void cdcecm_mkepdesc(int epidx,
         break;
 
       default:
-        DEBUGASSERT(false);
+        DEBUGPANIC();
     }
 }
 

--- a/drivers/wireless/ieee80211/bcm43xxx/bcmf_core.c
+++ b/drivers/wireless/ieee80211/bcm43xxx/bcmf_core.c
@@ -565,7 +565,7 @@ int bcmf_core_upload_firmware(FAR struct bcmf_sdio_dev_s *sbus)
 #endif
 
       default:
-        DEBUGASSERT(false);
+        DEBUGPANIC();
     }
 
   nxsig_usleep(50 * 1000);
@@ -668,7 +668,7 @@ int bcmf_core_upload_firmware(FAR struct bcmf_sdio_dev_s *sbus)
 #endif
 
       default:
-        DEBUGASSERT(false);
+        DEBUGPANIC();
     }
 
   return OK;

--- a/libs/libc/netdb/lib_getnameinfo.c
+++ b/libs/libc/netdb/lib_getnameinfo.c
@@ -135,7 +135,7 @@ int getnameinfo(FAR const struct sockaddr *addr, socklen_t addrlen,
                 break;
 
               default:
-                DEBUGASSERT(0);
+                DEBUGPANIC();
             }
 
           /* Fall-back to numeric for the host name. */
@@ -154,7 +154,7 @@ int getnameinfo(FAR const struct sockaddr *addr, socklen_t addrlen,
                 return EAI_OVERFLOW;
 
               default:
-                DEBUGASSERT(0);
+                DEBUGPANIC();
             }
         }
     }

--- a/mm/mm_heap/mm_realloc.c
+++ b/mm/mm_heap/mm_realloc.c
@@ -97,7 +97,7 @@ FAR void *mm_realloc(FAR struct mm_heap_s *heap, FAR void *oldmem,
     {
       /* There must have been an integer overflow */
 
-      DEBUGASSERT(false);
+      DEBUGPANIC();
       return NULL;
     }
 

--- a/net/usrsock/usrsock_accept.c
+++ b/net/usrsock/usrsock_accept.c
@@ -343,7 +343,7 @@ int usrsock_accept(FAR struct socket *psock, FAR struct sockaddr *addr,
               else
                 {
                   nerr("net_timedwait errno: %d\n", ret);
-                  DEBUGASSERT(false);
+                  DEBUGPANIC();
                 }
             }
 

--- a/net/usrsock/usrsock_dev.c
+++ b/net/usrsock/usrsock_dev.c
@@ -985,7 +985,7 @@ static int usrsockdev_close(FAR struct file *filep)
           if (ret != -ETIMEDOUT && ret != -EINTR)
             {
               ninfo("net_timedwait errno: %d\n", ret);
-              DEBUGASSERT(false);
+              DEBUGPANIC();
             }
         }
       else

--- a/net/usrsock/usrsock_recvmsg.c
+++ b/net/usrsock/usrsock_recvmsg.c
@@ -342,7 +342,7 @@ ssize_t usrsock_recvmsg(FAR struct socket *psock, FAR struct msghdr *msg,
               else
                 {
                   nerr("net_timedwait errno: %zd\n", ret);
-                  DEBUGASSERT(false);
+                  DEBUGPANIC();
                 }
             }
 

--- a/net/usrsock/usrsock_sendmsg.c
+++ b/net/usrsock/usrsock_sendmsg.c
@@ -323,7 +323,7 @@ ssize_t usrsock_sendmsg(FAR struct socket *psock,
               else
                 {
                   nerr("net_timedwait errno: %zd\n", ret);
-                  DEBUGASSERT(false);
+                  DEBUGPANIC();
                 }
             }
 

--- a/sched/semaphore/sem_holder.c
+++ b/sched/semaphore/sem_holder.c
@@ -102,7 +102,7 @@ nxsem_allocholder(FAR sem_t *sem, FAR struct tcb_s *htcb)
     {
       serr("ERROR: Insufficient pre-allocated holders\n");
       pholder          = NULL;
-      DEBUGASSERT(0);
+      DEBUGPANIC();
     }
 
   if (pholder != NULL)

--- a/wireless/ieee802154/mac802154.c
+++ b/wireless/ieee802154/mac802154.c
@@ -1516,7 +1516,7 @@ static void mac802154_rxdatareq(FAR struct ieee802154_privmac_s *priv,
             }
           else
             {
-              DEBUGASSERT(false);
+              DEBUGPANIC();
             }
         }
 
@@ -1578,7 +1578,7 @@ static void mac802154_rxdatareq(FAR struct ieee802154_privmac_s *priv,
     }
   else
     {
-      DEBUGASSERT(false);
+      DEBUGPANIC();
     }
 
   /* Set the destination addr mode inside the frame control field */


### PR DESCRIPTION
## Summary
This PR intends to provide a minor improvement to code readability by converting some `DEBUGASSERT(false)` calls into `DEBUGPANIC()`.

## Impact
Both macros are similar, should have no impact to the generated code nor to the execution flow.

## Testing
CI build pass.

