### PR TITLE
mm: Fixed the usage of CONFIG_MM_BACKTRACE & CONFIG_DEBUG_MM.

### DIFF
--- a/fs/procfs/fs_procfsproc.c
+++ b/fs/procfs/fs_procfsproc.c
@@ -90,7 +90,7 @@ enum proc_node_e
 #ifdef CONFIG_SCHED_CRITMONITOR
   PROC_CRITMON,                       /* Critical section monitor */
 #endif
-#ifdef CONFIG_DEBUG_MM
+#ifdef CONFIG_MM_BACKTRACE
   PROC_HEAP,                          /* Task heap info */
 #endif
   PROC_STACK,                         /* Task stack info */
@@ -279,7 +279,7 @@ static const struct proc_node_s g_critmon =
 };
 #endif
 
-#ifdef CONFIG_DEBUG_MM
+#ifdef CONFIG_MM_BACKTRACE
 static const struct proc_node_s g_heap =
 {
   "heap",         "heap",   (uint8_t)PROC_HEAP,          DTYPE_FILE        /* Task heap info */
@@ -326,7 +326,7 @@ static FAR const struct proc_node_s * const g_nodeinfo[] =
 #ifdef CONFIG_SCHED_CRITMONITOR
   &g_critmon,      /* Critical section Monitor */
 #endif
-#ifdef CONFIG_DEBUG_MM
+#ifdef CONFIG_MM_BACKTRACE
   &g_heap,         /* Task heap info */
 #endif
   &g_stack,        /* Task stack info */
@@ -352,7 +352,7 @@ static const struct proc_node_s * const g_level0info[] =
 #ifdef CONFIG_SCHED_CRITMONITOR
   &g_critmon,      /* Critical section monitor */
 #endif
-#ifdef CONFIG_DEBUG_MM
+#ifdef CONFIG_MM_BACKTRACE
   &g_heap,         /* Task heap info */
 #endif
   &g_stack,        /* Task stack info */

--- a/include/malloc.h
+++ b/include/malloc.h
@@ -52,7 +52,7 @@ struct mallinfo
                  * by free (not in use) chunks. */
 };
 
-#ifdef CONFIG_DEBUG_MM
+#ifdef CONFIG_MM_BACKTRACE
 struct mallinfo_task
 {
   pid_t pid;    /* The pid of task */
@@ -72,7 +72,7 @@ extern "C"
 
 struct mallinfo mallinfo(void);
 size_t malloc_size(FAR void *ptr);
-#ifdef CONFIG_DEBUG_MM
+#ifdef CONFIG_MM_BACKTRACE
 struct mallinfo_task mallinfo_task(pid_t pid);
 #endif
 

--- a/include/nuttx/fs/procfs.h
+++ b/include/nuttx/fs/procfs.h
@@ -133,7 +133,7 @@ struct procfs_meminfo_entry_s
   FAR const char *name;
   FAR struct mm_heap_s *heap;
   struct procfs_meminfo_entry_s *next;
-#if defined(CONFIG_DEBUG_MM)
+#if defined(CONFIG_MM_BACKTRACE)
 
   /* This is dynamic control flag whether to turn on backtrace in the heap,
    * you can set it by /proc/memdump.

--- a/mm/mm_heap/mm_initialize.c
+++ b/mm/mm_heap/mm_initialize.c
@@ -220,7 +220,7 @@ FAR struct mm_heap_s *mm_initialize(FAR const char *name,
 #  if defined(CONFIG_BUILD_FLAT) || defined(__KERNEL__)
   heap->mm_procfs.name = name;
   heap->mm_procfs.heap = heap;
-#    if defined (CONFIG_DEBUG_MM) && defined(CONFIG_MM_BACKTRACE_DEFAULT)
+#    if defined (CONFIG_MM_BACKTRACE) && defined(CONFIG_MM_BACKTRACE_DEFAULT)
   heap->mm_procfs.backtrace = true;
 #    endif
 #  endif


### PR DESCRIPTION
## Summary

The option `CONFIG_DEBUG_MM` was used innapropriatelly in places that `CONFIG_MM_BACKTRACE` should have been used.

This created various problems, like #6641.

## Impact

nsh ps is working correctly now.
procfs builds with the correct options.

## Testing
Tested on sim.  
I used `ps` command in nsh, both for `CONFIG_MM_BACKTRACE` enabled and disabled.  
The output is correct in both cases.
