### PR TITLE
arch/stm32f7/stm32_tim.c: include the missing RCC header

### DIFF
--- a/arch/arm/src/stm32f7/stm32_tim.c
+++ b/arch/arm/src/stm32f7/stm32_tim.c
@@ -37,6 +37,7 @@
 
 #include "chip.h"
 #include "arm_internal.h"
+#include "stm32_rcc.h"
 #include "stm32_gpio.h"
 #include "stm32_tim.h"
 


### PR DESCRIPTION
## Summary
arch/stm32f7/stm32_tim.c: include the missing RCC header

## Impact

## Testing
CI
