### PR TITLE
arch/stm32/stm32_foc.c: fix some ADC and PWM ifdefs

### DIFF
--- a/arch/arm/src/stm32/stm32_foc.c
+++ b/arch/arm/src/stm32/stm32_foc.c
@@ -246,17 +246,17 @@
  */
 
 #  if defined(CONFIG_STM32_HAVE_IP_ADC_V2)
-#    ifdef CONFIG_STM32_HAVE_TIM1
+#    ifdef CONFIG_STM32_FOC_USE_TIM1
 #      define ADC_JEXTSEL_T1CC4 (ADC12_JSQR_JEXTSEL_T1CC4)
 #    endif
-#    ifdef CONFIG_STM32_HAVE_TIM8
+#    ifdef CONFIG_STM32_FOC_USE_TIM8
 #      define ADC_JEXTSEL_T8CC4 (ADC12_JSQR_JEXTSEL_T8CC4)
 #    endif
 #  elif defined(CONFIG_STM32_HAVE_IP_ADC_V1)
-#    ifdef CONFIG_STM32_HAVE_TIM1
+#    ifdef CONFIG_STM32_FOC_USE_TIM1
 #      define ADC_JEXTSEL_T1CC4  (ADC_CR2_JEXTSEL_T1CC4)
 #    endif
-#    ifdef CONFIG_STM32_HAVE_TIM8
+#    ifdef CONFIG_STM32_FOC_USE_TIM8
 #      define ADC_JEXTSEL_T8CC4  (ADC_CR2_JEXTSEL_T8CC4)
 #    endif
 #  else
@@ -392,7 +392,7 @@
  */
 
 #ifdef CONFIG_STM32_FOC_USE_ADC1
-#  ifndef CONFIG_STM32_HAVE_ADC1
+#  ifndef CONFIG_STM32_ADC1
 #    error ADC1 not supported !
 #  endif
 #  ifndef ADC1_HAVE_JEXTCFG
@@ -406,7 +406,7 @@
 #  endif
 #endif
 #ifdef CONFIG_STM32_FOC_USE_ADC2
-#  ifndef CONFIG_STM32_HAVE_ADC2
+#  ifndef CONFIG_STM32_ADC2
 #    error ADC2 not supported !
 #  endif
 #  ifndef ADC2_HAVE_JEXTCFG
@@ -420,7 +420,7 @@
 #  endif
 #endif
 #ifdef CONFIG_STM32_FOC_USE_ADC3
-#  ifndef CONFIG_STM32_HAVE_ADC3
+#  ifndef CONFIG_STM32_ADC3
 #    error ADC3 not supported !
 #  endif
 #  ifndef ADC3_HAVE_JEXTCFG
@@ -434,7 +434,7 @@
 #  endif
 #endif
 #ifdef CONFIG_STM32_FOC_USE_ADC4
-#  ifndef CONFIG_STM32_HAVE_ADC4
+#  ifndef CONFIG_STM32_ADC4
 #    error ADC4 not supported !
 #  endif
 #  ifndef ADC4_HAVE_JEXTCFG
@@ -514,13 +514,13 @@
 
 #if defined(CONFIG_STM32_HAVE_IP_ADC_V1) && !defined(HAVE_BASIC_ADC)
 #  define FOC_ADC_HAVE_CMN (1)
-#  ifdef CONFIG_STM32_HAVE_ADC1
+#  ifdef CONFIG_STM32_FOC_USE_ADC1
 #    define FOC_ADC1_CMN (&g_stm32_foc_adccmn123)
 #  endif
-#  ifdef CONFIG_STM32_HAVE_ADC2
+#  ifdef CONFIG_STM32_FOC_USE_ADC2
 #    define FOC_ADC2_CMN (&g_stm32_foc_adccmn123)
 #  endif
-#  ifdef CONFIG_STM32_HAVE_ADC3
+#  ifdef CONFIG_STM32_FOC_USE_ADC3
 #    define FOC_ADC3_CMN (&g_stm32_foc_adccmn123)
 #  endif
 #endif
@@ -529,13 +529,13 @@
 
 #if defined(CONFIG_STM32_HAVE_IP_ADC_V1) && defined(HAVE_BASIC_ADC)
 #  undef FOC_ADC_HAVE_CMN
-#  ifdef CONFIG_STM32_HAVE_ADC1
+#  ifdef CONFIG_STM32_FOC_USE_ADC1
 #    define FOC_ADC1_CMN (0)
 #  endif
-#  ifdef CONFIG_STM32_HAVE_ADC2
+#  ifdef CONFIG_STM32_FOC_USE_ADC2
 #    define FOC_ADC2_CMN (0)
 #  endif
-#  ifdef CONFIG_STM32_HAVE_ADC3
+#  ifdef CONFIG_STM32_FOC_USE_ADC3
 #    define FOC_ADC3_CMN (0)
 #  endif
 #endif
@@ -544,16 +544,16 @@
 
 #ifdef CONFIG_STM32_HAVE_IP_ADC_V2
 #  define FOC_ADC_HAVE_CMN (1)
-#  ifdef CONFIG_STM32_HAVE_ADC1
+#  ifdef CONFIG_STM32_FOC_USE_ADC1
 #    define FOC_ADC1_CMN (&g_stm32_foc_adccmn12)
 #  endif
-#  ifdef CONFIG_STM32_HAVE_ADC2
+#  ifdef CONFIG_STM32_FOC_USE_ADC2
 #    define FOC_ADC2_CMN (&g_stm32_foc_adccmn12)
 #  endif
-#  ifdef CONFIG_STM32_HAVE_ADC3
+#  ifdef CONFIG_STM32_FOC_USE_ADC3
 #    define FOC_ADC3_CMN (&g_stm32_foc_adccmn34)
 #  endif
-#  ifdef CONFIG_STM32_HAVE_ADC4
+#  ifdef CONFIG_STM32_FOC_USE_ADC4
 #    define FOC_ADC4_CMN (&g_stm32_foc_adccmn34)
 #  endif
 #endif


### PR DESCRIPTION
## Summary
Small mistakes I found when porting the FOC driver to STM32F7

## Impact
None
## Testing
CI
