### PR TITLE
mm/kasan: node header should updated from unpoisoning memory

### DIFF
--- a/mm/mm_heap/mm.h
+++ b/mm/mm_heap/mm.h
@@ -105,6 +105,7 @@
      do \
        { \
          FAR struct mm_allocnode_s *tmp = (FAR struct mm_allocnode_s *)(ptr); \
+         kasan_unpoison(tmp, SIZEOF_MM_ALLOCNODE); \
          tmp->pid = getpid(); \
          if ((heap)->mm_procfs.backtrace) \
            { \
@@ -115,6 +116,7 @@
            { \
              tmp->backtrace[0] = 0; \
            } \
+         kasan_poison(tmp, SIZEOF_MM_ALLOCNODE); \
        } \
      while (0)
 #else

--- a/mm/mm_heap/mm_malloc.c
+++ b/mm/mm_heap/mm_malloc.c
@@ -229,7 +229,6 @@ FAR void *mm_malloc(FAR struct mm_heap_s *heap, size_t size)
       /* Handle the case of an exact size match */
 
       node->preceding |= MM_ALLOC_BIT;
-      MM_ADD_BACKTRACE(heap, node);
       ret = (FAR void *)((FAR char *)node + SIZEOF_MM_ALLOCNODE);
     }
 
@@ -238,6 +237,7 @@ FAR void *mm_malloc(FAR struct mm_heap_s *heap, size_t size)
 
   if (ret)
     {
+      MM_ADD_BACKTRACE(heap, node);
       kasan_unpoison(ret, mm_malloc_size(ret));
 #ifdef CONFIG_MM_FILL_ALLOCATIONS
       memset(ret, 0xaa, alignsize - SIZEOF_MM_ALLOCNODE);

--- a/mm/mm_heap/mm_memalign.c
+++ b/mm/mm_heap/mm_memalign.c
@@ -178,7 +178,6 @@ FAR void *mm_memalign(FAR struct mm_heap_s *heap, size_t alignment,
 
       newnode->size = (size_t)next - (size_t)newnode;
       newnode->preceding = precedingsize | MM_ALLOC_BIT;
-      MM_ADD_BACKTRACE(heap, newnode);
 
       /* Reduce the size of the original chunk and mark it not allocated, */
 
@@ -223,6 +222,8 @@ FAR void *mm_memalign(FAR struct mm_heap_s *heap, size_t alignment,
     }
 
   mm_givesemaphore(heap);
+
+  MM_ADD_BACKTRACE(heap, node);
 
   kasan_unpoison((FAR void *)alignedchunk,
                  mm_malloc_size((FAR void *)alignedchunk));

--- a/mm/mm_heap/mm_realloc.c
+++ b/mm/mm_heap/mm_realloc.c
@@ -128,11 +128,12 @@ FAR void *mm_realloc(FAR struct mm_heap_s *heap, FAR void *oldmem,
                        oldsize - oldnode->size);
         }
 
-      MM_ADD_BACKTRACE(heap, oldnode);
-
       /* Then return the original address */
 
       mm_givesemaphore(heap);
+
+      MM_ADD_BACKTRACE(heap, oldnode);
+
       return oldmem;
     }
 
@@ -334,9 +335,9 @@ FAR void *mm_realloc(FAR struct mm_heap_s *heap, FAR void *oldmem,
             }
         }
 
-      MM_ADD_BACKTRACE(heap, (FAR char *)newmem - SIZEOF_MM_ALLOCNODE);
-
       mm_givesemaphore(heap);
+
+      MM_ADD_BACKTRACE(heap, (FAR char *)newmem - SIZEOF_MM_ALLOCNODE);
 
       kasan_unpoison(newmem, mm_malloc_size(newmem));
       if (newmem != oldmem)


### PR DESCRIPTION
## Summary

mm/kasan: node header should updated from unpoisoning memory
mm_heap/backtrace: move MM_ADD_BACKTRACE out of heap lock

```
| (gdb) bt
| #0  up_assert (filename=0x7fffffffdc6c "\001", lineno=0) at sim/up_assert.c:75
| #1  0x00005555555e636b in _assert (filename=0x555555627225 "kasan/kasan.c", linenum=104) at assert/lib_assert.c:36
| #2  0x00005555555a388e in kasan_report (addr=140737284458088, size=1, is_write=true) at kasan/kasan.c:104
| #3  0x00005555555a40a1 in __asan_storeN_noabort (addr=140737284458088, size=1) at kasan/kasan.c:297
| #4  0x00005555555a4519 in __asan_store1_noabort (addr=140737284458088) at kasan/kasan.c:348
| #5  0x00005555555a26d7 in memset (s=0x7ffff3d8c668, c=0, n=63) at string/lib_memset.c:169
| #6  0x00005555555a46a4 in mm_addregion (heap=0x7ffff3d8c000, heapstart=0x7ffff3d8c648, heapsize=66058656) at mm_heap/mm_initialize.c:131
| #7  0x00005555555a4a00 in mm_initialize (name=0x555555627068 "Umem", heapstart=0x7ffff3d8c648, heapsize=67107256) at mm_heap/mm_initialize.c:231
| #8  0x00005555555a33b1 in umm_initialize (heap_start=0x7ffff3d8c000, heap_size=67108864) at umm_heap/umm_initialize.c:84
| #9  0x000055555558f17c in nx_start () at init/nx_start.c:469
| #10 0x0000555555589559 in main (argc=1, argv=0x7fffffffdf58, envp=0x7fffffffdf68) at sim/up_head.c:131
| (gdb)

```

## Impact

N/A

## Testing

sim/kasan

enable config:
CONFIG_DEBUG_MM=y
CONFIG_MM_BACKTRACE=8
CONFIG_MM_BACKTRACE_DEFAULT=y
CONFIG_MM_DUMP_ON_FAILURE=y
