### PR TITLE
arch/stack: get correct stack remain and limit dump size when sp is not within stack

### DIFF
--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -837,6 +837,11 @@ config ARCH_STACKDUMP
 	---help---
 		Enable to do stack dumps after assertions
 
+config ARCH_STACKDUMP_MAX_LENGTH
+	int "The maximum length for dump stack on assertions"
+	depends on ARCH_STACKDUMP
+	default 0
+
 config DUMP_ON_EXIT
 	bool "Dump all tasks state on exit"
 	default n

--- a/arch/arm/src/common/arm_assert.c
+++ b/arch/arm/src/common/arm_assert.c
@@ -352,10 +352,17 @@ static void arm_dump_stack(const char *tag, uint32_t sp,
   else
     {
       _alert("ERROR: %s Stack pointer is not within the stack\n", tag);
-
       if (force)
         {
-          arm_stackdump(base, top);
+#ifdef CONFIG_STACK_COLORATION
+          uint32_t remain;
+
+          remain = size - arm_stack_check((FAR void *)(uintptr_t)base, size);
+          base  += remain;
+          size  -= remain;
+#endif
+
+          arm_stackdump(base, base + size);
         }
     }
 }

--- a/arch/arm/src/common/arm_assert.c
+++ b/arch/arm/src/common/arm_assert.c
@@ -362,6 +362,13 @@ static void arm_dump_stack(const char *tag, uint32_t sp,
           size  -= remain;
 #endif
 
+#if CONFIG_ARCH_STACKDUMP_MAX_LENGTH > 0
+          if (size > CONFIG_ARCH_STACKDUMP_MAX_LENGTH)
+            {
+              size = CONFIG_ARCH_STACKDUMP_MAX_LENGTH;
+            }
+#endif
+
           arm_stackdump(base, base + size);
         }
     }

--- a/arch/arm/src/common/arm_checkstack.c
+++ b/arch/arm/src/common/arm_checkstack.c
@@ -43,7 +43,11 @@
  ****************************************************************************/
 
 /****************************************************************************
- * Name: do_stackcheck
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: arm_stack_check
  *
  * Description:
  *   Determine (approximately) how much stack has been used by searching the
@@ -59,7 +63,7 @@
  *
  ****************************************************************************/
 
-static size_t do_stackcheck(void *stackbase, size_t nbytes)
+size_t arm_stack_check(void *stackbase, size_t nbytes)
 {
   uintptr_t start;
   uintptr_t end;
@@ -135,10 +139,6 @@ static size_t do_stackcheck(void *stackbase, size_t nbytes)
 }
 
 /****************************************************************************
- * Public Functions
- ****************************************************************************/
-
-/****************************************************************************
  * Name: arm_stack_color
  *
  * Description:
@@ -199,7 +199,7 @@ void arm_stack_color(void *stackbase, size_t nbytes)
 
 size_t up_check_tcbstack(struct tcb_s *tcb)
 {
-  return do_stackcheck(tcb->stack_base_ptr, tcb->adj_stack_size);
+  return arm_stack_check(tcb->stack_base_ptr, tcb->adj_stack_size);
 }
 
 ssize_t up_check_tcbstack_remain(struct tcb_s *tcb)
@@ -221,11 +221,11 @@ ssize_t up_check_stack_remain(void)
 size_t up_check_intstack(void)
 {
 #ifdef CONFIG_SMP
-  return do_stackcheck((void *)arm_intstack_alloc(),
-                        STACK_ALIGN_DOWN(CONFIG_ARCH_INTERRUPTSTACK));
+  return arm_stack_check((void *)arm_intstack_alloc(),
+                         STACK_ALIGN_DOWN(CONFIG_ARCH_INTERRUPTSTACK));
 #else
-  return do_stackcheck((void *)&g_intstackalloc,
-                        STACK_ALIGN_DOWN(CONFIG_ARCH_INTERRUPTSTACK));
+  return arm_stack_check((void *)&g_intstackalloc,
+                         STACK_ALIGN_DOWN(CONFIG_ARCH_INTERRUPTSTACK));
 #endif
 }
 

--- a/arch/arm/src/common/arm_checkstack.c
+++ b/arch/arm/src/common/arm_checkstack.c
@@ -209,12 +209,12 @@ ssize_t up_check_tcbstack_remain(struct tcb_s *tcb)
 
 size_t up_check_stack(void)
 {
-  return up_check_tcbstack(this_task());
+  return up_check_tcbstack(running_task());
 }
 
 ssize_t up_check_stack_remain(void)
 {
-  return up_check_tcbstack_remain(this_task());
+  return up_check_tcbstack_remain(running_task());
 }
 
 #if CONFIG_ARCH_INTERRUPTSTACK > 3

--- a/arch/arm/src/common/arm_internal.h
+++ b/arch/arm/src/common/arm_internal.h
@@ -440,6 +440,7 @@ void arm_usbuninitialize(void);
 
 /* Debug ********************************************************************/
 #ifdef CONFIG_STACK_COLORATION
+size_t arm_stack_check(void *stackbase, size_t nbytes);
 void arm_stack_color(void *stackbase, size_t nbytes);
 #endif
 

--- a/arch/arm64/src/common/arm64_checkstack.c
+++ b/arch/arm64/src/common/arm64_checkstack.c
@@ -210,12 +210,12 @@ ssize_t up_check_tcbstack_remain(struct tcb_s *tcb)
 
 size_t up_check_stack(void)
 {
-  return up_check_tcbstack(this_task());
+  return up_check_tcbstack(running_task());
 }
 
 ssize_t up_check_stack_remain(void)
 {
-  return up_check_tcbstack_remain(this_task());
+  return up_check_tcbstack_remain(running_task());
 }
 
 #if CONFIG_ARCH_INTERRUPTSTACK > 7

--- a/arch/arm64/src/common/arm64_checkstack.c
+++ b/arch/arm64/src/common/arm64_checkstack.c
@@ -46,14 +46,16 @@
  * Private Function Prototypes
  ****************************************************************************/
 
-static size_t do_stackcheck(void *stackbase, size_t nbytes);
-
 /****************************************************************************
  * Private Functions
  ****************************************************************************/
 
 /****************************************************************************
- * Name: do_stackcheck
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: arm64_stack_check
  *
  * Description:
  *   Determine (approximately) how much stack has been used by searching the
@@ -69,7 +71,7 @@ static size_t do_stackcheck(void *stackbase, size_t nbytes);
  *
  ****************************************************************************/
 
-static size_t do_stackcheck(void *stackbase, size_t nbytes)
+size_t arm64_stack_check(void *stackbase, size_t nbytes)
 {
   uintptr_t start;
   uintptr_t end;
@@ -145,10 +147,6 @@ static size_t do_stackcheck(void *stackbase, size_t nbytes)
 }
 
 /****************************************************************************
- * Public Functions
- ****************************************************************************/
-
-/****************************************************************************
  * Name: arm64_stack_color
  *
  * Description:
@@ -200,7 +198,7 @@ void arm64_stack_color(void *stackbase, size_t nbytes)
 
 size_t up_check_tcbstack(struct tcb_s *tcb)
 {
-  return do_stackcheck(tcb->stack_base_ptr, tcb->adj_stack_size);
+  return arm64_stack_check(tcb->stack_base_ptr, tcb->adj_stack_size);
 }
 
 ssize_t up_check_tcbstack_remain(struct tcb_s *tcb)
@@ -222,11 +220,11 @@ ssize_t up_check_stack_remain(void)
 size_t up_check_intstack(void)
 {
 #ifdef CONFIG_SMP
-  return do_stackcheck((void *)arm64_intstack_alloc(),
-                        STACK_ALIGN_DOWN(CONFIG_ARCH_INTERRUPTSTACK));
+  return arm64_stack_check((void *)arm64_intstack_alloc(),
+                           STACK_ALIGN_DOWN(CONFIG_ARCH_INTERRUPTSTACK));
 #else
-  return do_stackcheck((void *)&g_interrupt_stack,
-                        STACK_ALIGN_DOWN(CONFIG_ARCH_INTERRUPTSTACK));
+  return arm64_stack_check((void *)&g_interrupt_stack,
+                           STACK_ALIGN_DOWN(CONFIG_ARCH_INTERRUPTSTACK));
 #endif
 }
 

--- a/arch/arm64/src/common/arm64_internal.h
+++ b/arch/arm64/src/common/arm64_internal.h
@@ -352,6 +352,7 @@ void arm64_usbuninitialize(void);
 /* Debug */
 
 #ifdef CONFIG_STACK_COLORATION
+size_t arm64_stack_check(void *stackbase, size_t nbytes);
 void arm64_stack_color(void *stackbase, size_t nbytes);
 #endif
 

--- a/arch/avr/src/avr/up_checkstack.c
+++ b/arch/avr/src/avr/up_checkstack.c
@@ -156,12 +156,12 @@ ssize_t up_check_tcbstack_remain(FAR struct tcb_s *tcb)
 
 size_t up_check_stack(void)
 {
-  return up_check_tcbstack(this_task());
+  return up_check_tcbstack(running_task());
 }
 
 ssize_t up_check_stack_remain(void)
 {
-  return up_check_tcbstack_remain(this_task());
+  return up_check_tcbstack_remain(running_task());
 }
 
 #if CONFIG_ARCH_INTERRUPTSTACK > 3

--- a/arch/avr/src/avr/up_checkstack.c
+++ b/arch/avr/src/avr/up_checkstack.c
@@ -45,10 +45,12 @@
  * Private Functions
  ****************************************************************************/
 
-static size_t do_stackcheck(uintptr_t alloc, size_t size);
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
 
 /****************************************************************************
- * Name: do_stackcheck
+ * Name: avr_stack_check
  *
  * Description:
  *   Determine (approximately) how much stack has been used be searching the
@@ -64,7 +66,7 @@ static size_t do_stackcheck(uintptr_t alloc, size_t size);
  *
  ****************************************************************************/
 
-static size_t do_stackcheck(uintptr_t alloc, size_t size)
+size_t avr_stack_check(uintptr_t alloc, size_t size)
 {
   FAR uint8_t *ptr;
   size_t mark;
@@ -125,10 +127,6 @@ static size_t do_stackcheck(uintptr_t alloc, size_t size)
 }
 
 /****************************************************************************
- * Public Functions
- ****************************************************************************/
-
-/****************************************************************************
  * Name: up_check_stack and friends
  *
  * Description:
@@ -146,7 +144,8 @@ static size_t do_stackcheck(uintptr_t alloc, size_t size)
 
 size_t up_check_tcbstack(FAR struct tcb_s *tcb)
 {
-  return do_stackcheck((uintptr_t)tcb->stack_base_ptr, tcb->adj_stack_size);
+  return avr_stack_check((uintptr_t)tcb->stack_base_ptr,
+                         tcb->adj_stack_size);
 }
 
 ssize_t up_check_tcbstack_remain(FAR struct tcb_s *tcb)
@@ -168,7 +167,7 @@ ssize_t up_check_stack_remain(void)
 size_t up_check_intstack(void)
 {
   uintptr_t start = (uintptr_t)g_intstackalloc;
-  return do_stackcheck(start, CONFIG_ARCH_INTERRUPTSTACK & ~3);
+  return avr_stack_check(start, CONFIG_ARCH_INTERRUPTSTACK & ~3);
 }
 
 size_t up_check_intstack_remain(void)

--- a/arch/avr/src/common/up_internal.h
+++ b/arch/avr/src/common/up_internal.h
@@ -172,5 +172,9 @@ void up_usbuninitialize(void);
 # define up_usbuninitialize()
 #endif
 
+#ifdef CONFIG_STACK_COLORATION
+size_t avr_stack_check(uintptr_t alloc, size_t size);
+#endif
+
 #endif /* __ASSEMBLY__ */
 #endif /* __ARCH_AVR_SRC_COMMON_UP_INTERNAL_H */

--- a/arch/ceva/src/common/up_checkstack.c
+++ b/arch/ceva/src/common/up_checkstack.c
@@ -38,10 +38,12 @@
  * Private Function Prototypes
  ****************************************************************************/
 
-static size_t do_stackcheck(uintptr_t alloc, size_t size);
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
 
 /****************************************************************************
- * Name: do_stackcheck
+ * Name: ceva_stack_check
  *
  * Description:
  *   Determine (approximately) how much stack has been used be searching the
@@ -57,7 +59,7 @@ static size_t do_stackcheck(uintptr_t alloc, size_t size);
  *
  ****************************************************************************/
 
-static size_t do_stackcheck(uintptr_t alloc, size_t size)
+size_t ceva_stack_check(uintptr_t alloc, size_t size)
 {
   uint32_t *ptr;
   size_t nwords;
@@ -120,10 +122,6 @@ static size_t do_stackcheck(uintptr_t alloc, size_t size)
 }
 
 /****************************************************************************
- * Public Functions
- ****************************************************************************/
-
-/****************************************************************************
  * Name: up_check_stack and friends
  *
  * Description:
@@ -141,8 +139,8 @@ static size_t do_stackcheck(uintptr_t alloc, size_t size)
 
 size_t up_check_tcbstack(struct tcb_s *tcb)
 {
-  return do_stackcheck((uintptr_t)tcb->stack_alloc_ptr,
-                       tcb->adj_stack_size);
+  return ceva_stack_check((uintptr_t)tcb->stack_alloc_ptr,
+                          tcb->adj_stack_size);
 }
 
 ssize_t up_check_tcbstack_remain(struct tcb_s *tcb)
@@ -162,8 +160,8 @@ ssize_t up_check_stack_remain(void)
 
 size_t up_check_intstack(void)
 {
-  return do_stackcheck((uintptr_t)&g_intstackalloc,
-                       &g_intstackbase - &g_intstackalloc);
+  return ceva_stack_check((uintptr_t)&g_intstackalloc,
+                          &g_intstackbase - &g_intstackalloc);
 }
 
 size_t up_check_intstack_remain(void)

--- a/arch/ceva/src/common/up_checkstack.c
+++ b/arch/ceva/src/common/up_checkstack.c
@@ -152,12 +152,12 @@ ssize_t up_check_tcbstack_remain(struct tcb_s *tcb)
 
 size_t up_check_stack(void)
 {
-  return up_check_tcbstack(this_task());
+  return up_check_tcbstack(running_task());
 }
 
 ssize_t up_check_stack_remain(void)
 {
-  return up_check_tcbstack_remain(this_task());
+  return up_check_tcbstack_remain(running_task());
 }
 
 size_t up_check_intstack(void)

--- a/arch/ceva/src/common/up_internal.h
+++ b/arch/ceva/src/common/up_internal.h
@@ -311,6 +311,7 @@ void up_usbuninitialize(void);
 #endif
 
 #ifdef CONFIG_STACK_COLORATION
+size_t ceva_stack_check(uintptr_t alloc, size_t size);
 void up_stack_color(void *stackbase, size_t nbytes);
 #endif
 

--- a/arch/or1k/src/common/up_checkstack.c
+++ b/arch/or1k/src/common/up_checkstack.c
@@ -42,14 +42,16 @@
  * Private Function Prototypes
  ****************************************************************************/
 
-static size_t do_stackcheck(uintptr_t alloc, size_t size);
-
 /****************************************************************************
  * Private Function
  ****************************************************************************/
 
 /****************************************************************************
- * Name: do_stackcheck
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: or1k_stack_check
  *
  * Description:
  *   Determine (approximately) how much stack has been used be searching the
@@ -65,7 +67,7 @@ static size_t do_stackcheck(uintptr_t alloc, size_t size);
  *
  ****************************************************************************/
 
-static size_t do_stackcheck(uintptr_t alloc, size_t size)
+size_t or1k_stack_check(uintptr_t alloc, size_t size)
 {
   uintptr_t start;
   uintptr_t end;
@@ -96,10 +98,6 @@ static size_t do_stackcheck(uintptr_t alloc, size_t size)
 }
 
 /****************************************************************************
- * Public Functions
- ****************************************************************************/
-
-/****************************************************************************
  * Name: up_check_stack and friends
  *
  * Description:
@@ -117,7 +115,8 @@ static size_t do_stackcheck(uintptr_t alloc, size_t size)
 
 size_t up_check_tcbstack(struct tcb_s *tcb)
 {
-  return do_stackcheck((uintptr_t)tcb->stack_base_ptr, tcb->adj_stack_size);
+  return or1k_stack_check((uintptr_t)tcb->stack_base_ptr,
+                          tcb->adj_stack_size);
 }
 
 ssize_t up_check_tcbstack_remain(struct tcb_s *tcb)
@@ -138,8 +137,8 @@ ssize_t up_check_stack_remain(void)
 #if CONFIG_ARCH_INTERRUPTSTACK > 3
 size_t up_check_intstack(void)
 {
-  return do_stackcheck((uintptr_t)&g_intstackalloc,
-                       (CONFIG_ARCH_INTERRUPTSTACK & ~3));
+  return or1k_stack_check((uintptr_t)&g_intstackalloc,
+                          (CONFIG_ARCH_INTERRUPTSTACK & ~3));
 }
 
 size_t up_check_intstack_remain(void)

--- a/arch/or1k/src/common/up_checkstack.c
+++ b/arch/or1k/src/common/up_checkstack.c
@@ -127,12 +127,12 @@ ssize_t up_check_tcbstack_remain(struct tcb_s *tcb)
 
 size_t up_check_stack(void)
 {
-  return up_check_tcbstack(this_task());
+  return up_check_tcbstack(running_task());
 }
 
 ssize_t up_check_stack_remain(void)
 {
-  return up_check_tcbstack_remain(this_task());
+  return up_check_tcbstack_remain(running_task());
 }
 
 #if CONFIG_ARCH_INTERRUPTSTACK > 3

--- a/arch/or1k/src/common/up_internal.h
+++ b/arch/or1k/src/common/up_internal.h
@@ -329,6 +329,7 @@ void up_usbuninitialize(void);
 
 /* Debug ********************************************************************/
 #ifdef CONFIG_STACK_COLORATION
+size_t or1k_stack_check(uintptr_t alloc, size_t size);
 void up_stack_color(void *stackbase, size_t nbytes);
 #endif
 

--- a/arch/risc-v/src/common/riscv_assert.c
+++ b/arch/risc-v/src/common/riscv_assert.c
@@ -339,6 +339,13 @@ static void riscv_dump_stack(const char *tag, uintptr_t sp,
           size  -= remain;
 #endif
 
+#if CONFIG_ARCH_STACKDUMP_MAX_LENGTH > 0
+          if (size > CONFIG_ARCH_STACKDUMP_MAX_LENGTH)
+            {
+              size = CONFIG_ARCH_STACKDUMP_MAX_LENGTH;
+            }
+#endif
+
           riscv_stackdump(base, base + size);
         }
     }

--- a/arch/risc-v/src/common/riscv_assert.c
+++ b/arch/risc-v/src/common/riscv_assert.c
@@ -331,7 +331,15 @@ static void riscv_dump_stack(const char *tag, uintptr_t sp,
 
       if (force)
         {
-          riscv_stackdump(base, top);
+#ifdef CONFIG_STACK_COLORATION
+          uint32_t remain;
+
+          remain = size - riscv_stack_check((uintptr_t)base, size);
+          base  += remain;
+          size  -= remain;
+#endif
+
+          riscv_stackdump(base, base + size);
         }
     }
 }

--- a/arch/risc-v/src/common/riscv_assert.c
+++ b/arch/risc-v/src/common/riscv_assert.c
@@ -308,6 +308,35 @@ static inline void riscv_showtasks(void)
 }
 
 /****************************************************************************
+ * Name: riscv_dump_stack
+ ****************************************************************************/
+
+static void riscv_dump_stack(const char *tag, uintptr_t sp,
+                             uintptr_t base, uint32_t size, bool force)
+{
+  uintptr_t top = base + size;
+
+  _alert("%s Stack:\n", tag);
+  _alert("sp:     %08" PRIxPTR "\n", sp);
+  _alert("  base: %08" PRIxPTR "\n", base);
+  _alert("  size: %08" PRIx32 "\n", size);
+
+  if (sp >= base && sp < top)
+    {
+      riscv_stackdump(sp, top);
+    }
+  else
+    {
+      _alert("ERROR: %s Stack pointer is not within the stack\n", tag);
+
+      if (force)
+        {
+          riscv_stackdump(base, top);
+        }
+    }
+}
+
+/****************************************************************************
  * Name: riscv_dumpstate
  ****************************************************************************/
 
@@ -315,15 +344,6 @@ static void riscv_dumpstate(void)
 {
   struct tcb_s *rtcb = running_task();
   uintptr_t sp = up_getsp();
-  uintptr_t ustackbase;
-  uintptr_t ustacksize;
-#if CONFIG_ARCH_INTERRUPTSTACK > 15
-  uintptr_t istackbase;
-  uintptr_t istacksize;
-#endif
-#ifdef CONFIG_ARCH_KERNEL_STACK
-  uintptr_t kstackbase = 0;
-#endif
 
   /* Show back trace */
 
@@ -346,101 +366,35 @@ static void riscv_dumpstate(void)
 
   riscv_registerdump(rtcb->xcp.regs);
 
-  /* Get the limits on the user stack memory */
-
-  ustackbase = (uintptr_t)rtcb->stack_base_ptr;
-  ustacksize = (uintptr_t)rtcb->adj_stack_size;
-
   /* Get the limits on the interrupt stack memory */
 
 #if CONFIG_ARCH_INTERRUPTSTACK > 15
-  istackbase = (uintptr_t)&g_intstackalloc;
-  istacksize = (CONFIG_ARCH_INTERRUPTSTACK & ~15);
-
-  /* Show interrupt stack info */
-
-  _alert("sp:     %" PRIxREG "\n", sp);
-  _alert("IRQ stack:\n");
-  _alert("  base: %" PRIxREG "\n", istackbase);
-  _alert("  size: %" PRIxREG "\n", istacksize);
-
-  /* Does the current stack pointer lie within the interrupt
-   * stack?
-   */
-
-  if (sp >= istackbase && sp < istackbase + istacksize)
+  riscv_dump_stack("IRQ", sp,
+                   (uintptr_t)&g_intstackalloc,
+                   (CONFIG_ARCH_INTERRUPTSTACK & ~15),
+                   !!CURRENT_REGS);
+  if (CURRENT_REGS)
     {
-      /* Yes.. dump the interrupt stack */
-
-      riscv_stackdump(sp, istackbase + istacksize);
-
-      /* Extract the user stack pointer */
-
-      if (CURRENT_REGS)
-        {
-          sp = CURRENT_REGS[REG_SP];
-        }
-
-      _alert("sp:     %" PRIxREG "\n", sp);
+      sp = CURRENT_REGS[REG_SP];
     }
-  else if (CURRENT_REGS)
-    {
-      _alert("ERROR: Stack pointer is not within the interrupt stack\n");
-      riscv_stackdump(istackbase, istackbase + istacksize);
-    }
+#endif
 
-  /* Show user stack info */
-
-  _alert("User stack:\n");
-  _alert("  base: %" PRIxREG "\n", ustackbase);
-  _alert("  size: %" PRIxREG "\n", ustacksize);
+  riscv_dump_stack("User", sp,
+                   (uintptr_t)rtcb->stack_base_ptr,
+                   (uint32_t)rtcb->adj_stack_size,
+#ifdef CONFIG_ARCH_KERNEL_STACK
+                 false
 #else
-  _alert("sp:         %" PRIxREG "\n", sp);
-  _alert("stack base: %" PRIxREG "\n", ustackbase);
-  _alert("stack size: %" PRIxREG "\n", ustacksize);
+                 true
 #endif
+                );
 
 #ifdef CONFIG_ARCH_KERNEL_STACK
-  /* Does this thread have a kernel stack allocated? */
-
-  if (rtcb->xcp.kstack)
-    {
-      kstackbase = (uintptr_t)rtcb->xcp.kstack;
-
-      _alert("Kernel stack:\n");
-      _alert("  base: %" PRIxREG "\n", kstackbase);
-      _alert("  size: %" PRIxREG "\n", CONFIG_ARCH_KERNEL_STACKSIZE);
-    }
+  riscv_dump_stack("Kernel", sp,
+                   (uintptr_t)rtcb->xcp.kstack,
+                   CONFIG_ARCH_KERNEL_STACKSIZE,
+                   false);
 #endif
-
-  /* Dump the user stack if the stack pointer lies within the allocated user
-   * stack memory.
-   */
-
-  if (sp >= ustackbase && sp < ustackbase + ustacksize)
-    {
-      _alert("User Stack\n");
-      riscv_stackdump(sp, ustackbase + ustacksize);
-    }
-
-#ifdef CONFIG_ARCH_KERNEL_STACK
-  /* Dump the kernel stack if the stack pointer lies within the allocated
-   * kernel stack memory.
-   */
-
-  else if (kstackbase != 0 &&
-           sp >= kstackbase &&
-           sp < kstackbase + CONFIG_ARCH_KERNEL_STACKSIZE)
-    {
-      _alert("Kernel Stack\n");
-      riscv_stackdump(sp, kstackbase + CONFIG_ARCH_KERNEL_STACKSIZE);
-    }
-#endif
-  else
-    {
-      _alert("ERROR: Stack pointer is not within allocated stack\n");
-      riscv_stackdump(ustackbase, ustackbase + ustacksize);
-    }
 }
 #else
 #  define riscv_dumpstate()

--- a/arch/risc-v/src/common/riscv_checkstack.c
+++ b/arch/risc-v/src/common/riscv_checkstack.c
@@ -41,10 +41,12 @@
  * Private Function Prototypes
  ****************************************************************************/
 
-static size_t do_stackcheck(uintptr_t alloc, size_t size);
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
 
 /****************************************************************************
- * Name: do_stackcheck
+ * Name: riscv_stack_check
  *
  * Description:
  *   Determine (approximately) how much stack has been used be searching the
@@ -60,7 +62,7 @@ static size_t do_stackcheck(uintptr_t alloc, size_t size);
  *
  ****************************************************************************/
 
-static size_t do_stackcheck(uintptr_t alloc, size_t size)
+size_t riscv_stack_check(uintptr_t alloc, size_t size)
 {
   uintptr_t start;
   uintptr_t end;
@@ -136,10 +138,6 @@ static size_t do_stackcheck(uintptr_t alloc, size_t size)
 }
 
 /****************************************************************************
- * Public Functions
- ****************************************************************************/
-
-/****************************************************************************
  * Name: up_check_stack and friends
  *
  * Description:
@@ -157,7 +155,8 @@ static size_t do_stackcheck(uintptr_t alloc, size_t size)
 
 size_t up_check_tcbstack(struct tcb_s *tcb)
 {
-  return do_stackcheck((uintptr_t)tcb->stack_base_ptr, tcb->adj_stack_size);
+  return riscv_stack_check((uintptr_t)tcb->stack_base_ptr,
+                           tcb->adj_stack_size);
 }
 
 ssize_t up_check_tcbstack_remain(struct tcb_s *tcb)
@@ -178,8 +177,8 @@ ssize_t up_check_stack_remain(void)
 #if CONFIG_ARCH_INTERRUPTSTACK > 15
 size_t up_check_intstack(void)
 {
-  return do_stackcheck((uintptr_t)&g_intstackalloc,
-                       (CONFIG_ARCH_INTERRUPTSTACK & ~15));
+  return riscv_stack_check((uintptr_t)&g_intstackalloc,
+                           (CONFIG_ARCH_INTERRUPTSTACK & ~15));
 }
 
 size_t up_check_intstack_remain(void)

--- a/arch/risc-v/src/common/riscv_checkstack.c
+++ b/arch/risc-v/src/common/riscv_checkstack.c
@@ -167,12 +167,12 @@ ssize_t up_check_tcbstack_remain(struct tcb_s *tcb)
 
 size_t up_check_stack(void)
 {
-  return up_check_tcbstack(this_task());
+  return up_check_tcbstack(running_task());
 }
 
 ssize_t up_check_stack_remain(void)
 {
-  return up_check_tcbstack_remain(this_task());
+  return up_check_tcbstack_remain(running_task());
 }
 
 #if CONFIG_ARCH_INTERRUPTSTACK > 15

--- a/arch/risc-v/src/common/riscv_internal.h
+++ b/arch/risc-v/src/common/riscv_internal.h
@@ -267,6 +267,7 @@ int riscv_misaligned(int irq, void *context, void *arg);
 /* Debug ********************************************************************/
 
 #ifdef CONFIG_STACK_COLORATION
+size_t riscv_stack_check(uintptr_t alloc, size_t size);
 void riscv_stack_color(void *stackbase, size_t nbytes);
 #endif
 

--- a/arch/sim/src/sim/up_checkstack.c
+++ b/arch/sim/src/sim/up_checkstack.c
@@ -166,10 +166,10 @@ ssize_t up_check_tcbstack_remain(struct tcb_s *tcb)
 
 size_t up_check_stack(void)
 {
-  return up_check_tcbstack(this_task());
+  return up_check_tcbstack(running_task());
 }
 
 ssize_t up_check_stack_remain(void)
 {
-  return up_check_tcbstack_remain(this_task());
+  return up_check_tcbstack_remain(running_task());
 }

--- a/arch/sim/src/sim/up_checkstack.c
+++ b/arch/sim/src/sim/up_checkstack.c
@@ -40,10 +40,12 @@
  * Private Function Prototypes
  ****************************************************************************/
 
-static size_t do_stackcheck(uintptr_t alloc, size_t size);
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
 
 /****************************************************************************
- * Name: do_stackcheck
+ * Name: sim_stack_check
  *
  * Description:
  *   Determine (approximately) how much stack has been used be searching the
@@ -59,7 +61,7 @@ static size_t do_stackcheck(uintptr_t alloc, size_t size);
  *
  ****************************************************************************/
 
-static size_t do_stackcheck(uintptr_t alloc, size_t size)
+size_t sim_stack_check(void *alloc, size_t size)
 {
   uintptr_t start;
   uintptr_t end;
@@ -73,8 +75,8 @@ static size_t do_stackcheck(uintptr_t alloc, size_t size)
 
   /* Get aligned addresses of the top and bottom of the stack */
 
-  start = (alloc + 3) & ~3;
-  end   = (alloc + size) & ~3;
+  start = ((uintptr_t)alloc + 3) & ~3;
+  end   = ((uintptr_t)alloc + size) & ~3;
 
   /* Get the adjusted size based on the top and bottom of the stack */
 
@@ -135,10 +137,6 @@ static size_t do_stackcheck(uintptr_t alloc, size_t size)
 }
 
 /****************************************************************************
- * Public Functions
- ****************************************************************************/
-
-/****************************************************************************
  * Name: up_check_stack and friends
  *
  * Description:
@@ -156,7 +154,8 @@ static size_t do_stackcheck(uintptr_t alloc, size_t size)
 
 size_t up_check_tcbstack(struct tcb_s *tcb)
 {
-  return do_stackcheck((uintptr_t)tcb->stack_base_ptr, tcb->adj_stack_size);
+  return sim_stack_check((void *)(uintptr_t)tcb->stack_base_ptr,
+                         tcb->adj_stack_size);
 }
 
 ssize_t up_check_tcbstack_remain(struct tcb_s *tcb)

--- a/arch/sim/src/sim/up_internal.h
+++ b/arch/sim/src/sim/up_internal.h
@@ -361,6 +361,7 @@ int sim_spi_uninitialize(struct spi_dev_s *dev);
 /* Debug ********************************************************************/
 
 #ifdef CONFIG_STACK_COLORATION
+size_t sim_stack_check(void *alloc, size_t size);
 void up_stack_color(void *stackbase, size_t nbytes);
 #endif
 

--- a/arch/sparc/src/common/up_checkstack.c
+++ b/arch/sparc/src/common/up_checkstack.c
@@ -210,12 +210,12 @@ ssize_t up_check_tcbstack_remain(struct tcb_s *tcb)
 
 size_t up_check_stack(void)
 {
-  return up_check_tcbstack(this_task());
+  return up_check_tcbstack(running_task());
 }
 
 ssize_t up_check_stack_remain(void)
 {
-  return up_check_tcbstack_remain(this_task());
+  return up_check_tcbstack_remain(running_task());
 }
 
 #if CONFIG_ARCH_INTERRUPTSTACK > 3

--- a/arch/sparc/src/common/up_checkstack.c
+++ b/arch/sparc/src/common/up_checkstack.c
@@ -44,7 +44,11 @@
  ****************************************************************************/
 
 /****************************************************************************
- * Name: do_stackcheck
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: sparc_stack_check
  *
  * Description:
  *   Determine (approximately) how much stack has been used by searching the
@@ -60,7 +64,7 @@
  *
  ****************************************************************************/
 
-static size_t do_stackcheck(void *stackbase, size_t nbytes)
+size_t sparc_stack_check(void *stackbase, size_t nbytes)
 {
   uintptr_t start;
   uintptr_t end;
@@ -136,10 +140,6 @@ static size_t do_stackcheck(void *stackbase, size_t nbytes)
 }
 
 /****************************************************************************
- * Public Functions
- ****************************************************************************/
-
-/****************************************************************************
  * Name: up_stack_color
  *
  * Description:
@@ -200,7 +200,7 @@ void up_stack_color(void *stackbase, size_t nbytes)
 
 size_t up_check_tcbstack(struct tcb_s *tcb)
 {
-  return do_stackcheck(tcb->stack_base_ptr, tcb->adj_stack_size);
+  return sparc_stack_check(tcb->stack_base_ptr, tcb->adj_stack_size);
 }
 
 ssize_t up_check_tcbstack_remain(struct tcb_s *tcb)
@@ -221,8 +221,8 @@ ssize_t up_check_stack_remain(void)
 #if CONFIG_ARCH_INTERRUPTSTACK > 3
 size_t up_check_intstack(void)
 {
-  return do_stackcheck((uintptr_t)&g_intstackalloc,
-                       STACK_ALIGN_DOWN(CONFIG_ARCH_INTERRUPTSTACK));
+  return sparc_stack_check((uintptr_t)&g_intstackalloc,
+                           STACK_ALIGN_DOWN(CONFIG_ARCH_INTERRUPTSTACK));
 }
 
 size_t up_check_intstack_remain(void)

--- a/arch/sparc/src/common/up_internal.h
+++ b/arch/sparc/src/common/up_internal.h
@@ -259,6 +259,7 @@ void up_usbuninitialize(void);
 
 /* Debug ********************************************************************/
 #ifdef CONFIG_STACK_COLORATION
+size_t sparc_stack_check(void *stackbase, size_t nbytes);
 void up_stack_color(void *stackbase, size_t nbytes);
 #endif
 

--- a/arch/xtensa/src/common/xtensa.h
+++ b/arch/xtensa/src/common/xtensa.h
@@ -346,6 +346,7 @@ int xtensa_swint(int irq, void *context, void *arg);
 /* Debug ********************************************************************/
 
 #ifdef CONFIG_STACK_COLORATION
+size_t xtensa_stack_check(uintptr_t alloc, size_t size);
 void xtensa_stack_color(void *stackbase, size_t nbytes);
 #endif
 

--- a/arch/xtensa/src/common/xtensa_checkstack.c
+++ b/arch/xtensa/src/common/xtensa_checkstack.c
@@ -170,12 +170,12 @@ ssize_t up_check_tcbstack_remain(struct tcb_s *tcb)
 
 size_t up_check_stack(void)
 {
-  return up_check_tcbstack(this_task());
+  return up_check_tcbstack(running_task());
 }
 
 ssize_t up_check_stack_remain(void)
 {
-  return up_check_tcbstack_remain(this_task());
+  return up_check_tcbstack_remain(running_task());
 }
 
 #if CONFIG_ARCH_INTERRUPTSTACK > 15

--- a/arch/xtensa/src/common/xtensa_checkstack.c
+++ b/arch/xtensa/src/common/xtensa_checkstack.c
@@ -42,10 +42,12 @@
  * Private Function Prototypes
  ****************************************************************************/
 
-static size_t do_stackcheck(uintptr_t alloc, size_t size);
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
 
 /****************************************************************************
- * Name: do_stackcheck
+ * Name: xtensa_stack_check
  *
  * Description:
  *   Determine (approximately) how much stack has been used be searching the
@@ -61,7 +63,7 @@ static size_t do_stackcheck(uintptr_t alloc, size_t size);
  *
  ****************************************************************************/
 
-static size_t do_stackcheck(uintptr_t alloc, size_t size)
+size_t xtensa_stack_check(uintptr_t alloc, size_t size)
 {
   uintptr_t start;
   uintptr_t end;
@@ -139,10 +141,6 @@ static size_t do_stackcheck(uintptr_t alloc, size_t size)
 }
 
 /****************************************************************************
- * Public Functions
- ****************************************************************************/
-
-/****************************************************************************
  * Name: up_check_stack and friends
  *
  * Description:
@@ -160,7 +158,8 @@ static size_t do_stackcheck(uintptr_t alloc, size_t size)
 
 size_t up_check_tcbstack(struct tcb_s *tcb)
 {
-  return do_stackcheck((uintptr_t)tcb->stack_base_ptr, tcb->adj_stack_size);
+  return xtensa_stack_check((uintptr_t)tcb->stack_base_ptr,
+                            tcb->adj_stack_size);
 }
 
 ssize_t up_check_tcbstack_remain(struct tcb_s *tcb)
@@ -182,9 +181,9 @@ ssize_t up_check_stack_remain(void)
 size_t up_check_intstack(void)
 {
 #ifdef CONFIG_SMP
-  return do_stackcheck(xtensa_intstack_alloc(), INTSTACK_SIZE);
+  return xtensa_stack_check(xtensa_intstack_alloc(), INTSTACK_SIZE);
 #else
-  return do_stackcheck((uintptr_t)&g_intstackalloc, INTSTACK_SIZE);
+  return xtensa_stack_check((uintptr_t)&g_intstackalloc, INTSTACK_SIZE);
 #endif
 }
 

--- a/arch/xtensa/src/common/xtensa_dumpstate.c
+++ b/arch/xtensa/src/common/xtensa_dumpstate.c
@@ -281,14 +281,16 @@ static void xtensa_dump_stack(const char *tag, uint32_t sp,
                               uint32_t base, uint32_t size, bool force)
 {
   uint32_t top = base + size;
+#ifdef CONFIG_STACK_COLORATION
+  uint32_t used = xtensa_stack_check((uintptr_t)base, size);
+#endif
 
   _alert("%s Stack:\n", tag);
   _alert("sp:     %08" PRIx32 "\n", sp);
   _alert("  base: %08" PRIx32 "\n", base);
   _alert("  size: %08" PRIx32 "\n", size);
 #ifdef CONFIG_STACK_COLORATION
-  _alert("  used: %08" PRIx32 "\n", xtensa_stack_check((uintptr_t)base,
-                                                       size));
+  _alert("  used: %08" PRIx32 "\n", used);
 #endif
 
   if (sp >= base && sp < top)
@@ -301,7 +303,12 @@ static void xtensa_dump_stack(const char *tag, uint32_t sp,
 
       if (force)
         {
-          xtensa_stackdump(base, top);
+#ifdef CONFIG_STACK_COLORATION
+          base += size - used;
+          size = used;
+#endif
+
+          xtensa_stackdump(base, base + size);
         }
     }
 }

--- a/arch/xtensa/src/common/xtensa_dumpstate.c
+++ b/arch/xtensa/src/common/xtensa_dumpstate.c
@@ -308,6 +308,13 @@ static void xtensa_dump_stack(const char *tag, uint32_t sp,
           size = used;
 #endif
 
+#if CONFIG_ARCH_STACKDUMP_MAX_LENGTH > 0
+          if (size > CONFIG_ARCH_STACKDUMP_MAX_LENGTH)
+            {
+              size = CONFIG_ARCH_STACKDUMP_MAX_LENGTH;
+            }
+#endif
+
           xtensa_stackdump(base, base + size);
         }
     }


### PR DESCRIPTION
## Summary
1. using running_task to get current tcb because this task maybe wrong in interrupt context.
2. Limit dump size when sp is not within stack. we need to limit this dump size because if the stack size of task is over syslog buffer, it will overwrite other dump message.
## Impact
N/A
## Testing
Vela Ci
