### PR TITLE
prctl: Replace strncpy with strlcpy for safety

### DIFF
--- a/sched/task/task_prctl.c
+++ b/sched/task/task_prctl.c
@@ -126,7 +126,7 @@ int prctl(int option, ...)
                * necessary.
                */
 
-              strncpy(tcb->name, name, CONFIG_TASK_NAME_SIZE);
+              strlcpy(tcb->name, name, sizeof(tcb->name));
               tcb->name[CONFIG_TASK_NAME_SIZE] = '\0';
             }
           else
@@ -135,7 +135,7 @@ int prctl(int option, ...)
                * necessary.
                */
 
-              strncpy(name, tcb->name, CONFIG_TASK_NAME_SIZE - 1);
+              strlcpy(name, tcb->name, sizeof(tcb->name));
               name[CONFIG_TASK_NAME_SIZE - 1] = '\0';
             }
         }


### PR DESCRIPTION
## Summary

strlcpy ensure the destination is NUL-terminated, and also fix warning:
```c
task/task_prctl.c:138:15: warning: 'strncpy' output may be truncated copying 30 bytes from a string of length 31 [-Wstringop-truncation]
  138 |               strncpy(name, tcb->name, CONFIG_TASK_NAME_SIZE - 1);
      |               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

## Impact
Refactor only
## Testing
CI and custom board
