### PR TITLE
sched: fix visual studio compiler error

### DIFF
--- a/arch/sim/src/Makefile
+++ b/arch/sim/src/Makefile
@@ -78,8 +78,10 @@ endif
 VPATH = sim
 DEPPATH = $(patsubst %,--dep-path %,$(subst :, ,$(VPATH)))
 
+CFLAGS += -fvisibility=default
 HOSTCFLAGS = $(ARCHWARNINGS) $(ARCHOPTIMIZATION) \
-   $(ARCHCFLAGS) $(HOSTINCLUDES) $(EXTRAFLAGS) -D__SIM__ -pipe
+   $(ARCHCFLAGS) $(HOSTINCLUDES) $(EXTRAFLAGS) -D__SIM__ -pipe \
+   -fvisibility=default
 
 HOSTCFLAGS += ${shell $(INCDIR) "$(CC)" $(ARCH_SRCDIR)}
 ifeq ($(CONFIG_HOST_MACOS),y)

--- a/arch/sim/src/sim/up_head.c
+++ b/arch/sim/src/sim/up_head.c
@@ -105,7 +105,6 @@ static void allsyms_relocate(void)
  *
  ****************************************************************************/
 
-__attribute__ ((visibility("default")))
 int main(int argc, char **argv, char **envp)
 {
   g_argc = argc;

--- a/arch/sim/src/sim/up_interruptcontext.c
+++ b/arch/sim/src/sim/up_interruptcontext.c
@@ -51,7 +51,6 @@ bool up_interrupt_context(void)
  * Name: up_doirq
  ****************************************************************************/
 
-__attribute__ ((visibility("default")))
 void *up_doirq(int irq, void *context)
 {
   /* Allocate temporary context on the stack */

--- a/arch/sim/src/sim/up_netdriver.c
+++ b/arch/sim/src/sim/up_netdriver.c
@@ -382,7 +382,6 @@ int netdriver_init(void)
   return netdev_register(dev, NET_LL_ETHERNET);
 }
 
-__attribute__ ((visibility("default")))
 void netdriver_setmacaddr(unsigned char *macaddr)
 {
   memcpy(g_sim_dev.d_mac.ether.ether_addr_octet, macaddr, IFHWADDRLEN);

--- a/arch/sim/src/sim/up_smpsignal.c
+++ b/arch/sim/src/sim/up_smpsignal.c
@@ -217,7 +217,6 @@ int up_cpu_paused(int cpu)
  *
  ****************************************************************************/
 
-__attribute__ ((visibility("default")))
 void up_cpu_started(void)
 {
 #ifdef CONFIG_SCHED_INSTRUMENTATION
@@ -286,7 +285,6 @@ int up_cpu_start(int cpu)
  *   On success returns OK (0), otherwise a negative value.
  ****************************************************************************/
 
-__attribute__ ((visibility("default")))
 int up_init_ipi(int irq)
 {
   up_enable_irq(irq);

--- a/arch/sim/src/sim/up_usrsock.c
+++ b/arch/sim/src/sim/up_usrsock.c
@@ -399,7 +399,6 @@ static const usrsock_handler_t g_usrsock_handler[] =
  * Public Functions
  ****************************************************************************/
 
-__attribute__ ((visibility("default")))
 int usrsock_event_callback(int16_t usockid, uint16_t events)
 {
   return usrsock_send_event(&g_usrsock, usockid, events);


### PR DESCRIPTION
## Summary

sched: fix visual studio compiler error

GCC __attribute__ is not fully compatible with MSVC, In the MSVC
environment the programmer typically explicitly exports function/class
symbols via the MSVC-specific __declspec(dllexport) modifier.

```
D:\code\incubator-nuttx\arch\sim\src\sim\up_head.c(107,15):
  error C2143: syntax error : missing ')' before '('
  [D:\code\n3\incubator-nuttx\vs2022\up_head.vcxproj]
```

Reference:
https://docs.microsoft.com/en-us/cpp/cpp/dllexport-dllimport?view=msvc-170

Signed-off-by: chao.an <anchao@xiaomi.com>

## Impact

N/A

## Testing

Visual studio + cmake