### PR TITLE
stm32wb/mbox: fixing TX buffer queue

### DIFF
--- a/arch/arm/src/stm32wb/stm32wb_mbox.c
+++ b/arch/arm/src/stm32wb/stm32wb_mbox.c
@@ -512,13 +512,13 @@ static bool stm32wb_mbox_txnext(struct stm32wb_mbox_channel_s *chan)
 
       if (chan->ch_num == STM32WB_MBOX_BLEACL_CHANNEL)
         {
-          memcpy(chan->msg_buf, &pkt_buf->acl_hdr,
-                 pkt_buf->acl_hdr.len);
+          memcpy(&chan->msg_buf->acl_hdr, &pkt_buf->acl_hdr,
+                 sizeof(pkt_buf->acl_hdr) + pkt_buf->acl_hdr.len);
         }
       else
         {
-          memcpy(chan->msg_buf, &pkt_buf->cmd_hdr,
-                 pkt_buf->cmd_hdr.param_len);
+          memcpy(&chan->msg_buf->cmd_hdr, &pkt_buf->cmd_hdr,
+                 sizeof(pkt_buf->cmd_hdr) + pkt_buf->cmd_hdr.param_len);
         }
 
       /* Start transmission */


### PR DESCRIPTION
## Summary
Fix of wrong copying from temp buffer to processing buffer.
Also renaming `msg_buf` to more suitable `cmd_buf`.

## Impact
Fixing the issue.

## Testing
Normally CPU2 processes commands very fast so the mailbox TX queue is empty all the time and the issue is not reproducing.  To test the logic the code was modified to put command into queue without a condition.

