### PR TITLE
arm/allocateheap: fix multiple definition of 'up_allocate_heap'

### DIFF
--- a/arch/arm/src/common/arm_allocateheap.c
+++ b/arch/arm/src/common/arm_allocateheap.c
@@ -105,7 +105,7 @@
 #ifdef CONFIG_BUILD_KERNEL
 void up_allocate_kheap(void **heap_start, size_t *heap_size)
 #else
-void up_allocate_heap(void **heap_start, size_t *heap_size)
+void weak_function up_allocate_heap(void **heap_start, size_t *heap_size)
 #endif
 {
 #if defined(CONFIG_BUILD_PROTECTED) && defined(CONFIG_MM_KERNEL_HEAP)


### PR DESCRIPTION

## Summary

arm/allocateheap: fix multiple definition of 'up_allocate_heap'

```
ld: arch/libarch.a(cxd56_allocateheap.c.obj): in function `up_allocate_heap':
arch/arm/src/cxd56xx/cxd56_allocateheap.c:113: multiple definition of `up_allocate_heap'; arch/libarch.a(arm_allocateheap.c.obj):
                                               arch/arm/src/common/arm_allocateheap.c:110: first defined here
```

Signed-off-by: chao.an <anchao@xiaomi.com>

## Impact

N/A

## Testing

ci-check
