### PR TITLE
Net thread-safe ether_ntoa_r & inet_ntoa_r

### DIFF
--- a/drivers/wireless/gs2200m.c
+++ b/drivers/wireless/gs2200m.c
@@ -2018,7 +2018,10 @@ static enum pkt_type_e gs2200m_send_bulk(FAR struct gs2200m_dev_s *dev,
     }
   else
     {
-      wlinfo("** addr=%s port=%d\n", inet_ntoa(msg->addr.sin_addr),
+      char inetaddr[INET_ADDRSTRLEN];
+
+      wlinfo("** addr=%s port=%d\n",
+             inet_ntoa_r(msg->addr.sin_addr, inetaddr, sizeof(inetaddr)),
              NTOHS(msg->addr.sin_port));
 
       /* NOTE: See 7.5.3.2 Bulk Data Handling for UDP
@@ -2027,7 +2030,8 @@ static enum pkt_type_e gs2200m_send_bulk(FAR struct gs2200m_dev_s *dev,
 
       snprintf(cmd, sizeof(cmd), "%cY%c%s:%d:%s",
                ASCII_ESC, msg->cid,
-               inet_ntoa(msg->addr.sin_addr), NTOHS(msg->addr.sin_port),
+               inet_ntoa_r(msg->addr.sin_addr, inetaddr, sizeof(inetaddr)),
+               NTOHS(msg->addr.sin_port),
                digits);
     }
 
@@ -2890,12 +2894,16 @@ static int gs2200m_ioctl_ifreq(FAR struct gs2200m_dev_s *dev,
 
   if (false == getreq && OK == ret)
     {
+      char inetaddr[INET_ADDRSTRLEN];
       memcpy(&in[0], &dev->net_dev.d_ipaddr, sizeof(in[0]));
       memcpy(&in[1], &dev->net_dev.d_netmask, sizeof(in[1]));
       memcpy(&in[2], &dev->net_dev.d_draddr, sizeof(in[2]));
-      strncpy(addr[0], inet_ntoa(in[0]), sizeof(addr[0]));
-      strncpy(addr[1], inet_ntoa(in[1]), sizeof(addr[1]));
-      strncpy(addr[2], inet_ntoa(in[2]), sizeof(addr[2]));
+      strncpy(addr[0], inet_ntoa_r(in[0], inetaddr, sizeof(inetaddr)),
+              sizeof(addr[0]));
+      strncpy(addr[1], inet_ntoa_r(in[1], inetaddr, sizeof(inetaddr)),
+              sizeof(addr[1]));
+      strncpy(addr[2], inet_ntoa_r(in[2], inetaddr, sizeof(inetaddr)),
+              sizeof(addr[2]));
 
       gs2200m_set_addresses(dev, addr[0], addr[1], addr[2]);
     }

--- a/include/arpa/inet.h
+++ b/include/arpa/inet.h
@@ -50,6 +50,7 @@ in_addr_t   inet_addr(FAR const char *cp);
 in_addr_t   inet_network(FAR const char *cp);
 
 FAR char   *inet_ntoa(struct in_addr in);
+FAR char   *inet_ntoa_r(struct in_addr in, FAR char *buf, size_t bufflen);
 in_addr_t   inet_lnaof(struct in_addr in);
 in_addr_t   inet_netof(struct in_addr in);
 

--- a/include/netinet/ether.h
+++ b/include/netinet/ether.h
@@ -50,6 +50,7 @@ extern "C"
 #endif
 
 FAR char *ether_ntoa(FAR const struct ether_addr *addr);
+FAR char *ether_ntoa_r(FAR const struct ether_addr *addr, FAR char *buf);
 FAR struct ether_addr *ether_aton(FAR const char *asc);
 int ether_ntohost(FAR char *hostname, FAR const struct ether_addr *addr);
 int ether_hostton(FAR const char *hostname, FAR struct ether_addr *addr);

--- a/libs/libc/net/lib_etherntoa.c
+++ b/libs/libc/net/lib_etherntoa.c
@@ -33,6 +33,25 @@
  ****************************************************************************/
 
 /****************************************************************************
+ * Name: ether_ntoa_r
+ *
+ * Description:
+ *   The ether_ntoa_r() function converts the Ethernet host address addr
+ *   given in network byte order to a string in standard
+ *   hex-digits-and-colons notation.
+ *
+ ****************************************************************************/
+
+FAR char *ether_ntoa_r(FAR const struct ether_addr *addr, FAR char *buf)
+{
+  sprintf(buf, "%02x:%02x:%02x:%02x:%02x:%02x",
+          addr->ether_addr_octet[0], addr->ether_addr_octet[1],
+          addr->ether_addr_octet[2], addr->ether_addr_octet[3],
+          addr->ether_addr_octet[4], addr->ether_addr_octet[5]);
+  return buf;
+}
+
+/****************************************************************************
  * Name: ether_ntoa
  *
  * Description:
@@ -46,9 +65,5 @@
 FAR char *ether_ntoa(FAR const struct ether_addr *addr)
 {
   static char buffer[20];
-  sprintf(buffer, "%02x:%02x:%02x:%02x:%02x:%02x",
-          addr->ether_addr_octet[0], addr->ether_addr_octet[1],
-          addr->ether_addr_octet[2], addr->ether_addr_octet[3],
-          addr->ether_addr_octet[4], addr->ether_addr_octet[5]);
-  return buffer;
+  return ether_ntoa_r(addr, buffer);
 }

--- a/libs/libc/net/lib_inetntoa.c
+++ b/libs/libc/net/lib_inetntoa.c
@@ -36,6 +36,23 @@
  ****************************************************************************/
 
 /****************************************************************************
+ * Name: inet_ntoa_r
+ *
+ * Description:
+ *   The inet_ntoa_r() function converts the Internet host address given in
+ *   network byte order to a string in standard numbers-and-dots notation.
+ *
+ ****************************************************************************/
+
+FAR char *inet_ntoa_r(struct in_addr in, FAR char *buf, size_t bufflen)
+{
+  FAR unsigned char *ptr = (FAR unsigned char *)&in.s_addr;
+  snprintf(buf, bufflen, "%u.%u.%u.%u",
+           ptr[0], ptr[1], ptr[2], ptr[3]);
+  return buf;
+}
+
+/****************************************************************************
  * Name: inet_ntoa
  *
  * Description:
@@ -48,11 +65,8 @@
 
 FAR char *inet_ntoa(struct in_addr in)
 {
-  static char buffer[INET_ADDRSTRLEN + 2];
-  FAR unsigned char *ptr = (FAR unsigned char *)&in.s_addr;
-  snprintf(buffer, INET_ADDRSTRLEN + 2, "%u.%u.%u.%u",
-           ptr[0], ptr[1], ptr[2], ptr[3]);
-  return buffer;
+  static char buffer[INET_ADDRSTRLEN];
+  return inet_ntoa_r(in, buffer, sizeof(buffer));
 }
 
 #endif /* CONFIG_NET_IPv4 || CONFIG_LIBC_IPv4_ADDRCONV */

--- a/net/procfs/netdev_statistics.c
+++ b/net/procfs/netdev_statistics.c
@@ -194,9 +194,13 @@ static int netprocfs_linklayer(FAR struct netprocfs_file_s *netfile)
 #if defined(CONFIG_NET_ETHERNET) || defined(CONFIG_DRIVERS_IEEE80211)
       case NET_LL_ETHERNET:
       case NET_LL_IEEE80211:
-        len += snprintf(&netfile->line[len], NET_LINELEN - len,
-                        "%s\tLink encap:Ethernet HWaddr %s",
-                        dev->d_ifname, ether_ntoa(&dev->d_mac.ether));
+        {
+          char hwaddr[20];
+          len += snprintf(&netfile->line[len], NET_LINELEN - len,
+                          "%s\tLink encap:Ethernet HWaddr %s",
+                          dev->d_ifname,
+                          ether_ntoa_r(&dev->d_mac.ether, hwaddr));
+        }
         break;
 #endif
 
@@ -258,6 +262,7 @@ static int netprocfs_inet4addresses(FAR struct netprocfs_file_s *netfile)
   FAR struct net_driver_s *dev;
   struct in_addr addr;
   int len = 0;
+  char inetaddr[INET_ADDRSTRLEN];
 
   DEBUGASSERT(netfile != NULL && netfile->dev != NULL);
   dev = netfile->dev;
@@ -266,13 +271,15 @@ static int netprocfs_inet4addresses(FAR struct netprocfs_file_s *netfile)
 
   addr.s_addr = dev->d_ipaddr;
   len += snprintf(&netfile->line[len], NET_LINELEN - len,
-                  "\tinet addr:%s ", inet_ntoa(addr));
+                  "\tinet addr:%s ", inet_ntoa_r(addr, inetaddr,
+                                                 sizeof(inetaddr)));
 
   /* Show the IPv4 default router address */
 
   addr.s_addr = dev->d_draddr;
   len += snprintf(&netfile->line[len], NET_LINELEN - len,
-                  "DRaddr:%s ", inet_ntoa(addr));
+                  "DRaddr:%s ", inet_ntoa_r(addr, inetaddr,
+                                            sizeof(inetaddr)));
 
   /* Show the IPv4 network mask */
 
@@ -283,7 +290,7 @@ static int netprocfs_inet4addresses(FAR struct netprocfs_file_s *netfile)
 #else
                   "Mask:%s\n\n",  /* Double space at end of device description */
 #endif
-                  inet_ntoa(addr));
+                  inet_ntoa_r(addr, inetaddr, sizeof(inetaddr)));
 
   return len;
 }


### PR DESCRIPTION
## Summary
Normal ntoa use a static buffer which consumes memory and isn't thread-safe the _r variant passes the char* to write the data too.

## Impact
Saves around 32 bytes by not statically allocated the buffers
Minimal ntoa calls replaced by ntoa_r calls, apps need to be updated as well to save on memory usage.

## Testing

```
Before
peter@NXL04520:~/nuttx/nuttx$ arm-none-eabi-size nuttx
   text    data     bss     dec     hex filename
 159348     784   23920  184052   2cef4 nuttx
peter@NXL04520:~/nuttx/nuttx$
After
peter@NXL04520:~/nuttx/nuttx$ arm-none-eabi-size  nuttx
   text    data     bss     dec     hex filename
 159356     784   23888  184028   2cedc nuttx
```



