### PR TITLE
drivers/syslog: Call up_nputs in syslog_default_write

### DIFF
--- a/drivers/syslog/syslog_channel.c
+++ b/drivers/syslog/syslog_channel.c
@@ -217,7 +217,7 @@ static ssize_t syslog_default_write(FAR struct syslog_channel_s *channel,
                                     FAR const char *buffer, size_t buflen)
 {
 #if defined(CONFIG_ARCH_LOWPUTC)
-  up_puts(buffer);
+  up_nputs(buffer, buflen);
 #endif
 
   UNUSED(channel);


### PR DESCRIPTION
## Summary
since the buffer may not be terminated by null, fixed the problem reported in https://github.com/apache/incubator-nuttx/pull/6656

## Impact
syslog

## Testing

