### PR TITLE
sched: Simplify the cpuload process

### DIFF
--- a/include/nuttx/arch.h
+++ b/include/nuttx/arch.h
@@ -2232,31 +2232,6 @@ void nxsched_alarm_expiration(FAR const struct timespec *ts);
 #endif
 
 /****************************************************************************
- * Name: nxsched_process_cpuload
- *
- * Description:
- *   Collect data that can be used for CPU load measurements.  When
- *   CONFIG_SCHED_CPULOAD_EXTCLK is defined, this is an exported interface,
- *   use the the external clock logic.  Otherwise, it is an OS internal
- *   interface.
- *
- * Input Parameters:
- *   None
- *
- * Returned Value:
- *   None
- *
- * Assumptions/Limitations:
- *   This function is called from a timer interrupt handler with all
- *   interrupts disabled.
- *
- ****************************************************************************/
-
-#if defined(CONFIG_SCHED_CPULOAD) && defined(CONFIG_SCHED_CPULOAD_EXTCLK)
-void weak_function nxsched_process_cpuload(void);
-#endif
-
-/****************************************************************************
  * Name: nxsched_process_cpuload_ticks
  *
  * Description:
@@ -2278,7 +2253,8 @@ void weak_function nxsched_process_cpuload(void);
  ****************************************************************************/
 
 #if defined(CONFIG_SCHED_CPULOAD) && defined(CONFIG_SCHED_CPULOAD_EXTCLK)
-void weak_function nxsched_process_cpuload_ticks(uint32_t ticks);
+void nxsched_process_cpuload_ticks(uint32_t ticks);
+#  define nxsched_process_cpuload() nxsched_process_cpuload_ticks(1)
 #endif
 
 /****************************************************************************

--- a/sched/Kconfig
+++ b/sched/Kconfig
@@ -821,7 +821,7 @@ config SCHED_CPULOAD_EXTCLK
 		achieved.  This option enables use of such an "external" clock.  The
 		implementation of the clock must be provided by platform-specific
 		logic; that platform-specific logic must call the system function
-		nxsched_process_cpuload() at each timer expiration with interrupts
+		nxsched_process_cpuload_ticks() at each timer expiration with interrupts
 		disabled.
 
 if SCHED_CPULOAD_EXTCLK

--- a/sched/sched/sched.h
+++ b/sched/sched/sched.h
@@ -386,11 +386,17 @@ int  nxsched_pause_cpu(FAR struct tcb_s *tcb);
 #  define nxsched_islocked_tcb(tcb) ((tcb)->lockcount > 0)
 #endif
 
-#if defined(CONFIG_SCHED_CPULOAD) && !defined(CONFIG_SCHED_CPULOAD_EXTCLK)
+#ifndef CONFIG_SCHED_CPULOAD_EXTCLK
+
 /* CPU load measurement support */
 
-void weak_function nxsched_process_cpuload(void);
-void weak_function nxsched_process_cpuload_ticks(uint32_t ticks);
+#  ifdef CONFIG_SCHED_CPULOAD
+void nxsched_process_cpuload_ticks(uint32_t ticks);
+#  else
+#    define nxsched_process_cpuload_ticks(ticks)
+#  endif
+
+#  define nxsched_process_cpuload() nxsched_process_cpuload_ticks(1)
 #endif
 
 /* Critical section monitor */

--- a/sched/sched/sched_cpuload.c
+++ b/sched/sched/sched_cpuload.c
@@ -123,32 +123,6 @@ static inline void nxsched_cpu_process_cpuload(int cpu, uint32_t ticks)
  ****************************************************************************/
 
 /****************************************************************************
- * Name: nxsched_process_cpuload
- *
- * Description:
- *   Collect data that can be used for CPU load measurements.  When
- *   CONFIG_SCHED_CPULOAD_EXTCLK is defined, this is an exported interface,
- *   use the the external clock logic.  Otherwise, it is an OS Internal
- *   interface.
- *
- * Input Parameters:
- *   None
- *
- * Returned Value:
- *   None
- *
- * Assumptions/Limitations:
- *   This function is called from a timer interrupt handler with all
- *   interrupts disabled.
- *
- ****************************************************************************/
-
-void weak_function nxsched_process_cpuload(void)
-{
-  nxsched_process_cpuload_ticks(1);
-}
-
-/****************************************************************************
  * Name: nxsched_process_cpuload_ticks
  *
  * Description:
@@ -169,7 +143,7 @@ void weak_function nxsched_process_cpuload(void)
  *
  ****************************************************************************/
 
-void weak_function nxsched_process_cpuload_ticks(uint32_t ticks)
+void nxsched_process_cpuload_ticks(uint32_t ticks)
 {
   int i;
   irqstate_t flags;

--- a/sched/sched/sched_cpuload_oneshot.c
+++ b/sched/sched/sched_cpuload_oneshot.c
@@ -226,12 +226,7 @@ static void nxsched_oneshot_callback(FAR struct oneshot_lowerhalf_s *lower,
 {
   /* Perform CPU load measurements */
 
-#ifdef CONFIG_HAVE_WEAKFUNCTIONS
-  if (nxsched_process_cpuload != NULL)
-#endif
-    {
-      nxsched_process_cpuload();
-    }
+  nxsched_process_cpuload();
 
   /* Then restart the oneshot */
 

--- a/sched/sched/sched_cpuload_period.c
+++ b/sched/sched/sched_cpuload_period.c
@@ -187,12 +187,7 @@ static bool nxsched_period_callback(FAR uint32_t *next_interval_us,
 
   /* Perform CPU load measurements */
 
-#ifdef CONFIG_HAVE_WEAKFUNCTIONS
-  if (nxsched_process_cpuload != NULL)
-#endif
-    {
-      nxsched_process_cpuload();
-    }
+  nxsched_process_cpuload();
 
   /* Then continue the timing */
 

--- a/sched/sched/sched_processtimer.c
+++ b/sched/sched/sched_processtimer.c
@@ -225,18 +225,11 @@ void nxsched_process_timer(void)
       clock_timer();
     }
 
-#if defined(CONFIG_SCHED_CPULOAD) && !defined(CONFIG_SCHED_CPULOAD_EXTCLK)
   /* Perform CPU load measurements (before any timer-initiated context
    * switches can occur)
    */
 
-#ifdef CONFIG_HAVE_WEAKFUNCTIONS
-  if (nxsched_process_cpuload != NULL)
-#endif
-    {
-      nxsched_process_cpuload();
-    }
-#endif
+  nxsched_process_cpuload();
 
   /* Check if the currently executing task has exceeded its
    * timeslice.

--- a/sched/sched/sched_timerexpiration.c
+++ b/sched/sched/sched_timerexpiration.c
@@ -382,18 +382,11 @@ static unsigned int nxsched_timer_process(unsigned int ticks,
   clock_update_wall_time();
 #endif
 
-#if defined(CONFIG_SCHED_CPULOAD) && !defined(CONFIG_SCHED_CPULOAD_EXTCLK)
   /* Perform CPU load measurements (before any timer-initiated context
    * switches can occur)
    */
 
-#ifdef CONFIG_HAVE_WEAKFUNCTIONS
-  if (nxsched_process_cpuload_ticks != NULL)
-#endif
-    {
-      nxsched_process_cpuload_ticks(ticks);
-    }
-#endif
+  nxsched_process_cpuload_ticks(ticks);
 
   /* Process watchdogs */
 


### PR DESCRIPTION
## Summary
1.Forward nxsched_process_cpuload to nxsched_process_cpuload_ticks directly
2.Define the dummy nxsched_process_cpuload_ticks when CPULOAD isn't enabled
3.Remove the weak attribute from nxsched_process_cpuload_ticks

## Impact
Code refactor only

## Testing
Pass CI
