### PR TITLE
fs/partition/fs_gpt.c: Fix compilation error

### DIFF
--- a/fs/partition/fs_gpt.c
+++ b/fs/partition/fs_gpt.c
@@ -26,6 +26,7 @@
 #include <ctype.h>
 #include <debug.h>
 #include <endian.h>
+#include <inttypes.h>
 
 #include <nuttx/kmalloc.h>
 


### PR DESCRIPTION
PRI?OFF macros are defined in inttypes, so include it

Signed-off-by: Jukka Laitinen <jukkax@ssrc.tii.ae>


