### PR TITLE
libs: fix visual studio Compiler Error C2124

### DIFF
--- a/libs/libc/stdlib/lib_strtof.c
+++ b/libs/libc/stdlib/lib_strtof.c
@@ -73,7 +73,12 @@
 
 static inline int is_real(float x)
 {
-  const float infinite = 1.0F / 0.0F;
+  /* NOTE: Windows MSVC restrictions, MSVC doesn't allow division through a
+   * zero literal, but allows it through non-const variable set to zero
+   */
+
+  float divzero = 0.0F;
+  const float infinite = 1.0F / divzero;
   return (x < infinite) && (x >= -infinite);
 }
 
@@ -99,7 +104,13 @@ float strtof(FAR const char *str, FAR char **endptr)
   int n;
   int num_digits;
   int num_decimals;
-  const float infinite = 1.0F / 0.0F;
+
+  /* NOTE: Windows MSVC restrictions, MSVC doesn't allow division through a
+   * zero literal, but allows it through non-const variable set to zero
+   */
+
+  float divzero = 0.0F;
+  const float infinite = 1.0F / divzero;
 
   /* Skip leading whitespace */
 


### PR DESCRIPTION
## Summary

libs: fix visual studio Compiler Error C2124

`D:\code\incubator-nuttx\libs\libc\stdlib\lib_strtof.c(76,1): error C2124: divide or mod by zero`

Windows MSVC restrictions, MSVC doesn't allow division through a
zero literal, but allows it through non-const variable set to zero

Reference:
https://docs.microsoft.com/en-us/cpp/error-messages/compiler-errors-1/compiler-error-c2124?view=msvc-170

Signed-off-by: chao.an <anchao@xiaomi.com>

## Impact

N/A

## Testing

visual studio + cmake