### PR TITLE
ESP32-S3: Fix alignment of FPU registers in exception context

### DIFF
--- a/arch/xtensa/include/irq.h
+++ b/arch/xtensa/include/irq.h
@@ -68,6 +68,10 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
+#ifndef ALIGN_UP
+#  define ALIGN_UP(num, align) (((num) + ((align) - 1)) & ~((align) - 1))
+#endif
+
 /* IRQ Stack Frame Format.  Each value is a uint32_t register index */
 
 #define REG_PC              (0)  /* Return PC */
@@ -138,18 +142,13 @@
 #endif
 
 #if XCHAL_CP_NUM > 0
-#  if (XCHAL_TOTAL_SA_ALIGN == 8) && ((_REG_CP_START & 1) == 1)
-  /* Fpu first address must align to cp align size. */
+  /* FPU first address must align to CP align size. */
 
-#    define REG_CP_DUMMY      (_REG_CP_START + 0)
-#    define XCPTCONTEXT_REGS  (_REG_CP_START + 1)
-#  else
-#    define XCPTCONTEXT_REGS  _REG_CP_START
-#  endif
-#  define XCPTCONTEXT_SIZE    ((4 * XCPTCONTEXT_REGS) + XTENSA_CP_SA_SIZE + 0x20)
+#  define XCPTCONTEXT_REGS  ALIGN_UP(_REG_CP_START, XCHAL_TOTAL_SA_ALIGN / 4)
+#  define XCPTCONTEXT_SIZE  ((4 * XCPTCONTEXT_REGS) + XTENSA_CP_SA_SIZE + 0x20)
 #else
-#  define XCPTCONTEXT_REGS    _REG_CP_START
-#  define XCPTCONTEXT_SIZE    ((4 * XCPTCONTEXT_REGS) + 0x20)
+#  define XCPTCONTEXT_REGS  _REG_CP_START
+#  define XCPTCONTEXT_SIZE  ((4 * XCPTCONTEXT_REGS) + 0x20)
 #endif
 
 /****************************************************************************


### PR DESCRIPTION
## Summary
This PR intends to fix the alignment of FPU registers in exception context for the **ESP32-S3** chip.
**ESP32-S3** requires a minimum alignment of 16 bytes for the total save area.

## Impact
Fixes #6914.

## Testing
Successful execution of `ostest` application on `esp32s3-devkit:nsh` with `MM_UBSAN` enabled.
