### PR TITLE
sched: fix visual studio Compiler Error C2010

### DIFF
--- a/include/nuttx/sched_note.h
+++ b/include/nuttx/sched_note.h
@@ -120,9 +120,9 @@
           sched_note_vprintf(SCHED_NOTE_IP, fmt, va)
 #  define SCHED_NOTE_VBPRINTF(event, fmt, va) \
           sched_note_vbprintf(SCHED_NOTE_IP, event, fmt, va)
-#  define SCHED_NOTE_PRINTF(fmt, args...) \
+#  define SCHED_NOTE_PRINTF(fmt, args, ...) \
           sched_note_printf(SCHED_NOTE_IP, fmt, ##args)
-#  define SCHED_NOTE_BPRINTF(event, fmt, args...) \
+#  define SCHED_NOTE_BPRINTF(event, fmt, args, ...) \
           sched_note_bprintf(SCHED_NOTE_IP, event, fmt, ##args)
 #  define SCHED_NOTE_BEGIN() \
           sched_note_begin(SCHED_NOTE_IP, __FUNCTION__)
@@ -133,8 +133,8 @@
 #  define SCHED_NOTE_DUMP(event, buf, len)
 #  define SCHED_NOTE_VPRINTF(fmt, va)
 #  define SCHED_NOTE_VBPRINTF(event, fmt, va)
-#  define SCHED_NOTE_PRINTF(fmt, args...)
-#  define SCHED_NOTE_BPRINTF(event, fmt, args...)
+#  define SCHED_NOTE_PRINTF(fmt, args, ...)
+#  define SCHED_NOTE_BPRINTF(event, fmt, args, ...)
 #  define SCHED_NOTE_BEGIN()
 #  define SCHED_NOTE_END()
 #endif
@@ -530,7 +530,7 @@ void sched_note_spinabort(FAR struct tcb_s *tcb,
 void sched_note_syscall_enter(int nr, int argc, ...);
 void sched_note_syscall_leave(int nr, uintptr_t result);
 #else
-#  define sched_note_syscall_enter(n,a...)
+#  define sched_note_syscall_enter(n,a,...)
 #  define sched_note_syscall_leave(n,r)
 #endif
 
@@ -560,10 +560,10 @@ void sched_note_end(uintptr_t ip, FAR const char *buf);
 #  define sched_note_dump(ip,e,b,l)
 #  define sched_note_vprintf(ip,f,v)
 #  define sched_note_vbprintf(ip,e,f,v)
-#  define sched_note_printf(ip,f...)
-#  define sched_note_bprintf(ip,e,f...)
-#  define sched_note_begin(ip,f...)
-#  define sched_note_end(ip,f...)
+#  define sched_note_printf(ip,f,...)
+#  define sched_note_bprintf(ip,e,f,...)
+#  define sched_note_begin(ip,f)
+#  define sched_note_end(ip,f)
 #endif /* CONFIG_SCHED_INSTRUMENTATION_DUMP */
 
 #if defined(__KERNEL__) || defined(CONFIG_BUILD_FLAT)
@@ -678,8 +678,8 @@ void sched_note_filter_irq(struct note_filter_irq_s *oldf,
 #  define SCHED_NOTE_DUMP(event, buf, len)
 #  define SCHED_NOTE_VPRINTF(fmt, va)
 #  define SCHED_NOTE_VBPRINTF(event, fmt, va)
-#  define SCHED_NOTE_PRINTF(fmt, args...)
-#  define SCHED_NOTE_BPRINTF(event, fmt, args...)
+#  define SCHED_NOTE_PRINTF(fmt, args,...)
+#  define SCHED_NOTE_BPRINTF(event, fmt, args,...)
 #  define SCHED_NOTE_BEGIN()
 #  define SCHED_NOTE_END()
 
@@ -699,17 +699,17 @@ void sched_note_filter_irq(struct note_filter_irq_s *oldf,
 #  define sched_note_spinlocked(t,s)
 #  define sched_note_spinunlock(t,s)
 #  define sched_note_spinabort(t,s)
-#  define sched_note_syscall_enter(n,a...)
+#  define sched_note_syscall_enter(n,a,...)
 #  define sched_note_syscall_leave(n,r)
 #  define sched_note_irqhandler(i,h,e)
 #  define sched_note_string(ip,b)
 #  define sched_note_dump(ip,e,b,l)
 #  define sched_note_vprintf(ip,f,v)
 #  define sched_note_vbprintf(ip,e,f,v)
-#  define sched_note_printf(ip,f...)
-#  define sched_note_bprintf(ip,e,f...)
-#  define sched_note_begin(ip,f...)
-#  define sched_note_end(ip,f...)
+#  define sched_note_printf(ip,f,...)
+#  define sched_note_bprintf(ip,e,f,...)
+#  define sched_note_begin(ip,f)
+#  define sched_note_end(ip,f)
 
 #endif /* CONFIG_SCHED_INSTRUMENTATION */
 #endif /* __INCLUDE_NUTTX_SCHED_NOTE_H */


### PR DESCRIPTION
## Summary

sched: fix visual studio Compiler Error C2010

```
D:\code\incubator-nuttx\include\nuttx/sched_note.h(710,1):
  error C2010: “.”: unexpected in macro formal parameter list
  [D:\code\incubator-nuttx\vs20225\sched\sched.vcxproj]
```

Compiler Error C2010: 'character' : unexpected in macro formal parameter list

Reference:
https://docs.microsoft.com/en-us/cpp/error-messages/compiler-errors-1/compiler-error-c2010?view=msvc-170

Signed-off-by: chao.an <anchao@xiaomi.com>


## Impact

N/A

## Testing

visual studio 2022 + cmake