### PR TITLE
drivers/rc: fix compile warning

### DIFF
--- a/drivers/rc/lirc_dev.c
+++ b/drivers/rc/lirc_dev.c
@@ -956,7 +956,8 @@ void lirc_raw_event(FAR struct lirc_lowerhalf_s *lower,
         }
 
       sample = ev.pulse ? LIRC_PULSE(ev.duration) : LIRC_SPACE(ev.duration);
-      rcinfo("delivering %uus %d to lirc\n", ev.duration, ev.pulse ? 1 : 0);
+      rcinfo("delivering %" PRIu32 "us %u to lirc\n",
+             ev.duration, ev.pulse ? 1 : 0);
     }
 
   flags = enter_critical_section();


### PR DESCRIPTION
## Summary

drivers/rc: fix compile warning

```
In file included from /home/archer/code/nuttx/n4/incubator-nuttx/drivers/rc/lirc_dev.c:29:
drivers/rc/lirc_dev.c: In function 'lirc_raw_event':
drivers/rc/lirc_dev.c:959:14: warning: format '%u' expects argument of type 'unsigned int',
                              but argument 3 has type 'uint32_t' {aka 'long unsigned int'} [-Wformat=]
  959 |       rcinfo("delivering %uus %d to lirc\n", ev.duration, ev.pulse ? 1 : 0);
      |              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  ~~~~~~~~~~~
      |                                                |
      |                                                uint32_t {aka long unsigned int}
drivers/rc/lirc_dev.c:959:27: note: format string is defined here
  959 |       rcinfo("delivering %uus %d to lirc\n", ev.duration, ev.pulse ? 1 : 0);
      |                          ~^
      |                           |
      |                           unsigned int
      |                          %lu
```

Signed-off-by: chao.an <anchao@xiaomi.com>

## Impact

N/A

## Testing

ci check