### PR TITLE
[TCP] Close RAM usage optimization

### DIFF
--- a/net/tcp/tcp.h
+++ b/net/tcp/tcp.h
@@ -304,11 +304,6 @@ struct tcp_conn_s
   FAR struct devif_callback_s *connevents;
   FAR struct devif_callback_s *connevents_tail;
 
-  /* Reference to TCP close callback instance */
-
-  FAR struct devif_callback_s *clscb;
-  struct work_s                clswork;
-
 #if defined(CONFIG_NET_TCP_WRITE_BUFFERS)
   /* Callback instance for TCP send() */
 


### PR DESCRIPTION
## Summary
Addresses some of the impact described in #6721 
Which optimizes the following PR #6398

## Impact
Reduces static ram usage by ~ 200 bytes
```
peter@NXL04520:~/nuttx/nuttx$ arm-none-eabi-size nuttx
   text    data     bss     dec     hex filename
 143800     784   24080  168664   292d8 nuttx
peter@NXL04520:~/nuttx/nuttx$ arm-none-eabi-size nuttx
   text    data     bss     dec     hex filename
 143768     784   23856  168408   291d8 nuttx
```

## Testing
I've briefly tested telnet and ipef, but I would like to have a proper review and test for this.

