### PR TITLE
arch/risc-v/src/mpfs: Fixes for MSSIO GPIO configurations

### DIFF
--- a/arch/risc-v/src/mpfs/hardware/mpfs250t_484_pinmap.h
+++ b/arch/risc-v/src/mpfs/hardware/mpfs250t_484_pinmap.h
@@ -80,8 +80,8 @@
                                       MSSIO_MUX_BANK_REG_OFFSET(bank,pin))
 
 /* Default EC configuration for all GPIOS */
-#define MSSIO_EC_DEFAULT (0x0428 << GPIO_EC_SHIFT)
-#define MSSIO_EC_USB_DEFAULT (0x0829 << GPIO_EC_SHIFT)
+#define MSSIO_EC_DEFAULT     GPIO_EC_DRVSTR(0x5)
+#define MSSIO_EC_USB_DEFAULT (GPIO_EC_BUFM(1) | GPIO_EC_DRVSTR(0x5) | GPIO_PULLUP)
 
 /* Basic GPIO definitions for MSSIO */
 

--- a/arch/risc-v/src/mpfs/mpfs_gpio.h
+++ b/arch/risc-v/src/mpfs/mpfs_gpio.h
@@ -75,16 +75,20 @@
 #define GPIO_EC_MASK         (0xFFF << GPIO_EC_SHIFT)
 #define GPIO_EC_PUPD_SHIFT   (30) /* Bit 30-31 Electrical Configuration PUPD */
 #define GPIO_EC_PUPD_MASK    (3 << GPIO_EC_PUPD_SHIFT)
+#define GPIO_PULLDOWN        (1 << GPIO_EC_PUPD_SHIFT)
+#define GPIO_PULLUP          (2 << GPIO_EC_PUPD_SHIFT)
 #define GPIO_EC_LOCKDN_SHIFT (29) /* Bit 29 Electrical Configuration Lockdn */
-#define GPIO_EC_LOCKDN_MASK  (1 << GPIO_EC_LOCKDN_SHIFT)
+#define GPIO_EC_LOCKDN       (1 << GPIO_EC_LOCKDN_SHIFT)
 #define GPIO_EC_ENHYST_SHIFT (28) /* Bit 28 Electrical Configuration Hyst */
-#define GPIO_EC_ENHYST_MASK  (1 << GPIO_EC_ENHYST_SHIFT)
-#define GPIO_CLAMP_SHIFT     (27) /* Bit 27 Electrical Configuration Clamp */
-#define GPIO_EC_CLAMP_MASK   (1 << GPIO_CLAMP_SHIFT)
+#define GPIO_EC_ENHYST       (1 << GPIO_EC_ENHYST_SHIFT)
+#define GPIO_EC_CLAMP_SHIFT  (27) /* Bit 27 Electrical Configuration Clamp */
+#define GPIO_EC_CLAMP        (1 << GPIO_EC_CLAMP_SHIFT)
 #define GPIO_EC_DRVSTR_SHIFT (23) /* Bit 23-26 Electrical Configuration drive strength */
-#define GPIO_EC_DRVSTR_MASK  (0xF << GPIO_EC_SHIFT)
+#define GPIO_EC_DRVSTR_MASK  (0xF << GPIO_EC_DRVSTR_SHIFT)
+#define GPIO_EC_DRVSTR(x)    (((x) << GPIO_EC_DRVSTR_SHIFT) & GPIO_EC_DRVSTR_MASK)
 #define GPIO_EC_BUFM_SHIFT   (20) /* Bit 20-22 Electrical Configuration Buffer Mode*/
 #define GPIO_EC_BUFM_MASK    (0x7 << GPIO_EC_BUFM_SHIFT)
+#define GPIO_EC_BUFM(x)      (((x) << GPIO_EC_BUFM_SHIFT) & GPIO_EC_BUFM_MASK)
 #define GPIO_AF_SHIFT        (16) /* Bit 16-19 Alternate Function */
 #define GPIO_AF_MASK         (15 << GPIO_AF_SHIFT)
 #define GPIO_MODE_SHIFT      (14) /* Bit 14-15: IO Mode */


### PR DESCRIPTION
- Clarify the macros MSSIO_EC_DEFAULT and MSSIO_EC_USB_DEFAULT
- Remove PULLDOWN bit from MSSIO_EC_DEFAULT, it was on by accident
- Fix some EC configuration macros; DRVSTR was wrong, clean up the others
- Define GPIO_PULLUP and GPIO_PULLDOWN like on many other platforms

Signed-off-by: Jukka Laitinen <jukkax@ssrc.tii.ae>


