### PR TITLE
ESP32-S3: Fix Data allocation offset within shared Internal SRAM1

### DIFF
--- a/boards/xtensa/esp32s3/esp32s3-devkit/scripts/esp32s3.ld
+++ b/boards/xtensa/esp32s3/esp32s3-devkit/scripts/esp32s3.ld
@@ -71,7 +71,7 @@ SECTIONS
      * and dram0_0_seg reflect the same address space on different buses.
      */
 
-    . = ORIGIN(dram0_0_seg) + _iram_end - _iram_start;
+    . = ORIGIN(dram0_0_seg) + MAX(_iram_end, _diram_i_start) - _diram_i_start;
   } > dram0_0_seg
 
   /* Shared RAM */

--- a/boards/xtensa/esp32s3/esp32s3-eye/scripts/esp32s3.ld
+++ b/boards/xtensa/esp32s3/esp32s3-eye/scripts/esp32s3.ld
@@ -71,7 +71,7 @@ SECTIONS
      * and dram0_0_seg reflect the same address space on different buses.
      */
 
-    . = ORIGIN(dram0_0_seg) + _iram_end - _iram_start;
+    . = ORIGIN(dram0_0_seg) + MAX(_iram_end, _diram_i_start) - _diram_i_start;
   } > dram0_0_seg
 
   /* Shared RAM */


### PR DESCRIPTION
## Summary
This PR intends to fix the offset calculation for preventing the overlapping between IRAM and DRAM regions.

On ESP32-S3, the **Internal SRAM 1** may be accessed both via the Instruction Bus as well via Data Bus:
![image](https://user-images.githubusercontent.com/38959758/186519751-12606baf-17df-45df-9cc5-be70d0e1faf3.png)

## Impact
Prior to this PR, the offset was greater than actually required, resulting in wasted memory space.

## Testing
`esp32s3-devkit:nsh` running `ostest` successfully.
Manual inspection of the output Linker map file.

