### PR TITLE
delay creating DNS bind socket

### DIFF
--- a/libs/libc/netdb/lib_dns.h
+++ b/libs/libc/netdb/lib_dns.h
@@ -177,7 +177,7 @@ void dns_semgive(void);
  *
  ****************************************************************************/
 
-int dns_bind(void);
+int dns_bind(sa_family_t family);
 
 /****************************************************************************
  * Name: dns_query
@@ -187,7 +187,6 @@ int dns_bind(void);
  *   return its IP address in 'ipaddr'
  *
  * Input Parameters:
- *   sd       - The socket descriptor previously initialized by dsn_bind().
  *   hostname - The hostname string to be resolved.
  *   addr     - The location to return the IP addresses associated with the
  *     hostname.
@@ -200,7 +199,7 @@ int dns_bind(void);
  *
  ****************************************************************************/
 
-int dns_query(int sd, FAR const char *hostname, FAR union dns_addr_u *addr,
+int dns_query(FAR const char *hostname, FAR union dns_addr_u *addr,
               FAR int *naddr);
 
 /****************************************************************************

--- a/libs/libc/netdb/lib_dnsbind.c
+++ b/libs/libc/netdb/lib_dnsbind.c
@@ -61,7 +61,7 @@
  *
  ****************************************************************************/
 
-int dns_bind(void)
+int dns_bind(sa_family_t family)
 {
   struct timeval tv;
   int sd;
@@ -77,7 +77,7 @@ int dns_bind(void)
 
   /* Create a new socket */
 
-  sd = socket(PF_INET, SOCK_DGRAM, 0);
+  sd = socket(family, SOCK_DGRAM, 0);
   if (sd < 0)
     {
       ret = -get_errno();

--- a/libs/libc/netdb/lib_gethostentbynamer.c
+++ b/libs/libc/netdb/lib_gethostentbynamer.c
@@ -432,25 +432,9 @@ static int lib_find_answer(FAR const char *name, FAR struct hostent_s *host,
 static int lib_dns_query(FAR const char *hostname,
                          FAR union dns_addr_u *addr, int *naddr)
 {
-  int sd;
-  int ret;
-
-  /* Create and bind a socket to the DNS server */
-
-  sd = dns_bind();
-  if (sd < 0)
-    {
-      return sd;
-    }
-
   /* Perform the query to get the IP address */
 
-  ret = dns_query(sd, hostname, addr, naddr);
-
-  /* Release the socket */
-
-  close(sd);
-  return ret;
+  return dns_query(hostname, addr, naddr);
 }
 #endif /* CONFIG_NETDB_DNSCLIENT */
 


### PR DESCRIPTION
## Summary
dns_bind create a socket with fixed domain PF_INET, that will be a  trap!
When IPv6 is enabled, and we may try to get domain name resolution  from a IPv6 DNS server.
In connect function, the input IPv6 address will be refused because address's family(AF_INET6) is not matched with
the socket's domain(PF_INET)
So we add parameter family to dns_bind function and delay it's call to where it knows which type of socket it will create.
Now it is called in dns_query_callback

## Impact
original DNS initialization logic has been changed, and DNS socket will be created in a later time.

## Testing
Testing cases has been done with nuttx sim:nsh program
Domain name resolution service is tested using Bind software
and DNS service is OK In both IPv4 and IPv6 DNS server