### PR TITLE
arch: arm64: Fix warnings in arm64_cpstart.c

### DIFF
--- a/arch/arm64/src/common/arm64_cpustart.c
+++ b/arch/arm64/src/common/arm64_cpustart.c
@@ -155,7 +155,7 @@ static void arm64_start_cpu(int cpu_num, char *stack, int stack_sz,
 
   if (pcsi_cpu_on(cpu_mpid, (uint64_t)&__start))
     {
-      sinfo("Failed to boot secondary CPU core %d (MPID:%#llx)\n", cpu_num,
+      sinfo("Failed to boot secondary CPU core %d (MPID:%#lx)\n", cpu_num,
             cpu_mpid);
       return;
     }
@@ -167,7 +167,7 @@ static void arm64_start_cpu(int cpu_num, char *stack, int stack_sz,
       SP_WFE();
     }
 
-  sinfo("Secondary CPU core %d (MPID:%#llx) is up\n", cpu_num, cpu_mpid);
+  sinfo("Secondary CPU core %d (MPID:%#lx) is up\n", cpu_num, cpu_mpid);
 }
 
 /****************************************************************************


### PR DESCRIPTION
## Summary

- Fix warnings in arm64_cpstart.c if CONFIG_DEBUG_INFO=n

## Impact

- None

## Testing

- Tested with qemu-a53:nsh_smp (not merged yet)

