### PR TITLE
libc/localtime: fix some issues and update to consistent with mainline

### DIFF
--- a/libs/libc/time/lib_localtime.c
+++ b/libs/libc/time/lib_localtime.c
@@ -2584,5 +2584,10 @@ time_t mktime(FAR struct tm *tmp)
 
 time_t timegm(FAR struct tm *tmp)
 {
+  if (tmp != NULL)
+    {
+      tmp->tm_isdst = 0;
+    }
+
   return time1(tmp, gmtsub, 0L);
 }

--- a/libs/libc/time/lib_localtime.c
+++ b/libs/libc/time/lib_localtime.c
@@ -326,8 +326,8 @@ static int g_lcl_isset;
 static int g_gmt_isset;
 static FAR struct state_s *g_lcl_ptr;
 static FAR struct state_s *g_gmt_ptr;
-static mutex_t g_lcl_lock = NXMUTEX_INITIALIZER;
-static mutex_t g_gmt_lock = NXMUTEX_INITIALIZER;
+static rmutex_t g_lcl_lock = NXRMUTEX_INITIALIZER;
+static rmutex_t g_gmt_lock = NXRMUTEX_INITIALIZER;
 
 /* Section 4.12.3 of X3.159-1989 requires that
  *    Except for the strftime function, these functions [asctime,
@@ -1775,7 +1775,8 @@ static FAR struct tm *gmtsub(FAR const time_t *timep,
         }
 #endif
 
-      nxmutex_lock(&g_gmt_lock);
+      nxrmutex_lock(&g_gmt_lock);
+
       if (!g_gmt_isset)
         {
           g_gmt_ptr = lib_malloc(sizeof *g_gmt_ptr);
@@ -1786,7 +1787,7 @@ static FAR struct tm *gmtsub(FAR const time_t *timep,
             }
         }
 
-      nxmutex_unlock(&g_gmt_lock);
+      nxrmutex_unlock(&g_gmt_lock);
     }
 
   tmp->tm_zone = GMT;
@@ -2493,7 +2494,8 @@ void tzset(void)
     }
 #endif
 
-  nxmutex_lock(&g_lcl_lock);
+  nxrmutex_lock(&g_lcl_lock);
+
   name = getenv("TZ");
   if (name == NULL)
     {
@@ -2545,7 +2547,7 @@ void tzset(void)
 tzname:
   settzname();
 out:
-  nxmutex_unlock(&g_lcl_lock);
+  nxrmutex_unlock(&g_lcl_lock);
 }
 
 FAR struct tm *localtime(FAR const time_t *timep)

--- a/libs/libc/time/lib_localtime.c
+++ b/libs/libc/time/lib_localtime.c
@@ -1768,7 +1768,7 @@ static FAR struct tm *gmtsub(FAR const time_t *timep,
   if (!g_gmt_isset)
     {
 #ifndef __KERNEL__
-      if (up_interrupt_context())
+      if (up_interrupt_context() || sched_idletask())
         {
           return NULL;
         }
@@ -2486,7 +2486,7 @@ void tzset(void)
   FAR const char *name;
 
 #ifndef __KERNEL__
-  if (up_interrupt_context())
+  if (up_interrupt_context() || sched_idletask())
     {
       return;
     }

--- a/libs/libc/time/lib_localtime.c
+++ b/libs/libc/time/lib_localtime.c
@@ -59,6 +59,7 @@
 #include <assert.h>
 #include <errno.h>
 
+#include <nuttx/init.h>
 #include <nuttx/fs/fs.h>
 #include <nuttx/mutex.h>
 
@@ -1768,7 +1769,7 @@ static FAR struct tm *gmtsub(FAR const time_t *timep,
   if (!g_gmt_isset)
     {
 #ifndef __KERNEL__
-      if (up_interrupt_context() || sched_idletask())
+      if (up_interrupt_context() || (sched_idletask() && OSINIT_IDLELOOP()))
         {
           return NULL;
         }
@@ -2486,7 +2487,7 @@ void tzset(void)
   FAR const char *name;
 
 #ifndef __KERNEL__
-  if (up_interrupt_context() || sched_idletask())
+  if (up_interrupt_context() || (sched_idletask() && OSINIT_IDLELOOP()))
     {
       return;
     }


### PR DESCRIPTION
## Summary
1. Fix some issues about semphore hold in interrupt and idle stask.
2. using recursive mutex fix deadlock.
3. fix gmtime issue for isdst is true.
4. update lib_localtime.c to conssisstent with mainline https://github.com/eggert/tz

## Impact

## Testing
timedatectl
set TZ Asia/Shanghai
timedatectl
timedatectl set-timezone Asia/Tokyo
timedatectl
timedatectl set-timezone Pacific/Honolulu
timedatectl
timedatectl set-timezone Asia/Shanghai
timedatectl
timedatectl set-timezone xxxaaa
timedatectl
