### PR TITLE
net/usrsock: Remove dev field from usrsockdev_s

### DIFF
--- a/net/usrsock/usrsock.h
+++ b/net/usrsock/usrsock.h
@@ -94,7 +94,6 @@ struct usrsock_conn_s
   int8_t        type;                /* Socket type (SOCK_STREAM, etc) */
   int16_t       usockid;             /* Connection number used for kernel<->daemon */
   uint16_t      flags;               /* Socket state flags */
-  struct usrsockdev_s *dev;          /* Device node used for this conn */
 
   struct
   {

--- a/net/usrsock/usrsock_dev.c
+++ b/net/usrsock/usrsock_dev.c
@@ -1134,16 +1134,8 @@ errout:
 int usrsockdev_do_request(FAR struct usrsock_conn_s *conn,
                           FAR struct iovec *iov, unsigned int iovcnt)
 {
-  FAR struct usrsockdev_s *dev = conn->dev;
+  FAR struct usrsockdev_s *dev = &g_usrsockdev;
   FAR struct usrsock_request_common_s *req_head = iov[0].iov_base;
-
-  if (!dev)
-    {
-      /* Setup conn for new usrsock device. */
-
-      dev = &g_usrsockdev;
-      conn->dev = dev;
-    }
 
   if (!usrsockdev_is_opened(dev))
     {


### PR DESCRIPTION
## Summary
since this field isn't really used at all

## Impact
Minor

## Testing
Pass CI
