### PR TITLE
S32K1xx: Fixed PM bug for clockconfig

### DIFF
--- a/arch/arm/src/s32k1xx/s32k1xx_clockconfig.c
+++ b/arch/arm/src/s32k1xx/s32k1xx_clockconfig.c
@@ -2546,13 +2546,6 @@ int s32k1xx_clockconfig(const struct clock_configuration_s *clkcfg)
 
   DEBUGASSERT(clkcfg != NULL);
 
-#ifdef CONFIG_PM
-  /* Register to receive power management callbacks */
-
-  ret = pm_register(&g_clock_pmcb);
-  DEBUGASSERT(ret == OK);
-#endif
-
   /* Set SCG configuration */
 
   ret = s32k1xx_scg_config(&clkcfg->scg);
@@ -2577,6 +2570,29 @@ int s32k1xx_clockconfig(const struct clock_configuration_s *clkcfg)
 
   return ret;
 }
+
+/****************************************************************************
+ * Name: s32k1xx_clock_pm_register
+ *
+ * Description:
+ *   This function is called after OS and PM init in order to register to
+ *   receive power management event callbacks.
+ *
+ * Input Parameters:
+ *   None
+ *
+ * Returned Values:
+ *   None
+ *
+ ****************************************************************************/
+#ifdef CONFIG_PM
+void s32k1xx_clock_pm_register(void)
+{
+  /* Register to receive power management callbacks */
+
+  pm_register(&g_clock_pmcb);
+}
+#endif
 
 /****************************************************************************
  * Name: s32k1xx_get_coreclk

--- a/arch/arm/src/s32k1xx/s32k1xx_clockconfig.h
+++ b/arch/arm/src/s32k1xx/s32k1xx_clockconfig.h
@@ -526,6 +526,24 @@ enum scg_system_clock_mode_e s32k1xx_set_runmode(enum scg_system_clock_mode_e
 int s32k1xx_clockconfig(const struct clock_configuration_s *clkcfg);
 
 /****************************************************************************
+ * Name: s32k1xx_clock_pm_register
+ *
+ * Description:
+ *   This function is called after OS and PM init in order to register to
+ *   receive power management event callbacks.
+ *
+ * Input Parameters:
+ *   None
+ *
+ * Returned Values:
+ *   None
+ *
+ ****************************************************************************/
+#ifdef CONFIG_PM
+void s32k1xx_clock_pm_register(void);
+#endif
+
+/****************************************************************************
  * Name: s32k1xx_get_coreclk
  *
  * Description:

--- a/arch/arm/src/s32k1xx/s32k1xx_pminitialize.c
+++ b/arch/arm/src/s32k1xx/s32k1xx_pminitialize.c
@@ -25,6 +25,7 @@
 #include <nuttx/config.h>
 #include <nuttx/power/pm.h>
 
+#include "s32k1xx_clockconfig.h"
 #include "arm_internal.h"
 
 #ifdef CONFIG_PM
@@ -56,6 +57,10 @@ void arm_pminitialize(void)
   /* Initialize the NuttX power management subsystem proper */
 
   pm_initialize();
+
+  /* Register clockconfig first to receive power management callbacks */
+
+  s32k1xx_clock_pm_register();
 }
 
 #endif /* CONFIG_PM */


### PR DESCRIPTION
## Summary
For S32K1xx the Power Management (PM) was not working with new NuttX version.
This bug fix makes sure the pm_register(clockconfig) function is done right after pm_initialization().

## Impact
Bug fix to make PM work for S32K1xx in current NuttX version.

## Testing
Tested with RDDRONE-BMS772 board.
