### PR TITLE
drivers/leds/ws2812: Revert SPI frequency change

### DIFF
--- a/drivers/leds/Kconfig
+++ b/drivers/leds/Kconfig
@@ -148,9 +148,13 @@ config WS2812_FREQUENCY
 	default 800000
 	depends on WS2812
 	---help---
-		This is should be set to the bit frequency of the
-		ws2812s being used.  Newer chips use an 800 kHz
-		bit frequency (the default); although, some older
-		chips run at 400 kHz.
+		Frequency in Hz.
+		On SPI mode (WS2812_NON_SPI_DRIVER not selected), this is
+		the SPI frequency (commonly a few MHz) to generate the required
+		waveforms to represent a 0/1 symbol.
+		On non SPI mode (WS2812_NON_SPI_DRIVER selected), this should be set
+		to the bit frequency of the ws2812s being used. Newer chips use an
+		800 kHz bit frequency (the default); although, some older chips run
+		at 400 kHz.
 		
 endmenu # LED Support

--- a/drivers/leds/ws2812.c
+++ b/drivers/leds/ws2812.c
@@ -78,10 +78,10 @@
  * Reset: low signal >50us
  */
 
-#if CONFIG_WS2812_FREQUENCY >= 360000 && CONFIG_WS2812_FREQUENCY <= 500000
+#if CONFIG_WS2812_FREQUENCY >= 3600000 && CONFIG_WS2812_FREQUENCY <= 5000000
 #  define WS2812_ZERO_BYTE  0b01000000 /* 200ns at 5 MHz, 278ns at 3.6 MHz */
 #  define WS2812_ONE_BYTE   0b01110000 /* 600ns at 5 MHz, 833ns at 3.6 MHz */
-#elif CONFIG_WS2812_FREQUENCY >= 590000 && CONFIG_WS2812_FREQUENCY <= 900000
+#elif CONFIG_WS2812_FREQUENCY >= 5900000 && CONFIG_WS2812_FREQUENCY <= 9000000
 #  define WS2812_ZERO_BYTE  0b01100000 /* 222ns at 9 MHz, 339ns at 5.9 MHz */
 #  define WS2812_ONE_BYTE   0b01111100 /* 556ns at 9 MHz, 847ns at 5.9 MHz */
 #else
@@ -93,7 +93,7 @@
  * Aiming for 60 us, safely above the 50us required.
  */
 
-#define WS2812_RST_CYCLES (CONFIG_WS2812_FREQUENCY * 60 / 100000 / 8)
+#define WS2812_RST_CYCLES (CONFIG_WS2812_FREQUENCY * 60 / 1000000 / 8)
 
 #define WS2812_BYTES_PER_LED  (8 * 3)
 
@@ -389,7 +389,7 @@ static inline void ws2812_configspi(FAR struct spi_dev_s *spi)
   SPI_SETMODE(spi, SPIDEV_MODE3);
   SPI_SETBITS(spi, 8);
   SPI_HWFEATURES(spi, 0);
-  SPI_SETFREQUENCY(spi, 10 * CONFIG_WS2812_FREQUENCY);
+  SPI_SETFREQUENCY(spi, CONFIG_WS2812_FREQUENCY);
 }
 
 /****************************************************************************


### PR DESCRIPTION
## Summary

https://github.com/apache/incubator-nuttx/commit/0c3db448bb64c8877a4dfa62416027b24a639a8e added the option to generate the waveforms to drive ws2812 and similar LEDs using different hardware (e.g. RP2040 PIO instead of SPI).

For that new mode, the concept of CONFIG_WS2812_FREQUENCY is different. Instead of the SPI frequency (commonly a few MHz), it is the frequency of the actual output waveform (commonly 400 or 800 kHz).

There was an attempt to express the SPI frequency divided by 10, but it's not actually the case either (it would be divided by 8).

I think it is clearer to explain in Kconfig what CONFIG_WS2812_FREQUENCY means for each mode and go back to the previous behaviour for the original SPI mode (also to avoid breaking out-of-tree boards).

## Impact
ws2812 driver only. And only for the original SPI mode.
It restores the previous behaviour of the driver, so this, in fact, avoids impact for out-of-tree boards.

## Testing
I don't have the custom board that I normally use at hand today to test it, but this should only revert the previous behaviour.

Thanks!
