### PR TITLE
Multiple improvements for stm32wl5 board nucleo-stm32wl5jc

### DIFF
--- a/arch/arm/src/stm32wl5/stm32wl5_pwr.c
+++ b/arch/arm/src/stm32wl5/stm32wl5_pwr.c
@@ -29,6 +29,7 @@
 #include <stdbool.h>
 #include <errno.h>
 
+#include "hardware/stm32wl5_pwr.h"
 #include "arm_internal.h"
 #include "stm32wl5_pwr.h"
 #include "stm32wl5_rcc.h"
@@ -105,4 +106,18 @@ bool stm32wl5_pwr_enablebkp(bool writable)
     }
 
   return waswritable;
+}
+
+/****************************************************************************
+ * Name: stm32wl5_pwr_boot_c2
+ *
+ * Description:
+ *   Boots up CPU2 (cortex-m0) after reset or wakeup from stop or standby
+ *   modes.
+ *
+ ****************************************************************************/
+
+void stm32wl5_pwr_boot_c2(void)
+{
+  modifyreg32(STM32WL5_PWR_CR4, 0, PWR_CR4_C2BOOT);
 }

--- a/arch/arm/src/stm32wl5/stm32wl5_pwr.h
+++ b/arch/arm/src/stm32wl5/stm32wl5_pwr.h
@@ -68,6 +68,17 @@ extern "C"
 
 bool stm32wl5_pwr_enablebkp(bool writable);
 
+/****************************************************************************
+ * Name: stm32wl5_pwr_boot_c2
+ *
+ * Description:
+ *   Boots up CPU2 (cortex-m0) after reset or wakeup from stop or standby
+ *   modes.
+ *
+ ****************************************************************************/
+
+void stm32wl5_pwr_boot_c2(void);
+
 #undef EXTERN
 #if defined(__cplusplus)
 }

--- a/boards/arm/stm32wl5/nucleo-wl55jc/Kconfig
+++ b/boards/arm/stm32wl5/nucleo-wl55jc/Kconfig
@@ -17,6 +17,13 @@ config ARCH_BOARD_NUCLEO_WL55JC_DEMO_LED_IRQ
 comment "[demo] LED on button interrupt requires NSH_ARCHINIT"
 	depends on !NSH_ARCHINIT || !ARCH_BUTTONS
 
+config ARCH_BOARD_ENABLE_CPU2
+	bool "Enable CPU2 on startup"
+	default n
+	---help---
+		When enabled, CPU2 (cortex-m0) will be started up. CPU2
+		will be booted after all initialization on CPU1 is done.
+
 menuconfig ARCH_BOARD_FLASH_MOUNT
 	bool "Enable FLASH partitioning and mounting"
 	depends on !DISABLE_MOUNTPOINT

--- a/boards/arm/stm32wl5/nucleo-wl55jc/Kconfig
+++ b/boards/arm/stm32wl5/nucleo-wl55jc/Kconfig
@@ -24,6 +24,127 @@ config ARCH_BOARD_ENABLE_CPU2
 		When enabled, CPU2 (cortex-m0) will be started up. CPU2
 		will be booted after all initialization on CPU1 is done.
 
+menuconfig ARCH_BOARD_IPCC
+	bool "Enabled IPCC"
+	select IPCC
+	select STM32WL5_IPCC
+	default n
+	---help---
+		Enables IPCC (inter processor communication controller)
+		to exchange data between CPU1 and CPU2. Channels are
+		indexed from 0. IPCC will be accessible as character
+		device under "/dev/ipccN" path, where N is an ipcc channel.
+
+if ARCH_BOARD_IPCC
+
+comment "IPCC buffering is off, enable IPCC_BUFFERED to configure buffers"
+	depends on !IPCC_BUFFERED
+
+comment "IPCC channel 1 enabled by default"
+
+config ARCH_BOARD_IPCC_CHAN1_RXBUF
+	int "Channel 1 RX buffer size"
+	default 256
+	depends on IPCC_BUFFERED
+
+config ARCH_BOARD_IPCC_CHAN1_TXBUF
+	int "Channel 1 TX buffer size"
+	default 256
+	depends on IPCC_BUFFERED
+
+config ARCH_BOARD_IPCC_CHAN2
+	bool "Enable channel 2"
+	default n
+	select STM32WL5_IPCC_CHAN2
+
+if ARCH_BOARD_IPCC_CHAN2
+
+config ARCH_BOARD_IPCC_CHAN2_RXBUF
+	int "Channel 2 RX buffer size"
+	default 256
+	depends on IPCC_BUFFERED
+
+config ARCH_BOARD_IPCC_CHAN2_TXBUF
+	int "Channel 2 TX buffer size"
+	default 256
+	depends on IPCC_BUFFERED
+
+config ARCH_BOARD_IPCC_CHAN3
+	bool "Enable channel 3"
+	default n
+	select STM32WL5_IPCC_CHAN3
+
+if ARCH_BOARD_IPCC_CHAN3
+
+config ARCH_BOARD_IPCC_CHAN3_RXBUF
+	int "Channel 3 RX buffer size"
+	default 256
+	depends on IPCC_BUFFERED
+
+config ARCH_BOARD_IPCC_CHAN3_TXBUF
+	int "Channel 3 TX buffer size"
+	default 256
+	depends on IPCC_BUFFERED
+
+config ARCH_BOARD_IPCC_CHAN4
+	bool "Enable channel 4"
+	default n
+	select STM32WL5_IPCC_CHAN4
+
+if ARCH_BOARD_IPCC_CHAN4
+
+config ARCH_BOARD_IPCC_CHAN4_RXBUF
+	int "Channel 4 RX buffer size"
+	default 256
+	depends on IPCC_BUFFERED
+
+config ARCH_BOARD_IPCC_CHAN4_TXBUF
+	int "Channel 4 TX buffer size"
+	default 256
+	depends on IPCC_BUFFERED
+
+config ARCH_BOARD_IPCC_CHAN5
+	bool "Enable channel 5"
+	default n
+	select STM32WL5_IPCC_CHAN5
+
+if ARCH_BOARD_IPCC_CHAN5
+
+config ARCH_BOARD_IPCC_CHAN5_RXBUF
+	int "Channel 5 RX buffer size"
+	default 256
+	depends on IPCC_BUFFERED
+
+config ARCH_BOARD_IPCC_CHAN5_TXBUF
+	int "Channel 5 TX buffer size"
+	default 256
+	depends on IPCC_BUFFERED
+
+config ARCH_BOARD_IPCC_CHAN6
+	bool "Enable channel 6"
+	default n
+	select STM32WL5_IPCC_CHAN6
+
+if ARCH_BOARD_IPCC_CHAN6
+
+config ARCH_BOARD_IPCC_CHAN2_RXBUF
+	int "Channel 6 RX buffer size"
+	default 256
+	depends on IPCC_BUFFERED
+
+config ARCH_BOARD_IPCC_CHAN6_TXBUF
+	int "Channel 6 TX buffer size"
+	default 256
+	depends on IPCC_BUFFERED
+
+endif # ARCH_BOARD_IPCC_CHAN6
+endif # ARCH_BOARD_IPCC_CHAN5
+endif # ARCH_BOARD_IPCC_CHAN4
+endif # ARCH_BOARD_IPCC_CHAN3
+endif # ARCH_BOARD_IPCC_CHAN2
+
+endif # ARCH_BOARD_IPCC
+
 menuconfig ARCH_BOARD_FLASH_MOUNT
 	bool "Enable FLASH partitioning and mounting"
 	depends on !DISABLE_MOUNTPOINT

--- a/boards/arm/stm32wl5/nucleo-wl55jc/src/Makefile
+++ b/boards/arm/stm32wl5/nucleo-wl55jc/src/Makefile
@@ -22,23 +22,11 @@ include $(TOPDIR)/Make.defs
 
 CSRCS = stm32_boot.c stm32_leds.c
 
-ifeq ($(CONFIG_BOARDCTL),y)
-CSRCS += stm32_appinit.c
-endif
-
-ifeq ($(CONFIG_ARCH_BUTTONS),y)
-CSRCS += stm32_buttons.c
-endif
-
-ifeq ($(CONFIG_ARCH_BOARD_FLASH_MOUNT),y)
-CSRCS += stm32_flash.c
-endif
-
-ifeq ($(CONFIG_SPI_DRIVER),y)
-  CSRCS += stm32_spi.c
-endif
-
-CSRCS-$(CONFIG_ARCH_BOARD_IPCC) = stm32_ipcc.c
+CSRCS-$(CONFIG_BOARDCTL) += stm32_appinit.c
+CSRCS-$(CONFIG_ARCH_BUTTONS) += stm32_buttons.c
+CSRCS-$(CONFIG_ARCH_BOARD_FLASH_MOUNT) += stm32_flash.c
+CSRCS-$(CONFIG_SPI_DRIVER) += stm32_spi.c
+CSRCS-$(CONFIG_ARCH_BOARD_IPCC) += stm32_ipcc.c
 
 ifeq ($(CONFIG_VIDEO_FB),y)
 ifeq ($(CONFIG_LCD_SSD1680),y)

--- a/boards/arm/stm32wl5/nucleo-wl55jc/src/Makefile
+++ b/boards/arm/stm32wl5/nucleo-wl55jc/src/Makefile
@@ -38,10 +38,14 @@ ifeq ($(CONFIG_SPI_DRIVER),y)
   CSRCS += stm32_spi.c
 endif
 
+CSRCS-$(CONFIG_ARCH_BOARD_IPCC) = stm32_ipcc.c
+
 ifeq ($(CONFIG_VIDEO_FB),y)
 ifeq ($(CONFIG_LCD_SSD1680),y)
   CSRCS += stm32_ssd1680.c
 endif
 endif
+
+CSRCS += $(CSRCS-y)
 
 include $(TOPDIR)/boards/Board.mk

--- a/boards/arm/stm32wl5/nucleo-wl55jc/src/nucleo-wl55jc.h
+++ b/boards/arm/stm32wl5/nucleo-wl55jc/src/nucleo-wl55jc.h
@@ -155,7 +155,8 @@ void board_leds_initialize(void);
 
 int stm32wl5_flash_init(void);
 
-/* Name: stm32wl5_spidev_initialize
+/****************************************************************************
+ * Name: stm32wl5_spidev_initialize
  *
  * Description:
  *   Initialize SPIs
@@ -163,5 +164,15 @@ int stm32wl5_flash_init(void);
  ****************************************************************************/
 
 void stm32wl5_spidev_initialize(void);
+
+/****************************************************************************
+ * Name: ipcc_init
+ *
+ * Description:
+ *   Initializes configured IPCC channels.
+ *
+ ****************************************************************************/
+
+int ipcc_init(void);
 
 #endif /* __BOARDS_ARM_STM32WL5_NUCLEO_WL55JC_SRC_NUCLEO_WL55JC_H */

--- a/boards/arm/stm32wl5/nucleo-wl55jc/src/stm32_appinit.c
+++ b/boards/arm/stm32wl5/nucleo-wl55jc/src/stm32_appinit.c
@@ -39,6 +39,7 @@
 
 #include <stm32wl5.h>
 #include <stm32wl5_uart.h>
+#include <stm32wl5_pwr.h>
 
 #include <arch/board/board.h>
 
@@ -130,6 +131,12 @@ int board_app_initialize(uintptr_t arg)
     {
       syslog(LOG_ERR, "ERROR: stm32wl5_flash_init() failed: %d\n", ret);
     }
+#endif
+
+#if defined(CONFIG_ARCH_BOARD_ENABLE_CPU2)
+  /* Start second CPU */
+
+  stm32wl5_pwr_boot_c2();
 #endif
 
   return ret;

--- a/boards/arm/stm32wl5/nucleo-wl55jc/src/stm32_appinit.c
+++ b/boards/arm/stm32wl5/nucleo-wl55jc/src/stm32_appinit.c
@@ -133,6 +133,16 @@ int board_app_initialize(uintptr_t arg)
     }
 #endif
 
+#if defined(CONFIG_ARCH_BOARD_IPCC)
+  /* Register IPCC driver */
+
+  ret = ipcc_init();
+  if (ret < 0)
+    {
+      syslog(LOG_ERR, "ERROR: ipcc_init() failed\n");
+    }
+#endif
+
 #if defined(CONFIG_ARCH_BOARD_ENABLE_CPU2)
   /* Start second CPU */
 

--- a/boards/arm/stm32wl5/nucleo-wl55jc/src/stm32_ipcc.c
+++ b/boards/arm/stm32wl5/nucleo-wl55jc/src/stm32_ipcc.c
@@ -1,0 +1,180 @@
+/****************************************************************************
+ * boards/arm/stm32wl5/nucleo-wl55jc/src/stm32_ipcc.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+#include <nuttx/ipcc.h>
+#include <debug.h>
+
+#include <stm32wl5_ipcc.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/* Define default values for macros if they are not define in config */
+
+#ifndef CONFIG_ARCH_BOARD_IPCC_CHAN1_RXBUF
+#  define CONFIG_ARCH_BOARD_IPCC_CHAN1_RXBUF 0
+#endif
+
+#ifndef CONFIG_ARCH_BOARD_IPCC_CHAN1_TXBUF
+#  define CONFIG_ARCH_BOARD_IPCC_CHAN1_TXBUF 0
+#endif
+
+#ifndef CONFIG_ARCH_BOARD_IPCC_CHAN2_RXBUF
+#  define CONFIG_ARCH_BOARD_IPCC_CHAN2_RXBUF 0
+#endif
+
+#ifndef CONFIG_ARCH_BOARD_IPCC_CHAN2_TXBUF
+#  define CONFIG_ARCH_BOARD_IPCC_CHAN2_TXBUF 0
+#endif
+
+#ifndef CONFIG_ARCH_BOARD_IPCC_CHAN3_RXBUF
+#  define CONFIG_ARCH_BOARD_IPCC_CHAN3_RXBUF 0
+#endif
+
+#ifndef CONFIG_ARCH_BOARD_IPCC_CHAN3_TXBUF
+#  define CONFIG_ARCH_BOARD_IPCC_CHAN3_TXBUF 0
+#endif
+
+#ifndef CONFIG_ARCH_BOARD_IPCC_CHAN4_RXBUF
+#  define CONFIG_ARCH_BOARD_IPCC_CHAN4_RXBUF 0
+#endif
+
+#ifndef CONFIG_ARCH_BOARD_IPCC_CHAN4_TXBUF
+#  define CONFIG_ARCH_BOARD_IPCC_CHAN4_TXBUF 0
+#endif
+
+#ifndef CONFIG_ARCH_BOARD_IPCC_CHAN5_RXBUF
+#  define CONFIG_ARCH_BOARD_IPCC_CHAN5_RXBUF 0
+#endif
+
+#ifndef CONFIG_ARCH_BOARD_IPCC_CHAN5_TXBUF
+#  define CONFIG_ARCH_BOARD_IPCC_CHAN5_TXBUF 0
+#endif
+
+#ifndef CONFIG_ARCH_BOARD_IPCC_CHAN6_RXBUF
+#  define CONFIG_ARCH_BOARD_IPCC_CHAN6_RXBUF 0
+#endif
+
+#ifndef CONFIG_ARCH_BOARD_IPCC_CHAN6_TXBUF
+#  define CONFIG_ARCH_BOARD_IPCC_CHAN6_TXBUF 0
+#endif
+
+/****************************************************************************
+ * Private Function Prototypes
+ ****************************************************************************/
+
+static int init_ipcc(int chan, size_t rxbuflen, size_t txbuflen);
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: init_ipcc
+ *
+ * Description:
+ *   Initializes IPCC channel with tx and rx buffer sizes. If ipcc is
+ *   unbuffered, rxbuflen and txbuflen are ignored.
+ *
+ * Input Parameters:
+ *   chan - channel number, indexed from 0
+ *   rxbuflen - size of rxbuffer for buffered transactions
+ *   txbuflen - size of txbuffer for buffered transactions
+ *
+ * Returned Value:
+ *   0 on success or -1 on errors.
+ *
+ ****************************************************************************/
+
+static int init_ipcc(int chan, size_t rxbuflen, size_t txbuflen)
+{
+  struct ipcc_lower_s *ipcc;
+  int ret;
+
+  if ((ipcc = stm32wl5_ipcc_init(chan)) == NULL)
+    {
+      syslog(LOG_ERR, "ERROR: stm32wl5_ipcc_init(%d) failed\n", chan);
+      return -1;
+    }
+
+#ifdef CONFIG_IPCC_BUFFERED
+  ret = ipcc_register(ipcc, rxbuflen, txbuflen);
+#else
+  UNUSED(rxbuflen);
+  UNUSED(txbuflen);
+  ret = ipcc_register(ipcc);
+#endif
+
+  if (ret < 0)
+    {
+      syslog(LOG_ERR, "ERROR: ipcc_register() failed: %d, channel: %d\n",
+             ret, chan);
+      return -1;
+    }
+
+  return 0;
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+int ipcc_init(void)
+{
+  int ret = 0;
+
+  /* First channel is always enabled in IPCC is enabled */
+
+  ret |= init_ipcc(0, CONFIG_ARCH_BOARD_IPCC_CHAN1_RXBUF,
+                   CONFIG_ARCH_BOARD_IPCC_CHAN1_TXBUF);
+
+#ifdef CONFIG_ARCH_BOARD_IPCC_CHAN2
+  ret |= init_ipcc(1, CONFIG_ARCH_BOARD_IPCC_CHAN2_RXBUF,
+                   CONFIG_ARCH_BOARD_IPCC_CHAN2_TXBUF);
+#endif
+
+#ifdef CONFIG_ARCH_BOARD_IPCC_CHAN3
+  ret |= init_ipcc(2, CONFIG_ARCH_BOARD_IPCC_CHAN3_RXBUF,
+                   CONFIG_ARCH_BOARD_IPCC_CHAN3_TXBUF);
+#endif
+
+#ifdef CONFIG_ARCH_BOARD_IPCC_CHAN4
+  ret |= init_ipcc(3, CONFIG_ARCH_BOARD_IPCC_CHAN4_RXBUF,
+                   CONFIG_ARCH_BOARD_IPCC_CHAN4_TXBUF);
+#endif
+
+#ifdef CONFIG_ARCH_BOARD_IPCC_CHAN5
+  ret |= init_ipcc(4, CONFIG_ARCH_BOARD_IPCC_CHAN5_RXBUF,
+                   CONFIG_ARCH_BOARD_IPCC_CHAN5_TXBUF);
+#endif
+
+#ifdef CONFIG_ARCH_BOARD_IPCC_CHAN6
+  ret |= init_ipcc(5, CONFIG_ARCH_BOARD_IPCC_CHAN6_RXBUF,
+                   CONFIG_ARCH_BOARD_IPCC_CHAN6_TXBUF);
+#endif
+
+  return ret;
+}

--- a/drivers/ipcc/ipcc_poll.c
+++ b/drivers/ipcc/ipcc_poll.c
@@ -132,6 +132,8 @@ int ipcc_poll(FAR struct file *filep, FAR struct pollfd *fds,
   /* Should immediately notify on any of the requested events?  */
 
   eventset = 0;
+
+#ifdef CONFIG_IPCC_BUFFERED
   if (circbuf_used(&priv->ipcc->rxbuf) > 0)
     {
       eventset |= (fds->events & POLLIN);
@@ -141,6 +143,7 @@ int ipcc_poll(FAR struct file *filep, FAR struct pollfd *fds,
     {
       eventset |= (fds->events & POLLOUT);
     }
+#endif
 
   if (eventset)
     {

--- a/include/nuttx/ipcc.h
+++ b/include/nuttx/ipcc.h
@@ -114,8 +114,10 @@ struct ipcc_ops_s
    *
    **************************************************************************/
 
+#ifdef CONFIG_IPCC_BUFFERED
   CODE ssize_t (*buffer_data)(FAR struct ipcc_lower_s *ipcc,
                               FAR struct circbuf_s *rxbuf);
+#endif
 
   /**************************************************************************
    * Name: write_notify
@@ -133,7 +135,9 @@ struct ipcc_ops_s
    *
    **************************************************************************/
 
+#ifdef CONFIG_IPCC_BUFFERED
   CODE ssize_t (*write_notify)(FAR struct ipcc_lower_s *ipcc);
+#endif
 
   /**************************************************************************
    * Name: cleanup


### PR DESCRIPTION
## Summary
This pull requests contains multiple commits with improvements for stm32wl5 chip and nucleo-stm32wl5jc board. In short it adds:

- fixes unbuffered IPCC communication
- fixes potential system deadlocks in certain situations when using IPCC
- adds support to boot second CPU during nuttx startup
- adds support to enable IPCC in stm32wl5jc board
- simplifies makefile
- splits Kconfig files into separate files to enhance maintanability and readability of these

More information can be found in commit messages.

## Impact
stm32wl5 chip and nucleo-stm32wl5jc - which are work in progress.

## Testing
Compilation and running.
