### PR TITLE
Make the full image instrumentation configurable

### DIFF
--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -304,6 +304,18 @@ config ARCH_COVERAGE
 	---help---
 		Generate code coverage
 
+config ARCH_COVERAGE_ALL
+	bool "Enable code coverage for the entire image"
+	depends on ARCH_COVERAGE
+	default y
+	---help---
+		This option activates code coverage instrumentation for the
+		entire image. If you don't enable this option, you have to
+		explicitly specify "-fprofile-generate -ftest-coverage" for
+		the files/directories you want to check. Enabling this option
+		will get image size increased and performance decreased
+		significantly.
+
 comment "Architecture Options"
 
 config ARCH_NOINTC

--- a/arch/arm/src/arm/Toolchain.defs
+++ b/arch/arm/src/arm/Toolchain.defs
@@ -79,7 +79,7 @@ ifeq ($(CONFIG_ARCH_COVERAGE),y)
   ARCHOPTIMIZATION += -fprofile-generate -ftest-coverage
 endif
 
-ifeq ($(CONFIG_MM_KASAN),y)
+ifeq ($(CONFIG_MM_KASAN_ALL),y)
   ARCHOPTIMIZATION += -fsanitize=kernel-address
 endif
 

--- a/arch/arm/src/arm/Toolchain.defs
+++ b/arch/arm/src/arm/Toolchain.defs
@@ -75,7 +75,7 @@ ifeq ($(CONFIG_STACK_CANARIES),y)
   ARCHOPTIMIZATION += -fstack-protector-all
 endif
 
-ifeq ($(CONFIG_ARCH_COVERAGE),y)
+ifeq ($(CONFIG_ARCH_COVERAGE_ALL),y)
   ARCHOPTIMIZATION += -fprofile-generate -ftest-coverage
 endif
 

--- a/arch/arm/src/armv6-m/Toolchain.defs
+++ b/arch/arm/src/armv6-m/Toolchain.defs
@@ -165,7 +165,7 @@ endif
 
 # Architecture flags
 
-ifeq ($(CONFIG_MM_KASAN),y)
+ifeq ($(CONFIG_MM_KASAN_ALL),y)
   ARCHOPTIMIZATION += -fsanitize=kernel-address
 endif
 

--- a/arch/arm/src/armv6-m/Toolchain.defs
+++ b/arch/arm/src/armv6-m/Toolchain.defs
@@ -79,7 +79,7 @@ ifeq ($(CONFIG_STACK_CANARIES),y)
   ARCHOPTIMIZATION += -fstack-protector-all
 endif
 
-ifeq ($(CONFIG_ARCH_COVERAGE),y)
+ifeq ($(CONFIG_ARCH_COVERAGE_ALL),y)
   ARCHOPTIMIZATION += -fprofile-generate -ftest-coverage
 endif
 

--- a/arch/arm/src/armv7-a/Toolchain.defs
+++ b/arch/arm/src/armv7-a/Toolchain.defs
@@ -96,7 +96,7 @@ else
   ARCHCPUFLAGS += -mfloat-abi=soft
 endif
 
-ifeq ($(CONFIG_MM_KASAN),y)
+ifeq ($(CONFIG_MM_KASAN_ALL),y)
   ARCHOPTIMIZATION += -fsanitize=kernel-address
 endif
 

--- a/arch/arm/src/armv7-a/Toolchain.defs
+++ b/arch/arm/src/armv7-a/Toolchain.defs
@@ -120,7 +120,7 @@ ifeq ($(CONFIG_STACK_CANARIES),y)
   ARCHOPTIMIZATION += -fstack-protector-all
 endif
 
-ifeq ($(CONFIG_ARCH_COVERAGE),y)
+ifeq ($(CONFIG_ARCH_COVERAGE_ALL),y)
   ARCHOPTIMIZATION += -fprofile-generate -ftest-coverage
 endif
 

--- a/arch/arm/src/armv7-m/Toolchain.defs
+++ b/arch/arm/src/armv7-m/Toolchain.defs
@@ -81,7 +81,7 @@ ifeq ($(CONFIG_STACK_CANARIES),y)
   ARCHOPTIMIZATION += -fstack-protector-all
 endif
 
-ifeq ($(CONFIG_ARCH_COVERAGE),y)
+ifeq ($(CONFIG_ARCH_COVERAGE_ALL),y)
   ARCHOPTIMIZATION += -fprofile-generate -ftest-coverage
 endif
 

--- a/arch/arm/src/armv7-m/Toolchain.defs
+++ b/arch/arm/src/armv7-m/Toolchain.defs
@@ -179,7 +179,7 @@ else
 endif
 endif
 
-ifeq ($(CONFIG_MM_KASAN),y)
+ifeq ($(CONFIG_MM_KASAN_ALL),y)
   ARCHOPTIMIZATION += -fsanitize=kernel-address
 endif
 

--- a/arch/arm/src/armv7-r/Toolchain.defs
+++ b/arch/arm/src/armv7-r/Toolchain.defs
@@ -96,7 +96,7 @@ ifeq ($(CONFIG_ENDIAN_BIG),y)
   ARCHCPUFLAGS += -mbig-endian
 endif
 
-ifeq ($(CONFIG_MM_KASAN),y)
+ifeq ($(CONFIG_MM_KASAN_ALL),y)
   ARCHOPTIMIZATION += -fsanitize=kernel-address
 endif
 

--- a/arch/arm/src/armv7-r/Toolchain.defs
+++ b/arch/arm/src/armv7-r/Toolchain.defs
@@ -69,7 +69,7 @@ ifeq ($(CONFIG_STACK_CANARIES),y)
   ARCHOPTIMIZATION += -fstack-protector-all
 endif
 
-ifeq ($(CONFIG_ARCH_COVERAGE),y)
+ifeq ($(CONFIG_ARCH_COVERAGE_ALL),y)
   ARCHOPTIMIZATION += -fprofile-generate -ftest-coverage
 endif
 

--- a/arch/arm/src/armv8-m/Toolchain.defs
+++ b/arch/arm/src/armv8-m/Toolchain.defs
@@ -188,7 +188,7 @@ else
 endif
 endif
 
-ifeq ($(CONFIG_MM_KASAN),y)
+ifeq ($(CONFIG_MM_KASAN_ALL),y)
   ARCHOPTIMIZATION += -fsanitize=kernel-address
 endif
 

--- a/arch/arm/src/armv8-m/Toolchain.defs
+++ b/arch/arm/src/armv8-m/Toolchain.defs
@@ -81,7 +81,7 @@ ifeq ($(CONFIG_STACK_CANARIES),y)
   ARCHOPTIMIZATION += -fstack-protector-all
 endif
 
-ifeq ($(CONFIG_ARCH_COVERAGE),y)
+ifeq ($(CONFIG_ARCH_COVERAGE_ALL),y)
   ARCHOPTIMIZATION += -fprofile-generate -ftest-coverage
 endif
 

--- a/arch/arm/src/common/arm_backtrace_fp.c
+++ b/arch/arm/src/common/arm_backtrace_fp.c
@@ -43,9 +43,7 @@
  *
  ****************************************************************************/
 
-#ifdef CONFIG_MM_KASAN
-__attribute__((no_sanitize_address))
-#endif
+nosanitize_address
 static int backtrace(uintptr_t *base, uintptr_t *limit,
                      uintptr_t *fp, uintptr_t *pc,
                      void **buffer, int size, int *skip)
@@ -106,9 +104,7 @@ static int backtrace(uintptr_t *base, uintptr_t *limit,
  *
  ****************************************************************************/
 
-#ifdef CONFIG_MM_KASAN
-__attribute__((no_sanitize_address))
-#endif
+nosanitize_address
 int up_backtrace(struct tcb_s *tcb,
                  void **buffer, int size, int skip)
 {

--- a/arch/arm/src/common/arm_backtrace_thumb.c
+++ b/arch/arm/src/common/arm_backtrace_thumb.c
@@ -99,10 +99,7 @@ static void **g_backtrace_code_regions;
  *
  ****************************************************************************/
 
-#ifdef CONFIG_MM_KASAN
-__attribute__((no_sanitize_address))
-#endif
-static int getlroffset(uint8_t *lr)
+nosanitize_address static int getlroffset(uint8_t *lr)
 {
   lr = (uint8_t *)((uintptr_t)lr & 0xfffffffe);
 
@@ -130,10 +127,7 @@ static int getlroffset(uint8_t *lr)
  *
  ****************************************************************************/
 
-#ifdef CONFIG_MM_KASAN
-__attribute__((no_sanitize_address))
-#endif
-static bool in_code_region(void *pc)
+nosanitize_address static bool in_code_region(void *pc)
 {
   int i = 0;
 
@@ -181,9 +175,7 @@ static bool in_code_region(void *pc)
  *
  ****************************************************************************/
 
-#ifdef CONFIG_MM_KASAN
-__attribute__((no_sanitize_address))
-#endif
+nosanitize_address
 static void *backtrace_push_internal(void **psp, void **ppc)
 {
   uint8_t *sp = *psp;
@@ -311,9 +303,7 @@ static void *backtrace_push_internal(void **psp, void **ppc)
  *
  ****************************************************************************/
 
-#ifdef CONFIG_MM_KASAN
-__attribute__((no_sanitize_address))
-#endif
+nosanitize_address
 static int backtrace_push(void *limit, void **sp, void *pc,
                           void **buffer, int size, int *skip)
 {
@@ -361,9 +351,7 @@ static int backtrace_push(void *limit, void **sp, void *pc,
  *
  ****************************************************************************/
 
-#ifdef CONFIG_MM_KASAN
-__attribute__((no_sanitize_address))
-#endif
+nosanitize_address
 static int backtrace_branch(void *limit, void *sp,
                             void **buffer, int size, int *skip)
 {
@@ -445,10 +433,7 @@ static int backtrace_branch(void *limit, void *sp,
  *
  ****************************************************************************/
 
-#ifdef CONFIG_MM_KASAN
-__attribute__((no_sanitize_address))
-#endif
-void up_backtrace_init_code_regions(void **regions)
+nosanitize_address void up_backtrace_init_code_regions(void **regions)
 {
   g_backtrace_code_regions = regions;
 }
@@ -477,9 +462,7 @@ void up_backtrace_init_code_regions(void **regions)
  *
  ****************************************************************************/
 
-#ifdef CONFIG_MM_KASAN
-__attribute__((no_sanitize_address))
-#endif
+nosanitize_address
 int up_backtrace(struct tcb_s *tcb,
                  void **buffer, int size, int skip)
 {

--- a/arch/arm/src/tlsr82/Toolchain.defs
+++ b/arch/arm/src/tlsr82/Toolchain.defs
@@ -140,7 +140,7 @@ endif
 
 # Architecture flags
 
-ifeq ($(CONFIG_MM_KASAN),y)
+ifeq ($(CONFIG_MM_KASAN_ALL),y)
   ARCHOPTIMIZATION += -fsanitize=kernel-address
 endif
 

--- a/arch/arm/src/tlsr82/tc32/tc32_backtrace.c
+++ b/arch/arm/src/tlsr82/tc32/tc32_backtrace.c
@@ -81,10 +81,7 @@ static void **g_backtrace_code_regions;
  *
  ****************************************************************************/
 
-#ifdef CONFIG_MM_KASAN
-__attribute__((no_sanitize_address))
-#endif
-static int getlroffset(uint8_t *lr)
+nosanitize_address static int getlroffset(uint8_t *lr)
 {
   lr = (uint8_t *)((uintptr_t)lr & 0xfffffffe);
 
@@ -116,10 +113,7 @@ static int getlroffset(uint8_t *lr)
  *
  ****************************************************************************/
 
-#ifdef CONFIG_MM_KASAN
-__attribute__((no_sanitize_address))
-#endif
-static bool in_code_region(void *pc)
+nosanitize_address static bool in_code_region(void *pc)
 {
   int i = 0;
 
@@ -167,9 +161,7 @@ static bool in_code_region(void *pc)
  *
  ****************************************************************************/
 
-#ifdef CONFIG_MM_KASAN
-__attribute__((no_sanitize_address))
-#endif
+nosanitize_address
 static void *backtrace_push_internal(void **psp, void **ppc)
 {
   uint8_t *sp = *psp;
@@ -290,9 +282,7 @@ static void *backtrace_push_internal(void **psp, void **ppc)
  *
  ****************************************************************************/
 
-#ifdef CONFIG_MM_KASAN
-__attribute__((no_sanitize_address))
-#endif
+nosanitize_address
 static int backtrace_push(void *limit, void **sp, void *pc,
                           void **buffer, int size, int *skip)
 {
@@ -340,9 +330,7 @@ static int backtrace_push(void *limit, void **sp, void *pc,
  *
  ****************************************************************************/
 
-#ifdef CONFIG_MM_KASAN
-__attribute__((no_sanitize_address))
-#endif
+nosanitize_address
 static int backtrace_branch(void *limit, void *sp,
                             void **buffer, int size, int *skip)
 {
@@ -425,10 +413,7 @@ static int backtrace_branch(void *limit, void *sp,
  *
  ****************************************************************************/
 
-#ifdef CONFIG_MM_KASAN
-__attribute__((no_sanitize_address))
-#endif
-void up_backtrace_init_code_regions(void **regions)
+nosanitize_address void up_backtrace_init_code_regions(void **regions)
 {
   g_backtrace_code_regions = regions;
 }
@@ -457,9 +442,7 @@ void up_backtrace_init_code_regions(void **regions)
  *
  ****************************************************************************/
 
-#ifdef CONFIG_MM_KASAN
-__attribute__((no_sanitize_address))
-#endif
+nosanitize_address
 int up_backtrace(struct tcb_s *tcb, void **buffer, int size, int skip)
 {
   struct tcb_s *rtcb = running_task();

--- a/arch/arm64/src/Toolchain.defs
+++ b/arch/arm64/src/Toolchain.defs
@@ -58,7 +58,7 @@ ifeq ($(CONFIG_STACK_CANARIES),y)
   ARCHOPTIMIZATION += -fstack-protector-all
 endif
 
-ifeq ($(CONFIG_ARCH_COVERAGE),y)
+ifeq ($(CONFIG_ARCH_COVERAGE_ALL),y)
   ARCHOPTIMIZATION += -fprofile-generate -ftest-coverage
 endif
 

--- a/arch/arm64/src/common/arm64_backtrace.c
+++ b/arch/arm64/src/common/arm64_backtrace.c
@@ -44,9 +44,7 @@
  *
  ****************************************************************************/
 
-#ifdef CONFIG_MM_KASAN
-__attribute__((no_sanitize_address))
-#endif
+nosanitize_address
 static int backtrace(uintptr_t *base, uintptr_t *limit,
                      uintptr_t *fp, uintptr_t *pc,
                      void **buffer, int size, int *skip)
@@ -107,9 +105,7 @@ static int backtrace(uintptr_t *base, uintptr_t *limit,
  *
  ****************************************************************************/
 
-#ifdef CONFIG_MM_KASAN
-__attribute__((no_sanitize_address))
-#endif
+nosanitize_address
 int up_backtrace(struct tcb_s *tcb,
                  void **buffer, int size, int skip)
 {

--- a/arch/risc-v/src/common/Toolchain.defs
+++ b/arch/risc-v/src/common/Toolchain.defs
@@ -63,7 +63,7 @@ ifeq ($(CONFIG_STACK_CANARIES),y)
   ARCHOPTIMIZATION += -fstack-protector-all
 endif
 
-ifeq ($(CONFIG_ARCH_COVERAGE),y)
+ifeq ($(CONFIG_ARCH_COVERAGE_ALL),y)
   ARCHOPTIMIZATION += -fprofile-generate -ftest-coverage
 endif
 

--- a/arch/risc-v/src/common/Toolchain.defs
+++ b/arch/risc-v/src/common/Toolchain.defs
@@ -162,7 +162,7 @@ ifeq ($(CONFIG_RISCV_TOOLCHAIN),GNU_RVG)
 
 endif
 
-ifeq ($(CONFIG_MM_KASAN),y)
+ifeq ($(CONFIG_MM_KASAN_ALL),y)
   ARCHOPTIMIZATION += -fsanitize=kernel-address
 endif
 

--- a/arch/xtensa/src/lx6/Toolchain.defs
+++ b/arch/xtensa/src/lx6/Toolchain.defs
@@ -43,7 +43,7 @@ endif
 
 ARCHCPUFLAGS = -mlongcalls
 
-ifeq ($(CONFIG_MM_KASAN),y)
+ifeq ($(CONFIG_MM_KASAN_ALL),y)
   ARCHOPTIMIZATION += -fsanitize=kernel-address
 endif
 

--- a/arch/xtensa/src/lx6/Toolchain.defs
+++ b/arch/xtensa/src/lx6/Toolchain.defs
@@ -75,7 +75,7 @@ ifeq ($(CONFIG_STACK_CANARIES),y)
   ARCHOPTIMIZATION += -fstack-protector-all
 endif
 
-ifeq ($(CONFIG_ARCH_COVERAGE),y)
+ifeq ($(CONFIG_ARCH_COVERAGE_ALL),y)
   ARCHOPTIMIZATION += -fprofile-generate -ftest-coverage
 endif
 

--- a/arch/xtensa/src/lx7/Toolchain.defs
+++ b/arch/xtensa/src/lx7/Toolchain.defs
@@ -43,7 +43,7 @@ endif
 
 ARCHCPUFLAGS = -mlongcalls
 
-ifeq ($(CONFIG_MM_KASAN),y)
+ifeq ($(CONFIG_MM_KASAN_ALL),y)
   ARCHOPTIMIZATION += -fsanitize=kernel-address
 endif
 

--- a/arch/xtensa/src/lx7/Toolchain.defs
+++ b/arch/xtensa/src/lx7/Toolchain.defs
@@ -75,7 +75,7 @@ ifeq ($(CONFIG_STACK_CANARIES),y)
   ARCHOPTIMIZATION += -fstack-protector-all
 endif
 
-ifeq ($(CONFIG_ARCH_COVERAGE),y)
+ifeq ($(CONFIG_ARCH_COVERAGE_ALL),y)
   ARCHOPTIMIZATION += -fprofile-generate -ftest-coverage
 endif
 

--- a/boards/sim/sim/sim/scripts/Make.defs
+++ b/boards/sim/sim/sim/scripts/Make.defs
@@ -73,7 +73,7 @@ endif
 
 ifeq ($(CONFIG_SIM_ASAN),y)
   ARCHOPTIMIZATION += -fsanitize=address
-else ifeq ($(CONFIG_MM_KASAN),y)
+else ifeq ($(CONFIG_MM_KASAN_ALL),y)
   ARCHOPTIMIZATION += -fsanitize=kernel-address
 endif
 

--- a/boards/sim/sim/sim/scripts/Make.defs
+++ b/boards/sim/sim/sim/scripts/Make.defs
@@ -67,7 +67,7 @@ ifeq ($(CONFIG_STACK_CANARIES),y)
   ARCHOPTIMIZATION += -fstack-protector-all
 endif
 
-ifeq ($(CONFIG_ARCH_COVERAGE),y)
+ifeq ($(CONFIG_ARCH_COVERAGE_ALL),y)
   ARCHOPTIMIZATION += -fprofile-generate -ftest-coverage
 endif
 

--- a/include/nuttx/compiler.h
+++ b/include/nuttx/compiler.h
@@ -191,6 +191,10 @@
 
 #  define noinstrument_function __attribute__ ((no_instrument_function))
 
+/* The nosanitize_address attribute informs GCC don't sanitize it */
+
+#  define nosanitize_address __attribute__ ((no_sanitize_address))
+
 /* The nostackprotect_function attribute disables stack protection in
  * sensitive functions, e.g., stack coloration routines.
  */
@@ -460,6 +464,7 @@
 #  define inline_function
 #  define noinline_function
 #  define noinstrument_function
+#  define nosanitize_address
 #  define nostackprotect_function
 
 #  define unused_code
@@ -591,6 +596,7 @@
 #  define inline_function
 #  define noinline_function
 #  define noinstrument_function
+#  define nosanitize_address
 #  define nostackprotect_function
 #  define unused_code
 #  define unused_data
@@ -691,6 +697,7 @@
 #  define inline_function
 #  define noinline_function
 #  define noinstrument_function
+#  define nosanitize_address
 #  define nostackprotect_function
 #  define unused_code
 #  define unused_data
@@ -757,6 +764,7 @@
 #  define inline_function
 #  define noinline_function
 #  define noinstrument_function
+#  define nosanitize_address
 #  define nostackprotect_function
 #  define unused_code
 #  define unused_data

--- a/mm/Kconfig
+++ b/mm/Kconfig
@@ -191,6 +191,17 @@ config MM_KASAN
 		bugs in native code. After turn on this option, Please
 		add -fsanitize=kernel-address to CFLAGS/CXXFLAGS too.
 
+config MM_KASAN_ALL
+	bool "Enable KASan for the entire image"
+	depends on MM_KASAN
+	default y
+	---help---
+		This option activates address sanitizer for the entire image.
+		If you don't enable this option, you have to explicitly specify
+		"-fsanitize=kernel-address" for the files/directories you want
+		to check. Enabling this option will get image size increased
+		and performance decreased significantly.
+
 config MM_UBSAN
 	bool "Undefined Behavior Sanitizer"
 	default n


### PR DESCRIPTION
## Summary

since it isn't possible to instrument the full image due to the size or speed limitation.

- mm/kasan: Add MM_KASAN_ALL option
- arch: Add ARCH_COVERAGE_ALL option 
- compiler.h: Add nosanitize_address macro

## Impact
asan and gcov

## Testing
Pass CI
