### PR TITLE
wireless: Add ioctl cmd to setting PTA prio

### DIFF
--- a/include/nuttx/wireless/wireless.h
+++ b/include/nuttx/wireless/wireless.h
@@ -145,6 +145,11 @@
 #define SIOCSIWCOUNTRY      _WLIOC(0x0037)  /* Set country code */
 #define SIOCGIWCOUNTRY      _WLIOC(0x0038)  /* Get country code */
 
+/* WIFI / BT coexist type */
+
+#define SIOCSIWPTAPRIO      _WLIOC(0x0039)  /* Set PTA priority type */
+#define SIOCGIWPTAPRIO      _WLIOC(0x003a)  /* Get PTA priority type */
+
 #define WL_IS80211POINTERCMD(cmd) ((cmd) == SIOCGIWSCAN || \
                                    (cmd) == SIOCSIWSCAN || \
                                    (cmd) == SIOCSIWCOUNTRY || \
@@ -158,7 +163,7 @@
 /* Device-specific network IOCTL commands *******************************************/
 
 #define WL_NETFIRST         0x0000          /* First network command */
-#define WL_NNETCMDS         0x0039          /* Number of network commands */
+#define WL_NNETCMDS         0x003b          /* Number of network commands */
 
 /* Reserved for Bluetooth network devices (see bt_ioctls.h) */
 
@@ -396,6 +401,14 @@
 #define IW_ENCODE_ALG_CCMP           3
 #define IW_ENCODE_ALG_PMK            4
 #define IW_ENCODE_ALG_AES_CMAC       5
+
+/* IW_COEX_PTA_PRIORITY values */
+
+#define IW_PTA_PRIORITY_COEX_MAXIMIZED 0
+#define IW_PTA_PRIORITY_COEX_HIGH      1
+#define IW_PTA_PRIORITY_BALANCED       2
+#define IW_PTA_PRIORITY_WLAN_HIGH      3
+#define IW_PTA_PRIORITY_WLAN_MAXIMIZED 4
 
 /************************************************************************************
  * Public Types


### PR DESCRIPTION
info:
https://docs.silabs.com/wifi/wf200/content-source/application-note/wifi-coexistence#pta-state-request

Is the PTA priority enumeration type sufficient?

## Summary

## Impact

## Testing

