### PR TITLE
fs/rpmsgfs: fix double free

### DIFF
--- a/fs/rpmsgfs/rpmsgfs.c
+++ b/fs/rpmsgfs/rpmsgfs.c
@@ -911,7 +911,6 @@ static int rpmsgfs_opendir(FAR struct inode *mountpt,
   if (rdir->dir == NULL)
     {
       ret = -ENOENT;
-      kmm_free(rdir);
       goto errout_with_semaphore;
     }
 


### PR DESCRIPTION


## Summary
fs/rpmsgfs: fix double free

Signed-off-by: Jiuzhu Dong <dongjiuzhu1@xiaomi.com>
## Impact
N/A
## Testing
local test
