### PR TITLE
make sure conn's domain is match with addr's family

### DIFF
--- a/net/inet/inet_sockif.c
+++ b/net/inet/inet_sockif.c
@@ -722,15 +722,23 @@ static int inet_connect(FAR struct socket *psock,
 #if defined(CONFIG_NET_TCP) && defined(NET_TCP_HAVE_STACK)
       case SOCK_STREAM:
         {
-          FAR struct socket_conn_s *conn = psock->s_conn;
+          FAR struct tcp_conn_s *conn = psock->s_conn;
 
           /* Verify that the socket is not already connected */
 
-          if (_SS_ISCONNECTED(conn->s_flags))
+          if (_SS_ISCONNECTED(conn->sconn.s_flags))
             {
               return -EISCONN;
             }
 
+#if defined(CONFIG_NET_IPv4) && defined(CONFIG_NET_IPv6)
+          if (conn->domain != addr->sa_family)
+            {
+              nerr("conn's domain must be the same as addr's family!\n");
+              return -EPROTOTYPE;
+            }
+
+#endif
           /* It's not ... Connect the TCP/IP socket */
 
           return psock_tcp_connect(psock, addr);
@@ -756,6 +764,14 @@ static int inet_connect(FAR struct socket *psock,
           /* Perform the connect/disconnect operation */
 
           conn = (FAR struct udp_conn_s *)psock->s_conn;
+#if defined(CONFIG_NET_IPv4) && defined(CONFIG_NET_IPv6)
+          if (conn->domain != addr->sa_family)
+            {
+              nerr("conn's domain must be the same as addr's family!\n");
+              return -EPROTOTYPE;
+            }
+
+#endif
           ret  = udp_connect(conn, addr);
           if (ret < 0 || addr == NULL)
             {


### PR DESCRIPTION
## Summary
add protection in the case when conn's domain isn't match with addr's family. 
When you create a IPv4 socket and connect to an IPv6 address,
the original code logic will use the input IPv6 address as a IPv4 address
only because the socket's domain is created in AF_INET!
This patch is to avoid this case, in which it refuses the connection and 
return EPROTOTYPE（error protocol type）
## Impact
When you use nuttx's socket in a wrong way, it will refuse this wrong operation
## Testing
Testing cases has been done with nuttx sim program
for example
ping www.baidu.com（UDP packet, DNS pkts）
wget http://www.baidu.com（TCP packet, HTTP pkts）