### PR TITLE
risc-v/mpfs: ihc: fix performance issue

### DIFF
--- a/arch/risc-v/src/mpfs/mpfs_ihc.c
+++ b/arch/risc-v/src/mpfs/mpfs_ihc.c
@@ -785,22 +785,18 @@ static int mpfs_ihc_tx_message(ihc_channel_t channel, uint32_t *message)
   uint32_t mhartid      = mpfs_ihc_context_to_local_hart_id(channel);
   uint32_t rhartid      = mpfs_ihc_context_to_remote_hart_id(channel);
   uint32_t message_size = getreg32(MPFS_IHC_MSG_SIZE(mhartid, rhartid));
-  uint32_t ctrl_reg     = getreg32(MPFS_IHC_CTRL(mhartid, rhartid));
+  uint32_t ctrl_reg;
+  uint32_t retries      = 10000;
 
   DEBUGASSERT(message_size <= IHC_MAX_MESSAGE_SIZE);
 
   /* Check if the system is busy.  All we can try is wait. */
 
-  if ((RMP_MESSAGE_PRESENT | ACK_INT) & ctrl_reg)
+  do
     {
-#ifndef CONFIG_MPFS_OPENSBI
-      nxsig_usleep(100);
-#endif
-
-      /* Give it a one more try */
-
       ctrl_reg = getreg32(MPFS_IHC_CTRL(mhartid, rhartid));
     }
+  while ((ctrl_reg & (RMP_MESSAGE_PRESENT | ACK_INT)) && --retries);
 
   /* Return if RMP bit 1 indicating busy */
 


### PR DESCRIPTION
nxsig_usleep() will wait for the next timer tick which is way
too much here. It's not sleeping 100 us, but rather, near 1/60 s.

This causes severe performance problems. Fix this by polling the
register for a while if the remote end is busy.

Signed-off-by: Eero Nurkkala <eero.nurkkala@offcode.fi>

## Summary

Performing pings in a loop from Linux <-> NuttX appears slow, only 28800 bytes / sec. After the fix,
minimum 1 280 000 * 2 bytes / sec.

## Impact

MPFS Polarfire

## Testing

MPFS Polarfire kit with NuttX on hart 1 and Linux on harts 3 and 4.
