### PR TITLE
arch/arm/src/stm32f7/Kconfig: add STM32F7_SYSCFG

### DIFF
--- a/arch/arm/src/stm32f7/Kconfig
+++ b/arch/arm/src/stm32f7/Kconfig
@@ -1592,6 +1592,10 @@ config STM32F7_SPI6
 	select SPI
 	select STM32F7_SPI
 
+config STM32F7_SYSCFG
+	bool "SYSCFG"
+	default y
+
 config STM32F7_TIM1
 	bool "TIM1"
 	default n


### PR DESCRIPTION
## Summary

According to https://github.com/apache/incubator-nuttx/blob/master/arch/arm/src/stm32f7/stm32_otghost.c#L70
the STM32F7_SYSCFG was needed for stm32f7 otgfs, but it was missing in `arch/arm/src/stm32f7/Kconfig`. 
So add it now.

## Impact

No impact is expected.

## Testing

This changes was tested compile `nucleo-144:f746-nsh` config file with CONFIG_STM32F7_OTGFS enabled.
Need more patches, compile ok, but OTG not work yet.
