### PR TITLE
S32K1 & S32K3: add basic documentation for MCU family and boards

### DIFF
--- a/Documentation/platforms/arm/s32k1xx/boards/rddrone-bms772/index.rst
+++ b/Documentation/platforms/arm/s32k1xx/boards/rddrone-bms772/index.rst
@@ -1,0 +1,95 @@
+==================
+NXP RDDRONE-BMS772
+==================
+
+`NXP RDDRONE-BMS772 <https://www.nxp.com/design/designs/smart-battery-management-for-mobile-robotics:RDDRONE-BMS772>`_ is a Battery Management System (BMS) reference design for mobile robotics, such as drones and rovers. Design files are available on the NXP website and may be used to develop your own BMS. RDDRONE-BMS772 is configurable and supports batteries of 3 to 6 cells, which it can monitor individually. The board features the `NXP S32K144 <https://www.nxp.com/products/processors-and-microcontrollers/s32-automotive-platform/s32k-general-purpose-mcus/s32k1-microcontrollers-for-general-purpose:S32K1>`_ MCU, which can monitor the `NXP MC33772B <https://www.nxp.com/products/power-management/battery-management/battery-cell-controllers/6-channel-li-ion-battery-cell-controller-ic:MC33772B>`_ Battery Cell Controller (BCC) and may commmunicates with the Vehicle Management Unit (VMU). When faults are detected the battery output can be disconnected to prevent further damage. Status information may be communicated over I2C/SMBus, CAN or NFC.
+
+NuttX contains basic board support RDDRONE-BMS772, which allows the S32K144 MCU to be initialized. A NuttX-compatible smart battery application for RDDRONE-BMS772 is also available. It contains additional drivers and example software to use most features of the battery management system. This application is currently published in a `separate repository <https://github.com/NXPHoverGames/RDDRONE-BMS772>`_, but (parts) may eventually be upstreamed to Apache NuttX.
+
+Features
+========
+
+- NXP FS32K144HAT0MLFT MCU
+    - 80 MHz Clock (Max.)
+    - 512 Kb Flash
+    -  64 Kb SRAM
+    -   4 Kb EEPROM
+
+- NXP MC33772BSP1AE Battery Cell Controller
+
+- NXP UJA1169TK/F/3 System Basis Chip
+
+- Connectivity:
+    - UART (Console @ 115,200 baud)
+    - CAN 2.0 (Transceiver part of UJA1169 SBC)
+    - I2C Master header to connect a display (e.g. small SSD1306-based OLEDs)
+    - I2C/SMBus Slave
+    - NFC (NTAG5 Boost)
+
+Serial Console
+==============
+
+By default, the serial console will be provided on the DCD-LZ UART (available on the 7-pin DCD-LZ debug connector J19):
+
+==============  ====  ==========
+DCD-LZ UART RX  PTC6  LPUART1_RX
+DCD-LZ UART TX  PTC7  LPUART1_TX
+==============  ====  ==========
+
+LEDs
+====
+
+The RDDRONE-BMS772 has one RGB LED:
+
+========  =====  ========
+RedLED    PTD16  FTM0 CH1
+GreenLED  PTB13  FTM0 CH1
+BlueLED   PTD15  FTM0 CH0
+========  =====  ========
+
+An output of '0' illuminates the LED.
+
+If CONFIG_ARCH_LEDS is not defined, then the user can control the LEDs in any way. The following definitions are used to access individual RGB components (see rddrone-bms772.h):
+
+- GPIO_LED_R
+- GPIO_LED_G
+- GPIO_LED_B
+
+The RGB components could, alternatively, be controlled through PWM using the common RGB LED driver.
+
+If CONFIG_ARCH_LEDs is defined, then NuttX will control the LEDs on board the RDDRONE-BMS772. The following definitions describe how NuttX controls the LEDs:
+
+================  =======================  =====  =====  ====
+State             Description              RED    GREEN  BLUE
+================  =======================  =====  =====  ====
+LED_STARTED       NuttX has been started   OFF    OFF    OFF
+LED_HEAPALLOCATE  Heap has been allocated  OFF    OFF    ON
+LED_IRQSENABLED   Interrupts enabled       OFF    OFF    ON
+LED_STACKCREATED  Idle stack created       OFF    ON     OFF
+LED_INIRQ         In an interrupt
+LED_SIGNAL        In a signal handler
+LED_ASSERTION     An assertion failed
+LED_PANIC         The system has crashed   FLASH  OFF    OFF
+LED_IDLE          S32K144 in sleep mode
+================  =======================  =====  =====  ====
+
+Configurations
+==============
+
+Each RDDRONE-BMS772 configuration is maintained in a sub-directory and can be selected as follows::
+
+    tools/configure.sh rddrone-bms772:<subdir>
+
+Where <subdir> is one of the sub-directories listed in the next paragraph.
+
+NOTES (common for all configurations):
+
+1. This configuration uses the mconf-based configuration tool. To change this configuration using that tool, you should:
+    a. Build and install the kconfig-mconf tool. See nuttx/README.txt. Also see additional README.txt files in the NuttX tools repository.
+    b. Execute 'make menuconfig' in nuttx/ in order to start the reconfiguration process.
+
+2. Unless otherwise stated, the serial console used is LPUART1 at 115,200 8N1.
+
+nsh
+---
+Configures the NuttShell (nsh) located at apps/examples/nsh. Support for builtin applications is enabled, but in the base configuration the only application selected is the "Hello, World!" example.

--- a/Documentation/platforms/arm/s32k1xx/boards/s32k118evb/index.rst
+++ b/Documentation/platforms/arm/s32k1xx/boards/s32k118evb/index.rst
@@ -1,0 +1,111 @@
+==============
+NXP S32K118EVB
+==============
+
+NXP S32K118EVB-Q064 is an evaluation board for the `NXP S32K118 MCU <https://www.nxp.com/products/processors-and-microcontrollers/s32-automotive-platform/s32k-general-purpose-mcus/s32k1-microcontrollers-for-general-purpose:S32K1>`_ based on an Arm Cortex-M0+ core.
+
+Features
+========
+
+- NXP FS32K118LAT0MLHT MCU
+    - 48 MHz Clock (Max.)
+    - 256 Kb Flash
+    -  25 Kb SRAM
+    -   2 Kb EEPROM
+
+- NXP UJA1169TK/F System Basis Chip
+
+- Connectivity:
+    - OpenSDA UART (Console @ 115,200 baud)
+    - CAN 2.0 (Transceiver part of UJA1169 SBC)
+    - I/O headers with GPIO, I2C, SPI, etc.
+
+Serial Console
+==============
+
+By default, the serial console will be provided on the OpenSDA VCOM port:
+
+===============  ====  ==========
+OpenSDA UART RX  PTB0  LPUART0_RX
+OpenSDA UART TX  PTB1  LPUART0_TX
+===============  ====  ==========
+
+USB drivers for the PEmicro CDC Serial Port are available here: http://www.pemicro.com/opensda/
+
+LEDs and Buttons
+================
+
+Leds
+----
+
+The S32K118EVB has one RGB LED:
+
+========  =====  ========
+RedLED    PTD16  FTM0 CH1
+GreenLED  PTD15  FTM0 CH0
+BlueLED   PTE8   FTM0 CH6
+========  =====  ========
+
+An output of '1' illuminates the LED.
+
+If CONFIG_ARCH_LEDS is not defined, then the user can control the LEDs in any way. The following definitions are used to access individual RGB components (see s32k118evb.h):
+
+- GPIO_LED_R
+- GPIO_LED_G
+- GPIO_LED_B
+
+The RGB components could, alternatively, be controlled through PWM using the common RGB LED driver.
+
+If CONFIG_ARCH_LEDs is defined, then NuttX will control the LEDs on board the S32K118EVB. The following definitions describe how NuttX controls the LEDs:
+
+================  =======================  =====  =====  ====
+State             Description              RED    GREEN  BLUE
+================  =======================  =====  =====  ====
+LED_STARTED       NuttX has been started   OFF    OFF    OFF
+LED_HEAPALLOCATE  Heap has been allocated  OFF    OFF    ON
+LED_IRQSENABLED   Interrupts enabled       OFF    OFF    ON
+LED_STACKCREATED  Idle stack created       OFF    ON     OFF
+LED_INIRQ         In an interrupt
+LED_SIGNAL        In a signal handler
+LED_ASSERTION     An assertion failed
+LED_PANIC         The system has crashed   FLASH  OFF    OFF
+LED_IDLE          S32K118 in sleep mode
+================  =======================  =====  =====  ====
+
+Buttons
+-------
+
+The S32K118EVB supports two buttons:
+
+===  ====
+SW2  PTD3
+SW3  PTD5
+===  ====
+
+OpenSDA Notes
+=============
+
+- USB drivers for the PEmicro CDC Serial Port are available here: http://www.pemicro.com/opensda/
+- The drag'n'drog interface expects files in .srec format.
+- Using Segger J-Link:  Easy... but remember to use the SWD connector J14 near the touch electrodes and not the OpenSDA connector near the OpenSDA USB connector J7.
+
+Configurations
+==============
+
+Each S32K118EVB configuration is maintained in a sub-directory and can be selected as follows::
+
+    tools/configure.sh s32k118evb:<subdir>
+
+Where <subdir> is one of the sub-directories listed in the next paragraph.
+
+NOTES (common for all configurations):
+
+1. This configuration uses the mconf-based configuration tool. To change this configuration using that tool, you should:
+    a. Build and install the kconfig-mconf tool. See nuttx/README.txt. Also see additional README.txt files in the NuttX tools repository.
+    b. Execute 'make menuconfig' in nuttx/ in order to start the reconfiguration process.
+
+2. Unless otherwise stated, the serial console used is LPUART1 at 115,200 8N1.
+
+nsh
+---
+Configures the NuttShell (nsh) located at apps/examples/nsh. Support for builtin applications is enabled, but in the base configuration the only application selected is the "Hello, World!" example.

--- a/Documentation/platforms/arm/s32k1xx/boards/s32k144evb/index.rst
+++ b/Documentation/platforms/arm/s32k1xx/boards/s32k144evb/index.rst
@@ -1,0 +1,111 @@
+==============
+NXP S32K144EVB
+==============
+
+`NXP S32K144EVB-Q100 <https://www.nxp.com/design/development-boards/automotive-development-platforms/s32k-mcu-platforms/s32k144-q100-general-purpose-evaluation-board:S32K144EVB>`_ is an evaluation board for the `NXP S32K144 MCU <https://www.nxp.com/products/processors-and-microcontrollers/s32-automotive-platform/s32k-general-purpose-mcus/s32k1-microcontrollers-for-general-purpose:S32K1>`_ based on an Arm Cortex-M4F core.
+
+Features
+========
+
+- NXP FS32K144HFT0VLLT MCU
+    - 80 MHz Clock (Max.)
+    - 512 Kb Flash
+    -  64 Kb SRAM
+    -   4 Kb EEPROM
+
+- NXP UJA1169TK/F System Basis Chip
+
+- Connectivity:
+    - OpenSDA UART (Console @ 115,200 baud)
+    - CAN 2.0 (Transceiver part of UJA1169 SBC)
+    - I/O headers with GPIO, I2C, SPI, etc.
+
+Serial Console
+==============
+
+By default, the serial console will be provided on the OpenSDA VCOM port:
+
+===============  ====  ==========
+OpenSDA UART RX  PTC6  LPUART1_RX
+OpenSDA UART TX  PTC7  LPUART1_TX
+===============  ====  ==========
+
+USB drivers for the PEmicro CDC Serial Port are available here: http://www.pemicro.com/opensda/
+
+LEDs and Buttons
+================
+
+Leds
+----
+
+The S32K144EVB has one RGB LED:
+
+========  =====  ========
+RedLED    PTD15  FTM0 CH0
+GreenLED  PTD16  FTM0 CH1
+BlueLED   PTD0   FTM0 CH2
+========  =====  ========
+
+An output of '0' illuminates the LED.
+
+If CONFIG_ARCH_LEDS is not defined, then the user can control the LEDs in any way. The following definitions are used to access individual RGB components (see s32k144evb.h):
+
+- GPIO_LED_R
+- GPIO_LED_G
+- GPIO_LED_B
+
+The RGB components could, alternatively, be controlled through PWM using the common RGB LED driver.
+
+If CONFIG_ARCH_LEDs is defined, then NuttX will control the LEDs on board the S32K144EVB. The following definitions describe how NuttX controls the LEDs:
+
+================  =======================  =====  =====  ====
+State             Description              RED    GREEN  BLUE
+================  =======================  =====  =====  ====
+LED_STARTED       NuttX has been started   OFF    OFF    OFF
+LED_HEAPALLOCATE  Heap has been allocated  OFF    OFF    ON
+LED_IRQSENABLED   Interrupts enabled       OFF    OFF    ON
+LED_STACKCREATED  Idle stack created       OFF    ON     OFF
+LED_INIRQ         In an interrupt
+LED_SIGNAL        In a signal handler
+LED_ASSERTION     An assertion failed
+LED_PANIC         The system has crashed   FLASH  OFF    OFF
+LED_IDLE          S32K144 in sleep mode
+================  =======================  =====  =====  ====
+
+Buttons
+-------
+
+The S32K144EVB supports two buttons:
+
+===  =====
+SW2  PTC12
+SW3  PTC13
+===  =====
+
+OpenSDA Notes
+=============
+
+- USB drivers for the PEmicro CDC Serial Port are available here: http://www.pemicro.com/opensda/
+- The drag'n'drog interface expects files in .srec format.
+- Using Segger J-Link:  Easy... but remember to use the SWD connector J14 near the touch electrodes and not the OpenSDA connector near the OpenSDA USB connector J7.
+
+Configurations
+==============
+
+Each S32K144EVB configuration is maintained in a sub-directory and can be selected as follows::
+
+    tools/configure.sh s32k144evb:<subdir>
+
+Where <subdir> is one of the sub-directories listed in the next paragraph.
+
+NOTES (common for all configurations):
+
+1. This configuration uses the mconf-based configuration tool. To change this configuration using that tool, you should:
+    a. Build and install the kconfig-mconf tool. See nuttx/README.txt. Also see additional README.txt files in the NuttX tools repository.
+    b. Execute 'make menuconfig' in nuttx/ in order to start the reconfiguration process.
+
+2. Unless otherwise stated, the serial console used is LPUART1 at 115,200 8N1.
+
+nsh
+---
+Configures the NuttShell (nsh) located at apps/examples/nsh. Support for builtin applications is enabled, but in the base configuration the only application selected is the "Hello, World!" example.

--- a/Documentation/platforms/arm/s32k1xx/boards/s32k146evb/index.rst
+++ b/Documentation/platforms/arm/s32k1xx/boards/s32k146evb/index.rst
@@ -1,0 +1,111 @@
+==============
+NXP S32K146EVB
+==============
+
+`NXP S32K146EVB-Q144 <https://www.nxp.com/design/development-boards/automotive-development-platforms/s32k-mcu-platforms/s32k146-q144-general-purpose-evaluation-board:S32K146EVB>`_ is an evaluation board for the `NXP S32K146 MCU <https://www.nxp.com/products/processors-and-microcontrollers/s32-automotive-platform/s32k-general-purpose-mcus/s32k1-microcontrollers-for-general-purpose:S32K1>`_ based on an Arm Cortex-M4F core.
+
+Features
+========
+
+- NXP FS32K146UAT0VLQT MCU
+    - 112 MHz Clock (Max.)
+    - 1024 Kb Flash
+    -  128 Kb SRAM
+    -    4 Kb EEPROM
+
+- NXP UJA1169TK/F System Basis Chip
+
+- Connectivity:
+    - OpenSDA UART (Console @ 115,200 baud)
+    - CAN 2.0 (Transceiver part of UJA1169 SBC)
+    - I/O headers with GPIO, I2C, SPI, etc.
+
+Serial Console
+==============
+
+By default, the serial console will be provided on the OpenSDA VCOM port:
+
+===============  ====  ==========
+OpenSDA UART RX  PTC6  LPUART1_RX
+OpenSDA UART TX  PTC7  LPUART1_TX
+===============  ====  ==========
+
+USB drivers for the PEmicro CDC Serial Port are available here: http://www.pemicro.com/opensda/
+
+LEDs and Buttons
+================
+
+Leds
+----
+
+The S32K146EVB has one RGB LED:
+
+========  =====  ========
+RedLED    PTD15  FTM0 CH0
+GreenLED  PTD16  FTM0 CH1
+BlueLED   PTD0   FTM0 CH2
+========  =====  ========
+
+An output of '0' illuminates the LED.
+
+If CONFIG_ARCH_LEDS is not defined, then the user can control the LEDs in any way. The following definitions are used to access individual RGB components (see s32k146evb.h):
+
+- GPIO_LED_R
+- GPIO_LED_G
+- GPIO_LED_B
+
+The RGB components could, alternatively, be controlled through PWM using the common RGB LED driver.
+
+If CONFIG_ARCH_LEDs is defined, then NuttX will control the LEDs on board the S32K146EVB. The following definitions describe how NuttX controls the LEDs:
+
+================  =======================  =====  =====  ====
+State             Description              RED    GREEN  BLUE
+================  =======================  =====  =====  ====
+LED_STARTED       NuttX has been started   OFF    OFF    OFF
+LED_HEAPALLOCATE  Heap has been allocated  OFF    OFF    ON
+LED_IRQSENABLED   Interrupts enabled       OFF    OFF    ON
+LED_STACKCREATED  Idle stack created       OFF    ON     OFF
+LED_INIRQ         In an interrupt
+LED_SIGNAL        In a signal handler
+LED_ASSERTION     An assertion failed
+LED_PANIC         The system has crashed   FLASH  OFF    OFF
+LED_IDLE          S32K146 in sleep mode
+================  =======================  =====  =====  ====
+
+Buttons
+-------
+
+The S32K146EVB supports two buttons:
+
+===  =====
+SW2  PTC12
+SW3  PTC13
+===  =====
+
+OpenSDA Notes
+=============
+
+- USB drivers for the PEmicro CDC Serial Port are available here: http://www.pemicro.com/opensda/
+- The drag'n'drog interface expects files in .srec format.
+- Using Segger J-Link:  Easy... but remember to use the SWD connector J14 near the touch electrodes and not the OpenSDA connector near the OpenSDA USB connector J7.
+
+Configurations
+==============
+
+Each S32K146EVB configuration is maintained in a sub-directory and can be selected as follows::
+
+    tools/configure.sh s32k146evb:<subdir>
+
+Where <subdir> is one of the sub-directories listed in the next paragraph.
+
+NOTES (common for all configurations):
+
+1. This configuration uses the mconf-based configuration tool. To change this configuration using that tool, you should:
+    a. Build and install the kconfig-mconf tool. See nuttx/README.txt. Also see additional README.txt files in the NuttX tools repository.
+    b. Execute 'make menuconfig' in nuttx/ in order to start the reconfiguration process.
+
+2. Unless otherwise stated, the serial console used is LPUART1 at 115,200 8N1.
+
+nsh
+---
+Configures the NuttShell (nsh) located at apps/examples/nsh. Support for builtin applications is enabled, but in the base configuration the only application selected is the "Hello, World!" example.

--- a/Documentation/platforms/arm/s32k1xx/boards/s32k148evb/index.rst
+++ b/Documentation/platforms/arm/s32k1xx/boards/s32k148evb/index.rst
@@ -1,0 +1,111 @@
+==============
+NXP S32K148EVB
+==============
+
+`NXP S32K148EVB-Q176 <hhttps://www.nxp.com/design/development-boards/automotive-development-platforms/s32k-mcu-platforms/s32k148-q176-general-purpose-evaluation-board:S32K148EVB>`_ is an evaluation board for the `NXP S32K148 MCU <https://www.nxp.com/products/processors-and-microcontrollers/s32-automotive-platform/s32k-general-purpose-mcus/s32k1-microcontrollers-for-general-purpose:S32K1>`_ based on an Arm Cortex-M4F core.
+
+Features
+========
+
+- NXP FS32K148UAT0VLUT MCU
+    - 112 MHz Clock (Max.)
+    - 2048 Kb Flash
+    -  256 Kb SRAM
+    -    4 Kb EEPROM
+
+- NXP UJA1132HWF5V4 System Basis Chip
+
+- Connectivity:
+    - OpenSDA UART (Console @ 115,200 baud)
+    - CAN 2.0 (Transceiver part of UJA1132 SBC)
+    - I/O headers with GPIO, I2C, SPI, etc.
+
+Serial Console
+==============
+
+By default, the serial console will be provided on the OpenSDA VCOM port:
+
+===============  ====  ==========
+OpenSDA UART RX  PTC6  LPUART1_RX
+OpenSDA UART TX  PTC7  LPUART1_TX
+===============  ====  ==========
+
+USB drivers for the PEmicro CDC Serial Port are available here: http://www.pemicro.com/opensda/
+
+LEDs and Buttons
+================
+
+Leds
+----
+
+The S32K148EVB has one RGB LED:
+
+========  =====  ========
+RedLED    PTE21  FTM4 CH1
+GreenLED  PTE22  FTM4 CH2
+BlueLED   PTE23  FTM4 CH3
+========  =====  ========
+
+An output of '1' illuminates the LED.
+
+If CONFIG_ARCH_LEDS is not defined, then the user can control the LEDs in any way. The following definitions are used to access individual RGB components (see s32k148evb.h):
+
+- GPIO_LED_R
+- GPIO_LED_G
+- GPIO_LED_B
+
+The RGB components could, alternatively, be controlled through PWM using the common RGB LED driver.
+
+If CONFIG_ARCH_LEDs is defined, then NuttX will control the LEDs on board the S32K148EVB. The following definitions describe how NuttX controls the LEDs:
+
+================  =======================  =====  =====  ====
+State             Description              RED    GREEN  BLUE
+================  =======================  =====  =====  ====
+LED_STARTED       NuttX has been started   OFF    OFF    OFF
+LED_HEAPALLOCATE  Heap has been allocated  OFF    OFF    ON
+LED_IRQSENABLED   Interrupts enabled       OFF    OFF    ON
+LED_STACKCREATED  Idle stack created       OFF    ON     OFF
+LED_INIRQ         In an interrupt
+LED_SIGNAL        In a signal handler
+LED_ASSERTION     An assertion failed
+LED_PANIC         The system has crashed   FLASH  OFF    OFF
+LED_IDLE          S32K148 in sleep mode
+================  =======================  =====  =====  ====
+
+Buttons
+-------
+
+The S32K148EVB supports two buttons:
+
+===  =====
+SW3  PTC12
+SW4  PTC13
+===  =====
+
+OpenSDA Notes
+=============
+
+- USB drivers for the PEmicro CDC Serial Port are available here: http://www.pemicro.com/opensda/
+- The drag'n'drog interface expects files in .srec format.
+- Using Segger J-Link:  Easy... but remember to use the SWD connector J14 near the touch electrodes and not the OpenSDA connector near the OpenSDA USB connector J7.
+
+Configurations
+==============
+
+Each S32K148EVB configuration is maintained in a sub-directory and can be selected as follows::
+
+    tools/configure.sh s32k148evb:<subdir>
+
+Where <subdir> is one of the sub-directories listed in the next paragraph.
+
+NOTES (common for all configurations):
+
+1. This configuration uses the mconf-based configuration tool. To change this configuration using that tool, you should:
+    a. Build and install the kconfig-mconf tool. See nuttx/README.txt. Also see additional README.txt files in the NuttX tools repository.
+    b. Execute 'make menuconfig' in nuttx/ in order to start the reconfiguration process.
+
+2. Unless otherwise stated, the serial console used is LPUART1 at 115,200 8N1.
+
+nsh
+---
+Configures the NuttShell (nsh) located at apps/examples/nsh. Support for builtin applications is enabled, but in the base configuration the only application selected is the "Hello, World!" example.

--- a/Documentation/platforms/arm/s32k1xx/boards/ucans32k146/index.rst
+++ b/Documentation/platforms/arm/s32k1xx/boards/ucans32k146/index.rst
@@ -1,0 +1,105 @@
+===============
+NXP UCANS32K146
+===============
+
+`NXP UCANS32K146 <https://www.nxp.com/design/development-boards/automotive-development-platforms/s32k-mcu-platforms/s32k146-uavcan-v1-and-mavcan-development-system:UCANS32K146>`_ is a CAN Node reference design and development platform for mobile robotics applications, such as drones and rovers. It features the `NXP S32K146 MCU <https://www.nxp.com/products/processors-and-microcontrollers/s32-automotive-platform/s32k-general-purpose-mcus/s32k1-microcontrollers-for-general-purpose:S32K1>`_ based on an Arm Cortex-M4F core. There exist a few different revisions/variants of this board. All variants with the S32K146 microcontroller are supported.
+
+Features
+========
+
+- NXP FS32K146UAT0VLHT MCU
+    - 112 MHz Clock (Max.)
+    - 1024 Kb Flash
+    -  128 Kb SRAM
+    -    4 Kb EEPROM
+
+- NXP UJA1169TK/F System Basis Chip
+
+- Connectivity:
+    - Console UART (Console @ 115,200 baud)
+    - 2x CAN FD
+    - I/O headers with GPIO, I2C, SPI, etc.
+
+Serial Console
+==============
+
+By default, the serial console will be provided on the DCD-LZ UART (available on the 7-pin DCD-LZ debug connector P6):
+
+==============  ====  ==========
+DCD-LZ UART RX  PTC6  LPUART1_RX
+DCD-LZ UART TX  PTC7  LPUART1_TX
+==============  ====  ==========
+
+LEDs and Buttons
+================
+
+Leds
+----
+
+The UCANS32K146 has one RGB LED:
+
+========  =====  ========
+RedLED    PTD15  FTM0 CH0
+GreenLED  PTD16  FTM0 CH1
+BlueLED   PTD0   FTM0 CH2
+========  =====  ========
+
+An output of '0' illuminates the LED.
+
+If CONFIG_ARCH_LEDS is not defined, then the user can control the LEDs in any way. The following definitions are used to access individual RGB components (see ucans32k146.h):
+
+- GPIO_LED_R
+- GPIO_LED_G
+- GPIO_LED_B
+
+The RGB components could, alternatively, be controlled through PWM using the common RGB LED driver.
+
+If CONFIG_ARCH_LEDs is defined, then NuttX will control the LEDs on board the UCANS32K146. The following definitions describe how NuttX controls the LEDs:
+
+================  =======================  =====  =====  ====
+State             Description              RED    GREEN  BLUE
+================  =======================  =====  =====  ====
+LED_STARTED       NuttX has been started   OFF    OFF    OFF
+LED_HEAPALLOCATE  Heap has been allocated  OFF    OFF    ON
+LED_IRQSENABLED   Interrupts enabled       OFF    OFF    ON
+LED_STACKCREATED  Idle stack created       OFF    ON     OFF
+LED_INIRQ         In an interrupt
+LED_SIGNAL        In a signal handler
+LED_ASSERTION     An assertion failed
+LED_PANIC         The system has crashed   FLASH  OFF    OFF
+LED_IDLE          S32K146 in sleep mode
+================  =======================  =====  =====  ====
+
+Buttons
+-------
+
+The UCANS32K146 supports one button:
+
+===  =====
+SW3  PTC14
+===  =====
+
+Configurations
+==============
+
+Each UCANS32K146 configuration is maintained in a sub-directory and can be selected as follows::
+
+    tools/configure.sh ucans32k146:<subdir>
+
+Where <subdir> is one of the sub-directories listed in the next paragraph.
+
+NOTES (common for all configurations):
+
+1. This configuration uses the mconf-based configuration tool. To change this configuration using that tool, you should:
+    a. Build and install the kconfig-mconf tool. See nuttx/README.txt. Also see additional README.txt files in the NuttX tools repository.
+    b. Execute 'make menuconfig' in nuttx/ in order to start the reconfiguration process.
+
+2. Unless otherwise stated, the serial console used is LPUART1 at 115,200 8N1.
+
+nsh
+---
+Configures the NuttShell (nsh) located at apps/examples/nsh. Support for builtin applications is enabled, but in the base configuration the only application selected is the "Hello, World!" example.
+
+can
+---
+Besides the NuttShell this configuration also enables (Socket)CAN support, as well as I2C and SPI support. It includes the SLCAN and can-utils applications for monitoring and debugging CAN applications.

--- a/Documentation/platforms/arm/s32k1xx/index.rst
+++ b/Documentation/platforms/arm/s32k1xx/index.rst
@@ -1,0 +1,139 @@
+===========
+NXP S32K1XX
+===========
+
+The `S32K1XX series <https://www.nxp.com/products/processors-and-microcontrollers/s32-automotive-platform/s32k-general-purpose-mcus/s32k1-microcontrollers-for-general-purpose:S32K1>`_ is a family of automotive-grade general-purpose microcontrollers from NXP Semiconductors. The lower end of the family is based on an Arm Cortex-M0+ core and can run at clockspeeds up to 48 MHz. The higher end chips are based on the Arm Cortex-M4F core which runs at up to 80 or 112 MHz.
+
+Supported MCUs
+==============
+
+The following list includes MCUs from the S32K1XX series and indicates whether they are supported in NuttX:
+
+========  =======  ==========  =========
+MCU       Support  Core        Frequency
+========  =======  ==========  =========
+S32K116   Yes*     Cortex-M0+   48 MHz
+S32K118   Yes*     Cortex-M0+   48 MHz
+S32K142   Yes*     Cortex-M4F  112 MHz
+S32K144   Yes      Cortex-M4F  112 MHz
+S32K146   Yes      Cortex-M4F  112 MHz
+S32K148   Yes      Cortex-M4F  112 MHz
+S32K142W  No**     Cortex-M4F   80 MHz
+S32K144W  No**     Cortex-M4F   80 MHz
+========  =======  ==========  =========
+
+| \* Supported but (mostly) untested.
+| ** Not supported (yet), but it is expected that existing code can be adapted with limited effort.
+
+Supported Modules & Peripherals
+===============================
+
+The following list indicates modules and peripherals supported in NuttX. Note that this list does not include all MCU modules. Please refer to the S32K1XX Reference Manual for a complete overview of its features.
+
+==========  =======  ==========================
+Peripheral  Support  Comments
+==========  =======  ==========================
+ADC         No
+CMP         No
+eDMA        No
+EEEPROM     Yes      EEPROM emulated by FlexRAM
+ENET        Yes
+FlexCAN     Yes      SocketCAN-compatible
+FlexIO      No
+FTM         Yes      PWM driver only
+GPIO        Yes
+LPI2C       Yes      I2C Master and Slave
+LPSPI       Yes
+LPUART      Yes
+QSPI        No
+RTC         Yes
+SAI         No
+==========  =======  ==========================
+
+ADC
+---
+
+12-Bit Successive Approximation (SAR) Analog-to-Digital Converter (ADC). No driver support (yet).
+
+CMP
+---
+
+Analog Comparator. No driver support (yet).
+
+
+eDMA
+----
+
+Enhanced Direct Memory Access module. There is a driver that was copied from the i.MX RT port, but this was not tested on S32K1XX.
+
+EEEPROM
+-------
+
+Emulated EEPROM (implemented by FlexRAM module). A basic block driver is available to read and write data.
+
+ENET
+----
+
+10/100 Mbit/s Ethernet MAC. Only available on S32K148. Driver is available.
+
+FlexCAN
+-------
+
+The S32K1XX family has up to 3x FlexCAN modules (which may not all have CAN FD support). A SocketCAN-compatible driver is available.
+
+FlexIO
+------
+
+A configurable module providing a range of functionality like emulation of a variety of serial/parallel communication protocols, flexible 16-bit timers or programmable logic blocks. No driver available.
+
+FTM
+---
+
+A PWM driver based on FlexTimer (FTM) is available.
+
+GPIO
+----
+
+Pins can be configured using :c:func:`s32k1xx_pinconfig` function. Writing to pins is done by :c:func:`s32k1xx_gpiowrite` function and reading is done by :c:func:`s32k1xx_gpioread`.
+
+LPI2C
+-----
+
+Low-Power Inter-Integrated Circuit (I2C) module supporting an interface to an I2C bus as master and/or
+as a slave. The lower-half of this driver is initialize by calling :c:func:`s32k1xx_i2cbus_initialize`.
+
+LPSPI
+-----
+
+Low-Power Serial Peripheral Interface (SPI) module that supports an interface to an SPI bus as a master
+and/or a slave. The lower-half of this driver is initialize by calling :c:func:`s32k1xx_lpspibus_initialize`.
+
+LPUART
+------
+
+Low-Power Universal Asynchronous Receiver/Transmitter (UART) module. UART is initialized automatically during
+MCU boot.
+
+QSPI
+----
+
+QuadSPI memory interface for external serial flash devices. No driver implemented.
+
+RTC
+---
+
+Real-Time Clock module. A basic driver has been implemented.
+
+SAI
+---
+
+The Synchronous Audio Interface for digital audio over I2S (Inter-IC Sound) is only available on S32K148. No driver implemented.
+
+Supported Boards
+================
+
+.. toctree::
+   :glob:
+   :maxdepth: 1
+
+   boards/*/*

--- a/Documentation/platforms/arm/s32k3xx/boards/mr-canhubk3/index.rst
+++ b/Documentation/platforms/arm/s32k3xx/boards/mr-canhubk3/index.rst
@@ -1,0 +1,109 @@
+===============
+NXP MR-CANHUBK3
+===============
+
+s a CAN Node reference design and development platform for mobile robotics applications, such as drones and rovers
+
+NXP MR-CANHUBK3 is a reference design and development platform for redundant networking and functional safety applications in Mobile Robotics, such as drones and rovers. It features the `NXP S32K344 MCU <https://www.nxp.com/products/processors-and-microcontrollers/s32-automotive-platform/s32k-general-purpose-mcus/s32k3-microcontrollers-for-general-purpose:S32K3>`_ based on a Arm Cortex-M7 core (Lock-Step).
+
+Features
+========
+
+- NXP FS32K344
+    - Lock-Step Configuration
+    - 160 MHz Clock (Max.)
+    - 4000 Kb Flash
+    -  512 Kb RAM
+
+- NXP FS26 Safety System Basis Chip
+
+- Connectivity:
+    - Console UART (Console @ 115,200 baud)
+    - 6x CAN FD
+    - 100Base-T1 Ethernet
+    - Connectors and I/O headers with GPIO, I2C, SPI, etc.
+
+Serial Console
+==============
+
+By default, the serial console will be provided on the DCD-LZ UART (available on the 7-pin DCD-LZ debug connector P6):
+
+==============  =====  ==========
+DCD-LZ UART RX  PTA8   LPUART2_RX
+DCD-LZ UART TX  PTA9   LPUART2_TX
+==============  =====  ==========
+
+LEDs and Buttons
+================
+
+Leds
+----
+
+The MR-CANHUBK3 has one RGB LED:
+
+========  =====  ===================================
+RedLED    PTE14  FXIO D7 / EMIOS0 CH19
+GreenLED  PTA27  FXIO D5 / EMIOS1 CH10 / EMIOS2 CH10
+BlueLED   PTE12  FXIO D8 / EMIOS1 CH5
+========  =====  ===================================
+
+An output of '0' illuminates the LED.
+
+If CONFIG_ARCH_LEDS is not defined, then the user can control the LEDs in any way. The following definitions are used to access individual RGB components (see mr-canhubk3.h):
+
+- GPIO_LED_R
+- GPIO_LED_G
+- GPIO_LED_B
+
+The RGB components could, alternatively, be controlled through PWM using the common RGB LED driver.
+
+If CONFIG_ARCH_LEDs is defined, then NuttX will control the LEDs on board the MR-CANHUBK3. The following definitions describe how NuttX controls the LEDs:
+
+================  =======================  =====  =====  ====
+State             Description              RED    GREEN  BLUE
+================  =======================  =====  =====  ====
+LED_STARTED       NuttX has been started   OFF    OFF    OFF
+LED_HEAPALLOCATE  Heap has been allocated  OFF    OFF    ON
+LED_IRQSENABLED   Interrupts enabled       OFF    OFF    ON
+LED_STACKCREATED  Idle stack created       OFF    ON     OFF
+LED_INIRQ         In an interrupt
+LED_SIGNAL        In a signal handler
+LED_ASSERTION     An assertion failed
+LED_PANIC         The system has crashed   FLASH  OFF    OFF
+LED_IDLE          S32K344 in sleep mode
+================  =======================  =====  =====  ====
+
+Buttons
+-------
+
+The MR-CANHUBK3 supports two buttons:
+
+===  =====  ==============
+SW1  PTD15  EIRQ31
+SW2  PTA25  EIRQ5 / WKPU34
+===  =====  ==============
+
+Configurations
+==============
+
+Each MR-CANHUBK3 configuration is maintained in a sub-directory and can be selected as follows::
+
+    tools/configure.sh mr-canhubk3:<subdir>
+
+Where <subdir> is one of the sub-directories listed in the next paragraph.
+
+NOTES (common for all configurations):
+
+1. This configuration uses the mconf-based configuration tool. To change this configuration using that tool, you should:
+    a. Build and install the kconfig-mconf tool. See nuttx/README.txt. Also see additional README.txt files in the NuttX tools repository.
+    b. Execute 'make menuconfig' in nuttx/ in order to start the reconfiguration process.
+
+2. Unless otherwise stated, the serial console used is LPUART2 at 115,200 8N1.
+
+nsh
+---
+Configures the NuttShell (nsh) located at apps/examples/nsh. Support for builtin applications is enabled, but in the base configuration the only application selected is the "Hello, World!" example.
+
+net
+---
+Besides the NuttShell this configuration also enables networking and (Socket)CAN support, as well as I2C and SPI support. It includes the SLCAN and can-utils applications for monitoring and debugging CAN applications.

--- a/Documentation/platforms/arm/s32k3xx/boards/s32k344evb/index.rst
+++ b/Documentation/platforms/arm/s32k3xx/boards/s32k344evb/index.rst
@@ -1,0 +1,120 @@
+==============
+NXP S32K344EVB
+==============
+
+`NXP S32K3X4EVB-Q257 <https://www.nxp.com/design/development-boards/automotive-development-platforms/s32k-mcu-platforms/s32k3x4-q257-full-featured-general-purpose-development-board:S32K3X4EVB-Q257>`_ is an evaluation board for the `NXP S32K344 MCU <https://www.nxp.com/products/processors-and-microcontrollers/s32-automotive-platform/s32k-general-purpose-mcus/s32k3-microcontrollers-for-general-purpose:S32K3>`_ based on a Arm Cortex-M7 core (Lock-Step).
+
+Features
+========
+
+- NXP FS32K344
+    - Lock-Step Configuration
+    - 160 MHz Clock (Max.)
+    - 4000 Kb Flash
+    -  512 Kb RAM
+
+- NXP FS26 Safety System Basis Chip
+
+- Connectivity:
+    - OpenSDA UART (Console @ 115,200 baud)
+    - 2x Secure CAN transceivers
+    - I/O headers with GPIO, I2C, SPI, etc.
+
+Serial Console
+==============
+
+By default, the serial console will be provided on the OpenSDA VCOM port:
+
+===============  =====  ==========
+OpenSDA UART RX  PTA15  LPUART6_RX
+OpenSDA UART TX  PTA16  LPUART6_TX
+===============  =====  ==========
+
+USB drivers for the PEmicro CDC Serial Port are available here: http://www.pemicro.com/opensda/
+
+LEDs and Buttons
+================
+
+Leds
+----
+
+The S32K344EVB has two RGB LEDs:
+
+=========  =====  =========================
+RedLED0    PTA29  EMIOS1 CH12 / EMIOS2 CH12
+GreenLED0  PTA30  EMIOS1 CH13 / EMIOS2 CH13
+BlueLED0   PTA31  EMIOS1 CH14 / FXIO D0
+=========  =====  =========================
+
+=========  =====  ===================================
+RedLED1    PTB18  EMIOS1 CH15 / EMIOS2 CH14 / FXIO D1
+GreenLED1  PTB25  EMIOS1 CH21 / EMIOS2 CH21 / FXIO D6
+BlueLED1   PTE12  EMIOS1 CH5  / FXIO D8
+=========  =====  ===================================
+
+An output of '1' illuminates the LED.
+
+If CONFIG_ARCH_LEDS is not defined, then the user can control the LEDs in any way. The following definitions are used to access individual RGB components (see s32k344evb.h):
+
+- GPIO_LED0_R
+- GPIO_LED0_G
+- GPIO_LED0_B
+
+- GPIO_LED1_R
+- GPIO_LED1_G
+- GPIO_LED1_B
+
+The RGB components could, alternatively, be controlled through PWM using the common RGB LED driver.
+
+If CONFIG_ARCH_LEDs is defined, then NuttX will control the LEDs on board the S32K344EVB. The following definitions describe how NuttX controls the LEDs:
+
+================  =======================  =====  =====  ====
+State             Description              RED    GREEN  BLUE
+================  =======================  =====  =====  ====
+LED_STARTED       NuttX has been started   OFF    OFF    OFF
+LED_HEAPALLOCATE  Heap has been allocated  OFF    OFF    ON
+LED_IRQSENABLED   Interrupts enabled       OFF    OFF    ON
+LED_STACKCREATED  Idle stack created       OFF    ON     OFF
+LED_INIRQ         In an interrupt
+LED_SIGNAL        In a signal handler
+LED_ASSERTION     An assertion failed
+LED_PANIC         The system has crashed   FLASH  OFF    OFF
+LED_IDLE          S32K344 in sleep mode
+================  =======================  =====  =====  ====
+
+Buttons
+-------
+
+The S32K344EVB supports two buttons:
+
+===  =====  ===============
+SW0  PTB26  EIRQ13 / WKPU41
+SW1  PTB19  WKPU38
+===  =====  ===============
+
+OpenSDA Notes
+=============
+
+- USB drivers for the PEmicro CDC Serial Port are available here: http://www.pemicro.com/opensda/
+- The drag'n'drog interface expects files in .srec format.
+
+Configurations
+==============
+
+Each S32K344EVB configuration is maintained in a sub-directory and can be selected as follows::
+
+    tools/configure.sh s32k344evb:<subdir>
+
+Where <subdir> is one of the sub-directories listed in the next paragraph.
+
+NOTES (common for all configurations):
+
+1. This configuration uses the mconf-based configuration tool. To change this configuration using that tool, you should:
+    a. Build and install the kconfig-mconf tool. See nuttx/README.txt. Also see additional README.txt files in the NuttX tools repository.
+    b. Execute 'make menuconfig' in nuttx/ in order to start the reconfiguration process.
+
+2. Unless otherwise stated, the serial console used is LPUART6 at 115,200 8N1.
+
+nsh
+---
+Configures the NuttShell (nsh) located at apps/examples/nsh. Support for builtin applications is enabled, but in the base configuration the only application selected is the "Hello, World!" example.

--- a/Documentation/platforms/arm/s32k3xx/index.rst
+++ b/Documentation/platforms/arm/s32k3xx/index.rst
@@ -1,0 +1,136 @@
+===========
+NXP S32K3XX
+===========
+
+The `S32K3XX series <https://www.nxp.com/products/processors-and-microcontrollers/s32-automotive-platform/s32k-general-purpose-mcus/s32k3-microcontrollers-for-general-purpose:S32K3>`_ is a family of automotive-grade general-purpose microcontrollers from NXP Semiconductors. The chips are based around single, dual (lock-step) or tripple Arm Cortex-M7 cores, running at clockspeeds up to 240 MHz.
+
+Supported MCUs
+==============
+
+The following list includes MCUs from the S32K3XX series and indicates whether they are supported in NuttX:
+
+========  =======  =================  =========
+MCU       Support  Cores              Frequency
+========  =======  =================  =========
+S32K311   No       1x Cortex-M7       120 MHz
+S32K312   No       1x Cortex-M7       120 MHz
+S32K314   Yes*     1x Cortex-M7       160 MHz
+S32K322   No       2x Cortex-M7       160 MHz
+S32K324   Yes*     2x Cortex-M7       160 MHz
+S32K341   No       LS Cortex-M7       160 MHz
+S32K342   No       LS Cortex-M7       160 MHz
+S32K344   Yes*     LS Cortex-M7       160 MHz
+S32K328   No       2x Cortex-M7       160 MHz
+S32K338   No       3x Cortex-M7       240 MHz
+S32K348   No       LS Cortex-M7       160 MHz
+S32K358   No       LS + 1x Cortex-M7  160 MHz
+========  =======  =================  =========
+
+| \* Same silicon in different configurations. Only a single core is currently being used (no SMP support).
+
+Supported Modules & Peripherals
+===============================
+
+The following list indicates modules and peripherals supported in NuttX. Note that this list does not include all MCU modules. Please refer to the S32K3XX Reference Manual for a complete overview of its features.
+
+==========  =======  ==========================
+Peripheral  Support  Comments
+==========  =======  ==========================
+ADC         No
+eDMA        Partial
+eMIOS       No
+EMAC        Yes
+FlexCAN     Yes      SocketCAN-compatible
+FlexIO      No
+GPIO        Yes
+LPCMP       No
+LPI2C       Yes      I2C Master only
+LPSPI       Yes
+LPUART      Yes
+QSPI        Yes
+RTC         No
+SAI         No
+==========  =======  ==========================
+
+ADC
+---
+
+12-Bit Successive Approximation (SAR) Analog-to-Digital Converter (ADC). No driver support (yet).
+
+eDMA
+----
+
+Enhanced Direct Memory Access module. There is a driver that was copied from the S32K1XX and i.MX RT ports. Some modifications have been made to make it work with S32K3XX, but it is far from feature-complete.
+
+eMIOS
+-----
+
+The Enhanced Modular IO Subsystem (eMIOS) is a flexible timer and I/O module for real-time control applications. Its channels can be used for (pulse) counters, PWM outputs, input period measurements, and more. There is no driver implementation available (yet).
+
+EMAC
+----
+
+10/100/200 Mbit/s Ethernet MAC. Driver is available.
+
+FlexCAN
+-------
+
+The S32K3XX family has up to 8x FlexCAN modules with CAN FD support. A SocketCAN-compatible driver is available.
+
+FlexIO
+------
+
+A configurable module providing a range of functionality like emulation of a variety of serial/parallel communication protocols, flexible 16-bit timers or programmable logic blocks. No driver available.
+
+GPIO
+----
+
+Pins can be configured using :c:func:`s32k3xx_pinconfig` function. Writing to pins is done by :c:func:`s32k3xx_gpiowrite` function and reading is done by :c:func:`s32k3xx_gpioread`.
+
+LPCMP
+---
+
+Analog Comparator. No driver support (yet).
+
+LPI2C
+-----
+
+Low-Power Inter-Integrated Circuit (I2C) module supporting an interface to an I2C bus as master and/or
+as a slave. The lower-half of this driver is initialize by calling :c:func:`s32k3xx_i2cbus_initialize`.
+
+LPSPI
+-----
+
+Low-Power Serial Peripheral Interface (SPI) module that supports an interface to an SPI bus as a master
+and/or a slave. The lower-half of this driver is initialize by calling :c:func:`s32k3xx_lpspibus_initialize`.
+
+LPUART
+------
+
+Low-Power Universal Asynchronous Receiver/Transmitter (UART) module. UART is initialized automatically during
+MCU boot.
+
+QSPI
+----
+
+QuadSPI memory interface for external serial flash devices. A basic driver is available.
+
+RTC
+---
+
+Real-Time Clock module. A driver is not (yet) available.
+
+SAI
+---
+
+Synchronous Audio Interface for digital audio over I2S (Inter-IC Sound). No driver implemented.
+
+
+Supported Boards
+================
+
+.. toctree::
+   :glob:
+   :maxdepth: 1
+
+   boards/*/*


### PR DESCRIPTION
## Summary
Add basic documentation for S32K1 and S32K3 MCU family and boards: S32K1XXEVB boards, RDDRONE-BMS772, UCANS32K146, S32K344EVB and MR-CANHUBK3.

## Impact
Improves documentation.

## Testing
Build locally.

