### PR TITLE
arm_secure_irq: fix NVIC_IRQ_DBGMONITOR un-secure set failed

### DIFF
--- a/arch/arm/src/armv8-m/arm_secure_irq.c
+++ b/arch/arm/src/armv8-m/arm_secure_irq.c
@@ -63,9 +63,8 @@ void up_secure_irq(int irq, bool secure)
         break;
 
       case NVIC_IRQ_DBGMONITOR:
-        regaddr = NVIC_DEMCR;
-        regbit  = NVIC_DEMCR_SDME;
-        secure  = !secure;
+        regaddr = NVIC_DAUTHCTRL;
+        regbit  = NVIC_DAUTHCTRL_SPIDENSEL;
         break;
 
       default:

--- a/arch/arm/src/armv8-m/nvic.h
+++ b/arch/arm/src/armv8-m/nvic.h
@@ -823,6 +823,11 @@
 #define NVIC_DSCEMCR_CLR_MON_PEND       (1 << 17) /* Bit 17: Clear monitor pend */
 #define NVIC_DSCEMCR_CLR_MON_REQ        (1 << 19) /* Bit 19: Clear monitor request */
 
+/* Debug Authentication Control Register (DAUTHCTRL) */
+
+#define NVIC_DAUTHCTRL_SPIDENSEL        (1 << 0)  /* Bit 0:  Secure invasive debug enable select */
+#define NVIC_DAUTHCTRL_INTSPIDEN        (1 << 1)  /* Bit 1:  Internal Secure invasive debug enable */
+
 /*  Floating-Point Context Control Register (FPCCR) */
 
 #define NVIC_FPCCR_LSPACT               (1 << 0)  /* Bit 0:  Lazy state preservation active */


### PR DESCRIPTION

## Summary

arm_secure_irq: fix NVIC_IRQ_DBGMONITOR un-secure set failed
NVIC_DEMCR.SDME is a read-only bit

## Impact

arm_secure_irq

## Testing

VELA
