### PR TITLE
bluetooth: fixing BT buffer addref/release balance

### DIFF
--- a/wireless/bluetooth/bt_hcicore.c
+++ b/wireless/bluetooth/bt_hcicore.c
@@ -1741,15 +1741,6 @@ int bt_hci_cmd_send(uint16_t opcode, FAR struct bt_buf_s *buf)
           return -ENOBUFS;
         }
     }
-  else
-    {
-      /* We manage the refcount the same for supplied and created
-       * buffers so increment the supplied count so we can manage
-       * it as-if we created it.
-       */
-
-      bt_buf_addref(buf);
-    }
 
   wlinfo("opcode %04x len %u\n", opcode, buf->len);
 
@@ -1792,10 +1783,6 @@ int bt_hci_cmd_send_sync(uint16_t opcode, FAR struct bt_buf_s *buf,
           wlerr("ERROR:  Failed to create buffer\n");
           return -ENOBUFS;
         }
-    }
-  else
-    {
-      bt_buf_addref(buf);
     }
 
   wlinfo("opcode %04x len %u\n", opcode, buf->len);
@@ -1861,7 +1848,6 @@ int bt_hci_cmd_send_sync(uint16_t opcode, FAR struct bt_buf_s *buf,
       bt_buf_release(buf->u.hci.sync);
     }
 
-  bt_buf_release(buf);
   return ret;
 }
 


### PR DESCRIPTION
## Summary
  
This PR fixes the issue when the BT command buffer gets released more times than its `ref` number. 
The issue is always reproducing when called `hci_initialize` function, and `DEBUG_ASSERT` is triggered. 

## Impact

Stability fix

## Testing

Tested by monitoring logs and verifying allocated buffers to be released.
With SMP test enabled it does good enough stress test to the buffer.
I've added `+++ (n)` after each buffer allocation, and `--- (n)` after deleting, where the `n` is a total existing buffer count after the operation.

<details>
  <summary> The log (click to expand) </summary>

```
NuttShell (NSH) Nustm32wb_blehci_rxevt: received SYS event from mailbox (evt: 255)
ttX-10.1.0-RC1
nsh> stm32wb_blehci_rxevt: system command ACK responsebt_initialize: btdev 0x200000d0
bt_hci_cmd_create: opcode 0c03 param_len 0
bt_buf_alloc:  +++ (1) buf 0x20002ff4 type 0 reserve 0
bt_hci_cmd_create: buf 0x20002ff4
bt_buf_extend: buf 0x20002ff4 len 3
bt_hci_cmd_send_sync: opcode 0c03 len 3
hci_tx_kthread: started
bt_buf_addref: buf 0x20002ff4 (old) ref 1 type 0
hci_tx_kthread: Sending command 0c03 buf 0x20002ff4 to driver
stm32wb_blehci_driversend: passing type CMD to mailbox driver
bt_buf_release:stm32wb_blehci_rxevt: received CMD_COMPLETE from mailbox (opcode: 0xc03, status: 0x0)
bt_receive: data 0x2003090d len 6
bt_buf_alloc:  +++ (2) buf 0x20002fdc type 1 reserve 1
bt_buf_extend: buf 0x20002fdc len 6
priority_rx_work: list 0x200027c0
priority_rx_work: buf 0x20002fdc type 1 len 6
bt_buf_consume: buf 0x20002fdc len 2
hci_cmd_complete: opcode 0c03
bt_buf_consume: buf 0x20002fdc len 3
hci_reset_complete: status 0
bt_buf_addref: buf 0x20002fdc (old) ref 1 type 1
bt_buf_release: buf 0x20002ff4 ref 2 type 0
bt_buf_release: Remaining references: 1
bt_buf_release: buf 0x20002fdc ref 2 type 1
bt_buf_release: Remaining references: 1
 buf 0x20002ff4 ref 2 type 0
bt_buf_release:  --- (1)  Buffer freed: 0x20002ff4
bt_buf_release: buf 0x20002fdc ref 1 type 1
bt_buf_release:  --- (0)  Buffer freed: 0x20002fdc
bt_hci_cmd_create: opcode 1003 param_len 0
bt_buf_alloc:  +++ (1) buf 0x20002fdc type 0 reserve 0
bt_hci_cmd_create: buf 0x20002fdc
bt_buf_extend: buf 0x20002fdc len 3
bt_hci_cmd_send_sync: opcode 1003 len 3
bt_buf_addref: buf 0x20002fdc (old) ref 1 type 0
hci_tx_kthread: Sending command 1003 buf 0x20002fdc to driver
stm32wb_blehci_driversend: passing type CMD to mailbox driver
bt_bstm32wb_blehci_rxevt: received CMD_COMPLETE from mailbox (opcode: 0x1003, status: 0x0)
bt_receive: data 0x2003090d len 14
bt_buf_alloc:  +++ (2) buf 0x20002ff4 type 1 reserve 1
bt_buf_extend: buf 0x20002ff4 len 14
priority_rx_work: list 0x200027c0
priority_rx_work: buf 0x20002ff4 type 1 len 14
bt_buf_consume: buf 0x20002ff4 len 2
hci_cmd_complete: opcode 1003
bt_buf_consume: buf 0x20002ff4 len 3
hci_cmd_complete: Unhandled opcode 1003
bt_buf_addref: buf 0x20002ff4 (old) ref 1 type 1
bt_buf_release: buf 0x20002fdc ref 2 type 0
bt_buf_release: Remaining references: 1
bt_buf_release: buf 0x20002ff4 ref 2 type 1
bt_buf_release: Remaining references: 1
uf_release: buf 0x20002fdc ref 2 type 0
bt_buf_release:  --- (1)  Buffer freed: 0x20002fdc
read_local_features_complete: status 0
bt_buf_release: buf 0x20002ff4 ref 1 type 1
bt_buf_release:  --- (0)  Buffer freed: 0x20002ff4
bt_hci_cmd_create: opcode 1001 param_len 0
bt_buf_alloc:  +++ (1) buf 0x20002ff4 type 0 reserve 0
bt_hci_cmd_create: buf 0x20002ff4
bt_buf_extend: buf 0x20002ff4 len 3
bt_hci_cmd_send_sync: opcode 1001 len 3
bt_buf_addref: buf 0x20002ff4 (old) ref 1 type 0
hci_tx_kthread: Sending command 1001 buf 0x20002ff4 to driver
stm32wb_blehci_driversend: passing type CMD to mailbox driver
bt_bstm32wb_blehci_rxevt: received CMD_COMPLETE from mailbox (opcode: 0x1001, status: 0x0)
bt_receive: data 0x2003090d len 14
bt_buf_alloc:  +++ (2) buf 0x20002fdc type 1 reserve 1
bt_buf_extend: buf 0x20002fdc len 14
priority_rx_work: list 0x200027c0
priority_rx_work: buf 0x20002fdc type 1 len 14
bt_buf_consume: buf 0x20002fdc len 2
hci_cmd_complete: opcode 1001
bt_buf_consume: buf 0x20002fdc len 3
hci_cmd_complete: Unhandled opcode 1001
bt_buf_addref: buf 0x20002fdc (old) ref 1 type 1
bt_buf_release: buf 0x20002ff4 ref 2 type 0
bt_buf_release: Remaining references: 1
bt_buf_release: buf 0x20002fdc ref 2 type 1
bt_buf_release: Remaining references: 1
uf_release: buf 0x20002ff4 ref 2 type 0
bt_buf_release:  --- (1)  Buffer freed: 0x20002ff4
read_local_ver_complete: status 0
bt_buf_release: buf 0x20002fdc ref 1 type 1
bt_buf_release:  --- (0)  Buffer freed: 0x20002fdc
bt_hci_cmd_create: opcode 1009 param_len 0
bt_buf_alloc:  +++ (1) buf 0x20002fdc type 0 reserve 0
bt_hci_cmd_create: buf 0x20002fdc
bt_buf_extend: buf 0x20002fdc len 3
bt_hci_cmd_send_sync: opcode 1009 len 3
bt_buf_addref: buf 0x20002fdc (old) ref 1 type 0
hci_tx_kthread: Sending command 1009 buf 0x20002fdc to driver
stm32wb_blehci_driversend: passing type CMD to mailbox driver
bt_bstm32wb_blehci_rxevt: received CMD_COMPLETE from mailbox (opcode: 0x1009, status: 0x0)
bt_receive: data 0x2003090d len 12
bt_buf_alloc:  +++ (2) buf 0x20002ff4 type 1 reserve 1
bt_buf_extend: buf 0x20002ff4 len 12
priority_rx_work: list 0x200027c0
priority_rx_work: buf 0x20002ff4 type 1 len 12
bt_buf_consume: buf 0x20002ff4 len 2
hci_cmd_complete: opcode 1009
bt_buf_consume: buf 0x20002ff4 len 3
hci_cmd_complete: Unhandled opcode 1009
bt_buf_addref: buf 0x20002ff4 (old) ref 1 type 1
bt_buf_release: buf 0x20002fdc ref 2 type 0
bt_buf_release: Remaining references: 1
bt_buf_release: buf 0x20002ff4 ref 2 type 1
bt_buf_release: Remaining references: 1
uf_release: buf 0x20002fdc ref 2 type 0
bt_buf_release:  --- (1)  Buffer freed: 0x20002fdc
read_bdaddr_complete: status 0
bt_buf_release: buf 0x20002ff4 ref 1 type 1
bt_buf_release:  --- (0)  Buffer freed: 0x20002ff4
bt_hci_cmd_create: opcode 2003 param_len 0
bt_buf_alloc:  +++ (1) buf 0x20002ff4 type 0 reserve 0
bt_hci_cmd_create: buf 0x20002ff4
bt_buf_extend: buf 0x20002ff4 len 3
bt_hci_cmd_send_sync: opcode 2003 len 3
bt_buf_addref: buf 0x20002ff4 (old) ref 1 type 0
hci_tx_kthread: Sending command 2003 buf 0x20002ff4 to driver
stm32wb_blehci_driversend: passing type CMD to mailbox driver
bt_bstm32wb_blehci_rxevt: received CMD_COMPLETE from mailbox (opcode: 0x2003, status: 0x0)
bt_receive: data 0x2003090d len 14
bt_buf_alloc:  +++ (2) buf 0x20002fdc type 1 reserve 1
bt_buf_extend: buf 0x20002fdc len 14
priority_rx_work: list 0x200027c0
priority_rx_work: buf 0x20002fdc type 1 len 14
bt_buf_consume: buf 0x20002fdc len 2
hci_cmd_complete: opcode 2003
bt_buf_consume: buf 0x20002fdc len 3
hci_cmd_complete: Unhandled opcode 2003
bt_buf_addref: buf 0x20002fdc (old) ref 1 type 1
bt_buf_release: buf 0x20002ff4 ref 2 type 0
bt_buf_release: Remaining references: 1
bt_buf_release: buf 0x20002fdc ref 2 type 1
bt_buf_release: Remaining references: 1
uf_release: buf 0x20002ff4 ref 2 type 0
bt_buf_release:  --- (1)  Buffer freed: 0x20002ff4
read_le_features_complete: status 0
bt_buf_release: buf 0x20002fdc ref 1 type 1
bt_buf_release:  --- (0)  Buffer freed: 0x20002fdc
bt_hci_cmd_create: opcode 2002 param_len 0
bt_buf_alloc:  +++ (1) buf 0x20002fdc type 0 reserve 0
bt_hci_cmd_create: buf 0x20002fdc
bt_buf_extend: buf 0x20002fdc len 3
bt_hci_cmd_send_sync: opcode 2002 len 3
bt_buf_addref: buf 0x20002fdc (old) ref 1 type 0
hci_tx_kthread: Sending command 2002 buf 0x20002fdc to driver
stm32wb_blehci_driversend: passing type CMD to mailbox driver
bt_bstm32wb_blehci_rxevt: received CMD_COMPLETE from mailbox (opcode: 0x2002, status: 0x0)
bt_receive: data 0x2003090d len 9
bt_buf_alloc:  +++ (2) buf 0x20002ff4 type 1 reserve 1
bt_buf_extend: buf 0x20002ff4 len 9
priority_rx_work: list 0x200027c0
priority_rx_work: buf 0x20002ff4 type 1 len 9
bt_buf_consume: buf 0x20002ff4 len 2
hci_cmd_complete: opcode 2002
bt_buf_consume: buf 0x20002ff4 len 3
hci_cmd_complete: Unhandled opcode 2002
bt_buf_addref: buf 0x20002ff4 (old) ref 1 type 1
bt_buf_release: buf 0x20002fdc ref 2 type 0
bt_buf_release: Remaining references: 1
bt_buf_release: buf 0x20002ff4 ref 2 type 1
bt_buf_release: Remaining references: 1
uf_release: buf 0x20002fdc ref 2 type 0
bt_buf_release:  --- (1)  Buffer freed: 0x20002fdc
le_read_buffer_size_complete: status 0
bt_buf_release: buf 0x20002ff4 ref 1 type 1
bt_buf_release:  --- (0)  Buffer freed: 0x20002ff4
bt_hci_cmd_create: opcode 0c01 param_len 8
bt_buf_alloc:  +++ (1) buf 0x20002ff4 type 0 reserve 0
bt_hci_cmd_create: buf 0x20002ff4
bt_buf_extend: buf 0x20002ff4 len 3
bt_buf_extend: buf 0x20002ff4 len 8
bt_hci_cmd_send_sync: opcode 0c01 len 11
bt_buf_addref: buf 0x20002ff4 (old) ref 1 type 0
hci_tx_kthread: Sending command 0c01 buf 0x20002ff4 to driver
stm32wb_blehci_driversend: passing type CMD to mailbox driver
bt_bstm32wb_blehci_rxevt: received CMD_COMPLETE from mailbox (opcode: 0xc01, status: 0x0)
bt_receive: data 0x2003090d len 6
bt_buf_alloc:  +++ (2) buf 0x20002fdc type 1 reserve 1
bt_buf_extend: buf 0x20002fdc len 6
priority_rx_work: list 0x200027c0
priority_rx_work: buf 0x20002fdc type 1 len 6
bt_buf_consume: buf 0x20002fdc len 2
hci_cmd_complete: opcode 0c01
bt_buf_consume: buf 0x20002fdc len 3
hci_cmd_complete: Unhandled opcode 0c01
bt_buf_addref: buf 0x20002fdc (old) ref 1 type 1
bt_buf_release: buf 0x20002ff4 ref 2 type 0
bt_buf_release: Remaining references: 1
bt_buf_release: buf 0x20002fdc ref 2 type 1
bt_buf_release: Remaining references: 1
uf_release: buf 0x20002ff4 ref 2 type 0
bt_buf_release:  --- (1)  Buffer freed: 0x20002ff4
bt_buf_release: buf 0x20002fdc ref 1 type 1
bt_buf_release:  --- (0)  Buffer freed: 0x20002fdc
bt_hci_cmd_create: opcode 0c33 param_len 7
bt_buf_alloc:  +++ (1) buf 0x20002fdc type 0 reserve 0
bt_hci_cmd_create: buf 0x20002fdc
bt_buf_extend: buf 0x20002fdc len 3
bt_buf_extend: buf 0x20002fdc len 7
bt_hci_cmd_send: opcode 0c33 len 10
bt_hci_cmd_create: opcode 0c31 param_len 1
bt_buf_alloc:  +++ (2) buf 0x20002ff4 type 0 reserve 0
bt_hci_cmd_create: buf 0x20002ff4
bt_buf_extend: buf 0x20002ff4 len 3
bt_buf_extend: buf 0x20002ff4 len 1
bt_hci_cmd_send_sync: opcode 0c31 len 4
bt_buf_addref: buf 0x20002fdc (old) ref 1 type 0
hci_tx_kthread: Sending command 0c33 buf 0x20002fdc to driver
stm32wb_blehci_driversend: passing type CMD to mailbox driver
bt_bstm32wb_blehci_rxevt: received CMD_COMPLETE from mailbox (opcode: 0xc33, status: 0x12)
bt_receive: data 0x2003090d len 6
bt_buf_alloc:  +++ (3) buf 0x20002fc4 type 1 reserve 1
bt_buf_extend: buf 0x20002fc4 len 6
priority_rx_work: list 0x200027c0
priority_rx_work: buf 0x20002fc4 type 1 len 6
bt_buf_consume: buf 0x20002fc4 len 2
hci_cmd_complete: opcode 0c33
bt_buf_consume: buf 0x20002fc4 len 3
hci_cmd_complete: Unhandled opcode 0c33
bt_buf_release: buf 0x20002fdc ref 2 type 0
bt_buf_release: Remaining references: 1
bt_buf_release: buf 0x20002fc4 ref 1 type 1
bt_buf_release:  --- (2)  Buffer freed: 0x20002fc4
uf_release: buf 0x20002fdc ref 2 type 0
bt_buf_release:  --- (1)  Buffer freed: 0x20002fdc
bt_buf_addref: buf 0x20002ff4 (old) ref 1 type 0
hci_tx_kthread: Sending command 0c31 buf 0x20002ff4 to driver
stm32wb_blehci_driversend: passing type CMD to mailbox driver
bt_bstm32wb_blehci_rxevt: received CMD_COMPLETE from mailbox (opcode: 0xc31, status: 0x0)
bt_receive: data 0x2003090d len 6
bt_buf_alloc:  +++ (2) buf 0x20002fdc type 1 reserve 1
bt_buf_extend: buf 0x20002fdc len 6
priority_rx_work: list 0x200027c0
priority_rx_work: buf 0x20002fdc type 1 len 6
bt_buf_consume: buf 0x20002fdc len 2
hci_cmd_complete: opcode 0c31
bt_buf_consume: buf 0x20002fdc len 3
hci_cmd_complete: Unhandled opcode 0c31
bt_buf_addref: buf 0x20002fdc (old) ref 1 type 1
bt_buf_release: buf 0x20002ff4 ref 2 type 0
bt_buf_release: Remaining references: 1
bt_buf_release: buf 0x20002fdc ref 2 type 1
bt_buf_release: Remaining references: 1
uf_release: buf 0x20002ff4 ref 2 type 0
bt_buf_release:  --- (1)  Buffer freed: 0x20002ff4
bt_buf_release: buf 0x20002fdc ref 1 type 1
bt_buf_release:  --- (0)  Buffer freed: 0x20002fdc
hci_initialize: HCI ver 11 rev 95, manufacturer 48
hci_initialize: ACL buffers: pkts 1 mtu 251
bt_l2cap_chan_register: CID 0x0004
bt_l2cap_chan_register: CID 0x0006
aes_test: Test aes-cmac0: AES CMAC of message with len 0
le_encrypt: key 3c4fcf098815f7aba6d2ae2816157e2b plaintext 00000000000000000000000000000000
bt_hci_cmd_create: opcode 2017 param_len 32
bt_buf_alloc:  +++ (1) buf 0x20002fdc type 0 reserve 0
bt_hci_cmd_create: buf 0x20002fdc
bt_buf_extend: buf 0x20002fdc len 3
bt_buf_extend: buf 0x20002fdc len 32
bt_hci_cmd_send_sync: opcode 2017 len 35
bt_buf_addref: buf 0x20002fdc (old) ref 1 type 0
hci_tx_kthread: Sending command 2017 buf 0x20002fdc to driver
stm32wb_blehci_driversend: passing type CMD to mailbox driver
bt_bstm32wb_blehci_rxevt: received CMD_COMPLETE from mailbox (opcode: 0x2017, status: 0x0)
bt_receive: data 0x2003090d len 22
bt_buf_alloc:  +++ (2) buf 0x20002ff4 type 1 reserve 1
bt_buf_extend: buf 0x20002ff4 len 22
priority_rx_work: list 0x200027c0
priority_rx_work: buf 0x20002ff4 type 1 len 22
bt_buf_consume: buf 0x20002ff4 len 2
hci_cmd_complete: opcode 2017
bt_buf_consume: buf 0x20002ff4 len 3
hci_cmd_complete: Unhandled opcode 2017
bt_buf_addref: buf 0x20002ff4 (old) ref 1 type 1
bt_buf_release: buf 0x20002fdc ref 2 type 0
bt_buf_release: Remaining references: 1
bt_buf_release: buf 0x20002ff4 ref 2 type 1
bt_buf_release: Remaining references: 1
uf_release: buf 0x20002fdc ref 2 type 0
bt_buf_release:  --- (1)  Buffer freed: 0x20002fdc
bt_buf_release: buf 0x20002ff4 ref 1 type 1
bt_buf_release:  --- (0)  Buffer freed: 0x20002ff4
le_encrypt: enc_data 6f541bb947f0423eb399b81a0c6bf77d
cmac_subkey: l 7df76b0c1ab899b33e42f047b91b546f
bt_smp_aes_cmac: key 2b7e151628aed2a6abf7158809cf4f3c subkeys k1 fbeed618357133667c85e08f7236a8de k2 f7ddac306ae266ccf90bc11ee4b
bt_smp_aes_cmac: len 0 n 1 flag 0
le_encrypt: key 3c4fcf098815f7aba6d2ae2816157e2b plaintext 3b516de41ec10bf9cc66e26a30acdd77
bt_hci_cmd_create: opcode 2017 param_len 32
bt_buf_alloc:  +++ (1) buf 0x20002ff4 type 0 reserve 0
bt_hci_cmd_create: buf 0x20002ff4
bt_buf_extend: buf 0x20002ff4 len 3
bt_buf_extend: buf 0x20002ff4 len 32
bt_hci_cmd_send_sync: opcode 2017 len 35
bt_buf_addref: buf 0x20002ff4 (old) ref 1 type 0
hci_tx_kthread: Sending command 2017 buf 0x20002ff4 to driver
stm32wb_blehci_driversend: passing type CMD to mailbox driver
bt_bstm32wb_blehci_rxevt: received CMD_COMPLETE from mailbox (opcode: 0x2017, status: 0x0)
bt_receive: data 0x2003090d len 22
bt_buf_alloc:  +++ (2) buf 0x20002fdc type 1 reserve 1
bt_buf_extend: buf 0x20002fdc len 22
priority_rx_work: list 0x200027c0
priority_rx_work: buf 0x20002fdc type 1 len 22
bt_buf_consume: buf 0x20002fdc len 2
hci_cmd_complete: opcode 2017
bt_buf_consume: buf 0x20002fdc len 3
hci_cmd_complete: Unhandled opcode 2017
bt_buf_addref: buf 0x20002fdc (old) ref 1 type 1
bt_buf_release: buf 0x20002ff4 ref 2 type 0
bt_buf_release: Remaining references: 1
bt_buf_release: buf 0x20002fdc ref 2 type 1
bt_buf_release: Remaining references: 1
uf_release: buf 0x20002ff4 ref 2 type 0
bt_buf_release:  --- (1)  Buffer freed: 0x20002ff4
bt_buf_release: buf 0x20002fdc ref 1 type 1
bt_buf_release:  --- (0)  Buffer freed: 0x20002fdc
le_encrypt: enc_data 4667759b127da37f283759e929691dbb
aes_test: Test aes-cmac0: Success
aes_test: Test aes-cmac16: AES CMAC of message with len 16
le_encrypt: key 3c4fcf098815f7aba6d2ae2816157e2b plaintext 00000000000000000000000000000000
bt_hci_cmd_create: opcode 2017 param_len 32
bt_buf_alloc:  +++ (1) buf 0x20002fdc type 0 reserve 0
bt_hci_cmd_create: buf 0x20002fdc
bt_buf_extend: buf 0x20002fdc len 3
bt_buf_extend: buf 0x20002fdc len 32
bt_hci_cmd_send_sync: opcode 2017 len 35
bt_buf_addref: buf 0x20002fdc (old) ref 1 type 0
hci_tx_kthread: Sending command 2017 buf 0x20002fdc to driver
stm32wb_blehci_driversend: passing type CMD to mailbox driver
bt_bstm32wb_blehci_rxevt: received CMD_COMPLETE from mailbox (opcode: 0x2017, status: 0x0)
bt_receive: data 0x2003090d len 22
bt_buf_alloc:  +++ (2) buf 0x20002ff4 type 1 reserve 1
bt_buf_extend: buf 0x20002ff4 len 22
priority_rx_work: list 0x200027c0
priority_rx_work: buf 0x20002ff4 type 1 len 22
bt_buf_consume: buf 0x20002ff4 len 2
hci_cmd_complete: opcode 2017
bt_buf_consume: buf 0x20002ff4 len 3
hci_cmd_complete: Unhandled opcode 2017
bt_buf_addref: buf 0x20002ff4 (old) ref 1 type 1
bt_buf_release: buf 0x20002fdc ref 2 type 0
bt_buf_release: Remaining references: 1
bt_buf_release: buf 0x20002ff4 ref 2 type 1
bt_buf_release: Remaining references: 1
uf_release: buf 0x20002fdc ref 2 type 0
bt_buf_release:  --- (1)  Buffer freed: 0x20002fdc
bt_buf_release: buf 0x20002ff4 ref 1 type 1
bt_buf_release:  --- (0)  Buffer freed: 0x20002ff4
le_encrypt: enc_data 6f541bb947f0423eb399b81a0c6bf77d
cmac_subkey: l 7df76b0c1ab899b33e42f047b91b546f
bt_smp_aes_cmac: key 2b7e151628aed2a6abf7158809cf4f3c subkeys k1 fbeed618357133667c85e08f7236a8de k2 f7ddac306ae266ccf90bc11ee4b
bt_smp_aes_cmac: len 16 n 1 flag 1
le_encrypt: key 3c4fcf098815f7aba6d2ae2816157e2b plaintext f4bfa5019e9eb895f0ac311bfa682f90
bt_hci_cmd_create: opcode 2017 param_len 32
bt_buf_alloc:  +++ (1) buf 0x20002ff4 type 0 reserve 0
bt_hci_cmd_create: buf 0x20002ff4
bt_buf_extend: buf 0x20002ff4 len 3
bt_buf_extend: buf 0x20002ff4 len 32
bt_hci_cmd_send_sync: opcode 2017 len 35
bt_buf_addref: buf 0x20002ff4 (old) ref 1 type 0
hci_tx_kthread: Sending command 2017 buf 0x20002ff4 to driver
stm32wb_blehci_driversend: passing type CMD to mailbox driver
bt_bstm32wb_blehci_rxevt: received CMD_COMPLETE from mailbox (opcode: 0x2017, status: 0x0)
bt_receive: data 0x2003090d len 22
bt_buf_alloc:  +++ (2) buf 0x20002fdc type 1 reserve 1
bt_buf_extend: buf 0x20002fdc len 22
priority_rx_work: list 0x200027c0
priority_rx_work: buf 0x20002fdc type 1 len 22
bt_buf_consume: buf 0x20002fdc len 2
hci_cmd_complete: opcode 2017
bt_buf_consume: buf 0x20002fdc len 3
hci_cmd_complete: Unhandled opcode 2017
bt_buf_addref: buf 0x20002fdc (old) ref 1 type 1
bt_buf_release: buf 0x20002ff4 ref 2 type 0
bt_buf_release: Remaining references: 1
bt_buf_release: buf 0x20002fdc ref 2 type 1
bt_buf_release: Remaining references: 1
uf_release: buf 0x20002ff4 ref 2 type 0
bt_buf_release:  --- (1)  Buffer freed: 0x20002ff4
bt_buf_release: buf 0x20002fdc ref 1 type 1
bt_buf_release:  --- (0)  Buffer freed: 0x20002fdc
le_encrypt: enc_data 7c284ad09ddd9bf744414d6bb4160a07
aes_test: Test aes-cmac16: Success
aes_test: Test aes-cmac40: AES CMAC of message with len 40
le_encrypt: key 3c4fcf098815f7aba6d2ae2816157e2b plaintext 00000000000000000000000000000000
bt_hci_cmd_create: opcode 2017 param_len 32
bt_buf_alloc:  +++ (1) buf 0x20002fdc type 0 reserve 0
bt_hci_cmd_create: buf 0x20002fdc
bt_buf_extend: buf 0x20002fdc len 3
bt_buf_extend: buf 0x20002fdc len 32
bt_hci_cmd_send_sync: opcode 2017 len 35
bt_buf_addref: buf 0x20002fdc (old) ref 1 type 0
hci_tx_kthread: Sending command 2017 buf 0x20002fdc to driver
stm32wb_blehci_driversend: passing type CMD to mailbox driver
bt_bstm32wb_blehci_rxevt: received CMD_COMPLETE from mailbox (opcode: 0x2017, status: 0x0)
bt_receive: data 0x2003090d len 22
bt_buf_alloc:  +++ (2) buf 0x20002ff4 type 1 reserve 1
bt_buf_extend: buf 0x20002ff4 len 22
priority_rx_work: list 0x200027c0
priority_rx_work: buf 0x20002ff4 type 1 len 22
bt_buf_consume: buf 0x20002ff4 len 2
hci_cmd_complete: opcode 2017
bt_buf_consume: buf 0x20002ff4 len 3
hci_cmd_complete: Unhandled opcode 2017
bt_buf_addref: buf 0x20002ff4 (old) ref 1 type 1
bt_buf_release: buf 0x20002fdc ref 2 type 0
bt_buf_release: Remaining references: 1
bt_buf_release: buf 0x20002ff4 ref 2 type 1
bt_buf_release: Remaining references: 1
uf_release: buf 0x20002fdc ref 2 type 0
bt_buf_release:  --- (1)  Buffer freed: 0x20002fdc
bt_buf_release: buf 0x20002ff4 ref 1 type 1
bt_buf_release:  --- (0)  Buffer freed: 0x20002ff4
le_encrypt: enc_data 6f541bb947f0423eb399b81a0c6bf77d
cmac_subkey: l 7df76b0c1ab899b33e42f047b91b546f
bt_smp_aes_cmac: key 2b7e151628aed2a6abf7158809cf4f3c subkeys k1 fbeed618357133667c85e08f7236a8de k2 f7ddac306ae266ccf90bc11ee4b
bt_smp_aes_cmac: len 40 n 3 flag 0
le_encrypt: key 3c4fcf098815f7aba6d2ae2816157e2b plaintext 2a179373117e3de9969f402ee2bec16b
bt_hci_cmd_create: opcode 2017 param_len 32
bt_buf_alloc:  +++ (1) buf 0x20002ff4 type 0 reserve 0
bt_hci_cmd_create: buf 0x20002ff4
bt_buf_extend: buf 0x20002ff4 len 3
bt_buf_extend: buf 0x20002ff4 len 32
bt_hci_cmd_send_sync: opcode 2017 len 35
bt_buf_addref: buf 0x20002ff4 (old) ref 1 type 0
hci_tx_kthread: Sending command 2017 buf 0x20002ff4 to driver
stm32wb_blehci_driversend: passing type CMD to mailbox driver
bt_bstm32wb_blehci_rxevt: received CMD_COMPLETE from mailbox (opcode: 0x2017, status: 0x0)
bt_receive: data 0x2003090d len 22
bt_buf_alloc:  +++ (2) buf 0x20002fdc type 1 reserve 1
bt_buf_extend: buf 0x20002fdc len 22
priority_rx_work: list 0x200027c0
priority_rx_work: buf 0x20002fdc type 1 len 22
bt_buf_consume: buf 0x20002fdc len 2
hci_cmd_complete: opcode 2017
bt_buf_consume: buf 0x20002fdc len 3
hci_cmd_complete: Unhandled opcode 2017
bt_buf_addref: buf 0x20002fdc (old) ref 1 type 1
bt_buf_release: buf 0x20002ff4 ref 2 type 0
bt_buf_release: Remaining references: 1
bt_buf_release: buf 0x20002fdc ref 2 type 1
bt_buf_release: Remaining references: 1
uf_release: buf 0x20002ff4 ref 2 type 0
bt_buf_release:  --- (1)  Buffer freed: 0x20002ff4
bt_buf_release: buf 0x20002fdc ref 1 type 1
bt_buf_release:  --- (0)  Buffer freed: 0x20002fdc
le_encrypt: enc_data 97ef6624f3ca9ea860367a0db47bd73a
le_encrypt: key 3c4fcf098815f7aba6d2ae2816157e2b plaintext c661c9615fa52936fc9a7913e3f1fa94
bt_hci_cmd_create: opcode 2017 param_len 32
bt_buf_alloc:  +++ (1) buf 0x20002fdc type 0 reserve 0
bt_hci_cmd_create: buf 0x20002fdc
bt_buf_extend: buf 0x20002fdc len 3
bt_buf_extend: buf 0x20002fdc len 32
bt_hci_cmd_send_sync: opcode 2017 len 35
bt_buf_addref: buf 0x20002fdc (old) ref 1 type 0
hci_tx_kthread: Sending command 2017 buf 0x20002fdc to driver
stm32wb_blehci_driversend: passing type CMD to mailbox driver
bt_bstm32wb_blehci_rxevt: received CMD_COMPLETE from mailbox (opcode: 0x2017, status: 0x0)
bt_receive: data 0x2003090d len 22
bt_buf_alloc:  +++ (2) buf 0x20002ff4 type 1 reserve 1
bt_buf_extend: buf 0x20002ff4 len 22
priority_rx_work: list 0x200027c0
priority_rx_work: buf 0x20002ff4 type 1 len 22
bt_buf_consume: buf 0x20002ff4 len 2
hci_cmd_complete: opcode 2017
bt_buf_consume: buf 0x20002ff4 len 3
hci_cmd_complete: Unhandled opcode 2017
bt_buf_addref: buf 0x20002ff4 (old) ref 1 type 1
bt_buf_release: buf 0x20002fdc ref 2 type 0
bt_buf_release: Remaining references: 1
bt_buf_release: buf 0x20002ff4 ref 2 type 1
bt_buf_release: Remaining references: 1
uf_release: buf 0x20002fdc ref 2 type 0
bt_buf_release:  --- (1)  Buffer freed: 0x20002fdc
bt_buf_release: buf 0x20002ff4 ref 1 type 1
bt_buf_release:  --- (0)  Buffer freed: 0x20002ff4
le_encrypt: enc_data 49dd2af17ce57a2892e69e307fc148b1
le_encrypt: key 3c4fcf098815f7aba6d2ae2816157e2b plaintext 728c4715622471514f6420f909715d76
bt_hci_cmd_create: opcode 2017 param_len 32
bt_buf_alloc:  +++ (1) buf 0x20002ff4 type 0 reserve 0
bt_hci_cmd_create: buf 0x20002ff4
bt_buf_extend: buf 0x20002ff4 len 3
bt_buf_extend: buf 0x20002ff4 len 32
bt_hci_cmd_send_sync: opcode 2017 len 35
bt_buf_addref: buf 0x20002ff4 (old) ref 1 type 0
hci_tx_kthread: Sending command 2017 buf 0x20002ff4 to driver
stm32wb_blehci_driversend: passing type CMD to mailbox driver
bt_bstm32wb_blehci_rxevt: received CMD_COMPLETE from mailbox (opcode: 0x2017, status: 0x0)
bt_receive: data 0x2003090d len 22
bt_buf_alloc:  +++ (2) buf 0x20002fdc type 1 reserve 1
bt_buf_extend: buf 0x20002fdc len 22
priority_rx_work: list 0x200027c0
priority_rx_work: buf 0x20002fdc type 1 len 22
bt_buf_consume: buf 0x20002fdc len 2
hci_cmd_complete: opcode 2017
bt_buf_consume: buf 0x20002fdc len 3
hci_cmd_complete: Unhandled opcode 2017
bt_buf_addref: buf 0x20002fdc (old) ref 1 type 1
bt_buf_release: buf 0x20002ff4 ref 2 type 0
bt_buf_release: Remaining references: 1
bt_buf_release: buf 0x20002fdc ref 2 type 1
bt_buf_release: Remaining references: 1
uf_release: buf 0x20002ff4 ref 2 type 0
bt_buf_release:  --- (1)  Buffer freed: 0x20002ff4
bt_buf_release: buf 0x20002fdc ref 1 type 1
bt_buf_release:  --- (0)  Buffer freed: 0x20002fdc
le_encrypt: enc_data 27c897146132ca3030e69ade4767a6df
aes_test: Test aes-cmac40: Success
aes_test: Test aes-cmac64: AES CMAC of message with len 64
le_encrypt: key 3c4fcf098815f7aba6d2ae2816157e2b plaintext 00000000000000000000000000000000
bt_hci_cmd_create: opcode 2017 param_len 32
bt_buf_alloc:  +++ (1) buf 0x20002fdc type 0 reserve 0
bt_hci_cmd_create: buf 0x20002fdc
bt_buf_extend: buf 0x20002fdc len 3
bt_buf_extend: buf 0x20002fdc len 32
bt_hci_cmd_send_sync: opcode 2017 len 35
bt_buf_addref: buf 0x20002fdc (old) ref 1 type 0
hci_tx_kthread: Sending command 2017 buf 0x20002fdc to driver
stm32wb_blehci_driversend: passing type CMD to mailbox driver
bt_bstm32wb_blehci_rxevt: received CMD_COMPLETE from mailbox (opcode: 0x2017, status: 0x0)
bt_receive: data 0x2003090d len 22
bt_buf_alloc:  +++ (2) buf 0x20002ff4 type 1 reserve 1
bt_buf_extend: buf 0x20002ff4 len 22
priority_rx_work: list 0x200027c0
priority_rx_work: buf 0x20002ff4 type 1 len 22
bt_buf_consume: buf 0x20002ff4 len 2
hci_cmd_complete: opcode 2017
bt_buf_consume: buf 0x20002ff4 len 3
hci_cmd_complete: Unhandled opcode 2017
bt_buf_addref: buf 0x20002ff4 (old) ref 1 type 1
bt_buf_release: buf 0x20002fdc ref 2 type 0
bt_buf_release: Remaining references: 1
bt_buf_release: buf 0x20002ff4 ref 2 type 1
bt_buf_release: Remaining references: 1
uf_release: buf 0x20002fdc ref 2 type 0
bt_buf_release:  --- (1)  Buffer freed: 0x20002fdc
bt_buf_release: buf 0x20002ff4 ref 1 type 1
bt_buf_release:  --- (0)  Buffer freed: 0x20002ff4
le_encrypt: enc_data 6f541bb947f0423eb399b81a0c6bf77d
cmac_subkey: l 7df76b0c1ab899b33e42f047b91b546f
bt_smp_aes_cmac: key 2b7e151628aed2a6abf7158809cf4f3c subkeys k1 fbeed618357133667c85e08f7236a8de k2 f7ddac306ae266ccf90bc11ee4b
bt_smp_aes_cmac: len 64 n 4 flag 1
le_encrypt: key 3c4fcf098815f7aba6d2ae2816157e2b plaintext 2a179373117e3de9969f402ee2bec16b
bt_hci_cmd_create: opcode 2017 param_len 32
bt_buf_alloc:  +++ (1) buf 0x20002ff4 type 0 reserve 0
bt_hci_cmd_create: buf 0x20002ff4
bt_buf_extend: buf 0x20002ff4 len 3
bt_buf_extend: buf 0x20002ff4 len 32
bt_hci_cmd_send_sync: opcode 2017 len 35
bt_buf_addref: buf 0x20002ff4 (old) ref 1 type 0
hci_tx_kthread: Sending command 2017 buf 0x20002ff4 to driver
stm32wb_blehci_driversend: passing type CMD to mailbox driver
bt_bstm32wb_blehci_rxevt: received CMD_COMPLETE from mailbox (opcode: 0x2017, status: 0x0)
bt_receive: data 0x2003090d len 22
bt_buf_alloc:  +++ (2) buf 0x20002fdc type 1 reserve 1
bt_buf_extend: buf 0x20002fdc len 22
priority_rx_work: list 0x200027c0
priority_rx_work: buf 0x20002fdc type 1 len 22
bt_buf_consume: buf 0x20002fdc len 2
hci_cmd_complete: opcode 2017
bt_buf_consume: buf 0x20002fdc len 3
hci_cmd_complete: Unhandled opcode 2017
bt_buf_addref: buf 0x20002fdc (old) ref 1 type 1
bt_buf_release: buf 0x20002ff4 ref 2 type 0
bt_buf_release: Remaining references: 1
bt_buf_release: buf 0x20002fdc ref 2 type 1
bt_buf_release: Remaining references: 1
uf_release: buf 0x20002ff4 ref 2 type 0
bt_buf_release:  --- (1)  Buffer freed: 0x20002ff4
bt_buf_release: buf 0x20002fdc ref 1 type 1
bt_buf_release:  --- (0)  Buffer freed: 0x20002fdc
le_encrypt: enc_data 97ef6624f3ca9ea860367a0db47bd73a
le_encrypt: key 3c4fcf098815f7aba6d2ae2816157e2b plaintext c661c9615fa52936fc9a7913e3f1fa94
bt_hci_cmd_create: opcode 2017 param_len 32
bt_buf_alloc:  +++ (1) buf 0x20002fdc type 0 reserve 0
bt_hci_cmd_create: buf 0x20002fdc
bt_buf_extend: buf 0x20002fdc len 3
bt_buf_extend: buf 0x20002fdc len 32
bt_hci_cmd_send_sync: opcode 2017 len 35
bt_buf_addref: buf 0x20002fdc (old) ref 1 type 0
hci_tx_kthread: Sending command 2017 buf 0x20002fdc to driver
stm32wb_blehci_driversend: passing type CMD to mailbox driver
bt_bstm32wb_blehci_rxevt: received CMD_COMPLETE from mailbox (opcode: 0x2017, status: 0x0)
bt_receive: data 0x2003090d len 22
bt_buf_alloc:  +++ (2) buf 0x20002ff4 type 1 reserve 1
bt_buf_extend: buf 0x20002ff4 len 22
priority_rx_work: list 0x200027c0
priority_rx_work: buf 0x20002ff4 type 1 len 22
bt_buf_consume: buf 0x20002ff4 len 2
hci_cmd_complete: opcode 2017
bt_buf_consume: buf 0x20002ff4 len 3
hci_cmd_complete: Unhandled opcode 2017
bt_buf_addref: buf 0x20002ff4 (old) ref 1 type 1
bt_buf_release: buf 0x20002fdc ref 2 type 0
bt_buf_release: Remaining references: 1
bt_buf_release: buf 0x20002ff4 ref 2 type 1
bt_buf_release: Remaining references: 1
uf_release: buf 0x20002fdc ref 2 type 0
bt_buf_release:  --- (1)  Buffer freed: 0x20002fdc
bt_buf_release: buf 0x20002ff4 ref 1 type 1
bt_buf_release:  --- (0)  Buffer freed: 0x20002ff4
le_encrypt: enc_data 49dd2af17ce57a2892e69e307fc148b1
le_encrypt: key 3c4fcf098815f7aba6d2ae2816157e2b plaintext a68f20eb652481cd8302c29339dd8081
bt_hci_cmd_create: opcode 2017 param_len 32
bt_buf_alloc:  +++ (1) buf 0x20002ff4 type 0 reserve 0
bt_hci_cmd_create: buf 0x20002ff4
bt_buf_extend: buf 0x20002ff4 len 3
bt_buf_extend: buf 0x20002ff4 len 32
bt_hci_cmd_send_sync: opcode 2017 len 35
bt_buf_addref: buf 0x20002ff4 (old) ref 1 type 0
hci_tx_kthread: Sending command 2017 buf 0x20002ff4 to driver
stm32wb_blehci_driversend: passing type CMD to mailbox driver
bt_bstm32wb_blehci_rxevt: received CMD_COMPLETE from mailbox (opcode: 0x2017, status: 0x0)
bt_receive: data 0x2003090d len 22
bt_buf_alloc:  +++ (2) buf 0x20002fdc type 1 reserve 1
bt_buf_extend: buf 0x20002fdc len 22
priority_rx_work: list 0x200027c0
priority_rx_work: buf 0x20002fdc type 1 len 22
bt_buf_consume: buf 0x20002fdc len 2
hci_cmd_complete: opcode 2017
bt_buf_consume: buf 0x20002fdc len 3
hci_cmd_complete: Unhandled opcode 2017
bt_buf_addref: buf 0x20002fdc (old) ref 1 type 1
bt_buf_release: buf 0x20002ff4 ref 2 type 0
bt_buf_release: Remaining references: 1
bt_buf_release: buf 0x20002fdc ref 2 type 1
bt_buf_release: Remaining references: 1
uf_release: buf 0x20002ff4 ref 2 type 0
bt_buf_release:  --- (1)  Buffer freed: 0x20002ff4
bt_buf_release: buf 0x20002fdc ref 1 type 1
bt_buf_release:  --- (0)  Buffer freed: 0x20002fdc
le_encrypt: enc_data 2b00ee4d7bb3904ddcc508afbf113dc9
le_encrypt: key 3c4fcf098815f7aba6d2ae2816157e2b plaintext e59fb4d98f123e9cad6d3645e2e34cc4
bt_hci_cmd_create: opcode 2017 param_len 32
bt_buf_alloc:  +++ (1) buf 0x20002fdc type 0 reserve 0
bt_hci_cmd_create: buf 0x20002fdc
bt_buf_extend: buf 0x20002fdc len 3
bt_buf_extend: buf 0x20002fdc len 32
bt_hci_cmd_send_sync: opcode 2017 len 35
bt_buf_addref: buf 0x20002fdc (old) ref 1 type 0
hci_tx_kthread: Sending command 2017 buf 0x20002fdc to driver
stm32wb_blehci_driversend: passing type CMD to mailbox driver
bt_bstm32wb_blehci_rxevt: received CMD_COMPLETE from mailbox (opcode: 0x2017, status: 0x0)
bt_receive: data 0x2003090d len 22
bt_buf_alloc:  +++ (2) buf 0x20002ff4 type 1 reserve 1
bt_buf_extend: buf 0x20002ff4 len 22
priority_rx_work: list 0x200027c0
priority_rx_work: buf 0x20002ff4 type 1 len 22
bt_buf_consume: buf 0x20002ff4 len 2
hci_cmd_complete: opcode 2017
bt_buf_consume: buf 0x20002ff4 len 3
hci_cmd_complete: Unhandled opcode 2017
bt_buf_addref: buf 0x20002ff4 (old) ref 1 type 1
bt_buf_release: buf 0x20002fdc ref 2 type 0
bt_buf_release: Remaining references: 1
bt_buf_release: buf 0x20002ff4 ref 2 type 1
bt_buf_release: Remaining references: 1
uf_release: buf 0x20002fdc ref 2 type 0
bt_buf_release:  --- (1)  Buffer freed: 0x20002fdc
bt_buf_release: buf 0x20002ff4 ref 1 type 1
bt_buf_release:  --- (0)  Buffer freed: 0x20002ff4
le_encrypt: enc_data fe3c3679177449fc929d3b7ebfbef051
aes_test: Test aes-cmac64: Success
bt_l2cap_chan_register: CID 0x0005
nsh> 
```
</details>