### PR TITLE
net/local:Make local udp send multi-thread safe

### DIFF
--- a/net/local/local.h
+++ b/net/local/local.h
@@ -141,6 +141,8 @@ struct local_conn_s
      lc_cfps[LOCAL_NCONTROLFDS]; /* Socket message control filep */
 #endif /* CONFIG_NET_LOCAL_SCM */
 
+  sem_t lc_sendsem;            /* Make sending multi-thread safe */
+
 #ifdef CONFIG_NET_LOCAL_STREAM
   /* SOCK_STREAM fields common to both client and server */
 

--- a/net/local/local_conn.c
+++ b/net/local/local_conn.c
@@ -130,6 +130,12 @@ FAR struct local_conn_s *local_alloc(void)
 
 #endif
 
+      /* This semaphore is used for sending safely in multithread.
+       * Make sure data will not be garbled when multi-thread sends.
+       */
+
+      nxsem_init(&conn->lc_sendsem, 0, 1);
+
       /* Add the connection structure to the list of listeners */
 
       net_lock();
@@ -209,6 +215,10 @@ void local_free(FAR struct local_conn_s *conn)
   nxsem_destroy(&conn->lc_waitsem);
   nxsem_destroy(&conn->lc_donesem);
 #endif
+
+  /* Destory sem associated with the connection */
+
+  nxsem_destroy(&conn->lc_sendsem);
 
   /* And free the connection structure */
 


### PR DESCRIPTION
Signed-off-by: 田昕 <tianxin7@xiaomi.com>

## Summary
When multiple threads sends data through one local udp socket, data may be garbled due to lack of sem.

## Impact
local socket

## Testing
tested on esp32c3
