### PR TITLE
rpmsg socket related update

### DIFF
--- a/net/rpmsg/rpmsg_sockif.c
+++ b/net/rpmsg/rpmsg_sockif.c
@@ -1010,7 +1010,8 @@ static ssize_t rpmsg_socket_send_continuous(FAR struct socket *psock,
 
       rpmsg_socket_unlock(&conn->sendlock);
 
-      ret = rpmsg_send_nocopy(&conn->ept, msg, block + sizeof(*msg));
+      ret = rpmsg_sendto_nocopy(&conn->ept, msg, block + sizeof(*msg),
+                                conn->ept.dest_addr);
       if (ret < 0)
         {
           break;
@@ -1111,7 +1112,7 @@ static ssize_t rpmsg_socket_send_single(FAR struct socket *psock,
 
   rpmsg_socket_unlock(&conn->sendlock);
 
-  ret = rpmsg_send_nocopy(&conn->ept, msg, total);
+  ret = rpmsg_sendto_nocopy(&conn->ept, msg, total, conn->ept.dest_addr);
 
   return ret > 0 ? len : ret;
 }

--- a/net/rpmsg/rpmsg_sockif.c
+++ b/net/rpmsg/rpmsg_sockif.c
@@ -569,7 +569,7 @@ static int rpmsg_socket_setaddr(FAR struct rpmsg_socket_conn_s *conn,
   FAR struct sockaddr_rpmsg *rpaddr = (FAR struct sockaddr_rpmsg *)addr;
 
   if (rpaddr->rp_family != AF_RPMSG ||
-      addrlen != sizeof(struct sockaddr_rpmsg))
+      addrlen < sizeof(struct sockaddr_rpmsg))
     {
       return -EINVAL;
     }

--- a/net/rpmsg/rpmsg_sockif.c
+++ b/net/rpmsg/rpmsg_sockif.c
@@ -632,7 +632,7 @@ static int rpmsg_socket_getsockname(FAR struct socket *psock,
   ret = rpmsg_socket_getaddr(psock->s_conn, addr, addrlen);
   if (ret >= 0)
     {
-      strncpy(((struct sockaddr_rpmsg *)addr)->rp_cpu,
+      strlcpy(((struct sockaddr_rpmsg *)addr)->rp_cpu,
               CONFIG_RPTUN_LOCAL_CPUNAME, RPMSG_SOCKET_CPU_SIZE);
     }
 

--- a/net/rpmsg/rpmsg_sockif.c
+++ b/net/rpmsg/rpmsg_sockif.c
@@ -216,7 +216,7 @@ static void rpmsg_socket_pollnotify(FAR struct rpmsg_socket_conn_s *conn,
 
       if (fds)
         {
-          fds->revents |= (fds->events & eventset);
+          fds->revents |= ((fds->events | POLLERR | POLLHUP) & eventset);
 
           if (fds->revents != 0)
             {


### PR DESCRIPTION
## Summary
rpmsg_socket: connect addrlen can bigger then expect
socket_rpmsg: set poll err instead return err
rpmsg_socket: defalut set POLLERR POLLHUP to events
rpmsg_socket: use sendto_nocopy() instead of send_nocopy()

## Impact

rpmsg socket

## Testing

VELA

