### PR TITLE
esp32c3-devkit: Fix /etc/passwd too

### DIFF
--- a/boards/risc-v/esp32c3/esp32c3-devkit/src/etc/passwd
+++ b/boards/risc-v/esp32c3/esp32c3-devkit/src/etc/passwd
@@ -1,1 +1,1 @@
-admin:8Tv+Hbmr3pLddSjtzL0kwC:0:0:/
+admin:8Tv+Hbmr3pLVb5HHZgd26D:0:0:/


### PR DESCRIPTION
## Summary
Fix /etc/passwd too
## Impact
Users could login on ESP32-C3 nsh> when login is activated
## Testing
N/A
