### PR TITLE
mpfs/opensbi: Add the ddr memory region back to opensbi ld script

### DIFF
--- a/boards/risc-v/mpfs/icicle/scripts/ld-envm-opensbi.script
+++ b/boards/risc-v/mpfs/icicle/scripts/ld-envm-opensbi.script
@@ -20,6 +20,7 @@
 
 MEMORY
 {
+    ddr (rx)      : ORIGIN = 0x80000000, LENGTH = 4M /* w/ cache */
     envm (rx)     : ORIGIN = 0x20220100, LENGTH = 128K - 256  /* 256 reserved for hss headers */
     l2lim  (rwx)  : ORIGIN = 0x08000000, LENGTH = 1024k
     l2zerodevice (rwx) : ORIGIN = 0x0A000000, LENGTH = 512k


### PR DESCRIPTION
## Summary
Fixes ld-envm-opensbi.script:41: warning: memory region `ddr' not declared
## Impact
Fixes build issue with icicle:opensbi target
## Testing
icicle:opensbi
