### PR TITLE
wireless/ieee802154: Don't set IFF_DOWN in mac802154netdev_register

### DIFF
--- a/include/net/if.h
+++ b/include/net/if.h
@@ -59,7 +59,6 @@
 
 /* Interface flag helpers */
 
-#define IFF_SET_DOWN(f)        do { (f) |= IFF_DOWN; } while (0)
 #define IFF_SET_UP(f)          do { (f) |= IFF_UP; } while (0)
 #define IFF_SET_RUNNING(f)     do { (f) |= IFF_RUNNING; } while (0)
 #define IFF_SET_BOUND(f)       do { (f) |= IFF_BOUND; } while (0)
@@ -69,7 +68,6 @@
 #define IFF_SET_MULTICAST(f)   do { (f) |= IFF_MULTICAST; } while (0)
 #define IFF_SET_BROADCAST(f)   do { (f) |= IFF_BROADCAST; } while (0)
 
-#define IFF_CLR_DOWN(f)        do { (f) &= ~IFF_DOWN; } while (0)
 #define IFF_CLR_UP(f)          do { (f) &= ~IFF_UP; } while (0)
 #define IFF_CLR_RUNNING(f)     do { (f) &= ~IFF_RUNNING; } while (0)
 #define IFF_CLR_BOUND(f)       do { (f) &= ~IFF_BOUND; } while (0)
@@ -79,7 +77,6 @@
 #define IFF_CLR_MULTICAST(f)   do { (f) &= ~IFF_MULTICAST; } while (0)
 #define IFF_CLR_BROADCAST(f)   do { (f) &= ~IFF_BROADCAST; } while (0)
 
-#define IFF_IS_DOWN(f)        (((f) & IFF_DOWN) != 0)
 #define IFF_IS_UP(f)          (((f) & IFF_UP) != 0)
 #define IFF_IS_RUNNING(f)     (((f) & IFF_RUNNING) != 0)
 #define IFF_IS_BOUND(f)       (((f) & IFF_BOUND) != 0)

--- a/wireless/ieee802154/mac802154_netdev.c
+++ b/wireless/ieee802154/mac802154_netdev.c
@@ -1334,7 +1334,6 @@ int mac802154netdev_register(MACHANDLE mac)
    * it up
    */
 
-  dev->d_flags = IFF_DOWN;
   return macnet_ifdown(&priv->md_dev.r_dev);
 
 errout:


### PR DESCRIPTION
## Summary
since IFF_DOWN is only used for request, not for status. Instead,
IFF_UP should be used to query the netdev status. The IFF_DOWN
related macros are also removed to avoid the confuse.

## Impact
Remove the unused macros

## Testing
Internal device
