### PR TITLE
rp2040: Add missing comma in rp2040_i2c_slave.c

### DIFF
--- a/arch/arm/src/rp2040/rp2040_i2c_slave.c
+++ b/arch/arm/src/rp2040/rp2040_i2c_slave.c
@@ -257,7 +257,7 @@ static int i2c_interrupt(int irq, void *context, void *arg)
        */
 
       modbits_reg32(RP2040_I2C_IC_INTR_MASK(priv->controller),
-                    0
+                    0,
                     RP2040_I2C_IC_INTR_MASK_M_TX_EMPTY);
     }
 


### PR DESCRIPTION
This patch fixes missing comma, found by cppcheck.

rp2040_i2c_slave.c:259:0: error: failed to expand 'modbits_reg32',
 Wrong number of parameters for macro 'modbits_reg32'.

Signed-off-by: Masanari Iida <standby24x7@gmail.com>
