### PR TITLE
Fix arm64 stack coloration

### DIFF
--- a/arch/arm64/src/common/arm64_checkstack.c
+++ b/arch/arm64/src/common/arm64_checkstack.c
@@ -73,7 +73,7 @@ static size_t do_stackcheck(void *stackbase, size_t nbytes)
 {
   uintptr_t start;
   uintptr_t end;
-  uint64_t *ptr;
+  uint32_t *ptr;
   size_t mark;
 
   if (nbytes == 0)
@@ -96,7 +96,7 @@ static size_t do_stackcheck(void *stackbase, size_t nbytes)
    * that does not have the magic value is the high water mark.
    */
 
-  for (ptr = (uint64_t *)start, mark = (nbytes >> 2);
+  for (ptr = (uint32_t *)start, mark = (nbytes >> 2);
        *ptr == STACK_COLOR && mark > 0;
        ptr++, mark--);
 

--- a/arch/arm64/src/common/arm64_cpustart.c
+++ b/arch/arm64/src/common/arm64_cpustart.c
@@ -212,6 +212,15 @@ int up_cpu_start(int cpu)
   sched_note_cpu_start(this_task(), cpu);
 #endif
 
+#ifdef CONFIG_STACK_COLORATION
+  /* If stack debug is enabled, then fill the stack with a
+   * recognizable value that we can use later to test for high
+   * water marks.
+   */
+
+  arm64_stack_color(g_cpu_idlestackalloc[cpu], SMP_STACK_SIZE);
+#endif
+
   cpu_ready_flag = 0;
   arm64_start_cpu(cpu, (char *)g_cpu_idlestackalloc[cpu], SMP_STACK_SIZE,
                   arm64_smp_init_top);


### PR DESCRIPTION
## Summary

- This PR contains the following commits
- commit1: arch: arm64: Fix do_stackcheck()
  - Since the stack coloration is done for every 32bits this function should be done in the same way.
- commit2: arch: arm64: Add stack coloration for SMP

## Impact

- None

## Testing

- Tested with qemu-a53
