### PR TITLE
arm/hostfs: fix build warning

### DIFF
--- a/arch/arm/src/common/arm_hostfs.c
+++ b/arch/arm/src/common/arm_hostfs.c
@@ -53,7 +53,7 @@
 static long host_call(unsigned int nbr, void *parm, size_t size)
 {
 #ifdef CONFIG_ARM_SEMIHOSTING_HOSTFS_CACHE_COHERENCE
-  up_clean_dcache(parm, parm + size);
+  up_clean_dcache((uintptr_t)parm, (uintptr_t)parm + size);
 #endif
 
   long ret = smh_call(nbr, parm);
@@ -124,7 +124,7 @@ int host_open(const char *pathname, int flags, int mode)
   };
 
 #ifdef CONFIG_ARM_SEMIHOSTING_HOSTFS_CACHE_COHERENCE
-  up_clean_dcache(pathname, pathname + open.len + 1);
+  up_clean_dcache((uintptr_t)pathname, (uintptr_t)pathname + open.len + 1);
 #endif
 
   return host_call(HOST_OPEN, &open, sizeof(open));
@@ -153,7 +153,7 @@ ssize_t host_read(int fd, void *buf, size_t count)
   ssize_t ret;
 
 #ifdef CONFIG_ARM_SEMIHOSTING_HOSTFS_CACHE_COHERENCE
-  up_invalidate_dcache(buf, buf + count);
+  up_invalidate_dcache((uintptr_t)buf, (uintptr_t)buf + count);
 #endif
 
   ret = host_call(HOST_READ, &read, sizeof(read));
@@ -178,7 +178,7 @@ ssize_t host_write(int fd, const void *buf, size_t count)
   ssize_t ret;
 
 #ifdef CONFIG_ARM_SEMIHOSTING_HOSTFS_CACHE_COHERENCE
-  up_clean_dcache(buf, buf + count);
+  up_clean_dcache((uintptr_t)buf, (uintptr_t)buf + count);
 #endif
 
   ret = host_call(HOST_WRITE, &write, sizeof(write));
@@ -290,7 +290,7 @@ int host_unlink(const char *pathname)
   };
 
 #ifdef CONFIG_ARM_SEMIHOSTING_HOSTFS_CACHE_COHERENCE
-  up_clean_dcache(pathname, pathname +
+  up_clean_dcache((uintptr_t)pathname, (uintptr_t)pathname +
                   remove.pathname_len + 1);
 #endif
 
@@ -324,8 +324,10 @@ int host_rename(const char *oldpath, const char *newpath)
   };
 
 #ifdef CONFIG_ARM_SEMIHOSTING_HOSTFS_CACHE_COHERENCE
-  up_clean_dcache(oldpath, oldpath + rename.oldpath_len + 1);
-  up_clean_dcache(newpath, newpath + rename.newpath_len + 1);
+  up_clean_dcache((uintptr_t)oldpath,
+                  (uintptr_t)oldpath + rename.oldpath_len + 1);
+  up_clean_dcache((uintptr_t)newpath,
+                  (uintptr_t)newpath + rename.newpath_len + 1);
 #endif
 
   return host_call(HOST_RENAME, &rename, sizeof(rename));


### PR DESCRIPTION
## Summary

arm/hostfs: fix build warning

```
arch/arm/src/common/arm_hostfs.c: In function 'host_read':
arch/arm/src/common/arm_hostfs.c:156:24:
  warning: passing argument 1 of 'up_invalidate_dcache' makes integer from pointer without a cast [-Wint-conversion]
  156 |   up_invalidate_dcache(buf, buf + count);
      |                        ^~~
      |                        |
      |                        void *
In file included from arch/arm/src/common/arm_hostfs.c:26:
include/nuttx/cache.h:261:37: note: expected 'uintptr_t' {aka 'unsigned int'} but argument is of type 'void *'
  261 | void up_invalidate_dcache(uintptr_t start, uintptr_t end);
      |                           ~~~~~~~~~~^~~~~
```

Signed-off-by: chao.an <anchao@xiaomi.com>


## Impact

N/A

## Testing

ci-check