### PR TITLE
stm32f0l0g0/SPI: support for half duplex and simplex rx/tx modes

### DIFF
--- a/arch/arm/src/stm32f0l0g0/Kconfig
+++ b/arch/arm/src/stm32f0l0g0/Kconfig
@@ -1320,6 +1320,22 @@ config STM32F0L0G0_SPI6
 	select SPI
 	select STM32F0L0G0_SPI
 
+config STM32F0L0G0_SPI1_COMMTYPE
+	int "SPI1 Operation mode"
+	default 0
+	range 0 3
+	depends on STM32F0L0G0_SPI1
+	---help---
+		Select full-duplex (0), simplex tx (1), simplex rx (2) or half-duplex (3)
+
+config STM32F0L0G0_SPI2_COMMTYPE
+	int "SPI2 Operation mode"
+	default 0
+	range 0 3
+	depends on STM32F0L0G0_SPI2
+	---help---
+		Select full-duplex (0), simplex tx (1), simplex rx (2) or half-duplex (3)
+
 config STM32F0L0G0_SYSCFG
 	bool "SYSCFG"
 	default y


### PR DESCRIPTION
## Summary

- stm32f0l0g0/SPI: add support for half duplex, simplex rx and simplex tx modes

## Impact

## Testing
stm32g0disco oled in half duplex and simplex tx modes
