### PR TITLE
driver/syslog: support syslog_rpmsg client and server chardev

### DIFF
--- a/drivers/syslog/Kconfig
+++ b/drivers/syslog/Kconfig
@@ -288,6 +288,10 @@ config SYSLOG_RPMSG_SERVER
 	---help---
 		Use rpmsg to receive message from remote proc.
 
+config SYSLOG_RPMSG_SERVER_CHARDEV
+	bool "SYSLOG rpmsg server character device"
+	default n
+
 menuconfig SYSLOG_FILE
 	bool "Syslog file output"
 	default n

--- a/drivers/syslog/Kconfig
+++ b/drivers/syslog/Kconfig
@@ -188,7 +188,8 @@ comment "SYSLOG channels"
 
 config SYSLOG_DEVPATH
 	string "System log device"
-	default "/dev/ttyS1"
+	default "/dev/kmsg" if CONFIG_RAMLOG_SYSLOG
+	default "/dev/ttyS1" if !CONFIG_RAMLOG_SYSLOG
 	---help---
 		The full path to the system logging device.  For the RAMLOG SYSLOG device,
 		this is normally "/dev/kmsg".  For character SYSLOG devices, it should be

--- a/drivers/syslog/Kconfig
+++ b/drivers/syslog/Kconfig
@@ -186,6 +186,15 @@ config SYSLOG_COLOR_OUTPUT
 
 comment "SYSLOG channels"
 
+config SYSLOG_DEVPATH
+	string "System log device"
+	default "/dev/ttyS1"
+	---help---
+		The full path to the system logging device.  For the RAMLOG SYSLOG device,
+		this is normally "/dev/kmsg".  For character SYSLOG devices, it should be
+		some other existing character device (or file) supported by the configuration
+		(such as "/dev/ttyS1")/
+
 if !ARCH_SYSLOG
 config SYSLOG_CHAR
 	bool "Log to a character device"
@@ -236,19 +245,6 @@ config SYSLOG_DEFAULT
 
 endif
 
-if SYSLOG_CHAR
-
-config SYSLOG_DEVPATH
-	string "System log device"
-	default "/dev/ttyS1"
-	---help---
-		The full path to the system logging device.  For the RAMLOG SYSLOG device,
-		this is normally "/dev/kmsg".  For character SYSLOG devices, it should be
-		some other existing character device (or file) supported by the configuration
-		(such as "/dev/ttyS1")/
-
-endif # SYSLOG_CHAR
-
 if RAMLOG_SYSLOG
 
 config RAMLOG_BUFFER_SECTION
@@ -285,6 +281,10 @@ config SYSLOG_RPMSG_OVERWRITE
 	---help---
 		Allow syslog rpmsg overwrite, may cause syslog to lose some logs.
 		Set 'n' if you don't want lost logs, but may harm performance.
+
+config SYSLOG_RPMSG_CHARDEV
+	bool "SYSLOG rpmsg character device"
+	default !SYSLOG_RPMSG_WORK_DELAY
 
 endif # SYSLOG_RPMSG
 

--- a/drivers/syslog/Kconfig
+++ b/drivers/syslog/Kconfig
@@ -275,13 +275,6 @@ config SYSLOG_RPMSG_WORK_DELAY
 	int "SYSLOG RPMSG work delay(ms)"
 	default 100
 
-config SYSLOG_RPMSG_OVERWRITE
-	bool "SYSLOG RPMSG overwrite"
-	default n
-	---help---
-		Allow syslog rpmsg overwrite, may cause syslog to lose some logs.
-		Set 'n' if you don't want lost logs, but may harm performance.
-
 config SYSLOG_RPMSG_CHARDEV
 	bool "SYSLOG rpmsg character device"
 	default !SYSLOG_RPMSG_WORK_DELAY

--- a/drivers/syslog/syslog_rpmsg.c
+++ b/drivers/syslog/syslog_rpmsg.c
@@ -44,7 +44,11 @@
  * Pre-processor definitions
  ****************************************************************************/
 
-#define SYSLOG_RPMSG_WORK_DELAY MSEC2TICK(CONFIG_SYSLOG_RPMSG_WORK_DELAY)
+#if CONFIG_SYSLOG_RPMSG_WORK_DELAY
+#  define SYSLOG_RPMSG_WORK_DELAY MSEC2TICK(CONFIG_SYSLOG_RPMSG_WORK_DELAY)
+#else
+#  define SYSLOG_RPMSG_WORK_DELAY MSEC2TICK(100)
+#endif
 
 #define SYSLOG_RPMSG_COUNT(p)       ((p)->head - (p)->tail)
 #define SYSLOG_RPMSG_SPACE(p)       ((p)->size - 1 - SYSLOG_RPMSG_COUNT(p))
@@ -234,10 +238,16 @@ static void syslog_rpmsg_putchar(FAR struct syslog_rpmsg_s *priv, int ch,
 
       /* Start work immediately when data more then 75% and meet '\n' */
 
-      if (space < priv->size / 4 && ch == '\n')
+      if (space < priv->size / 4)
         {
           delay = 0;
         }
+#if CONFIG_SYSLOG_RPMSG_WORK_DELAY == 0
+      else
+        {
+          return;
+        }
+#endif
 
       work_queue(HPWORK, &priv->work, syslog_rpmsg_work, priv, delay);
     }
@@ -259,8 +269,7 @@ static void syslog_rpmsg_device_created(FAR struct rpmsg_device *rdev,
                              syslog_rpmsg_ept_cb, NULL);
       if (ret == 0)
         {
-          work_queue(HPWORK, &priv->work,
-                     syslog_rpmsg_work, priv, SYSLOG_RPMSG_WORK_DELAY);
+          work_queue(HPWORK, &priv->work, syslog_rpmsg_work, priv, 0);
         }
     }
 }
@@ -292,8 +301,7 @@ static int syslog_rpmsg_ept_cb(FAR struct rpmsg_endpoint *ept,
   else if (header->command == SYSLOG_RPMSG_RESUME)
     {
       priv->suspend = false;
-      work_queue(HPWORK, &priv->work,
-        syslog_rpmsg_work, priv, SYSLOG_RPMSG_WORK_DELAY);
+      work_queue(HPWORK, &priv->work, syslog_rpmsg_work, priv, 0);
     }
   else if (header->command == SYSLOG_RPMSG_TRANSFER_DONE)
     {

--- a/drivers/syslog/syslog_rpmsg.c
+++ b/drivers/syslog/syslog_rpmsg.c
@@ -290,6 +290,11 @@ static int syslog_rpmsg_ept_cb(FAR struct rpmsg_endpoint *ept,
       priv->suspend = false;
       work_queue(HPWORK, &priv->work, syslog_rpmsg_work, priv, 0);
     }
+  else if (header->command == SYSLOG_RPMSG_SYNC)
+    {
+      syslog_rpmsg_transfer(priv, true);
+      rpmsg_send(ept, data, len);
+    }
 
   return 0;
 }

--- a/drivers/syslog/syslog_rpmsg.c
+++ b/drivers/syslog/syslog_rpmsg.c
@@ -420,6 +420,10 @@ void syslog_rpmsg_init_early(FAR void *buffer, size_t size)
     {
       priv->head = priv->tail = 0;
     }
+  else if (priv->head < priv->tail)
+    {
+      priv->head += priv->size;
+    }
 }
 
 int syslog_rpmsg_init(void)

--- a/drivers/syslog/syslog_rpmsg.c
+++ b/drivers/syslog/syslog_rpmsg.c
@@ -71,10 +71,6 @@ struct syslog_rpmsg_s
 
   struct rpmsg_endpoint ept;
   bool                  suspend;
-  bool                  transfer;   /* The transfer flag */
-  ssize_t               trans_len;  /* The data length when transfer */
-
-  sem_t                 sem;
 };
 
 /****************************************************************************
@@ -124,102 +120,94 @@ static const struct file_operations g_syslog_rpmsgfops =
  * Private Functions
  ****************************************************************************/
 
-static void syslog_rpmsg_work(FAR void *priv_)
+static bool syslog_rpmsg_transfer(FAR struct syslog_rpmsg_s *priv, bool wait)
 {
   FAR struct syslog_rpmsg_transfer_s *msg = NULL;
-  FAR struct syslog_rpmsg_s *priv = priv_;
   irqstate_t flags;
   uint32_t space;
   size_t len;
   size_t off;
   size_t len_end;
 
-  if (is_rpmsg_ept_ready(&priv->ept))
+  do
     {
-      msg = rpmsg_get_tx_payload_buffer(&priv->ept, &space, false);
-    }
+      msg = rpmsg_get_tx_payload_buffer(&priv->ept, &space, wait);
+      if (!msg)
+        {
+          return false;
+        }
 
-  if (!msg)
+      memset(msg, 0, sizeof(*msg));
+
+      flags = enter_critical_section();
+
+      space  -= sizeof(*msg);
+      len     = SYSLOG_RPMSG_COUNT(priv);
+      off     = SYSLOG_RPMSG_TAILOFF(priv);
+      len_end = priv->size - off;
+
+      if (len > space)
+        {
+          len = space;
+        }
+
+      if (len > len_end)
+        {
+          memcpy(msg->data, &priv->buffer[off], len_end);
+          memcpy(msg->data + len_end, priv->buffer, len - len_end);
+          memset(&priv->buffer[off], 0, len_end);
+          memset(priv->buffer, 0, len - len_end);
+        }
+      else
+        {
+          memcpy(msg->data, &priv->buffer[off], len);
+          memset(&priv->buffer[off], 0, len);
+        }
+
+      msg->count          = len;
+      priv->tail         += len;
+      msg->header.command = SYSLOG_RPMSG_TRANSFER;
+      rpmsg_send_nocopy(&priv->ept, msg, sizeof(*msg) + len);
+      len                 = SYSLOG_RPMSG_COUNT(priv);
+
+      leave_critical_section(flags);
+    }
+  while (len > 0);
+
+  return true;
+}
+
+static void syslog_rpmsg_work(FAR void *priv_)
+{
+  FAR struct syslog_rpmsg_s *priv = priv_;
+
+  if (!syslog_rpmsg_transfer(priv, false))
     {
       work_queue(HPWORK, &priv->work, syslog_rpmsg_work, priv,
                  SYSLOG_RPMSG_WORK_DELAY);
-      return;
     }
-
-  memset(msg, 0, sizeof(*msg));
-
-  flags = enter_critical_section();
-
-  space  -= sizeof(*msg);
-  len     = SYSLOG_RPMSG_COUNT(priv);
-  off     = SYSLOG_RPMSG_TAILOFF(priv);
-  len_end = priv->size - off;
-
-  if (len > space)
-    {
-      len = space;
-    }
-
-  if (len > len_end)
-    {
-      memcpy(msg->data, &priv->buffer[off], len_end);
-      memcpy(msg->data + len_end, priv->buffer, len - len_end);
-    }
-  else
-    {
-      memcpy(msg->data, &priv->buffer[off], len);
-    }
-
-  priv->trans_len = len;
-  priv->transfer  = true;
-
-  leave_critical_section(flags);
-
-  msg->header.command = SYSLOG_RPMSG_TRANSFER;
-  msg->count          = len;
-  rpmsg_send_nocopy(&priv->ept, msg, sizeof(*msg) + len);
 }
 
 static void syslog_rpmsg_putchar(FAR struct syslog_rpmsg_s *priv, int ch,
                                  bool last)
 {
-  size_t next;
-
-  while (1)
+  if (priv->head + 1 - priv->tail >= priv->size)
     {
-      next = priv->head + 1;
-
-      if (next - priv->tail >= priv->size)
+      if (!priv->flush && !up_interrupt_context() && !sched_idletask())
         {
-#ifndef CONFIG_SYSLOG_RPMSG_OVERWRITE
-          if (!priv->flush && !up_interrupt_context() && !sched_idletask())
-            {
-              nxsem_wait(&priv->sem);
-            }
-          else
-#endif
-            {
-              /* Overwrite */
-
-              priv->buffer[SYSLOG_RPMSG_TAILOFF(priv)] = 0;
-              priv->tail += 1;
-
-              if (priv->transfer)
-                {
-                  priv->trans_len--;
-                }
-
-              break;
-            }
+          syslog_rpmsg_transfer(priv, true);
         }
       else
         {
-          break;
+          /* Overwrite */
+
+          priv->buffer[SYSLOG_RPMSG_TAILOFF(priv)] = 0;
+          priv->tail++;
         }
     }
 
   priv->buffer[SYSLOG_RPMSG_HEADOFF(priv)] = ch & 0xff;
-  priv->head = next;
+  priv->head++;
 
   if (priv->flush)
     {
@@ -230,13 +218,12 @@ static void syslog_rpmsg_putchar(FAR struct syslog_rpmsg_s *priv, int ch,
       return;
     }
 
-  if (last && !priv->suspend && !priv->transfer &&
-          is_rpmsg_ept_ready(&priv->ept))
+  if (last && !priv->suspend && is_rpmsg_ept_ready(&priv->ept))
     {
       clock_t delay = SYSLOG_RPMSG_WORK_DELAY;
       size_t space = SYSLOG_RPMSG_SPACE(priv);
 
-      /* Start work immediately when data more then 75% and meet '\n' */
+      /* Start work immediately when data more then 75% and meet last */
 
       if (space < priv->size / 4)
         {
@@ -303,48 +290,6 @@ static int syslog_rpmsg_ept_cb(FAR struct rpmsg_endpoint *ept,
       priv->suspend = false;
       work_queue(HPWORK, &priv->work, syslog_rpmsg_work, priv, 0);
     }
-  else if (header->command == SYSLOG_RPMSG_TRANSFER_DONE)
-    {
-      irqstate_t flags;
-      ssize_t len_end;
-      size_t off;
-      int sval;
-
-      flags = enter_critical_section();
-
-      if (priv->trans_len > 0)
-        {
-          off = SYSLOG_RPMSG_TAILOFF(priv);
-          len_end = priv->size - off;
-
-          if (priv->trans_len > len_end)
-            {
-              memset(&priv->buffer[off], 0, len_end);
-              memset(priv->buffer, 0, priv->trans_len - len_end);
-            }
-          else
-            {
-              memset(&priv->buffer[off], 0, priv->trans_len);
-            }
-
-          priv->tail += priv->trans_len;
-
-          nxsem_get_value(&priv->sem, &sval);
-          while (sval++ < 0)
-            {
-              nxsem_post(&priv->sem);
-            }
-        }
-
-      priv->transfer = false;
-
-      if (SYSLOG_RPMSG_COUNT(priv))
-        {
-          work_queue(HPWORK, &priv->work, syslog_rpmsg_work, priv, 0);
-        }
-
-      leave_critical_section(flags);
-    }
 
   return 0;
 }
@@ -363,10 +308,8 @@ static ssize_t syslog_rpmsg_file_read(FAR struct file *filep,
   priv = (FAR struct syslog_rpmsg_s *)inode->i_private;
 
   flags = enter_critical_section();
-  if (!priv->suspend && !priv->transfer &&
-      is_rpmsg_ept_ready(&priv->ept))
+  if (!priv->suspend && is_rpmsg_ept_ready(&priv->ept))
     {
-      priv->transfer = true;
       work_queue(HPWORK, &priv->work, syslog_rpmsg_work, priv, 0);
     }
 
@@ -449,9 +392,6 @@ void syslog_rpmsg_init_early(FAR void *buffer, size_t size)
   size_t i;
 
   DEBUGASSERT((size & (size - 1)) == 0);
-
-  nxsem_init(&priv->sem, 0, 0);
-  nxsem_set_protocol(&priv->sem, SEM_PRIO_NONE);
 
   priv->buffer = buffer;
   priv->size   = size;

--- a/drivers/syslog/syslog_rpmsg.h
+++ b/drivers/syslog/syslog_rpmsg.h
@@ -30,6 +30,7 @@
 #define SYSLOG_RPMSG_TRANSFER           0
 #define SYSLOG_RPMSG_SUSPEND            1
 #define SYSLOG_RPMSG_RESUME             2
+#define SYSLOG_RPMSG_SYNC               3
 
 /****************************************************************************
  * Public Types
@@ -46,6 +47,12 @@ begin_packed_struct struct syslog_rpmsg_transfer_s
   struct syslog_rpmsg_header_s header;
   int32_t                      count;
   char                         data[0];
+} end_packed_struct;
+
+begin_packed_struct struct syslog_rpmsg_sync_s
+{
+  struct syslog_rpmsg_header_s header;
+  uint64_t                     cookie;
 } end_packed_struct;
 
 #endif /* __DRIVERS_SYSLOG_SYSLOG_RPMSG_H */

--- a/drivers/syslog/syslog_rpmsg.h
+++ b/drivers/syslog/syslog_rpmsg.h
@@ -28,9 +28,8 @@
 #define SYSLOG_RPMSG_EPT_NAME           "rpmsg-syslog"
 
 #define SYSLOG_RPMSG_TRANSFER           0
-#define SYSLOG_RPMSG_TRANSFER_DONE      1
-#define SYSLOG_RPMSG_SUSPEND            2
-#define SYSLOG_RPMSG_RESUME             3
+#define SYSLOG_RPMSG_SUSPEND            1
+#define SYSLOG_RPMSG_RESUME             2
 
 /****************************************************************************
  * Public Types

--- a/drivers/syslog/syslog_rpmsg_server.c
+++ b/drivers/syslog/syslog_rpmsg_server.c
@@ -157,7 +157,6 @@ static int syslog_rpmsg_ept_cb(FAR struct rpmsg_endpoint *ept,
   if (header->command == SYSLOG_RPMSG_TRANSFER)
     {
       FAR struct syslog_rpmsg_transfer_s *msg = data;
-      struct syslog_rpmsg_header_s done;
       unsigned int copied = msg->count;
       unsigned int printed = 0;
       FAR const char *nl;
@@ -200,10 +199,6 @@ static int syslog_rpmsg_ept_cb(FAR struct rpmsg_endpoint *ept,
           memcpy(priv->tmpbuf + priv->nextpos, msg->data + printed, copied);
           priv->nextpos += copied;
         }
-
-      done.command = SYSLOG_RPMSG_TRANSFER_DONE;
-      done.result  = printed + copied;
-      rpmsg_send(ept, &done, sizeof(done));
     }
 
   return 0;

--- a/drivers/syslog/syslog_rpmsg_server.c
+++ b/drivers/syslog/syslog_rpmsg_server.c
@@ -26,7 +26,10 @@
 
 #include <assert.h>
 
+#include <nuttx/fs/ioctl.h>
 #include <nuttx/kmalloc.h>
+#include <nuttx/list.h>
+#include <nuttx/mutex.h>
 #include <nuttx/rptun/openamp.h>
 #include <nuttx/syslog/syslog_rpmsg.h>
 
@@ -45,6 +48,9 @@
 
 struct syslog_rpmsg_server_s
 {
+#ifdef CONFIG_SYSLOG_RPMSG_SERVER_CHARDEV
+  struct list_node      node;
+#endif
   struct rpmsg_endpoint ept;
   FAR char              *tmpbuf;
   unsigned int          nextpos;
@@ -64,10 +70,68 @@ static void syslog_rpmsg_ns_unbind(FAR struct rpmsg_endpoint *ept);
 static int  syslog_rpmsg_ept_cb(FAR struct rpmsg_endpoint *ept,
                                 FAR void *data, size_t len, uint32_t src,
                                 FAR void *priv_);
+#ifdef CONFIG_SYSLOG_RPMSG_SERVER_CHARDEV
+static int syslog_rpmsg_file_ioctl(FAR struct file *filep, int cmd,
+                                   unsigned long arg);
+#endif
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+#ifdef CONFIG_SYSLOG_RPMSG_SERVER_CHARDEV
+static struct list_node g_list = LIST_INITIAL_VALUE(g_list);
+static mutex_t g_lock = NXMUTEX_INITIALIZER;
+
+static const struct file_operations g_syslog_rpmsg_fops =
+{
+  NULL,                    /* open */
+  NULL,                    /* close */
+  NULL,                    /* read */
+  NULL,                    /* write */
+  NULL,                    /* seek */
+  syslog_rpmsg_file_ioctl, /* ioctl */
+  NULL                     /* poll */
+#ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
+  , NULL                   /* unlink */
+#endif
+};
 
 /****************************************************************************
  * Private Functions
  ****************************************************************************/
+
+static int syslog_rpmsg_file_ioctl(FAR struct file *filep, int cmd,
+                                   unsigned long arg)
+{
+  FAR struct syslog_rpmsg_server_s *priv;
+  struct syslog_rpmsg_sync_s msg;
+  sem_t sem;
+
+  if (cmd != FIOC_DUMP)
+    {
+      return -ENOTTY;
+    }
+
+  nxsem_init(&sem, 0, 0);
+  nxsem_set_protocol(&sem, SEM_PRIO_NONE);
+
+  nxmutex_lock(&g_lock);
+  list_for_every_entry(&g_list, priv, struct syslog_rpmsg_server_s, node)
+    {
+      msg.cookie = (uint64_t)(uintptr_t)&sem;
+      msg.header.command = SYSLOG_RPMSG_SYNC;
+      if (rpmsg_send(&priv->ept, &msg, sizeof(msg)) >= 0)
+        {
+          rpmsg_wait(&priv->ept, &sem);
+        }
+    }
+
+  nxmutex_unlock(&g_lock);
+  nxsem_destroy(&sem);
+  return OK;
+}
+#endif
 
 static void syslog_rpmsg_write(FAR const char *buf1, size_t len1,
                                FAR const char *buf2, size_t len2)
@@ -123,6 +187,12 @@ static void syslog_rpmsg_ns_bind(FAR struct rpmsg_device *rdev,
 
   priv->ept.priv = priv;
 
+#ifdef CONFIG_SYSLOG_RPMSG_SERVER_CHARDEV
+  nxmutex_lock(&g_lock);
+  list_add_tail(&g_list, &priv->node);
+  nxmutex_unlock(&g_lock);
+#endif
+
   ret = rpmsg_create_ept(&priv->ept, rdev, SYSLOG_RPMSG_EPT_NAME,
                          RPMSG_ADDR_ANY, dest,
                          syslog_rpmsg_ept_cb, syslog_rpmsg_ns_unbind);
@@ -142,6 +212,12 @@ static void syslog_rpmsg_ns_unbind(FAR struct rpmsg_endpoint *ept)
     }
 
   rpmsg_destroy_ept(ept);
+
+#ifdef CONFIG_SYSLOG_RPMSG_SERVER_CHARDEV
+  nxmutex_lock(&g_lock);
+  list_delete(&priv->node);
+  nxmutex_unlock(&g_lock);
+#endif
 
   kmm_free(priv->tmpbuf);
   kmm_free(priv);
@@ -200,6 +276,15 @@ static int syslog_rpmsg_ept_cb(FAR struct rpmsg_endpoint *ept,
           priv->nextpos += copied;
         }
     }
+#ifdef CONFIG_SYSLOG_RPMSG_SERVER_CHARDEV
+  else if (header->command == SYSLOG_RPMSG_SYNC)
+    {
+      FAR struct syslog_rpmsg_sync_s *msg = data;
+      FAR sem_t *sem = (FAR sem_t *)(uintptr_t)msg->cookie;
+
+      rpmsg_post(ept, sem);
+    }
+#endif
 
   return 0;
 }
@@ -210,6 +295,16 @@ static int syslog_rpmsg_ept_cb(FAR struct rpmsg_endpoint *ept,
 
 int syslog_rpmsg_server_init(void)
 {
+#ifdef CONFIG_SYSLOG_RPMSG_SERVER_CHARDEV
+  int ret;
+
+  ret = register_driver("/dev/logrpmsg", &g_syslog_rpmsg_fops, 0666, NULL);
+  if (ret < 0)
+    {
+      return ret;
+    }
+#endif
+
   return rpmsg_register_callback(NULL,
                                  NULL,
                                  NULL,

--- a/include/nuttx/syslog/ramlog.h
+++ b/include/nuttx/syslog/ramlog.h
@@ -66,10 +66,6 @@
  * CONFIG_RAMLOG_BUFSIZE - Size of the console RAM log.  Default: 1024
  */
 
-#if defined(CONFIG_RAMLOG_SYSLOG) && !defined(CONFIG_SYSLOG_DEVPATH)
-#  define CONFIG_SYSLOG_DEVPATH "/dev/kmsg"
-#endif
-
 #ifndef CONFIG_RAMLOG_NPOLLWAITERS
 #  define CONFIG_RAMLOG_NPOLLWAITERS 4
 #endif


### PR DESCRIPTION
## Summary

driver/syslog update:
* Support syslog_rpmsg client and server chardev.
* Remove client and server transfer ack to pptimize syslog transmission efficiency.
* when CONFIG_SYSLOG_RPMSG_WORK_DELAY is zero, remote core will transfer syslog if used space over 75% to reduce the number of ipc to save power consumption.
* Syslog server can flush remote client syslog space by ioctl with FIOC_DUMP for server chardev:/dev/logrpmsg.

## Impact
* Optimize transmission efficiency, reduce IPC times and save power consumption
## Testing
Vela CI and test
