### PR TITLE
serial:fix a compile bug

### DIFF
--- a/include/nuttx/serial/serial.h
+++ b/include/nuttx/serial/serial.h
@@ -278,7 +278,8 @@ struct uart_dev_s
 #endif
   bool                 isconsole;    /* true: This is the serial console */
 
-#if defined(CONFIG_TTY_SIGINT) || defined(CONFIG_TTY_SIGTSTP)
+#if defined(CONFIG_TTY_SIGINT) || defined(CONFIG_TTY_SIGTSTP) || \
+    defined(CONFIG_TTY_FORCE_PANIC) || defined(CONFIG_TTY_LAUNCH)
   pid_t                pid;          /* Thread PID to receive signals (-1 if none) */
 #endif
 


### PR DESCRIPTION
serial_io.c use pid,but the headfile Inconsistent macro definitions
Signed-off-by: anjiahao <anjiahao@xiaomi.com>

## Summary
fix compile bug
## Impact

## Testing
CI
