### PR TITLE
arch/sim: Remove up_smpsignal.o and up_touchscreen.o from REQUIREDOBJS

### DIFF
--- a/arch/sim/src/Makefile
+++ b/arch/sim/src/Makefile
@@ -109,7 +109,6 @@ endif
 
 ifeq ($(CONFIG_SMP),y)
   CSRCS += up_smpsignal.c up_cpuidlestack.c
-  REQUIREDOBJS += up_smpsignal$(OBJEXT)
   HOSTSRCS += up_simsmp.c
 endif
 
@@ -132,7 +131,6 @@ ifeq ($(CONFIG_SIM_X11FB),y)
   STDLIBS += -lX11 -lXext
 ifeq ($(CONFIG_SIM_TOUCHSCREEN),y)
   CSRCS += up_touchscreen.c
-  REQUIREDOBJS += up_touchscreen$(OBJEXT)
   HOSTSRCS += up_x11eventloop.c
 else ifeq ($(CONFIG_SIM_AJOYSTICK),y)
   CSRCS += up_ajoystick.c


### PR DESCRIPTION
## Summary
since it isn't required anymore

## Impact
Minor

## Testing
Pass CI
