### PR TITLE
Fix notify disassocitaion

### DIFF
--- a/drivers/wireless/Kconfig
+++ b/drivers/wireless/Kconfig
@@ -55,6 +55,17 @@ config WL_GS2200M_CHECK_VERSION
 	bool "Check the version of GS2200M"
 	default n
 
+config WL_GS2200M_SYNC_INTERVAL
+	int "Sync loss interval in station mode (100ms)"
+	default 100
+	range 1 63325
+	---help---
+		Time interval to recognize dis-association situation.
+		The value indicate n times of Wi-Fi beacon. If the node
+		lost receiving beacon n times, behave as dis-associtaion.
+		Time difference between 2 beacons are approximetely 100 msec.
+		So the unit of the value is 100 ms.
+
 config WL_GS2200M_LOGLEVEL
 	int "Log level"
 	default 0

--- a/drivers/wireless/gs2200m.c
+++ b/drivers/wireless/gs2200m.c
@@ -2113,6 +2113,34 @@ static enum pkt_type_e gs2200m_activate_wrx(FAR struct gs2200m_dev_s *dev,
 }
 
 /****************************************************************************
+ * Name: gs2200m_powersave_wrx
+ * NOTE: See 9.1.1 Active Radio Receive
+ ****************************************************************************/
+
+static enum pkt_type_e gs2200m_powersave_wrx(FAR struct gs2200m_dev_s *dev,
+                                             uint8_t on)
+{
+  char cmd[30];
+
+  snprintf(cmd, sizeof(cmd), "AT+WRXPS=%d\r\n", on);
+  return gs2200m_send_cmd2(dev, cmd);
+}
+
+/****************************************************************************
+ * Name: gs2200m_syncloss
+ * NOTE: See 5.1.4 Sync loss interval
+ ****************************************************************************/
+
+static enum pkt_type_e gs2200m_syncloss(FAR struct gs2200m_dev_s *dev,
+                                            int val)
+{
+  char cmd[30];
+
+  snprintf(cmd, sizeof(cmd), "AT+WSYNCINTRL=%d\r\n", val);
+  return gs2200m_send_cmd2(dev, cmd);
+}
+
+/****************************************************************************
  * Name: gs2200m_set_gpio
  * NOTE: See 10.3 GPIO Commands
  ****************************************************************************/
@@ -2666,6 +2694,11 @@ static int gs2200m_ioctl_assoc_sta(FAR struct gs2200m_dev_s *dev,
     }
 
   dev->disassociate_flag = false;
+
+  /* Sync lost time interval */
+
+  t = gs2200m_syncloss(dev, CONFIG_WL_GS2200M_SYNC_INTERVAL);
+  ASSERT(TYPE_OK == t);
 
   return OK;
 }
@@ -3409,6 +3442,11 @@ static int gs2200m_start(FAR struct gs2200m_dev_s *dev)
   /* Activate RX */
 
   t = gs2200m_activate_wrx(dev, 1);
+  ASSERT(TYPE_OK == t);
+
+  /* Power save disable */
+
+  t = gs2200m_powersave_wrx(dev, 0);
   ASSERT(TYPE_OK == t);
 
   /* Set Bulk Data mode */

--- a/include/nuttx/wireless/gs2200m.h
+++ b/include/nuttx/wireless/gs2200m.h
@@ -58,6 +58,8 @@ extern "C"
 #define GS2200M_IOC_IFREQ    _WLCIOC(GS2200M_FIRST + 7)
 #define GS2200M_IOC_NAME     _WLCIOC(GS2200M_FIRST + 8)
 
+#define DISASSOCIATION_CID  ('x')
+
 /* NOTE: do not forget to update include/nuttx/wireless/ioctl.h */
 
 struct gs2200m_connect_msg


### PR DESCRIPTION
## Summary
 After recover disassociation, usrsock daemon must destroy all sockets.
 Add notification to prompt the daemon to do so.

## Impact
Only for gs2200m driver

## Testing
Check if tcpblaster on spresense:wifi work well and if it received an error when disassociation happened.
