### PR TITLE
Fix typos

### DIFF
--- a/arch/arm/src/nrf52/nrf52_radio.c
+++ b/arch/arm/src/nrf52/nrf52_radio.c
@@ -594,7 +594,7 @@ static int nrf52_radio_pkt_cfg(struct nrf52_radio_dev_s *dev,
 
   pcnf1 |= (cfg->bal_len << RADIO_PCNF1_BALEN_SHIFT);
 
-  /* Configure on-air endianess of packet */
+  /* Configure on-air endianness of packet */
 
   pcnf1 |= (cfg->endian << RADIO_PCNF1_ENDIAN_SHIFT);
 

--- a/arch/arm/src/nrf52/nrf52_radio.h
+++ b/arch/arm/src/nrf52/nrf52_radio.h
@@ -137,7 +137,7 @@ struct nrf52_radio_pktcfg_s
   uint8_t pl_len;               /* Preamble length */
   uint8_t term_len;             /* TERM length */
   bool    crcinc;               /* LENGTH includes CRC */
-  bool    endian;               /* On air endianess of packet:
+  bool    endian;               /* On air endianness of packet:
                                  * 0 - little
                                  * 1 - big
                                  */

--- a/arch/arm/src/phy62xx/flash.c
+++ b/arch/arm/src/phy62xx/flash.c
@@ -184,7 +184,7 @@ void __RAMRUN hal_spif_init(void)
   *(volatile uint32_t *) 0x4000c804 = 0x41220eb;    /* Device Read Instruction Register */
   return;
 
-  /* load defualt configure */
+  /* load default configure */
 
   while (1)
     {

--- a/arch/arm/src/phy62xx/global_config.h
+++ b/arch/arm/src/phy62xx/global_config.h
@@ -156,7 +156,7 @@
 
 #define   RC32_TRACKINK_ALLOW              0x00000001       /* enable tracking RC 32KHz clock with 16MHz hclk */
 #define   SLAVE_LATENCY_ALLOW              0x00000002       /* slave latency allow switch */
-#define   LL_DEBUG_ALLOW                   0x00000004       /* enable invoke RAM project debug output fucntion */
+#define   LL_DEBUG_ALLOW                   0x00000004       /* enable invoke RAM project debug output function */
 #define   LL_WHITELIST_ALLOW               0x00000008       /* enable whitelist filter */
 #define   LL_RC32K_SEL                     0x00000010       /* select RC32K RTC, otherwise select crystal 32K RTC */
 #define   SIMUL_CONN_ADV_ALLOW             0x00000020       /* allow send adv in connect state */

--- a/arch/renesas/src/rx65n/rx65n_usbhost.c
+++ b/arch/renesas/src/rx65n/rx65n_usbhost.c
@@ -5034,7 +5034,7 @@ static inline void rx65n_usbhost_edfree(struct rx65n_usbhost_ed_s *ed)
 static struct rx65n_usbhost_gtd_s *rx65n_usbhost_tdalloc(uint8_t ep_num)
 {
   /* Currently each TD would associate with one EP. So the ep_numb is
-   * passed to tdalloc fucntion and it would return the TD with this,
+   * passed to tdalloc function and it would return the TD with this,
    * there is no need to free this
    */
 
@@ -5686,7 +5686,7 @@ static int rx65n_usbhost_enqueuetd(struct rx65n_usbhost_s *priv,
   /* Allocate a TD from the free list */
 
   /* Currently each TD would associate with one EP. So the epnumb
-   * is passed to tdalloc fucntion and it would return the TD with
+   * is passed to tdalloc function and it would return the TD with
    * this, there is no need to free this - there is no need
    */
 

--- a/arch/x86_64/Kconfig
+++ b/arch/x86_64/Kconfig
@@ -37,7 +37,7 @@ choice
 	default ARCH_BOARD_QEMU
 
 config ARCH_BOARD_QEMU
-	bool "Qemu envrionment"
+	bool "Qemu environment"
 	---help---
 		Targeting virtualized qemu environment
 

--- a/boards/arm/cxd56xx/common/src/cxd56_altmdm.c
+++ b/boards/arm/cxd56xx/common/src/cxd56_altmdm.c
@@ -375,7 +375,7 @@ int board_altmdm_initialize(const char *devpath)
 
   if (!g_devhandle)
     {
-      /* Initialize spi deivce */
+      /* Initialize spi device */
 
       spi = cxd56_spibus_initialize(SPI_CH);
       if (!spi)

--- a/boards/arm/cxd56xx/common/src/cxd56_bmi160_scu.c
+++ b/boards/arm/cxd56xx/common/src/cxd56_bmi160_scu.c
@@ -119,7 +119,7 @@ int board_bmi160_initialize(int bus)
 
   sninfo("Initializing BMI160..\n");
 
-  /* Initialize i2c deivce */
+  /* Initialize i2c device */
 
   i2c = cxd56_i2cbus_initialize(bus);
   if (!i2c)

--- a/boards/arm/cxd56xx/common/src/cxd56_emmcdev.c
+++ b/boards/arm/cxd56xx/common/src/cxd56_emmcdev.c
@@ -65,7 +65,7 @@ int board_emmc_initialize(void)
       return -ENODEV;
     }
 
-  /* Initialize the eMMC deivce */
+  /* Initialize the eMMC device */
 
   ret = cxd56_emmcinitialize();
   if (ret < 0)
@@ -74,7 +74,7 @@ int board_emmc_initialize(void)
       return -ENODEV;
     }
 
-  /* Mount the eMMC deivce */
+  /* Mount the eMMC device */
 
   ret = nx_mount("/dev/emmc0", "/mnt/emmc", "vfat", 0, NULL);
   if (ret < 0)

--- a/boards/arm/cxd56xx/common/src/cxd56_spisd.c
+++ b/boards/arm/cxd56xx/common/src/cxd56_spisd.c
@@ -68,7 +68,7 @@ int board_spisd_initialize(int minor, int bus)
 
   cxd56_gpio_config(MMCSD_DETECT, true);
 
-  /* Initialize spi deivce */
+  /* Initialize spi device */
 
   spi = cxd56_spibus_initialize(bus);
   if (!spi)

--- a/boards/arm/imxrt/imxrt1060-evk/scripts/flash-ocram.ld
+++ b/boards/arm/imxrt/imxrt1060-evk/scripts/flash-ocram.ld
@@ -29,7 +29,7 @@
  * 256Kib to OCRRAM, 128Kib ITCM and 128Kib DTCM.
  * This can be changed by using a dcd by minipulating
  * IOMUX GPR16 and GPR17.
- * The configuartion we will use is 384Kib to OCRRAM, 0Kib ITCM and
+ * The configuration we will use is 384Kib to OCRRAM, 0Kib ITCM and
  * 128Kib DTCM.
  *
  * This is the OCRAM inker script.

--- a/boards/arm/imxrt/imxrt1064-evk/scripts/flash-ocram.ld
+++ b/boards/arm/imxrt/imxrt1064-evk/scripts/flash-ocram.ld
@@ -29,7 +29,7 @@
  * 256Kib to OCRRAM, 128Kib ITCM and 128Kib DTCM.
  * This can be changed by using a dcd by minipulating
  * IOMUX GPR16 and GPR17.
- * The configuartion we will use is 384Kib to OCRRAM, 0Kib ITCM and
+ * The configuration we will use is 384Kib to OCRRAM, 0Kib ITCM and
  * 128Kib DTCM.
  *
  * This is the OCRAM inker script.

--- a/boards/arm/imxrt/teensy-4.x/scripts/flash-ocram.ld
+++ b/boards/arm/imxrt/teensy-4.x/scripts/flash-ocram.ld
@@ -29,7 +29,7 @@
  * 256Kib to OCRRAM, 128Kib ITCM and 128Kib DTCM.
  * This can be changed by using a dcd by minipulating
  * IOMUX GPR16 and GPR17.
- * The configuartion we will use is 384Kib to OCRRAM, 0Kib ITCM and
+ * The configuration we will use is 384Kib to OCRRAM, 0Kib ITCM and
  * 128Kib DTCM.
  *
  * This is the OCRAM inker script.

--- a/boards/arm/imxrt/teensy-4.x/src/teensy-4.h
+++ b/boards/arm/imxrt/teensy-4.x/src/teensy-4.h
@@ -78,7 +78,7 @@
 #define GPIO_LPSPI4_CS       (GPIO_OUTPUT | GPIO_OUTPUT_ONE | \
                               GPIO_PORT2 | GPIO_PIN0 | IOMUX_LPSPI4_CS)
 
-/* LCD dispay */
+/* LCD display */
 
 #define GPIO_LCD_RST        (GPIO_OUTPUT | GPIO_OUTPUT_ONE | \
                               GPIO_PORT2 | GPIO_PIN18 | IOMUX_LPSPI4_CS)    /* B1_02 */

--- a/boards/arm/lpc17xx_40xx/lpcxpresso-lpc1768/README.txt
+++ b/boards/arm/lpc17xx_40xx/lpcxpresso-lpc1768/README.txt
@@ -603,7 +603,7 @@ Where <subdir> is one of the following:
        At last attempt, the SPI-based mircroSD does not work at
        higher fequencies.  Setting the SPI frequency to 400000
        removes the problem.   There must be some more optimal
-       value that could be determined with additional experimetnation.
+       value that could be determined with additional experimentation.
 
        Jumpers: J55 must be set to provide chip select PIO1_11 signal as
        the SD slot chip select.

--- a/boards/arm/rp2040/common/src/rp2040_spisd.c
+++ b/boards/arm/rp2040/common/src/rp2040_spisd.c
@@ -59,7 +59,7 @@ int board_spisd_initialize(int minor, int bus)
   int ret;
   struct spi_dev_s *spi;
 
-  /* Initialize spi deivce */
+  /* Initialize spi device */
 
   spi = rp2040_spibus_initialize(bus);
   if (!spi)

--- a/boards/arm/s32k1xx/rddrone-bms772/src/s32k1xx_smbus_sbd.c
+++ b/boards/arm/s32k1xx/rddrone-bms772/src/s32k1xx_smbus_sbd.c
@@ -383,7 +383,7 @@ static ssize_t smbus_sbd_write(struct file *filep, const char *buffer,
  *   arg    - Pointer to the SMBus Smart Battery Data slave device struct
  *
  * Returned Value:
- *   OK if a new write buffer was succesfully registered in response to the
+ *   OK if a new write buffer was successfully registered in response to the
  *   received command; A negated errno value is returned on any failure.
  *
  ****************************************************************************/

--- a/boards/arm/s32k1xx/rddrone-bms772/src/s32k1xx_ssd1306.c
+++ b/boards/arm/s32k1xx/rddrone-bms772/src/s32k1xx_ssd1306.c
@@ -78,7 +78,7 @@ int board_lcd_initialize(void)
       return -ENODEV;
     }
 
-  lcdinfo("Succesfully initialized SSD1306 on LPI2C0\n");
+  lcdinfo("Successfully initialized SSD1306 on LPI2C0\n");
 
   return ret;
 }

--- a/boards/arm/s32k3xx/mr-canhubk3/src/s32k3xx_bringup.c
+++ b/boards/arm/s32k3xx/mr-canhubk3/src/s32k3xx_bringup.c
@@ -103,7 +103,7 @@ int s32k3xx_bringup(void)
     }
   else
     {
-      _info("s32k3xx_spidev_initialize() succesful\n");
+      _info("s32k3xx_spidev_initialize() successful\n");
     }
 #endif
 
@@ -117,7 +117,7 @@ int s32k3xx_bringup(void)
     }
   else
     {
-      _info("btn_lower_initialize() succesful\n");
+      _info("btn_lower_initialize() successful\n");
     }
 #endif
 
@@ -131,7 +131,7 @@ int s32k3xx_bringup(void)
     }
   else
     {
-      _info("userled_lower_initialize() succesful\n");
+      _info("userled_lower_initialize() successful\n");
     }
 #endif
 
@@ -145,7 +145,7 @@ int s32k3xx_bringup(void)
     }
   else
     {
-      _info("Mounting procfs at /proc succesful\n");
+      _info("Mounting procfs at /proc successful\n");
     }
 #endif
 
@@ -159,7 +159,7 @@ int s32k3xx_bringup(void)
     }
   else
     {
-      _info("s32k3xx_i2cdev_initialize() succesful\n");
+      _info("s32k3xx_i2cdev_initialize() successful\n");
     }
 #endif
 
@@ -173,7 +173,7 @@ int s32k3xx_bringup(void)
     }
   else
     {
-      _info("s32k3xx_qspi_initialize() succesful\n");
+      _info("s32k3xx_qspi_initialize() successful\n");
 
       /* Use the QSPI device instance to initialize the MX25 device */
 
@@ -184,7 +184,7 @@ int s32k3xx_bringup(void)
         }
       else
         {
-          _info("mx25rxx_initialize() succesful\n");
+          _info("mx25rxx_initialize() successful\n");
 
 #  ifdef HAVE_MX25L_LITTLEFS
           /* Configure the device with no partition support */
@@ -199,7 +199,7 @@ int s32k3xx_bringup(void)
             }
           else
             {
-              _info("register_mtddriver() succesful\n");
+              _info("register_mtddriver() successful\n");
 
               ret = nx_mount(blockdev, "/mnt/qspi", "littlefs", 0, NULL);
               if (ret < 0)
@@ -212,7 +212,7 @@ int s32k3xx_bringup(void)
                     }
                   else
                     {
-                      _info("nx_mount() succesful\n");
+                      _info("nx_mount() successful\n");
                     }
                 }
             }
@@ -227,7 +227,7 @@ int s32k3xx_bringup(void)
             }
           else
             {
-              _info("nxffs_initialize() succesful\n");
+              _info("nxffs_initialize() successful\n");
 
               /* Mount the file system at /mnt/qspi */
 
@@ -238,7 +238,7 @@ int s32k3xx_bringup(void)
                 }
               else
                 {
-                  _info("nx_mount() succesful\n");
+                  _info("nx_mount() successful\n");
                 }
             }
 
@@ -253,7 +253,7 @@ int s32k3xx_bringup(void)
 #    ifdef CONFIG_BCH
           else
             {
-              _info("ftl_initialize() succesful\n");
+              _info("ftl_initialize() successful\n");
 
               /* Use the minor number to create device paths */
 
@@ -271,7 +271,7 @@ int s32k3xx_bringup(void)
                 }
               else
                 {
-                  _info("bchdev_register %s succesful\n", chardev);
+                  _info("bchdev_register %s successful\n", chardev);
                 }
             }
 #    endif /* CONFIG_BCH */

--- a/boards/arm/s32k3xx/mr-canhubk3/src/s32k3xx_selftest.c
+++ b/boards/arm/s32k3xx/mr-canhubk3/src/s32k3xx_selftest.c
@@ -86,7 +86,7 @@ static int s32k3xx_selftest_se050(void)
 
   if (lpi2c1 != NULL)
     {
-      _info("s32k3xx_i2cbus_initialize() succesful\n");
+      _info("s32k3xx_i2cbus_initialize() successful\n");
     }
   else
     {
@@ -107,7 +107,7 @@ static int s32k3xx_selftest_se050(void)
   ret = I2C_TRANSFER(lpi2c1, &se050_msg, 1);
   if (ret == 0)
     {
-      _info("SE050 ACK succesful\n");
+      _info("SE050 ACK successful\n");
     }
   else
     {
@@ -123,7 +123,7 @@ static int s32k3xx_selftest_se050(void)
 
   if (ret == 0)
     {
-      _info("s32k3xx_i2cbus_uninitialize() succesful\n");
+      _info("s32k3xx_i2cbus_uninitialize() successful\n");
 
       /* Return error if we had any earlier, otherwise return result of
        * s32k3xx_i2cbus_uninitialize()
@@ -244,7 +244,7 @@ static int s32k3xx_selftest_can(void)
     {
       if (s32k3xx_gpioread(errn_pins[i]))
         {
-          _info("CAN%d flag check succesful\n", i);
+          _info("CAN%d flag check successful\n", i);
         }
       else
         {
@@ -353,7 +353,7 @@ static int s32k3xx_selftest_sct(void)
     {
       if (s32k3xx_gpioread(rxd_pins[i - 4]))
         {
-          _info("CAN%d RXD high check succesful\n", i);
+          _info("CAN%d RXD high check successful\n", i);
         }
       else
         {
@@ -379,7 +379,7 @@ static int s32k3xx_selftest_sct(void)
     {
       if (!s32k3xx_gpioread(rxd_pins[i - 4]))
         {
-          _info("CAN%d RXD low check succesful\n", i);
+          _info("CAN%d RXD low check successful\n", i);
         }
       else
         {
@@ -457,7 +457,7 @@ void s32k3xx_selftest(void)
 
   if (!error)
     {
-      _info("s32k3xx_selftest() succesful\n");
+      _info("s32k3xx_selftest() successful\n");
     }
 }
 

--- a/boards/arm/s32k3xx/mr-canhubk3/src/s32k3xx_tja1153.c
+++ b/boards/arm/s32k3xx/mr-canhubk3/src/s32k3xx_tja1153.c
@@ -327,7 +327,7 @@ int s32k3xx_tja1153_initialize(int bus)
     }
 
   close(sock);
-  _info("CAN%d TJA1153 configuration succesful\n", bus);
+  _info("CAN%d TJA1153 configuration successful\n", bus);
   return 0;
 }
 

--- a/boards/arm/sama5/sama5d4-ek/README.txt
+++ b/boards/arm/sama5/sama5d4-ek/README.txt
@@ -2572,7 +2572,7 @@ I2C Tool
     o The I2C dev command may have bad side effects on your I2C devices.
       Use only at your own risk.
 
-    As an example, the I2C dev comman can be used to list all devices
+    As an example, the I2C dev command can be used to list all devices
     responding on TWI0 (the default) like this:
 
       nsh> i2c dev 0x03 0x77

--- a/boards/arm/stm32/b-g431b-esc1/src/stm32_foc.c
+++ b/boards/arm/stm32/b-g431b-esc1/src/stm32_foc.c
@@ -212,7 +212,7 @@ static void board_foc_trace(struct foc_dev_s *dev, int type, bool state);
  * Private Data
  ****************************************************************************/
 
-/* OPAMP confuguration:
+/* OPAMP configuration:
  *   - connected with ADC through output pin (OPAINTOEN=0)
  *   - Current U+ - OPAMP1_VINP0 (PA1)
  *   - Current U- - OPAMP1_VINP0 (PA3)

--- a/boards/arm/stm32/nucleo-f446re/src/stm32_foc_ihm08m1.c
+++ b/boards/arm/stm32/nucleo-f446re/src/stm32_foc_ihm08m1.c
@@ -67,7 +67,7 @@
  * Private Data
  ****************************************************************************/
 
-/* FOC ADC configration:
+/* FOC ADC configuration:
  *    - Current Phase V    -> ADC1 INJ1 -> ADC1_IN0  (PA0)
  *    - Current Phase U    -> ADC1 INJ2 -> ADC1_IN11 (PC1)
  *    - Current Phase W    -> ADC1 INJ3 -> ADC1_IN10 (PC0)

--- a/boards/arm/stm32/nucleo-g431rb/src/stm32_foc_ihm16m1.c
+++ b/boards/arm/stm32/nucleo-g431rb/src/stm32_foc_ihm16m1.c
@@ -67,7 +67,7 @@
  * Private Data
  ****************************************************************************/
 
-/* FOC ADC configration:
+/* FOC ADC configuration:
  *    - Current Phase V    -> ADC1 INJ1 -> ADC1_IN2  (PA1)
  *    - Current Phase U    -> ADC1 INJ2 -> ADC1_IN12 (PB1)
  *    - Current Phase W    -> ADC1 INJ3 -> ADC1_IN15 (PB0)

--- a/boards/arm/stm32wl5/nucleo-wl55jc/Kconfig
+++ b/boards/arm/stm32wl5/nucleo-wl55jc/Kconfig
@@ -138,7 +138,7 @@ config ARCH_BOARD_FLASH_PART1_FS_SMARTFS
 		when flashing new software, unless you exceeded reserved
 		memory for program code.
 
-		Smartfs uses quite substential ammount of FLASH data to
+		Smartfs uses quite substential amount of FLASH data to
 		get to workable state and mount. Looks like 8 page sizes
 		is absolute minimum (so a 16KiB!).
 

--- a/boards/arm/stm32wl5/nucleo-wl55jc/README.txt
+++ b/boards/arm/stm32wl5/nucleo-wl55jc/README.txt
@@ -50,8 +50,8 @@ Serial Console
 
   NSH is configured to use LPUART and virtual serial port. After flashing
   you can open /dev/ttyACM0 (may change depending on your system) and nsh
-  prompt will be waiting for you there. Serial device does not disapear
-  when flashing and reseting board - it can be left opened and flashing
+  prompt will be waiting for you there. Serial device does not disappear
+  when flashing and resetting board - it can be left opened and flashing
   will work without problems.
 
 Configuration

--- a/boards/arm/stm32wl5/nucleo-wl55jc/include/board.h
+++ b/boards/arm/stm32wl5/nucleo-wl55jc/include/board.h
@@ -152,7 +152,7 @@
  * PA1 - Button 2
  * PC6 - Button 3
  *
- * Buttons need to be pulled up internaly by chip,
+ * Buttons need to be pulled up internally by chip,
  * and button press will pull pin down to LOW level.
  */
 

--- a/boards/arm/stm32wl5/nucleo-wl55jc/src/stm32_flash.c
+++ b/boards/arm/stm32wl5/nucleo-wl55jc/src/stm32_flash.c
@@ -228,7 +228,7 @@ int stm32wl5_flash_init(void)
       finfo("[%s] creating partition, size: %d, fs: %s, offset: %d\n",
             name, size, fs, offset);
 
-      /* create mtd parition */
+      /* create mtd partition */
 
       mtd_part = mtd_partition(mtd, offset, size);
 
@@ -313,7 +313,7 @@ int stm32wl5_flash_init(void)
               ferr("[%s]ERROR: nx_mount failed: %d\n", name, ret);
               if (ret == ENODEV)
                 {
-                  syslog(LOG_INFO, "[%s] mtd, smartfs seems unformated. "
+                  syslog(LOG_INFO, "[%s] mtd, smartfs seems unformatted. "
                          "Did you run 'mksmartfs %s'?\n", name, src);
                 }
 

--- a/boards/arm/tlsr82/tlsr8278adk80d/scripts/flash_boot.ld
+++ b/boards/arm/tlsr82/tlsr8278adk80d/scripts/flash_boot.ld
@@ -72,7 +72,7 @@ SECTIONS
     PROVIDE(_rstored_ = . );
     PROVIDE(_code_size_ = .);
 
-    /* __LOAD_FLASH for MCU RUN IN Flash 0x100 alighned, must greater
+    /* __LOAD_FLASH for MCU RUN IN Flash 0x100 aligned, must greater
      * than or equal to : 0x808000 + ram_code_size + irq_vector(0x100) +
      * IC_tag(0x100) + IC_cache(0x800) == 0x808a00 + ram_code_size
      *

--- a/boards/arm/tlsr82/tlsr8278adk80d/scripts/flash_boot_ble.ld
+++ b/boards/arm/tlsr82/tlsr8278adk80d/scripts/flash_boot_ble.ld
@@ -147,7 +147,7 @@ SECTIONS
     PROVIDE(_rstored_ = . );
     PROVIDE(_code_size_ = .);
 
-    /* __LOAD_FLASH for MCU RUN IN Flash 0x100 alighned, must greater
+    /* __LOAD_FLASH for MCU RUN IN Flash 0x100 aligned, must greater
      * than or equal to : 0x808000 + ram_code_size + irq_vector(0x100) +
      * IC_tag(0x100) + IC_cache(0x800) == 0x808a00 + ram_code_size
      *

--- a/boards/arm64/qemu/qemu-a53/README.txt
+++ b/boards/arm64/qemu/qemu-a53/README.txt
@@ -55,7 +55,7 @@ Getting Started
    Configuring NuttX and compile:
    $ ./tools/configure.sh -l qemu-a53:nsh_smp
    $ make
-   Runing with qemu
+   Running with qemu
    $ qemu-system-aarch64 -cpu cortex-a53 -smp 4 -nographic \
       -machine virt,virtualization=on,gic-version=3 \
       -net none -chardev stdio,id=con,mux=on -serial chardev:con \
@@ -98,7 +98,7 @@ Status
   Running ostest seem PASSED.
 
 2.qemu-a53 board configuration support: qemu-a53 board can configuring
-  and compiling, And runing with qemu-system-aarch64
+  and compiling, And running with qemu-system-aarch64
   at Ubuntu 18.04.
 3.FPU support for armv8-a: FPU context switching in NEON/floating-point
   TRAP was supported.  FPU registers saving at vfork and independent
@@ -196,7 +196,7 @@ the content of FP registers used for floating point argument passing
 into the va_list object in case there were actual float arguments from
 the caller. But In practice this is almost never the case. 
 Seeing the save_count/restore_count at the g_cpu_fpu_ctx, which will
-be increase when saving/restoring FPU context. After runing ostest,
+be increase when saving/restoring FPU context. After running ostest,
 we can see the count with GDB:
    
 (gdb) p g_cpu_fpu_ctx
@@ -218,7 +218,7 @@ index c58fb45512..acac6febaa
  VPATH += :syslog
 +syslog/lib_syslog.c_CFLAGS += -mgeneral-regs-only
    
-    With the option to make NuttX and booting. After runing ostest, see 
+    With the option to make NuttX and booting. After running ostest, see 
 the count with GDB again:
 
 (gdb) p g_cpu_fpu_ctx
@@ -240,7 +240,7 @@ Add the option to your code maybe increase FPU performance
 handling for this case, it will inc/dec at enter/leave exception. If the
 exception_depth > 1, that means an exception occurring when another exception
 is executing, the present implement is to switch FPU context to idle thread,
-it will handle most case for calling printf-like rountine at IRQ routine.
+it will handle most case for calling printf-like routine at IRQ routine.
     But in fact, this case will make uncertainty interrupt processing time sine
 it's uncertainty for trap exception handling. It would be best to add
 "-mgeneral-regs-only" option to compile the IRQ code avoiding accessing FP

--- a/boards/renesas/rx65n/rx65n-grrose/include/README.TXT
+++ b/boards/renesas/rx65n/rx65n-grrose/include/README.TXT
@@ -25,7 +25,7 @@ README
   script; /etc/passwd is a the password file.  It supports a single user:
 
     USERNAME:  admin
-    PASSWORD:  Adminstrator
+    PASSWORD:  Administrator
 
     nsh> cat /etc/passwd
     admin:8Tv+Hbmr3pLddSjtzL0kwC:0:0:/

--- a/boards/renesas/rx65n/rx65n-rsk2mb/include/README.TXT
+++ b/boards/renesas/rx65n/rx65n-rsk2mb/include/README.TXT
@@ -25,7 +25,7 @@ README
   script; /etc/passwd is a the password file.  It supports a single user:
 
     USERNAME:  admin
-    PASSWORD:  Adminstrator
+    PASSWORD:  Administrator
 
     nsh> cat /etc/passwd
     admin:8Tv+Hbmr3pLddSjtzL0kwC:0:0:/

--- a/boards/risc-v/c906/smartl-c906/scripts/Make.defs
+++ b/boards/risc-v/c906/smartl-c906/scripts/Make.defs
@@ -33,7 +33,7 @@ ARCHSCRIPT += $(BOARD_DIR)$(DELIM)scripts$(DELIM)$(LDSCRIPT)
 # The following options are for the toolchain from T-HEAD.
 # For more info ahout the T-HEAD ISA extensions, please refer to the C906 user guide.
 # ARCHCPUFLAGS = -march=rv64gcxthead -mabi=lp64d -mtune=c906 -mcmodel=medany
-# TODO: We are not going to enable this at this time for the CI compatiblity.
+# TODO: We are not going to enable this at this time for the CI compatibility.
 
 ARCHCPUFLAGS += -mcmodel=medany
 

--- a/boards/risc-v/c906/smartl-c906/src/c906_leds.c
+++ b/boards/risc-v/c906/smartl-c906/src/c906_leds.c
@@ -48,7 +48,7 @@ void board_autoled_initialize(void)
  * Name: board_autoled_on
  *
  * Description:
- *    Turn on the LED specificed.
+ *    Turn on the LED specified.
  *
  * Input Parameters:
  *   led - The LED which is under this control
@@ -63,7 +63,7 @@ void board_autoled_on(int led)
  * Name: board_autoled_off
  *
  * Description:
- *    Turn off the LED specificed.
+ *    Turn off the LED specified.
  *
  * Input Parameters:
  *   led - The LED which is under this control

--- a/boards/risc-v/mpfs/icicle/scripts/Make.defs
+++ b/boards/risc-v/mpfs/icicle/scripts/Make.defs
@@ -52,7 +52,7 @@ ARCHSCRIPT += $(BOARD_DIR)$(DELIM)scripts$(DELIM)$(LDSCRIPT)
 # The following options are for the toolchain from T-HEAD.
 # For more info ahout the T-HEAD ISA extensions, please refer to the MPFS user guide.
 # ARCHCPUFLAGS = -march=rv64gcxthead -mabi=lp64d -mcmodel=medany
-# TODO: We are not going to enable this at this time for the CI compatiblity.
+# TODO: We are not going to enable this at this time for the CI compatibility.
 
 ARCHCPUFLAGS += -mcmodel=medany
 

--- a/boards/risc-v/mpfs/icicle/src/mpfs_autoleds.c
+++ b/boards/risc-v/mpfs/icicle/src/mpfs_autoleds.c
@@ -58,7 +58,7 @@ void board_autoled_initialize(void)
  * Name: board_autoled_on
  *
  * Description:
- *    Turn on the LED specificed.
+ *    Turn on the LED specified.
  *
  * Input Parameters:
  *   led - The LED which is under this control
@@ -115,7 +115,7 @@ void board_autoled_on(int led)
  * Name: board_autoled_off
  *
  * Description:
- *    Turn off the LED specificed.
+ *    Turn off the LED specified.
  *
  * Input Parameters:
  *   led - The LED which is under this control

--- a/boards/risc-v/mpfs/m100pfsevp/scripts/Make.defs
+++ b/boards/risc-v/mpfs/m100pfsevp/scripts/Make.defs
@@ -33,7 +33,7 @@ ARCHSCRIPT += $(BOARD_DIR)$(DELIM)scripts$(DELIM)$(LDSCRIPT)
 # The following options are for the toolchain from T-HEAD.
 # For more info ahout the T-HEAD ISA extensions, please refer to the MPFS user guide.
 # ARCHCPUFLAGS = -march=rv64gcxthead -mabi=lp64d -mcmodel=medany
-# TODO: We are not going to enable this at this time for the CI compatiblity.
+# TODO: We are not going to enable this at this time for the CI compatibility.
 
 ARCHCPUFLAGS += -mcmodel=medany
 

--- a/boards/risc-v/mpfs/m100pfsevp/src/mpfs_autoleds.c
+++ b/boards/risc-v/mpfs/m100pfsevp/src/mpfs_autoleds.c
@@ -51,7 +51,7 @@ void board_autoled_initialize(void)
  * Name: board_autoled_on
  *
  * Description:
- *    Turn on the LED specificed.
+ *    Turn on the LED specified.
  *
  * Input Parameters:
  *   led - The LED which is under this control
@@ -73,7 +73,7 @@ void board_autoled_on(int led)
  * Name: board_autoled_off
  *
  * Description:
- *    Turn off the LED specificed.
+ *    Turn off the LED specified.
  *
  * Input Parameters:
  *   led - The LED which is under this control

--- a/boards/risc-v/rv32m1/rv32m1-vega/README.txt
+++ b/boards/risc-v/rv32m1/rv32m1-vega/README.txt
@@ -232,8 +232,8 @@ nsh-itcm
   This configuration is a variant of the NSH configuration used for
   demonstrating ITCM. When ITCM is selected, RI5CY Exception Vectors and
   Interrupt Service Routines are placed in ITCM. Performance can be calculated
-  by getprime, and you might find it deteriorated a litte ironically. The drawback
+  by getprime, and you might find it deteriorated a little ironically. The drawback
   may be caused by long jump frequently between ITCM and flash. Besides, an instr-
   uction cache is enabled always after RI5CY resets, and amelioration could not be 
   achieved with even ITCM enabled.
-  What if codes fullfill the 64KB ITCM ?
+  What if codes fulfill the 64KB ITCM ?

--- a/boards/sim/sim/sim/Kconfig
+++ b/boards/sim/sim/sim/Kconfig
@@ -56,7 +56,7 @@ config SIM_WTGAHRS2_UARTN
 	default -1
 	depends on SENSORS_WTGAHRS2 && SIM_UART_NUMBER > 0
 	---help---
-		We can select the number accoding to which SIM_UARTX_NAME is uesd to sensor.
+		We can select the number according to which SIM_UARTX_NAME is used to sensor.
 		This range is 0-4.
 
 config SIM_I2CBUS_ID

--- a/boards/sim/sim/sim/README.txt
+++ b/boards/sim/sim/sim/README.txt
@@ -1382,7 +1382,7 @@ ustream
 vncserver
 
   This a simple vnc server test configuration, Remmina is tested and recommended since
-  there are some compatibility issues. By defualt SIM will be blocked at startup to
+  there are some compatibility issues. By default SIM will be blocked at startup to
   wait client connection, if a client connected, then the fb example will launch. 
 
 vpnkit

--- a/boards/sparc/bm3803/xx3803/Kconfig
+++ b/boards/sparc/bm3803/xx3803/Kconfig
@@ -19,7 +19,7 @@ config XX3803_WDG_TIMEOUT
 
 if XX3803_WDG
 config XX3803_WDG_THREAD
-	bool "Watchdog Deamon Thread"
+	bool "Watchdog Daemon Thread"
 
 if XX3803_WDG_THREAD
 config XX3803_WDG_THREAD_NAME

--- a/boards/sparc/bm3803/xx3803/src/bm3803_boot.c
+++ b/boards/sparc/bm3803/xx3803/src/bm3803_boot.c
@@ -49,7 +49,7 @@
  *
  * Description:
  *   All bm3803 architectures must provide the following entry point.
- *   This entry point is called early in the intitialization -- after all
+ *   This entry point is called early in the initialization -- after all
  *   memory has been configured and mapped but before any devices have been
  *   initialized.
  *

--- a/boards/sparc/bm3823/xx3823/src/bm3823_boot.c
+++ b/boards/sparc/bm3823/xx3823/src/bm3823_boot.c
@@ -49,7 +49,7 @@
  *
  * Description:
  *   All bm3823 architectures must provide the following entry point.
- *   This entry point is called early in the intitialization -- after all
+ *   This entry point is called early in the initialization -- after all
  *   memory has been configured and mapped but before any devices have been
  *   initialized.
  *

--- a/boards/z80/ez80/z20x/README.txt
+++ b/boards/z80/ez80/z20x/README.txt
@@ -33,7 +33,7 @@ Contents
 
   o ZDS-II Compiler Versions
   o Environments
-  o Memory Constaints
+  o Memory Constraints
   o Serial Console
   o LEDs and Buttons
     - LEDs
@@ -83,7 +83,7 @@ Native
   The Windows native build has not been attempt.  I would expect that it
   would have numerous problems.
 
-Memory Constaints
+Memory Constraints
 =================
 
   The eZ80F92 has a smaller FLASH memory of 128Kb.  That combined with the

--- a/drivers/misc/rwbuffer.c
+++ b/drivers/misc/rwbuffer.c
@@ -418,7 +418,7 @@ static ssize_t rwb_writebuffer(FAR struct rwbuffer_s *rwb,
 #ifdef CONFIG_DRVR_READAHEAD
 static inline void rwb_resetrhbuffer(FAR struct rwbuffer_s *rwb)
 {
-  /* We assume that the caller holds the readAheadBufferSemphore */
+  /* We assume that the caller holds the readAheadBufferSemaphore */
 
   rwb->rhnblocks    = 0;
   rwb->rhblockstart = -1;
@@ -436,9 +436,10 @@ rwb_bufferread(FAR struct rwbuffer_s *rwb,  off_t startblock,
 {
   FAR uint8_t *rhbuffer;
 
-  /* We assume that (1) the caller holds the readAheadBufferSemphore, and (2)
-   * that the caller already knows that all of the blocks are in the
-   * read-ahead buffer.
+  /* We assume that:
+   * (1) the caller holds the readAheadBufferSemaphore, and
+   * (2) the caller already knows that all of the blocks are in the
+   *     read-ahead buffer.
    */
 
   /* Convert the units from blocks to bytes */

--- a/sched/init/nx_start.c
+++ b/sched/init/nx_start.c
@@ -575,7 +575,7 @@ void nx_start(void)
     }
 #endif
 
-  /* Disables context switching beacuse we need take the memory manager
+  /* Disables context switching because we need take the memory manager
    * semaphore on this CPU so that it will not be available on the other
    * CPUs until we have finished initialization.
    */

--- a/sched/semaphore/sem_holder.c
+++ b/sched/semaphore/sem_holder.c
@@ -989,7 +989,7 @@ void nxsem_release_holder(FAR sem_t *sem)
 
   if (total == 1)
     {
-      /* If the sempahore has only one holder, we can decrement the counts
+      /* If the semaphore has only one holder, we can decrement the counts
        * simply.
        */
 

--- a/sched/tls/task_initinfo.c
+++ b/sched/tls/task_initinfo.c
@@ -37,7 +37,7 @@
  * Name: task_init_info
  *
  * Description:
- *   Allocate and initilize task_info_s structure.
+ *   Allocate and initialize task_info_s structure.
  *
  * Input Parameters:
  *   - group: The group of new task

--- a/sched/tls/tls.h
+++ b/sched/tls/tls.h
@@ -53,7 +53,7 @@
  * Name: task_init_info
  *
  * Description:
- *   Allocate and initilize task_info_s structure.
+ *   Allocate and initialize task_info_s structure.
  *
  * Input Parameters:
  *   - group: The group of new task
@@ -85,7 +85,7 @@ void task_uninit_info(FAR struct task_group_s *group);
  * Name: tls_init_info
  *
  * Description:
- *   Allocate and initilize tls_info_s structure.
+ *   Allocate and initialize tls_info_s structure.
  *
  * Input Parameters:
  *   - tcb: The TCB of new task

--- a/sched/tls/tls_initinfo.c
+++ b/sched/tls/tls_initinfo.c
@@ -35,7 +35,7 @@
  * Name: tls_init_info
  *
  * Description:
- *   Allocate and initilize tls_info_s structure.
+ *   Allocate and initialize tls_info_s structure.
  *
  * Input Parameters:
  *   - tcb: The TCB of new task


### PR DESCRIPTION
## Summary

Fix various typos, mostly in comments.

Note: Please ignore nxstyle failures in `arch/arm/src/phy62xx/flash.c`. These require renaming numerous defines, types, and variables across quite a few files and are outside the scope of this PR.

## Impact

Improves readability.

## Testing

nxstyle.