### PR TITLE
arch/stm32f7: port ADC driver from arch/stm32

### DIFF
--- a/arch/arm/src/stm32f7/Kconfig
+++ b/arch/arm/src/stm32f7/Kconfig
@@ -5242,11 +5242,65 @@ endmenu
 menu "ADC Configuration"
 	depends on STM32F7_ADC
 
+config STM32F7_ADC1_RESOLUTION
+	int "ADC1 resolution"
+	depends on STM32F7_ADC1
+	default 0
+	range 0 3
+	---help---
+		ADC1 resolution. 0 - 12 bit, 1 - 10 bit, 2 - 8 bit, 3 - 6 bit
+
+config STM32F7_ADC2_RESOLUTION
+	int "ADC2 resolution"
+	depends on STM32F7_ADC2
+	default 0
+	range 0 3
+	---help---
+		ADC2 resolution. 0 - 12 bit, 1 - 10 bit, 2 - 8 bit, 3 - 6 bit
+
+config STM32F7_ADC3_RESOLUTION
+	int "ADC3 resolution"
+	depends on STM32F7_ADC3
+	default 0
+	range 0 3
+	---help---
+		ADC3 resolution. 0 - 12 bit, 1 - 10 bit, 2 - 8 bit, 3 - 6 bit
+
+config STM32F7_ADC_MAX_SAMPLES
+	int "The maximum number of channels that can be sampled"
+	default 16
+	---help---
+		The maximum number of samples which can be handled without
+		overrun depends on various factors. This is the user's
+		responsibility to correctly select this value.
+		Since the interface to update the sampling time is available
+		for all supported devices, the user can change the default
+		values in the board initialization logic and avoid ADC overrun.
+
 config STM32F7_ADC_NO_STARTUP_CONV
 	bool "Do not start conversion when opening ADC device"
 	default n
 	---help---
 		Do not start conversion when opening ADC device.
+
+config STM32F7_ADC_NOIRQ
+	bool "Do not use default ADC interrupts"
+	default n
+	---help---
+		Do not use default ADC interrupts handlers.
+
+config STM32F7_ADC_LL_OPS
+	bool "ADC low-level operations"
+	default n
+	---help---
+		Enable low-level ADC ops.
+
+config STM32F7_ADC_CHANGE_SAMPLETIME
+	bool "ADC sample time configuration"
+	default n
+	depends on STM32F7_ADC_LL_OPS
+	---help---
+		Enable ADC sample time configuration (SMPRx registers).
 
 config STM32F7_ADC1_DMA
 	bool "ADC1 DMA"
@@ -5257,6 +5311,30 @@ config STM32F7_ADC1_DMA
 		DMA transfer, which is necessary if multiple channels are read
 		or if very high trigger frequencies are used.
 
+config STM32F7_ADC1_SCAN
+	bool "ADC1 scan mode"
+	depends on STM32F7_ADC1
+	default y if STM32F7_ADC1_DMA
+	default n
+
+config STM32F7_ADC1_DMA_CFG
+	int "ADC1 DMA configuration"
+	depends on STM32F7_ADC1_DMA
+	range 0 1
+	default 0
+	---help---
+		0 - ADC1 DMA in One Shot Mode, 1 - ADC1 DMA in Circular Mode
+
+config STM32F7_ADC1_ANIOC_TRIGGER
+	int "ADC1 software trigger (ANIOC_TRIGGER) configuration"
+	depends on STM32F7_ADC1
+	range 1 3
+	default 3
+	---help---
+		1 - ANIOC_TRIGGER only starts regular conversion
+		2 - ANIOC_TRIGGER only starts injected conversion
+		3 - ANIOC_TRIGGER starts both regular and injected conversions
+
 config STM32F7_ADC2_DMA
 	bool "ADC2 DMA"
 	depends on STM32F7_ADC2 && STM32F7_HAVE_ADC2_DMA
@@ -5266,6 +5344,30 @@ config STM32F7_ADC2_DMA
 		DMA transfer, which is necessary if multiple channels are read
 		or if very high trigger frequencies are used.
 
+config STM32F7_ADC2_SCAN
+	bool "ADC2 scan mode"
+	depends on STM32F7_ADC2
+	default y if STM32F7_ADC2_DMA
+	default n
+
+config STM32F7_ADC2_DMA_CFG
+	int "ADC2 DMA configuration"
+	depends on STM32F7_ADC2_DMA
+	range 0 1
+	default 0
+	---help---
+		0 - ADC2 DMA in One Shot Mode, 1 - ADC2 DMA in Circular Mode
+
+config STM32F7_ADC2_ANIOC_TRIGGER
+	int "ADC2 software trigger (ANIOC_TRIGGER) configuration"
+	depends on STM32F7_ADC2
+	range 1 3
+	default 3
+	---help---
+		1 - ANIOC_TRIGGER only starts regular conversion
+		2 - ANIOC_TRIGGER only starts injected conversion
+		3 - ANIOC_TRIGGER starts both regular and injected conversions
+
 config STM32F7_ADC3_DMA
 	bool "ADC3 DMA"
 	depends on STM32F7_ADC3 && STM32F7_HAVE_ADC3_DMA
@@ -5274,6 +5376,96 @@ config STM32F7_ADC3_DMA
 		If DMA is selected, then the ADC may be configured to support
 		DMA transfer, which is necessary if multiple channels are read
 		or if very high trigger frequencies are used.
+
+config STM32F7_ADC3_SCAN
+	bool "ADC3 scan mode"
+	depends on STM32F7_ADC3
+	default y if STM32F7_ADC3_DMA
+	default n
+
+config STM32F7_ADC3_DMA_CFG
+	int "ADC3 DMA configuration"
+	depends on STM32F7_ADC3_DMA
+	range 0 1
+	default 0
+	---help---
+		0 - ADC3 DMA in One Shot Mode, 1 - ADC3 DMA in Circular Mode
+
+config STM32F7_ADC3_ANIOC_TRIGGER
+	int "ADC3 software trigger (ANIOC_TRIGGER) configuration"
+	depends on STM32F7_ADC3
+	range 1 3
+	default 3
+	---help---
+		1 - ANIOC_TRIGGER only starts regular conversion
+		2 - ANIOC_TRIGGER only starts injected conversion
+		3 - ANIOC_TRIGGER starts both regular and injected conversions
+
+config STM32F7_ADC1_INJECTED_CHAN
+	int "ADC1 injected channels"
+	depends on STM32F7_ADC1
+	range 0 4
+	default 0
+	---help---
+		Support for ADC1 injected channels.
+
+config STM32F7_ADC2_INJECTED_CHAN
+	int "ADC2 injected channels"
+	depends on STM32F7_ADC2
+	range 0 4
+	default 0
+	---help---
+		Support for ADC2 injected channels.
+
+config STM32F7_ADC3_INJECTED_CHAN
+	int "ADC3 injected channels"
+	depends on STM32F7_ADC3
+	range 0 4
+	default 0
+	---help---
+		Support for ADC3 injected channels.
+
+config STM32F7_ADC1_EXTSEL
+	bool "ADC1 external trigger for regular group"
+	depends on STM32F7_ADC1 && !STM32F7_HAVE_ADC1_TIMER
+	default n
+	---help---
+		Enable EXTSEL for ADC1.
+
+config STM32F7_ADC2_EXTSEL
+	bool "ADC2 external trigger for regular group"
+	depends on STM32F7_ADC2 && !STM32F7_HAVE_ADC2_TIMER
+	default n
+	---help---
+		Enable EXTSEL for ADC2.
+
+config STM32F7_ADC3_EXTSEL
+	bool "ADC3 external trigger for regular group"
+	depends on STM32F7_ADC3 && !STM32F7_HAVE_ADC3_TIMER
+	default n
+	---help---
+		Enable EXTSEL for ADC3.
+
+config STM32F7_ADC1_JEXTSEL
+	bool "ADC1 external trigger for injected group"
+	depends on STM32F7_ADC1
+	default n
+	---help---
+		Enable JEXTSEL for ADC1.
+
+config STM32F7_ADC2_JEXTSEL
+	bool "ADC2 external trigger for injected group"
+	depends on STM32F7_ADC2
+	default n
+	---help---
+		Enable JEXTSEL for ADC2.
+
+config STM32F7_ADC3_JEXTSEL
+	bool "ADC3 external trigger for injected group"
+	depends on STM32F7_ADC3
+	default n
+	---help---
+		Enable JEXTSEL for ADC3.
 
 endmenu # "ADC Configuration"
 

--- a/arch/arm/src/stm32f7/hardware/stm32f72xx73xx_adc.h
+++ b/arch/arm/src/stm32f7/hardware/stm32f72xx73xx_adc.h
@@ -372,8 +372,10 @@
 #define ADC_JSQR_JSQ3_MASK           (0x1f << ADC_JSQR_JSQ3_SHIFT)
 #define ADC_JSQR_JSQ4_SHIFT          (15)      /* Bits 19-15: 4th conversion in injected sequence */
 #define ADC_JSQR_JSQ4_MASK           (0x1f << ADC_JSQR_JSQ4_SHIFT)
+#define ADC_JSQR_JSQ_SHIFT           (5)       /* Shift between JSQx bits */
 #define ADC_JSQR_JL_SHIFT            (20)      /* Bits 21-20: Injected Sequence length */
 #define ADC_JSQR_JL_MASK             (3 << ADC_JSQR_JL_SHIFT)
+#  define ADC_JSQR_JL(n)             (((n) - 1) << ADC_JSQR_JL_SHIFT) /* n=1..4 */
 
 /* ADC injected data register 1-4 */
 

--- a/arch/arm/src/stm32f7/hardware/stm32f74xx77xx_adc.h
+++ b/arch/arm/src/stm32f7/hardware/stm32f74xx77xx_adc.h
@@ -372,8 +372,10 @@
 #define ADC_JSQR_JSQ3_MASK           (0x1f << ADC_JSQR_JSQ3_SHIFT)
 #define ADC_JSQR_JSQ4_SHIFT          (15)      /* Bits 19-15: 4th conversion in injected sequence */
 #define ADC_JSQR_JSQ4_MASK           (0x1f << ADC_JSQR_JSQ4_SHIFT)
+#define ADC_JSQR_JSQ_SHIFT           (5)       /* Shift between JSQx bits */
 #define ADC_JSQR_JL_SHIFT            (20)      /* Bits 21-20: Injected Sequence length */
 #define ADC_JSQR_JL_MASK             (3 << ADC_JSQR_JL_SHIFT)
+#  define ADC_JSQR_JL(n)             (((n) - 1) << ADC_JSQR_JL_SHIFT) /* n=1..4 */
 
 /* ADC injected data register 1-4 */
 

--- a/arch/arm/src/stm32f7/stm32_adc.h
+++ b/arch/arm/src/stm32f7/stm32_adc.h
@@ -34,6 +34,25 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
+/* Generalized definitions for ADC  *****************************************/
+
+#define STM32_ADC_DMAREG_OFFSET    STM32_ADC_CR2_OFFSET
+#define ADC_DMAREG_DMA             ADC_CR2_DMA
+#define STM32_ADC_EXTREG_OFFSET    STM32_ADC_CR2_OFFSET
+#define ADC_EXTREG_EXTSEL_MASK     ADC_CR2_EXTSEL_MASK
+#define ADC_EXTREG_EXTSEL_SHIFT    ADC_CR2_EXTSEL_SHIFT
+#define STM32_ADC_JEXTREG_OFFSET   STM32_ADC_CR2_OFFSET
+#define ADC_JEXTREG_JEXTSEL_MASK   ADC_CR2_JEXTSEL_MASK
+#define ADC_EXTREG_JEXTSEL_SHIFT   ADC_CR2_JEXTSEL_SHIFT
+#define STM32_ADC_ISR_OFFSET       STM32_ADC_SR_OFFSET
+#define STM32_ADC_IER_OFFSET       STM32_ADC_CR1_OFFSET
+#define ADC_EXTREG_EXTEN_MASK      ADC_CR2_EXTEN_MASK
+#define ADC_EXTREG_EXTEN_NONE      ADC_CR2_EXTEN_NONE
+#define ADC_EXTREG_EXTEN_DEFAULT   ADC_CR2_EXTEN_RISING
+#define ADC_JEXTREG_JEXTEN_MASK    ADC_CR2_JEXTEN_MASK
+#define ADC_JEXTREG_JEXTEN_NONE    ADC_CR2_JEXTEN_NONE
+#define ADC_JEXTREG_JEXTEN_DEFAULT ADC_CR2_JEXTEN_RISING
+
 /* Configuration ************************************************************/
 
 /* Timer devices may be used for different purposes.  One special purpose is
@@ -87,18 +106,6 @@
 
 /* Up to 3 ADC interfaces are supported */
 
-#if STM32F7_NADC < 3
-#  undef CONFIG_STM32F7_ADC3
-#endif
-
-#if STM32F7_NADC < 2
-#  undef CONFIG_STM32F7_ADC2
-#endif
-
-#if STM32F7_NADC < 1
-#  undef CONFIG_STM32F7_ADC1
-#endif
-
 #if defined(CONFIG_STM32F7_ADC1) || defined(CONFIG_STM32F7_ADC2) || \
     defined(CONFIG_STM32F7_ADC3)
 
@@ -126,6 +133,14 @@
 #  define ADC3_HAVE_DMA 1
 #else
 #  undef  ADC3_HAVE_DMA
+#endif
+
+/* Injected channels support */
+
+#if (defined(CONFIG_STM32F7_ADC1) && (CONFIG_STM32F7_ADC1_INJECTED_CHAN > 0)) || \
+    (defined(CONFIG_STM32F7_ADC2) && (CONFIG_STM32F7_ADC2_INJECTED_CHAN > 0)) || \
+    (defined(CONFIG_STM32F7_ADC3) && (CONFIG_STM32F7_ADC3_INJECTED_CHAN > 0))
+#  define ADC_HAVE_INJECTED
 #endif
 
 /* Timer configuration:  If a timer trigger is specified, then get
@@ -175,35 +190,35 @@
 #endif
 
 #if defined(CONFIG_STM32F7_TIM1_ADC2)
-#    define ADC2_HAVE_TIMER           1
-#    define ADC2_TIMER_BASE           STM32_TIM1_BASE
-#    define ADC2_TIMER_PCLK_FREQUENCY STM32_APB2_TIM1_CLKIN
+#  define ADC2_HAVE_TIMER           1
+#  define ADC2_TIMER_BASE           STM32_TIM1_BASE
+#  define ADC2_TIMER_PCLK_FREQUENCY STM32_APB2_TIM1_CLKIN
 #elif defined(CONFIG_STM32F7_TIM2_ADC2)
-#    define ADC2_HAVE_TIMER           1
-#    define ADC2_TIMER_BASE           STM32_TIM2_BASE
-#    define ADC2_TIMER_PCLK_FREQUENCY STM32_APB1_TIM2_CLKIN
+#  define ADC2_HAVE_TIMER           1
+#  define ADC2_TIMER_BASE           STM32_TIM2_BASE
+#  define ADC2_TIMER_PCLK_FREQUENCY STM32_APB1_TIM2_CLKIN
 #elif defined(CONFIG_STM32F7_TIM3_ADC2)
-#    define ADC2_HAVE_TIMER           1
-#    define ADC2_TIMER_BASE           STM32_TIM3_BASE
-#    define ADC2_TIMER_PCLK_FREQUENCY STM32_APB1_TIM3_CLKIN
+#  define ADC2_HAVE_TIMER           1
+#  define ADC2_TIMER_BASE           STM32_TIM3_BASE
+#  define ADC2_TIMER_PCLK_FREQUENCY STM32_APB1_TIM3_CLKIN
 #elif defined(CONFIG_STM32F7_TIM4_ADC2)
-#    define ADC2_HAVE_TIMER           1
-#    define ADC2_TIMER_BASE           STM32_TIM4_BASE
-#    define ADC2_TIMER_PCLK_FREQUENCY STM32_APB1_TIM4_CLKIN
+#  define ADC2_HAVE_TIMER           1
+#  define ADC2_TIMER_BASE           STM32_TIM4_BASE
+#  define ADC2_TIMER_PCLK_FREQUENCY STM32_APB1_TIM4_CLKIN
 #elif defined(CONFIG_STM32F7_TIM5_ADC2)
-#    define ADC2_HAVE_TIMER           1
-#    define ADC2_TIMER_BASE           STM32_TIM5_BASE
-#    define ADC2_TIMER_PCLK_FREQUENCY STM32_APB1_TIM5_CLKIN
+#  define ADC2_HAVE_TIMER           1
+#  define ADC2_TIMER_BASE           STM32_TIM5_BASE
+#  define ADC2_TIMER_PCLK_FREQUENCY STM32_APB1_TIM5_CLKIN
 #elif defined(CONFIG_STM32F7_TIM6_ADC2)
-#    define ADC2_HAVE_TIMER           1
-#    define ADC2_TIMER_BASE           STM32_TIM6_BASE
-#    define ADC2_TIMER_PCLK_FREQUENCY STM32_APB1_TIM6_CLKIN
+#  define ADC2_HAVE_TIMER           1
+#  define ADC2_TIMER_BASE           STM32_TIM6_BASE
+#  define ADC2_TIMER_PCLK_FREQUENCY STM32_APB1_TIM6_CLKIN
 #elif defined(CONFIG_STM32F7_TIM8_ADC2)
-#    define ADC2_HAVE_TIMER           1
-#    define ADC2_TIMER_BASE           STM32_TIM8_BASE
-#    define ADC2_TIMER_PCLK_FREQUENCY STM32_APB2_TIM8_CLKIN
+#  define ADC2_HAVE_TIMER           1
+#  define ADC2_TIMER_BASE           STM32_TIM8_BASE
+#  define ADC2_TIMER_PCLK_FREQUENCY STM32_APB2_TIM8_CLKIN
 #else
-#    undef  ADC2_HAVE_TIMER
+#  undef  ADC2_HAVE_TIMER
 #endif
 
 #ifdef ADC2_HAVE_TIMER
@@ -217,35 +232,31 @@
 #endif
 
 #if defined(CONFIG_STM32F7_TIM1_ADC3)
-#    define ADC3_HAVE_TIMER           1
-#    define ADC3_TIMER_BASE           STM32_TIM1_BASE
-#    define ADC3_TIMER_PCLK_FREQUENCY STM32_APB2_TIM1_CLKIN
+#  define ADC3_HAVE_TIMER           1
+#  define ADC3_TIMER_BASE           STM32_TIM1_BASE
+#  define ADC3_TIMER_PCLK_FREQUENCY STM32_APB2_TIM1_CLKIN
 #elif defined(CONFIG_STM32F7_TIM2_ADC3)
-#    define ADC3_HAVE_TIMER           1
-#    define ADC3_TIMER_BASE           STM32_TIM2_BASE
-#    define ADC3_TIMER_PCLK_FREQUENCY STM32_APB1_TIM2_CLKIN
+#  define ADC3_HAVE_TIMER           1
+#  define ADC3_TIMER_BASE           STM32_TIM2_BASE
+#  define ADC3_TIMER_PCLK_FREQUENCY STM32_APB1_TIM2_CLKIN
 #elif defined(CONFIG_STM32F7_TIM3_ADC3)
-#    define ADC3_HAVE_TIMER           1
-#    define ADC3_TIMER_BASE           STM32_TIM3_BASE
-#    define ADC3_TIMER_PCLK_FREQUENCY STM32_APB1_TIM3_CLKIN
+#  define ADC3_HAVE_TIMER           1
+#  define ADC3_TIMER_BASE           STM32_TIM3_BASE
+#  define ADC3_TIMER_PCLK_FREQUENCY STM32_APB1_TIM3_CLKIN
 #elif defined(CONFIG_STM32F7_TIM4_ADC3)
-#    define ADC3_HAVE_TIMER           1
-#    define ADC3_TIMER_BASE           STM32_TIM4_BASE
-#    define ADC3_TIMER_PCLK_FREQUENCY STM32_APB1_TIM4_CLKIN
+#  define ADC3_HAVE_TIMER           1
+#  define ADC3_TIMER_BASE           STM32_TIM4_BASE
+#  define ADC3_TIMER_PCLK_FREQUENCY STM32_APB1_TIM4_CLKIN
 #elif defined(CONFIG_STM32F7_TIM5_ADC3)
-#    define ADC3_HAVE_TIMER           1
-#    define ADC3_TIMER_BASE           STM32_TIM5_BASE
-#    define ADC3_TIMER_PCLK_FREQUENCY STM32_APB1_TIM5_CLKIN
-#elif defined(CONFIG_STM32F7_TIM6_ADC3)
-#    define ADC3_HAVE_TIMER           1
-#    define ADC3_TIMER_BASE           STM32_TIM6_BASE
-#    define ADC3_TIMER_PCLK_FREQUENCY STM32_APB1_TIM6_CLKIN
+#  define ADC3_HAVE_TIMER           1
+#  define ADC3_TIMER_BASE           STM32_TIM5_BASE
+#  define ADC3_TIMER_PCLK_FREQUENCY STM32_APB1_TIM5_CLKIN
 #elif defined(CONFIG_STM32F7_TIM8_ADC3)
-#    define ADC3_HAVE_TIMER           1
-#    define ADC3_TIMER_BASE           STM32_TIM8_BASE
-#    define ADC3_TIMER_PCLK_FREQUENCY STM32_APB2_TIM8_CLKIN
+#  define ADC3_HAVE_TIMER           1
+#  define ADC3_TIMER_BASE           STM32_TIM8_BASE
+#  define ADC3_TIMER_PCLK_FREQUENCY STM32_APB2_TIM8_CLKIN
 #else
-#    undef  ADC3_HAVE_TIMER
+#  undef  ADC3_HAVE_TIMER
 #endif
 
 #ifdef ADC3_HAVE_TIMER
@@ -390,7 +401,15 @@
 #define ADC3_EXTSEL_T8CC3      ADC_CR2_EXTSEL_T8CC3
 #define ADC3_EXTSEL_T8CC4      ADC_CR2_EXTSEL_T8CC4
 #define ADC3_EXTSEL_T8TRGO     ADC_CR2_EXTSEL_T8TRGO
-#define ADC3_EXTSEL_T8TRGO2     ADC_CR2_EXTSEL_T8TRGO2
+#define ADC3_EXTSEL_T8TRGO2    ADC_CR2_EXTSEL_T8TRGO2
+
+/* EXTSEL configuration *****************************************************/
+
+/* NOTE:
+ * this configuration if used only if CONFIG_STM32F7_TIMx_ADCy is selected.
+ * You can still connect the ADC with a timer trigger using the
+ * CONFIG_STM32F7_ADCx_EXTSEL option.
+ */
 
 #if defined(CONFIG_STM32F7_TIM1_ADC1)
 #  if CONFIG_STM32F7_ADC1_TIMTRIG == 0
@@ -704,9 +723,287 @@
 #  endif
 #endif
 
+/* Regular channels external trigger support */
+
+#ifdef ADC1_EXTSEL_VALUE
+#  define ADC1_HAVE_EXTCFG  1
+#  define ADC1_EXTCFG_VALUE (ADC1_EXTSEL_VALUE | ADC_EXTREG_EXTEN_DEFAULT)
+#elif defined(CONFIG_STM32F7_ADC1_EXTSEL)
+#  define ADC1_HAVE_EXTCFG  1
+#  define ADC1_EXTCFG_VALUE 0
+#else
+#  undef ADC1_HAVE_EXTCFG
+#endif
+#ifdef ADC2_EXTSEL_VALUE
+#  define ADC2_HAVE_EXTCFG  1
+#  define ADC2_EXTCFG_VALUE (ADC2_EXTSEL_VALUE | ADC_EXTREG_EXTEN_DEFAULT)
+#elif defined(CONFIG_STM32F7_ADC2_EXTSEL)
+#  define ADC2_HAVE_EXTCFG  1
+#  define ADC2_EXTCFG_VALUE 0
+#else
+#  undef ADC2_HAVE_EXTCFG
+#endif
+#ifdef ADC3_EXTSEL_VALUE
+#  define ADC3_HAVE_EXTCFG  1
+#  define ADC3_EXTCFG_VALUE (ADC3_EXTSEL_VALUE | ADC_EXTREG_EXTEN_DEFAULT)
+#elif defined(CONFIG_STM32F7_ADC3_EXTSEL)
+#  define ADC3_HAVE_EXTCFG  1
+#  define ADC3_EXTCFG_VALUE 0
+#else
+#  undef ADC3_HAVE_EXTCFG
+#endif
+
+#if defined(ADC1_HAVE_EXTCFG) || defined(ADC2_HAVE_EXTCFG) || \
+    defined(ADC3_HAVE_EXTCFG) || defined(ADC3_HAVE_EXTCFG)
+#  define ADC_HAVE_EXTCFG
+#endif
+
+/* JEXTSEL configuration ****************************************************/
+
+/* There is no automatic timer tirgger configuration from Kconfig for
+ * injected channels conversion.
+ */
+
+/* Injected channels external trigger support */
+
+#ifdef ADC1_JEXTSEL_VALUE
+#  define ADC1_HAVE_JEXTCFG  1
+#  define ADC1_JEXTCFG_VALUE (ADC1_JEXTSEL_VALUE | ADC_JEXTREG_JEXTEN_DEFAULT)
+#elif defined(CONFIG_STM32F7_ADC1_JEXTSEL)
+#  define ADC1_HAVE_JEXTCFG  1
+#  define ADC1_JEXTCFG_VALUE 0
+#else
+#  undef ADC1_HAVE_JEXTCFG
+#endif
+#ifdef ADC2_JEXTSEL_VALUE
+#  define ADC2_HAVE_JEXTCFG  1
+#  define ADC2_JEXTCFG_VALUE (ADC2_JEXTSEL_VALUE | ADC_JEXTREG_JEXTEN_DEFAULT)
+#elif defined(CONFIG_STM32F7_ADC2_JEXTSEL)
+#  define ADC2_HAVE_JEXTCFG  1
+#  define ADC2_JEXTCFG_VALUE 0
+#else
+#  undef ADC2_HAVE_JEXTCFG
+#endif
+#ifdef ADC3_JEXTSEL_VALUE
+#  define ADC3_HAVE_JEXTCFG  1
+#  define ADC3_JEXTCFG_VALUE (ADC3_JEXTSEL_VALUE | ADC_JEXTREG_JEXTEN_DEFAULT)
+#elif defined(CONFIG_STM32F7_ADC3_JEXTSEL)
+#  define ADC3_HAVE_JEXTCFG  1
+#  define ADC3_JEXTCFG_VALUE 0
+#else
+#  undef ADC3_HAVE_JEXTCFG
+#endif
+
+#if defined(ADC1_HAVE_JEXTCFG) || defined(ADC2_HAVE_JEXTCFG) || \
+    defined(ADC3_HAVE_JEXTCFG)
+#  define ADC_HAVE_JEXTCFG
+#endif
+
+/* ADC interrupts ***********************************************************/
+
+#define ADC_ISR_EOC                ADC_SR_EOC
+#define ADC_IER_EOC                ADC_CR1_EOCIE
+#define ADC_ISR_AWD                ADC_SR_AWD
+#define ADC_IER_AWD                ADC_CR1_AWDIE
+#define ADC_ISR_JEOC               ADC_SR_JEOC
+#define ADC_IER_JEOC               ADC_CR1_JEOCIE
+#define ADC_ISR_JEOS               0 /* No JEOS */
+#define ADC_IER_JEOS               0 /* No JEOS */
+#define ADC_ISR_OVR                ADC_SR_OVR
+#define ADC_IER_OVR                ADC_CR1_OVRIE
+
+#define ADC_ISR_ALLINTS (ADC_ISR_EOC | ADC_ISR_AWD | ADC_ISR_JEOC | \
+                         ADC_ISR_JEOS | ADC_ISR_OVR)
+#define ADC_IER_ALLINTS (ADC_IER_EOC | ADC_IER_AWD | ADC_IER_JEOC | \
+                         ADC_IER_JEOS | ADC_IER_OVR)
+
+/* Low-level ops helpers ****************************************************/
+
+#define STM32_ADC_INT_ACK(adc, source)              \
+        (adc)->llops->int_ack(adc, source)
+#define STM32_ADC_INT_GET(adc)                      \
+        (adc)->llops->int_get(adc)
+#define STM32_ADC_INT_ENABLE(adc, source)           \
+        (adc)->llops->int_en(adc, source)
+#define STM32_ADC_INT_DISABLE(adc, source)          \
+        (adc)->llops->int_dis(adc, source)
+#define STM32_ADC_REGDATA_GET(adc)                  \
+        (adc)->llops->val_get(adc)
+#define STM32_ADC_REGBUF_REGISTER(adc, buffer, len) \
+        (adc)->llops->regbuf_reg(adc, buffer, len)
+#define STM32_ADC_REG_STARTCONV(adc, state)         \
+        (adc)->llops->reg_startconv(adc, state)
+#define STM32_ADC_OFFSET_SET(adc, ch, i, o)         \
+        (adc)->llops->offset_set(adc, ch, i, o)
+#define STM32_ADC_EXTCFG_SET(adc, c)                \
+        (adc)->llops->extcfg_set(adc, c)
+#define STM32_ADC_INJ_STARTCONV(adc, state)         \
+        (adc)->llops->inj_startconv(adc, state)
+#define STM32_ADC_INJDATA_GET(adc, chan)            \
+        (adc)->llops->inj_get(adc, chan)
+#define STM32_ADC_JEXTCFG_SET(adc, c)               \
+        (adc)->llops->jextcfg_set(adc, c)
+#define STM32_ADC_SAMPLETIME_SET(adc, time_samples) \
+        (adc)->llops->stime_set(adc, time_samples)
+#define STM32_ADC_SAMPLETIME_WRITE(adc)             \
+        (adc)->llops->stime_write(adc)
+#define STM32_ADC_DUMP_REGS(adc)                    \
+        (adc)->llops->dump_regs(adc)
+#define STM32_ADC_SETUP(adc)                        \
+        (adc)->llops->setup(adc)
+#define STM32_ADC_SHUTDOWN(adc)                     \
+        (adc)->llops->shutdown(adc)
+
 /****************************************************************************
  * Public Types
  ****************************************************************************/
+
+enum adc_io_cmds_e
+{
+  IO_STOP_ADC,
+  IO_START_ADC,
+  IO_START_CONV,
+  IO_TRIGGER_REG,
+#ifdef ADC_HAVE_INJECTED
+  IO_TRIGGER_INJ,
+#endif
+};
+
+/* ADC resolution can be reduced in order to perform faster conversion */
+
+enum stm32_adc_resoluton_e
+{
+  ADC_RESOLUTION_12BIT = 0,     /* 12 bit */
+  ADC_RESOLUTION_10BIT = 1,     /* 10 bit */
+  ADC_RESOLUTION_8BIT  = 2,     /* 8 bit */
+  ADC_RESOLUTION_6BIT  = 3      /* 6 bit */
+};
+
+#ifdef CONFIG_STM32F7_ADC_LL_OPS
+
+#ifdef CONFIG_STM32F7_ADC_CHANGE_SAMPLETIME
+
+/* Channel and sample time pair */
+
+typedef struct adc_channel_s
+{
+  uint8_t channel:5;
+
+  /* Sampling time individually for each channel */
+
+  uint8_t sample_time:3;
+} adc_channel_t;
+
+/* This structure will be used while setting channels to specified by the
+ * "channel-sample time" pairs' values
+ */
+
+struct adc_sample_time_s
+{
+  adc_channel_t *channel;                /* Array of channels */
+  uint8_t        channels_nbr:5;         /* Number of channels in array */
+  bool           all_same:1;             /* All channels will get the
+                                          * same value of the sample time */
+  uint8_t        all_ch_sample_time:3;   /* Sample time for all channels */
+};
+#endif /* CONFIG_STM32F7_ADC_CHANGE_SAMPLETIME */
+
+/* This structure provides the publicly visible representation of the
+ * "lower-half" ADC driver structure.
+ */
+
+struct stm32_adc_dev_s
+{
+  /* Publicly visible portion of the "lower-half" ADC driver structure */
+
+  const struct stm32_adc_ops_s *llops;
+
+  /* Require cast-compatibility with private "lower-half" ADC structure */
+};
+
+/* Low-level operations for ADC */
+
+struct stm32_adc_ops_s
+{
+  /* Low-level ADC setup */
+
+  int (*setup)(struct stm32_adc_dev_s *dev);
+
+  /* Low-level ADC shutdown */
+
+  void (*shutdown)(struct stm32_adc_dev_s *dev);
+
+  /* Acknowledge interrupts */
+
+  void (*int_ack)(struct stm32_adc_dev_s *dev, uint32_t source);
+
+  /* Get pending interrupts */
+
+  uint32_t (*int_get)(struct stm32_adc_dev_s *dev);
+
+  /* Enable interrupts */
+
+  void (*int_en)(struct stm32_adc_dev_s *dev, uint32_t source);
+
+  /* Disable interrupts */
+
+  void (*int_dis)(struct stm32_adc_dev_s *dev, uint32_t source);
+
+  /* Get current ADC data register */
+
+  uint32_t (*val_get)(struct stm32_adc_dev_s *dev);
+
+  /* Register buffer for ADC DMA transfer */
+
+  int (*regbuf_reg)(struct stm32_adc_dev_s *dev,
+                    uint16_t *buffer, uint8_t len);
+
+  /* Start/stop regular conversion */
+
+  void (*reg_startconv)(struct stm32_adc_dev_s *dev, bool state);
+
+  /* Set offset for channel */
+
+  int (*offset_set)(struct stm32_adc_dev_s *dev, uint8_t ch, uint8_t i,
+                    uint16_t offset);
+
+#ifdef ADC_HAVE_EXTCFG
+  /* Configure the ADC external trigger for regular conversion */
+
+  void (*extcfg_set)(struct stm32_adc_dev_s *dev, uint32_t extcfg);
+#endif
+
+#ifdef ADC_HAVE_JEXTCFG
+  /* Configure the ADC external trigger for injected conversion */
+
+  void (*jextcfg_set)(struct stm32_adc_dev_s *dev, uint32_t jextcfg);
+#endif
+
+#ifdef ADC_HAVE_INJECTED
+  /* Get current ADC injected data register */
+
+  uint32_t (*inj_get)(struct stm32_adc_dev_s *dev, uint8_t chan);
+
+  /* Start/stop injected conversion */
+
+  void (*inj_startconv)(struct stm32_adc_dev_s *dev, bool state);
+#endif
+
+#ifdef CONFIG_STM32F7_ADC_CHANGE_SAMPLETIME
+  /* Set ADC sample time */
+
+  void (*stime_set)(struct stm32_adc_dev_s *dev,
+                    struct adc_sample_time_s *time_samples);
+
+  /* Write ADC sample time */
+
+  void (*stime_write)(struct stm32_adc_dev_s *dev);
+#endif
+
+  void (*dump_regs)(struct stm32_adc_dev_s *dev);
+};
+
+#endif /* CONFIG_STM32F7_ADC_LL_OPS */
 
 /****************************************************************************
  * Public Function Prototypes
@@ -722,15 +1019,15 @@ extern "C"
 #endif
 
 /****************************************************************************
- * Name: stm32_adc_initialiize
+ * Name: stm32_adc_initialize
  *
  * Description:
- *   Initialize the ADC.
+ *   Initialize the ADC. See stm32_adc.c for more details.
  *
  * Input Parameters:
- *   intf      - Could be {1,2,3} for ADC1, ADC2, or ADC3
- *   chanlist  - The list of channels
- *   nchannels - Number of channels
+ *   intf      - Could be {1,2,3} for ADC1, ADC2, ADC3
+ *   chanlist  - The list of channels (regular + injected)
+ *   nchannels - Number of channels (regular + injected)
  *
  * Returned Value:
  *   Valid ADC device structure reference on success; a NULL on failure
@@ -741,6 +1038,7 @@ struct adc_dev_s;
 struct adc_dev_s *stm32_adc_initialize(int intf,
                                        const uint8_t *chanlist,
                                        int nchannels);
+
 #undef EXTERN
 #ifdef __cplusplus
 }


### PR DESCRIPTION
## Summary
arch/arm/src/stm32f7: port ADC driver from arch/stm32
This change adds support for the following features:

- injected channels (default: 0)
- ADC resolution (default: 12bit)
- ADC low-level operations
- ADC external triggers
- custom ADC interrupts
- ADC sample time configuration
- configurable ADC SCAN mode (default on if DMA)
- configurable ADC DMA mode (default: one shot mode)
- reset the ADC block only if all ADC instances are closed

## Impact
There should be no implications for old configurations. 
The default behavior of the driver should remains the same.

## Testing

- The FOC motor controller based on steval-eth001v1 board (ADC1, regular channel DMA transfer with software trigger, injected channels with external trigger from TIM1, custom ADC interrupts),
- nucleo-f722 and examples/adc (ADC1 + no DMA, ADC1 + DMA, ADC1+TIM2CH2+no DMA, ADC1 +TIM2CH2 +DMA)
