### PR TITLE
Added extern C {} wrapper consistent with other headers in include/sys

### DIFF
--- a/include/sys/utsname.h
+++ b/include/sys/utsname.h
@@ -73,9 +73,27 @@ struct utsname
 };
 
 /****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#undef EXTERN
+#if defined(__cplusplus)
+#define EXTERN extern "C"
+extern "C"
+{
+#else
+#define EXTERN extern
+#endif
+
+/****************************************************************************
  * Public Function Prototypes
  ****************************************************************************/
 
 int uname(FAR struct utsname *name);
+
+#undef EXTERN
+#if defined(__cplusplus)
+}
+#endif
 
 #endif /* __INCLUDE_SYS_UTSNAME_H */


### PR DESCRIPTION
## Summary
Added a call to uname() from a c++ application and got a linker error for undefined reference to uname()
```bash
LD: nuttx
arm-none-eabi-ld: ... ): in function `helloxx_main':
helloxx_main.cxx:(.text.helloxx_main+0x42): undefined reference to `uname(utsname*)'
make[1]: *** [Makefile:159: nuttx] Error 1
make[1]: Leaving directory ' ...'
make: *** [tools/Unix.mk:509: nuttx] Error 2
```

Found that the uname() function was part of the libc.a generated by our project and investigated this header file and found that it was not set up to allow linkage from a c++ file. Also noticed that this was the only header in the include/sys folder with no extern C {} wrapper for function prototypes. 

## Impact
Unable to call uname() from a c++ program

## Testing
This change, when applied to our product code, compiled cleanly and the uname() API worked as expected.

