### PR TITLE
include: Add IPTR/IOBJ definitions.

### DIFF
--- a/include/nuttx/compiler.h
+++ b/include/nuttx/compiler.h
@@ -772,6 +772,8 @@
 #  define NEAR
 #  define DSEG
 #  define CODE
+#  define IOBJ
+#  define IPTR
 
 #  undef  CONFIG_SMALL_MEMORY
 #  undef  CONFIG_LONG_IS_NOT_INT


### PR DESCRIPTION
In case of other compiler, these deinitions are missed.

Signed-off-by: xiangdong6 <xiangdong6@xiaomi.com>

## Summary

## Impact

## Testing

