### PR TITLE
Multiple stm32wl5jc flash usage improvements

### DIFF
--- a/boards/arm/stm32wl5/nucleo-wl55jc/Kconfig
+++ b/boards/arm/stm32wl5/nucleo-wl55jc/Kconfig
@@ -46,6 +46,19 @@ comment "FLASH partitioning and mounting requires !DISABLE_MOUNTPOINT"
 
 if ARCH_BOARD_FLASH_MOUNT
 
+config ARCH_BOARD_FLASH_BL_PROG_SIZE
+	int "Size reserved for bootloader program code"
+	default 0
+	---help---
+		How much memory to reserve for bootloader program code.
+		If you are using bootloader in your application, specify
+		max size of bootloader partition. This memory will be
+		reserved at the beginning of flash, and CPU1 progmem will
+		be right after bootloader.
+
+		If you don't use bootloader and just want to run program
+		directly after reset, set this to 0.
+
 config ARCH_BOARD_FLASH_CPU1_PROG_SIZE
 	int "Size reserved for CPU1 program code"
 	default 127

--- a/boards/arm/stm32wl5/nucleo-wl55jc/src/stm32_appinit.c
+++ b/boards/arm/stm32wl5/nucleo-wl55jc/src/stm32_appinit.c
@@ -48,6 +48,12 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
+/* Define proc mountpoint in case procfs is used but nsh is not */
+
+#ifndef CONFIG_NSH_PROC_MOUNTPOINT
+#define CONFIG_NSH_PROC_MOUNTPOINT "/proc"
+#endif
+
 /****************************************************************************
  * Public Functions
  ****************************************************************************/

--- a/boards/arm/stm32wl5/nucleo-wl55jc/src/stm32_appinit.c
+++ b/boards/arm/stm32wl5/nucleo-wl55jc/src/stm32_appinit.c
@@ -116,7 +116,7 @@ int board_app_initialize(uintptr_t arg)
     }
 #endif
 
-#if defined(CONFIG_ARCH_BOARD_ENABLE_FLASH_MOUNT)
+#if defined(CONFIG_ARCH_BOARD_FLASH_MOUNT)
   /* Register partition table for on-board FLASH memory */
 
   ret = stm32wl5_flash_init();

--- a/boards/arm/stm32wl5/nucleo-wl55jc/src/stm32_flash.c
+++ b/boards/arm/stm32wl5/nucleo-wl55jc/src/stm32_flash.c
@@ -39,6 +39,32 @@
  * Pre-Processor Definitions
  ****************************************************************************/
 
+/* Define default values to silent compiler warning about undefined macro */
+
+#ifndef CONFIG_ARCH_BOARD_FLASH_CPU1_PROG_SIZE
+#define CONFIG_ARCH_BOARD_FLASH_CPU1_PROG_SIZE 0
+#endif
+
+#ifndef CONFIG_ARCH_BOARD_FLASH_CPU2_PROG_SIZE
+#define CONFIG_ARCH_BOARD_FLASH_CPU2_PROG_SIZE 0
+#endif
+
+#ifndef CONFIG_ARCH_BOARD_FLASH_PART1_SIZE
+#define CONFIG_ARCH_BOARD_FLASH_PART1_SIZE 0
+#endif
+
+#ifndef CONFIG_ARCH_BOARD_FLASH_PART2_SIZE
+#define CONFIG_ARCH_BOARD_FLASH_PART2_SIZE 0
+#endif
+
+#ifndef CONFIG_ARCH_BOARD_FLASH_PART3_SIZE
+#define CONFIG_ARCH_BOARD_FLASH_PART3_SIZE 0
+#endif
+
+#ifndef CONFIG_ARCH_BOARD_FLASH_PART4_SIZE
+#define CONFIG_ARCH_BOARD_FLASH_PART4_SIZE 0
+#endif
+
 #if (CONFIG_ARCH_BOARD_FLASH_CPU1_PROG_SIZE + \
      CONFIG_ARCH_BOARD_FLASH_CPU2_PROG_SIZE + \
      CONFIG_ARCH_BOARD_FLASH_PART1_SIZE + \
@@ -140,6 +166,12 @@ int stm32wl5_flash_init(void)
   int ret;
   int i;
 
+  /* Silent compiler warning in case these filesystems are not enabled */
+
+  UNUSED(nxf_minor);
+  UNUSED(smart_minor);
+  UNUSED(mtdconfig_minor);
+
   /* create an instance of the stm32 flash program memory device driver */
 
   if ((mtd = progmem_initialize()) == NULL)
@@ -164,6 +196,12 @@ int stm32wl5_flash_init(void)
       const char *name;
       const char *mnt;
       const char *fs;
+
+      /* Silent compiler warning in case where only non mountable
+       * partitions are defined.
+       */
+
+      UNUSED(mnt);
 
       size = part_table[i].size;
       name = part_table[i].name;

--- a/boards/arm/stm32wl5/nucleo-wl55jc/src/stm32_flash.c
+++ b/boards/arm/stm32wl5/nucleo-wl55jc/src/stm32_flash.c
@@ -109,10 +109,12 @@ static const struct part_table part_table[] =
   },
 
 #if CONFIG_ARCH_BOARD_FLASH_CPU2_PROG_SIZE > 0
+  {
     .size   = CONFIG_ARCH_BOARD_FLASH_CPU2_PROG_SIZE,
     .name   = "cpu2-progmem",
     .mnt    = NULL,
     .fs     = "rawfs"
+  },
 #endif
 
   {

--- a/boards/arm/stm32wl5/nucleo-wl55jc/src/stm32_flash.c
+++ b/boards/arm/stm32wl5/nucleo-wl55jc/src/stm32_flash.c
@@ -41,6 +41,10 @@
 
 /* Define default values to silent compiler warning about undefined macro */
 
+#ifndef CONFIG_ARCH_BOARD_FLASH_BL_PROG_SIZE
+#define CONFIG_ARCH_BOARD_FLASH_BL_PROG_SIZE 0
+#endif
+
 #ifndef CONFIG_ARCH_BOARD_FLASH_CPU1_PROG_SIZE
 #define CONFIG_ARCH_BOARD_FLASH_CPU1_PROG_SIZE 0
 #endif
@@ -65,7 +69,8 @@
 #define CONFIG_ARCH_BOARD_FLASH_PART4_SIZE 0
 #endif
 
-#if (CONFIG_ARCH_BOARD_FLASH_CPU1_PROG_SIZE + \
+#if (CONFIG_ARCH_BOARD_FLASH_BL_PROG_SIZE + \
+     CONFIG_ARCH_BOARD_FLASH_CPU1_PROG_SIZE + \
      CONFIG_ARCH_BOARD_FLASH_CPU2_PROG_SIZE + \
      CONFIG_ARCH_BOARD_FLASH_PART1_SIZE + \
      CONFIG_ARCH_BOARD_FLASH_PART2_SIZE + \
@@ -74,7 +79,8 @@
 #   error "Sum of all flash pertitions cannot be bigger than 128"
 #endif
 
-#if (CONFIG_ARCH_BOARD_FLASH_CPU1_PROG_SIZE + \
+#if (CONFIG_ARCH_BOARD_FLASH_BL_PROG_SIZE + \
+     CONFIG_ARCH_BOARD_FLASH_CPU1_PROG_SIZE + \
      CONFIG_ARCH_BOARD_FLASH_CPU2_PROG_SIZE + \
      CONFIG_ARCH_BOARD_FLASH_PART1_SIZE + \
      CONFIG_ARCH_BOARD_FLASH_PART2_SIZE + \
@@ -101,6 +107,15 @@ struct part_table
 
 static const struct part_table part_table[] =
 {
+#if CONFIG_ARCH_BOARD_FLASH_BL_PROG_SIZE > 0
+  {
+    .size   = CONFIG_ARCH_BOARD_FLASH_BL_PROG_SIZE,
+    .name   = "bl-progmem",
+    .mnt    = NULL,
+    .fs     = "rawfs"
+  },
+#endif
+
   {
     .size   = CONFIG_ARCH_BOARD_FLASH_CPU1_PROG_SIZE,
     .name   = "cpu1-progmem",


### PR DESCRIPTION
## Summary
Multiple improvements to flash usage on stm32wl5jc.

Also adds support to define bootloader area in mtd partition table.
For more info please check commit messages.

## Impact
Only one board - stm32wl5jc, by default bootloader is not specified.

## Testing
Compilation and shell validation in runtime.