### PR TITLE
boards: spresense: Reduce power consumption with LTE board

### DIFF
--- a/boards/arm/cxd56xx/spresense/src/cxd56_bringup.c
+++ b/boards/arm/cxd56xx/spresense/src/cxd56_bringup.c
@@ -248,6 +248,12 @@ int cxd56_bringup(void)
 #endif
 
 #ifndef CONFIG_CXD56_SUBCORE
+  /* Set the special pins for the host interface to GPIO mode because
+   * their mode is automatically changed by latching the SYSTEM0/1 pins.
+   */
+
+  CXD56_PIN_CONFIGS(PINCONFS_SPI2A_GPIO);
+
   /* Initialize CPU clock to max frequency */
 
   board_clock_initialize();


### PR DESCRIPTION
## Summary
The SPI2_CS_X and SPI2_SCK pins are used for connection to the LTE modem.
These pins are the special pins for the host interface that are set
automatically by latching the SYSTEM0/1 pins. So, it causes a problem
with increased current consumption when the modem is in power off state.
To prevent it, set these pins to GPIO HiZ during board initialization.

## Impact
Only Spresense board.

## Testing
Confirmed that power consumption is reduced on Spresense LTE boards.
