### PR TITLE
Added lock in ifr ioctl calls.

### DIFF
--- a/net/netdev/netdev_ioctl.c
+++ b/net/netdev/netdev_ioctl.c
@@ -641,6 +641,8 @@ static int netdev_ifr_ioctl(FAR struct socket *psock, int cmd,
 
   ninfo("cmd: %d\n", cmd);
 
+  net_lock();
+
   /* Execute the command */
 
   switch (cmd)
@@ -1138,6 +1140,8 @@ static int netdev_ifr_ioctl(FAR struct socket *psock, int cmd,
         }
         break;
     }
+
+  net_unlock();
 
   return ret;
 }


### PR DESCRIPTION
## Summary

Network device ioctl calls were not protected against concurrent access.
If two different threads try such a call simultaneously, the operation was corrupted.

In my case, this was especially true for MIIM operations on the Ethernet PHY. But I think that I can see other calls that may fail similarly.

This PR locks the network when such an ioctl operation is performed, so they are thread-safe now.

## Impact

Network device ioctl calls are now thread-safe.  
No functional change is expected by this PR.

## Testing

I am using a custom target for testing, based on the STM32F427 MCU.

I can confirm that the network operates normally after the change.  
By stepping through with my debugger, I can see that the lock is working correctly and no side-effects were observed.

However, please do review this commit carefully!  
Please comment if you know that this change may/may not cause a dead-lock or any other problem.
