### PR TITLE
board/cxd56xx/audio: Fix CXD56 audio initialization

### DIFF
--- a/boards/arm/cxd56xx/common/src/cxd56_audio.c
+++ b/boards/arm/cxd56xx/common/src/cxd56_audio.c
@@ -481,6 +481,10 @@ int board_audio_initialize_driver(int minor)
       return -ENODEV;
     }
 
+#ifndef CONFIG_AUDIO_FORMAT_PCM
+  pcm = cxd56;
+#else
+
   /* Initialize a PCM decoder with the CXD56 instance. */
 
   pcm = pcm_decode_initialize(cxd56);
@@ -490,6 +494,8 @@ int board_audio_initialize_driver(int minor)
 
       return -ENODEV;
     }
+
+#endif
 
   /* Create a device name */
 


### PR DESCRIPTION
## Summary

Fix PCM decoder config where it is always initialized assuming
it was enabled despite being optional.

## Impact
CXD56xx

## Testing
Test that nxplayer on spresense/audio config works well with/without CONFIG_AUDIO_FORMAT_PCM