### PR TITLE
Use GCC for LD on MIPS processors

### DIFF
--- a/arch/mips/src/Makefile
+++ b/arch/mips/src/Makefile
@@ -53,8 +53,8 @@ OBJS = $(AOBJS) $(COBJS)
 
 # Override in Make.defs if linker is not 'ld'
 
-LDSTARTGROUP ?= --start-group
-LDENDGROUP ?= --end-group
+LDSTARTGROUP ?= -Wl,--start-group
+LDENDGROUP ?= -Wl,--end-group
 LDFLAGS += $(addprefix -T,$(call CONVERT_PATH,$(ARCHSCRIPT)))
 
 BOARDMAKE = $(if $(wildcard board$(DELIM)Makefile),y,)
@@ -89,7 +89,7 @@ board/libboard$(LIBEXT):
 
 nuttx$(EXEEXT): $(HEAD_OBJ) board/libboard$(LIBEXT) $(ARCHSCRIPT)
 	@echo "LD: nuttx"
-	$(Q) $(LD) --entry=__start $(LDFLAGS) $(LIBPATHS) $(EXTRA_LIBPATHS) \
+	$(Q) $(LD) -Wl,--entry=__start $(LDFLAGS) $(LIBPATHS) $(EXTRA_LIBPATHS) \
 		-o $(NUTTX) $(HEAD_OBJ) $(EXTRA_OBJS) \
 		$(LDSTARTGROUP) $(LDLIBS) $(EXTRA_LIBS) $(LDENDGROUP)
 ifneq ($(CONFIG_WINDOWS_NATIVE),y)

--- a/arch/mips/src/mips32/Toolchain.defs
+++ b/arch/mips/src/mips32/Toolchain.defs
@@ -245,14 +245,14 @@ endif
 # Optimization of unused sections
 
 ifeq ($(CONFIG_DEBUG_OPT_UNUSED_SECTIONS),y)
-  LDFLAGS          += --gc-sections
+  LDFLAGS          += -Wl,--gc-sections
   ARCHOPTIMIZATION += -ffunction-sections -fdata-sections
 endif
 
 # Debug link map
 
 ifeq ($(CONFIG_DEBUG_LINK_MAP),y)
-  LDFLAGS += --cref -Map=$(call CONVERT_PATH,$(TOPDIR)$(DELIM)nuttx.map)
+  LDFLAGS += -Wl,--cref -Wl,-Map=$(call CONVERT_PATH,$(TOPDIR)$(DELIM)nuttx.map)
 endif
 
 ifeq ($(CONFIG_DEBUG_SYMBOLS),y)
@@ -280,7 +280,7 @@ LDFLAGS += -nostdlib
 CC = $(CROSSDEV)gcc
 CXX = $(CROSSDEV)g++
 CPP = $(CROSSDEV)gcc -E -P -x c
-LD = $(CROSSDEV)ld
+LD = $(CROSSDEV)gcc
 STRIP = $(CROSSDEV)strip --strip-unneeded
 AR = $(CROSSDEV)ar rcs
 NM = $(CROSSDEV)nm


### PR DESCRIPTION
## Summary
I built GCC 11.2 with crosstool-ng and found that the linking process failed.  This led me to issue #3826, which is the same issue but for ARM.  I applied effectively the same patch as #3836 in order to get it to compile

## Impact
Seems to be minimal.  Other compilers may have issues.

## Testing
Nuttx now compiles with newer versions of GCC.  This shouldn't have any effect on the actual compiled code.  I have not tested with other compilers apart from the one crosstool-ng built one.
