### PR TITLE
rpmsgfs: fix ioctl operation can not work bug

### DIFF
--- a/fs/rpmsgfs/rpmsgfs_client.c
+++ b/fs/rpmsgfs/rpmsgfs_client.c
@@ -176,7 +176,7 @@ static int rpmsgfs_ioctl_handler(FAR struct rpmsg_endpoint *ept,
 
   if (cookie->result >= 0 && rsp->arglen > 0)
     {
-      memcpy(cookie->data, (FAR void *)(uintptr_t)rsp->arg, rsp->arglen);
+      memcpy(cookie->data, (FAR void *)(uintptr_t)rsp->buf, rsp->arglen);
     }
 
   rpmsg_post(ept, &cookie->sem);

--- a/fs/rpmsgfs/rpmsgfs_server.c
+++ b/fs/rpmsgfs/rpmsgfs_server.c
@@ -480,7 +480,7 @@ static int rpmsgfs_ioctl_handler(FAR struct rpmsg_endpoint *ept,
     }
 
   msg->header.result = ret;
-  return rpmsg_send(ept, msg, sizeof(*msg));
+  return rpmsg_send(ept, msg, len);
 }
 
 static int rpmsgfs_sync_handler(FAR struct rpmsg_endpoint *ept,


### PR DESCRIPTION
Signed-off-by: wangbowen6 <wangbowen6@xiaomi.com>

## Summary
old rpmsgfs ioctl implement is wrong.

## Impact
rpmsgfs

## Testing
local test
