### PR TITLE
mm/mm_heap: update MM_BACKTRACE and malloc failed output

### DIFF
--- a/fs/procfs/fs_procfsmeminfo.c
+++ b/fs/procfs/fs_procfsmeminfo.c
@@ -415,7 +415,7 @@ static ssize_t memdump_read(FAR struct file *filep, FAR char *buffer,
   procfile = (FAR struct meminfo_file_s *)filep->f_priv;
   DEBUGASSERT(procfile);
 
-#ifdef CONFIG_MM_BACKTRACE
+#if CONFIG_MM_BACKTRACE >= 0
   linesize  = procfs_snprintf(procfile->line, MEMINFO_LINELEN,
                               "usage: <pid/used/free/on/off>\n"
                               "on/off backtrace\n"
@@ -460,7 +460,7 @@ static ssize_t memdump_write(FAR struct file *filep, FAR const char *buffer,
   procfile = filep->f_priv;
   DEBUGASSERT(procfile);
 
-#ifdef CONFIG_MM_BACKTRACE
+#if CONFIG_MM_BACKTRACE > 0
   if (strcmp(buffer, "on") == 0)
     {
       for (entry = g_procfs_meminfo; entry != NULL; entry = entry->next)
@@ -490,7 +490,7 @@ static ssize_t memdump_write(FAR struct file *filep, FAR const char *buffer,
       case 'f':
         pid = (pid_t)-2;
         break;
-#ifdef CONFIG_MM_BACKTRACE
+#if CONFIG_MM_BACKTRACE >= 0
       default:
         pid = atoi(buffer);
 #endif

--- a/fs/procfs/fs_procfsproc.c
+++ b/fs/procfs/fs_procfsproc.c
@@ -90,7 +90,7 @@ enum proc_node_e
 #ifdef CONFIG_SCHED_CRITMONITOR
   PROC_CRITMON,                       /* Critical section monitor */
 #endif
-#ifdef CONFIG_MM_BACKTRACE
+#if CONFIG_MM_BACKTRACE >= 0
   PROC_HEAP,                          /* Task heap info */
 #endif
   PROC_STACK,                         /* Task stack info */
@@ -178,7 +178,7 @@ static ssize_t proc_critmon(FAR struct proc_file_s *procfile,
                  FAR struct tcb_s *tcb, FAR char *buffer, size_t buflen,
                  off_t offset);
 #endif
-#ifdef CONFIG_MM_BACKTRACE
+#if CONFIG_MM_BACKTRACE >= 0
 static ssize_t proc_heap(FAR struct proc_file_s *procfile,
                          FAR struct tcb_s *tcb, FAR char *buffer,
                          size_t buflen, off_t offset);
@@ -279,7 +279,7 @@ static const struct proc_node_s g_critmon =
 };
 #endif
 
-#ifdef CONFIG_MM_BACKTRACE
+#if CONFIG_MM_BACKTRACE >= 0
 static const struct proc_node_s g_heap =
 {
   "heap",         "heap",   (uint8_t)PROC_HEAP,          DTYPE_FILE        /* Task heap info */
@@ -326,7 +326,7 @@ static FAR const struct proc_node_s * const g_nodeinfo[] =
 #ifdef CONFIG_SCHED_CRITMONITOR
   &g_critmon,      /* Critical section Monitor */
 #endif
-#ifdef CONFIG_MM_BACKTRACE
+#if CONFIG_MM_BACKTRACE >= 0
   &g_heap,         /* Task heap info */
 #endif
   &g_stack,        /* Task stack info */
@@ -352,7 +352,7 @@ static const struct proc_node_s * const g_level0info[] =
 #ifdef CONFIG_SCHED_CRITMONITOR
   &g_critmon,      /* Critical section monitor */
 #endif
-#ifdef CONFIG_MM_BACKTRACE
+#if CONFIG_MM_BACKTRACE >= 0
   &g_heap,         /* Task heap info */
 #endif
   &g_stack,        /* Task stack info */
@@ -904,7 +904,7 @@ static ssize_t proc_critmon(FAR struct proc_file_s *procfile,
  * Name: proc_heap
  ****************************************************************************/
 
-#ifdef CONFIG_MM_BACKTRACE
+#if CONFIG_MM_BACKTRACE >= 0
 static ssize_t proc_heap(FAR struct proc_file_s *procfile,
                          FAR struct tcb_s *tcb, FAR char *buffer,
                          size_t buflen, off_t offset)
@@ -1575,7 +1575,7 @@ static ssize_t proc_read(FAR struct file *filep, FAR char *buffer,
       ret = proc_critmon(procfile, tcb, buffer, buflen, filep->f_pos);
       break;
 #endif
-#ifdef CONFIG_MM_BACKTRACE
+#if CONFIG_MM_BACKTRACE >= 0
     case PROC_HEAP: /* Task heap info */
       ret = proc_heap(procfile, tcb, buffer, buflen, filep->f_pos);
       break;

--- a/include/malloc.h
+++ b/include/malloc.h
@@ -52,7 +52,7 @@ struct mallinfo
                  * by free (not in use) chunks. */
 };
 
-#ifdef CONFIG_MM_BACKTRACE
+#if CONFIG_MM_BACKTRACE >= 0
 struct mallinfo_task
 {
   pid_t pid;    /* The pid of task */
@@ -72,7 +72,7 @@ extern "C"
 
 struct mallinfo mallinfo(void);
 size_t malloc_size(FAR void *ptr);
-#ifdef CONFIG_MM_BACKTRACE
+#if CONFIG_MM_BACKTRACE >= 0
 struct mallinfo_task mallinfo_task(pid_t pid);
 #endif
 

--- a/include/nuttx/fs/procfs.h
+++ b/include/nuttx/fs/procfs.h
@@ -133,7 +133,7 @@ struct procfs_meminfo_entry_s
   FAR const char *name;
   FAR struct mm_heap_s *heap;
   struct procfs_meminfo_entry_s *next;
-#if defined(CONFIG_MM_BACKTRACE)
+#if CONFIG_MM_BACKTRACE >= 0
 
   /* This is dynamic control flag whether to turn on backtrace in the heap,
    * you can set it by /proc/memdump.

--- a/include/nuttx/mm/mm.h
+++ b/include/nuttx/mm/mm.h
@@ -297,7 +297,7 @@ void kmm_extend(FAR void *mem, size_t size, int region);
 
 struct mallinfo; /* Forward reference */
 int mm_mallinfo(FAR struct mm_heap_s *heap, FAR struct mallinfo *info);
-#ifdef CONFIG_MM_BACKTRACE
+#if CONFIG_MM_BACKTRACE >= 0
 struct mallinfo_task; /* Forward reference */
 int mm_mallinfo_task(FAR struct mm_heap_s *heap,
                      FAR struct mallinfo_task *info);
@@ -307,7 +307,7 @@ int mm_mallinfo_task(FAR struct mm_heap_s *heap,
 
 #ifdef CONFIG_MM_KERNEL_HEAP
 struct mallinfo kmm_mallinfo(void);
-#  ifdef CONFIG_MM_BACKTRACE
+#  if CONFIG_MM_BACKTRACE >= 0
 struct mallinfo_task kmm_mallinfo_task(pid_t pid);
 #  endif
 #endif

--- a/mm/Kconfig
+++ b/mm/Kconfig
@@ -187,14 +187,17 @@ config MM_KASAN
 		add -fsanitize=kernel-address to CFLAGS/CXXFLAGS too.
 
 config MM_BACKTRACE
-	bool "Owner tracking and backtrace"
-	default n
-	depends on DEBUG_MM
+	int "The depth of backtrace"
+	default -1
+	---help---
+		Config the depth of backtrace in memory block by specified this
+		config: disable backtrace by -1, only record pid info by zero and
+		enable record backtrace info by 8(fixed depth).
 
 config MM_BACKTRACE_DEFAULT
 	bool "Enable the backtrace record by default"
 	default n
-	depends on MM_BACKTRACE
+	depends on MM_BACKTRACE > 0
 
 config MM_DUMP_ON_FAILURE
 	bool "Dump heap info on allocation failure"

--- a/mm/kmm_heap/kmm_mallinfo.c
+++ b/mm/kmm_heap/kmm_mallinfo.c
@@ -59,7 +59,7 @@ struct mallinfo kmm_mallinfo(void)
  *
  ****************************************************************************/
 
-#ifdef CONFIG_MM_BACKTRACE
+#if CONFIG_MM_BACKTRACE >= 0
 struct mallinfo_task kmm_mallinfo_task(pid_t pid)
 {
   struct mallinfo_task info;

--- a/mm/mm_heap/mm.h
+++ b/mm/mm_heap/mm.h
@@ -90,9 +90,17 @@
 #  define MM_MAX_SHIFT    (22)  /*  4 Mb */
 #endif
 
-#ifdef CONFIG_MM_BACKTRACE
-#  define MM_MIN_SHIFT       (MM_MIN_SHIFT_ + 2)
-#  define MM_BACKTRACE_DEPTH 8
+#if CONFIG_MM_BACKTRACE == 0
+#  define MM_MIN_SHIFT    (MM_MIN_SHIFT_ + 1)
+#  define MM_ADD_BACKTRACE(heap, ptr) \
+     do \
+       { \
+         FAR struct mm_allocnode_s *tmp = (FAR struct mm_allocnode_s *)(ptr); \
+         tmp->pid = getpid(); \
+       } \
+     while (0)
+#elif CONFIG_MM_BACKTRACE > 0
+#  define MM_MIN_SHIFT    (MM_MIN_SHIFT_ + 2)
 #  define MM_ADD_BACKTRACE(heap, ptr) \
      do \
        { \
@@ -101,7 +109,7 @@
          if ((heap)->mm_procfs.backtrace) \
            { \
              memset(tmp->backtrace, 0, sizeof(tmp->backtrace)); \
-             backtrace(tmp->backtrace, MM_BACKTRACE_DEPTH); \
+             backtrace(tmp->backtrace, CONFIG_MM_BACKTRACE); \
            } \
          else \
            { \
@@ -165,12 +173,14 @@ typedef uint32_t mmsize_t;
 
 struct mm_allocnode_s
 {
-#ifdef CONFIG_MM_BACKTRACE
-  pid_t pid;                               /* The pid for caller */
-  FAR void *backtrace[MM_BACKTRACE_DEPTH]; /* The backtrace buffer for caller */
+#if CONFIG_MM_BACKTRACE >= 0
+  pid_t pid;                                /* The pid for caller */
+#  if CONFIG_MM_BACKTRACE > 0
+  FAR void *backtrace[CONFIG_MM_BACKTRACE]; /* The backtrace buffer for caller */
+#  endif
 #endif
-  mmsize_t size;                           /* Size of this chunk */
-  mmsize_t preceding;                      /* Size of the preceding chunk */
+  mmsize_t size;                            /* Size of this chunk */
+  mmsize_t preceding;                       /* Size of the preceding chunk */
 };
 
 static_assert(SIZEOF_MM_ALLOCNODE <= MM_MIN_CHUNK,
@@ -180,13 +190,15 @@ static_assert(SIZEOF_MM_ALLOCNODE <= MM_MIN_CHUNK,
 
 struct mm_freenode_s
 {
-#ifdef CONFIG_MM_BACKTRACE
-  pid_t pid;                               /* The pid for caller */
-  FAR void *backtrace[MM_BACKTRACE_DEPTH]; /* The backtrace buffer for caller */
+#if CONFIG_MM_BACKTRACE >= 0
+  pid_t pid;                                /* The pid for caller */
+#  if CONFIG_MM_BACKTRACE > 0
+  FAR void *backtrace[CONFIG_MM_BACKTRACE]; /* The backtrace buffer for caller */
+#  endif
 #endif
-  mmsize_t size;                           /* Size of this chunk */
-  mmsize_t preceding;                      /* Size of the preceding chunk */
-  FAR struct mm_freenode_s *flink;         /* Supports a doubly linked list */
+  mmsize_t size;                            /* Size of this chunk */
+  mmsize_t preceding;                       /* Size of the preceding chunk */
+  FAR struct mm_freenode_s *flink;          /* Supports a doubly linked list */
   FAR struct mm_freenode_s *blink;
 };
 

--- a/mm/mm_heap/mm_initialize.c
+++ b/mm/mm_heap/mm_initialize.c
@@ -220,7 +220,7 @@ FAR struct mm_heap_s *mm_initialize(FAR const char *name,
 #  if defined(CONFIG_BUILD_FLAT) || defined(__KERNEL__)
   heap->mm_procfs.name = name;
   heap->mm_procfs.heap = heap;
-#    if defined (CONFIG_MM_BACKTRACE) && defined(CONFIG_MM_BACKTRACE_DEFAULT)
+#    ifdef CONFIG_MM_BACKTRACE_DEFAULT
   heap->mm_procfs.backtrace = true;
 #    endif
 #  endif

--- a/mm/mm_heap/mm_mallinfo.c
+++ b/mm/mm_heap/mm_mallinfo.c
@@ -75,7 +75,7 @@ static void mallinfo_handler(FAR struct mm_allocnode_s *node, FAR void *arg)
     }
 }
 
-#ifdef CONFIG_MM_BACKTRACE
+#if CONFIG_MM_BACKTRACE >= 0
 static void mallinfo_task_handler(FAR struct mm_allocnode_s *node,
                                   FAR void *arg)
 {
@@ -137,7 +137,7 @@ int mm_mallinfo(FAR struct mm_heap_s *heap, FAR struct mallinfo *info)
  *
  ****************************************************************************/
 
-#ifdef CONFIG_MM_BACKTRACE
+#if CONFIG_MM_BACKTRACE >= 0
 int mm_mallinfo_task(FAR struct mm_heap_s *heap,
                      FAR struct mallinfo_task *info)
 {

--- a/mm/mm_heap/mm_malloc.c
+++ b/mm/mm_heap/mm_malloc.c
@@ -31,6 +31,7 @@
 
 #include <nuttx/arch.h>
 #include <nuttx/mm/mm.h>
+#include <nuttx/sched.h>
 
 #include "mm_heap/mm.h"
 #include "kasan/kasan.h"
@@ -81,6 +82,18 @@ static void mm_free_delaylist(FAR struct mm_heap_s *heap)
     }
 #endif
 }
+
+#ifdef CONFIG_MM_BACKTRACE
+void mm_dump_handler(FAR struct tcb_s *tcb, FAR void *arg)
+{
+  struct mallinfo_task info;
+
+  info.pid = tcb->pid;
+  mm_mallinfo_task(arg, &info);
+  mwarn("pid:%5d, used:%10d, nused:%10d\n",
+        tcb->pid, info.uordblks, info.aordblks);
+}
+#endif
 
 /****************************************************************************
  * Public Functions
@@ -254,7 +267,9 @@ FAR void *mm_malloc(FAR struct mm_heap_s *heap, size_t size)
       mwarn("Total:%d, used:%d, free:%d, largest:%d, nused:%d, nfree:%d\n",
             minfo.arena, minfo.uordblks, minfo.fordblks,
             minfo.mxordblk, minfo.aordblks, minfo.ordblks);
-      mm_memdump(heap, -1);
+#  ifdef CONFIG_MM_BACKTRACE
+      nxsched_foreach(mm_dump_handler, heap);
+#  endif
 #endif
 #ifdef CONFIG_MM_PANIC_ON_FAILURE
       PANIC();

--- a/mm/mm_heap/mm_malloc.c
+++ b/mm/mm_heap/mm_malloc.c
@@ -83,7 +83,7 @@ static void mm_free_delaylist(FAR struct mm_heap_s *heap)
 #endif
 }
 
-#ifdef CONFIG_MM_BACKTRACE
+#if CONFIG_MM_BACKTRACE >= 0
 void mm_dump_handler(FAR struct tcb_s *tcb, FAR void *arg)
 {
   struct mallinfo_task info;
@@ -267,7 +267,7 @@ FAR void *mm_malloc(FAR struct mm_heap_s *heap, size_t size)
       mwarn("Total:%d, used:%d, free:%d, largest:%d, nused:%d, nfree:%d\n",
             minfo.arena, minfo.uordblks, minfo.fordblks,
             minfo.mxordblk, minfo.aordblks, minfo.ordblks);
-#  ifdef CONFIG_MM_BACKTRACE
+#  if CONFIG_MM_BACKTRACE >= 0
       nxsched_foreach(mm_dump_handler, heap);
 #  endif
 #endif

--- a/mm/mm_heap/mm_memdump.c
+++ b/mm/mm_heap/mm_memdump.c
@@ -65,27 +65,31 @@ static void memdump_handler(FAR struct mm_allocnode_s *node, FAR void *arg)
   if ((node->preceding & MM_ALLOC_BIT) != 0)
     {
       DEBUGASSERT(node->size >= SIZEOF_MM_ALLOCNODE);
-#ifndef CONFIG_MM_BACKTRACE
+#if CONFIG_MM_BACKTRACE < 0
       if (info->pid == -1)
 #else
       if (info->pid == -1 || node->pid == info->pid)
 #endif
         {
-#ifndef CONFIG_MM_BACKTRACE
+#if CONFIG_MM_BACKTRACE < 0
           syslog(LOG_INFO, "%12zu%*p\n",
                  (size_t)node->size, MM_PTR_FMT_WIDTH,
                  ((FAR char *)node + SIZEOF_MM_ALLOCNODE));
 #else
+#  if CONFIG_MM_BACKTRACE > 0
           int i;
           FAR const char *format = " %0*p";
-          char buf[MM_BACKTRACE_DEPTH * MM_PTR_FMT_WIDTH + 1];
+#  endif
+          char buf[CONFIG_MM_BACKTRACE * MM_PTR_FMT_WIDTH + 1];
 
           buf[0] = '\0';
-          for (i = 0; i < MM_BACKTRACE_DEPTH && node->backtrace[i]; i++)
+#  if CONFIG_MM_BACKTRACE > 0
+          for (i = 0; i < CONFIG_MM_BACKTRACE && node->backtrace[i]; i++)
             {
               sprintf(buf + i * MM_PTR_FMT_WIDTH, format,
                       MM_PTR_FMT_WIDTH - 1, node->backtrace[i]);
             }
+#  endif
 
           syslog(LOG_INFO, "%6d%12zu%*p%s\n",
                  (int)node->pid, (size_t)node->size, MM_PTR_FMT_WIDTH,
@@ -141,7 +145,7 @@ void mm_memdump(FAR struct mm_heap_s *heap, pid_t pid)
   if (pid >= -1)
     {
       syslog(LOG_INFO, "Dump all used memory node info:\n");
-#ifndef CONFIG_MM_BACKTRACE
+#if CONFIG_MM_BACKTRACE < 0
       syslog(LOG_INFO, "%12s%*s\n", "Size", MM_PTR_FMT_WIDTH, "Address");
 #else
       syslog(LOG_INFO, "%6s%12s%*s %s\n", "PID", "Size", MM_PTR_FMT_WIDTH,

--- a/mm/umm_heap/umm_mallinfo.c
+++ b/mm/umm_heap/umm_mallinfo.c
@@ -59,7 +59,7 @@ struct mallinfo mallinfo(void)
  *
  ****************************************************************************/
 
-#ifdef CONFIG_MM_BACKTRACE
+#if CONFIG_MM_BACKTRACE >= 0
 struct mallinfo_task mallinfo_task(pid_t pid)
 {
   struct mallinfo_task info;


### PR DESCRIPTION
## Summary

1. Output memory info about each task when malloc failed. 
  * I think outputting each task information directly is more useful than dumping the entire heap, because it can be clear know who is occupying the most memory blocks, who may leak, and if there is too much dump heap, it may trigger wdt interrupt.
example:
![image](https://user-images.githubusercontent.com/70748590/180386467-5009e1d9-cacd-4c6f-865a-39c71dc7cf62.png)
2. change the type config MM_BACKTRACE from bool to int.
Initially, the entire backtrace function relied on DEBUG_MM, but due to the conflict with memory-related log output control, it was replaced with a new config MM_BACKTRACE.

* Therefore, this config will control the trace function, including pid information and backtrace information, but some platforms have limited resources, and these two information need to be controlled separately, so thid PR will do this:

* when MM_BACKTRACE = -1, disable trace function
* when MM_BACKTRACE = 0, only enable pid information for trac function.
* when MM_BACKTRACE = 8, enbale entir trace function. 8 is the default backtrace stack depth, if you need a larger depth, you need to update MM_MIN_SHIFT in mm/mm_heap/mm.h synchronously.

## Impact
memory debug function
## Testing
Vlea CI
