### PR TITLE
libc: add lib_dump utils

### DIFF
--- a/include/debug.h
+++ b/include/debug.h
@@ -1071,6 +1071,26 @@ extern "C"
 {
 #endif
 
+/* Type of the call out function pointer provided to
+ * lib_dumphandler() or lib_dumpvhandler()
+ */
+
+typedef CODE void (*lib_dump_handler_t)(FAR void *arg,
+                                        FAR const char *fmt, ...)
+                  printflike(2, 3);
+
+/* Dump a buffer of data with handler */
+
+void lib_dumphandler(FAR const char *msg, FAR const uint8_t *buffer,
+                     unsigned int buflen, lib_dump_handler_t handler,
+                     FAR void *arg);
+
+/* Do a pretty buffer dump from multiple buffers with handler. */
+
+void lib_dumpvhandler(FAR const char *msg, FAR const struct iovec *iov,
+                      int iovcnt, lib_dump_handler_t handler,
+                      FAR void *arg);
+
 /* Dump a buffer of data */
 
 void lib_dumpbuffer(FAR const char *msg, FAR const uint8_t *buffer,
@@ -1080,6 +1100,16 @@ void lib_dumpbuffer(FAR const char *msg, FAR const uint8_t *buffer,
 
 void lib_dumpvbuffer(FAR const char *msg, FAR const struct iovec *iov,
                      int iovcnt);
+
+/* Dump a buffer of data with fd */
+
+void lib_dumpfile(int fd, FAR const char *msg, FAR const uint8_t *buffer,
+                  unsigned int buflen);
+
+/* Do a pretty buffer dump from multiple buffers with fd. */
+
+void lib_dumpvfile(int fd, FAR const char *msg, FAR const struct iovec *iov,
+                   int iovcnt);
 
 /* The system logging interfaces are normally accessed via the macros
  * provided above.  If the cross-compiler's C pre-processor supports a

--- a/libs/libc/misc/lib_dumpbuffer.c
+++ b/libs/libc/misc/lib_dumpbuffer.c
@@ -33,6 +33,26 @@
  ****************************************************************************/
 
 /****************************************************************************
+ * Name: lib_dumphandler
+ *
+ * Description:
+ *  Do a pretty buffer dump with handler output.
+ *
+ ****************************************************************************/
+
+void lib_dumphandler(FAR const char *msg, FAR const uint8_t *buffer,
+                     unsigned int buflen, lib_dump_handler_t handler,
+                     FAR void *arg)
+{
+  struct iovec buf;
+
+  buf.iov_base = (FAR void *)buffer;
+  buf.iov_len = buflen;
+
+  lib_dumpvhandler(msg, &buf, 1, handler, arg);
+}
+
+/****************************************************************************
  * Name: lib_dumpbuffer
  *
  * Description:
@@ -52,4 +72,23 @@ void lib_dumpbuffer(FAR const char *msg, FAR const uint8_t *buffer,
   buf.iov_len = buflen;
 
   lib_dumpvbuffer(msg, &buf, 1);
+}
+
+/****************************************************************************
+ * Name: lib_dumpfile
+ *
+ * Description:
+ *  Do a pretty buffer dump with fd output.
+ *
+ ****************************************************************************/
+
+void lib_dumpfile(int fd, FAR const char *msg, FAR const uint8_t *buffer,
+                  unsigned int buflen)
+{
+  struct iovec buf;
+
+  buf.iov_base = (FAR void *)buffer;
+  buf.iov_len = buflen;
+
+  lib_dumpvfile(fd, msg, &buf, 1);
 }


### PR DESCRIPTION
Signed-off-by: chengkai <chengkai@xiaomi.com>

## Summary
add some lib_dump  debug api  
1. void lib_dumphandler(FAR const char *msg, FAR const uint8_t *buffer,
                     unsigned int buflen, lib_dump_handler_t handler,
                     FAR void *arg);
2. void lib_dumpvhandler(FAR const char *msg, FAR const struct iovec *iov,
                      int iovcnt, lib_dump_handler_t handler,
                      FAR void *arg);
3.  void lib_dumpfile(int fd, FAR const char *msg, FAR const uint8_t *buffer,
                  unsigned int buflen);
4. void lib_dumpvfile(int fd, FAR const char *msg, FAR const struct iovec *iov,
                   int iovcnt);               
                       
## Impact
lib_dumpvbuffer api

## Testing
pass ci

