### PR TITLE
mtd/smartfs: Fix uninitialized variable

### DIFF
--- a/drivers/mtd/smart.c
+++ b/drivers/mtd/smart.c
@@ -2192,8 +2192,7 @@ static int smart_scan(FAR struct smart_struct_s *dev)
             {
               if (dev->partname[0] != '\0')
                 {
-                  snprintf(dev->rwbuffer, sizeof(devname),
-                           "/dev/smart%d%sd%d",
+                  snprintf(devname, sizeof(devname), "/dev/smart%d%sd%d",
                            dev->minor, dev->partname, x + 1);
                 }
               else
@@ -2219,8 +2218,6 @@ static int smart_scan(FAR struct smart_struct_s *dev)
 
               rootdirdev->dev = dev;
               rootdirdev->rootdirnum = x;
-              ret = register_blockdriver(dev->rwbuffer, &g_bops, 0,
-                                         rootdirdev);
 
               /* Inode private data is a reference to the SMART device
                * structure.


### PR DESCRIPTION
## Summary
If CONFIG_SMARTFS_MULTI_ROOT_DIRS is enabled and dev->partname is not empty,
dev->rwbuffer is an uninitialized variable and register_blockdriver is called.

## Impact
SmartFS: CONFIG_SMARTFS_MULTI_ROOT_DIRS is enabled and partition name is used.

## Testing
Build pass
