### PR TITLE
arch/sim: fix visual studio Linker Tools Error LNK2019

### DIFF
--- a/arch/sim/include/irq.h
+++ b/arch/sim/include/irq.h
@@ -77,7 +77,13 @@ extern "C"
 
 static inline uintptr_t up_getsp(void)
 {
+#ifdef _MSC_VER
+  uintptr_t regval;
+  __asm mov regval, esp;
+  return regval;
+#else
   return (uintptr_t)__builtin_frame_address(0);
+#endif
 }
 
 /****************************************************************************


### PR DESCRIPTION
## Summary

arch/sim: fix visual studio Linker Tools Error LNK2019

```
nuttx_all.lib(up_initialstate.obj) : error LNK2019:
  unresolved external symbol '___builtin_frame_addres' referenced in function '_up_getsp'
```

Return stack pointer from esp

Signed-off-by: chao.an <anchao@xiaomi.com>


## Impact

N/A

## Testing

virtual studio + cmake

