### PR TITLE
include: Fixed null struct may caused build issue.

### DIFF
--- a/include/nuttx/net/netdev.h
+++ b/include/nuttx/net/netdev.h
@@ -258,21 +258,25 @@ struct net_driver_s
 
   /* Link layer address */
 
+#if defined(CONFIG_NET_ETHERNET) || defined(CONFIG_NET_6LOWPAN) || \
+    defined(CONFIG_NET_BLUETOOTH) || defined(CONFIG_NET_IEEE802154) || \
+    defined(CONFIG_NET_TUN)
   union
   {
-#ifdef CONFIG_NET_ETHERNET
+# if defined(CONFIG_NET_ETHERNET) || defined(CONFIG_NET_TUN)
     /* Ethernet device identity */
 
     struct ether_addr ether;    /* Device Ethernet MAC address */
-#endif
+# endif
 
-#if defined(CONFIG_NET_6LOWPAN) || defined(CONFIG_NET_BLUETOOTH) || \
+# if defined(CONFIG_NET_6LOWPAN) || defined(CONFIG_NET_BLUETOOTH) || \
     defined(CONFIG_NET_IEEE802154)
   /* The address assigned to an IEEE 802.15.4 or generic packet radio. */
 
     struct netdev_varaddr_s radio;
-#endif
+# endif
   } d_mac;
+#endif
 
   /* Network identity */
 

--- a/include/nuttx/spinlock.h
+++ b/include/nuttx/spinlock.h
@@ -33,9 +33,7 @@
 #include <nuttx/irq.h>
 
 #ifndef CONFIG_SPINLOCK
-typedef struct
-{
-} spinlock_t;
+typedef uint8_t spinlock_t;
 #else
 
 /* The architecture specific spinlock.h header file must also provide the


### PR DESCRIPTION
## Summary

netdev: fix visual studio Compiler Error C2016

```
D:\code\incubator-nuttx\include\nuttx/net/netdev.h(275,3):
  error C2016: C requires that a struct or union has at least one member
  [D:\code\incubator-nuttx\vs20222\boards\board.vcxproj]
```

Compiler error C2016: C requires that a struct or union has at least one member

Reference:
https://docs.microsoft.com/en-us/cpp/error-messages/compiler-errors-1/compiler-errors-c2001-through-c2099?view=msvc-170

Signed-off-by: xiangdong6 <xiangdong6@xiaomi.com>
Signed-off-by: chao.an <anchao@xiaomi.com>

## Impact

N/A

## Testing

visual studio 2022 + cmake