### PR TITLE
sched: fix visual studio Compiler Warning (level 4) C4706

### DIFF
--- a/sched/environ/env_dup.c
+++ b/sched/environ/env_dup.c
@@ -78,7 +78,7 @@ int env_dup(FAR struct task_group_s *group, FAR char * const *envcp)
 
   /* Is there an environment ? */
 
-  if (envcp || (envcp = ptcb->group->tg_envp))
+  if (envcp || (envcp = ptcb->group->tg_envp) != NULL)
     {
       /* Count the strings */
 


### PR DESCRIPTION

## Summary

sched: fix visual studio Compiler Warning (level 4) C4706

D:\code\incubator-nuttx\sched\environ\env_dup.c(81):
  warning C4706: assignment within conditional expression
  [D:\code\nuttx\incubator-nuttx\vs20221\sched\sched.vcxproj]

Reference:
https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4706?view=msvc-170

Signed-off-by: chao.an <anchao@xiaomi.com>

## Impact

N/A

## Testing

visual studio 2022 + cmake