### PR TITLE
arm/backtrace: use sp unwind if FRAME_POINTER is enabled on thumb mode

### DIFF
--- a/arch/arm/src/common/Make.defs
+++ b/arch/arm/src/common/Make.defs
@@ -65,7 +65,11 @@ endif
 
 ifeq ($(CONFIG_SCHED_BACKTRACE),y)
   ifeq ($(CONFIG_FRAME_POINTER),y)
-    CMN_CSRCS += arm_backtrace_fp.c
+    ifeq ($(CONFIG_ARM_THUMB),y)
+      CMN_CSRCS += arm_backtrace_thumb.c
+    else
+      CMN_CSRCS += arm_backtrace_fp.c
+    endif
   else
     CMN_CSRCS += arm_backtrace_thumb.c
   endif


### PR DESCRIPTION

## Summary

arm/backtrace: use sp unwind if FRAME_POINTER is enabled on thumb mode

GCC toolchain Bug 92172 - ARM Thumb2 frame pointers inconsistent with clang

https://gcc.gnu.org/bugzilla/show_bug.cgi?id=92172

Signed-off-by: chao.an <anchao@xiaomi.com>

## Impact

N/A

## Testing

sabre-6quad:nsh