### PR TITLE
sched/Makefile: move task_reparent.c to appropriate Makefile

### DIFF
--- a/sched/group/Make.defs
+++ b/sched/group/Make.defs
@@ -23,7 +23,6 @@ CSRCS += group_setupstreams.c group_setupidlefiles.c group_setuptaskfiles.c
 CSRCS += group_foreachchild.c group_killchildren.c group_signal.c
 
 ifeq ($(CONFIG_SCHED_HAVE_PARENT),y)
-CSRCS += task_reparent.c
 ifeq ($(CONFIG_SCHED_CHILD_STATUS),y)
 CSRCS += group_childstatus.c
 endif

--- a/sched/task/Make.defs
+++ b/sched/task/Make.defs
@@ -26,7 +26,7 @@ CSRCS += task_cancelpt.c task_terminate.c task_gettid.c exit.c
 CSRCS += task_tls_alloc.c
 
 ifeq ($(CONFIG_SCHED_HAVE_PARENT),y)
-CSRCS += task_getppid.c
+CSRCS += task_getppid.c task_reparent.c
 endif
 
 ifeq ($(CONFIG_ARCH_HAVE_VFORK),y)


### PR DESCRIPTION
## Summary

sched/Makefile: move task_reparent.c to appropriate Makefile

## Impact

N/A 

## Testing

ci check