### PR TITLE
arch/sim: set CMDLINE env to the argument user pass to nuttx

### DIFF
--- a/arch/sim/src/sim/up_initialize.c
+++ b/arch/sim/src/sim/up_initialize.c
@@ -31,11 +31,29 @@
 #include <nuttx/spi/spi_flash.h>
 #include <nuttx/spi/qspi_flash.h>
 
+#include <stdlib.h>
+
 #include "up_internal.h"
 
 /****************************************************************************
  * Private Functions
  ****************************************************************************/
+
+#ifndef CONFIG_DISABLE_ENVIRON
+static void up_init_cmdline(void)
+{
+  char cmdline[ARG_MAX] = "";
+  int i;
+
+  for (i = 1; i < g_argc; i++)
+    {
+      strlcat(cmdline, g_argv[i], sizeof(cmdline));
+      strlcat(cmdline, " ", sizeof(cmdline));
+    }
+
+  setenv("CMDLINE", cmdline, true);
+}
+#endif
 
 /****************************************************************************
  * Name: up_init_smartfs
@@ -224,6 +242,10 @@ void up_initialize(void)
    */
 
   pm_initialize();
+#endif
+
+#ifndef CONFIG_DISABLE_ENVIRON
+  up_init_cmdline();
 #endif
 
   /* Register some tty-port to access tty-port on sim platform */


### PR DESCRIPTION
## Summary

## Impact
New functionality

## Testing
Pass CI
