### PR TITLE
sched: fix visual studio Compiler Warning (level 4) C4189 

### DIFF
--- a/sched/group/group_setupidlefiles.c
+++ b/sched/group/group_setupidlefiles.c
@@ -58,12 +58,11 @@
 
 int group_setupidlefiles(FAR struct task_tcb_s *tcb)
 {
-  FAR struct task_group_s *group = tcb->cmn.group;
 #ifdef CONFIG_DEV_CONSOLE
   int fd;
 #endif
 
-  DEBUGASSERT(group != NULL);
+  DEBUGASSERT(tcb->cmn.group != NULL);
 
   /* Open stdin, dup to get stdout and stderr. This should always
    * be the first file opened and, hence, should always get file

--- a/sched/pthread/pthread_create.c
+++ b/sched/pthread/pthread_create.c
@@ -151,9 +151,8 @@ static inline void pthread_addjoininfo(FAR struct task_group_s *group,
 static void pthread_start(void)
 {
   FAR struct pthread_tcb_s *ptcb = (FAR struct pthread_tcb_s *)this_task();
-  FAR struct join_s *pjoin = (FAR struct join_s *)ptcb->joininfo;
 
-  DEBUGASSERT(pjoin != NULL);
+  DEBUGASSERT(ptcb->joininfo != NULL);
 
   /* The priority of this thread may have been boosted to avoid priority
    * inversion problems.  If that is the case, then drop to the correct


### PR DESCRIPTION

## Summary

sched: fix visual studio Compiler Warning (level 4) C4189]

D:\code\incubator-nuttx\sched\pthread\pthread_create.c(154,22):
  warning C4189: “pjoin”: local variable is initialized but not referenced
  [D:\code\incubator-nuttx\vs20221\sched\sched.vcxproj]

D:\code\incubator-nuttx\sched\group\group_setupidlefiles.c(61,28):
  warning C4189: “group”: local variable is initialized but not referenced
  [D:\code\incubator-nuttx\vs20221\sched\sched.vcxproj]

Reference:
https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4189?view=msvc-170

Signed-off-by: chao.an <anchao@xiaomi.com>

## Impact

N/A

## Testing

visual studio 2022 + cmake