### PR TITLE
driver/ioe_rpmsg: split server and client ept_cb to simplify code

### DIFF
--- a/drivers/ioexpander/ioe_rpmsg.c
+++ b/drivers/ioexpander/ioe_rpmsg.c
@@ -63,8 +63,7 @@ struct ioe_rpmsg_cookie_s
 
 begin_packed_struct struct ioe_rpmsg_header_s
 {
-  uint32_t                     command : 31;
-  uint32_t                     response : 1;
+  uint32_t                     command;
   int32_t                      result;
   uint64_t                     cookie;
 } end_packed_struct;
@@ -143,9 +142,12 @@ struct ioe_rpmsg_client_s
  * Private Function Prototypes
  ****************************************************************************/
 
-static int ioe_rpmsg_ept_cb(FAR struct rpmsg_endpoint *ept,
-                            FAR void *data, size_t len,
-                            uint32_t src, FAR void *priv_);
+static int ioe_rpmsg_client_ept_cb(FAR struct rpmsg_endpoint *ept,
+                                   FAR void *data, size_t len,
+                                   uint32_t src, FAR void *priv_);
+static int ioe_rpmsg_server_ept_cb(FAR struct rpmsg_endpoint *ept,
+                                   FAR void *data, size_t len,
+                                   uint32_t src, FAR void *priv_);
 
 static int ioe_rpmsg_direction_handler(FAR struct rpmsg_endpoint *ept,
                                        FAR void *data, size_t len,
@@ -202,7 +204,6 @@ static const rpmsg_ept_cb g_ioe_rpmsg_handler[] =
 #ifdef CONFIG_IOEXPANDER_INT_ENABLE
   [IOE_RPMSG_ATTACH]    = ioe_rpmsg_attach_handler,
   [IOE_RPMSG_DETACH]    = ioe_rpmsg_detach_handler,
-  [IOE_RPMSG_IRQ]       = ioe_rpmsg_irq_handler,
 #endif
 };
 
@@ -271,7 +272,6 @@ static int ioe_rpmsg_sendrecv(FAR struct rpmsg_endpoint *ept,
   nxsem_set_protocol(&cookie.sem, SEM_PRIO_NONE);
 
   msg->command = command;
-  msg->response = 0;
   msg->result = -ENXIO;
   msg->cookie = (uintptr_t)&cookie;
 
@@ -453,7 +453,7 @@ static void ioe_rpmsg_irqworker(FAR void *priv_)
   msg.cbarg  = cb->cbarg;
 
   msg.header.command  = IOE_RPMSG_IRQ;
-  msg.header.response = 0;
+  msg.header.cookie   = 0;
   rpmsg_send(cb->ept, &msg, sizeof(msg));
 
   cb->pendset = 0;
@@ -538,30 +538,27 @@ static int ioe_rpmsg_irq_handler(FAR struct rpmsg_endpoint *ept,
 
 #endif
 
-static int ioe_rpmsg_ept_cb(FAR struct rpmsg_endpoint *ept, FAR void *data,
-                            size_t len, uint32_t src, FAR void *priv_)
+static int ioe_rpmsg_client_ept_cb(FAR struct rpmsg_endpoint *ept,
+                                   FAR void *data, size_t len,
+                                   uint32_t src, FAR void *priv_)
 {
   FAR struct ioe_rpmsg_header_s *msg = data;
-  uint32_t cmd = msg->command;
-  int ret = -EINVAL;
-
   struct ioe_rpmsg_cookie_s *cookie =
               (struct ioe_rpmsg_cookie_s *)(uintptr_t)msg->cookie;
 
-  if (msg->response && cookie)
+  if (cookie)
     {
       cookie->result = msg->result;
       rpmsg_post(ept, &cookie->sem);
-      ret = 0;
     }
-  else if (cmd < ARRAY_SIZE(g_ioe_rpmsg_handler)
-           && g_ioe_rpmsg_handler[cmd])
+#ifdef CONFIG_IOEXPANDER_INT_ENABLE
+  else if (msg->command == IOE_RPMSG_IRQ)
     {
-      msg->response = 1;
-      ret = g_ioe_rpmsg_handler[cmd](ept, data, len, src, priv_);
+      ioe_rpmsg_irq_handler(ept, data, len, src, priv_);
     }
+#endif
 
-  return ret;
+  return 0;
 }
 
 static void ioe_rpmsg_client_created(FAR struct rpmsg_device *rdev,
@@ -576,7 +573,7 @@ static void ioe_rpmsg_client_created(FAR struct rpmsg_device *rdev,
 
       priv->ept.priv = priv;
       rpmsg_create_ept(&priv->ept, rdev, eptname, RPMSG_ADDR_ANY,
-                       RPMSG_ADDR_ANY, ioe_rpmsg_ept_cb, NULL);
+                       RPMSG_ADDR_ANY, ioe_rpmsg_client_ept_cb, NULL);
 
       rpmsg_post(&priv->ept, &priv->sem);
     }
@@ -592,6 +589,21 @@ static void ioe_rpmsg_client_destroy(FAR struct rpmsg_device *rdev,
       rpmsg_wait(&priv->ept, &priv->sem);
       rpmsg_destroy_ept(&priv->ept);
     }
+}
+
+static int ioe_rpmsg_server_ept_cb(FAR struct rpmsg_endpoint *ept,
+                                   FAR void *data, size_t len,
+                                   uint32_t src, FAR void *priv_)
+{
+  FAR struct ioe_rpmsg_header_s *msg = data;
+  uint32_t cmd = msg->command;
+
+  if (cmd < ARRAY_SIZE(g_ioe_rpmsg_handler) && g_ioe_rpmsg_handler[cmd])
+    {
+      return g_ioe_rpmsg_handler[cmd](ept, data, len, src, priv_);
+    }
+
+  return 0;
 }
 
 static void ioe_rpmsg_server_unbind(FAR struct rpmsg_endpoint *ept)
@@ -624,7 +636,7 @@ static void ioe_rpmsg_server_bind(FAR struct rpmsg_device *rdev,
       ept->priv = priv;
 
       rpmsg_create_ept(ept, rdev, name, RPMSG_ADDR_ANY, RPMSG_ADDR_ANY,
-                       ioe_rpmsg_ept_cb, ioe_rpmsg_server_unbind);
+                       ioe_rpmsg_server_ept_cb, ioe_rpmsg_server_unbind);
     }
 }
 


### PR DESCRIPTION


## Summary
driver/ioe_rpmsg: split server and client ept_cb to simplify code

Signed-off-by: Jiuzhu Dong <dongjiuzhu1@xiaomi.com>
## Impact
N/A
## Testing
Vela CI
