### PR TITLE
net/slip: Rename and clarify orphaned Kconfig options

### DIFF
--- a/net/Kconfig
+++ b/net/Kconfig
@@ -196,7 +196,7 @@ menuconfig NET_SLIP
 
 if NET_SLIP
 
-config SLIP_NINTERFACES
+config NET_SLIP_NINTERFACES
 	int "Number of SLIP interfaces"
 	default 1
 	---help---
@@ -204,14 +204,17 @@ config SLIP_NINTERFACES
 		interfaces to support.
 		Default: 1
 
-config SLIP_STACKSIZE
-	int "SLIP stack size"
+config NET_SLIP_STACKSIZE
+	int "SLIP per-thread stack size"
 	default DEFAULT_TASK_STACKSIZE
 	---help---
 		Select the stack size of the SLIP RX and TX tasks.
 
-config SLIP_DEFPRIO
-	int "SLIP priority"
+		SLIP starts two dedicated threads per interface
+		to handle network events, enabling high performance.
+
+config NET_SLIP_DEFPRIO
+	int "SLIP threads priority"
 	default 128
 	---help---
 		The priority of the SLIP RX and TX tasks. Default: 128


### PR DESCRIPTION
## Summary
Rename the SLIP options to be consistent with the driver source.
2d7c072723902aa763d3851f6399c39cbb1851fe deleted them from drivers/net/Kconfig as "duplicates" despite them having slightly different names 
(SLIP_STACKSIZE vs NET_SLIP_STACKSIZE). See https://github.com/apache/incubator-nuttx/blob/b10658653ba4567191ffcd98e0e4c1a3df3f0db0/drivers/net/slip.c#L68
```c
#ifndef CONFIG_NET_SLIP_STACKSIZE
#  define CONFIG_NET_SLIP_STACKSIZE 2048
#endif

#ifndef CONFIG_NET_SLIP_DEFPRIO
#  define CONFIG_NET_SLIP_DEFPRIO 128
#endif
```
but https://github.com/apache/incubator-nuttx/blob/b10658653ba4567191ffcd98e0e4c1a3df3f0db0/net/Kconfig#L207
This reserves 2048 bytes by default (not even CONFIG_DEFAULT_TASK_SIZE) for each of 2 threads, 
even though I see typically only 300-400 bytes used on armv6-m UART 115200 link responding to 50..250-byte ICMP pings.

Make kthread stacksize configurable again.

I don't feel like these options truly belonged in drivers/net/Kconfig with external MACs, either.
## Impact
Boards using SLIP. Currently in-tree only sim:tcpblaster and olimex-lpc1766stk:slip-httpd.
## Testing
nucleo-h743zi2: builds without errors.
Milandr mdr32: builds and runs with reduced stack footprint (rxslip+txslip 4k->1.5k).