### PR TITLE
include: Declare nxtask_delete function.

### DIFF
--- a/include/nuttx/kthread.h
+++ b/include/nuttx/kthread.h
@@ -27,7 +27,7 @@
  ****************************************************************************/
 
 #include <nuttx/config.h>
-#include <sched.h>
+#include <nuttx/sched.h>
 
 /****************************************************************************
  * Pre-processor Definitions
@@ -48,47 +48,6 @@ extern "C"
 /****************************************************************************
  * Public Function Prototypes
  ****************************************************************************/
-
-/****************************************************************************
- * Name: nxtask_create
- *
- * Description:
- *   This function creates and activates a new user task with a specified
- *   priority and returns its system-assigned ID.
- *
- *   The entry address entry is the address of the "main" function of the
- *   task.  This function will be called once the C environment has been
- *   set up.  The specified function will be called with four arguments.
- *   Should the specified routine return, a call to exit() will
- *   automatically be made.
- *
- *   Note that four (and only four) arguments must be passed for the spawned
- *   functions.
- *
- *   nxtask_create() is identical to the function task_create(), differing
- *   only in its return value:  This function does not modify the errno
- *   variable.  This is a non-standard, internal OS function and is not
- *   intended for use by application logic.  Applications should use
- *   task_create().
- *
- * Input Parameters:
- *   name       - Name of the new task
- *   priority   - Priority of the new task
- *   stack_size - size (in bytes) of the stack needed
- *   entry      - Entry point of a new task
- *   arg        - A pointer to an array of input parameters.  The array
- *                should be terminated with a NULL argv[] value. If no
- *                parameters are required, argv may be NULL.
- *
- * Returned Value:
- *   Returns the positive, non-zero process ID of the new task or a negated
- *   errno value to indicate the nature of any failure.  If memory is
- *   insufficient or the task cannot be created -ENOMEM will be returned.
- *
- ****************************************************************************/
-
-int nxtask_create(FAR const char *name, int priority,
-                  int stack_size, main_t entry, FAR char * const argv[]);
 
 /****************************************************************************
  * Name: kthread_create_with_stack

--- a/include/nuttx/sched.h
+++ b/include/nuttx/sched.h
@@ -924,6 +924,74 @@ int nxtask_init(FAR struct task_tcb_s *tcb, const char *name, int priority,
 void nxtask_uninit(FAR struct task_tcb_s *tcb);
 
 /****************************************************************************
+ * Name: nxtask_create
+ *
+ * Description:
+ *   This function creates and activates a new user task with a specified
+ *   priority and returns its system-assigned ID.
+ *
+ *   The entry address entry is the address of the "main" function of the
+ *   task.  This function will be called once the C environment has been
+ *   set up.  The specified function will be called with four arguments.
+ *   Should the specified routine return, a call to exit() will
+ *   automatically be made.
+ *
+ *   Note that four (and only four) arguments must be passed for the spawned
+ *   functions.
+ *
+ *   nxtask_create() is identical to the function task_create(), differing
+ *   only in its return value:  This function does not modify the errno
+ *   variable.  This is a non-standard, internal OS function and is not
+ *   intended for use by application logic.  Applications should use
+ *   task_create().
+ *
+ * Input Parameters:
+ *   name       - Name of the new task
+ *   priority   - Priority of the new task
+ *   stack_size - size (in bytes) of the stack needed
+ *   entry      - Entry point of a new task
+ *   arg        - A pointer to an array of input parameters.  The array
+ *                should be terminated with a NULL argv[] value. If no
+ *                parameters are required, argv may be NULL.
+ *
+ * Returned Value:
+ *   Returns the positive, non-zero process ID of the new task or a negated
+ *   errno value to indicate the nature of any failure.  If memory is
+ *   insufficient or the task cannot be created -ENOMEM will be returned.
+ *
+ ****************************************************************************/
+
+int nxtask_create(FAR const char *name, int priority,
+                  int stack_size, main_t entry, FAR char * const argv[]);
+
+/****************************************************************************
+ * Name: nxtask_delete
+ *
+ * Description:
+ *   This function causes a specified task to cease to exist.  Its stack and
+ *   TCB will be deallocated.
+ *
+ *   The logic in this function only deletes non-running tasks.  If the
+ *   'pid' parameter refers to the currently running task, then processing
+ *   is redirected to exit(). This can only happen if a task calls
+ *   nxtask_delete() in order to delete itself.
+ *
+ *   This function obeys the semantics of pthread cancellation:  task
+ *   deletion is deferred if cancellation is disabled or if deferred
+ *   cancellation is supported (with cancellation points enabled).
+ *
+ * Input Parameters:
+ *   pid - The task ID of the task to delete.  A pid of zero
+ *         signifies the calling task.
+ *
+ * Returned Value:
+ *   OK on success; or negated errno on failure
+ *
+ ****************************************************************************/
+
+int nxtask_delete(pid_t pid);
+
+/****************************************************************************
  * Name: nxtask_activate
  *
  * Description:


### PR DESCRIPTION
Add nxtask_delete declaration in order to prevent build warnings.

Signed-off-by: xiangdong6 <xiangdong6@xiaomi.com>

## Summary
It genarate build warning.

## Impact
No impact.

## Testing
passed

