### PR TITLE
Ability to use newer pico-sdk with RP2040 builds (Issue #4919)

### DIFF
--- a/arch/arm/src/rp2040/boot2/Make.defs
+++ b/arch/arm/src/rp2040/boot2/Make.defs
@@ -46,6 +46,10 @@ $(BOOT_STAGE2).bin: %.bin: %.elf
 	$(OBJCOPY) -Obinary $< $@
 
 $(BOOT_STAGE2).elf: $(BOOT2SRC)
+	$(Q) touch $(PICO_SDK_PATH)/src/common/pico_base/include/pico/version.h
+	$(Q) touch $(PICO_SDK_PATH)/src/common/pico_base/include/pico/config_autogen.h
 	$(CC) -nostdlib $(ARCHSCRIPT) $(BOOT2CFLAGS) -o $@ $<
+	$(DELFILE) $(PICO_SDK_PATH)/src/common/pico_base/include/pico/version.h
+	$(DELFILE) $(PICO_SDK_PATH)/src/common/pico_base/include/pico/config_autogen.h
 
 EXTRADELFILE = $(BOOT_STAGE2).*


### PR DESCRIPTION
## Summary

The RP2040 builds of NuttX use code from RaspberryPi's pico-sdk to build the second stage boot loader.  In newer versions of pico-sdk, the files included by the source that NuttX uses were changed to include two files that are normally built by CMake. They may not be available when NuttX builds need them.

It turns out that nothing in these include files is actually needed to assemble the source NuttX uses.  This change just adds empty files to satisfy the includes before the file is assembled and deletes them afterward.

## Impact

No other impact. Since CMake places the "real" versions of these two file in a separate "build" directory, the ones this change adds do not overwrite anything.

## Testing

Built RP2040 versions with old and new versions of pico-sdk.