### PR TITLE
OpenSBI: Add configurable support for domain init

### DIFF
--- a/arch/risc-v/src/mpfs/mpfs_opensbi.c
+++ b/arch/risc-v/src/mpfs/mpfs_opensbi.c
@@ -124,6 +124,12 @@ static int  mpfs_opensbi_ecall_handler(long extid, long funcid,
 
 extern void riscv_lowputc(char ch);
 
+/* domains init implemented in board specific file */
+
+#ifdef CONFIG_OPENSBI_DOMAINS
+extern int board_domains_init(void);
+#endif
+
 /****************************************************************************
  * Private Data
  ****************************************************************************/
@@ -157,6 +163,9 @@ static struct aclint_mtimer_data mpfs_mtimer =
 
 static const struct sbi_platform_operations platform_ops =
 {
+#ifdef CONFIG_OPENSBI_DOMAINS
+  .domains_init        = board_domains_init,
+#endif
   .console_init        = mpfs_opensbi_console_init,
   .early_init          = mpfs_early_init,
   .irqchip_init        = mpfs_irqchip_init,

--- a/arch/risc-v/src/opensbi/Kconfig
+++ b/arch/risc-v/src/opensbi/Kconfig
@@ -10,3 +10,8 @@ config OPENSBI
 	---help---
 		Enable or disable Open Source Supervisor Binary Interface (OpenSBI) features
 		for RISC-V.
+
+config OPENSBI_DOMAINS
+	bool "Support multiple OpenSBI boot domains"
+	depends on OPENSBI
+	default n


### PR DESCRIPTION
Initialize .domains_init function entry point in sbi_platform_operations when
CONFIG_OPENSBI_DOMAINS=y. In this case, the board specific code must provide
the "board_domains_init" function.

Signed-off-by: Jouni Ukkonen <jouni.ukkonen@unikie.com>

## Summary

This adds support for multiple opensbi domains for mpfs arch; the domain initialization must be done in a board-specific function.

The domains are needed in order to run multiple operating systems in parallel using a single SBI library.

## Impact

None for other than mpfs arch.

## Testing

Tested by running 2 parallel OS:s in S-mode on Microchip Polarfire SOC FPGA platform
