### PR TITLE
driver/sensor: rename /dev/sensor -> /dev/uorb

### DIFF
--- a/drivers/sensors/fakesensor.c
+++ b/drivers/sensors/fakesensor.c
@@ -359,7 +359,7 @@ static int fakesensor_thread(int argc, char** argv)
  * Name: fakesensor_init
  *
  * Description:
- *   This function generates a sensor node under /dev/sensor/. And then
+ *   This function generates a sensor node under /dev/uorb/. And then
  *   report the data from csv file.
  *
  * Input Parameters:

--- a/drivers/sensors/sensor.c
+++ b/drivers/sensors/sensor.c
@@ -47,7 +47,7 @@
 /* Device naming ************************************************************/
 
 #define ROUND_DOWN(x, y)    (((x) / (y)) * (y))
-#define DEVNAME_FMT         "/dev/sensor/sensor_%s%s%d"
+#define DEVNAME_FMT         "/dev/uorb/sensor_%s%s%d"
 #define DEVNAME_UNCAL       "_uncal"
 #define TIMING_BUF_ESIZE    (sizeof(unsigned long))
 
@@ -1074,7 +1074,7 @@ int sensor_register(FAR struct sensor_lowerhalf_s *lower, int devno)
  *   dev   - A pointer to an instance of lower half sensor driver. This
  *           instance is bound to the sensor driver and must persists as long
  *           as the driver persists.
- *   path  - The user specifies path of device. ex: /dev/sensor/xxx.
+ *   path  - The user specifies path of device. ex: /dev/uorb/xxx.
  *   esize - The element size of intermediate circular buffer.
  *
  * Returned Value:
@@ -1203,7 +1203,7 @@ void sensor_unregister(FAR struct sensor_lowerhalf_s *lower, int devno)
  *   dev   - A pointer to an instance of lower half sensor driver. This
  *           instance is bound to the sensor driver and must persists as long
  *           as the driver persists.
- *   path  - The user specifies path of device, ex: /dev/sensor/xxx
+ *   path  - The user specifies path of device, ex: /dev/uorb/xxx
  ****************************************************************************/
 
 void sensor_custom_unregister(FAR struct sensor_lowerhalf_s *lower,

--- a/drivers/sensors/sensor_rpmsg.c
+++ b/drivers/sensors/sensor_rpmsg.c
@@ -1273,7 +1273,7 @@ static void sensor_rpmsg_device_created(FAR struct rpmsg_device *rdev,
  *
  * Input Parameters:
  *   lower - The instance of lower half sensor driver.
- *   path  - The path of character node, ex: /dev/sensor/xxx.
+ *   path  - The path of character node, ex: /dev/uorb/xxx.
  *
  * Returned Value:
  *   The takeover rpmsg lowerhalf returned on success, NULL on failure.

--- a/include/nuttx/sensors/fakesensor.h
+++ b/include/nuttx/sensors/fakesensor.h
@@ -40,7 +40,7 @@ extern "C"
  * Name: fakesensor_init
  *
  * Description:
- *   This function generates a sensor node under /dev/sensor/. And then
+ *   This function generates a sensor node under /dev/uorb/. And then
  *   report the data from csv file.
  *
  * Input Parameters:

--- a/include/nuttx/sensors/sensor.h
+++ b/include/nuttx/sensors/sensor.h
@@ -45,7 +45,7 @@
  * Some special sensor whose event size is not fixed or dynamically change,
  * are called sensor of custom type. You should treat its events as byte
  * streams and use sensor_custom_register to register character device
- * with specific path, ex: "/dev/sensor/custom_dummy".
+ * with specific path, ex: "/dev/uorb/custom_dummy".
  */
 
 #define SENSOR_TYPE_CUSTOM                          0
@@ -1070,7 +1070,7 @@ int sensor_register(FAR struct sensor_lowerhalf_s *dev, int devno);
  *   dev   - A pointer to an instance of lower half sensor driver. This
  *           instance is bound to the sensor driver and must persist as long
  *           as the driver persists.
- *   path  - The user specifies path of device. ex: /dev/sensor/xxx.
+ *   path  - The user specifies path of device. ex: /dev/uorb/xxx.
  *   esize - The element size of intermediate circular buffer.
  *
  * Returned Value:
@@ -1109,7 +1109,7 @@ void sensor_unregister(FAR struct sensor_lowerhalf_s *dev, int devno);
  *   dev   - A pointer to an instance of lower half sensor driver. This
  *           instance is bound to the sensor driver and must persists as long
  *           as the driver persists.
- *   path  - The user specifies path of device, ex: /dev/sensor/xxx
+ *   path  - The user specifies path of device, ex: /dev/uorb/xxx
  ****************************************************************************/
 
 void sensor_custom_unregister(FAR struct sensor_lowerhalf_s *dev,
@@ -1137,7 +1137,7 @@ int usensor_initialize(void);
  *
  * Input Parameters:
  *   lower - The instance of lower half sensor driver.
- *   path  - The path of character node, ex: /dev/sensor/xxx.
+ *   path  - The path of character node, ex: /dev/uorb/xxx.
  *
  * Returned Value:
  *   The takeover rpmsg lowerhalf returned on success, NULL on failure.


### PR DESCRIPTION

## Summary
driver/sensor: rename /dev/sensor -> /dev/uorb

Because this directory contains all topics, not just sensors.

This PR is related to https://github.com/apache/incubator-nuttx-apps/pull/1257

Signed-off-by: Jiuzhu Dong <dongjiuzhu1@xiaomi.com>
## Impact
rename  directory for sensor device
## Testing
Local test

