### PR TITLE
arch/arm/src/stm32f7/stm32_otg.h: fix stm32_otghost_initialize defini…

### DIFF
--- a/arch/arm/src/stm32f7/stm32_otg.h
+++ b/arch/arm/src/stm32f7/stm32_otg.h
@@ -84,7 +84,7 @@ extern "C"
 #endif
 
 /****************************************************************************
- * Name: stm32_otghost_initialize
+ * Name: stm32_otgfshost_initialize
  *
  * Description:
  *   Initialize USB host device controller hardware.
@@ -110,7 +110,7 @@ extern "C"
 
 #ifdef CONFIG_USBHOST
 struct usbhost_connection_s;
-struct usbhost_connection_s *stm32_otghost_initialize(int controller);
+struct usbhost_connection_s *stm32_otgfshost_initialize(int controller);
 #endif
 
 /****************************************************************************


### PR DESCRIPTION
The `stm32_otghost_initialize` function was defined in `arch/arm/src/stm32f7/stm32_otg.h`, 
but not used in anywhere. According to `boards/arm/stm32f7/nucleo-144/src/stm32_usb.c`,
and other boards stm32_otg.h, the `stm32_otghost_initialize` should be `stm32_otgfshost_initialize`

## Summary

Fix function definition typo.

## Impact

No impact is expected.

## Testing

This changes was tested compile nucleo-144:f746-nsh config file with CONFIG_STM32F7_OTGFS enabled.
Need more patches, compile ok, but OTG not work yet. 