### PR TITLE
Add Embedded Template Library (ETL) support

### DIFF
--- a/include/.gitignore
+++ b/include/.gitignore
@@ -9,3 +9,4 @@
 /machine
 /openamp
 /metal
+/etl

--- a/libs/libxx/.gitignore
+++ b/libs/libxx/.gitignore
@@ -3,3 +3,4 @@
 /libcxxabi
 /libcxx-*.src.tar.xz
 /libcxxabi-*.src.tar.xz
+/etl

--- a/libs/libxx/Kconfig
+++ b/libs/libxx/Kconfig
@@ -50,6 +50,18 @@ config UCLIBCXX
 
 endchoice
 
+if LIBCXXMINI
+
+config ETL
+	bool "Embedded Template Library (ETL)"
+	depends on ALLOW_MIT_COMPONENTS
+	---help---
+		ETL A C++ Template library for Embedded applications
+		Implements C++ templates such as containers, string
+		singleton math without C++ STL libraries
+
+endif
+
 if LIBCXX || UCLIBCXX
 
 choice

--- a/libs/libxx/Makefile
+++ b/libs/libxx/Makefile
@@ -35,6 +35,9 @@ else ifeq ($(CONFIG_LIBCXX),y)
 include libcxx.defs
 else
 include libcxxmini.defs
+ifeq ($(CONFIG_ETL),y)
+include etl.defs
+endif
 endif
 
 ifeq ($(CONFIG_LIBCXXABI),y)

--- a/libs/libxx/etl.defs
+++ b/libs/libxx/etl.defs
@@ -1,0 +1,49 @@
+############################################################################
+# libs/libxx/stdex.defs
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+###########################################################################
+
+ETL_VERSION=20.32.1
+
+$(ETL_VERSION).tar.gz:
+	$(Q) curl -O -L https://github.com/ETLCPP/etl/archive/refs/tags/$(ETL_VERSION).tar.gz
+
+etl: $(ETL_VERSION).tar.gz
+	$(Q) tar -xf $(ETL_VERSION).tar.gz
+	$(Q) $(DELFILE) $(ETL_VERSION).tar.gz
+	$(Q) mv etl-$(ETL_VERSION) etl
+	$(Q) touch $@
+ifeq ($(CONFIG_ARCH_ARMV5M), y)
+	$(Q) cp $(CURDIR)/etl/include/etl/profiles/armv5_no_stl.h $(CURDIR)/etl/include/etl/etl_profile.h
+else ifeq ($(CONFIG_ARCH_ARMV6M), y)
+	$(Q) cp $(CURDIR)/etl/include/etl/profiles/armv6_no_stl.h $(CURDIR)/etl/include/etl/etl_profile.h
+else ifeq ($(CONFIG_ARCH_ARMV7M), y)
+	$(Q) cp $(CURDIR)/etl/include/etl/profiles/armv7_no_stl.h $(CURDIR)/etl/include/etl/etl_profile.h
+else
+	$(Q) cp $(CURDIR)/etl/include/etl/profiles/gcc_generic_no_stl.h $(CURDIR)/etl/include/etl/etl_profile.h
+endif
+
+$(TOPDIR)/include/etl: etl
+	$(Q) $(DIRLINK) $(CURDIR)/etl/include $(TOPDIR)/include/etl
+
+context:: $(TOPDIR)/include/etl
+
+distclean::
+	$(Q) $(DELFILE) $(ETL_VERSION).tar.gz
+	$(Q) $(DIRUNLINK) $(TOPDIR)/include/etl
+	$(call DELDIR, etl)

--- a/tools/Config.mk
+++ b/tools/Config.mk
@@ -570,6 +570,9 @@ else ifeq ($(CONFIG_UCLIBCXX),y)
   ARCHXXINCLUDES += ${shell $(INCDIR) -s "$(CC)" $(TOPDIR)$(DELIM)include$(DELIM)uClibc++}
 else
   ARCHXXINCLUDES += ${shell $(INCDIR) -s "$(CC)" $(TOPDIR)$(DELIM)include$(DELIM)cxx}
+  ifeq ($(CONFIG_ETL),y)
+    ARCHXXINCLUDES += ${shell $(INCDIR) -s "$(CC)" $(TOPDIR)$(DELIM)include$(DELIM)etl}
+  endif
 endif
 ARCHXXINCLUDES += ${shell $(INCDIR) -s "$(CC)" $(TOPDIR)$(DELIM)include}
 


### PR DESCRIPTION
## Summary
Adds support for the Embedded Template Library (ETL).
Which implements various embedded systems friendly C++ classes such as etl::vector without the need of the STL library.

## Impact
Minimal it's behind a kconfig 
Furthermore it's quite lightweight the ETL example application only increases program size by 2263 bytes

## Testing
See ETL testing app

