### PR TITLE
stm32f7:Serial Fix breakage from  #6779

### DIFF
--- a/arch/arm/src/stm32f7/stm32_serial.c
+++ b/arch/arm/src/stm32f7/stm32_serial.c
@@ -3639,10 +3639,10 @@ void arm_serialinit(void)
 
 #if !defined(SERIAL_HAVE_ONLY_DMA)
 #  if defined(SERIAL_HAVE_RXDMA)
-  UNUSED(&g_uart_rxdma_ops);
+  UNUSED(g_uart_rxdma_ops);
 #  endif
 #  if defined(SERIAL_HAVE_TXDMA)
-  UNUSED(&g_uart_txdma_ops);
+  UNUSED(g_uart_txdma_ops);
 #  endif
 #endif
 


### PR DESCRIPTION
## Summary

Reported in https://github.com/apache/incubator-nuttx/issues/6819

stm32f7:Serial Fix breakage from  #6779

## Impact
Code builds

## Testing

nucleo-144:f746-nsh

Compile with only RX DMA enabled

nucleo-144:f746-nsh

CONFIG_USART3_RXDMA=y
CONFIG_STM32F7_DMA=y
CONFIG_STM32F7_DMA1=y
CONFIG_STM32F7_DMA2=y
