### PR TITLE
arch/arm/src/stm32f7/stm32_otghost.c: fix undeclared ret

### DIFF
--- a/arch/arm/src/stm32f7/stm32_otghost.c
+++ b/arch/arm/src/stm32f7/stm32_otghost.c
@@ -4684,6 +4684,7 @@ static ssize_t stm32_transfer(struct usbhost_driver_s *drvr,
   struct stm32_usbhost_s *priv = (struct stm32_usbhost_s *)drvr;
   unsigned int chidx = (unsigned int)ep;
   ssize_t nbytes;
+  int ret;
 
   uinfo("chidx: %d buflen: %d\n",  (unsigned int)ep, buflen);
 


### PR DESCRIPTION
I try to enable otgfs on stm32f7 boards, but got some issues,
one of them is undeclared `ret` in arch/arm/src/stm32f7/stm32_otghost.c.
To get nuttx compile with otgfs enabled on stm32f7, need also edit 
other files.

## Summary

Similar to this issues on stm32h7: https://github.com/apache/incubator-nuttx/commit/fa713c09e8acb9ce0ec8f02cc5a706216e71015a

## Impact

No impact is expected.

## Testing

This changes was tested on compile with `nucleo-144:f746-nsh` config file.