### PR TITLE
driver/sensor: add calibrate interface for sensor driver.

### DIFF
--- a/drivers/sensors/sensor.c
+++ b/drivers/sensors/sensor.c
@@ -470,6 +470,18 @@ static int sensor_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
         }
         break;
 
+      case SNIOC_CALIBRATE:
+        {
+          if (lower->ops->calibrate == NULL)
+            {
+              ret = -ENOTSUP;
+              break;
+            }
+
+          ret = lower->ops->calibrate(lower, arg);
+        }
+        break;
+
       case SNIOC_GET_NEVENTBUF:
         {
           *val = lower->buffer_number + lower->batch_number;

--- a/include/nuttx/sensors/ioctl.h
+++ b/include/nuttx/sensors/ioctl.h
@@ -305,4 +305,14 @@
 
 #define SNIOC_SET_CALIBVALUE       _SNIOC(0x0087)
 
+/* Command:      SNIOC_CALIBRATE
+ * Description:  Trigger calibration and obtain calibration value.
+ * Argument:     A argument of calibration value for sensor.
+ * Note:         If getting calibvalue is failed, return errno, otherwise,
+ *               return OK.
+ *               This cmd is handled by sensor_ops_s::get_calibvalue.
+ */
+
+#define SNIOC_CALIBRATE            _SNIOC(0x0088)
+
 #endif /* __INCLUDE_NUTTX_SENSORS_IOCTL_H */

--- a/include/nuttx/sensors/sensor.h
+++ b/include/nuttx/sensors/sensor.h
@@ -748,6 +748,30 @@ struct sensor_ops_s
   CODE int (*set_calibvalue)(FAR struct sensor_lowerhalf_s *lower,
                              unsigned long arg);
 
+/****************************************************************************
+   * Name: calibrate
+   *
+   * This operation can trigger the calibration operation, and if the
+   * calibration operation is short-lived, the calibration result value can
+   * be obtained at the same time, the calibration value to be written in or
+   * the non-volatile memory of the sensor or dedicated registers. When the
+   * upper-level application calibration is completed, the current
+   * calibration value of the sensor needs to be obtained and backed up,
+   * so that the last calibration value can be directly obtained after
+   * power-on.
+   *
+   * Input Parameters:
+   *   lower      - The instance of lower half sensor driver.
+   *   arg        - The parameters associated with calibration value.
+   *
+   * Returned Value:
+   *   Zero (OK) on success; a negated errno value on failure.
+   *
+   **************************************************************************/
+
+  CODE int (*calibrate)(FAR struct sensor_lowerhalf_s *lower,
+                        unsigned long arg);
+
   /**************************************************************************
    * Name: control
    *


### PR DESCRIPTION

## Summary
driver/sensor: add calibrate interface for sensor driver.

Add standard sensor interface for calibrate, can trigger
calibration and obtain calibration value.

Signed-off-by: Jiuzhu Dong <dongjiuzhu1@xiaomi.com>
## Impact
add calibrate interface
## Testing
Vela CI
