### PR TITLE
samv7: add support for RX DMA and RS-485 mode to serial driver

### DIFF
--- a/arch/arm/src/samv7/Kconfig
+++ b/arch/arm/src/samv7/Kconfig
@@ -1107,6 +1107,33 @@ config SAMV7_SDRAMHEAP
 
 endmenu # SDRAM Configuration
 
+menu "Serial Driver Configuration"
+	depends on SAMV7_HAVE_USART0 || SAMV7_HAVE_USART1 || SAMV7_HAVE_USART2
+
+config SAMV7_SERIAL_RXDMA_BUFFER
+	int "Rx DMA buffer size"
+	default 128
+	range 32 4096
+	depends on SAMV7_HAVE_USART0 || SAMV7_HAVE_USART1 || SAMV7_HAVE_USART2
+	---help---
+		The DMA buffer size when using RX DMA to emulate a FIFO.
+
+config SAMV7_SERIAL_DMA_TIMEOUT
+	int "Rx DMA timeout"
+	default 30
+	range 0 131071
+	depends on SAMV7_HAVE_USART0 || SAMV7_HAVE_USART1 || SAMV7_HAVE_USART2
+	---help---
+		USART support timeout interrupt for idle bus. This ensures the reception of bytes
+		that did not filled the entire RX buffer. This option can be turn off by setting
+		timeout to zero but then some other polling is required. This is not supported for
+		UART, only for USART driver. SAMV7_SERIAL_DMA_TIMEOUT is in bit times and the delay
+		is in seconds.
+
+		The delay is calculated as: Delay = SAMV7_SERIAL_DMA_TIMEOUT * bit_period
+
+endmenu
+
 menu "SPI Device Driver Configuration"
 	depends on SAMV7_SPI
 

--- a/arch/arm/src/samv7/Kconfig
+++ b/arch/arm/src/samv7/Kconfig
@@ -797,26 +797,65 @@ config SAMV7_USBHOSTHS
 	depends on SAMV7_HAVE_USBHS
 	select USBHOST
 
-config SAMV7_USART0
+menuconfig SAMV7_USART0
 	bool "USART 0"
 	default n
 	depends on SAMV7_HAVE_USART0
 	select USART0_SERIALDRIVER
 	select ARCH_HAVE_SERIAL_TERMIOS
 
-config SAMV7_USART1
+if SAMV7_USART0
+
+config SAMV7_USART0_RS485MODE
+	bool "RS-485 on USART0"
+	default n
+	---help---
+		Enable RS-485 interface on USART0. Please note that the pin is set
+		to logical 1 before the serial driver is opened. Board specific
+		logic is required to set the pin to logical 0 before the driver is
+		opened for the first time.
+
+endif
+
+menuconfig SAMV7_USART1
 	bool "USART 1"
 	default n
 	depends on SAMV7_HAVE_USART1
 	select USART1_SERIALDRIVER
 	select ARCH_HAVE_SERIAL_TERMIOS
 
-config SAMV7_USART2
+if SAMV7_USART1
+
+config SAMV7_USART1_RS485MODE
+	bool "RS-485 on USART1"
+	default n
+	---help---
+		Enable RS-485 interface on USART1. Please note that the pin is set
+		to logical 1 before the serial driver is opened. Board specific
+		logic is required to set the pin to logical 0 before the driver is
+		opened for the first time.
+
+endif
+
+menuconfig SAMV7_USART2
 	bool "USART 2"
 	default n
 	depends on SAMV7_HAVE_USART2
 	select USART2_SERIALDRIVER
 	select ARCH_HAVE_SERIAL_TERMIOS
+
+if SAMV7_USART2
+
+config SAMV7_USART2_RS485MODE
+	bool "RS-485 on USART2"
+	default n
+	---help---
+		Enable RS-485 interface on USART2. Please note that the pin is set
+		to logical 1 before the serial driver is opened. Board specific
+		logic is required to set the pin to logical 0 before the driver is
+		opened for the first time.
+
+endif
 
 config SAMV7_WDT
 	bool "Watchdog Timer (WDT)"

--- a/arch/arm/src/samv7/sam_serial.h
+++ b/arch/arm/src/samv7/sam_serial.h
@@ -44,8 +44,64 @@
 #  define SERIAL_HAVE_RS485 1
 #endif
 
+/* Is RX DMA used on the console UART? */
+
+#undef SERIAL_HAVE_CONSOLE_RXDMA
+#if defined(CONFIG_USART0_SERIAL_CONSOLE) && defined(CONFIG_USART0_RXDMA)
+#  define SERIAL_HAVE_CONSOLE_RXDMA
+#elif defined(CONFIG_USART1_SERIAL_CONSOLE) && defined(CONFIG_USART1_RXDMA)
+#  define SERIAL_HAVE_CONSOLE_RXDMA
+#elif defined(CONFIG_USART1_SERIAL_CONSOLE) && defined(CONFIG_USART2_RXDMA)
+#  define SERIAL_HAVE_CONSOLE_RXDMA
+#endif
+
+/* RX DMA ops */
+
+#undef SERIAL_HAVE_NODMA_OPS
+#if !defined(CONFIG_USART0_RXDMA) && defined(CONFIG_SAMV7_USART0)
+#  define SERIAL_HAVE_NODMA_OPS
+#elif !defined(CONFIG_USART1_RXDMA) && defined(CONFIG_SAMV7_USART1)
+#  define SERIAL_HAVE_NODMA_OPS
+#elif !defined(CONFIG_USART2_RXDMA) && defined(CONFIG_SAMV7_USART2)
+#  define SERIAL_HAVE_NODMA_OPS
+#elif defined(CONFIG_SAMV7_UART0)
+#  define SERIAL_HAVE_NODMA_OPS
+#elif defined(CONFIG_SAMV7_UART1)
+#  define SERIAL_HAVE_NODMA_OPS
+#elif defined(CONFIG_SAMV7_UART2)
+#  define SERIAL_HAVE_NODMA_OPS
+#elif defined(CONFIG_SAMV7_UART3)
+#  define SERIAL_HAVE_NODMA_OPS
+#elif defined(CONFIG_SAMV7_UART4)
+#  define SERIAL_HAVE_NODMA_OPS
+#endif
+
+#undef SERIAL_HAVE_RXDMA_OPS
+#if defined(CONFIG_USART0_RXDMA)
+#  define SERIAL_HAVE_RXDMA_OPS
+#elif defined(CONFIG_USART1_RXDMA)
+#  define SERIAL_HAVE_RXDMA_OPS
+#elif defined(CONFIG_USART2_RXDMA)
+#  define SERIAL_HAVE_RXDMA_OPS
+#endif
+
 /****************************************************************************
  * Public Function Prototypes
  ****************************************************************************/
+
+/****************************************************************************
+ * Name: sam_serial_dma_poll
+ *
+ * Description:
+ *   Checks receive DMA buffers for received bytes that have not accumulated
+ *   to the point where the DMA half/full interrupt has triggered.
+ *
+ *   This function should be called from a timer or other periodic context.
+ *
+ ****************************************************************************/
+
+#ifdef SERIAL_HAVE_RXDMA
+void sam_serial_dma_poll(void)
+#endif
 
 #endif /* __ARCH_ARM_SRC_SAMV7_SAM_SERIAL_H */

--- a/arch/arm/src/samv7/sam_serial.h
+++ b/arch/arm/src/samv7/sam_serial.h
@@ -1,0 +1,51 @@
+/****************************************************************************
+ * arch/arm/src/samv7/sam_serial.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __ARCH_ARM_SRC_SAMV7_SAM_SERIAL_H
+#define __ARCH_ARM_SRC_SAMV7_SAM_SERIAL_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <stdint.h>
+
+#include "chip.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/* Is RS-485 used? */
+
+#undef SERIAL_HAVE_RS485
+#if defined(CONFIG_SAMV7_USART0_RS485MODE) || \
+    defined(CONFIG_SAMV7_USART1_RS485MODE) || \
+    defined(CONFIG_SAMV7_USART2_RS485MODE)
+#  define SERIAL_HAVE_RS485 1
+#endif
+
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
+
+#endif /* __ARCH_ARM_SRC_SAMV7_SAM_SERIAL_H */

--- a/arch/arm/src/samv7/sam_xdmac.h
+++ b/arch/arm/src/samv7/sam_xdmac.h
@@ -31,6 +31,8 @@
 
 #include "chip.h"
 
+#include "hardware/sam_xdmac.h"
+
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
@@ -223,6 +225,20 @@ extern "C"
  ****************************************************************************/
 
 /****************************************************************************
+ * Name: sam_destaddr
+ *
+ * Description:
+ *   Returns the pointer to the destionation address, i.e the last address
+ *   data were written by DMA.
+ *
+ * Assumptions:
+ *   - DMA handle allocated by sam_dmachannel()
+ *
+ ****************************************************************************/
+
+size_t sam_destaddr(DMA_HANDLE handle);
+
+/****************************************************************************
  * Name: sam_dmachannel
  *
  * Description:
@@ -303,6 +319,43 @@ int sam_dmatxsetup(DMA_HANDLE handle, uint32_t paddr,
 
 int sam_dmarxsetup(DMA_HANDLE handle, uint32_t paddr,
                    uint32_t maddr, size_t nbytes);
+
+/****************************************************************************
+ * Name: sam_dmarxsetup_circular
+ *
+ * Description:
+ *   Configure DMA for receipt of two circular buffers for peripheral to
+ *   memory transfer. Function sam_dmastart_circular() needs to be called
+ *   to start the transfer. Only peripheral to memory transfer is currently
+ *   supported.
+ *
+ * Input Parameters:
+ *   handle - DMA handler
+ *   descr - array with DMA descriptors
+ *   maddr - array of memory addresses (i.e. destination addresses)
+ *   paddr - peripheral address (i.e. source address)
+ *   nbytes - number of bytes to transfer
+ *   ndescrs - number of descriptors (i.e. the lenght of descr array)
+ *
+ ****************************************************************************/
+
+int sam_dmarxsetup_circular(DMA_HANDLE handle,
+                            struct chnext_view1_s *descr[],
+                            uint32_t maddr[],
+                            uint32_t paddr,
+                            size_t nbytes,
+                            uint8_t ndescrs);
+
+/****************************************************************************
+ * Name: sam_dmastart_circular
+ *
+ * Description:
+ *   Start the DMA transfer with circular buffers.
+ *
+ ****************************************************************************/
+
+int sam_dmastart_circular(DMA_HANDLE handle, dma_callback_t callback,
+                          void *arg);
 
 /****************************************************************************
  * Name: sam_dmastart


### PR DESCRIPTION
## Summary

These three commits add support for RX DMA and RS-485 mode to serial driver.

The first commit b66dd73 introduces the support of RS-485. In this mode the hardware automatically sets RTS pin high when
data are transfered and low then no transfer occurs.¨

Commit 5444f06 adds functions sam_dmarxsetup_circular() and sam_dmarxstart_circular() that create API for operating with two or more circular buffers.

These functions are used in commit 0f27516 that adds RX DMA support to serial driver. It uses two circular
buffers which size can be setup by SAMV7_SERIAL_RXDMA_BUFFER option. The idle bus interrupt is enabled to ensures data are read even if the buffer is not yet full. The timeout can be setup by SAMV7_SERIAL_DMA_TIMEOUT option. Only RX DMA is supported so far.

## Impact

SAMV7 only. Serial driver and DMA driver only.

## Testing
Tested on SAME70-XPLAINED board and custom board with the SAME70 MCU..

