### PR TITLE
lcd/apa102: Fix APA102 RGB LED Matrix interleaving issue

### DIFF
--- a/drivers/lcd/apa102.c
+++ b/drivers/lcd/apa102.c
@@ -443,7 +443,15 @@ static int apa102_putrun(FAR struct lcd_dev_s *dev, fb_coord_t row,
     {
       uint16_t *ptr = (uint16_t *)buffer;
 
-      priv->fb[(row * APA102_XRES) + col + i] = rgb565_apa102(*ptr++);
+      if (row % 2 == 0)
+        {
+          priv->fb[(row * APA102_XRES) + col + i] = rgb565_apa102(*ptr++);
+        }
+      else
+        {
+          priv->fb[(row * APA102_XRES) + APA102_XRES - col - i - 1] =
+            rgb565_apa102(*ptr++);
+        }
     }
 
   /* Update the display with converted data */
@@ -490,8 +498,16 @@ static int apa102_putarea(FAR struct lcd_dev_s *dev,
     {
       for (j = col_start; j <= col_end; j++)
         {
-          priv->fb[(i * APA102_XRES) + j] =
-            rgb565_apa102(*(src + (i * APA102_XRES) + j));
+          if (i % 2 == 0)
+            {
+              priv->fb[(i * APA102_XRES) + j] =
+                rgb565_apa102(*(src + (i * APA102_XRES) + j));
+            }
+          else
+            {
+              priv->fb[(i * APA102_XRES) + APA102_XRES - j - 1] =
+                rgb565_apa102(*(src + (i * APA102_XRES) + j));
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
I found an issue in the APA102 framebuffer that wasn't spot
before by fb test because this application draw symetric squares

Normally in a display each line starts at left and increase to the
right, however for this APA102 matrix the next line starts at the
end of previous line and move the opposite direction, forming a
zig-zag pattern.

## Impact
Fix not symetric images
## Testing
APA102 RGB LED Matrix
