### PR TITLE
arch/sim/wchar_t: fix visual studio Compiler Error C2371

### DIFF
--- a/arch/sim/include/types.h
+++ b/arch/sim/include/types.h
@@ -88,6 +88,8 @@ typedef _uint64_t          _uintmax_t;
 
 #if defined(__WCHAR_TYPE__)
 typedef __WCHAR_TYPE__     _wchar_t;
+#elif defined(_MSC_VER)
+typedef unsigned short     _wchar_t;
 #else
 typedef int                _wchar_t;
 #endif


### PR DESCRIPTION
## Summary

arch/sim/wchar_t: fix visual studio Compiler Error C2371

type of 'wchar_t' confilt with vcruntime:

```
C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.33.31629\include\vcruntime.h(228,28):
  error C2371: 'wchar_t': redefinition; different basic types
D:\code\incubator-nuttx\include\sys/types.h(174): message : see declaration of 'wchar_t'
```

typedef wchar_t as unsigned char to compatible with vcrtuntime

Signed-off-by: chao.an <anchao@xiaomi.com>

## Impact

N/A

## Testing

virtual studio + cmake