### PR TITLE
wireless/bluetooth:add btsnoop open-close ioctl cmd

### DIFF
--- a/include/nuttx/wireless/bluetooth/bt_ioctl.h
+++ b/include/nuttx/wireless/bluetooth/bt_ioctl.h
@@ -61,9 +61,13 @@
 #define HCI_GATTRD_DATA     32   /* Max number of bytes in GATT read data */
 #define HCI_GATTWR_DATA     16   /* Max number of bytes in GATT write data */
 
+#ifndef CONFIG_BLUETOOTH_MAXSCANDATA
+#  define CONFIG_BLUETOOTH_MAXSCANDATA 64
+#endif
+
 /* Bluetooth network device IOCTL commands. */
 
-#if !defined(WL_BLUETOOTHCMDS) || WL_BLUETOOTHCMDS != 26
+#if !defined(WL_BLUETOOTHCMDS) || WL_BLUETOOTHCMDS != 28
 #  error Incorrect setting for number of Bluetooth IOCTL commands
 #endif
 
@@ -187,6 +191,11 @@
 
 #define SIOCBTCONNECT          _WLIOC(WL_BLUETOOTHFIRST + 24)
 #define SIOCBTDISCONNECT       _WLIOC(WL_BLUETOOTHFIRST + 25)
+
+/* btsnoop open and close operations */
+
+#define SIOCBTSNOOPOPEN        _WLIOC(WL_BLUETOOTHFIRST + 26)
+#define SIOCBTSNOOPCLOSE       _WLIOC(WL_BLUETOOTHFIRST + 27)
 
 /* Definitions associated with struct btreg_s *******************************/
 

--- a/include/nuttx/wireless/wireless.h
+++ b/include/nuttx/wireless/wireless.h
@@ -168,7 +168,7 @@
 /* Reserved for Bluetooth network devices (see bt_ioctls.h) */
 
 #define WL_BLUETOOTHFIRST     (WL_NETFIRST + WL_NNETCMDS)
-#define WL_BLUETOOTHCMDS      (26)
+#define WL_BLUETOOTHCMDS      (28)
 #define WL_IBLUETOOTHCMD(cmd) (_WLIOCVALID(cmd) && \
                               _IOC_NR(cmd) >= WL_BLUETOOTHFIRST && \
                               _IOC_NR(cmd) < (WL_BLUETOOTHFIRST + WL_BLUETOOTHCMDS))


### PR DESCRIPTION
1. SIOCBTSNOOPOPEN: open btsnoop
2. SIOCBTSNOOPCLOSE: close btsnoop

Signed-off-by: chengkai <chengkai@xiaomi.com>

## Summary
add btsnoop control cmd

1. SIOCBTSNOOPOPEN: open btsnoop
2. SIOCBTSNOOPCLOSE: close btsnoop

## Impact

## Testing
pass ci
