### PR TITLE
NXP S32K1XX boards: add up_perf_init to support SEGGER SystemView

### DIFF
--- a/boards/arm/s32k1xx/s32k144evb/include/board.h
+++ b/boards/arm/s32k1xx/s32k144evb/include/board.h
@@ -37,7 +37,9 @@
 
 #define BOARD_XTAL_FREQUENCY  8000000
 
-/* The S32K144 will run at 80 MHz */
+/* The S32K144 will run at 80 MHz in RUN mode */
+
+#define S32K144EVB_RUN_SYSCLK_FREQUENCY  80000000
 
 /* LED definitions **********************************************************/
 

--- a/boards/arm/s32k1xx/s32k144evb/src/s32k1xx_boot.c
+++ b/boards/arm/s32k1xx/s32k144evb/src/s32k1xx_boot.c
@@ -23,8 +23,9 @@
  ****************************************************************************/
 
 #include <nuttx/config.h>
+#include <nuttx/arch.h>
 #include <nuttx/board.h>
-
+#include <arch/board/board.h>
 #include "s32k144evb.h"
 
 /****************************************************************************
@@ -44,6 +45,10 @@
 
 void s32k1xx_board_initialize(void)
 {
+#ifdef CONFIG_SEGGER_SYSVIEW
+  up_perf_init((void *)S32K144EVB_RUN_SYSCLK_FREQUENCY);
+#endif
+
 #ifdef CONFIG_ARCH_LEDS
   /* Configure on-board LEDs if LED support has been selected */
 

--- a/boards/arm/s32k1xx/s32k146evb/include/board.h
+++ b/boards/arm/s32k1xx/s32k146evb/include/board.h
@@ -37,7 +37,9 @@
 
 #define BOARD_XTAL_FREQUENCY  8000000
 
-/* The S32K146 will run at 80 MHz */
+/* The S32K146 will run at 80 MHz in RUN mode */
+
+#define S32K146EVB_RUN_SYSCLK_FREQUENCY  80000000
 
 /* LED definitions **********************************************************/
 

--- a/boards/arm/s32k1xx/s32k146evb/src/s32k1xx_boot.c
+++ b/boards/arm/s32k1xx/s32k146evb/src/s32k1xx_boot.c
@@ -23,8 +23,9 @@
  ****************************************************************************/
 
 #include <nuttx/config.h>
+#include <nuttx/arch.h>
 #include <nuttx/board.h>
-
+#include <arch/board/board.h>
 #include "s32k146evb.h"
 
 /****************************************************************************
@@ -44,6 +45,10 @@
 
 void s32k1xx_board_initialize(void)
 {
+#ifdef CONFIG_SEGGER_SYSVIEW
+  up_perf_init((void *)S32K146EVB_RUN_SYSCLK_FREQUENCY);
+#endif
+
 #ifdef CONFIG_ARCH_LEDS
   /* Configure on-board LEDs if LED support has been selected */
 

--- a/boards/arm/s32k1xx/s32k148evb/include/board.h
+++ b/boards/arm/s32k1xx/s32k148evb/include/board.h
@@ -37,7 +37,9 @@
 
 #define BOARD_XTAL_FREQUENCY  8000000
 
-/* The S32K148 will run at 80 MHz */
+/* The S32K148 will run at 80 MHz in RUN mode */
+
+#define S32K148EVB_RUN_SYSCLK_FREQUENCY  80000000
 
 /* LED definitions **********************************************************/
 

--- a/boards/arm/s32k1xx/s32k148evb/src/s32k1xx_boot.c
+++ b/boards/arm/s32k1xx/s32k148evb/src/s32k1xx_boot.c
@@ -23,8 +23,9 @@
  ****************************************************************************/
 
 #include <nuttx/config.h>
+#include <nuttx/arch.h>
 #include <nuttx/board.h>
-
+#include <arch/board/board.h>
 #include "s32k148evb.h"
 
 /****************************************************************************
@@ -44,6 +45,10 @@
 
 void s32k1xx_board_initialize(void)
 {
+#ifdef CONFIG_SEGGER_SYSVIEW
+  up_perf_init((void *)S32K148EVB_RUN_SYSCLK_FREQUENCY);
+#endif
+
 #ifdef CONFIG_ARCH_LEDS
   /* Configure on-board LEDs if LED support has been selected */
 

--- a/boards/arm/s32k1xx/ucans32k146/include/board.h
+++ b/boards/arm/s32k1xx/ucans32k146/include/board.h
@@ -37,7 +37,9 @@
 
 #define BOARD_XTAL_FREQUENCY  8000000
 
-/* The S32K146 will run at 80 MHz */
+/* The S32K146 will run at 80 MHz in RUN mode */
+
+#define UCANS32K146_RUN_SYSCLK_FREQUENCY  80000000
 
 /* LED definitions **********************************************************/
 

--- a/boards/arm/s32k1xx/ucans32k146/src/s32k1xx_boot.c
+++ b/boards/arm/s32k1xx/ucans32k146/src/s32k1xx_boot.c
@@ -23,8 +23,9 @@
  ****************************************************************************/
 
 #include <nuttx/config.h>
+#include <nuttx/arch.h>
 #include <nuttx/board.h>
-
+#include <arch/board/board.h>
 #include "ucans32k146.h"
 
 /****************************************************************************
@@ -44,6 +45,10 @@
 
 void s32k1xx_board_initialize(void)
 {
+#ifdef CONFIG_SEGGER_SYSVIEW
+  up_perf_init((void *)UCANS32K146_RUN_SYSCLK_FREQUENCY);
+#endif
+
 #ifdef CONFIG_ARCH_LEDS
   /* Configure on-board LEDs if LED support has been selected */
 


### PR DESCRIPTION
## Summary
Adds up_perf_init call to S32K1 board initialization for the S32K14X EVBs and UCANS32K146 board. This allows SEGGER SystemView to be used when the appropriate Kconfig options are selected.

## Impact
Allows SEGGER SystemView to be used with existing S32K14X board configurations.

## Testing
Basic functionality tested on a S32K146EVB, with SEGGER SystemView V3.32.

