### PR TITLE
net/local: Remove the sync preamble from datagram

### DIFF
--- a/net/local/local.h
+++ b/net/local/local.h
@@ -48,17 +48,6 @@
 #define LOCAL_NPOLLWAITERS 2
 #define LOCAL_NCONTROLFDS  4
 
-/* Packet format in FIFO:
- *
- * 1. Sync bytes (7 at most)
- * 2. End/Start byte
- * 3. 16-bit packet length (in host order)
- * 4. Packet data (in host order)
- */
-
-#define LOCAL_SYNC_BYTE   0x42     /* Byte in sync sequence */
-#define LOCAL_END_BYTE    0xbd     /* End of sync sequence */
-
 /****************************************************************************
  * Public Type Definitions
  ****************************************************************************/

--- a/net/local/local_recvutils.c
+++ b/net/local/local_recvutils.c
@@ -142,46 +142,9 @@ int local_sync(FAR struct file *filep)
 {
   size_t readlen;
   uint16_t pktlen;
-  uint8_t sync;
   int ret;
 
-  /* Loop until a valid pre-amble is encountered:  SYNC bytes followed
-   * by one END byte.
-   */
-
-  do
-    {
-      /* Read until we encounter a sync byte */
-
-      do
-        {
-          readlen = sizeof(uint8_t);
-          ret     = local_fifo_read(filep, &sync, &readlen, false);
-          if (ret < 0)
-            {
-              nerr("ERROR: Failed to read sync bytes: %d\n", ret);
-              return ret;
-            }
-        }
-      while (sync != LOCAL_SYNC_BYTE);
-
-      /* Then read to the end of the SYNC sequence */
-
-      do
-        {
-          readlen = sizeof(uint8_t);
-          ret     = local_fifo_read(filep, &sync, &readlen, false);
-          if (ret < 0)
-            {
-              nerr("ERROR: Failed to read sync bytes: %d\n", ret);
-              return ret;
-            }
-        }
-      while (sync == LOCAL_SYNC_BYTE);
-    }
-  while (sync != LOCAL_END_BYTE);
-
-  /* Then read the packet length */
+  /* Read the packet length */
 
   readlen = sizeof(uint16_t);
   ret     = local_fifo_read(filep, (FAR uint8_t *)&pktlen, &readlen, false);

--- a/net/local/local_sendpacket.c
+++ b/net/local/local_sendpacket.c
@@ -39,22 +39,6 @@
 #if defined(CONFIG_NET) && defined(CONFIG_NET_LOCAL)
 
 /****************************************************************************
- * Pre-processor Definitions
- ****************************************************************************/
-
-#define LOCAL_PREAMBLE_SIZE 8
-
-/****************************************************************************
- * Private Data
- ****************************************************************************/
-
-static const uint8_t g_preamble[LOCAL_PREAMBLE_SIZE] =
-{
-  LOCAL_SYNC_BYTE, LOCAL_SYNC_BYTE, LOCAL_SYNC_BYTE, LOCAL_SYNC_BYTE,
-  LOCAL_SYNC_BYTE, LOCAL_SYNC_BYTE, LOCAL_SYNC_BYTE, LOCAL_END_BYTE
-};
-
-/****************************************************************************
  * Private Functions
  ****************************************************************************/
 
@@ -139,14 +123,6 @@ int local_send_packet(FAR struct file *filep, FAR const struct iovec *buf,
 
   if (preamble)
     {
-      /* Send the packet preamble */
-
-      ret = local_fifo_write(filep, g_preamble, LOCAL_PREAMBLE_SIZE);
-      if (ret != LOCAL_PREAMBLE_SIZE)
-        {
-          return ret;
-        }
-
       /* Send the packet length */
 
       for (len16 = 0, iov = buf; iov != end; iov++)
@@ -180,7 +156,7 @@ int local_send_packet(FAR struct file *filep, FAR const struct iovec *buf,
         }
     }
 
-  return (len16 > 0) ? len16 : ret;
+  return len16 > 0 ? len16 : ret;
 }
 
 #endif /* CONFIG_NET && CONFIG_NET_LOCAL */


### PR DESCRIPTION
## Summary
since pipe is a reliable transport, the sync just waste the space and time

## Impact
More fast

## Testing
Pass internal test
