### PR TITLE
boards/stm32g071b-disco: add ina230 support and gpio dev support

### DIFF
--- a/boards/arm/stm32f0l0g0/stm32g071b-disco/src/Make.defs
+++ b/boards/arm/stm32f0l0g0/stm32g071b-disco/src/Make.defs
@@ -43,6 +43,10 @@ ifeq ($(CONFIG_LCD_SSD1306),y)
 CSRCS += stm32_lcd_ssd1306.c
 endif
 
+ifeq ($(CONFIG_SENSORS_INA226),y)
+CSRCS += stm32_ina226.c
+endif
+
 DEPPATH += --dep-path board
 VPATH += :board
 CFLAGS += $(shell $(INCDIR) "$(CC)" $(TOPDIR)$(DELIM)arch$(DELIM)$(CONFIG_ARCH)$(DELIM)src$(DELIM)board$(DELIM)board)

--- a/boards/arm/stm32f0l0g0/stm32g071b-disco/src/Make.defs
+++ b/boards/arm/stm32f0l0g0/stm32g071b-disco/src/Make.defs
@@ -47,6 +47,10 @@ ifeq ($(CONFIG_SENSORS_INA226),y)
 CSRCS += stm32_ina226.c
 endif
 
+ifeq ($(CONFIG_DEV_GPIO),y)
+CSRCS += stm32_gpio.c
+endif
+
 DEPPATH += --dep-path board
 VPATH += :board
 CFLAGS += $(shell $(INCDIR) "$(CC)" $(TOPDIR)$(DELIM)arch$(DELIM)$(CONFIG_ARCH)$(DELIM)src$(DELIM)board$(DELIM)board)

--- a/boards/arm/stm32f0l0g0/stm32g071b-disco/src/stm32_bringup.c
+++ b/boards/arm/stm32f0l0g0/stm32g071b-disco/src/stm32_bringup.c
@@ -101,6 +101,15 @@ int stm32_bringup(void)
     }
 #endif
 
+#ifdef CONFIG_DEV_GPIO
+  ret = stm32_gpio_initialize();
+  if (ret < 0)
+    {
+      syslog(LOG_ERR, "Failed to initialize GPIO Driver: %d\n", ret);
+      return ret;
+    }
+#endif
+
   UNUSED(ret);
   return OK;
 }

--- a/boards/arm/stm32f0l0g0/stm32g071b-disco/src/stm32_bringup.c
+++ b/boards/arm/stm32f0l0g0/stm32g071b-disco/src/stm32_bringup.c
@@ -89,6 +89,18 @@ int stm32_bringup(void)
   board_lcd_initialize();
 #endif
 
+#ifdef CONFIG_SENSORS_INA226
+  /* Initialize and register the INA226 */
+
+  ret = stm32_ina226_initialization();
+  if (ret != OK)
+    {
+      syslog(LOG_ERR,
+             "ERROR: Failed to register the INA226 drivers: %d\n", ret);
+      return ret;
+    }
+#endif
+
   UNUSED(ret);
   return OK;
 }

--- a/boards/arm/stm32f0l0g0/stm32g071b-disco/src/stm32_gpio.c
+++ b/boards/arm/stm32f0l0g0/stm32g071b-disco/src/stm32_gpio.c
@@ -1,0 +1,320 @@
+/****************************************************************************
+ * boards/arm/stm32f0l0g0/stm32g071b-disco/src/stm32_gpio.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <stdbool.h>
+#include <assert.h>
+#include <debug.h>
+
+#include <nuttx/ioexpander/gpio.h>
+
+#include <arch/board/board.h>
+
+#include "stm32_gpio.h"
+
+#include "stm32g071b-disco.h"
+
+/****************************************************************************
+ * Private Types
+ ****************************************************************************/
+
+struct stm32gpio_dev_s
+{
+  struct gpio_dev_s gpio;
+  uint8_t id;
+};
+
+struct stm32gpint_dev_s
+{
+  struct stm32gpio_dev_s stm32gpio;
+  pin_interrupt_t callback;
+};
+
+/****************************************************************************
+ * Private Function Prototypes
+ ****************************************************************************/
+
+static int gpin_read(struct gpio_dev_s *dev, bool *value);
+static int gpout_read(struct gpio_dev_s *dev, bool *value);
+static int gpout_write(struct gpio_dev_s *dev, bool value);
+static int gpint_read(struct gpio_dev_s *dev, bool *value);
+static int gpint_attach(struct gpio_dev_s *dev,
+                        pin_interrupt_t callback);
+static int gpint_enable(struct gpio_dev_s *dev, bool enable);
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+static const struct gpio_operations_s gpin_ops =
+{
+  .go_read   = gpin_read,
+  .go_write  = NULL,
+  .go_attach = NULL,
+  .go_enable = NULL,
+};
+
+static const struct gpio_operations_s gpout_ops =
+{
+  .go_read   = gpout_read,
+  .go_write  = gpout_write,
+  .go_attach = NULL,
+  .go_enable = NULL,
+};
+
+static const struct gpio_operations_s gpint_ops =
+{
+  .go_read   = gpint_read,
+  .go_write  = NULL,
+  .go_attach = gpint_attach,
+  .go_enable = gpint_enable,
+};
+
+#if BOARD_NGPIOIN > 0
+/* This array maps the GPIO pins used as INPUT */
+
+static const uint32_t g_gpioinputs[BOARD_NGPIOIN] =
+{
+  GPIO_IN1,
+  GPIO_IN2
+};
+
+static struct stm32gpio_dev_s g_gpin[BOARD_NGPIOIN];
+#endif
+
+#if BOARD_NGPIOOUT
+/* This array maps the GPIO pins used as OUTPUT */
+
+static const uint32_t g_gpiooutputs[BOARD_NGPIOOUT] =
+{
+  GPIO_OUT1,
+  GPIO_OUT2,
+  GPIO_OUT3,
+  GPIO_OUT4
+};
+
+static struct stm32gpio_dev_s g_gpout[BOARD_NGPIOOUT];
+#endif
+
+#if BOARD_NGPIOINT > 0
+/* This array maps the GPIO pins used as INTERRUPT INPUTS */
+
+static const uint32_t g_gpiointinputs[BOARD_NGPIOINT] =
+{
+  GPIO_INT1,
+};
+
+static struct stm32gpint_dev_s g_gpint[BOARD_NGPIOINT];
+#endif
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+static int stm32gpio_interrupt(int irq, void *context, void *arg)
+{
+  struct stm32gpint_dev_s *stm32gpint =
+                        (struct stm32gpint_dev_s *)arg;
+
+  DEBUGASSERT(stm32gpint != NULL && stm32gpint->callback != NULL);
+  gpioinfo("Interrupt! callback=%p\n", stm32gpint->callback);
+
+  stm32gpint->callback(&stm32gpint->stm32gpio.gpio,
+                       stm32gpint->stm32gpio.id);
+  return OK;
+}
+
+static int gpin_read(struct gpio_dev_s *dev, bool *value)
+{
+  struct stm32gpio_dev_s *stm32gpio =
+                        (struct stm32gpio_dev_s *)dev;
+
+  DEBUGASSERT(stm32gpio != NULL && value != NULL);
+  DEBUGASSERT(stm32gpio->id < BOARD_NGPIOIN);
+  gpioinfo("Reading...\n");
+
+  *value = stm32_gpioread(g_gpioinputs[stm32gpio->id]);
+  return OK;
+}
+
+static int gpout_read(struct gpio_dev_s *dev, bool *value)
+{
+  struct stm32gpio_dev_s *stm32gpio =
+                        (struct stm32gpio_dev_s *)dev;
+
+  DEBUGASSERT(stm32gpio != NULL && value != NULL);
+  DEBUGASSERT(stm32gpio->id < BOARD_NGPIOOUT);
+  gpioinfo("Reading...\n");
+
+  *value = stm32_gpioread(g_gpiooutputs[stm32gpio->id]);
+  return OK;
+}
+
+static int gpout_write(struct gpio_dev_s *dev, bool value)
+{
+  struct stm32gpio_dev_s *stm32gpio =
+                             (struct stm32gpio_dev_s *)dev;
+
+  DEBUGASSERT(stm32gpio != NULL);
+  DEBUGASSERT(stm32gpio->id < BOARD_NGPIOOUT);
+  gpioinfo("Writing %d\n", (int)value);
+
+  stm32_gpiowrite(g_gpiooutputs[stm32gpio->id], value);
+  return OK;
+}
+
+static int gpint_read(struct gpio_dev_s *dev, bool *value)
+{
+  struct stm32gpint_dev_s *stm32gpint =
+                              (struct stm32gpint_dev_s *)dev;
+
+  DEBUGASSERT(stm32gpint != NULL && value != NULL);
+  DEBUGASSERT(stm32gpint->stm32gpio.id < BOARD_NGPIOINT);
+  gpioinfo("Reading int pin...\n");
+
+  *value = stm32_gpioread(g_gpiointinputs[stm32gpint->stm32gpio.id]);
+  return OK;
+}
+
+static int gpint_attach(struct gpio_dev_s *dev,
+                        pin_interrupt_t callback)
+{
+  struct stm32gpint_dev_s *stm32gpint =
+                             (struct stm32gpint_dev_s *)dev;
+
+  gpioinfo("Attaching the callback\n");
+
+  /* Make sure the interrupt is disabled */
+
+  stm32_gpiosetevent(g_gpiointinputs[stm32gpint->stm32gpio.id], false,
+                     false, false, NULL, NULL);
+
+  gpioinfo("Attach %p\n", callback);
+  stm32gpint->callback = callback;
+  return OK;
+}
+
+static int gpint_enable(struct gpio_dev_s *dev, bool enable)
+{
+  struct stm32gpint_dev_s *stm32gpint =
+                              (struct stm32gpint_dev_s *)dev;
+
+  if (enable)
+    {
+      if (stm32gpint->callback != NULL)
+        {
+          gpioinfo("Enabling the interrupt\n");
+
+          /* Configure the interrupt for rising edge */
+
+          stm32_gpiosetevent(g_gpiointinputs[stm32gpint->stm32gpio.id],
+                             true, false, false, stm32gpio_interrupt,
+                             &g_gpint[stm32gpint->stm32gpio.id]);
+        }
+    }
+  else
+    {
+      gpioinfo("Disable the interrupt\n");
+      stm32_gpiosetevent(g_gpiointinputs[stm32gpint->stm32gpio.id],
+                         false, false, false, NULL, NULL);
+    }
+
+  return OK;
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: stm32_gpio_initialize
+ *
+ * Description:
+ *   Initialize GPIO drivers for use with /apps/examples/gpio
+ *
+ ****************************************************************************/
+
+int stm32_gpio_initialize(void)
+{
+  int i;
+  int pincount = 0;
+
+#if BOARD_NGPIOIN > 0
+  for (i = 0; i < BOARD_NGPIOIN; i++)
+    {
+      /* Setup and register the GPIO pin */
+
+      g_gpin[i].gpio.gp_pintype = GPIO_INPUT_PIN;
+      g_gpin[i].gpio.gp_ops     = &gpin_ops;
+      g_gpin[i].id              = i;
+      gpio_pin_register(&g_gpin[i].gpio, pincount);
+
+      /* Configure the pin that will be used as input */
+
+      stm32_configgpio(g_gpioinputs[i]);
+
+      pincount++;
+    }
+#endif
+
+#if BOARD_NGPIOOUT > 0
+  for (i = 0; i < BOARD_NGPIOOUT; i++)
+    {
+      /* Setup and register the GPIO pin */
+
+      g_gpout[i].gpio.gp_pintype = GPIO_OUTPUT_PIN;
+      g_gpout[i].gpio.gp_ops     = &gpout_ops;
+      g_gpout[i].id              = i;
+      gpio_pin_register(&g_gpout[i].gpio, pincount);
+
+      /* Configure the pin that will be used as output */
+
+      stm32_gpiowrite(g_gpiooutputs[i], 0);
+      stm32_configgpio(g_gpiooutputs[i]);
+
+      pincount++;
+    }
+#endif
+
+#if BOARD_NGPIOINT > 0
+  for (i = 0; i < BOARD_NGPIOINT; i++)
+    {
+      /* Setup and register the GPIO pin */
+
+      g_gpint[i].stm32gpio.gpio.gp_pintype = GPIO_INTERRUPT_PIN;
+      g_gpint[i].stm32gpio.gpio.gp_ops     = &gpint_ops;
+      g_gpint[i].stm32gpio.id              = i;
+      gpio_pin_register(&g_gpint[i].stm32gpio.gpio, pincount);
+
+      /* Configure the pin that will be used as interrupt input */
+
+      stm32_configgpio(g_gpiointinputs[i]);
+
+      pincount++;
+    }
+#endif
+
+  return 0;
+}

--- a/boards/arm/stm32f0l0g0/stm32g071b-disco/src/stm32_ina226.c
+++ b/boards/arm/stm32f0l0g0/stm32g071b-disco/src/stm32_ina226.c
@@ -1,0 +1,121 @@
+/****************************************************************************
+ * boards/arm/stm32f0l0g0/stm32g071b-disco/src/stm32_ina226.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <errno.h>
+#include <debug.h>
+
+#include <nuttx/i2c/i2c_master.h>
+#include <nuttx/sensors/ina226.h>
+
+#include "stm32_i2c.h"
+#include "stm32g071b-disco.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#ifndef CONFIG_STM32F0L0G0_I2C1
+#  error I2C1 must be enabled!
+#endif
+
+#define INA226_1_I2C_ADDR    0x40 /* VBUS */
+#define INA226_2_I2C_ADDR    0x41 /* CC1 */
+#define INA226_3_I2C_ADDR    0x42 /* CC2 */
+
+#define INA226_I2C_BUS       1
+#define INA226_SHUNT_VAL     15000
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: stm32_ina226_initialization
+ *
+ * Description:
+ *   Initialize and configure the INA226
+ *
+ ****************************************************************************/
+
+int stm32_ina226_initialization(void)
+{
+  struct i2c_master_s *i2c         = NULL;
+  static bool          initialized = false;
+  int                  ret         = OK;
+
+  /* Have we already initialized? */
+
+  if (!initialized)
+    {
+      /* No.. Get the I2C bus driver */
+
+      i2c = stm32_i2cbus_initialize(INA226_I2C_BUS);
+      if (!i2c)
+        {
+          serr("ERROR: Failed to initialize I2C%d\n", INA226_I2C_BUS);
+          goto errout;
+        }
+
+      /* Now bind the I2C interface to the INA226 drivers */
+
+      ret = ina226_register("/dev/ina226_1",
+                            i2c, INA226_1_I2C_ADDR,
+                            INA226_SHUNT_VAL, 0);
+      if (ret < 0)
+        {
+          serr("ERROR: Failed to bind I2C%d to the INA226_1 driver\n",
+               INA226_I2C_BUS);
+          goto errout;
+        }
+
+      ret = ina226_register("/dev/ina226_2",
+                            i2c, INA226_2_I2C_ADDR,
+                            INA226_SHUNT_VAL, 0);
+      if (ret < 0)
+        {
+          serr("ERROR: Failed to bind I2C%d to the INA226_2 driver\n",
+               INA226_I2C_BUS);
+          goto errout;
+        }
+
+      ret = ina226_register("/dev/ina226_3",
+                            i2c, INA226_3_I2C_ADDR,
+                            INA226_SHUNT_VAL, 0);
+      if (ret < 0)
+        {
+          serr("ERROR: Failed to bind I2C%d to the INA226_3 driver\n",
+               INA226_I2C_BUS);
+          goto errout;
+        }
+
+      /* Now we are initialized */
+
+      initialized = true;
+    }
+
+errout:
+  return ret;
+}

--- a/boards/arm/stm32f0l0g0/stm32g071b-disco/src/stm32g071b-disco.h
+++ b/boards/arm/stm32f0l0g0/stm32g071b-disco/src/stm32g071b-disco.h
@@ -114,4 +114,16 @@ void stm32_spidev_initialize(void);
 int stm32_djoy_initialization(void);
 #endif
 
+/****************************************************************************
+ * Name: stm32_ina226_initialization
+ *
+ * Description:
+ *   Initialize and configure the INA226
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_SENSORS_INA226
+int stm32_ina226_initialization(void);
+#endif
+
 #endif /* __BOARDS_ARM_STM32F0L0G0_STM32G071B_DISCO_SRC_STM32G071B_DISCO_H */

--- a/boards/arm/stm32f0l0g0/stm32g071b-disco/src/stm32g071b-disco.h
+++ b/boards/arm/stm32f0l0g0/stm32g071b-disco/src/stm32g071b-disco.h
@@ -68,6 +68,38 @@
 #define GPIO_SSD1306_RST   (GPIO_OUTPUT | GPIO_PUSHPULL | GPIO_SPEED_HIGH | \
                             GPIO_OUTPUT_SET | GPIO_PORTA | GPIO_PIN6)
 
+/* GPIO definitions *********************************************************/
+
+/* IN1  - STLK_ON    - PA11
+ * IN2  - SMPS_ON    - PA12
+ *
+ * OUT1 - ENCC1      - PB10
+ * OUT2 - ENCC1      - PB11
+ * OUT3 - RD_CC1     - PB12
+ * OUT4 - EN_SMPS    - PA0
+ *
+ * INT1 - Door sense - PC8
+ */
+
+#define BOARD_NGPIOIN     (2)   /* GPIO input pins */
+#define BOARD_NGPIOOUT    (4)   /* GPIO input with interrupts */
+#define BOARD_NGPIOINT    (1)   /* GPIO output pins */
+
+#define GPIO_IN1          (GPIO_INPUT | GPIO_FLOAT | GPIO_PORTA | GPIO_PIN11)
+#define GPIO_IN2          (GPIO_INPUT | GPIO_FLOAT | GPIO_PORTA | GPIO_PIN12)
+
+#define GPIO_OUT1         (GPIO_OUTPUT | GPIO_PUSHPULL | GPIO_SPEED_HIGH | \
+                           GPIO_OUTPUT_CLEAR | GPIO_PORTB | GPIO_PIN10)
+#define GPIO_OUT2         (GPIO_OUTPUT | GPIO_PUSHPULL | GPIO_SPEED_HIGH | \
+                           GPIO_OUTPUT_CLEAR | GPIO_PORTB | GPIO_PIN11)
+#define GPIO_OUT3         (GPIO_OUTPUT | GPIO_PUSHPULL | GPIO_SPEED_HIGH | \
+                           GPIO_OUTPUT_CLEAR | GPIO_PORTB | GPIO_PIN12)
+#define GPIO_OUT4         (GPIO_OUTPUT | GPIO_PUSHPULL | GPIO_SPEED_HIGH | \
+                           GPIO_OUTPUT_CLEAR | GPIO_PORTA | GPIO_PIN0)
+
+#define GPIO_INT1         (GPIO_INPUT | GPIO_PULLUP | GPIO_EXTI |  \
+                           GPIO_PORTC | GPIO_PIN8)
+
 /****************************************************************************
  * Public Data
  ****************************************************************************/
@@ -124,6 +156,18 @@ int stm32_djoy_initialization(void);
 
 #ifdef CONFIG_SENSORS_INA226
 int stm32_ina226_initialization(void);
+#endif
+
+/****************************************************************************
+ * Name: stm32_gpio_initialize
+ *
+ * Description:
+ *   Initialize GPIO drivers
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_DEV_GPIO
+int stm32_gpio_initialize(void);
 #endif
 
 #endif /* __BOARDS_ARM_STM32F0L0G0_STM32G071B_DISCO_SRC_STM32G071B_DISCO_H */

--- a/drivers/sensors/Kconfig
+++ b/drivers/sensors/Kconfig
@@ -499,11 +499,11 @@ config INA219_I2C_FREQUENCY
 	depends on SENSORS_INA219
 
 config SENSORS_INA226
-	bool "INA226 current and voltage monitor"
+	bool "INA226/INA230 current and voltage monitor"
 	default n
 	select I2C
 	---help---
-		Enable driver support for the Texas Instruments INA226 power monitor.
+		Enable driver support for the Texas Instruments INA226/INA230 power monitor.
 
 config INA226_I2C_FREQUENCY
 	int "INA226 I2C frequency"


### PR DESCRIPTION
## Summary

- sensors: use the INA226 driver also for INA230 chips
- stm32g071b-disco: ina230 support
- stm32g071b-disco: gpio dev support

## Impact

## Testing
gpio and ina226 examples
