### PR TITLE
add heapcheck(memcheck) flag

### DIFF
--- a/include/nuttx/sched.h
+++ b/include/nuttx/sched.h
@@ -107,7 +107,7 @@
 #define TCB_FLAG_SYSCALL           (1 << 10)                     /* Bit 9: In a system call */
 #define TCB_FLAG_EXIT_PROCESSING   (1 << 11)                     /* Bit 10: Exitting */
 #define TCB_FLAG_FREE_STACK        (1 << 12)                     /* Bit 12: Free stack after exit */
-#define TCB_FLAG_MEM_CHECK         (1 << 13)                     /* Bit 13: Memory check */
+#define TCB_FLAG_HEAPCHECK         (1 << 13)                     /* Bit 13: Heap check */
                                                                  /* Bits 14-15: Available */
 
 /* Values for struct task_group tg_flags */

--- a/sched/irq/irq_dispatch.c
+++ b/sched/irq/irq_dispatch.c
@@ -175,8 +175,8 @@ void irq_dispatch(int irq, FAR void *context)
 #endif
 
 #ifdef CONFIG_DEBUG_MM
-  if ((g_running_tasks[this_cpu()]->flags & TCB_FLAG_MEM_CHECK) || \
-       (this_task()->flags & TCB_FLAG_MEM_CHECK))
+  if ((g_running_tasks[this_cpu()]->flags & TCB_FLAG_HEAPCHECK) || \
+       (this_task()->flags & TCB_FLAG_HEAPCHECK))
     {
       kmm_checkcorruption();
     }


### PR DESCRIPTION
## Summary
### What
1. replaced  `TCB_FLAG_MEM_CHECK` by `TCB_FLAG_HEAPCHECK`
2. add heapcheck flag

### Why

> kmm_checkcorruption is used to check whether memory heap is normal. 

1. Comparing with flag name `TCB_FLAG_MEM_CHECK`, `TCB_FLAG_HEAPCHECK` should be more suitable in such condition.
2. A dynamic flag control would efficiently debug using  `kmm_checkcorruption()`.

### How
`kmm_checkcorruption()` with flexible flag control for developer to choose for each tcb.

1 for open heapcheck, 0 for close
 `echo 1 > /proc/xxx/heapcheck`
 `echo 0 > /proc/xxx/heapcheck`


## Impact
Using of `TCB_FLAG_MEM_CHECK` may need to be replaced with `TCB_FLAG_HEAPCHECK`.

## Testing
Vela CI