### PR TITLE
Fixed path calculation in BBS RAM.

### DIFF
--- a/arch/arm/src/stm32/stm32_bbsram.c
+++ b/arch/arm/src/stm32/stm32_bbsram.c
@@ -742,7 +742,6 @@ int stm32_bbsraminitialize(char *devpath, int *sizes)
 {
   int i;
   int fcnt;
-  char path[32];
   char devname[32];
 
   int ret = OK;
@@ -753,7 +752,7 @@ int stm32_bbsraminitialize(char *devpath, int *sizes)
     }
 
   i = strlen(devpath);
-  if (i == 0 || i > sizeof(path) + 3)
+  if (i == 0 || i > sizeof(devname) - 3)
     {
       return -EINVAL;
     }
@@ -782,12 +781,9 @@ int stm32_bbsraminitialize(char *devpath, int *sizes)
 
   fcnt = stm32_bbsram_probe(sizes, g_bbsram);
 
-  strncpy(path, devpath, sizeof(path));
-  strcat(path, "%d");
-
   for (i = 0; i < fcnt && ret >= OK; i++)
     {
-      snprintf(devname, sizeof(devname), path, i);
+      snprintf(devname, sizeof(devname), "%s%d", devpath, i);
       ret = register_driver(devname, &stm32_bbsram_fops, 0666, &g_bbsram[i]);
     }
 

--- a/arch/arm/src/stm32f7/stm32_bbsram.c
+++ b/arch/arm/src/stm32f7/stm32_bbsram.c
@@ -742,7 +742,6 @@ int stm32_bbsraminitialize(char *devpath, int *sizes)
 {
   int i;
   int fcnt;
-  char path[32];
   char devname[32];
 
   int ret = OK;
@@ -753,7 +752,7 @@ int stm32_bbsraminitialize(char *devpath, int *sizes)
     }
 
   i = strlen(devpath);
-  if (i == 0 || i > sizeof(path) + 3)
+  if (i == 0 || i > sizeof(devname) - 3)
     {
       return -EINVAL;
     }
@@ -782,12 +781,9 @@ int stm32_bbsraminitialize(char *devpath, int *sizes)
 
   fcnt = stm32_bbsram_probe(sizes, g_bbsram);
 
-  strncpy(path, devpath, sizeof(path));
-  strcat(path, "%d");
-
   for (i = 0; i < fcnt && ret >= OK; i++)
     {
-      snprintf(devname, sizeof(devname), path, i);
+      snprintf(devname, sizeof(devname), "%s%d", devpath, i);
       ret = register_driver(devname, &stm32_bbsram_fops, 0666, &g_bbsram[i]);
     }
 

--- a/arch/arm/src/stm32h7/stm32_bbsram.c
+++ b/arch/arm/src/stm32h7/stm32_bbsram.c
@@ -800,7 +800,6 @@ int stm32_bbsraminitialize(char *devpath, int *sizes)
 {
   int i;
   int fcnt;
-  char path[32];
   char devname[32];
 
   int ret = OK;
@@ -811,7 +810,7 @@ int stm32_bbsraminitialize(char *devpath, int *sizes)
     }
 
   i = strlen(devpath);
-  if (i == 0 || i > sizeof(path) + 3)
+  if (i == 0 || i > sizeof(devname) - 3)
     {
       return -EINVAL;
     }
@@ -853,12 +852,9 @@ int stm32_bbsraminitialize(char *devpath, int *sizes)
 
   fcnt = stm32_bbsram_probe(sizes, g_bbsram);
 
-  strncpy(path, devpath, sizeof(path));
-  strcat(path, "%d");
-
   for (i = 0; i < fcnt && ret >= OK; i++)
     {
-      snprintf(devname, sizeof(devname), path, i);
+      snprintf(devname, sizeof(devname), "%s%d", devpath, i);
       ret = register_driver(devname, &stm32_bbsram_fops, 0666, &g_bbsram[i]);
     }
 

--- a/arch/renesas/src/rx65n/rx65n_sbram.c
+++ b/arch/renesas/src/rx65n/rx65n_sbram.c
@@ -671,7 +671,6 @@ int rx65n_sbraminitialize(char *devpath, int *sizes)
 {
   int i;
   int fcnt;
-  char path[32];
   char devname[32];
 
   int ret = OK;
@@ -682,7 +681,7 @@ int rx65n_sbraminitialize(char *devpath, int *sizes)
     }
 
   i = strlen(devpath);
-  if (i == 0 || i > sizeof(path) + 3)
+  if (i == 0 || i > sizeof(devname) - 3)
     {
       return -EINVAL;
     }
@@ -703,12 +702,9 @@ int rx65n_sbraminitialize(char *devpath, int *sizes)
 
   fcnt = rx65n_sbram_probe(sizes, g_sbram);
 
-  strncpy(path, devpath, sizeof(path));
-  strcat(path, "%d");
-
   for (i = 0; i < fcnt && ret >= OK; i++)
     {
-      snprintf(devname, sizeof(devname), path, i);
+      snprintf(devname, sizeof(devname), "%s%d", devpath, i);
       ret = register_driver(devname, &rx65n_sbram_fops, 0666, &g_sbram[i]);
     }
 


### PR DESCRIPTION
## Summary

Various improvements in calculation of the device path for the backup-RAM.  
The same algorithm was used in STM32, STM32F7, STM32H7 & RX65N.

* The maximum size calculation was wrong, and allowed for a buffer overflow.
* The whole trick with `strncpy` and `strcat`, was unnecessary and dangerous.
* Fixes a compiler warning (about `strncpy`).
* We also got rid of 32 bytes of stack usage :)

## Impact

Usage of the backup RAM is safer now.

## Testing

Tested on a custom target using the STM32F427.
I checked the produced path with my debugger, and it is correct.
