### PR TITLE
driver/power:add ioctl cmd for voltage info and protocol and add update event mask

### DIFF
--- a/drivers/power/battery_charger.c
+++ b/drivers/power/battery_charger.c
@@ -171,6 +171,7 @@ static int bat_charger_open(FAR struct file *filep)
   nxsem_init(&priv->lock, 0, 1);
   nxsem_init(&priv->wait, 0, 0);
   nxsem_set_protocol(&priv->wait, SEM_PRIO_NONE);
+  priv->mask = dev->mask;
   list_add_tail(&dev->flist, &priv->node);
   nxsem_post(&dev->batsem);
   filep->f_priv = priv;
@@ -472,6 +473,7 @@ int battery_charger_changed(FAR struct battery_charger_dev_s *dev,
       return ret;
     }
 
+  dev->mask |= mask;
   list_for_every_entry(&dev->flist, priv,
                        struct battery_charger_priv_s, node)
     {

--- a/drivers/power/battery_charger.c
+++ b/drivers/power/battery_charger.c
@@ -388,6 +388,16 @@ static int bat_charger_ioctl(FAR struct file *filep, int cmd,
         }
         break;
 
+      case BATIOC_GET_PROTOCOL:
+        {
+          FAR int *ptr = (FAR int *)(uintptr_t)arg;
+          if (ptr)
+            {
+              ret = dev->ops->get_protocol(dev, ptr);
+            }
+        }
+        break;
+
       default:
         _err("ERROR: Unrecognized cmd: %d\n", cmd);
         ret = -ENOTTY;

--- a/drivers/power/battery_gauge.c
+++ b/drivers/power/battery_gauge.c
@@ -173,6 +173,7 @@ static int bat_gauge_open(FAR struct file *filep)
   nxsem_init(&priv->lock, 0, 1);
   nxsem_init(&priv->wait, 0, 0);
   nxsem_set_protocol(&priv->wait, SEM_PRIO_NONE);
+  priv->mask = dev->mask;
   list_add_tail(&dev->flist, &priv->node);
   nxsem_post(&dev->batsem);
   filep->f_priv = priv;
@@ -440,6 +441,7 @@ int battery_gauge_changed(FAR struct battery_gauge_dev_s *dev,
       return ret;
     }
 
+  dev->mask |= mask;
   list_for_every_entry(&dev->flist, priv,
                        struct battery_gauge_priv_s, node)
     {

--- a/drivers/power/battery_monitor.c
+++ b/drivers/power/battery_monitor.c
@@ -172,6 +172,7 @@ static int bat_monitor_open(FAR struct file *filep)
   nxsem_init(&priv->lock, 0, 1);
   nxsem_init(&priv->wait, 0, 0);
   nxsem_set_protocol(&priv->wait, SEM_PRIO_NONE);
+  priv->mask = dev->mask;
   list_add_tail(&dev->flist, &priv->node);
   nxsem_post(&dev->batsem);
   filep->f_priv = priv;
@@ -515,6 +516,7 @@ int battery_monitor_changed(FAR struct battery_monitor_dev_s *dev,
       return ret;
     }
 
+  dev->mask |= mask;
   list_for_every_entry(&dev->flist, priv,
                        struct battery_monitor_priv_s, node)
     {

--- a/include/nuttx/power/battery_charger.h
+++ b/include/nuttx/power/battery_charger.h
@@ -144,6 +144,8 @@ struct battery_charger_dev_s
 
   struct list_node flist;
 
+  uint32_t mask;  /* record drive support features */
+
   /* Data fields specific to the lower-half driver may follow */
 };
 

--- a/include/nuttx/power/battery_charger.h
+++ b/include/nuttx/power/battery_charger.h
@@ -125,7 +125,11 @@ struct battery_charger_operations_s
 
   /* Get the actual output voltage for charging */
 
-  int (*get_voltage)(struct battery_charger_dev_s *dev, int *value);
+  int (*get_voltage)(struct battery_charger_dev_s *dev, FAR int *value);
+
+  /* Get charge protocol */
+
+  int (*get_protocol)(struct battery_charger_dev_s *dev, FAR int *value);
 };
 
 /* This structure defines the battery driver state structure */

--- a/include/nuttx/power/battery_gauge.h
+++ b/include/nuttx/power/battery_gauge.h
@@ -131,6 +131,8 @@ struct battery_gauge_dev_s
 
   struct list_node flist;
 
+  uint32_t mask;  /* record drive support features */
+
   /* Data fields specific to the lower-half driver may follow */
 };
 

--- a/include/nuttx/power/battery_ioctl.h
+++ b/include/nuttx/power/battery_ioctl.h
@@ -56,6 +56,7 @@
 #define BATIOC_COULOMBS      _BATIOC(0x0010)
 #define BATIOC_CHIPID        _BATIOC(0x0011)
 #define BATIOC_GET_VOLTAGE   _BATIOC(0x0012)
+#define BATIOC_GET_PROTOCOL  _BATIOC(0x0013)
 
 /* Special input values for BATIOC_INPUT_CURRENT that may optionally
  * be supported by lower-half driver:
@@ -108,6 +109,14 @@ enum battery_health_e
   BATTERY_HEALTH_WD_TMR_EXP,    /* Battery WatchDog Timer Expired */
   BATTERY_HEALTH_SAFE_TMR_EXP,  /* Battery Safety Timer Expired */
   BATTERY_HEALTH_DISCONNECTED   /* Battery is not connected */
+};
+
+/* battery charge protocol type */
+
+enum battery_protocol_e
+{
+  BATTERY_PROTOCOL_QC3P0 = 1 << 0,      /* Battery charge protocol of adapter is QC 3.0 */
+  BATTERY_PROTOCOL_TX_XIAOMI = 1 << 1,  /* Battery charge protocol of TX is xiaomi standard */
 };
 
 /* Battery operation message */

--- a/include/nuttx/power/battery_monitor.h
+++ b/include/nuttx/power/battery_monitor.h
@@ -305,6 +305,8 @@ struct battery_monitor_dev_s
 
   struct list_node flist;
 
+  uint32_t mask;  /* record drive support features */
+
   /* Data fields specific to the lower-half driver may follow */
 };
 


### PR DESCRIPTION
## Summary
driver/power:
get voltage info by cmd BATIOC_VOLTAGE_INFO.
get charger protocol by cmd BATIOC_GET_PROTOCOL.
add mask to record power device update event.

## Impact
N/A
## Testing
Vela Ci
