### PR TITLE
tcp: reset conn->nrtx when ack received

### DIFF
--- a/net/tcp/tcp_input.c
+++ b/net/tcp/tcp_input.c
@@ -773,6 +773,7 @@ found:
                     tcp_getsequence(conn->sndseq), ackseq, unackseq,
                     (uint32_t)conn->tx_unacked);
               tcp_setsequence(conn->sndseq, ackseq);
+              conn->nrtx = 0;
             }
         }
 #endif


### PR DESCRIPTION
Otherwise, when a long test triggers multiple timeout retransmissions,
the late timeout retransmissions are always delayed between 24 and 48 seconds

## Summary

## Impact

## Testing

