### PR TITLE
arch/arm/stm32f7: fix cache invalidation issue in Ethernet RX

### DIFF
--- a/arch/arm/src/stm32f7/stm32_ethernet.c
+++ b/arch/arm/src/stm32f7/stm32_ethernet.c
@@ -219,8 +219,8 @@
 #  define CONFIG_STM32F7_ETH_NTXDESC 4
 #endif
 
-#ifndef min
-#  define min(a,b) ((a) < (b) ? (a) : (b))
+#ifndef MIN
+#  define MIN(a,b) ((a) < (b) ? (a) : (b))
 #endif
 
 /* We need at least one more free buffer than transmit buffers */
@@ -1732,7 +1732,8 @@ static int stm32_recvframe(struct stm32_ethmac_s *priv)
                    */
 
                   up_invalidate_dcache((uintptr_t)dev->d_buf,
-                                       min(dev->d_len, ALIGNED_BUFSIZE));
+                                       (uintptr_t)dev->d_buf +
+                                       MIN(dev->d_len, ALIGNED_BUFSIZE));
 
                   ninfo("rxhead: %p d_buf: %p d_len: %d\n",
                         priv->rxhead, dev->d_buf, dev->d_len);


### PR DESCRIPTION
## Summary
Fix cache invalidation issue in Ethernet RX for stm32f7

## Impact
Reception of Ethernet packets should be improved

## Testing
Pass CI