### PR TITLE
procfs related update

### DIFF
--- a/fs/procfs/fs_procfs.c
+++ b/fs/procfs/fs_procfs.c
@@ -664,6 +664,11 @@ static int procfs_opendir(FAR struct inode *mountpt, FAR const char *relpath,
               break;
             }
         }
+
+      if (x == g_procfs_entrycount)
+        {
+          return -ENOENT;
+        }
     }
 
   dir->u.procfs = priv;

--- a/sched/irq/irq_procfs.c
+++ b/sched/irq/irq_procfs.c
@@ -206,6 +206,7 @@ static int irq_callback(int irq, FAR struct irq_info_s *info,
    * rate    = <interrupt-count> * TICKS_PER_SEC / elapsed
    */
 
+  elapsed = elapsed ? elapsed : 1;
   intpart = (unsigned int)((copy.count * TICK_PER_SEC) / elapsed);
   if (intpart >= 10000)
     {


### PR DESCRIPTION
## Summary

procfs: procfs_opendir should return fail if can't match
irq_procfs: fix divide 0 error

## Impact

procfs

## Testing

VELA
