### PR TITLE
sys/sysmacros.h: support sysmacros header

### DIFF
--- a/include/sys/sysmacros.h
+++ b/include/sys/sysmacros.h
@@ -1,0 +1,32 @@
+/****************************************************************************
+ * include/sys/sysmacros.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __INCLUDE_SYS_SYSMACROS_H
+#define __INCLUDE_SYS_SYSMACROS_H
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define major(x)          ((int)(0x00ff & ((x) >> 8)))
+#define minor(x)          ((int)(0xffff00ff & (x)))
+#define makedev(maj, min) ((0xff00 & ((maj) << 8)) | (0xffff00ff & (min)))
+
+#endif /* __INCLUDE_SYS_SYSMACROS_H */

--- a/include/sys/types.h
+++ b/include/sys/types.h
@@ -131,7 +131,7 @@ typedef int16_t      gid_t;
 
 /* dev_t is used for device IDs */
 
-typedef uint16_t     dev_t;
+typedef uint32_t     dev_t;
 
 /* ino_t is used for file serial numbers */
 


### PR DESCRIPTION


## Summary
Add sys/sysmacros.h 

Refer to:
https://fossies.org/linux/glibc/misc/sys/sysmacros.h
https://github.com/bminor/musl/blob/master/include/sys/sysmacros.h


Signed-off-by: Jiuzhu Dong <dongjiuzhu1@xiaomi.com>
## Impact
N/A
## Testing
Vela CI
