### PR TITLE
fs/hostfs: Change nuttx_dev_t from uint16_t to uint32_t

### DIFF
--- a/include/nuttx/fs/hostfs.h
+++ b/include/nuttx/fs/hostfs.h
@@ -108,7 +108,7 @@
 typedef int16_t      nuttx_blksize_t;
 typedef int16_t      nuttx_gid_t;
 typedef int16_t      nuttx_uid_t;
-typedef uint16_t     nuttx_dev_t;
+typedef uint32_t     nuttx_dev_t;
 typedef uint16_t     nuttx_ino_t;
 typedef uint16_t     nuttx_nlink_t;
 #ifdef CONFIG_FS_LARGEFILE


### PR DESCRIPTION
## Summary
Follow up the following change:
```
commit 008cb0d31a49706724fbb4896bc7a5df1c52dd9f
Author: Jiuzhu Dong <dongjiuzhu1@xiaomi.com>
Date:   Thu Jul 14 02:27:34 2022 +0000

    sys/sysmacros.h: support sysmacros header

    Signed-off-by: Jiuzhu Dong <dongjiuzhu1@xiaomi.com>
```

## Impact
Fix the issue report here: https://github.com/apache/incubator-nuttx/pull/6662

## Testing
Wait @fjpanag verify the change.
