### PR TITLE
Several IMXRT fixes 

### DIFF
--- a/arch/arm/src/imxrt/hardware/imxrt_snvs.h
+++ b/arch/arm/src/imxrt/hardware/imxrt_snvs.h
@@ -47,6 +47,8 @@
 #define IMXRT_SNVS_LPLR_OFFSET        0x0034  /* SNVS_LP Lock Register */
 #define IMXRT_SNVS_LPCR_OFFSET        0x0038  /* SNVS_LP Control Register */
 #define IMXRT_SNVS_LPSR_OFFSET        0x004c  /* SNVS_LP Status Register */
+#define IMXRT_SNVS_LPSRTCMR_OFFSET    0x0050  /* SNVS_LP Secure Real Time Counter MSB Register */
+#define IMXRT_SNVS_LPSRTCLR_OFFSET    0x0054  /* SNVS_LP Secure Real Time Counter LSB Register */
 #define IMXRT_SNVS_LPSMCMR_OFFSET     0x005c  /* SNVS_LP Secure Monotonic Counter MSB Register */
 #define IMXRT_SNVS_LPSMCLR_OFFSET     0x0060  /* SNVS_LP Secure Monotonic Counter LSB Register */
 
@@ -80,6 +82,8 @@
 #define IMXRT_SNVS_LPLR               (IMXRT_SNVSHP_BASE + IMXRT_SNVS_LPLR_OFFSET)
 #define IMXRT_SNVS_LPCR               (IMXRT_SNVSHP_BASE + IMXRT_SNVS_LPCR_OFFSET)
 #define IMXRT_SNVS_LPSR               (IMXRT_SNVSHP_BASE + IMXRT_SNVS_LPSR_OFFSET)
+#define IMXRT_SNVS_LPSRTCMR           (IMXRT_SNVSHP_BASE + IMXRT_SNVS_LPSRTCMR_OFFSET)
+#define IMXRT_SNVS_LPSRTCLR           (IMXRT_SNVSHP_BASE + IMXRT_SNVS_LPSRTCLR_OFFSET)
 #define IMXRT_SNVS_LPSMCMR            (IMXRT_SNVSHP_BASE + IMXRT_SNVS_LPSMCMR_OFFSET)
 #define IMXRT_SNVS_LPSMCLR            (IMXRT_SNVSHP_BASE + IMXRT_SNVS_LPSMCLR_OFFSET)
 

--- a/arch/arm/src/imxrt/imxrt_lowputc.h
+++ b/arch/arm/src/imxrt/imxrt_lowputc.h
@@ -40,6 +40,15 @@
  * Public Types
  ****************************************************************************/
 
+#undef EXTERN
+#if defined(__cplusplus)
+#define EXTERN extern "C"
+extern "C"
+{
+#else
+#define EXTERN extern
+#endif
+
 #ifdef HAVE_LPUART_DEVICE
 /* This structure describes the configuration of an UART */
 
@@ -102,4 +111,9 @@ void imxrt_lowputc(int ch);
 #  define imxrt_lowputc(ch)
 #endif
 
-#endif /* __ARCH_ARM_SRC_IMXRT_IMXRT_LOWPUTC_H */
+#undef EXTERN
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __ARCH_ARM_SRC_IMXRT_LOWPUTC_H */

--- a/arch/arm/src/imxrt/imxrt_lpsrtc.c
+++ b/arch/arm/src/imxrt/imxrt_lpsrtc.c
@@ -193,10 +193,10 @@ int up_rtc_settime(const struct timespec *ts)
   /* Disable the LPSRTC */
 
   regval  = getreg32(IMXRT_SNVS_LPCR);
-  regval &= ~SNVS_LPCR_MCENV;
+  regval &= ~SVNS_LPCR_SRTCENV;
   putreg32(regval, IMXRT_SNVS_LPCR);
 
-  while ((getreg32(IMXRT_SNVS_LPCR) & SNVS_LPCR_MCENV) != 0)
+  while ((getreg32(IMXRT_SNVS_LPCR) & SVNS_LPCR_SRTCENV) != 0)
     {
     }
 
@@ -207,8 +207,8 @@ int up_rtc_settime(const struct timespec *ts)
    * IMXRT_SNVS_LPSMCLR 32-bit LSB of alarm setting.
    */
 
-  putreg32((uint32_t)ts->tv_sec >> 17, IMXRT_SNVS_LPSMCMR);
-  putreg32((uint32_t)ts->tv_sec << 15, IMXRT_SNVS_LPSMCLR);
+  putreg32((uint32_t)ts->tv_sec >> 17, IMXRT_SNVS_LPSRTCMR);
+  putreg32((uint32_t)ts->tv_sec << 15, IMXRT_SNVS_LPSRTCLR);
 
   /* The time has been set */
 

--- a/arch/arm/src/imxrt/imxrt_usdhc.c
+++ b/arch/arm/src/imxrt/imxrt_usdhc.c
@@ -2217,7 +2217,9 @@ static void imxrt_blocksetup(struct sdio_dev_s *dev,
 
   /* Configure block size for next transfer */
 
+#if defined(CONFIG_ARMV7M_DCACHE)
   priv->blocksize = blocklen;
+#endif
 
   putreg32(USDHC_BLKATTR_SIZE(blocklen) | USDHC_BLKATTR_CNT(nblocks),
            priv->addr + IMXRT_USDHC_BLKATTR_OFFSET);


### PR DESCRIPTION
## Summary

2 compiler error fixes and one driver change making the RTC be set able

## Impact

Code will build with CPP and if CONFIG_ARMV7M_DCACHE is off

## Testing

PX4 nxp_fmurt1062-v2 and `date` command. Power removed and restored 10 minutes later and time persists and it same as the time set + 10 minutes. 

