### PR TITLE
fs/littlefs: fix file size mismatch

### DIFF
--- a/fs/littlefs/lfs_vfs.c
+++ b/fs/littlefs/lfs_vfs.c
@@ -1419,6 +1419,7 @@ static int littlefs_stat(FAR struct inode *mountpt, FAR const char *relpath,
       return ret;
     }
 
+  info.size = 0;
   ret = lfs_stat(&fs->lfs, relpath, &info);
   littlefs_semgive(fs);
 


### PR DESCRIPTION


## Summary
fs/littlefs: fix file size mismatch

/misc:
 drwxrwxrwx542515384 .
 drwxrwxrwx542515384 ..
 -rw-rw-rw-     463 factory.prop

Signed-off-by: Jiuzhu Dong <dongjiuzhu1@xiaomi.com>
## Impact
N/A
## Testing
local test
