### PR TITLE
optimize UNUSED macro

### DIFF
--- a/include/nuttx/compiler.h
+++ b/include/nuttx/compiler.h
@@ -385,7 +385,7 @@
 
 /* Indicate that a local variable is not used */
 
-#  define UNUSED(a) ((void)(1 || (a)))
+#  define UNUSED(a) ((void)(1 || &(a)))
 
 #  if defined(__clang__)
 #    define no_builtin(n) __attribute__((no_builtin(n)))
@@ -485,7 +485,7 @@
 
 /* Indicate that a local variable is not used */
 
-#  define UNUSED(a) ((void)(1 || (a)))
+#  define UNUSED(a) ((void)(1 || &(a)))
 
 /* It is assumed that the system is build using the small
  * data model with storage defaulting to internal RAM.
@@ -654,7 +654,7 @@
 
 /* Indicate that a local variable is not used */
 
-#  define UNUSED(a) ((void)(1 || (a)))
+#  define UNUSED(a) ((void)(1 || &(a)))
 
 /* Older Zilog compilers support both types double and long long, but the
  * size is 32-bits (same as long and single precision) so it is safer to say
@@ -721,7 +721,7 @@
 
 /* Indicate that a local variable is not used */
 
-#  define UNUSED(a) ((void)(1 || (a)))
+#  define UNUSED(a) ((void)(1 || &(a)))
 
 #  define CONFIG_CPP_HAVE_VARARGS 1 /* Supports variable argument macros */
 #  define CONFIG_HAVE_FILENAME 1    /* Has __FILE__ */
@@ -783,7 +783,7 @@
 #  undef  CONFIG_HAVE_DOUBLE
 #  undef  CONFIG_HAVE_LONG_DOUBLE
 
-#  define UNUSED(a) ((void)(1 || (a)))
+#  define UNUSED(a) ((void)(1 || &(a)))
 
 #  define offsetof(a, b) ((size_t)(&(((a *)(0))->b)))
 


### PR DESCRIPTION
Signed-off-by: liyi <liyi25@xiaomi.com>

## Summary
optimize UNUSED macro to fit more type of input parameter, for example, a structure

## Impact
macro UNUSED can fit more types.

## Testing
before change
![image](https://user-images.githubusercontent.com/38680504/182783930-6612eca7-1a68-43c0-98f8-2cc221a032a3.png)
when input parameter of  UNUSED is not a integer, the compile will fail!
after change, it can work well.