### PR TITLE
sim: Increased priority of loop task.

### DIFF
--- a/arch/sim/src/sim/up_initialize.c
+++ b/arch/sim/src/sim/up_initialize.c
@@ -254,7 +254,7 @@ void up_initialize(void)
   audio_register("pcm0c", sim_audio_initialize(false));
 #endif
 
-  kthread_create("loop_task", SCHED_PRIORITY_MIN,
+  kthread_create("loop_task", SCHED_PRIORITY_MAX,
                  CONFIG_DEFAULT_TASK_STACKSIZE,
                  up_loop_task, NULL);
 }


### PR DESCRIPTION
## Summary

In simulator there is the loop task that performs various house-keeping functions.  
It mostly emulates functions that normally would happen in interrupts.

This task was assigned a very low priority, so house-keeping was taking place if and when there was any idle time in the system.
In case of high load, it couldn't run.

This PR increases the loop task priority to max, as it is better suited for its interrupt-like role.

## Impact

Simulator house-keeping tasks run more reliably and steadily, even in high load cases.

## Testing

After the change I run the simulator and used my firmware. It seems that nothing is broken.

Simultaneously, I tested whether it fixes things.  
I have a piece of code that looks like this:

```c
	clock_t start = clock();

	char buf[1];
	while (read(s_dev, buf, 1) == 1)
	{
		// Do stuff with the received byte.

		if ((clock() - start) > TIMEOUT)
			break;
	}
```

This was not working before, as there was no idle CPU time for the loop task to operate (although it works on an actual hardware target).

After the change, I am able to receive bytes from the simulated serial port.
