### PR TITLE
arch/stm32f0l0g0: add SPI3 support (STM32G0B0 chips)

### DIFF
--- a/arch/arm/src/stm32f0l0g0/Kconfig
+++ b/arch/arm/src/stm32f0l0g0/Kconfig
@@ -1090,6 +1090,10 @@ config STM32F0L0G0_HAVE_SPI2
 	bool
 	default n
 
+config STM32F0L0G0_HAVE_SPI3
+	bool
+	default n
+
 config STM32F0L0G0_HAVE_SAIPLL
 	bool
 	default n
@@ -1269,6 +1273,13 @@ config STM32F0L0G0_SPI2
 	bool "SPI2"
 	default n
 	depends on STM32F0L0G0_HAVE_SPI2
+	select SPI
+	select STM32F0L0G0_SPI
+
+config STM32F0L0G0_SPI3
+	bool "SPI3"
+	default n
+	depends on STM32F0L0G0_HAVE_SPI3
 	select SPI
 	select STM32F0L0G0_SPI
 
@@ -2718,6 +2729,14 @@ config STM32F0L0G0_SPI2_DMA
 	---help---
 		Use DMA to improve SPI2 transfer performance.  Cannot be used with STM32F0L0G0_SPI_INTERRUPT.
 
+config STM32F0L0G0_SPI3_DMA
+	bool "SPI3 DMA"
+	default n
+	depends on STM32F0L0G0_SPI3 && !STM32F0L0G0_SPI_INTERRUPTS
+	select STM32F0L0G0_SPI_DMA
+	---help---
+		Use DMA to improve SPI3 transfer performance.  Cannot be used with STM32F0L0G0_SPI_INTERRUPT.
+
 config STM32F0L0G0_SPI1_COMMTYPE
 	int "SPI1 Operation mode"
 	default 0
@@ -2731,6 +2750,14 @@ config STM32F0L0G0_SPI2_COMMTYPE
 	default 0
 	range 0 3
 	depends on STM32F0L0G0_SPI2
+	---help---
+		Select full-duplex (0), simplex tx (1), simplex rx (2) or half-duplex (3)
+
+config STM32F0L0G0_SPI3_COMMTYPE
+	int "SPI3 Operation mode"
+	default 0
+	range 0 3
+	depends on STM32F0L0G0_SPI3
 	---help---
 		Select full-duplex (0), simplex tx (1), simplex rx (2) or half-duplex (3)
 

--- a/arch/arm/src/stm32f0l0g0/stm32_spi.h
+++ b/arch/arm/src/stm32f0l0g0/stm32_spi.h
@@ -116,6 +116,13 @@ uint8_t stm32_spi2status(struct spi_dev_s *dev, uint32_t devid);
 int stm32_spi2cmddata(struct spi_dev_s *dev, uint32_t devid, bool cmd);
 #endif
 
+#ifdef CONFIG_STM32F0L0G0_SPI3
+void stm32_spi3select(struct spi_dev_s *dev, uint32_t devid,
+                      bool selected);
+uint8_t stm32_spi3status(struct spi_dev_s *dev, uint32_t devid);
+int stm32_spi3cmddata(struct spi_dev_s *dev, uint32_t devid, bool cmd);
+#endif
+
 /****************************************************************************
  * Name: stm32_spi1/2/...register
  *
@@ -144,6 +151,11 @@ int stm32_spi1register(struct spi_dev_s *dev, spi_mediachange_t callback,
 
 #ifdef CONFIG_STM32F0L0G0_SPI2
 int stm32_spi2register(struct spi_dev_s *dev, spi_mediachange_t callback,
+                       void *arg);
+#endif
+
+#ifdef CONFIG_STM32F0L0G0_SPI3
+int stm32_spi3register(struct spi_dev_s *dev, spi_mediachange_t callback,
                        void *arg);
 #endif
 #endif


### PR DESCRIPTION
## Summary
arch/stm32f0l0g0: add SPI3 support (STM32G0B0 chips)

## Impact

## Testing
CI
