### PR TITLE
pic32mx: add option to disable JTAG at runtime

### DIFF
--- a/arch/mips/src/pic32mx/Kconfig
+++ b/arch/mips/src/pic32mx/Kconfig
@@ -1019,6 +1019,16 @@ config PIC32MX_GPIOIRQ
 	---help---
 		Build in support for interrupts based on GPIO inputs from IOPorts
 
+config PIC32MX_JTAG_ENABLE
+	bool "Enable JTAG"
+	default n
+	depends on ARCH_CHIP_PIC32MX3 || ARCH_CHIP_PIC32MX4 || ARCH_CHIP_PIC32MX5 || ARCH_CHIP_PIC32MX6 || ARCH_CHIP_PIC32MX7
+	---help---
+		Enable JTAG on power-up.  This is a run-time setting needed for the 3xx/4xx/5xx/6xx/7xx series.
+		PIC32MX devices are hardwired to enable JTAG by default at boot time.  NuttX disables JTAG by
+		default in order to prevent unintentional data leakage over JTAG.
+
+
 menu "SPI Driver Configuration"
 	depends on PIC32MX_SPI
 

--- a/arch/mips/src/pic32mx/pic32mx_lowinit.c
+++ b/arch/mips/src/pic32mx/pic32mx_lowinit.c
@@ -34,6 +34,7 @@
 #include "pic32mx.h"
 #include "pic32mx_bmx.h"
 #include "pic32mx_che.h"
+#include "pic32mx_ddp.h"
 
 /****************************************************************************
  * Pre-processor Definitions
@@ -156,6 +157,58 @@ static inline void pic32mx_cache(void)
 }
 
 /****************************************************************************
+ * Name: pic32mx_disable_jtag
+ *
+ * Description:
+ *   Disable the JTAG connection
+ *
+ * Assumptions:
+ *   Interrupts are disabled.
+ *
+ ****************************************************************************/
+
+static inline void pic32mx_disable_jtag(void)
+{
+#if defined(CHIP_PIC32MX3) || defined(CHIP_PIC32MX4) || defined(CHIP_PIC32MX5) || \
+    defined(CHIP_PIC32MX6) || defined(CHIP_PIC32MX7)
+  register uint32_t regval;
+
+  regval = getreg32(PIC32MX_DDP_CON);
+
+  /* Clear the JTAG enable bit */
+
+  regval &= ~DDP_CON_JTAGEN;
+  putreg32(regval, PIC32MX_DDP_CON);
+#endif
+}
+
+/****************************************************************************
+ * Name: pic32mx_enable_jtag
+ *
+ * Description:
+ *   Enable the JTAG connection
+ *
+ * Assumptions:
+ *   Interrupts are disabled.
+ *
+ ****************************************************************************/
+
+static inline void pic32mx_enable_jtag(void)
+{
+#if defined(CHIP_PIC32MX3) || defined(CHIP_PIC32MX4) || defined(CHIP_PIC32MX5) || \
+    defined(CHIP_PIC32MX6) || defined(CHIP_PIC32MX7)
+  register uint32_t regval;
+
+  regval = getreg32(PIC32MX_DDP_CON);
+
+  /* Set the JTAG enable bit */
+
+  regval |= DDP_CON_JTAGEN;
+  putreg32(regval, PIC32MX_DDP_CON);
+#endif
+}
+
+/****************************************************************************
  * Public Functions
  ****************************************************************************/
 
@@ -190,6 +243,12 @@ void pic32mx_lowinit(void)
 
 #ifdef USE_EARLYSERIALINIT
   up_earlyserialinit();
+#endif
+
+#ifdef CONFIG_PIC32MX_JTAG_ENABLE
+  pic32mx_enable_jtag();
+#else
+  pic32mx_disable_jtag();
 #endif
 
   /* Perform board-level initialization */


### PR DESCRIPTION
## Summary

Add a new option to optionally disable JTAG at runtime.  Defaults to enabling
JTAG at runtime as that is the state the processor comes up in.  This only
affects 3xx/4xx/5xx/6xx/7xx series of processors as the 1xx/2xx series of
processors have a different method of configuring JTAG.

## Impact

By default, JTAG will remain enabled on the processors.  This is the default
that the processor comes up in.

## Testing

Validated with my explorer 16 board and PIC32MX.  I made sure that both settings
of the JTAG option work correctly.

