### PR TITLE
drivers/net: make sure that net driver d_buf is 16-bit aligned

### DIFF
--- a/arch/arm/src/c5471/c5471_ethernet.c
+++ b/arch/arm/src/c5471/c5471_ethernet.c
@@ -284,7 +284,8 @@
 
 /* A single packet buffer is used */
 
-static uint8_t g_pktbuf[MAX_NETDEV_PKTSIZE + CONFIG_NET_GUARDSIZE];
+static uint8_t g_pktbuf[CONFIG_C5471_NET_NINTERFACES]
+                       [MAX_NETDEV_PKTSIZE + CONFIG_NET_GUARDSIZE];
 
 /* The c5471_driver_s encapsulates all state information for a single c5471
  * hardware interface
@@ -2389,7 +2390,7 @@ void arm_netinitialize(void)
 
   memset(g_c5471, 0,
     CONFIG_C5471_NET_NINTERFACES * sizeof(struct c5471_driver_s));
-  g_c5471[0].c_dev.d_buf     = g_pktbuf;        /* Single packet buffer */
+  g_c5471[0].c_dev.d_buf     = g_pktbuf[0];     /* Single packet buffer */
   g_c5471[0].c_dev.d_ifup    = c5471_ifup;      /* I/F down callback */
   g_c5471[0].c_dev.d_ifdown  = c5471_ifdown;    /* I/F up (new IP address) callback */
   g_c5471[0].c_dev.d_txavail = c5471_txavail;   /* New TX data callback */

--- a/arch/arm/src/lpc17xx_40xx/lpc17_40_ethernet.c
+++ b/arch/arm/src/lpc17xx_40xx/lpc17_40_ethernet.c
@@ -308,7 +308,7 @@ struct lpc17_40_driver_s
 
 /* A single packet buffer per interface is used */
 
-static uint8_t g_pktbuf[PKTBUF_SIZE * CONFIG_LPC17_40_NINTERFACES];
+static uint8_t g_pktbuf[CONFIG_LPC17_40_NINTERFACES][PKTBUF_SIZE];
 
 /* Array of ethernet driver status structures */
 
@@ -3149,7 +3149,6 @@ static inline int lpc17_40_ethinitialize(int intf)
 #endif
 {
   struct lpc17_40_driver_s *priv;
-  uint8_t *pktbuf;
   uint32_t regval;
   int ret;
   int i;
@@ -3172,14 +3171,10 @@ static inline int lpc17_40_ethinitialize(int intf)
 
   lpc17_40_showpins();
 
-  /* Select the packet buffer */
-
-  pktbuf = &g_pktbuf[PKTBUF_SIZE * intf];
-
   /* Initialize the driver structure */
 
   memset(priv, 0, sizeof(struct lpc17_40_driver_s));
-  priv->lp_dev.d_buf     = pktbuf;             /* Single packet buffer */
+  priv->lp_dev.d_buf     = g_pktbuf[intf];     /* Single packet buffer */
   priv->lp_dev.d_ifup    = lpc17_40_ifup;      /* I/F down callback */
   priv->lp_dev.d_ifdown  = lpc17_40_ifdown;    /* I/F up (new IP address) callback */
   priv->lp_dev.d_txavail = lpc17_40_txavail;   /* New TX data callback */

--- a/arch/arm/src/tiva/lm/lm3s_ethernet.c
+++ b/arch/arm/src/tiva/lm/lm3s_ethernet.c
@@ -199,7 +199,8 @@ struct tiva_driver_s
 
 /* A single packet buffer is used */
 
-static uint8_t g_pktbuf[MAX_NETDEV_PKTSIZE + CONFIG_NET_GUARDSIZE];
+static uint8_t g_pktbuf[TIVA_NETHCONTROLLERS]
+                       [MAX_NETDEV_PKTSIZE + CONFIG_NET_GUARDSIZE];
 
 /* Ethernet peripheral state */
 
@@ -1605,20 +1606,20 @@ static inline int tiva_ethinitialize(int intf)
   /* Initialize the driver structure */
 
   memset(priv, 0, sizeof(struct tiva_driver_s));
-  priv->ld_dev.d_buf     = g_pktbuf;      /* Single packet buffer */
-  priv->ld_dev.d_ifup    = tiva_ifup;     /* I/F down callback */
-  priv->ld_dev.d_ifdown  = tiva_ifdown;   /* I/F up (new IP address) callback */
-  priv->ld_dev.d_txavail = tiva_txavail;  /* New TX data callback */
+  priv->ld_dev.d_buf     = g_pktbuf[intf]; /* Single packet buffer */
+  priv->ld_dev.d_ifup    = tiva_ifup;      /* I/F down callback */
+  priv->ld_dev.d_ifdown  = tiva_ifdown;    /* I/F up (new IP address) callback */
+  priv->ld_dev.d_txavail = tiva_txavail;   /* New TX data callback */
 #ifdef CONFIG_NET_MCASTGROUP
-  priv->ld_dev.d_addmac  = tiva_addmac;   /* Add multicast MAC address */
-  priv->ld_dev.d_rmmac   = tiva_rmmac;    /* Remove multicast MAC address */
+  priv->ld_dev.d_addmac  = tiva_addmac;    /* Add multicast MAC address */
+  priv->ld_dev.d_rmmac   = tiva_rmmac;     /* Remove multicast MAC address */
 #endif
-  priv->ld_dev.d_private = priv;          /* Used to recover private state from dev */
+  priv->ld_dev.d_private = priv;           /* Used to recover private state from dev */
 
 #if TIVA_NETHCONTROLLERS > 1
 # error "A mechanism to associate base address an IRQ with an interface is needed"
-  priv->ld_base          = ??;            /* Ethernet controller base address */
-  priv->ld_irq           = ??;            /* Ethernet controller IRQ number */
+  priv->ld_base          = ??;             /* Ethernet controller base address */
+  priv->ld_irq           = ??;             /* Ethernet controller IRQ number */
 #endif
 
 #ifdef CONFIG_TIVA_BOARDMAC

--- a/arch/hc/src/m9s12/m9s12_ethernet.c
+++ b/arch/hc/src/m9s12/m9s12_ethernet.c
@@ -89,7 +89,8 @@ struct emac_driver_s
 
 /* A single packet buffer is used */
 
-static uint8_t g_pktbuf[MAX_NETDEV_PKTSIZE + CONFIG_NET_GUARDSIZE];
+static uint8_t g_pktbuf[CONFIG_HCS12_NINTERFACES]
+                       [MAX_NETDEV_PKTSIZE + CONFIG_NET_GUARDSIZE];
 
 /* Driver state structure */
 
@@ -693,7 +694,7 @@ int emac_initialize(int intf)
 
   /* Get the interface structure associated with this interface number. */
 
-  DEBUGASSERT(inf <  CONFIG_HCS12_NINTERFACES);
+  DEBUGASSERT(inf < CONFIG_HCS12_NINTERFACES);
   priv = &g_emac[intf];
 
   /* Check if a Ethernet chip is recognized at its I/O base */
@@ -710,7 +711,7 @@ int emac_initialize(int intf)
   /* Initialize the driver structure */
 
   memset(priv, 0, sizeof(struct emac_driver_s));
-  priv->d_dev.d_buf     = g_pktbuf;      /* Single packet buffer */
+  priv->d_dev.d_buf     = g_pktbuf[inf]; /* Single packet buffer */
   priv->d_dev.d_ifup    = emac_ifup;     /* I/F down callback */
   priv->d_dev.d_ifdown  = emac_ifdown;   /* I/F up (new IP address) callback */
   priv->d_dev.d_txavail = emac_txavail;  /* New TX data callback */

--- a/arch/misoc/src/common/misoc_net.c
+++ b/arch/misoc/src/common/misoc_net.c
@@ -116,7 +116,8 @@ struct misoc_net_driver_s
 
 /* A single packet buffer is used */
 
-static uint8_t g_pktbuf[MAX_NETDEV_PKTSIZE + CONFIG_NET_GUARDSIZE];
+static uint8_t g_pktbuf[CONFIG_MISOC_NET_NINTERFACES]
+                       [MAX_NETDEV_PKTSIZE + CONFIG_NET_GUARDSIZE];
 
 /* Driver state structure */
 
@@ -1092,7 +1093,7 @@ int misoc_net_initialize(int intf)
   priv->tx_buf  = priv->tx0_buf;
   priv->tx_slot = 0;
 
-  priv->misoc_net_dev.d_buf     = g_pktbuf;           /* Single packet buffer */
+  priv->misoc_net_dev.d_buf     = g_pktbuf[intf];     /* Single packet buffer */
   priv->misoc_net_dev.d_ifup    = misoc_net_ifup;     /* I/F up (new IP address) callback */
   priv->misoc_net_dev.d_ifdown  = misoc_net_ifdown;   /* I/F down callback */
   priv->misoc_net_dev.d_txavail = misoc_net_txavail;  /* New TX data callback */

--- a/arch/risc-v/src/mpfs/mpfs_ethernet.c
+++ b/arch/risc-v/src/mpfs/mpfs_ethernet.c
@@ -210,7 +210,8 @@ struct gmac_txdesc_s
 #endif
 };
 
-static uint8_t g_pktbuf[MAX_NETDEV_PKTSIZE + CONFIG_NET_GUARDSIZE];
+static uint8_t g_pktbuf[MPFS_NETHERNET]
+                       [MAX_NETDEV_PKTSIZE + CONFIG_NET_GUARDSIZE];
 
 #if defined(CONFIG_MPFS_GMAC_PREALLOCATE)
 static uint8_t g_txbuffer[CONFIG_MPFS_ETHMAC_NTXBUFFERS * GMAC_TX_UNITSIZE]
@@ -3554,7 +3555,7 @@ int mpfs_ethinitialize(int intf)
   /* Initialize the driver structure */
 
   memset(priv, 0, sizeof(struct mpfs_ethmac_s));
-  priv->dev.d_buf     = g_pktbuf;       /* Single packet buffer */
+  priv->dev.d_buf     = g_pktbuf[intf]; /* Single packet buffer */
   priv->dev.d_ifup    = mpfs_ifup;      /* I/F up (new IP address) callback */
   priv->dev.d_ifdown  = mpfs_ifdown;    /* I/F down callback */
   priv->dev.d_txavail = mpfs_txavail;   /* New TX data callback */

--- a/arch/z80/src/ez80/ez80_emac.c
+++ b/arch/z80/src/ez80/ez80_emac.c
@@ -378,17 +378,17 @@ static int  ez80emac_miiconfigure(FAR struct ez80emac_driver_s *priv);
 /* Multi-cast filtering */
 
 #ifdef CONFIG_EZ80_MCFILTER
-static void ez80emac_machash(FAR uint8_t *mac, int *ndx, int *bitno)
+static void ez80emac_machash(FAR uint8_t *mac, FAR int *ndx, FAR int *bitno);
 #endif
 
 /* TX/RX logic */
 
-static int  ez80emac_transmit(struct ez80emac_driver_s *priv);
-static int  ez80emac_txpoll(struct net_driver_s *dev);
+static int  ez80emac_transmit(FAR struct ez80emac_driver_s *priv);
+static int  ez80emac_txpoll(FAR struct net_driver_s *dev);
 
 static inline FAR struct ez80emac_desc_s *ez80emac_rwp(void);
 static inline FAR struct ez80emac_desc_s *ez80emac_rrp(void);
-static int  ez80emac_receive(struct ez80emac_driver_s *priv);
+static int  ez80emac_receive(FAR struct ez80emac_driver_s *priv);
 
 /* Interrupt handling */
 
@@ -411,16 +411,16 @@ static void ez80emac_txtimeout_expiry(wdparm_t arg);
 
 /* NuttX callback functions */
 
-static int  ez80emac_ifup(struct net_driver_s *dev);
-static int  ez80emac_ifdown(struct net_driver_s *dev);
+static int  ez80emac_ifup(FAR struct net_driver_s *dev);
+static int  ez80emac_ifdown(FAR struct net_driver_s *dev);
 
 static void ez80emac_txavail_work(FAR void *arg);
-static int  ez80emac_txavail(struct net_driver_s *dev);
+static int  ez80emac_txavail(FAR struct net_driver_s *dev);
 
 #ifdef CONFIG_NET_MCASTGROUP
-static int ez80emac_addmac(struct net_driver_s *dev,
+static int ez80emac_addmac(FAR struct net_driver_s *dev,
              FAR const uint8_t *mac);
-static int ez80emac_rmmac(struct net_driver_s *dev,
+static int ez80emac_rmmac(FAR struct net_driver_s *dev,
              FAR const uint8_t *mac);
 #endif
 
@@ -944,7 +944,7 @@ static int ez80emac_miiconfigure(FAR struct ez80emac_driver_s *priv)
  ****************************************************************************/
 
 #ifdef CONFIG_EZ80_MCFILTER
-static void ez80emac_machash(FAR uint8_t *mac, int *ndx, int *bitno)
+static void ez80emac_machash(FAR uint8_t *mac, FAR int *ndx, FAR int *bitno)
 {
   uint32_t hash;
   uint32_t crc32;
@@ -1021,14 +1021,14 @@ static void ez80emac_machash(FAR uint8_t *mac, int *ndx, int *bitno)
  *
  ****************************************************************************/
 
-static int ez80emac_transmit(struct ez80emac_driver_s *priv)
+static int ez80emac_transmit(FAR struct ez80emac_driver_s *priv)
 {
   FAR struct ez80emac_desc_s *txdesc;
   FAR struct ez80emac_desc_s *txnext;
-  uint8_t   *psrc;
-  uint8_t   *pdest;
-  uint24_t   len;
-  irqstate_t flags;
+  FAR uint8_t *psrc;
+  FAR uint8_t *pdest;
+  uint24_t     len;
+  irqstate_t   flags;
 
   /* Careful:  This function can be called from outside of the interrupt
    * handler and, therefore, may be suspended when debug output is generated!
@@ -1057,11 +1057,11 @@ static int ez80emac_transmit(struct ez80emac_driver_s *priv)
   txdesc = priv->txnext;
 
   len    = EMAC_PKTBUF_ALIGN(priv->dev.d_len + SIZEOF_EMACSDESC);
-  txnext = (FAR struct ez80emac_desc_s *)((uint8_t *)txdesc + len);
+  txnext = (FAR struct ez80emac_desc_s *)((FAR uint8_t *)txdesc + len);
 
   /* Handle wraparound to the beginning of the TX region */
 
-  if ((uint8_t *)txnext + SIZEOF_EMACSDESC >= (uint8_t *)priv->rxstart)
+  if ((uint8_t *)txnext + SIZEOF_EMACSDESC >= (FAR uint8_t *)priv->rxstart)
     {
       txnext = (FAR struct ez80emac_desc_s *)
         ((FAR uint8_t *)priv->txstart +
@@ -1078,8 +1078,8 @@ static int ez80emac_transmit(struct ez80emac_driver_s *priv)
    */
 
   psrc            = priv->dev.d_buf;
-  pdest           = (uint8_t *)txdesc + SIZEOF_EMACSDESC;
-  len             = (uint8_t *)priv->rxstart - pdest;
+  pdest           = (FAR uint8_t *)txdesc + SIZEOF_EMACSDESC;
+  len             = (FAR uint8_t *)priv->rxstart - pdest;
   if (len >= priv->dev.d_len)
     {
       /* The entire packet will fit into the EMAC SRAM without wrapping */
@@ -1264,15 +1264,15 @@ static inline FAR struct ez80emac_desc_s *ez80emac_rrp(void)
  *
  ****************************************************************************/
 
-static int ez80emac_receive(struct ez80emac_driver_s *priv)
+static int ez80emac_receive(FAR struct ez80emac_driver_s *priv)
 {
   FAR struct ez80emac_desc_s *rxdesc = priv->rxnext;
   FAR struct ez80emac_desc_s *rwp;
-  uint8_t *psrc;
-  uint8_t *pdest;
-  int     pktlen;
-  int     npackets;
-  uint8_t pktgood;
+  FAR uint8_t *psrc;
+  FAR uint8_t *pdest;
+  int          pktlen;
+  int          npackets;
+  uint8_t      pktgood;
 
   /* The RRP register points to where the next Receive packet is read from.
    * The read-only EMAC Receive Write Pointer (RWP) register reports the
@@ -2080,7 +2080,7 @@ static int ez80emac_ifup(FAR struct net_driver_s *dev)
  *
  ****************************************************************************/
 
-static int ez80emac_ifdown(struct net_driver_s *dev)
+static int ez80emac_ifdown(FAR struct net_driver_s *dev)
 {
   FAR struct ez80emac_driver_s *priv =
     (FAR struct ez80emac_driver_s *)dev->d_private;
@@ -2205,7 +2205,8 @@ static int ez80emac_txavail(FAR struct net_driver_s *dev)
  ****************************************************************************/
 
 #ifdef CONFIG_NET_MCASTGROUP
-static int ez80emac_addmac(struct net_driver_s *dev, FAR const uint8_t *mac)
+static int ez80emac_addmac(FAR struct net_driver_s *dev,
+                           FAR const uint8_t *mac)
 {
   FAR struct ez80emac_driver_s *priv =
     (FAR struct ez80emac_driver_s *)dev->d_private;
@@ -2237,7 +2238,8 @@ static int ez80emac_addmac(struct net_driver_s *dev, FAR const uint8_t *mac)
  ****************************************************************************/
 
 #ifdef CONFIG_NET_MCASTGROUP
-static int ez80emac_rmmac(struct net_driver_s *dev, FAR const uint8_t *mac)
+static int ez80emac_rmmac(FAR struct net_driver_s *dev,
+                          FAR const uint8_t *mac)
 {
   FAR struct ez80emac_driver_s *priv =
     (FAR struct ez80emac_driver_s *)dev->d_private;
@@ -2266,7 +2268,7 @@ static int ez80emac_rmmac(struct net_driver_s *dev, FAR const uint8_t *mac)
 
 static int ez80_emacinitialize(void)
 {
-  struct ez80emac_driver_s *priv = &g_emac;
+  FAR struct ez80emac_driver_s *priv = &g_emac;
   uint24_t addr;
   uint8_t regval;
   int ret;
@@ -2494,7 +2496,7 @@ errout:
 
 int up_netinitialize(void)
 {
-  struct ez80emac_driver_s *priv = &g_emac;
+  FAR struct ez80emac_driver_s *priv = &g_emac;
   int ret;
 
   /* Disable all interrupts */

--- a/drivers/net/Kconfig
+++ b/drivers/net/Kconfig
@@ -260,7 +260,7 @@ menuconfig ENCX24J600
 
 if ENCX24J600
 
-config ENC28J60_NINTERFACES
+config ENCX24J600_NINTERFACES
 	int "Number of physical ENCX24J600"
 	default 1
 	range 1 1

--- a/drivers/net/dm90x0.c
+++ b/drivers/net/dm90x0.c
@@ -273,6 +273,10 @@
 
 #define DM6X_TXTIMEOUT (60*CLK_TCK)
 
+/* Packet buffer size */
+
+#define PKTBUF_SIZE (MAX_NETDEV_PKTSIZE + CONFIG_NET_GUARDSIZE)
+
 /* This is a helper pointer for accessing the contents of Ethernet header */
 
 #define BUF ((FAR struct eth_hdr_s *)priv->dm_dev.d_buf)
@@ -323,7 +327,7 @@ struct dm9x_driver_s
 
 /* A single packet buffer is used */
 
-static uint8_t g_pktbuf[MAX_NETDEV_PKTSIZE + CONFIG_NET_GUARDSIZE];
+static uint16_t g_pktbuf[CONFIG_DM9X_NINTERFACES][(PKTBUF_SIZE + 1) / 2];
 
 /* At present, only a single DM90x0 device is supported. */
 
@@ -1866,15 +1870,15 @@ int dm9x_initialize(void)
   /* Initialize the driver structure */
 
   memset(g_dm9x, 0, CONFIG_DM9X_NINTERFACES*sizeof(struct dm9x_driver_s));
-  g_dm9x[0].dm_dev.d_buf     = g_pktbuf;      /* Single packet buffer */
-  g_dm9x[0].dm_dev.d_ifup    = dm9x_ifup;     /* I/F down callback */
-  g_dm9x[0].dm_dev.d_ifdown  = dm9x_ifdown;   /* I/F up (new IP address) callback */
-  g_dm9x[0].dm_dev.d_txavail = dm9x_txavail;  /* New TX data callback */
+  g_dm9x[0].dm_dev.d_buf     = (FAR uint8_t *)g_pktbuf[0]; /* Single packet buffer */
+  g_dm9x[0].dm_dev.d_ifup    = dm9x_ifup;                  /* I/F down callback */
+  g_dm9x[0].dm_dev.d_ifdown  = dm9x_ifdown;                /* I/F up (new IP address) callback */
+  g_dm9x[0].dm_dev.d_txavail = dm9x_txavail;               /* New TX data callback */
 #ifdef CONFIG_NET_MCASTGROUP
-  g_dm9x[0].dm_dev.d_addmac  = dm9x_addmac;   /* Add multicast MAC address */
-  g_dm9x[0].dm_dev.d_rmmac   = dm9x_rmmac;    /* Remove multicast MAC address */
+  g_dm9x[0].dm_dev.d_addmac  = dm9x_addmac;                /* Add multicast MAC address */
+  g_dm9x[0].dm_dev.d_rmmac   = dm9x_rmmac;                 /* Remove multicast MAC address */
 #endif
-  g_dm9x[0].dm_dev.d_private = g_dm9x;        /* Used to recover private state from dev */
+  g_dm9x[0].dm_dev.d_private = g_dm9x;                     /* Used to recover private state from dev */
 
   /* Read the MAC address */
 

--- a/drivers/net/enc28j60.c
+++ b/drivers/net/enc28j60.c
@@ -175,6 +175,10 @@
 #define enc_bfsgreg(priv,ctrlreg,setbits) \
   enc_wrgreg2(priv, ENC_BFS | GETADDR(ctrlreg), setbits)
 
+/* Packet buffer size */
+
+#define PKTBUF_SIZE (MAX_NETDEV_PKTSIZE + CONFIG_NET_GUARDSIZE)
+
 /* This is a helper pointer for accessing the contents of Ethernet header */
 
 #define BUF ((FAR struct eth_hdr_s *)priv->dev.d_buf)
@@ -250,7 +254,7 @@ struct enc_driver_s
 
 /* A single packet buffer is used */
 
-static uint8_t g_pktbuf[MAX_NETDEV_PKTSIZE + CONFIG_NET_GUARDSIZE];
+static uint16_t g_pktbuf[CONFIG_ENC28J60_NINTERFACES][(PKTBUF_SIZE + 1) / 2];
 
 /* Driver status structure */
 
@@ -2528,17 +2532,17 @@ int enc_initialize(FAR struct spi_dev_s *spi,
   memset(g_enc28j60, 0,
          CONFIG_ENC28J60_NINTERFACES * sizeof(struct enc_driver_s));
 
-  priv->dev.d_buf     = g_pktbuf;     /* Single packet buffer */
-  priv->dev.d_ifup    = enc_ifup;     /* I/F down callback */
-  priv->dev.d_ifdown  = enc_ifdown;   /* I/F up (new IP address) callback */
-  priv->dev.d_txavail = enc_txavail;  /* New TX data callback */
+  priv->dev.d_buf     = (FAR uint8_t *)g_pktbuf[devno]; /* Single packet buffer */
+  priv->dev.d_ifup    = enc_ifup;                       /* I/F down callback */
+  priv->dev.d_ifdown  = enc_ifdown;                     /* I/F up (new IP address) callback */
+  priv->dev.d_txavail = enc_txavail;                    /* New TX data callback */
 #ifdef CONFIG_NET_MCASTGROUP
-  priv->dev.d_addmac  = enc_addmac;   /* Add multicast MAC address */
-  priv->dev.d_rmmac   = enc_rmmac;    /* Remove multicast MAC address */
+  priv->dev.d_addmac  = enc_addmac;                     /* Add multicast MAC address */
+  priv->dev.d_rmmac   = enc_rmmac;                      /* Remove multicast MAC address */
 #endif
-  priv->dev.d_private = priv;         /* Used to recover private state from dev */
-  priv->spi           = spi;          /* Save the SPI instance */
-  priv->lower         = lower;        /* Save the low-level MCU interface */
+  priv->dev.d_private = priv;                           /* Used to recover private state from dev */
+  priv->spi           = spi;                            /* Save the SPI instance */
+  priv->lower         = lower;                          /* Save the low-level MCU interface */
 
   /* The interface should be in the down state.  However, this function is
    * called too early in initialization to perform the ENC28J60 reset in

--- a/drivers/net/encx24j600.c
+++ b/drivers/net/encx24j600.c
@@ -158,6 +158,10 @@
 
 #define ENC_NTXDESCR ((PKTMEM_RX_START - PKTMEM_START) / PKTMEM_ALIGNED_BUFSIZE)
 
+/* Packet buffer size */
+
+#define PKTBUF_SIZE (MAX_NETDEV_PKTSIZE + CONFIG_NET_GUARDSIZE)
+
 /* This is a helper pointer for accessing the contents of Ethernet header */
 
 #define BUF ((FAR struct eth_hdr_s *)priv->dev.d_buf)
@@ -253,7 +257,8 @@ struct enc_driver_s
 
 /* A single packet buffer is used */
 
-static uint8_t g_pktbuf[MAX_NETDEV_PKTSIZE + CONFIG_NET_GUARDSIZE];
+static uint16_t g_pktbuf[CONFIG_ENCX24J600_NINTERFACES]
+                        [(PKTBUF_SIZE + 1) / 2];
 
 /* Driver status structure */
 
@@ -2711,17 +2716,17 @@ int enc_initialize(FAR struct spi_dev_s *spi,
   memset(g_encx24j600, 0,
          CONFIG_ENCX24J600_NINTERFACES * sizeof(struct enc_driver_s));
 
-  priv->dev.d_buf     = g_pktbuf;     /* Single packet buffer */
-  priv->dev.d_ifup    = enc_ifup;     /* I/F up (new IP address) callback */
-  priv->dev.d_ifdown  = enc_ifdown;   /* I/F down callback */
-  priv->dev.d_txavail = enc_txavail;  /* New TX data callback */
+  priv->dev.d_buf     = (FAR uint8_t *)g_pktbuf[devno]; /* Single packet buffer */
+  priv->dev.d_ifup    = enc_ifup;                       /* I/F up (new IP address) callback */
+  priv->dev.d_ifdown  = enc_ifdown;                     /* I/F down callback */
+  priv->dev.d_txavail = enc_txavail;                    /* New TX data callback */
 #ifdef CONFIG_NET_MCASTGROUP
-  priv->dev.d_addmac  = enc_addmac;   /* Add multicast MAC address */
-  priv->dev.d_rmmac   = enc_rmmac;    /* Remove multicast MAC address */
+  priv->dev.d_addmac  = enc_addmac;                     /* Add multicast MAC address */
+  priv->dev.d_rmmac   = enc_rmmac;                      /* Remove multicast MAC address */
 #endif
-  priv->dev.d_private = priv;         /* Used to recover private state from dev */
-  priv->spi           = spi;          /* Save the SPI instance */
-  priv->lower         = lower;        /* Save the low-level MCU interface */
+  priv->dev.d_private = priv;                           /* Used to recover private state from dev */
+  priv->spi           = spi;                            /* Save the SPI instance */
+  priv->lower         = lower;                          /* Save the low-level MCU interface */
 
   /* The interface should be in the down state.  However, this function is
    * called too early in initialization to perform the ENCX24J600 reset in

--- a/drivers/net/ftmac100.c
+++ b/drivers/net/ftmac100.c
@@ -85,6 +85,10 @@
 
 #define FTMAC100_TXTIMEOUT (60*CLK_TCK)
 
+/* Packet buffer size */
+
+#define PKTBUF_SIZE (MAX_NETDEV_PKTSIZE + CONFIG_NET_GUARDSIZE)
+
 /* This is a helper pointer for accessing the contents of the Ethernet
  * header.
  */
@@ -171,7 +175,8 @@ struct ftmac100_driver_s
 
 /* A single packet buffer is used */
 
-static uint8_t g_pktbuf[MAX_NETDEV_PKTSIZE + CONFIG_NET_GUARDSIZE];
+static uint16_t g_pktbuf[CONFIG_FTMAC100_NINTERFACES]
+                        [(PKTBUF_SIZE + 1) / 2];
 
 /* Driver state structure. */
 
@@ -1488,15 +1493,15 @@ int ftmac100_initialize(int intf)
   /* Initialize the driver structure */
 
   memset(priv, 0, sizeof(struct ftmac100_driver_s));
-  priv->ft_dev.d_buf     = g_pktbuf;          /* Single packet buffer */
-  priv->ft_dev.d_ifup    = ftmac100_ifup;     /* I/F up (new IP address) callback */
-  priv->ft_dev.d_ifdown  = ftmac100_ifdown;   /* I/F down callback */
-  priv->ft_dev.d_txavail = ftmac100_txavail;  /* New TX data callback */
+  priv->ft_dev.d_buf     = (FAR uint8_t *)g_pktbuf[intf]; /* Single packet buffer */
+  priv->ft_dev.d_ifup    = ftmac100_ifup;                 /* I/F up (new IP address) callback */
+  priv->ft_dev.d_ifdown  = ftmac100_ifdown;               /* I/F down callback */
+  priv->ft_dev.d_txavail = ftmac100_txavail;              /* New TX data callback */
 #ifdef CONFIG_NET_MCASTGROUP
-  priv->ft_dev.d_addmac  = ftmac100_addmac;   /* Add multicast MAC address */
-  priv->ft_dev.d_rmmac   = ftmac100_rmmac;    /* Remove multicast MAC address */
+  priv->ft_dev.d_addmac  = ftmac100_addmac;               /* Add multicast MAC address */
+  priv->ft_dev.d_rmmac   = ftmac100_rmmac;                /* Remove multicast MAC address */
 #endif
-  priv->ft_dev.d_private = g_ftmac100;        /* Used to recover private state from dev */
+  priv->ft_dev.d_private = g_ftmac100;                    /* Used to recover private state from dev */
   priv->iobase           = CONFIG_FTMAC100_BASE;
 
   /* Put the interface in the down state.  This usually amounts to resetting

--- a/drivers/net/lan91c111.c
+++ b/drivers/net/lan91c111.c
@@ -81,12 +81,12 @@
 
 struct lan91c111_driver_s
 {
-  uintptr_t base;                         /* Base address */
-  int       irq;                          /* IRQ number */
-  uint16_t  bank;                         /* Current bank */
-  struct work_s irqwork;                  /* For deferring interrupt work to the work queue */
-  struct work_s pollwork;                 /* For deferring poll work to the work queue */
-  uint8_t pktbuf[MAX_NETDEV_PKTSIZE + 4]; /* +4 due to getregs32/putregs32 */
+  uintptr_t base;                                     /* Base address */
+  int       irq;                                      /* IRQ number */
+  struct work_s irqwork;                              /* For deferring interrupt work to the work queue */
+  struct work_s pollwork;                             /* For deferring poll work to the work queue */
+  uint16_t  bank;                                     /* Current bank */
+  uint16_t  pktbuf[(MAX_NETDEV_PKTSIZE + 4 + 1) / 2]; /* +4 due to getregs32/putregs32 */
 
   /* This holds the information visible to the NuttX network */
 
@@ -1493,18 +1493,18 @@ int lan91c111_initialize(uintptr_t base, int irq)
 
   /* Initialize the driver structure */
 
-  dev->d_buf     = priv->pktbuf;      /* Single packet buffer */
-  dev->d_ifup    = lan91c111_ifup;    /* I/F up (new IP address) callback */
-  dev->d_ifdown  = lan91c111_ifdown;  /* I/F down callback */
-  dev->d_txavail = lan91c111_txavail; /* New TX data callback */
+  dev->d_buf     = (FAR uint8_t *)priv->pktbuf; /* Single packet buffer */
+  dev->d_ifup    = lan91c111_ifup;              /* I/F up (new IP address) callback */
+  dev->d_ifdown  = lan91c111_ifdown;            /* I/F down callback */
+  dev->d_txavail = lan91c111_txavail;           /* New TX data callback */
 #ifdef CONFIG_NET_MCASTGROUP
-  dev->d_addmac  = lan91c111_addmac;  /* Add multicast MAC address */
-  dev->d_rmmac   = lan91c111_rmmac;   /* Remove multicast MAC address */
+  dev->d_addmac  = lan91c111_addmac;            /* Add multicast MAC address */
+  dev->d_rmmac   = lan91c111_rmmac;             /* Remove multicast MAC address */
 #endif
 #ifdef CONFIG_NETDEV_IOCTL
-  dev->d_ioctl   = lan91c111_ioctl;   /* Handle network IOCTL commands */
+  dev->d_ioctl   = lan91c111_ioctl;             /* Handle network IOCTL commands */
 #endif
-  dev->d_private = priv;              /* Used to recover private state from dev */
+  dev->d_private = priv;                        /* Used to recover private state from dev */
 
   /* Put the interface in the down state. This usually amounts to resetting
    * the device and/or calling lan91c111_ifdown().

--- a/drivers/net/skeleton.c
+++ b/drivers/net/skeleton.c
@@ -80,6 +80,10 @@
 
 #define SKELETON_TXTIMEOUT (60*CLK_TCK)
 
+/* Packet buffer size */
+
+#define PKTBUF_SIZE (MAX_NETDEV_PKTSIZE + CONFIG_NET_GUARDSIZE)
+
 /* This is a helper pointer for accessing the contents of Ethernet header */
 
 #define BUF ((FAR struct eth_hdr_s *)priv->sk_dev.d_buf)
@@ -124,7 +128,7 @@ struct skel_driver_s
  * allocated dynamically in cases where more than one are needed.
  */
 
-static uint8_t g_pktbuf[MAX_NETDEV_PKTSIZE + CONFIG_NET_GUARDSIZE];
+static uint16_t g_pktbuf[CONFIG_SKELETON_NINTERFACES][(PKTBUF_SIZE + 1) / 2];
 
 /* Driver state structure */
 
@@ -1070,18 +1074,18 @@ int skel_initialize(int intf)
   /* Initialize the driver structure */
 
   memset(priv, 0, sizeof(struct skel_driver_s));
-  priv->sk_dev.d_buf     = g_pktbuf;      /* Single packet buffer */
-  priv->sk_dev.d_ifup    = skel_ifup;     /* I/F up (new IP address) callback */
-  priv->sk_dev.d_ifdown  = skel_ifdown;   /* I/F down callback */
-  priv->sk_dev.d_txavail = skel_txavail;  /* New TX data callback */
+  priv->sk_dev.d_buf     = (FAR uint8_t *)g_pktbuf[intf]; /* Single packet buffer */
+  priv->sk_dev.d_ifup    = skel_ifup;                     /* I/F up (new IP address) callback */
+  priv->sk_dev.d_ifdown  = skel_ifdown;                   /* I/F down callback */
+  priv->sk_dev.d_txavail = skel_txavail;                  /* New TX data callback */
 #ifdef CONFIG_NET_MCASTGROUP
-  priv->sk_dev.d_addmac  = skel_addmac;   /* Add multicast MAC address */
-  priv->sk_dev.d_rmmac   = skel_rmmac;    /* Remove multicast MAC address */
+  priv->sk_dev.d_addmac  = skel_addmac;                   /* Add multicast MAC address */
+  priv->sk_dev.d_rmmac   = skel_rmmac;                    /* Remove multicast MAC address */
 #endif
 #ifdef CONFIG_NETDEV_IOCTL
-  priv->sk_dev.d_ioctl   = skel_ioctl;    /* Handle network IOCTL commands */
+  priv->sk_dev.d_ioctl   = skel_ioctl;                    /* Handle network IOCTL commands */
 #endif
-  priv->sk_dev.d_private = g_skel;        /* Used to recover private state from dev */
+  priv->sk_dev.d_private = g_skel;                        /* Used to recover private state from dev */
 
   /* Put the interface in the down state.  This usually amounts to resetting
    * the device and/or calling skel_ifdown().

--- a/drivers/usbhost/usbhost_cdcmbim.c
+++ b/drivers/usbhost/usbhost_cdcmbim.c
@@ -229,7 +229,7 @@ struct usbhost_cdcmbim_s
 
   bool                    bifup;        /* true:ifup false:ifdown */
   struct net_driver_s     netdev;       /* Interface understood by the network */
-  uint8_t                 txpktbuf[MAX_NETDEV_PKTSIZE];
+  uint16_t                txpktbuf[(MAX_NETDEV_PKTSIZE + 1) / 2];
 };
 
 /****************************************************************************
@@ -2331,7 +2331,7 @@ static int cdcmbim_txpoll(struct net_driver_s *dev)
    * the field d_len is set to a value > 0.
    */
 
-  DEBUGASSERT(priv->netdev.d_buf == priv->txpktbuf);
+  DEBUGASSERT(priv->netdev.d_buf == (FAR uint8_t *)priv->txpktbuf);
 
   usbhost_takesem(&priv->exclsem);
 
@@ -2460,7 +2460,7 @@ static void cdcmbim_txavail_work(void *arg)
 
   net_lock();
 
-  priv->netdev.d_buf = priv->txpktbuf;
+  priv->netdev.d_buf = (FAR uint8_t *)priv->txpktbuf;
 
   if (priv->bifup)
     {

--- a/net/pkt/pkt_input.c
+++ b/net/pkt/pkt_input.c
@@ -39,7 +39,7 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-#define PKTBUF ((FAR struct eth_hdr_s *)&dev->d_buf)
+#define PKTBUF ((FAR struct eth_hdr_s *)dev->d_buf)
 
 /****************************************************************************
  * Public Functions
@@ -68,7 +68,7 @@
 int pkt_input(struct net_driver_s *dev)
 {
   FAR struct pkt_conn_s *conn;
-  FAR struct eth_hdr_s  *pbuf = (FAR struct eth_hdr_s *)dev->d_buf;
+  FAR struct eth_hdr_s  *pbuf = PKTBUF;
   int ret = OK;
 
   conn = pkt_active(pbuf);


### PR DESCRIPTION
## Summary
- make sure that net driver `d_buf` is 16-bit aligned
- fix buffer selection multi-instance netdev drivers 
- add missing `FAR` in multiple palces
- perform some renaming in w5500 driver to remove `sk_` (skeleton) prefix
- fix config option to select number of ENCX24J600 interfaces

## Impact
Should be none for working cases

## Testing
Pass CI