### PR TITLE
iob_s add io_private filed, user can use it to keep context

### DIFF
--- a/include/nuttx/mm/iob.h
+++ b/include/nuttx/mm/iob.h
@@ -97,6 +97,8 @@ struct iob_s
 
   FAR struct iob_s *io_flink;
 
+  FAR void *io_private;  /* Interpreted by user */
+
   /* Payload */
 
 #if CONFIG_IOB_BUFSIZE < 256

--- a/include/nuttx/mm/iob.h
+++ b/include/nuttx/mm/iob.h
@@ -70,6 +70,16 @@
 #  error CONFIG_IOB_NBUFFERS <= CONFIG_IOB_THROTTLE
 #endif
 
+/* Default config of alignment and header padding size */
+
+#if !defined(CONFIG_IOB_ALIGNMENT)
+#  define CONFIG_IOB_ALIGNMENT      1
+#endif
+
+#if !defined(CONFIG_IOB_HEADER_SIZE)
+#  define CONFIG_IOB_HEADER_SIZE    0
+#endif
+
 /* IOB helpers */
 
 #define IOB_DATA(p)      (&(p)->io_data[(p)->io_offset])
@@ -110,7 +120,7 @@ struct iob_s
 #endif
   unsigned int io_pktlen; /* Total length of the packet */
 
-  uint8_t  io_data[CONFIG_IOB_BUFSIZE];
+  FAR uint8_t *io_data;
 };
 
 #if CONFIG_IOB_NCHAINS > 0

--- a/mm/iob/Kconfig
+++ b/mm/iob/Kconfig
@@ -32,6 +32,18 @@ config IOB_BUFSIZE
 		chain.  This setting determines the data payload each preallocated
 		I/O buffer.
 
+config IOB_ALIGNMENT
+	int "Alignment size of each I/O buffer"
+	default 1
+	---help---
+		All I/O buffers are aligned to the value specified by this config.
+
+config IOB_HEADER_SIZE
+	int "Header size of each I/O buffer"
+	default 0
+	---help---
+		This setting determines the reserved size in front of each I/O buffer.
+
 config IOB_NCHAINS
 	int "Number of pre-allocated I/O buffer chain heads"
 	default 0 if !NET_READAHEAD

--- a/mm/iob/iob_initialize.c
+++ b/mm/iob/iob_initialize.c
@@ -31,6 +31,17 @@
 #include "iob.h"
 
 /****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define ROUNDUP(x, y)   (((x) + (y) - 1) / (y) * (y))
+
+/* Fix the I/O Buffer size with specified alignment size */
+
+#define IOB_BUF_ALIGN_SIZE ROUNDUP(CONFIG_IOB_BUFSIZE + \
+                          CONFIG_IOB_HEADER_SIZE, CONFIG_IOB_ALIGNMENT)
+
+/****************************************************************************
  * Private Data
  ****************************************************************************/
 
@@ -40,6 +51,11 @@ static struct iob_s        g_iob_pool[CONFIG_IOB_NBUFFERS];
 #if CONFIG_IOB_NCHAINS > 0
 static struct iob_qentry_s g_iob_qpool[CONFIG_IOB_NCHAINS];
 #endif
+
+/* memory prepared for I/O buffers */
+
+static uint8_t g_iob_buffer[CONFIG_IOB_NBUFFERS * IOB_BUF_ALIGN_SIZE]
+                           aligned_data(CONFIG_IOB_ALIGNMENT);
 
 /****************************************************************************
  * Public Data
@@ -101,6 +117,11 @@ void iob_initialize(void)
   for (i = 0; i < CONFIG_IOB_NBUFFERS; i++)
     {
       FAR struct iob_s *iob = &g_iob_pool[i];
+
+      /* Reserve the pad size for each I/O buffer */
+
+      iob->io_data = g_iob_buffer + i * IOB_BUF_ALIGN_SIZE +
+                                    CONFIG_IOB_HEADER_SIZE;
 
       /* Add the pre-allocate I/O buffer to the head of the free list */
 


### PR DESCRIPTION
Signed-off-by: luojun1 <luojun1@xiaomi.com>
Change-Id: Ia065b2ba3910bad01b1548a9bac75e003c3ee823

## Summary
add io_private field to iob_s, user can use it to keep context
## Impact
none
## Testing
none
