### PR TITLE
Added memory health checks.

### DIFF
--- a/include/nuttx/mm/mm.h
+++ b/include/nuttx/mm/mm.h
@@ -312,6 +312,12 @@ struct mallinfo_task kmm_mallinfo_task(pid_t pid);
 #  endif
 #endif
 
+/* Functions contained in mm_check.c ****************************************/
+
+#ifdef CONFIG_MM_HEALTH_CHECK
+void mm_check_init(void);
+#endif
+
 /* Functions contained in mm_memdump.c **************************************/
 
 void mm_memdump(FAR struct mm_heap_s *heap, pid_t pid);

--- a/mm/Kconfig
+++ b/mm/Kconfig
@@ -207,3 +207,34 @@ config MM_PANIC_ON_FAILURE
 	depends on DEBUG_MM
 
 source "mm/iob/Kconfig"
+
+config MM_HEALTH_CHECK
+	bool "Memory health checks"
+	default n
+	---help---
+		If enabled, a worker will be used to perform
+		various health checks on the system memories.
+		
+		The checks include:
+		* Check all stacks for overflow.
+		* The the heap for any corruption.
+
+config MM_CHECK_PERIOD
+	int "Health check period"
+	default 1
+	depends on MM_HEALTH_CHECK
+	---help---
+		The time period that the health checks will
+		be executed. In seconds.
+
+config MM_STACK_USAGE_SAFE_PERCENT
+	int "Safe stack usage"
+	default 90
+	depends on MM_HEALTH_CHECK
+	---help---
+		The stack usage that is considered safe. In
+		percent.
+		
+		If the stack usage goes beyond this percentage,
+		the memory checks will assume that an overflow
+		has occured.

--- a/mm/Makefile
+++ b/mm/Makefile
@@ -30,6 +30,7 @@ include shm/Make.defs
 include iob/Make.defs
 include circbuf/Make.defs
 include kasan/Make.defs
+include mm_check/Make.defs
 
 BINDIR ?= bin
 

--- a/mm/mm_check/Make.defs
+++ b/mm/mm_check/Make.defs
@@ -1,0 +1,30 @@
+############################################################################
+# mm/mm_check/Make.defs
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+# Memory health checks.
+
+ifeq ($(CONFIG_MM_HEALTH_CHECK),y)
+CSRCS += mm_check.c
+
+# Add the health checks to the build.
+
+DEPPATH += --dep-path mm_check
+VPATH += :mm_check
+endif

--- a/mm/mm_check/mm_check.c
+++ b/mm/mm_check/mm_check.c
@@ -1,0 +1,94 @@
+/****************************************************************************
+ * mm/mm_check/mm_check.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/mm/mm.h>
+#include <nuttx/sched.h>
+#include <nuttx/irq.h>
+#include <nuttx/wqueue.h>
+#include <nuttx/arch.h>
+#include <nuttx/compiler.h>
+#include <nuttx/config.h>
+
+#include <time.h>
+#include <assert.h>
+#include <sys/types.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#ifndef CONFIG_SCHED_LPWORK
+#error "Low priority work queue is required for the memory health checks."
+#endif
+
+/****************************************************************************
+ * Private Types
+ ****************************************************************************/
+
+static struct work_s work_q;
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+static void mm_check_worker(FAR void * arg)
+{
+  UNUSED(arg);
+
+  int i;
+  FAR struct tcb_s *tcb;
+  irqstate_t flags;
+  extern FAR struct tcb_s **g_pidhash;
+  extern volatile int g_npidhash;
+
+  for (i = 0; i < g_npidhash; i++)
+    {
+      flags = enter_critical_section();
+
+      tcb = g_pidhash[i];
+
+      if (tcb && ((up_check_tcbstack(tcb) * 100 / tcb->adj_stack_size)
+          > CONFIG_MM_STACK_USAGE_SAFE_PERCENT))
+        {
+          PANIC();
+        }
+
+      leave_critical_section(flags);
+    }
+
+  kmm_checkcorruption();
+
+  work_queue(LPWORK, &work_q, mm_check_worker, NULL,
+             (CONFIG_MM_CHECK_PERIOD * CLOCKS_PER_SEC));
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+void mm_check_init()
+{
+  work_queue(LPWORK, &work_q, mm_check_worker, NULL,
+             (CONFIG_MM_CHECK_PERIOD * CLOCKS_PER_SEC));
+}

--- a/sched/init/nx_start.c
+++ b/sched/init/nx_start.c
@@ -502,6 +502,12 @@ void nx_start(void)
   iob_initialize();
 #endif
 
+#ifdef CONFIG_MM_HEALTH_CHECK
+  /* Initialize the memory health checks. */
+
+  mm_check_init();
+#endif
+
   /* Initialize the logic that determine unique process IDs. */
 
   g_npidhash = 4;


### PR DESCRIPTION
## Summary

The PR #5368 removed the memory checks from the idle thread, due to issues with priority inheritance.

This is an attempt to restore these checks, this time running in a worker.

If this feature is enabled, a worker will be started during system boot, that performs the following checks periodically:
* Checks the stacks of all threads for any possible overflow.
* Checks the heap for any corruption.

## Impact

None on existing systems.

## Testing

I did a quick test on a custom board running on an STM32F427 MCU.  
The check is started and executed as expected.

---

Note, although this code is tested to be working, it is marked as a draft.

I am not very sure about the correct structure of the code, and if it adheres to NuttX standards.
Please review it, and provide me with some feedback.

Mostly, is it correct to create this new dir `mm_check`, or does the code belong anywhere else?  
Is the worker started at the correct place?  
Any naming issues?  
Etc...
