### PR TITLE
arch: qemu-rv: Fix high CPU usage in SMP mode

### DIFF
--- a/arch/risc-v/src/qemu-rv/qemu_rv_head.S
+++ b/arch/risc-v/src/qemu-rv/qemu_rv_head.S
@@ -52,13 +52,21 @@ __start:
   j    2f
 1:
 
-  /* In case of single CPU config, stop here */
+  /* Load the number of CPUs that the kernel supports */
 
-#if !defined(CONFIG_SMP) || (CONFIG_SMP_NCPUS == 1)
-  csrw mie, zero
-  wfi
+#ifdef CONFIG_SMP
+  li   t1, CONFIG_SMP_NCPUS
+#else
+  li   t1, 1
 #endif
 
+  /* If a0 (mhartid) >= t1 (the number of CPUs), stop here */
+
+  blt  a0, t1, 3f
+  csrw mie, zero
+  wfi
+
+3:
   /* To get g_cpu_basestack[mhartid], must get g_cpu_basestack first */
 
   la   t0, g_cpu_basestack


### PR DESCRIPTION
## Summary

- I noticed that QEMU shows high CPU usage if the number of
  CPUs does not match the kernel configuration. (e.g. -smp 8
  and CONFIG_SMP_NCPUS=2)
- This commit fixes this issue.

## Impact

- qemu-rv only

## Testing

- Tested with the following configs
  - rv-virt:smp64 (CONFIG_NCPUS=1/2/8)
  - rv-virt:nsh64

