### PR TITLE
stm32_bh1750.h stm32_bmp180.c: Fix mistakes in comments

### DIFF
--- a/boards/arm/stm32/common/include/stm32_bh1750.h
+++ b/boards/arm/stm32/common/include/stm32_bh1750.h
@@ -59,7 +59,7 @@ extern "C"
  * Name: board_bh1750_initialize
  *
  * Description:
- *   Initialize and register the MPL115A Pressure Sensor driver.
+ *   Initialize and register the BH1750FVI Ambient Light driver.
  *
  * Input Parameters:
  *   devno - The device number, used to build the device path as /dev/lightN

--- a/boards/arm/stm32l4/nucleo-l476rg/src/stm32_bmp180.c
+++ b/boards/arm/stm32l4/nucleo-l476rg/src/stm32_bmp180.c
@@ -44,7 +44,7 @@
  * Name: stm32_bmp180initialize
  *
  * Description:
- *   Initialize and register the MPL115A Pressure Sensor driver.
+ *   Initialize and register the BMP180 Pressure Sensor driver.
  *
  * Input Parameters:
  *   devpath - The full path to the driver to register. E.g., "/dev/press0"


### PR DESCRIPTION
## Summary
Fix mistakes in comments
boards/arm/stm32/common/include/stm32_bh1750.h
boards/arm/stm32l4/nucleo-l476rg/src/stm32_bmp180.c
## Impact
none
## Testing

