### PR TITLE
net/usrsock: Change xid from uint64_t to uint32_t

### DIFF
--- a/arch/sim/src/sim/up_usrsock.c
+++ b/arch/sim/src/sim/up_usrsock.c
@@ -91,7 +91,7 @@ static int usrsock_send(struct usrsock_s *usrsock,
 }
 
 static int usrsock_send_ack(struct usrsock_s *usrsock,
-                            uint64_t xid, int32_t result)
+                            uint32_t xid, int32_t result)
 {
   struct usrsock_message_req_ack_s ack;
 
@@ -106,7 +106,7 @@ static int usrsock_send_ack(struct usrsock_s *usrsock,
 
 static int usrsock_send_dack(struct usrsock_s *usrsock,
                              struct usrsock_message_datareq_ack_s *ack,
-                             uint64_t xid, int32_t result,
+                             uint32_t xid, int32_t result,
                              uint16_t valuelen,
                              uint16_t valuelen_nontrunc)
 {

--- a/include/nuttx/net/usrsock.h
+++ b/include/nuttx/net/usrsock.h
@@ -96,7 +96,7 @@ enum usrsock_message_types_e
 
 begin_packed_struct struct usrsock_request_common_s
 {
-  uint64_t xid;
+  uint32_t xid;
   int8_t   reqid;
   int8_t   reserved;
 } end_packed_struct;
@@ -230,7 +230,7 @@ begin_packed_struct struct usrsock_message_req_ack_s
   struct usrsock_message_common_s head;
 
   int32_t  result;
-  uint64_t xid;
+  uint32_t xid;
 } end_packed_struct;
 
 /* Request acknowledgment/completion message */

--- a/net/usrsock/usrsock.h
+++ b/net/usrsock/usrsock.h
@@ -98,7 +98,7 @@ struct usrsock_conn_s
   struct
   {
     sem_t    sem;               /* Request semaphore (only one outstanding request) */
-    uint64_t xid;               /* Expected message exchange id */
+    uint32_t xid;               /* Expected message exchange id */
     bool     inprogress;        /* Request was received but daemon is still processing */
     uint16_t valuelen;          /* Length of value from daemon */
     uint16_t valuelen_nontrunc; /* Actual length of value at daemon */

--- a/net/usrsock/usrsock_dev.c
+++ b/net/usrsock/usrsock_dev.c
@@ -61,8 +61,9 @@
 
 struct usrsockdev_s
 {
-  sem_t   devsem;     /* Lock for device node */
-  uint8_t ocount;     /* The number of times the device has been opened */
+  sem_t    devsem; /* Lock for device node */
+  uint8_t  ocount; /* The number of times the device has been opened */
+  uint32_t newxid; /* New transcation Id */
 
   struct
   {
@@ -710,7 +711,7 @@ static ssize_t usrsockdev_handle_req_response(FAR struct usrsockdev_s *dev,
       break;
 
     default:
-      nwarn("unknown message type: %d, flags: %d, xid: %" PRIu64 ", "
+      nwarn("unknown message type: %d, flags: %d, xid: %" PRIu32 ", "
             "result: %" PRId32 "\n",
             hdr->head.msgid, hdr->head.flags, hdr->xid, hdr->result);
       return -EINVAL;
@@ -734,7 +735,7 @@ static ssize_t usrsockdev_handle_req_response(FAR struct usrsockdev_s *dev,
       /* No connection waiting for this message. */
 
       nwarn("Could find connection waiting for response"
-            "with xid=%" PRIu64 "\n", hdr->xid);
+            "with xid=%" PRIu32 "\n", hdr->xid);
 
       ret = -EINVAL;
       goto unlock_out;
@@ -1146,7 +1147,12 @@ int usrsockdev_do_request(FAR struct usrsock_conn_s *conn,
 
   /* Get exchange id. */
 
-  req_head->xid = (uintptr_t)conn;
+  if (++dev->newxid == 0)
+    {
+      ++dev->newxid;
+    }
+
+  req_head->xid = dev->newxid;
 
   /* Prepare connection for response. */
 


### PR DESCRIPTION
## Summary
by generating the new xid for each transaction

## Impact
Minor

## Testing
sim:adb
