### PR TITLE
sim: Fix the /etc/passwd after TEA algo fixing

### DIFF
--- a/boards/sim/sim/sim/src/etc/passwd
+++ b/boards/sim/sim/sim/src/etc/passwd
@@ -1,1 +1,1 @@
-admin:8Tv+Hbmr3pLddSjtzL0kwC:0:0:/
+admin:8Tv+Hbmr3pLVb5HHZgd26D:0:0:/


### PR DESCRIPTION
## Summary
After TEA fixing https://github.com/apache/incubator-nuttx-apps/pull/1097 the Console Login to SIM stopped to work.
## Impact
It makes sim nsh board profile work again
## Testing
sim
