### PR TITLE
local socket related update

### DIFF
--- a/net/local/local.h
+++ b/net/local/local.h
@@ -145,6 +145,7 @@ struct local_conn_s
   /* SOCK_STREAM fields common to both client and server */
 
   sem_t lc_waitsem;            /* Use to wait for a connection to be accepted */
+  sem_t lc_donesem;            /* Use to wait for client connected done */
   FAR struct socket *lc_psock; /* A reference to the socket structure */
 
   /* The following is a list if poll structures of threads waiting for

--- a/net/local/local_accept.c
+++ b/net/local/local_accept.c
@@ -243,6 +243,12 @@ int local_accept(FAR struct socket *psock, FAR struct sockaddr *addr,
             }
 
           nxsem_post(&client->lc_waitsem);
+
+          if (ret == OK)
+            {
+              ret = net_lockedwait(&client->lc_donesem);
+            }
+
           return ret;
         }
 

--- a/net/local/local_conn.c
+++ b/net/local/local_conn.c
@@ -124,6 +124,10 @@ FAR struct local_conn_s *local_alloc(void)
 
       nxsem_init(&conn->lc_waitsem, 0, 0);
       nxsem_set_protocol(&conn->lc_waitsem, SEM_PRIO_NONE);
+
+      nxsem_init(&conn->lc_donesem, 0, 0);
+      nxsem_set_protocol(&conn->lc_donesem, SEM_PRIO_NONE);
+
 #endif
 
       /* Add the connection structure to the list of listeners */
@@ -203,6 +207,7 @@ void local_free(FAR struct local_conn_s *conn)
 
   local_release_fifos(conn);
   nxsem_destroy(&conn->lc_waitsem);
+  nxsem_destroy(&conn->lc_donesem);
 #endif
 
   /* And free the connection structure */

--- a/net/local/local_connect.c
+++ b/net/local/local_connect.c
@@ -269,6 +269,13 @@ int psock_local_connect(FAR struct socket *psock,
   net_lock();
   while ((conn = local_nextconn(conn)) != NULL)
     {
+      /* Slef found, continue */
+
+      if (conn == psock->s_conn)
+        {
+          continue;
+        }
+
       /* Handle according to the server connection type */
 
       switch (conn->lc_type)

--- a/net/local/local_connect.c
+++ b/net/local/local_connect.c
@@ -178,6 +178,8 @@ static int inline local_stream_connect(FAR struct local_conn_s *client,
 
   DEBUGASSERT(client->lc_infile.f_inode != NULL);
 
+  nxsem_post(&client->lc_donesem);
+
   if (!nonblock)
     {
       client->lc_state = LOCAL_STATE_CONNECTED;

--- a/net/local/local_recvutils.c
+++ b/net/local/local_recvutils.c
@@ -78,14 +78,22 @@ int local_fifo_read(FAR struct file *filep, FAR uint8_t *buf,
       nread = file_read(filep, buf, remaining);
       if (nread < 0)
         {
-          if (nread != -EINTR)
+          ret = (int)nread;
+
+          if (nread == -EINTR)
             {
-              ret = (int)nread;
+              ninfo("Ignoring signal\n");
+              continue;
+            }
+          else if (nread == -EAGAIN)
+            {
+              goto errout;
+            }
+          else
+            {
               nerr("ERROR: file_read() failed: %d\n", ret);
               goto errout;
             }
-
-          ninfo("Ignoring signal\n");
         }
       else if (nread == 0)
         {

--- a/net/local/local_recvutils.c
+++ b/net/local/local_recvutils.c
@@ -80,12 +80,12 @@ int local_fifo_read(FAR struct file *filep, FAR uint8_t *buf,
         {
           ret = (int)nread;
 
-          if (nread == -EINTR)
+          if (ret == -EINTR)
             {
               ninfo("Ignoring signal\n");
               continue;
             }
-          else if (nread == -EAGAIN)
+          else if (ret == -EAGAIN)
             {
               goto errout;
             }

--- a/net/local/local_sendpacket.c
+++ b/net/local/local_sendpacket.c
@@ -86,13 +86,20 @@ static int local_fifo_write(FAR struct file *filep, FAR const uint8_t *buf,
       ret = file_write(filep, buf + nwritten, len - nwritten);
       if (ret < 0)
         {
-          if (ret != -EINTR)
+          if (ret == -EINTR)
+            {
+              continue;
+            }
+          else if (ret == -EAGAIN)
+            {
+              break;
+            }
+          else
             {
               nerr("ERROR: file_write failed: %zd\n", ret);
               break;
             }
 
-          continue;
         }
 
       nwritten += ret;

--- a/net/local/local_sendpacket.c
+++ b/net/local/local_sendpacket.c
@@ -99,7 +99,6 @@ static int local_fifo_write(FAR struct file *filep, FAR const uint8_t *buf,
               nerr("ERROR: file_write failed: %zd\n", ret);
               break;
             }
-
         }
 
       nwritten += ret;


### PR DESCRIPTION
## Summary
local: connect operation should jump self's connection

local: server accept should wait client connect done
    
    server:
    at accept last nxsem_post(&client->lc_waitsem);
    
    client:
    connect wait(&client->lc_waitsem) then local_open_client_rx();
    
    But if the server priority is higher then client,
    and after server accept return, immediately call send().
    At this time the client has no way do local_open_client_rx().
    Then server send() return error.
    
    Fix:
    add lc_done sem to client


## Impact

local socket

## Testing

VELA

