### PR TITLE
iob: Remove iob_user_e enum and related code

### DIFF
--- a/Documentation/reference/os/iob.rst
+++ b/Documentation/reference/os/iob.rst
@@ -193,15 +193,13 @@ Public Function Prototypes
   buffer at the head of the free list without waiting for a buffer
   to become free.
 
-.. c:function:: FAR struct iob_s *iob_free(FAR struct iob_s *iob, \
-                                           enum iob_user_e producerid);
+.. c:function:: FAR struct iob_s *iob_free(FAR struct iob_s *iob);
 
   Free the I/O buffer at the head of a buffer chain
   returning it to the free list. The link to the next I/O buffer in
   the chain is return.
 
-.. c:function:: void iob_free_chain(FAR struct iob_s *iob, \
-                                    enum iob_user_e producerid);
+.. c:function:: void iob_free_chain(FAR struct iob_s *iob);
 
   Free an entire buffer chain, starting at the
   beginning of the I/O buffer chain
@@ -235,8 +233,7 @@ Public Function Prototypes
   :return: Returns a reference to the I/O buffer chain at
     the head of the queue.
 
-.. c:function:: void iob_free_queue(FAR struct iob_queue_s *qhead, \
-                                    enum iob_user_e producerid);
+.. c:function:: void iob_free_queue(FAR struct iob_queue_s *qhead);
 
   Free an entire queue of I/O buffer chains.
 
@@ -280,14 +277,14 @@ Public Function Prototypes
   Concatenate iob_s chain iob2 to iob1.
 
 .. c:function:: FAR struct iob_s *iob_trimhead(FAR struct iob_s *iob, \
-                   unsigned int trimlen, enum iob_user_e producerid)
+                   unsigned int trimlen)
 
   Remove bytes from the beginning of an I/O chain.
   Emptied I/O buffers are freed and, hence, the beginning of the
   chain may change.
 
 .. c:function:: FAR struct iob_s *iob_trimhead_queue(FAR struct iob_queue_s *qhead, \
-                                        unsigned int trimlen, enum iob_user_e producerid);
+                                        unsigned int trimlen);
 
   Remove bytes from the beginning of an I/O chain
   at the head of the queue. Emptied I/O buffers are freed and,
@@ -301,21 +298,19 @@ Public Function Prototypes
     returned.
 
 .. c:function:: FAR struct iob_s *iob_trimtail(FAR struct iob_s *iob, \
-                                        unsigned int trimlen, enum iob_user_e producerid);
+                                        unsigned int trimlen);
 
   Remove bytes from the end of an I/O chain.
   Emptied I/O buffers are freed NULL will be returned in the special
   case where the entry I/O buffer chain is freed.
 
-.. c:function:: FAR struct iob_s *iob_pack(FAR struct iob_s *iob, \
-                                        enum iob_user_e producerid);
+.. c:function:: FAR struct iob_s *iob_pack(FAR struct iob_s *iob);
 
   Pack all data in the I/O buffer chain so that the
   data offset is zero and all but the final buffer in the chain are
   filled. Any emptied buffers at the end of the chain are freed.
 
-.. c:function:: int iob_contig(FAR struct iob_s *iob, unsigned int len, \
-                                        enum iob_user_e producerid);
+.. c:function:: int iob_contig(FAR struct iob_s *iob, unsigned int len);
 
   Ensure that there is ``len`` bytes of contiguous
   space at the beginning of the I/O buffer chain starting at

--- a/drivers/syslog/syslog_stream.c
+++ b/drivers/syslog/syslog_stream.c
@@ -208,7 +208,7 @@ void syslogstream_create(FAR struct lib_syslogstream_s *stream)
 #ifdef CONFIG_SYSLOG_BUFFER
   /* Allocate an IOB */
 
-  iob                  = iob_tryalloc(true, IOBUSER_SYSLOG);
+  iob                  = iob_tryalloc(true);
   stream->iob          = iob;
 
   if (iob != NULL)
@@ -252,7 +252,7 @@ void syslogstream_destroy(FAR struct lib_syslogstream_s *stream)
 
       /* Free the IOB */
 
-      iob_free(stream->iob, IOBUSER_SYSLOG);
+      iob_free(stream->iob);
       stream->iob = NULL;
     }
 }

--- a/drivers/wireless/ieee802154/mrf24j40/mrf24j40_interrupt.c
+++ b/drivers/wireless/ieee802154/mrf24j40/mrf24j40_interrupt.c
@@ -230,7 +230,7 @@ static void mrf24j40_irqwork_rx(FAR struct mrf24j40_radio_s *dev)
 
   /* Allocate an IOB to put the frame into */
 
-  ind->frame = iob_alloc(false, IOBUSER_WIRELESS_RAD802154);
+  ind->frame = iob_alloc(false);
   ind->frame->io_flink = NULL;
   ind->frame->io_len = 0;
   ind->frame->io_pktlen = 0;

--- a/drivers/wireless/ieee802154/xbee/xbee.c
+++ b/drivers/wireless/ieee802154/xbee/xbee.c
@@ -163,7 +163,7 @@ static void xbee_attnworker(FAR void *arg)
 
   /* Allocate an IOB for the incoming data. */
 
-  iob             = iob_alloc(false, IOBUSER_WIRELESS_RAD802154);
+  iob             = iob_alloc(false);
   iob->io_flink   = NULL;
   iob->io_len     = 0;
   iob->io_offset  = 0;
@@ -263,11 +263,9 @@ static void xbee_attnworker(FAR void *arg)
                            * processing.
                            */
 
-                          iob->io_flink =
-                            iob_tryalloc(false, IOBUSER_WIRELESS_RAD802154);
+                          iob->io_flink = iob_tryalloc(false);
 
                           iob = iob->io_flink;
-
                           if (iob != NULL)
                             {
                               iob->io_flink  = NULL;
@@ -330,7 +328,7 @@ static void xbee_attnworker(FAR void *arg)
               wlwarn("Partial API frame clocked in. Dropping!\n");
             }
 
-          iob_free(iob, IOBUSER_WIRELESS_RAD802154);
+          iob_free(iob);
         }
     }
 
@@ -804,7 +802,7 @@ static void xbee_process_apiframes(FAR struct xbee_priv_s *priv,
 
       nextframe = frame->io_flink;
       frame->io_flink = NULL;
-      iob_free(frame, IOBUSER_WIRELESS_RAD802154);
+      iob_free(frame);
       frame = nextframe;
     }
 }
@@ -1032,8 +1030,7 @@ static void xbee_notify_worker(FAR void *arg)
 
           if (dispose)
             {
-              iob_free(primitive->u.dataind.frame,
-                       IOBUSER_WIRELESS_RAD802154);
+              iob_free(primitive->u.dataind.frame);
               ieee802154_primitive_free(primitive);
             }
         }
@@ -1328,7 +1325,7 @@ void xbee_send_apiframe(FAR struct xbee_priv_s *priv,
    * data.
    */
 
-  iob             = iob_tryalloc(false, IOBUSER_WIRELESS_RAD802154);
+  iob             = iob_tryalloc(false);
   iob->io_flink   = NULL;
   iob->io_len     = 0;
   iob->io_offset  = 0;
@@ -1422,8 +1419,7 @@ void xbee_send_apiframe(FAR struct xbee_priv_s *priv,
                            * processing.
                            */
 
-                          iob->io_flink =
-                            iob_tryalloc(false, IOBUSER_WIRELESS_RAD802154);
+                          iob->io_flink = iob_tryalloc(false);
                           iob = iob->io_flink;
 
                           if (iob != NULL)
@@ -1483,7 +1479,7 @@ void xbee_send_apiframe(FAR struct xbee_priv_s *priv,
               wlwarn("Partial API frame clocked in. Dropping!\n");
             }
 
-          iob_free(iob, IOBUSER_WIRELESS_RAD802154);
+          iob_free(iob);
         }
     }
 

--- a/drivers/wireless/ieee802154/xbee/xbee_mac.c
+++ b/drivers/wireless/ieee802154/xbee/xbee_mac.c
@@ -404,7 +404,7 @@ int xbee_req_data(XBEEHANDLE xbee,
   while (!priv->txdone);
 
   nxsem_post(&priv->tx_sem);
-  iob_free(frame, IOBUSER_WIRELESS_RAD802154);
+  iob_free(frame);
   return OK;
 }
 

--- a/drivers/wireless/ieee802154/xbee/xbee_netdev.c
+++ b/drivers/wireless/ieee802154/xbee/xbee_netdev.c
@@ -1116,13 +1116,13 @@ static int xbeenet_req_data(FAR struct radio_driver_s *netdev,
         {
           wlerr("ERROR: xbeemac_req_data failed: %d\n", ret);
 
-          iob_free(iob, IOBUSER_WIRELESS_RAD802154);
+          iob_free(iob);
           for (iob = framelist; iob != NULL; iob = framelist)
             {
               /* Remove the IOB from the queue and free */
 
               framelist = iob->io_flink;
-              iob_free(iob, IOBUSER_WIRELESS_RAD802154);
+              iob_free(iob);
             }
 
           NETDEV_TXERRORS(&priv->xd_dev.r_dev);

--- a/drivers/wireless/spirit/drivers/spirit_netdev.c
+++ b/drivers/wireless/spirit/drivers/spirit_netdev.c
@@ -694,7 +694,7 @@ static void spirit_free_txhead(FAR struct spirit_driver_s *priv)
 
   /* Free the IOB contained in the metadata container */
 
-  iob_free(pktmeta->pm_iob, IOBUSER_WIRELESS_PACKETRADIO);
+  iob_free(pktmeta->pm_iob);
 
   /* Then free the meta data container itself */
 
@@ -1152,7 +1152,7 @@ static void spirit_interrupt_work(FAR void *arg)
 
       if (priv->rxbuffer != NULL)
         {
-          iob_free(priv->rxbuffer, IOBUSER_WIRELESS_PACKETRADIO);
+          iob_free(priv->rxbuffer);
           priv->rxbuffer = NULL;
         }
 #endif
@@ -1306,7 +1306,7 @@ static void spirit_interrupt_work(FAR void *arg)
 
       if (priv->rxbuffer == NULL)
         {
-          priv->rxbuffer = iob_alloc(false, IOBUSER_WIRELESS_PACKETRADIO);
+          priv->rxbuffer = iob_alloc(false);
         }
 
       if (priv->rxbuffer != NULL)
@@ -1381,7 +1381,7 @@ static void spirit_interrupt_work(FAR void *arg)
             {
               /* Allocate an I/O buffer to hold the received packet. */
 
-              iob = iob_alloc(false, IOBUSER_WIRELESS_PACKETRADIO);
+              iob = iob_alloc(false);
             }
 
           if (iob == NULL)
@@ -1423,7 +1423,7 @@ static void spirit_interrupt_work(FAR void *arg)
                 {
                   wlerr("ERROR: Failed to allocate metadata... dropping\n");
                   NETDEV_RXDROPPED(&priv->radio.r_dev);
-                  iob_free(iob, IOBUSER_WIRELESS_PACKETRADIO);
+                  iob_free(iob);
                 }
               else
                 {
@@ -1504,7 +1504,7 @@ static void spirit_interrupt_work(FAR void *arg)
         {
           /* If not, then allocate one now. */
 
-          priv->rxbuffer = iob_alloc(false, IOBUSER_WIRELESS_PACKETRADIO);
+          priv->rxbuffer = iob_alloc(false);
           iob            = priv->rxbuffer;
           offset         = 0;
         }
@@ -1532,7 +1532,7 @@ static void spirit_interrupt_work(FAR void *arg)
               /* Free the IOB */
 
               priv->rxbuffer = NULL;
-              iob_free(iob, IOBUSER_WIRELESS_PACKETRADIO);
+              iob_free(iob);
             }
           else
             {
@@ -1594,7 +1594,7 @@ static void spirit_interrupt_work(FAR void *arg)
 
       if (priv->rxbuffer != NULL)
         {
-          iob_free(priv->rxbuffer, IOBUSER_WIRELESS_PACKETRADIO);
+          iob_free(priv->rxbuffer);
           priv->rxbuffer = NULL;
         }
 #endif
@@ -2289,7 +2289,7 @@ static int spirit_req_data(FAR struct radio_driver_s *netdev,
         {
           wlerr("ERROR: Failed to allocate metadata... dropping\n");
           NETDEV_RXDROPPED(&priv->radio.r_dev);
-          iob_free(iob, IOBUSER_WIRELESS_PACKETRADIO);
+          iob_free(iob);
           continue;
         }
 

--- a/fs/procfs/fs_procfsiobinfo.c
+++ b/fs/procfs/fs_procfsiobinfo.c
@@ -84,82 +84,6 @@ static int     iobinfo_dup(FAR const struct file *oldp,
 static int     iobinfo_stat(FAR const char *relpath, FAR struct stat *buf);
 
 /****************************************************************************
- * Private Data
- ****************************************************************************/
-
-/* CAUTION: The order of these entries and the preprocessor logic must match
- * logic found in the enum iob_user_e declaration found in iob.h
- */
-
-static FAR const char *g_iob_user_names[] =
-{
-#ifdef CONFIG_SYSLOG_BUFFER
-  "syslog",
-#endif
-#ifdef CONFIG_IOB_UNITTEST
-  "unittest",
-#endif
-#ifdef CONFIG_NET_6LOWPAN
-  "sixlowpan",
-#endif
-#ifdef CONFIG_NET_ICMP_SOCKET
-  "icmp_sock",
-#endif
-#ifdef CONFIG_NET_ICMPv6_SOCKET
-  "icmpv6_sock",
-#endif
-#ifdef CONFIG_NET_UDP
-  "udp_sock",
-#endif
-#ifdef CONFIG_NET_TCP
-  "tcp_sock",
-#endif
-#ifdef CONFIG_NET_IEEE802154
-  "ieee802154_sock",
-#endif
-#ifdef CONFIG_NET_BLUETOOTH
-  "bluetooth_sock",
-#endif
-#if defined(CONFIG_NET_UDP) && !defined(NET_UDP_NO_STACK)
-  "udp_readahead",
-#endif
-#ifdef CONFIG_NET_UDP_WRITE_BUFFERS
-  "udp_writebuffer",
-#endif
-#if defined(CONFIG_NET_TCP) && !defined(NET_TCP_NO_STACK)
-  "tcp_readahead",
-#endif
-#ifdef CONFIG_NET_TCP_WRITE_BUFFERS
-  "tcp_writebuffer",
-#endif
-#ifdef CONFIG_NET_IPFORWARD
-  "ipforward",
-#endif
-#ifdef CONFIG_WIRELESS_IEEE802154
-  "rad802154",
-#endif
-#ifdef CONFIG_IEEE802154_MAC
-  "mac802154",
-#endif
-#ifdef CONFIG_IEEE802154_MACDEV
-  "mac802154_macdev",
-#endif
-#ifdef CONFIG_IEEE802154_NETDEV
-  "mac802154_netdev",
-#endif
- #ifdef CONFIG_WL_SPIRIT
-  "packetradio",
-#endif
-#ifdef CONFIG_WIRELESS_BLUETOOTH
-  "bluetooth",
-#endif
-#ifdef CONFIG_NET_CAN
-  "can",
-#endif
-  "global",
-};
-
-/****************************************************************************
  * Public Data
  ****************************************************************************/
 
@@ -253,12 +177,11 @@ static ssize_t iobinfo_read(FAR struct file *filep, FAR char *buffer,
                             size_t buflen)
 {
   FAR struct iobinfo_file_s *iobfile;
-  FAR struct iob_userstats_s *userstats;
+  FAR struct iob_stats_s stats;
   size_t linesize;
   size_t copysize;
   size_t totalsize;
   off_t offset;
-  int i;
 
   finfo("buffer=%p buflen=%d\n", buffer, (int)buflen);
 
@@ -273,64 +196,27 @@ static ssize_t iobinfo_read(FAR struct file *filep, FAR char *buffer,
   /* The first line is the headers */
 
   linesize  = procfs_snprintf(iobfile->line, IOBINFO_LINELEN,
-                       "                           TOTAL           TOTAL\n");
+                              "%10s%10s%10s%10s\n",
+                              "ntotal", "nfree", "nwait", "nthrottle");
 
   copysize  = procfs_memcpy(iobfile->line, linesize, buffer, buflen,
                             &offset);
   totalsize = copysize;
 
-  if (totalsize < buflen)
-    {
-      buffer    += copysize;
-      buflen    -= copysize;
+  buffer   += copysize;
+  buflen   -= copysize;
 
-      linesize  = procfs_snprintf(iobfile->line, IOBINFO_LINELEN,
-                           "        USER            CONSUMED        "
-                           "PRODUCED\n");
+  /* The second line is the usage statistics */
 
-      copysize  = procfs_memcpy(iobfile->line, linesize, buffer, buflen,
-                                &offset);
-      totalsize += copysize;
-    }
+  iob_getstats(&stats);
+  linesize   = procfs_snprintf(iobfile->line, IOBINFO_LINELEN,
+                               "%10d%10d%10d%10d\n",
+                               stats.ntotal, stats.nfree,
+                               stats.nwait, stats.nthrottle);
 
-  /* Loop through each IOB user printing the usage statistics */
-
-  for (i = 0; i < IOBUSER_GLOBAL; i++)
-    {
-      if (totalsize < buflen)
-        {
-          buffer    += copysize;
-          buflen    -= copysize;
-
-          userstats  = iob_getuserstats(i);
-          linesize   = procfs_snprintf(iobfile->line, IOBINFO_LINELEN,
-                                    "%-16s%16lu%16lu\n",
-                                    g_iob_user_names[i],
-                                    (unsigned long)userstats->totalconsumed,
-                                    (unsigned long)userstats->totalproduced);
-
-          copysize   = procfs_memcpy(iobfile->line, linesize, buffer, buflen,
-                                     &offset);
-          totalsize += copysize;
-        }
-    }
-
-  if (totalsize < buflen)
-    {
-      buffer    += copysize;
-      buflen    -= copysize;
-
-      userstats  = iob_getuserstats(IOBUSER_GLOBAL);
-      linesize   = procfs_snprintf(iobfile->line, IOBINFO_LINELEN,
-                                   "\n%-16s%16lu%16lu\n",
-                                   g_iob_user_names[IOBUSER_GLOBAL],
-                                   (unsigned long)userstats->totalconsumed,
-                                   (unsigned long)userstats->totalproduced);
-
-      copysize   = procfs_memcpy(iobfile->line, linesize, buffer, buflen,
-                                 &offset);
-      totalsize += copysize;
-    }
+  copysize   = procfs_memcpy(iobfile->line, linesize, buffer, buflen,
+                             &offset);
+  totalsize += copysize;
 
   /* Update the file offset */
 

--- a/include/nuttx/net/net.h
+++ b/include/nuttx/net/net.h
@@ -479,7 +479,6 @@ int net_lockedwait_uninterruptible(sem_t *sem);
  * Input Parameters:
  *   throttled  - An indication of the IOB allocation is "throttled"
  *   timeout    - The relative time to wait until a timeout is declared.
- *   consumerid - id representing who is consuming the IOB
  *
  * Returned Value:
  *   A pointer to the newly allocated IOB is returned on success.  NULL is
@@ -487,8 +486,7 @@ int net_lockedwait_uninterruptible(sem_t *sem);
  *
  ****************************************************************************/
 
-FAR struct iob_s *net_iobtimedalloc(bool throttled, unsigned int timeout,
-                                    enum iob_user_e consumerid);
+FAR struct iob_s *net_iobtimedalloc(bool throttled, unsigned int timeout);
 
 /****************************************************************************
  * Name: net_ioballoc
@@ -504,7 +502,6 @@ FAR struct iob_s *net_iobtimedalloc(bool throttled, unsigned int timeout,
  *
  * Input Parameters:
  *   throttled  - An indication of the IOB allocation is "throttled"
- *   consumerid - id representing who is consuming the IOB
  *
  * Returned Value:
  *   A pointer to the newly allocated IOB is returned on success.  NULL is
@@ -512,7 +509,7 @@ FAR struct iob_s *net_iobtimedalloc(bool throttled, unsigned int timeout,
  *
  ****************************************************************************/
 
-FAR struct iob_s *net_ioballoc(bool throttled, enum iob_user_e consumerid);
+FAR struct iob_s *net_ioballoc(bool throttled);
 #endif
 
 /****************************************************************************

--- a/mm/iob/iob.h
+++ b/mm/iob/iob.h
@@ -143,45 +143,5 @@ FAR struct iob_qentry_s *iob_free_qentry(FAR struct iob_qentry_s *iobq);
 void iob_notifier_signal(void);
 #endif
 
-/****************************************************************************
- * Name: iob_stats_onalloc
- *
- * Description:
- *   An IOB has just been allocated for the consumer. This is a hook for the
- *   IOB statistics to be updated when /proc/iobinfo is enabled.
- *
- * Input Parameters:
- *   consumerid - id representing who is consuming the IOB
- *
- * Returned Value:
- *   None.
- *
- ****************************************************************************/
-
-#if !defined(CONFIG_DISABLE_MOUNTPOINT) && defined(CONFIG_FS_PROCFS) && \
-    defined(CONFIG_MM_IOB) && !defined(CONFIG_FS_PROCFS_EXCLUDE_IOBINFO)
-void iob_stats_onalloc(enum iob_user_e consumerid);
-#endif
-
-/****************************************************************************
- * Name: iob_stats_onfree
- *
- * Description:
- *   An IOB has just been freed by the producer. This is a hook for the
- *   IOB statistics to be updated when /proc/iobinfo is enabled.
- *
- * Input Parameters:
- *   consumerid - id representing who is consuming the IOB
- *
- * Returned Value:
- *   None.
- *
- ****************************************************************************/
-
-#if !defined(CONFIG_DISABLE_MOUNTPOINT) && defined(CONFIG_FS_PROCFS) && \
-    defined(CONFIG_MM_IOB) && !defined(CONFIG_FS_PROCFS_EXCLUDE_IOBINFO)
-void iob_stats_onfree(enum iob_user_e producerid);
-#endif
-
 #endif /* CONFIG_MM_IOB */
 #endif /* __MM_IOB_IOB_H */

--- a/mm/iob/iob_alloc.c
+++ b/mm/iob/iob_alloc.c
@@ -47,7 +47,7 @@
  *
  ****************************************************************************/
 
-static FAR struct iob_s *iob_alloc_committed(enum iob_user_e consumerid)
+static FAR struct iob_s *iob_alloc_committed(void)
 {
   FAR struct iob_s *iob = NULL;
   irqstate_t flags;
@@ -73,11 +73,6 @@ static FAR struct iob_s *iob_alloc_committed(enum iob_user_e consumerid)
       iob->io_len    = 0;    /* Length of the data in the entry */
       iob->io_offset = 0;    /* Offset to the beginning of data */
       iob->io_pktlen = 0;    /* Total length of the packet */
-
-#if !defined(CONFIG_DISABLE_MOUNTPOINT) && defined(CONFIG_FS_PROCFS) && \
-    defined(CONFIG_MM_IOB) && !defined(CONFIG_FS_PROCFS_EXCLUDE_IOBINFO)
-      iob_stats_onalloc(consumerid);
-#endif
     }
 
   leave_critical_section(flags);
@@ -93,8 +88,7 @@ static FAR struct iob_s *iob_alloc_committed(enum iob_user_e consumerid)
  *
  ****************************************************************************/
 
-static FAR struct iob_s *iob_allocwait(bool throttled, unsigned int timeout,
-                                       enum iob_user_e consumerid)
+static FAR struct iob_s *iob_allocwait(bool throttled, unsigned int timeout)
 {
   FAR struct iob_s *iob;
   irqstate_t flags;
@@ -121,7 +115,7 @@ static FAR struct iob_s *iob_allocwait(bool throttled, unsigned int timeout,
    * decremented atomically.
    */
 
-  iob = iob_tryalloc(throttled, consumerid);
+  iob = iob_tryalloc(throttled);
   while (ret == OK && iob == NULL)
     {
       /* If not successful, then the semaphore count was less than or equal
@@ -145,7 +139,7 @@ static FAR struct iob_s *iob_allocwait(bool throttled, unsigned int timeout,
            * freed and we hold a count for one IOB.
            */
 
-          iob = iob_alloc_committed(consumerid);
+          iob = iob_alloc_committed();
           if (iob == NULL)
             {
               /* We need release our count so that it is available to
@@ -155,7 +149,7 @@ static FAR struct iob_s *iob_allocwait(bool throttled, unsigned int timeout,
                */
 
               nxsem_post(sem);
-              iob = iob_tryalloc(throttled, consumerid);
+              iob = iob_tryalloc(throttled);
             }
 
           /* REVISIT: I think this logic should be moved inside of
@@ -197,12 +191,10 @@ static FAR struct iob_s *iob_allocwait(bool throttled, unsigned int timeout,
  * Input Parameters:
  *   throttled  - An indication of the IOB allocation is "throttled"
  *   timeout    - Timeout value in milliseconds.
- *   consumerid - id representing who is consuming the IOB
  *
  ****************************************************************************/
 
-FAR struct iob_s *iob_timedalloc(bool throttled, unsigned int timeout,
-                                 enum iob_user_e consumerid)
+FAR struct iob_s *iob_timedalloc(bool throttled, unsigned int timeout)
 {
   /* Were we called from the interrupt level? */
 
@@ -210,13 +202,13 @@ FAR struct iob_s *iob_timedalloc(bool throttled, unsigned int timeout,
     {
       /* Yes, then try to allocate an I/O buffer without waiting */
 
-      return iob_tryalloc(throttled, consumerid);
+      return iob_tryalloc(throttled);
     }
   else
     {
       /* Then allocate an I/O buffer, waiting as necessary */
 
-      return iob_allocwait(throttled, timeout, consumerid);
+      return iob_allocwait(throttled, timeout);
     }
 }
 
@@ -228,9 +220,9 @@ FAR struct iob_s *iob_timedalloc(bool throttled, unsigned int timeout,
  *
  ****************************************************************************/
 
-FAR struct iob_s *iob_alloc(bool throttled, enum iob_user_e consumerid)
+FAR struct iob_s *iob_alloc(bool throttled)
 {
-  return iob_timedalloc(throttled, UINT_MAX, consumerid);
+  return iob_timedalloc(throttled, UINT_MAX);
 }
 
 /****************************************************************************
@@ -242,7 +234,7 @@ FAR struct iob_s *iob_alloc(bool throttled, enum iob_user_e consumerid)
  *
  ****************************************************************************/
 
-FAR struct iob_s *iob_tryalloc(bool throttled, enum iob_user_e consumerid)
+FAR struct iob_s *iob_tryalloc(bool throttled)
 {
   FAR struct iob_s *iob;
   irqstate_t flags;
@@ -300,11 +292,6 @@ FAR struct iob_s *iob_tryalloc(bool throttled, enum iob_user_e consumerid)
            */
 
           g_throttle_sem.semcount--;
-#endif
-
-#if !defined(CONFIG_DISABLE_MOUNTPOINT) && defined(CONFIG_FS_PROCFS) && \
-    defined(CONFIG_MM_IOB) && !defined(CONFIG_FS_PROCFS_EXCLUDE_IOBINFO)
-          iob_stats_onalloc(consumerid);
 #endif
 
           leave_critical_section(flags);

--- a/mm/iob/iob_clone.c
+++ b/mm/iob/iob_clone.c
@@ -53,8 +53,7 @@
  *
  ****************************************************************************/
 
-int iob_clone(FAR struct iob_s *iob1, FAR struct iob_s *iob2, bool throttled,
-              enum iob_user_e consumerid)
+int iob_clone(FAR struct iob_s *iob1, FAR struct iob_s *iob2, bool throttled)
 {
   FAR uint8_t *src;
   FAR uint8_t *dest;
@@ -146,7 +145,7 @@ int iob_clone(FAR struct iob_s *iob1, FAR struct iob_s *iob2, bool throttled,
            * destination I/O buffer chain.
            */
 
-          next = iob_alloc(throttled, consumerid);
+          next = iob_alloc(throttled);
           if (!next)
             {
               ioberr("ERROR: Failed to allocate an I/O buffer\n");

--- a/mm/iob/iob_contig.c
+++ b/mm/iob/iob_contig.c
@@ -54,8 +54,7 @@
  *
  ****************************************************************************/
 
-int iob_contig(FAR struct iob_s *iob, unsigned int len,
-               enum iob_user_e producerid)
+int iob_contig(FAR struct iob_s *iob, unsigned int len)
 {
   FAR struct iob_s *next;
   unsigned int ncopy;
@@ -120,7 +119,7 @@ int iob_contig(FAR struct iob_s *iob, unsigned int len,
 
           if (next->io_len == 0)
             {
-              iob->io_flink = iob_free(next, producerid);
+              iob->io_flink = iob_free(next);
             }
         }
       while (len > iob->io_len);

--- a/mm/iob/iob_copyin.c
+++ b/mm/iob/iob_copyin.c
@@ -52,8 +52,7 @@
 
 static int iob_copyin_internal(FAR struct iob_s *iob, FAR const uint8_t *src,
                                unsigned int len, unsigned int offset,
-                               bool throttled, bool can_block,
-                               enum iob_user_e consumerid)
+                               bool throttled, bool can_block)
 {
   FAR struct iob_s *head = iob;
   FAR struct iob_s *next;
@@ -177,11 +176,11 @@ static int iob_copyin_internal(FAR struct iob_s *iob, FAR const uint8_t *src,
 
           if (can_block)
             {
-              next = iob_alloc(throttled, consumerid);
+              next = iob_alloc(throttled);
             }
           else
             {
-              next = iob_tryalloc(throttled, consumerid);
+              next = iob_tryalloc(throttled);
             }
 
           if (next == NULL)
@@ -217,11 +216,9 @@ static int iob_copyin_internal(FAR struct iob_s *iob, FAR const uint8_t *src,
  ****************************************************************************/
 
 int iob_copyin(FAR struct iob_s *iob, FAR const uint8_t *src,
-               unsigned int len, unsigned int offset, bool throttled,
-               enum iob_user_e consumerid)
+               unsigned int len, unsigned int offset, bool throttled)
 {
-  return iob_copyin_internal(iob, src, len, offset,
-                             throttled, true, consumerid);
+  return iob_copyin_internal(iob, src, len, offset, throttled, true);
 }
 
 /****************************************************************************
@@ -235,9 +232,7 @@ int iob_copyin(FAR struct iob_s *iob, FAR const uint8_t *src,
  ****************************************************************************/
 
 int iob_trycopyin(FAR struct iob_s *iob, FAR const uint8_t *src,
-                  unsigned int len, unsigned int offset, bool throttled,
-                  enum iob_user_e consumerid)
+                  unsigned int len, unsigned int offset, bool throttled)
 {
-  return iob_copyin_internal(iob, src, len, offset, throttled, false,
-                             consumerid);
+  return iob_copyin_internal(iob, src, len, offset, throttled, false);
 }

--- a/mm/iob/iob_free.c
+++ b/mm/iob/iob_free.c
@@ -71,8 +71,7 @@
  *
  ****************************************************************************/
 
-FAR struct iob_s *iob_free(FAR struct iob_s *iob,
-                           enum iob_user_e producerid)
+FAR struct iob_s *iob_free(FAR struct iob_s *iob)
 {
   FAR struct iob_s *next = iob->io_flink;
   irqstate_t flags;
@@ -146,11 +145,6 @@ FAR struct iob_s *iob_free(FAR struct iob_s *iob,
 
   nxsem_post(&g_iob_sem);
   DEBUGASSERT(g_iob_sem.semcount <= CONFIG_IOB_NBUFFERS);
-
-#if !defined(CONFIG_DISABLE_MOUNTPOINT) && defined(CONFIG_FS_PROCFS) && \
-    defined(CONFIG_MM_IOB) && !defined(CONFIG_FS_PROCFS_EXCLUDE_IOBINFO)
-  iob_stats_onfree(producerid);
-#endif
 
 #if CONFIG_IOB_THROTTLE > 0
   nxsem_post(&g_throttle_sem);

--- a/mm/iob/iob_free_chain.c
+++ b/mm/iob/iob_free_chain.c
@@ -42,7 +42,7 @@
  *
  ****************************************************************************/
 
-void iob_free_chain(FAR struct iob_s *iob, enum iob_user_e producerid)
+void iob_free_chain(FAR struct iob_s *iob)
 {
   FAR struct iob_s *next;
 
@@ -50,6 +50,6 @@ void iob_free_chain(FAR struct iob_s *iob, enum iob_user_e producerid)
 
   for (; iob; iob = next)
     {
-      next = iob_free(iob, producerid);
+      next = iob_free(iob);
     }
 }

--- a/mm/iob/iob_free_queue.c
+++ b/mm/iob/iob_free_queue.c
@@ -44,8 +44,7 @@
  *
  ****************************************************************************/
 
-void iob_free_queue(FAR struct iob_queue_s *qhead,
-                    enum iob_user_e producerid)
+void iob_free_queue(FAR struct iob_queue_s *qhead)
 {
   FAR struct iob_qentry_s *iobq;
   FAR struct iob_qentry_s *nextq;
@@ -77,7 +76,7 @@ void iob_free_queue(FAR struct iob_queue_s *qhead,
 
       /* Free the I/O chain */
 
-      iob_free_chain(iob, producerid);
+      iob_free_chain(iob);
     }
 }
 

--- a/mm/iob/iob_free_queue_qentry.c
+++ b/mm/iob/iob_free_queue_qentry.c
@@ -46,8 +46,7 @@
  ****************************************************************************/
 
 void iob_free_queue_qentry(FAR struct iob_s *iob,
-                           FAR struct iob_queue_s *iobq,
-                           enum iob_user_e producerid)
+                           FAR struct iob_queue_s *iobq)
 {
   FAR struct iob_qentry_s *prev = NULL;
   FAR struct iob_qentry_s *qentry;
@@ -80,7 +79,7 @@ void iob_free_queue_qentry(FAR struct iob_s *iob,
 
           /* Free the I/O chain */
 
-          iob_free_chain(iob, producerid);
+          iob_free_chain(iob);
 
           break;
         }

--- a/mm/iob/iob_pack.c
+++ b/mm/iob/iob_pack.c
@@ -44,8 +44,7 @@
  *
  ****************************************************************************/
 
-FAR struct iob_s *iob_pack(FAR struct iob_s *iob,
-                           enum iob_user_e producerid)
+FAR struct iob_s *iob_pack(FAR struct iob_s *iob)
 {
   FAR struct iob_s *head;
   FAR struct iob_s *next;
@@ -56,7 +55,7 @@ FAR struct iob_s *iob_pack(FAR struct iob_s *iob,
 
   while (iob->io_len <= 0)
     {
-      iob = iob_free(iob, producerid);
+      iob = iob_free(iob);
       if (iob == NULL)
         {
           return NULL;
@@ -120,7 +119,7 @@ FAR struct iob_s *iob_pack(FAR struct iob_s *iob,
             {
               /* Yes.. free the next entry in I/O buffer chain */
 
-              next          = iob_free(next, producerid);
+              next          = iob_free(next);
               iob->io_flink = next;
             }
         }

--- a/mm/iob/iob_statistics.c
+++ b/mm/iob/iob_statistics.c
@@ -24,76 +24,16 @@
 
 #include <nuttx/config.h>
 
-#include <sys/types.h>
-#include <stdio.h>
-#include <string.h>
-#include <assert.h>
-#include <debug.h>
-
 #include <nuttx/mm/iob.h>
+
+#include "iob.h"
 
 #if !defined(CONFIG_DISABLE_MOUNTPOINT) && defined(CONFIG_FS_PROCFS) && \
     !defined(CONFIG_FS_PROCFS_EXCLUDE_IOBINFO)
 
 /****************************************************************************
- * Private Data
- ****************************************************************************/
-
-struct iob_userstats_s g_iobuserstats[IOBUSER_NENTRIES];
-
-/****************************************************************************
  * Public Functions
  ****************************************************************************/
-
-/****************************************************************************
- * Name: iob_stats_onalloc
- *
- * Description:
- *   An IOB has just been allocated for the consumer. This is a hook for the
- *   IOB statistics to be updated when /proc/iobinfo is enabled.
- *
- * Input Parameters:
- *   consumerid - id representing who is consuming the IOB
- *
- * Returned Value:
- *   None.
- *
- ****************************************************************************/
-
-void iob_stats_onalloc(enum iob_user_e consumerid)
-{
-  DEBUGASSERT(consumerid < IOBUSER_NENTRIES);
-  g_iobuserstats[consumerid].totalconsumed++;
-
-  /* Increment the global statistic as well */
-
-  g_iobuserstats[IOBUSER_GLOBAL].totalconsumed++;
-}
-
-/****************************************************************************
- * Name: iob_stats_onfree
- *
- * Description:
- *   An IOB has just been freed by the producer. This is a hook for the
- *   IOB statistics to be updated when /proc/iobinfo is enabled.
- *
- * Input Parameters:
- *   consumerid - id representing who is consuming the IOB
- *
- * Returned Value:
- *   None.
- *
- ****************************************************************************/
-
-void iob_stats_onfree(enum iob_user_e producerid)
-{
-  DEBUGASSERT(producerid < IOBUSER_NENTRIES);
-  g_iobuserstats[producerid].totalproduced++;
-
-  /* Increment the global statistic as well */
-
-  g_iobuserstats[IOBUSER_GLOBAL].totalproduced++;
-}
 
 /****************************************************************************
  * Name: iob_getuserstats
@@ -103,17 +43,39 @@ void iob_stats_onfree(enum iob_user_e producerid)
  *   consumer/producer
  *
  * Input Parameters:
- *   userid - id representing the IOB producer/consumer
+ *   stats - point to IOB usage statistics
  *
  * Returned Value:
  *   None.
  *
  ****************************************************************************/
 
-FAR struct iob_userstats_s * iob_getuserstats(enum iob_user_e userid)
+void iob_getstats(FAR struct iob_stats_s *stats)
 {
-  DEBUGASSERT(userid < IOBUSER_NENTRIES);
-  return &g_iobuserstats[userid];
+  stats->ntotal = CONFIG_IOB_NBUFFERS;
+
+  nxsem_get_value(&g_iob_sem, &stats->nfree);
+  if (stats->nfree < 0)
+    {
+      stats->nwait = -stats->nfree;
+      stats->nfree = 0;
+    }
+  else
+    {
+      stats->nwait = 0;
+    }
+
+#if CONFIG_IOB_THROTTLE > 0
+  nxsem_get_value(&g_throttle_sem, &stats->nthrottle);
+  if (stats->nthrottle < 0)
+    {
+      stats->nthrottle = -stats->nthrottle;
+    }
+  else
+#endif
+    {
+      stats->nthrottle = 0;
+    }
 }
 
 #endif /* !CONFIG_DISABLE_MOUNTPOINT && CONFIG_FS_PROCFS &&

--- a/mm/iob/iob_test.c
+++ b/mm/iob/iob_test.c
@@ -96,7 +96,7 @@ int main(int argc, char **argv)
   int i;
 
   iob_initialize();
-  iob = iob_alloc(false, IOBUSER_UNITTEST);
+  iob = iob_alloc(false);
 
   for (i = 0; i < 4096; i++)
     {
@@ -105,11 +105,11 @@ int main(int argc, char **argv)
 
   memset(buffer2, 0xff, 4096);
 
-  iob_copyin(iob, buffer2, 47, 0, false, IOBUSER_UNITTEST);
+  iob_copyin(iob, buffer2, 47, 0, false);
   printf("Copy IN: 47, offset 0\n");
   dump_chain(iob);
 
-  iob_copyin(iob, buffer1, 4096, 47, false, IOBUSER_UNITTEST);
+  iob_copyin(iob, buffer1, 4096, 47, false);
   printf("Copy IN: 4096, offset 47\n");
   dump_chain(iob);
 
@@ -121,11 +121,11 @@ int main(int argc, char **argv)
       fprintf(stderr, "Buffer1 does not match buffer2\n");
     }
 
-  iob = iob_trimhead(iob, 47, IOBUSER_UNITTEST);
+  iob = iob_trimhead(iob, 47);
   printf("Trim: 47 from the beginning of the list\n");
   dump_chain(iob);
 
-  iob = iob_trimtail(iob, 493, IOBUSER_UNITTEST);
+  iob = iob_trimtail(iob, 493);
   printf("Trim: 493 from the end of the list\n");
   dump_chain(iob);
 
@@ -137,7 +137,7 @@ int main(int argc, char **argv)
       fprintf(stderr, "Buffer1 does not match buffer2\n");
     }
 
-  iob = iob_trimhead(iob, 1362, IOBUSER_UNITTEST);
+  iob = iob_trimhead(iob, 1362);
   printf("Trim: 1362 from the beginning of the list\n");
   dump_chain(iob);
 
@@ -149,7 +149,7 @@ int main(int argc, char **argv)
       fprintf(stderr, "Buffer1 does not match buffer2\n");
     }
 
-  iob = iob_pack(iob, IOBUSER_UNITTEST);
+  iob = iob_pack(iob);
   printf("Packed\n");
   dump_chain(iob);
 
@@ -161,7 +161,7 @@ int main(int argc, char **argv)
       fprintf(stderr, "Buffer1 does not match buffer2\n");
     }
 
-  while (iob) iob = iob_free(iob, IOBUSER_UNITTEST);
+  while (iob) iob = iob_free(iob);
   return EXIT_SUCCESS;
 }
 

--- a/mm/iob/iob_trimhead.c
+++ b/mm/iob/iob_trimhead.c
@@ -44,8 +44,7 @@
  *
  ****************************************************************************/
 
-FAR struct iob_s *iob_trimhead(FAR struct iob_s *iob, unsigned int trimlen,
-                               enum iob_user_e producerid)
+FAR struct iob_s *iob_trimhead(FAR struct iob_s *iob, unsigned int trimlen)
 {
   unsigned int pktlen;
 
@@ -92,7 +91,7 @@ FAR struct iob_s *iob_trimhead(FAR struct iob_s *iob, unsigned int trimlen,
               /* Free this entry and set the next I/O buffer as the head */
 
               iobinfo("iob=%p: Freeing\n", iob);
-              iob_free(iob, producerid);
+              iob_free(iob);
               iob = next;
             }
           else

--- a/mm/iob/iob_trimhead_queue.c
+++ b/mm/iob/iob_trimhead_queue.c
@@ -55,8 +55,7 @@
  ****************************************************************************/
 
 FAR struct iob_s *iob_trimhead_queue(FAR struct iob_queue_s *qhead,
-                                     unsigned int trimlen,
-                                     enum iob_user_e producerid)
+                                     unsigned int trimlen)
 {
   FAR struct iob_qentry_s *qentry;
   FAR struct iob_s *iob = NULL;
@@ -73,7 +72,7 @@ FAR struct iob_s *iob_trimhead_queue(FAR struct iob_queue_s *qhead,
         {
           /* Trim the I/Buffer chain and update the queue head */
 
-          iob = iob_trimhead(iob, trimlen, producerid);
+          iob = iob_trimhead(iob, trimlen);
           qentry->qe_head = iob;
         }
     }

--- a/mm/iob/iob_trimtail.c
+++ b/mm/iob/iob_trimtail.c
@@ -43,8 +43,7 @@
  *
  ****************************************************************************/
 
-FAR struct iob_s *iob_trimtail(FAR struct iob_s *iob, unsigned int trimlen,
-                               enum iob_user_e producerid)
+FAR struct iob_s *iob_trimtail(FAR struct iob_s *iob, unsigned int trimlen)
 {
   FAR struct iob_s *entry;
   FAR struct iob_s *penultimate;
@@ -91,7 +90,7 @@ FAR struct iob_s *iob_trimtail(FAR struct iob_s *iob, unsigned int trimlen,
 
               /* Free the last, empty buffer in the list */
 
-              iob_free(last, producerid);
+              iob_free(last);
 
               /* There should be a buffer before this one */
 

--- a/net/bluetooth/bluetooth_conn.c
+++ b/net/bluetooth/bluetooth_conn.c
@@ -188,7 +188,7 @@ void bluetooth_conn_free(FAR struct bluetooth_conn_s *conn)
 
       if (container->bn_iob)
         {
-          iob_free(container->bn_iob, IOBUSER_NET_SOCK_BLUETOOTH);
+          iob_free(container->bn_iob);
         }
 
       /* And free the container itself */

--- a/net/bluetooth/bluetooth_input.c
+++ b/net/bluetooth/bluetooth_input.c
@@ -158,7 +158,7 @@ static int bluetooth_queue_frame(FAR struct bluetooth_conn_s *conn,
 
       /* Free both the IOB and the container */
 
-      iob_free(container->bn_iob, IOBUSER_NET_SOCK_BLUETOOTH);
+      iob_free(container->bn_iob);
       bluetooth_container_free(container);
     }
   else
@@ -259,7 +259,7 @@ int bluetooth_input(FAR struct radio_driver_s *radio,
           if (ret < 0)
             {
               nerr("ERROR: Failed to queue frame: %d\n", ret);
-              iob_free(frame, IOBUSER_NET_SOCK_BLUETOOTH);
+              iob_free(frame);
             }
         }
 

--- a/net/bluetooth/bluetooth_recvmsg.c
+++ b/net/bluetooth/bluetooth_recvmsg.c
@@ -183,7 +183,7 @@ static ssize_t
 
       /* Free both the IOB and the container */
 
-      iob_free(iob, IOBUSER_NET_SOCK_BLUETOOTH);
+      iob_free(iob);
       bluetooth_container_free(container);
     }
 

--- a/net/bluetooth/bluetooth_sendmsg.c
+++ b/net/bluetooth/bluetooth_sendmsg.c
@@ -145,7 +145,7 @@ static uint16_t bluetooth_sendto_eventhandler(FAR struct net_driver_s *dev,
 
       /* Allocate an IOB to hold the frame data */
 
-      iob = net_ioballoc(false, IOBUSER_NET_SOCK_BLUETOOTH);
+      iob = net_ioballoc(false);
       if (iob == NULL)
         {
           nwarn("WARNING: Failed to allocate IOB\n");

--- a/net/can/can_callback.c
+++ b/net/can/can_callback.c
@@ -195,7 +195,7 @@ uint16_t can_datahandler(FAR struct can_conn_s *conn, FAR uint8_t *buffer,
    * packet.
    */
 
-  iob = iob_tryalloc(true, IOBUSER_NET_CAN_READAHEAD);
+  iob = iob_tryalloc(true);
   if (iob == NULL)
     {
       nerr("ERROR: Failed to create new I/O buffer chain\n");
@@ -204,8 +204,7 @@ uint16_t can_datahandler(FAR struct can_conn_s *conn, FAR uint8_t *buffer,
 
   /* Copy the new appdata into the I/O buffer chain (without waiting) */
 
-  ret = iob_trycopyin(iob, buffer, buflen, 0, true,
-                      IOBUSER_NET_CAN_READAHEAD);
+  ret = iob_trycopyin(iob, buffer, buflen, 0, true);
   if (ret < 0)
     {
       /* On a failure, iob_copyin return a negated error value but does
@@ -213,7 +212,7 @@ uint16_t can_datahandler(FAR struct can_conn_s *conn, FAR uint8_t *buffer,
        */
 
       nerr("ERROR: Failed to add data to the I/O buffer chain: %d\n", ret);
-      iob_free_chain(iob, IOBUSER_NET_CAN_READAHEAD);
+      iob_free_chain(iob);
       return 0;
     }
 
@@ -225,7 +224,7 @@ uint16_t can_datahandler(FAR struct can_conn_s *conn, FAR uint8_t *buffer,
   if (ret < 0)
     {
       nerr("ERROR: Failed to queue the I/O buffer chain: %d\n", ret);
-      iob_free_chain(iob, IOBUSER_NET_CAN_READAHEAD);
+      iob_free_chain(iob);
       return 0;
     }
 

--- a/net/can/can_recvmsg.c
+++ b/net/can/can_recvmsg.c
@@ -272,7 +272,7 @@ static inline int can_readahead(struct can_recvfrom_s *pstate)
 
           /* And free the I/O buffer chain */
 
-          iob_free_chain(iob, IOBUSER_NET_CAN_READAHEAD);
+          iob_free_chain(iob);
         }
       else
         {
@@ -281,8 +281,7 @@ static inline int can_readahead(struct can_recvfrom_s *pstate)
            * buffer queue).
            */
 
-          iob_trimhead_queue(&conn->readahead, recvlen,
-                             IOBUSER_NET_CAN_READAHEAD);
+          iob_trimhead_queue(&conn->readahead, recvlen);
         }
 
       /* do not pass frames with DLC > 8 to a legacy socket */
@@ -356,7 +355,7 @@ static inline int can_readahead_timestamp(struct can_conn_s *conn,
 
           /* And free the I/O buffer chain */
 
-          iob_free_chain(iob, IOBUSER_NET_CAN_READAHEAD);
+          iob_free_chain(iob);
         }
       else
         {
@@ -365,8 +364,7 @@ static inline int can_readahead_timestamp(struct can_conn_s *conn,
            * buffer queue).
            */
 
-          iob_trimhead_queue(&conn->readahead, recvlen,
-                             IOBUSER_NET_CAN_READAHEAD);
+          iob_trimhead_queue(&conn->readahead, recvlen);
         }
 
       return recvlen;

--- a/net/icmp/icmp_input.c
+++ b/net/icmp/icmp_input.c
@@ -113,7 +113,7 @@ static uint16_t icmp_datahandler(FAR struct net_driver_s *dev,
    * packet.
    */
 
-  iob = iob_tryalloc(true, IOBUSER_NET_SOCK_ICMP);
+  iob = iob_tryalloc(true);
   if (iob == NULL)
     {
       nerr("ERROR: Failed to create new I/O buffer chain\n");
@@ -137,8 +137,7 @@ static uint16_t icmp_datahandler(FAR struct net_driver_s *dev,
    */
 
   addrsize = sizeof(struct sockaddr_in);
-  ret      = iob_trycopyin(iob, &addrsize, sizeof(uint8_t), 0, true,
-                           IOBUSER_NET_SOCK_ICMP);
+  ret      = iob_trycopyin(iob, &addrsize, sizeof(uint8_t), 0, true);
   if (ret < 0)
     {
       /* On a failure, iob_trycopyin return a negated error value but does
@@ -152,8 +151,7 @@ static uint16_t icmp_datahandler(FAR struct net_driver_s *dev,
   offset = sizeof(uint8_t);
 
   ret = iob_trycopyin(iob, (FAR const uint8_t *)&inaddr,
-                      sizeof(struct sockaddr_in), offset, true,
-                      IOBUSER_NET_SOCK_ICMP);
+                      sizeof(struct sockaddr_in), offset, true);
   if (ret < 0)
     {
       /* On a failure, iob_trycopyin return a negated error value but does
@@ -174,8 +172,8 @@ static uint16_t icmp_datahandler(FAR struct net_driver_s *dev,
   /* Copy the new ICMP reply into the I/O buffer chain (without waiting) */
 
   buflen = ICMPSIZE(iphdrlen);
-  ret = iob_trycopyin(iob, (FAR uint8_t *)ICMPBUF(iphdrlen), buflen, offset,
-                      true, IOBUSER_NET_SOCK_ICMP);
+  ret = iob_trycopyin(iob, (FAR uint8_t *)ICMPBUF(iphdrlen),
+                      buflen, offset, true);
   if (ret < 0)
     {
       /* On a failure, iob_copyin return a negated error value but does
@@ -202,7 +200,7 @@ static uint16_t icmp_datahandler(FAR struct net_driver_s *dev,
   return buflen;
 
 drop_with_chain:
-  iob_free_chain(iob, IOBUSER_NET_SOCK_ICMP);
+  iob_free_chain(iob);
 
 drop:
   dev->d_len = 0;

--- a/net/icmp/icmp_recvmsg.c
+++ b/net/icmp/icmp_recvmsg.c
@@ -307,7 +307,7 @@ out:
 
       /* And free the I/O buffer chain */
 
-      iob_free_chain(iob, IOBUSER_NET_SOCK_ICMP);
+      iob_free_chain(iob);
     }
 
   return ret;
@@ -492,7 +492,7 @@ errout:
           conn->nreqs = 0;
           conn->dev   = NULL;
 
-          iob_free_queue(&conn->readahead, IOBUSER_NET_SOCK_ICMP);
+          iob_free_queue(&conn->readahead);
         }
     }
 

--- a/net/icmp/icmp_sendmsg.c
+++ b/net/icmp/icmp_sendmsg.c
@@ -358,7 +358,7 @@ ssize_t icmp_sendmsg(FAR struct socket *psock, FAR struct msghdr *msg,
       conn->nreqs = 0;
       conn->dev   = NULL;
 
-      iob_free_queue(&conn->readahead, IOBUSER_NET_SOCK_ICMP);
+      iob_free_queue(&conn->readahead);
     }
 
 #ifdef CONFIG_NET_ARP_SEND
@@ -471,7 +471,7 @@ errout:
   conn->nreqs = 0;
   conn->dev   = NULL;
 
-  iob_free_queue(&conn->readahead, IOBUSER_NET_SOCK_ICMP);
+  iob_free_queue(&conn->readahead);
   return ret;
 }
 

--- a/net/icmp/icmp_sockif.c
+++ b/net/icmp/icmp_sockif.c
@@ -476,7 +476,7 @@ static int icmp_close(FAR struct socket *psock)
     {
       /* Yes... free any read-ahead data */
 
-      iob_free_queue(&conn->readahead, IOBUSER_NET_SOCK_ICMP);
+      iob_free_queue(&conn->readahead);
 
       /* Then free the connection structure */
 

--- a/net/icmpv6/icmpv6_input.c
+++ b/net/icmpv6/icmpv6_input.c
@@ -103,7 +103,7 @@ static uint16_t icmpv6_datahandler(FAR struct net_driver_s *dev,
    * packet.
    */
 
-  iob = iob_tryalloc(true, IOBUSER_NET_SOCK_ICMPv6);
+  iob = iob_tryalloc(true);
   if (iob == NULL)
     {
       nerr("ERROR: Failed to create new I/O buffer chain\n");
@@ -123,8 +123,7 @@ static uint16_t icmpv6_datahandler(FAR struct net_driver_s *dev,
    */
 
   addrsize = sizeof(struct sockaddr_in6);
-  ret      = iob_trycopyin(iob, &addrsize, sizeof(uint8_t), 0, true,
-                           IOBUSER_NET_SOCK_ICMPv6);
+  ret      = iob_trycopyin(iob, &addrsize, sizeof(uint8_t), 0, true);
   if (ret < 0)
     {
       /* On a failure, iob_trycopyin return a negated error value but does
@@ -138,8 +137,7 @@ static uint16_t icmpv6_datahandler(FAR struct net_driver_s *dev,
   offset = sizeof(uint8_t);
 
   ret = iob_trycopyin(iob, (FAR const uint8_t *)&inaddr,
-                      sizeof(struct sockaddr_in6), offset, true,
-                      IOBUSER_NET_SOCK_ICMPv6);
+                      sizeof(struct sockaddr_in6), offset, true);
   if (ret < 0)
     {
       /* On a failure, iob_trycopyin return a negated error value but does
@@ -158,8 +156,7 @@ static uint16_t icmpv6_datahandler(FAR struct net_driver_s *dev,
   buflen = ICMPv6SIZE;
   icmpv6 = ICMPv6BUF;
 
-  ret = iob_trycopyin(iob, (FAR uint8_t *)ICMPv6REPLY, buflen, offset, true,
-                      IOBUSER_NET_SOCK_ICMPv6);
+  ret = iob_trycopyin(iob, (FAR uint8_t *)ICMPv6REPLY, buflen, offset, true);
   if (ret < 0)
     {
       /* On a failure, iob_copyin return a negated error value but does
@@ -186,7 +183,7 @@ static uint16_t icmpv6_datahandler(FAR struct net_driver_s *dev,
   return buflen;
 
 drop_with_chain:
-  iob_free_chain(iob, IOBUSER_NET_SOCK_ICMPv6);
+  iob_free_chain(iob);
 
 drop:
   dev->d_len = 0;

--- a/net/icmpv6/icmpv6_recvmsg.c
+++ b/net/icmpv6/icmpv6_recvmsg.c
@@ -314,7 +314,7 @@ out:
 
       /* And free the I/O buffer chain */
 
-      iob_free_chain(iob, IOBUSER_NET_SOCK_ICMPv6);
+      iob_free_chain(iob);
     }
 
   return ret;
@@ -502,7 +502,7 @@ errout:
           conn->nreqs = 0;
           conn->dev   = NULL;
 
-          iob_free_queue(&conn->readahead, IOBUSER_NET_SOCK_ICMPv6);
+          iob_free_queue(&conn->readahead);
         }
     }
 

--- a/net/icmpv6/icmpv6_sendmsg.c
+++ b/net/icmpv6/icmpv6_sendmsg.c
@@ -349,7 +349,7 @@ ssize_t icmpv6_sendmsg(FAR struct socket *psock, FAR struct msghdr *msg,
       conn->nreqs = 0;
       conn->dev   = NULL;
 
-      iob_free_queue(&conn->readahead, IOBUSER_NET_SOCK_ICMPv6);
+      iob_free_queue(&conn->readahead);
     }
 
 #ifdef CONFIG_NET_ICMPv6_NEIGHBOR
@@ -462,7 +462,7 @@ errout:
   conn->nreqs = 0;
   conn->dev   = NULL;
 
-  iob_free_queue(&conn->readahead, IOBUSER_NET_SOCK_ICMPv6);
+  iob_free_queue(&conn->readahead);
   return ret;
 }
 

--- a/net/icmpv6/icmpv6_sockif.c
+++ b/net/icmpv6/icmpv6_sockif.c
@@ -476,7 +476,7 @@ static int icmpv6_close(FAR struct socket *psock)
     {
       /* Yes... free any read-ahead data */
 
-      iob_free_queue(&conn->readahead, IOBUSER_NET_SOCK_ICMPv6);
+      iob_free_queue(&conn->readahead);
 
       /* Then free the connection structure */
 

--- a/net/ieee802154/ieee802154_conn.c
+++ b/net/ieee802154/ieee802154_conn.c
@@ -176,7 +176,7 @@ void ieee802154_conn_free(FAR struct ieee802154_conn_s *conn)
 
       if (container->ic_iob)
         {
-          iob_free(container->ic_iob, IOBUSER_NET_SOCK_IEEE802154);
+          iob_free(container->ic_iob);
         }
 
       /* And free the container itself */

--- a/net/ieee802154/ieee802154_input.c
+++ b/net/ieee802154/ieee802154_input.c
@@ -165,7 +165,7 @@ static int ieee802154_queue_frame(FAR struct ieee802154_conn_s *conn,
 
       /* Free both the IOB and the container */
 
-      iob_free(container->ic_iob, IOBUSER_NET_SOCK_IEEE802154);
+      iob_free(container->ic_iob);
       ieee802154_container_free(container);
     }
   else
@@ -266,7 +266,7 @@ int ieee802154_input(FAR struct radio_driver_s *radio,
           if (ret < 0)
             {
               nerr("ERROR: Failed to queue frame: %d\n", ret);
-              iob_free(frame, IOBUSER_NET_SOCK_IEEE802154);
+              iob_free(frame);
             }
         }
 

--- a/net/ieee802154/ieee802154_recvmsg.c
+++ b/net/ieee802154/ieee802154_recvmsg.c
@@ -183,7 +183,7 @@ static ssize_t
 
       /* Free both the IOB and the container */
 
-      iob_free(iob, IOBUSER_NET_SOCK_IEEE802154);
+      iob_free(iob);
       ieee802154_container_free(container);
     }
 

--- a/net/ieee802154/ieee802154_sendmsg.c
+++ b/net/ieee802154/ieee802154_sendmsg.c
@@ -332,7 +332,7 @@ static uint16_t ieee802154_sendto_eventhandler(FAR struct net_driver_s *dev,
 
       /* Allocate an IOB to hold the frame data */
 
-      iob = net_ioballoc(false, IOBUSER_NET_SOCK_IEEE802154);
+      iob = net_ioballoc(false);
       if (iob == NULL)
         {
           nwarn("WARNING: Failed to allocate IOB\n");

--- a/net/ipforward/ipfwd_forward.c
+++ b/net/ipforward/ipfwd_forward.c
@@ -190,7 +190,7 @@ static uint16_t ipfwd_eventhandler(FAR struct net_driver_s *dev,
 
       if (fwd->f_iob != NULL)
         {
-          iob_free_chain(fwd->f_iob, IOBUSER_NET_IPFORWARD);
+          iob_free_chain(fwd->f_iob);
         }
 
       /* And release the forwarding state structure */

--- a/net/ipforward/ipv4_forward.c
+++ b/net/ipforward/ipv4_forward.c
@@ -274,7 +274,7 @@ static int ipv4_dev_forward(FAR struct net_driver_s *dev,
    * where waiting for an IOB is a good idea
    */
 
-  fwd->f_iob = iob_tryalloc(false, IOBUSER_NET_IPFORWARD);
+  fwd->f_iob = iob_tryalloc(false);
   if (fwd->f_iob == NULL)
     {
       nwarn("WARNING: iob_tryalloc() failed\n");
@@ -292,7 +292,7 @@ static int ipv4_dev_forward(FAR struct net_driver_s *dev,
    */
 
   ret = iob_trycopyin(fwd->f_iob, (FAR const uint8_t *)ipv4,
-                      dev->d_len, 0, false, IOBUSER_NET_IPFORWARD);
+                      dev->d_len, 0, false);
   if (ret < 0)
     {
       nwarn("WARNING: iob_trycopyin() failed: %d\n", ret);
@@ -324,7 +324,7 @@ static int ipv4_dev_forward(FAR struct net_driver_s *dev,
 errout_with_iobchain:
   if (fwd != NULL && fwd->f_iob != NULL)
     {
-      iob_free_chain(fwd->f_iob, IOBUSER_NET_IPFORWARD);
+      iob_free_chain(fwd->f_iob);
     }
 
 errout_with_fwd:

--- a/net/ipforward/ipv6_forward.c
+++ b/net/ipforward/ipv6_forward.c
@@ -409,7 +409,7 @@ static int ipv6_dev_forward(FAR struct net_driver_s *dev,
        * waiting for an IOB is a good idea
        */
 
-      fwd->f_iob = iob_tryalloc(false, IOBUSER_NET_IPFORWARD);
+      fwd->f_iob = iob_tryalloc(false);
       if (fwd->f_iob == NULL)
         {
           nwarn("WARNING: iob_tryalloc() failed\n");
@@ -427,7 +427,7 @@ static int ipv6_dev_forward(FAR struct net_driver_s *dev,
        */
 
       ret = iob_trycopyin(fwd->f_iob, (FAR const uint8_t *)ipv6,
-                          dev->d_len, 0, false, IOBUSER_NET_IPFORWARD);
+                          dev->d_len, 0, false);
       if (ret < 0)
         {
           nwarn("WARNING: iob_trycopyin() failed: %d\n", ret);
@@ -460,7 +460,7 @@ static int ipv6_dev_forward(FAR struct net_driver_s *dev,
 errout_with_iobchain:
   if (fwd != NULL && fwd->f_iob != NULL)
     {
-      iob_free_chain(fwd->f_iob, IOBUSER_NET_IPFORWARD);
+      iob_free_chain(fwd->f_iob);
     }
 
 errout_with_fwd:

--- a/net/sixlowpan/sixlowpan_framelist.c
+++ b/net/sixlowpan/sixlowpan_framelist.c
@@ -410,7 +410,7 @@ int sixlowpan_queue_frames(FAR struct radio_driver_s *radio,
    * necessary.
    */
 
-  iob = net_ioballoc(false, IOBUSER_NET_6LOWPAN);
+  iob = net_ioballoc(false);
   DEBUGASSERT(iob != NULL);
 
   /* Initialize the IOB */
@@ -634,7 +634,7 @@ int sixlowpan_queue_frames(FAR struct radio_driver_s *radio,
            * necessary.
            */
 
-          iob = net_ioballoc(false, IOBUSER_NET_6LOWPAN);
+          iob = net_ioballoc(false);
           DEBUGASSERT(iob != NULL);
 
           /* Initialize the IOB */

--- a/net/sixlowpan/sixlowpan_input.c
+++ b/net/sixlowpan/sixlowpan_input.c
@@ -763,7 +763,7 @@ int sixlowpan_input(FAR struct radio_driver_s *radio,
 
       if (ret >= 0)
         {
-          iob_free(iob, IOBUSER_NET_6LOWPAN);
+          iob_free(iob);
         }
 
       /* Was the frame successfully processed? Is the packet in d_buf fully

--- a/net/tcp/tcp.h
+++ b/net/tcp/tcp.h
@@ -69,15 +69,12 @@
 #  define TCP_WBIOB(wrb)             ((wrb)->wb_iob)
 #  define TCP_WBCOPYOUT(wrb,dest,n)  (iob_copyout(dest,(wrb)->wb_iob,(n),0))
 #  define TCP_WBCOPYIN(wrb,src,n,off) \
-     (iob_copyin((wrb)->wb_iob,src,(n),(off),true,\
-                 IOBUSER_NET_TCP_WRITEBUFFER))
+     (iob_copyin((wrb)->wb_iob,src,(n),(off),true))
 #  define TCP_WBTRYCOPYIN(wrb,src,n,off) \
-     (iob_trycopyin((wrb)->wb_iob,src,(n),(off),true,\
-                    IOBUSER_NET_TCP_WRITEBUFFER))
+     (iob_trycopyin((wrb)->wb_iob,src,(n),(off),true))
 
 #  define TCP_WBTRIM(wrb,n) \
-     do { (wrb)->wb_iob = iob_trimhead((wrb)->wb_iob,(n),\
-                            IOBUSER_NET_TCP_WRITEBUFFER); } while (0)
+     do { (wrb)->wb_iob = iob_trimhead((wrb)->wb_iob,(n)); } while (0)
 
 #ifdef CONFIG_DEBUG_FEATURES
 #  define TCP_WBDUMP(msg,wrb,len,offset) \

--- a/net/tcp/tcp_callback.c
+++ b/net/tcp/tcp_callback.c
@@ -264,7 +264,7 @@ uint16_t tcp_datahandler(FAR struct tcp_conn_s *conn, FAR uint8_t *buffer,
 
       if (iob == NULL)
         {
-          iob = iob_tryalloc(throttled, IOBUSER_NET_TCP_READAHEAD);
+          iob = iob_tryalloc(throttled);
           if (iob == NULL)
             {
               continue;
@@ -278,8 +278,7 @@ uint16_t tcp_datahandler(FAR struct tcp_conn_s *conn, FAR uint8_t *buffer,
           uint32_t olen = iob->io_pktlen;
 
           ret = iob_trycopyin(iob, buffer + copied, buflen - copied,
-                              olen, throttled,
-                              IOBUSER_NET_TCP_READAHEAD);
+                              olen, throttled);
           copied += iob->io_pktlen - olen;
           if (ret < 0)
             {

--- a/net/tcp/tcp_conn.c
+++ b/net/tcp/tcp_conn.c
@@ -794,7 +794,7 @@ void tcp_free(FAR struct tcp_conn_s *conn)
 
   /* Release any read-ahead buffers attached to the connection */
 
-  iob_free_chain(conn->readahead, IOBUSER_NET_TCP_READAHEAD);
+  iob_free_chain(conn->readahead);
   conn->readahead = NULL;
 
 #ifdef CONFIG_NET_TCP_WRITE_BUFFERS

--- a/net/tcp/tcp_recvfrom.c
+++ b/net/tcp/tcp_recvfrom.c
@@ -270,7 +270,7 @@ static inline void tcp_readahead(struct tcp_recvfrom_s *pstate)
         {
           /* Free free the I/O buffer chain */
 
-          iob_free_chain(iob, IOBUSER_NET_TCP_READAHEAD);
+          iob_free_chain(iob);
           conn->readahead = NULL;
         }
       else
@@ -279,8 +279,7 @@ static inline void tcp_readahead(struct tcp_recvfrom_s *pstate)
            * buffer chain.
            */
 
-          conn->readahead = iob_trimhead(iob, recvlen,
-                                         IOBUSER_NET_TCP_READAHEAD);
+          conn->readahead = iob_trimhead(iob, recvlen);
         }
     }
 }

--- a/net/tcp/tcp_send_buffered.c
+++ b/net/tcp/tcp_send_buffered.c
@@ -1406,11 +1406,10 @@ ssize_t psock_tcp_send(FAR struct socket *psock, FAR const void *buf,
            * we risk a deadlock with other threads competing on IOBs.
            */
 
-          iob = net_iobtimedalloc(true, tcp_send_gettimeout(start, timeout),
-                                  IOBUSER_NET_TCP_WRITEBUFFER);
+          iob = net_iobtimedalloc(true, tcp_send_gettimeout(start, timeout));
           if (iob != NULL)
             {
-              iob_free_chain(iob, IOBUSER_NET_TCP_WRITEBUFFER);
+              iob_free_chain(iob);
             }
         }
 

--- a/net/tcp/tcp_wrbuffer.c
+++ b/net/tcp/tcp_wrbuffer.c
@@ -150,8 +150,7 @@ FAR struct tcp_wrbuffer_s *tcp_wrbuffer_timedalloc(unsigned int timeout)
 
   /* Now get the first I/O buffer for the write buffer structure */
 
-  wrb->wb_iob = net_iobtimedalloc(true, timeout,
-                                  IOBUSER_NET_TCP_WRITEBUFFER);
+  wrb->wb_iob = net_iobtimedalloc(true, timeout);
 
   /* Did we get an IOB?  We should always get one except under some really
    * weird error conditions.
@@ -234,7 +233,7 @@ void tcp_wrbuffer_release(FAR struct tcp_wrbuffer_s *wrb)
 
   if (wrb->wb_iob != NULL)
     {
-      iob_free_chain(wrb->wb_iob, IOBUSER_NET_TCP_WRITEBUFFER);
+      iob_free_chain(wrb->wb_iob);
     }
 
 #ifdef CONFIG_NET_TCP_FAST_RETRANSMIT

--- a/net/udp/udp_callback.c
+++ b/net/udp/udp_callback.c
@@ -87,7 +87,7 @@ static uint16_t udp_datahandler(FAR struct net_driver_s *dev,
   while (iob_get_queue_size(&conn->readahead) > conn->rcvbufs)
     {
       iob = iob_remove_queue(&conn->readahead);
-      iob_free_chain(iob, IOBUSER_NET_UDP_READAHEAD);
+      iob_free_chain(iob);
     }
 #endif
 
@@ -95,7 +95,7 @@ static uint16_t udp_datahandler(FAR struct net_driver_s *dev,
    * We will not wait for an I/O buffer to become available in this context.
    */
 
-  iob = iob_tryalloc(true, IOBUSER_NET_UDP_READAHEAD);
+  iob = iob_tryalloc(true);
   if (iob == NULL)
     {
       nerr("ERROR: Failed to create new I/O buffer chain\n");
@@ -172,7 +172,7 @@ static uint16_t udp_datahandler(FAR struct net_driver_s *dev,
    */
 
   ret = iob_trycopyin(iob, (FAR const uint8_t *)&src_addr_size,
-                      sizeof(uint8_t), 0, true, IOBUSER_NET_UDP_READAHEAD);
+                      sizeof(uint8_t), 0, true);
   if (ret < 0)
     {
       /* On a failure, iob_trycopyin return a negated error value but does
@@ -180,12 +180,12 @@ static uint16_t udp_datahandler(FAR struct net_driver_s *dev,
        */
 
       nerr("ERROR: Failed to add data to the I/O buffer chain: %d\n", ret);
-      iob_free_chain(iob, IOBUSER_NET_UDP_READAHEAD);
+      iob_free_chain(iob);
       return 0;
     }
 
   ret = iob_trycopyin(iob, (FAR const uint8_t *)src_addr, src_addr_size,
-                      sizeof(uint8_t), true, IOBUSER_NET_UDP_READAHEAD);
+                      sizeof(uint8_t), true);
   if (ret < 0)
     {
       /* On a failure, iob_trycopyin return a negated error value but does
@@ -193,7 +193,7 @@ static uint16_t udp_datahandler(FAR struct net_driver_s *dev,
        */
 
       nerr("ERROR: Failed to add data to the I/O buffer chain: %d\n", ret);
-      iob_free_chain(iob, IOBUSER_NET_UDP_READAHEAD);
+      iob_free_chain(iob);
       return 0;
     }
 
@@ -202,8 +202,7 @@ static uint16_t udp_datahandler(FAR struct net_driver_s *dev,
       /* Copy the new appdata into the I/O buffer chain */
 
       ret = iob_trycopyin(iob, buffer, buflen,
-                          src_addr_size + sizeof(uint8_t), true,
-                          IOBUSER_NET_UDP_READAHEAD);
+                          src_addr_size + sizeof(uint8_t), true);
       if (ret < 0)
         {
           /* On a failure, iob_trycopyin return a negated error value but
@@ -212,7 +211,7 @@ static uint16_t udp_datahandler(FAR struct net_driver_s *dev,
 
           nerr("ERROR: Failed to add data to the I/O buffer chain: %d\n",
                ret);
-          iob_free_chain(iob, IOBUSER_NET_UDP_READAHEAD);
+          iob_free_chain(iob);
           return 0;
         }
     }
@@ -223,7 +222,7 @@ static uint16_t udp_datahandler(FAR struct net_driver_s *dev,
   if (ret < 0)
     {
       nerr("ERROR: Failed to queue the I/O buffer chain: %d\n", ret);
-      iob_free_chain(iob, IOBUSER_NET_UDP_READAHEAD);
+      iob_free_chain(iob);
       return 0;
     }
 

--- a/net/udp/udp_conn.c
+++ b/net/udp/udp_conn.c
@@ -677,7 +677,7 @@ void udp_free(FAR struct udp_conn_s *conn)
 
   /* Release any read-ahead buffers attached to the connection */
 
-  iob_free_queue(&conn->readahead, IOBUSER_NET_UDP_READAHEAD);
+  iob_free_queue(&conn->readahead);
 
 #ifdef CONFIG_NET_UDP_WRITE_BUFFERS
   /* Release any write buffers attached to the connection */

--- a/net/udp/udp_recvfrom.c
+++ b/net/udp/udp_recvfrom.c
@@ -262,7 +262,7 @@ out:
 
       /* And free the I/O buffer chain */
 
-      iob_free_chain(iob, IOBUSER_NET_UDP_READAHEAD);
+      iob_free_chain(iob);
     }
 }
 

--- a/net/udp/udp_sendto_buffered.c
+++ b/net/udp/udp_sendto_buffered.c
@@ -749,8 +749,8 @@ ssize_t psock_udp_sendto(FAR struct socket *psock, FAR const void *buf,
 
       if (nonblock)
         {
-          ret = iob_trycopyin(wrb->wb_iob, (FAR uint8_t *)buf, len, 0, false,
-                              IOBUSER_NET_SOCK_UDP);
+          ret = iob_trycopyin(wrb->wb_iob, (FAR uint8_t *)buf,
+                              len, 0, false);
         }
       else
         {
@@ -763,8 +763,7 @@ ssize_t psock_udp_sendto(FAR struct socket *psock, FAR const void *buf,
            */
 
           blresult = net_breaklock(&count);
-          ret = iob_copyin(wrb->wb_iob, (FAR uint8_t *)buf, len, 0, false,
-                           IOBUSER_NET_SOCK_UDP);
+          ret = iob_copyin(wrb->wb_iob, (FAR uint8_t *)buf, len, 0, false);
           if (blresult >= 0)
             {
               net_restorelock(count);

--- a/net/udp/udp_wrbuffer.c
+++ b/net/udp/udp_wrbuffer.c
@@ -144,7 +144,7 @@ FAR struct udp_wrbuffer_s *udp_wrbuffer_alloc(void)
 
   /* Now get the first I/O buffer for the write buffer structure */
 
-  wrb->wb_iob = net_ioballoc(false, IOBUSER_NET_UDP_WRITEBUFFER);
+  wrb->wb_iob = net_ioballoc(false);
   if (!wrb->wb_iob)
     {
       nerr("ERROR: Failed to allocate I/O buffer\n");
@@ -202,8 +202,7 @@ FAR struct udp_wrbuffer_s *udp_wrbuffer_timedalloc(unsigned int timeout)
 
   /* Now get the first I/O buffer for the write buffer structure */
 
-  wrb->wb_iob = net_iobtimedalloc(true, timeout,
-                                  IOBUSER_NET_UDP_WRITEBUFFER);
+  wrb->wb_iob = net_iobtimedalloc(true, timeout);
 
   /* Did we get an IOB?  We should always get one except under some really
    * weird error conditions.
@@ -264,7 +263,7 @@ FAR struct udp_wrbuffer_s *udp_wrbuffer_tryalloc(void)
 
   /* Now get the first I/O buffer for the write buffer structure */
 
-  wrb->wb_iob = iob_tryalloc(false, IOBUSER_NET_UDP_WRITEBUFFER);
+  wrb->wb_iob = iob_tryalloc(false);
   if (!wrb->wb_iob)
     {
       nerr("ERROR: Failed to allocate I/O buffer\n");
@@ -298,7 +297,7 @@ void udp_wrbuffer_release(FAR struct udp_wrbuffer_s *wrb)
 
   if (wrb->wb_iob)
     {
-      iob_free_chain(wrb->wb_iob, IOBUSER_NET_UDP_WRITEBUFFER);
+      iob_free_chain(wrb->wb_iob);
     }
 
   /* Then free the write buffer structure */

--- a/net/utils/net_lock.c
+++ b/net/utils/net_lock.c
@@ -446,7 +446,6 @@ int net_lockedwait_uninterruptible(sem_t *sem)
  * Input Parameters:
  *   throttled  - An indication of the IOB allocation is "throttled"
  *   timeout    - The relative time to wait until a timeout is declared.
- *   consumerid - id representing who is consuming the IOB
  *
  * Returned Value:
  *   A pointer to the newly allocated IOB is returned on success.  NULL is
@@ -454,12 +453,11 @@ int net_lockedwait_uninterruptible(sem_t *sem)
  *
  ****************************************************************************/
 
-FAR struct iob_s *net_iobtimedalloc(bool throttled, unsigned int timeout,
-                                    enum iob_user_e consumerid)
+FAR struct iob_s *net_iobtimedalloc(bool throttled, unsigned int timeout)
 {
   FAR struct iob_s *iob;
 
-  iob = iob_tryalloc(throttled, consumerid);
+  iob = iob_tryalloc(throttled);
   if (iob == NULL && timeout != 0)
     {
       unsigned int count;
@@ -470,7 +468,7 @@ FAR struct iob_s *net_iobtimedalloc(bool throttled, unsigned int timeout,
        */
 
       blresult = net_breaklock(&count);
-      iob      = iob_timedalloc(throttled, timeout, consumerid);
+      iob      = iob_timedalloc(throttled, timeout);
       if (blresult >= 0)
         {
           net_restorelock(count);
@@ -494,7 +492,6 @@ FAR struct iob_s *net_iobtimedalloc(bool throttled, unsigned int timeout,
  *
  * Input Parameters:
  *   throttled  - An indication of the IOB allocation is "throttled"
- *   consumerid - id representing who is consuming the IOB
  *
  * Returned Value:
  *   A pointer to the newly allocated IOB is returned on success.  NULL is
@@ -502,8 +499,8 @@ FAR struct iob_s *net_iobtimedalloc(bool throttled, unsigned int timeout,
  *
  ****************************************************************************/
 
-FAR struct iob_s *net_ioballoc(bool throttled, enum iob_user_e consumerid)
+FAR struct iob_s *net_ioballoc(bool throttled)
 {
-  return net_iobtimedalloc(throttled, UINT_MAX, consumerid);
+  return net_iobtimedalloc(throttled, UINT_MAX);
 }
 #endif

--- a/wireless/bluetooth/bt_buf.c
+++ b/wireless/bluetooth/bt_buf.c
@@ -343,7 +343,7 @@ FAR struct bt_buf_s *bt_buf_alloc(enum bt_buf_type_e type,
        * available buffers.
        */
 
-      buf->frame = iob_alloc(false, IOBUSER_WIRELESS_BLUETOOTH);
+      buf->frame = iob_alloc(false);
       if (!buf->frame)
         {
           wlerr("ERROR:  Failed to allocate an IOB\n");
@@ -408,7 +408,7 @@ void bt_buf_release(FAR struct bt_buf_s *buf)
 
   if (buf->frame != NULL)
     {
-      iob_free(buf->frame, IOBUSER_WIRELESS_BLUETOOTH);
+      iob_free(buf->frame);
       buf->frame = NULL;
     }
 

--- a/wireless/bluetooth/bt_netdev.c
+++ b/wireless/bluetooth/bt_netdev.c
@@ -422,7 +422,7 @@ drop:
 
   if (ret < 0)
     {
-      iob_free(frame, IOBUSER_WIRELESS_BLUETOOTH);
+      iob_free(frame);
 
       /* Increment statistics */
 
@@ -573,7 +573,7 @@ drop:
 
   if (ret < 0)
     {
-      iob_free(frame, IOBUSER_WIRELESS_BLUETOOTH);
+      iob_free(frame);
 
       /* Increment statistics */
 

--- a/wireless/ieee802154/mac802154.c
+++ b/wireless/ieee802154/mac802154.c
@@ -242,7 +242,7 @@ void mac802154_createdatareq(FAR struct ieee802154_privmac_s *priv,
 
   /* Allocate an IOB to put the frame in */
 
-  iob = iob_alloc(false, IOBUSER_WIRELESS_MAC802154);
+  iob = iob_alloc(false);
   DEBUGASSERT(iob != NULL);
 
   iob->io_flink  = NULL;
@@ -417,8 +417,7 @@ static void mac802154_notify_worker(FAR void *arg)
 
           if (dispose)
             {
-              iob_free(primitive->u.dataind.frame,
-                       IOBUSER_WIRELESS_MAC802154);
+              iob_free(primitive->u.dataind.frame);
               ieee802154_primitive_free(primitive);
             }
         }
@@ -751,7 +750,7 @@ static void mac802154_purge_worker(FAR void *arg)
 
           /* Free the IOB, the notification, and the tx descriptor */
 
-          iob_free(txdesc->frame, IOBUSER_WIRELESS_MAC802154);
+          iob_free(txdesc->frame);
           ieee802154_primitive_free((FAR struct ieee802154_primitive_s *)
                                     txdesc->conf);
           mac802154_txdesc_free(priv, txdesc);
@@ -992,7 +991,7 @@ static void mac802154_txdone_worker(FAR void *arg)
 
       /* Free the IOB and the tx descriptor */
 
-      iob_free(txdesc->frame, IOBUSER_WIRELESS_MAC802154);
+      iob_free(txdesc->frame);
       mac802154_txdesc_free(priv, txdesc);
     }
 
@@ -1533,7 +1532,7 @@ static void mac802154_rxdatareq(FAR struct ieee802154_privmac_s *priv,
 
   /* Allocate an IOB to put the frame in */
 
-  iob = iob_alloc(false, IOBUSER_WIRELESS_MAC802154);
+  iob = iob_alloc(false);
   DEBUGASSERT(iob != NULL);
 
   iob->io_flink  = NULL;

--- a/wireless/ieee802154/mac802154_assoc.c
+++ b/wireless/ieee802154/mac802154_assoc.c
@@ -132,7 +132,7 @@ int mac802154_req_associate(MACHANDLE mac,
 
   /* Allocate an IOB to put the frame in */
 
-  iob = iob_alloc(false, IOBUSER_WIRELESS_MAC802154);
+  iob = iob_alloc(false);
   DEBUGASSERT(iob != NULL);
 
   iob->io_flink  = NULL;
@@ -145,7 +145,7 @@ int mac802154_req_associate(MACHANDLE mac,
   ret = mac802154_txdesc_alloc(priv, &txdesc, true);
   if (ret < 0)
     {
-      iob_free(iob, IOBUSER_WIRELESS_MAC802154);
+      iob_free(iob);
       mac802154_unlock(priv)
       mac802154_givesem(&priv->opsem);
       return ret;
@@ -325,7 +325,7 @@ int mac802154_resp_associate(MACHANDLE mac,
 
   /* Allocate an IOB to put the frame in */
 
-  iob = iob_alloc(false, IOBUSER_WIRELESS_MAC802154);
+  iob = iob_alloc(false);
   DEBUGASSERT(iob != NULL);
 
   iob->io_flink  = NULL;
@@ -401,7 +401,7 @@ int mac802154_resp_associate(MACHANDLE mac,
   ret = mac802154_lock(priv, true);
   if (ret < 0)
     {
-      iob_free(iob, IOBUSER_WIRELESS_MAC802154);
+      iob_free(iob);
       return ret;
     }
 
@@ -410,7 +410,7 @@ int mac802154_resp_associate(MACHANDLE mac,
   ret = mac802154_txdesc_alloc(priv, &txdesc, true);
   if (ret < 0)
     {
-      iob_free(iob, IOBUSER_WIRELESS_MAC802154);
+      iob_free(iob);
       mac802154_unlock(priv)
       return ret;
     }

--- a/wireless/ieee802154/mac802154_device.c
+++ b/wireless/ieee802154/mac802154_device.c
@@ -479,7 +479,7 @@ static ssize_t mac802154dev_read(FAR struct file *filep, FAR char *buffer,
 
   /* Free the IOB */
 
-  iob_free(ind->frame, IOBUSER_WIRELESS_MAC802154_CHARDEV);
+  iob_free(ind->frame);
 
   /* Deallocate the data indication */
 
@@ -525,7 +525,7 @@ static ssize_t mac802154dev_write(FAR struct file *filep,
 
   /* Allocate an IOB to put the frame in */
 
-  iob = iob_alloc(false, IOBUSER_WIRELESS_MAC802154_CHARDEV);
+  iob = iob_alloc(false);
   DEBUGASSERT(iob != NULL);
 
   iob->io_flink  = NULL;
@@ -554,7 +554,7 @@ static ssize_t mac802154dev_write(FAR struct file *filep,
   ret = mac802154_req_data(dev->md_mac, &tx->meta, iob, true);
   if (ret < 0)
     {
-      iob_free(iob, IOBUSER_WIRELESS_MAC802154_CHARDEV);
+      iob_free(iob);
       wlerr("ERROR: req_data failed %d\n", ret);
       return ret;
     }

--- a/wireless/ieee802154/mac802154_netdev.c
+++ b/wireless/ieee802154/mac802154_netdev.c
@@ -1117,13 +1117,13 @@ static int macnet_req_data(FAR struct radio_driver_s *netdev,
         {
           wlerr("ERROR: mac802154_req_data failed: %d\n", ret);
 
-          iob_free(iob, IOBUSER_WIRELESS_MAC802154_NETDEV);
+          iob_free(iob);
           for (iob = framelist; iob != NULL; iob = framelist)
             {
               /* Remove the IOB from the queue and free */
 
               framelist = iob->io_flink;
-              iob_free(iob, IOBUSER_WIRELESS_MAC802154_NETDEV);
+              iob_free(iob);
             }
 
           NETDEV_TXERRORS(&priv->md_dev.r_dev);


### PR DESCRIPTION
## Summary
since it is impossible to track producer and consumer correctly if TCP/IP stack pass IOB directly to netdev
See the related PR https://github.com/apache/incubator-nuttx/pull/6834 and Issue https://github.com/apache/incubator-nuttx/issues/6835

## Impact
Simplify the IOB statistics information

## Testing
sim:sixlowpan
