### PR TITLE
net: remove pvconn reference from all devif callback

### DIFF
--- a/net/arp/arp_poll.c
+++ b/net/arp/arp_poll.c
@@ -60,7 +60,7 @@ int arp_poll(FAR struct net_driver_s *dev, devif_poll_callback_t callback)
 
   /* Perform the ARP callbacks */
 
-  devif_conn_event(dev, NULL, ARP_POLL, dev->d_conncb);
+  devif_conn_event(dev, ARP_POLL, dev->d_conncb);
 
   /* Call back into the driver */
 

--- a/net/arp/arp_send.c
+++ b/net/arp/arp_send.c
@@ -71,7 +71,6 @@ static void arp_send_terminate(FAR struct arp_send_s *state, int result)
  ****************************************************************************/
 
 static uint16_t arp_send_eventhandler(FAR struct net_driver_s *dev,
-                                      FAR void *pvconn,
                                       FAR void *priv, uint16_t flags)
 {
   FAR struct arp_send_s *state = (FAR struct arp_send_s *)priv;

--- a/net/bluetooth/bluetooth_callback.c
+++ b/net/bluetooth/bluetooth_callback.c
@@ -69,8 +69,7 @@ uint16_t bluetooth_callback(FAR struct radio_driver_s *radio,
     {
       /* Perform the callback */
 
-      flags = devif_conn_event(&radio->r_dev, conn,
-                               flags, conn->bc_conn.list);
+      flags = devif_conn_event(&radio->r_dev, flags, conn->bc_conn.list);
     }
 
   return flags;

--- a/net/bluetooth/bluetooth_recvmsg.c
+++ b/net/bluetooth/bluetooth_recvmsg.c
@@ -205,7 +205,6 @@ static ssize_t
  ****************************************************************************/
 
 static uint16_t bluetooth_recvfrom_eventhandler(FAR struct net_driver_s *dev,
-                                                 FAR void *pvconn,
                                                  FAR void *pvpriv,
                                                  uint16_t flags)
 {
@@ -215,7 +214,7 @@ static uint16_t bluetooth_recvfrom_eventhandler(FAR struct net_driver_s *dev,
 
   ninfo("flags: %04x\n", flags);
 
-  DEBUGASSERT(pvpriv != NULL && dev != NULL && pvconn != NULL);
+  DEBUGASSERT(pvpriv != NULL && dev != NULL);
 
   /* Ignore polls from non Bluetooth network drivers */
 
@@ -228,7 +227,7 @@ static uint16_t bluetooth_recvfrom_eventhandler(FAR struct net_driver_s *dev,
 
 #warning Missing logic
 
-  pstate = (FAR struct bluetooth_recvfrom_s *)pvpriv;
+  pstate = pvpriv;
   radio  = (FAR struct radio_driver_s *)dev;
 
   /* 'pstate' might be null in some race conditions (?) */

--- a/net/bluetooth/bluetooth_sendmsg.c
+++ b/net/bluetooth/bluetooth_sendmsg.c
@@ -82,7 +82,6 @@ struct bluetooth_sendto_s
  ****************************************************************************/
 
 static uint16_t bluetooth_sendto_eventhandler(FAR struct net_driver_s *dev,
-                                               FAR void *pvconn,
                                                FAR void *pvpriv,
                                                uint16_t flags)
 {
@@ -106,7 +105,7 @@ static uint16_t bluetooth_sendto_eventhandler(FAR struct net_driver_s *dev,
 
 #warning Missing logic
 
-  pstate = (FAR struct bluetooth_sendto_s *)pvpriv;
+  pstate = pvpriv;
   radio  = (FAR struct radio_driver_s *)dev;
 
   ninfo("flags: %04x sent: %zd\n", flags, pstate->is_sent);

--- a/net/can/can_callback.c
+++ b/net/can/can_callback.c
@@ -139,7 +139,7 @@ uint16_t can_callback(FAR struct net_driver_s *dev,
 
       if (net_trylock() == OK)
         {
-          flags = devif_conn_event(dev, conn, flags, conn->sconn.list);
+          flags = devif_conn_event(dev, flags, conn->sconn.list);
           net_unlock();
         }
 

--- a/net/can/can_recvmsg.c
+++ b/net/can/can_recvmsg.c
@@ -404,10 +404,9 @@ static int can_recv_filter(struct can_conn_s *conn, canid_t id)
 #endif
 
 static uint16_t can_recvfrom_eventhandler(FAR struct net_driver_s *dev,
-                                          FAR void *pvconn,
                                           FAR void *pvpriv, uint16_t flags)
 {
-  struct can_recvfrom_s *pstate = (struct can_recvfrom_s *)pvpriv;
+  struct can_recvfrom_s *pstate = pvpriv;
 #if defined(CONFIG_NET_CANPROTO_OPTIONS) || defined(CONFIG_NET_TIMESTAMP)
   struct can_conn_s *conn = (struct can_conn_s *)pstate->pr_sock->s_conn;
 #endif

--- a/net/can/can_sendmsg.c
+++ b/net/can/can_sendmsg.c
@@ -77,10 +77,9 @@ struct send_s
  ****************************************************************************/
 
 static uint16_t psock_send_eventhandler(FAR struct net_driver_s *dev,
-                                        FAR void *pvconn,
                                         FAR void *pvpriv, uint16_t flags)
 {
-  FAR struct send_s *pstate = (FAR struct send_s *)pvpriv;
+  FAR struct send_s *pstate = pvpriv;
 
   if (pstate)
     {

--- a/net/can/can_sockif.c
+++ b/net/can/can_sockif.c
@@ -100,7 +100,7 @@ const struct sock_intf_s g_can_sockif =
  *
  * Input Parameters:
  *   dev      The structure of the network driver that caused the event
- *   conn     The connection structure associated with the socket
+ *   pvpriv   An instance of struct can_poll_s cast to void*
  *   flags    Set of events describing why the callback was invoked
  *
  * Returned Value:
@@ -112,10 +112,9 @@ const struct sock_intf_s g_can_sockif =
  ****************************************************************************/
 
 static uint16_t can_poll_eventhandler(FAR struct net_driver_s *dev,
-                                      FAR void *conn,
                                       FAR void *pvpriv, uint16_t flags)
 {
-  FAR struct can_poll_s *info = (FAR struct can_poll_s *)pvpriv;
+  FAR struct can_poll_s *info = pvpriv;
 
   DEBUGASSERT(!info || (info->psock && info->fds));
 

--- a/net/devif/devif.h
+++ b/net/devif/devif.h
@@ -253,7 +253,6 @@
 struct net_driver_s;       /* Forward reference */
 
 typedef CODE uint16_t (*devif_callback_event_t)(FAR struct net_driver_s *dev,
-                                                FAR void *pvconn,
                                                 FAR void *pvpriv,
                                                 uint16_t flags);
 
@@ -389,9 +388,6 @@ void devif_dev_callback_free(FAR struct net_driver_s *dev,
  * Input Parameters:
  *   dev - The network device state structure associated with the network
  *     device that initiated the callback event.
- *   pvconn - Holds a reference to the TCP connection structure or the UDP
- *     port structure. It can be NULL if the event is not related to a TCP
- *     connection or UDP port.
  *   flags - The bit set of events to be notified.
  *   list - The list to traverse in performing the notifications
  *
@@ -403,8 +399,8 @@ void devif_dev_callback_free(FAR struct net_driver_s *dev,
  *
  ****************************************************************************/
 
-uint16_t devif_conn_event(FAR struct net_driver_s *dev, FAR void *pvconn,
-                          uint16_t flags, FAR struct devif_callback_s *list);
+uint16_t devif_conn_event(FAR struct net_driver_s *dev, uint16_t flags,
+                          FAR struct devif_callback_s *list);
 
 /****************************************************************************
  * Name: devif_dev_event
@@ -415,9 +411,6 @@ uint16_t devif_conn_event(FAR struct net_driver_s *dev, FAR void *pvconn,
  * Input Parameters:
  *   dev - The network device state structure associated with the network
  *     device that initiated the callback event.
- *   pvconn - Holds a reference to the TCP connection structure or the UDP
- *     port structure. It can be NULL if the event is not related to a TCP
- *     connection or UDP port.
  *   flags - The bit set of events to be notified.
  *
  * Returned Value:
@@ -428,8 +421,7 @@ uint16_t devif_conn_event(FAR struct net_driver_s *dev, FAR void *pvconn,
  *
  ****************************************************************************/
 
-uint16_t devif_dev_event(FAR struct net_driver_s *dev, void *pvconn,
-                         uint16_t flags);
+uint16_t devif_dev_event(FAR struct net_driver_s *dev, uint16_t flags);
 
 /****************************************************************************
  * Send data on the current connection.

--- a/net/devif/devif_callback.c
+++ b/net/devif/devif_callback.c
@@ -465,9 +465,6 @@ void devif_dev_callback_free(FAR struct net_driver_s *dev,
  * Input Parameters:
  *   dev - The network device state structure associated with the network
  *     device that initiated the callback event.
- *   pvconn - Holds a reference to the TCP connection structure or the UDP
- *     port structure. It can be NULL if the event is not related to a TCP
- *     connection or UDP port.
  *   flags - The bit set of events to be notified.
  *   list - The list to traverse in performing the notifications
  *
@@ -479,8 +476,8 @@ void devif_dev_callback_free(FAR struct net_driver_s *dev,
  *
  ****************************************************************************/
 
-uint16_t devif_conn_event(FAR struct net_driver_s *dev, void *pvconn,
-                          uint16_t flags, FAR struct devif_callback_s *list)
+uint16_t devif_conn_event(FAR struct net_driver_s *dev, uint16_t flags,
+                          FAR struct devif_callback_s *list)
 {
   FAR struct devif_callback_s *next;
 
@@ -507,7 +504,7 @@ uint16_t devif_conn_event(FAR struct net_driver_s *dev, void *pvconn,
            * beginning of the list (which will be ignored on this pass)
            */
 
-          flags = list->event(dev, pvconn, list->priv, flags);
+          flags = list->event(dev, list->priv, flags);
         }
 
       /* Set up for the next time through the loop */
@@ -528,9 +525,6 @@ uint16_t devif_conn_event(FAR struct net_driver_s *dev, void *pvconn,
  * Input Parameters:
  *   dev - The network device state structure associated with the network
  *     device that initiated the callback event.
- *   pvconn - Holds a reference to the TCP connection structure or the UDP
- *     port structure. It can be NULL if the event is not related to a TCP
- *     connection or UDP port.
  *   flags - The bit set of events to be notified.
  *
  * Returned Value:
@@ -541,8 +535,7 @@ uint16_t devif_conn_event(FAR struct net_driver_s *dev, void *pvconn,
  *
  ****************************************************************************/
 
-uint16_t devif_dev_event(FAR struct net_driver_s *dev, void *pvconn,
-                         uint16_t flags)
+uint16_t devif_dev_event(FAR struct net_driver_s *dev, uint16_t flags)
 {
   FAR struct devif_callback_s *cb;
   FAR struct devif_callback_s *next;
@@ -570,7 +563,7 @@ uint16_t devif_dev_event(FAR struct net_driver_s *dev, void *pvconn,
            * beginning of the list (which will be ignored on this pass)
            */
 
-          flags = cb->event(dev, pvconn, cb->priv, flags);
+          flags = cb->event(dev, cb->priv, flags);
         }
     }
 

--- a/net/icmp/icmp_input.c
+++ b/net/icmp/icmp_input.c
@@ -330,7 +330,7 @@ void icmp_input(FAR struct net_driver_s *dev)
           goto drop;
         }
 
-      flags = devif_conn_event(dev, conn, ICMP_NEWDATA, conn->sconn.list);
+      flags = devif_conn_event(dev, ICMP_NEWDATA, conn->sconn.list);
       if ((flags & ICMP_NEWDATA) != 0)
         {
           uint16_t nbuffered;

--- a/net/icmp/icmp_netpoll.c
+++ b/net/icmp/icmp_netpoll.c
@@ -49,7 +49,7 @@
  *
  * Input Parameters:
  *   dev      The structure of the network driver that caused the event
- *   conn     The connection structure associated with the socket
+ *   pvpriv   An instance of struct icmp_poll_s cast to void*
  *   flags    Set of events describing why the callback was invoked
  *
  * Returned Value:
@@ -61,10 +61,9 @@
  ****************************************************************************/
 
 static uint16_t icmp_poll_eventhandler(FAR struct net_driver_s *dev,
-                                       FAR void *pvconn,
                                        FAR void *pvpriv, uint16_t flags)
 {
-  FAR struct icmp_poll_s *info = (FAR struct icmp_poll_s *)pvpriv;
+  FAR struct icmp_poll_s *info = pvpriv;
   FAR struct icmp_conn_s *conn;
   FAR struct socket *psock;
   pollevent_t eventset;

--- a/net/icmp/icmp_poll.c
+++ b/net/icmp/icmp_poll.c
@@ -72,7 +72,7 @@ void icmp_poll(FAR struct net_driver_s *dev, FAR struct icmp_conn_s *conn)
 
   /* Perform the application callback */
 
-  devif_conn_event(dev, conn, ICMP_POLL, conn->sconn.list);
+  devif_conn_event(dev, ICMP_POLL, conn->sconn.list);
 }
 
 #endif /* CONFIG_NET && CONFIG_NET_ICMP && CONFIG_NET_ICMP_SOCKET */

--- a/net/icmp/icmp_recvmsg.c
+++ b/net/icmp/icmp_recvmsg.c
@@ -80,7 +80,6 @@ struct icmp_recvfrom_s
  * Input Parameters:
  *   dev        The structure of the network driver that generated the
  *              event.
- *   conn       The received packet, cast to (void *)
  *   pvpriv     An instance of struct icmp_recvfrom_s cast to void*
  *   flags      Set of events describing why the callback was invoked
  *
@@ -93,10 +92,9 @@ struct icmp_recvfrom_s
  ****************************************************************************/
 
 static uint16_t recvfrom_eventhandler(FAR struct net_driver_s *dev,
-                                  FAR void *pvconn,
-                                  FAR void *pvpriv, uint16_t flags)
+                                      FAR void *pvpriv, uint16_t flags)
 {
-  FAR struct icmp_recvfrom_s *pstate = (struct icmp_recvfrom_s *)pvpriv;
+  FAR struct icmp_recvfrom_s *pstate = pvpriv;
   FAR struct socket *psock;
   FAR struct icmp_conn_s *conn;
   FAR struct ipv4_hdr_s *ipv4;

--- a/net/icmp/icmp_sendmsg.c
+++ b/net/icmp/icmp_sendmsg.c
@@ -178,7 +178,6 @@ static void sendto_request(FAR struct net_driver_s *dev,
  * Input Parameters:
  *   dev        The structure of the network driver that generated the
  *              event.
- *   conn       The received packet, cast to (void *)
  *   pvpriv     An instance of struct icmp_sendto_s cast to (void *)
  *   flags      Set of events describing why the callback was invoked
  *
@@ -191,10 +190,9 @@ static void sendto_request(FAR struct net_driver_s *dev,
  ****************************************************************************/
 
 static uint16_t sendto_eventhandler(FAR struct net_driver_s *dev,
-                                  FAR void *conn,
-                                  FAR void *pvpriv, uint16_t flags)
+                                    FAR void *pvpriv, uint16_t flags)
 {
-  FAR struct icmp_sendto_s *pstate = (struct icmp_sendto_s *)pvpriv;
+  FAR struct icmp_sendto_s *pstate = pvpriv;
 
   ninfo("flags: %04x\n", flags);
 

--- a/net/icmpv6/icmpv6_autoconfig.c
+++ b/net/icmpv6/icmpv6_autoconfig.c
@@ -90,7 +90,6 @@ static void icmpv6_router_terminate(FAR struct icmpv6_router_s *state,
  ****************************************************************************/
 
 static uint16_t icmpv6_router_eventhandler(FAR struct net_driver_s *dev,
-                                           FAR void *pvconn,
                                            FAR void *priv, uint16_t flags)
 {
   FAR struct icmpv6_router_s *state = (FAR struct icmpv6_router_s *)priv;

--- a/net/icmpv6/icmpv6_input.c
+++ b/net/icmpv6/icmpv6_input.c
@@ -457,7 +457,7 @@ void icmpv6_input(FAR struct net_driver_s *dev, unsigned int iplen)
 
         /* Dispatch the ECHO reply to the waiting thread */
 
-        flags = devif_conn_event(dev, conn, flags, conn->sconn.list);
+        flags = devif_conn_event(dev, flags, conn->sconn.list);
 
         /* Was the ECHO reply consumed by any waiting thread? */
 

--- a/net/icmpv6/icmpv6_neighbor.c
+++ b/net/icmpv6/icmpv6_neighbor.c
@@ -73,7 +73,6 @@ struct icmpv6_neighbor_s
  ****************************************************************************/
 
 static uint16_t icmpv6_neighbor_eventhandler(FAR struct net_driver_s *dev,
-                                             FAR void *pvconn,
                                              FAR void *priv, uint16_t flags)
 {
   FAR struct icmpv6_neighbor_s *state = (FAR struct icmpv6_neighbor_s *)priv;

--- a/net/icmpv6/icmpv6_netpoll.c
+++ b/net/icmpv6/icmpv6_netpoll.c
@@ -49,7 +49,7 @@
  *
  * Input Parameters:
  *   dev      The structure of the network driver that caused the event
- *   conn     The connection structure associated with the socket
+ *   pvpriv   An instance of struct icmpv6_poll_s cast to void*
  *   flags    Set of events describing why the callback was invoked
  *
  * Returned Value:
@@ -61,10 +61,9 @@
  ****************************************************************************/
 
 static uint16_t icmpv6_poll_eventhandler(FAR struct net_driver_s *dev,
-                                         FAR void *pvconn,
                                          FAR void *pvpriv, uint16_t flags)
 {
-  FAR struct icmpv6_poll_s *info = (FAR struct icmpv6_poll_s *)pvpriv;
+  FAR struct icmpv6_poll_s *info = pvpriv;
   FAR struct icmpv6_conn_s *conn;
   FAR struct socket *psock;
   pollevent_t eventset;

--- a/net/icmpv6/icmpv6_poll.c
+++ b/net/icmpv6/icmpv6_poll.c
@@ -73,7 +73,7 @@ void icmpv6_poll(FAR struct net_driver_s *dev,
 
   /* Perform the application callback */
 
-  devif_conn_event(dev, conn, ICMPv6_POLL,
+  devif_conn_event(dev, ICMPv6_POLL,
                    conn ? conn->sconn.list : dev->d_conncb);
 }
 

--- a/net/icmpv6/icmpv6_recvmsg.c
+++ b/net/icmpv6/icmpv6_recvmsg.c
@@ -83,7 +83,6 @@ struct icmpv6_recvfrom_s
  * Input Parameters:
  *   dev        The structure of the network driver that generated the
  *              event
- *   conn       The received packet, cast to (void *)
  *   pvpriv     An instance of struct icmpv6_recvfrom_s cast to void*
  *   flags      Set of events describing why the callback was invoked
  *
@@ -96,10 +95,9 @@ struct icmpv6_recvfrom_s
  ****************************************************************************/
 
 static uint16_t recvfrom_eventhandler(FAR struct net_driver_s *dev,
-                                  FAR void *pvconn,
-                                  FAR void *pvpriv, uint16_t flags)
+                                      FAR void *pvpriv, uint16_t flags)
 {
-  FAR struct icmpv6_recvfrom_s *pstate = (struct icmpv6_recvfrom_s *)pvpriv;
+  FAR struct icmpv6_recvfrom_s *pstate = pvpriv;
   FAR struct socket *psock;
   FAR struct icmpv6_conn_s *conn;
   FAR struct ipv6_hdr_s *ipv6;

--- a/net/icmpv6/icmpv6_sendmsg.c
+++ b/net/icmpv6/icmpv6_sendmsg.c
@@ -168,7 +168,6 @@ static void sendto_request(FAR struct net_driver_s *dev,
  * Input Parameters:
  *   dev        The structure of the network driver that generated the
  *              event
- *   pvconn     The received packet, cast to (void *)
  *   pvpriv     An instance of struct icmpv6_sendto_s cast to (void *)
  *   flags      Set of events describing why the callback was invoked
  *
@@ -181,10 +180,9 @@ static void sendto_request(FAR struct net_driver_s *dev,
  ****************************************************************************/
 
 static uint16_t sendto_eventhandler(FAR struct net_driver_s *dev,
-                                    FAR void *pvconn,
                                     FAR void *pvpriv, uint16_t flags)
 {
-  FAR struct icmpv6_sendto_s *pstate = (struct icmpv6_sendto_s *)pvpriv;
+  FAR struct icmpv6_sendto_s *pstate = pvpriv;
 
   ninfo("flags: %04x\n", flags);
 

--- a/net/ieee802154/ieee802154_callback.c
+++ b/net/ieee802154/ieee802154_callback.c
@@ -66,8 +66,7 @@ uint16_t ieee802154_callback(FAR struct radio_driver_s *radio,
     {
       /* Perform the callback */
 
-      flags = devif_conn_event(&radio->r_dev, conn, flags,
-                               conn->sconn.list);
+      flags = devif_conn_event(&radio->r_dev, flags, conn->sconn.list);
     }
 
   return flags;

--- a/net/ieee802154/ieee802154_recvmsg.c
+++ b/net/ieee802154/ieee802154_recvmsg.c
@@ -206,8 +206,7 @@ static ssize_t
 
 static uint16_t
   ieee802154_recvfrom_eventhandler(FAR struct net_driver_s *dev,
-                                   FAR void *pvconn, FAR void *pvpriv,
-                                   uint16_t flags)
+                                   FAR void *pvpriv, uint16_t flags)
 {
   FAR struct ieee802154_recvfrom_s *pstate;
   FAR struct radio_driver_s *radio;
@@ -215,7 +214,7 @@ static uint16_t
 
   ninfo("flags: %04x\n", flags);
 
-  DEBUGASSERT(pvpriv != NULL && dev != NULL && pvconn != NULL);
+  DEBUGASSERT(pvpriv != NULL && dev != NULL);
 
   /* Ignore polls from non IEEE 802.15.4 network drivers */
 
@@ -228,7 +227,7 @@ static uint16_t
 
 #warning Missing logic
 
-  pstate = (FAR struct ieee802154_recvfrom_s *)pvpriv;
+  pstate = pvpriv;
   radio  = (FAR struct radio_driver_s *)dev;
 
   /* 'pstate' might be null in some race conditions (?) */

--- a/net/ieee802154/ieee802154_sendmsg.c
+++ b/net/ieee802154/ieee802154_sendmsg.c
@@ -271,7 +271,6 @@ static void ieee802154_meta_data(FAR struct radio_driver_s *radio,
  ****************************************************************************/
 
 static uint16_t ieee802154_sendto_eventhandler(FAR struct net_driver_s *dev,
-                                               FAR void *pvconn,
                                                FAR void *pvpriv,
                                                uint16_t flags)
 {
@@ -295,7 +294,7 @@ static uint16_t ieee802154_sendto_eventhandler(FAR struct net_driver_s *dev,
 
 #warning Missing logic
 
-  pstate = (FAR struct ieee802154_sendto_s *)pvpriv;
+  pstate = pvpriv;
   radio  = (FAR struct radio_driver_s *)dev;
 
   ninfo("flags: %04x sent: %zd\n", flags, pstate->is_sent);

--- a/net/ipforward/ipfwd_forward.c
+++ b/net/ipforward/ipfwd_forward.c
@@ -107,7 +107,6 @@ static inline void forward_ipselect(FAR struct forward_s *fwd)
  * Input Parameters:
  *   dev        The structure of the network driver that generated the
  *              event
- *   conn       An instance of the forwarding structure cast to (void *)
  *   pvpriv     An instance of struct forward_s cast to (void *)
  *   flags      Set of events describing why the callback was invoked
  *
@@ -120,10 +119,9 @@ static inline void forward_ipselect(FAR struct forward_s *fwd)
  ****************************************************************************/
 
 static uint16_t ipfwd_eventhandler(FAR struct net_driver_s *dev,
-                                   FAR void *conn,
                                    FAR void *pvpriv, uint16_t flags)
 {
-  FAR struct forward_s *fwd = (FAR struct forward_s *)pvpriv;
+  FAR struct forward_s *fwd = pvpriv;
 
   ninfo("flags: %04x\n", flags);
   DEBUGASSERT(fwd != NULL && fwd->f_iob != NULL && fwd->f_dev != NULL);

--- a/net/ipforward/ipfwd_poll.c
+++ b/net/ipforward/ipfwd_poll.c
@@ -171,7 +171,7 @@ void ipfwd_poll(FAR struct net_driver_s *dev)
    * the packet was forwarded, then the new set will be zero.
    */
 
-  flags = devif_conn_event(dev, NULL, IPFWD_POLL, dev->d_conncb);
+  flags = devif_conn_event(dev, IPFWD_POLL, dev->d_conncb);
 
 #ifdef CONFIG_NET_6LOWPAN
   if ((flags & DEVPOLL_MASK) == 0)

--- a/net/netdev/netdev_carrier.c
+++ b/net/netdev/netdev_carrier.c
@@ -94,7 +94,7 @@ int netdev_carrier_off(FAR struct net_driver_s *dev)
 
       /* Notify clients that the network has been taken down */
 
-      devif_dev_event(dev, NULL, NETDEV_DOWN);
+      devif_dev_event(dev, NETDEV_DOWN);
       arp_cleanup(dev);
 
       return OK;

--- a/net/netdev/netdev_ioctl.c
+++ b/net/netdev/netdev_ioctl.c
@@ -1939,7 +1939,7 @@ int netdev_ifdown(FAR struct net_driver_s *dev)
 
               /* Notify clients that the network has been taken down */
 
-              devif_dev_event(dev, NULL, NETDEV_DOWN);
+              devif_dev_event(dev, NETDEV_DOWN);
 
 #ifdef CONFIG_NETDOWN_NOTIFIER
               /* Provide signal notifications to threads that want to be

--- a/net/pkt/pkt_callback.c
+++ b/net/pkt/pkt_callback.c
@@ -63,7 +63,7 @@ uint16_t pkt_callback(FAR struct net_driver_s *dev,
     {
       /* Perform the callback */
 
-      flags = devif_conn_event(dev, conn, flags, conn->sconn.list);
+      flags = devif_conn_event(dev, flags, conn->sconn.list);
     }
 
   return flags;

--- a/net/pkt/pkt_recvmsg.c
+++ b/net/pkt/pkt_recvmsg.c
@@ -168,10 +168,9 @@ static inline void pkt_recvfrom_sender(FAR struct net_driver_s *dev,
  ****************************************************************************/
 
 static uint16_t pkt_recvfrom_eventhandler(FAR struct net_driver_s *dev,
-                                          FAR void *pvconn,
                                           FAR void *pvpriv, uint16_t flags)
 {
-  struct pkt_recvfrom_s *pstate = (struct pkt_recvfrom_s *)pvpriv;
+  struct pkt_recvfrom_s *pstate = pvpriv;
 
   ninfo("flags: %04x\n", flags);
 

--- a/net/pkt/pkt_sendmsg.c
+++ b/net/pkt/pkt_sendmsg.c
@@ -73,10 +73,9 @@ struct send_s
  ****************************************************************************/
 
 static uint16_t psock_send_eventhandler(FAR struct net_driver_s *dev,
-                                        FAR void *pvconn,
                                         FAR void *pvpriv, uint16_t flags)
 {
-  FAR struct send_s *pstate = (FAR struct send_s *)pvpriv;
+  FAR struct send_s *pstate = pvpriv;
 
   ninfo("flags: %04x sent: %zd\n", flags, pstate->snd_sent);
 

--- a/net/sixlowpan/sixlowpan_send.c
+++ b/net/sixlowpan/sixlowpan_send.c
@@ -85,9 +85,9 @@ struct sixlowpan_send_s
  *   send operation when polled by the lower, device interfacing layer.
  *
  * Input Parameters:
- *   dev   - The structure of the network driver that generated the event.
- *   conn  - The connection structure associated with the socket
- *   flags - Set of events describing why the callback was invoked
+ *   dev    - The structure of the network driver that generated the event.
+ *   pvpriv - An instance of struct sixlowpan_send_s cast to void*
+ *   flags  - Set of events describing why the callback was invoked
  *
  * Returned Value:
  *   None
@@ -98,10 +98,9 @@ struct sixlowpan_send_s
  ****************************************************************************/
 
 static uint16_t send_eventhandler(FAR struct net_driver_s *dev,
-                                  FAR void *pvconn,
                                   FAR void *pvpriv, uint16_t flags)
 {
-  FAR struct sixlowpan_send_s *sinfo = (FAR struct sixlowpan_send_s *)pvpriv;
+  FAR struct sixlowpan_send_s *sinfo = pvpriv;
 
   ninfo("flags: %04x\n", flags);
 

--- a/net/sixlowpan/sixlowpan_tcpsend.c
+++ b/net/sixlowpan/sixlowpan_tcpsend.c
@@ -288,7 +288,6 @@ static int sixlowpan_tcp_header(FAR struct tcp_conn_s *conn,
  *
  * Input Parameters:
  *   dev    - The structure of the network driver that generated the event.
- *   pvconn - The connection structure associated with the socket
  *   pvpriv - The event handler's private data argument
  *   flags  - Set of events describing why the callback was invoked
  *
@@ -301,10 +300,9 @@ static int sixlowpan_tcp_header(FAR struct tcp_conn_s *conn,
  ****************************************************************************/
 
 static uint16_t tcp_send_eventhandler(FAR struct net_driver_s *dev,
-                                      FAR void *pvconn,
                                       FAR void *pvpriv, uint16_t flags)
 {
-  FAR struct sixlowpan_send_s *sinfo = (FAR struct sixlowpan_send_s *)pvpriv;
+  FAR struct sixlowpan_send_s *sinfo = pvpriv;
   FAR struct tcp_conn_s *conn = sinfo->s_conn;
   struct ipv6tcp_hdr_s ipv6tcp;
   int ret;

--- a/net/sixlowpan/sixlowpan_tcpsend.c
+++ b/net/sixlowpan/sixlowpan_tcpsend.c
@@ -76,7 +76,7 @@
 
 struct sixlowpan_send_s
 {
-  FAR struct socket           *s_sock;          /* Internal socket reference */
+  FAR struct tcp_conn_s       *s_conn;          /* Internal connect reference */
   FAR struct devif_callback_s *s_cb;            /* Reference to callback
                                                  * instance */
   sem_t                        s_waitsem;       /* Supports waiting for
@@ -305,7 +305,7 @@ static uint16_t tcp_send_eventhandler(FAR struct net_driver_s *dev,
                                       FAR void *pvpriv, uint16_t flags)
 {
   FAR struct sixlowpan_send_s *sinfo = (FAR struct sixlowpan_send_s *)pvpriv;
-  FAR struct tcp_conn_s *conn = (FAR struct tcp_conn_s *)pvconn;
+  FAR struct tcp_conn_s *conn = sinfo->s_conn;
   struct ipv6tcp_hdr_s ipv6tcp;
   int ret;
 
@@ -391,8 +391,6 @@ static uint16_t tcp_send_eventhandler(FAR struct net_driver_s *dev,
 
   else if ((flags & TCP_DISCONN_EVENTS) != 0)
     {
-      FAR struct socket *psock = sinfo->s_sock;
-
       nwarn("WARNING: Lost connection\n");
 
       /* We could get here recursively through the callback actions of
@@ -400,7 +398,6 @@ static uint16_t tcp_send_eventhandler(FAR struct net_driver_s *dev,
        * already been disconnected.
        */
 
-      DEBUGASSERT(psock != NULL);
       if (_SS_ISCONNECTED(conn->sconn.s_flags))
         {
           /* Report the disconnection event to all socket clones */
@@ -620,7 +617,7 @@ static int sixlowpan_send_packet(FAR struct socket *psock,
           nxsem_init(&sinfo.s_waitsem, 0, 0);
           nxsem_set_protocol(&sinfo.s_waitsem, SEM_PRIO_NONE);
 
-          sinfo.s_sock      = psock;
+          sinfo.s_conn      = conn;
           sinfo.s_result    = -EBUSY;
           sinfo.s_destmac   = destmac;
           sinfo.s_buf       = buf;

--- a/net/tcp/tcp.h
+++ b/net/tcp/tcp.h
@@ -1722,7 +1722,6 @@ int tcp_wrbuffer_test(void);
 
 #ifdef CONFIG_DEBUG_FEATURES
 void tcp_event_handler_dump(FAR struct net_driver_s *dev,
-                            FAR void *pvconn,
                             FAR void *pvpriv,
                             uint16_t flags,
                             FAR struct tcp_conn_s *conn);

--- a/net/tcp/tcp.h
+++ b/net/tcp/tcp.h
@@ -301,6 +301,10 @@ struct tcp_conn_s
   FAR struct devif_callback_s *connevents;
   FAR struct devif_callback_s *connevents_tail;
 
+  /* Reference to TCP close callback instance */
+
+  FAR struct devif_callback_s *clscb;
+
 #if defined(CONFIG_NET_TCP_WRITE_BUFFERS)
   /* Callback instance for TCP send() */
 

--- a/net/tcp/tcp_callback.c
+++ b/net/tcp/tcp_callback.c
@@ -166,7 +166,7 @@ uint16_t tcp_callback(FAR struct net_driver_s *dev,
    *                 not set, then dev->d_len should also be cleared).
    */
 
-  flags = devif_conn_event(dev, conn, flags, conn->sconn.list);
+  flags = devif_conn_event(dev, flags, conn->sconn.list);
 
   /* There may be no new data handler in place at them moment that the new
    * incoming data is received.  If the new incoming data was not handled,
@@ -190,7 +190,7 @@ uint16_t tcp_callback(FAR struct net_driver_s *dev,
     {
       /* Perform the callback disconnect callbacks */
 
-      flags = devif_conn_event(dev, conn, flags, conn->connevents);
+      flags = devif_conn_event(dev, flags, conn->connevents);
     }
 
 #ifdef CONFIG_NET_TCP_NOTIFIER

--- a/net/tcp/tcp_close.c
+++ b/net/tcp/tcp_close.c
@@ -66,8 +66,7 @@ static void tcp_close_work(FAR void *param)
  ****************************************************************************/
 
 static uint16_t tcp_close_eventhandler(FAR struct net_driver_s *dev,
-                                       FAR void *pvconn, FAR void *pvpriv,
-                                       uint16_t flags)
+                                       FAR void *pvpriv, uint16_t flags)
 {
   FAR struct tcp_conn_s *conn = pvpriv;
 

--- a/net/tcp/tcp_close.c
+++ b/net/tcp/tcp_close.c
@@ -69,8 +69,7 @@ static uint16_t tcp_close_eventhandler(FAR struct net_driver_s *dev,
                                        FAR void *pvconn, FAR void *pvpriv,
                                        uint16_t flags)
 {
-  FAR struct tcp_conn_s *conn = pvconn;
-  FAR struct devif_callback_s *cb = pvpriv;
+  FAR struct tcp_conn_s *conn = pvpriv;
 
   ninfo("flags: %04x\n", flags);
 
@@ -177,7 +176,7 @@ static uint16_t tcp_close_eventhandler(FAR struct net_driver_s *dev,
   return flags;
 
 end_wait:
-  tcp_callback_free(conn, cb);
+  tcp_callback_free(conn, conn->clscb);
 
   /* Free network resources */
 
@@ -253,7 +252,6 @@ static inline void tcp_close_txnotify(FAR struct socket *psock,
 static inline int tcp_close_disconnect(FAR struct socket *psock)
 {
   FAR struct tcp_conn_s *conn;
-  FAR struct devif_callback_s *cb;
   int ret = OK;
 
   /* Interrupts are disabled here to avoid race conditions */
@@ -306,13 +304,13 @@ static inline int tcp_close_disconnect(FAR struct socket *psock)
 
   if ((conn->tcpstateflags == TCP_ESTABLISHED ||
        conn->tcpstateflags == TCP_LAST_ACK) &&
-      (cb = tcp_callback_alloc(conn)) != NULL)
+      (conn->clscb = tcp_callback_alloc(conn)) != NULL)
     {
       /* Set up to receive TCP data event callbacks */
 
-      cb->flags = (TCP_NEWDATA | TCP_POLL | TCP_DISCONN_EVENTS);
-      cb->event = tcp_close_eventhandler;
-      cb->priv  = cb; /* reference for event handler to free cb */
+      conn->clscb->flags = TCP_NEWDATA | TCP_POLL | TCP_DISCONN_EVENTS;
+      conn->clscb->event = tcp_close_eventhandler;
+      conn->clscb->priv  = conn; /* reference for event handler to free cb */
 
       /* Notify the device driver of the availability of TX data */
 

--- a/net/tcp/tcp_connect.c
+++ b/net/tcp/tcp_connect.c
@@ -68,7 +68,6 @@ static inline int psock_setup_callbacks(FAR struct socket *psock,
 static void psock_teardown_callbacks(FAR struct tcp_connect_s *pstate,
                                      int status);
 static uint16_t psock_connect_eventhandler(FAR struct net_driver_s *dev,
-                                           FAR void *pvconn,
                                            FAR void *pvpriv, uint16_t flags);
 
 /****************************************************************************
@@ -149,7 +148,7 @@ static void psock_teardown_callbacks(FAR struct tcp_connect_s *pstate,
  *
  * Input Parameters:
  *   dev      The structure of the network driver that reported the event
- *   pvconn   The connection structure associated with the socket
+ *   pvpriv   An instance of struct tcp_connect_s cast to void*
  *   flags    Set of events describing why the callback was invoked
  *
  * Returned Value:
@@ -161,10 +160,9 @@ static void psock_teardown_callbacks(FAR struct tcp_connect_s *pstate,
  ****************************************************************************/
 
 static uint16_t psock_connect_eventhandler(FAR struct net_driver_s *dev,
-                                           FAR void *pvconn,
                                            FAR void *pvpriv, uint16_t flags)
 {
-  struct tcp_connect_s *pstate = (struct tcp_connect_s *)pvpriv;
+  struct tcp_connect_s *pstate = pvpriv;
   FAR struct tcp_conn_s *conn = pstate->tc_conn;
 
   ninfo("flags: %04x\n", flags);

--- a/net/tcp/tcp_dump.c
+++ b/net/tcp/tcp_dump.c
@@ -47,31 +47,30 @@
  ****************************************************************************/
 
 void tcp_event_handler_dump(FAR struct net_driver_s *dev,
-                            FAR void *pvconn,
                             FAR void *pvpriv,
                             uint16_t flags,
                             FAR struct tcp_conn_s *conn)
 {
 #ifdef CONFIG_NET_TCP_WRITE_BUFFERS
-  nerr("ERROR: conn->dev == NULL or pvconn != conn:"
-       " dev=%p pvconn=%p pvpriv=%p flags=0x%04x"
+  nerr("ERROR: conn->dev == NULL:"
+       " dev=%p pvpriv=%p flags=0x%04x"
        " conn->dev=%p conn->flags=0x%04x tcpstateflags=0x%02x crefs=%d"
        " isn=%" PRIu32 " sndseq=%" PRIu32
        " tx_unacked=%" PRId32 " sent=%" PRId32
        " conn=%p s_flags=0x%02x\n",
-       dev, pvconn, pvpriv, flags,
+       dev, pvpriv, flags,
        conn->dev, conn->flags, conn->tcpstateflags, conn->crefs,
        conn->isn, tcp_getsequence(conn->sndseq),
        (uint32_t)conn->tx_unacked, conn->sent,
        conn, conn->sconn.s_flags);
 #else
-  nerr("ERROR: conn->dev == NULL or pvconn != conn:"
-       " dev=%p pvconn=%p pvpriv=%p flags=0x%04x"
+  nerr("ERROR: conn->dev == NULL:"
+       " dev=%p pvpriv=%p flags=0x%04x"
        " conn->dev=%p conn->flags=0x%04x tcpstateflags=0x%02x crefs=%d"
        " sndseq=%" PRIu32
        " tx_unacked=%" PRId32
        " conn=%p s_flags=0x%02x\n",
-       dev, pvconn, pvpriv, flags,
+       dev, pvpriv, flags,
        conn->dev, conn->flags, conn->tcpstateflags, conn->crefs,
        tcp_getsequence(conn->sndseq),
        (uint32_t)conn->tx_unacked,

--- a/net/tcp/tcp_monitor.c
+++ b/net/tcp/tcp_monitor.c
@@ -43,8 +43,7 @@
 static void tcp_close_connection(FAR struct tcp_conn_s *conn,
                                  uint16_t flags);
 static uint16_t tcp_monitor_event(FAR struct net_driver_s *dev,
-                                  FAR void *pvconn, FAR void *pvpriv,
-                                  uint16_t flags);
+                                  FAR void *pvpriv, uint16_t flags);
 
 /****************************************************************************
  * Private Functions
@@ -114,7 +113,7 @@ static void tcp_close_connection(FAR struct tcp_conn_s *conn, uint16_t flags)
  *
  * Input Parameters:
  *   dev      The device which as active when the event was detected.
- *   conn     The connection structure associated with the socket
+ *   pvpriv   An instance of struct tcp_conn_s cast to void*
  *   flags    Set of events describing why the callback was invoked
  *
  * Returned Value:
@@ -126,8 +125,7 @@ static void tcp_close_connection(FAR struct tcp_conn_s *conn, uint16_t flags)
  ****************************************************************************/
 
 static uint16_t tcp_monitor_event(FAR struct net_driver_s *dev,
-                                  FAR void *pvconn, FAR void *pvpriv,
-                                  uint16_t flags)
+                                  FAR void *pvpriv, uint16_t flags)
 {
   FAR struct tcp_conn_s *conn = pvpriv;
 

--- a/net/tcp/tcp_netpoll.c
+++ b/net/tcp/tcp_netpoll.c
@@ -52,7 +52,7 @@
  *
  * Input Parameters:
  *   dev      The structure of the network driver that caused the event
- *   conn     The connection structure associated with the socket
+ *   pvpriv   An instance of struct tcp_poll_s cast to void*
  *   flags    Set of events describing why the callback was invoked
  *
  * Returned Value:
@@ -64,10 +64,9 @@
  ****************************************************************************/
 
 static uint16_t tcp_poll_eventhandler(FAR struct net_driver_s *dev,
-                                      FAR void *conn,
                                       FAR void *pvpriv, uint16_t flags)
 {
-  FAR struct tcp_poll_s *info = (FAR struct tcp_poll_s *)pvpriv;
+  FAR struct tcp_poll_s *info = pvpriv;
   int reason;
 
   ninfo("flags: %04x\n", flags);

--- a/net/tcp/tcp_recvfrom.c
+++ b/net/tcp/tcp_recvfrom.c
@@ -363,7 +363,7 @@ static inline void tcp_sender(FAR struct net_driver_s *dev,
  *
  * Input Parameters:
  *   dev      The structure of the network driver that generated the event.
- *   pvconn   The connection structure associated with the socket
+ *   pvpriv   An instance of struct tcp_recvfrom_s cast to void*
  *   flags    Set of events describing why the callback was invoked
  *
  * Returned Value:
@@ -375,24 +375,9 @@ static inline void tcp_sender(FAR struct net_driver_s *dev,
  ****************************************************************************/
 
 static uint16_t tcp_recvhandler(FAR struct net_driver_s *dev,
-                                FAR void *pvconn, FAR void *pvpriv,
-                                uint16_t flags)
+                                FAR void *pvpriv, uint16_t flags)
 {
-  FAR struct tcp_recvfrom_s *pstate = (struct tcp_recvfrom_s *)pvpriv;
-
-#if 0 /* REVISIT: The assertion fires.  Why? */
-  FAR struct tcp_conn_s *conn = (FAR struct tcp_conn_s *)pvconn;
-
-  /* The TCP socket is connected and, hence, should be bound to a device.
-   * Make sure that the polling device is the own that we are bound to.
-   */
-
-  DEBUGASSERT(conn->dev == NULL || conn->dev == dev);
-  if (conn->dev != NULL && conn->dev != dev)
-    {
-      return flags;
-    }
-#endif
+  FAR struct tcp_recvfrom_s *pstate = pvpriv;
 
   ninfo("flags: %04x\n", flags);
 

--- a/net/tcp/tcp_send_buffered.c
+++ b/net/tcp/tcp_send_buffered.c
@@ -299,7 +299,7 @@ static inline void send_ipselect(FAR struct net_driver_s *dev,
  *
  * Input Parameters:
  *   dev      The structure of the network driver that caused the event
- *   conn     The connection structure associated with the socket
+ *   pvpriv   An instance of struct tcp_conn_s cast to void*
  *   flags    Set of events describing why the callback was invoked
  *
  * Returned Value:
@@ -311,17 +311,8 @@ static inline void send_ipselect(FAR struct net_driver_s *dev,
  ****************************************************************************/
 
 static uint16_t psock_send_eventhandler(FAR struct net_driver_s *dev,
-                                        FAR void *pvconn, FAR void *pvpriv,
-                                        uint16_t flags)
+                                        FAR void *pvpriv, uint16_t flags)
 {
-  /* FAR struct tcp_conn_s *conn = (FAR struct tcp_conn_s *)pvconn;
-   *
-   * Do not use pvconn argument to get the TCP connection pointer (the above
-   * commented line) because pvconn is normally NULL for some events like
-   * NETDEV_DOWN. Instead, the TCP connection pointer can be reliably
-   * obtained from the corresponding TCP socket.
-   */
-
   FAR struct tcp_conn_s *conn = pvpriv;
 #ifdef CONFIG_NET_TCP_FAST_RETRANSMIT
   uint32_t rexmitno = 0;
@@ -332,19 +323,6 @@ static uint16_t psock_send_eventhandler(FAR struct net_driver_s *dev,
    */
 
   DEBUGASSERT(conn != NULL);
-
-#ifdef CONFIG_DEBUG_FEATURES
-  if (conn->dev == NULL || (pvconn != conn && pvconn != NULL))
-    {
-      tcp_event_handler_dump(dev, pvconn, pvpriv, flags, conn);
-    }
-#endif
-
-  /* If pvconn is not NULL, make sure that pvconn refers to the same
-   * connection as the socket is bound to.
-   */
-
-  DEBUGASSERT(pvconn == conn || pvconn == NULL);
 
   /* The TCP socket is connected and, hence, should be bound to a device.
    * Make sure that the polling device is the one that we are bound to.

--- a/net/tcp/tcp_send_unbuffered.c
+++ b/net/tcp/tcp_send_unbuffered.c
@@ -157,7 +157,7 @@ static inline void tcpsend_ipselect(FAR struct net_driver_s *dev,
  *
  * Input Parameters:
  *   dev      The structure of the network driver that caused the event
- *   conn     The connection structure associated with the socket
+ *   pvpriv   An instance of struct send_s cast to void*
  *   flags    Set of events describing why the callback was invoked
  *
  * Returned Value:
@@ -169,18 +169,9 @@ static inline void tcpsend_ipselect(FAR struct net_driver_s *dev,
  ****************************************************************************/
 
 static uint16_t tcpsend_eventhandler(FAR struct net_driver_s *dev,
-                                     FAR void *pvconn,
                                      FAR void *pvpriv, uint16_t flags)
 {
-  /* FAR struct tcp_conn_s *conn = (FAR struct tcp_conn_s *)pvconn;
-   *
-   * Do not use pvconn argument to get the TCP connection pointer (the above
-   * commented line) because pvconn is normally NULL for some events like
-   * NETDEV_DOWN. Instead, the TCP connection pointer can be reliably
-   * obtained from the corresponding TCP socket.
-   */
-
-  FAR struct send_s *pstate = (FAR struct send_s *)pvpriv;
+  FAR struct send_s *pstate = pvpriv;
   FAR struct socket *psock;
   FAR struct tcp_conn_s *conn;
 
@@ -195,19 +186,6 @@ static uint16_t tcpsend_eventhandler(FAR struct net_driver_s *dev,
 
   conn = psock->s_conn;
   DEBUGASSERT(conn != NULL);
-
-#ifdef CONFIG_DEBUG_NET_ERROR
-  if (conn->dev == NULL || (pvconn != conn && pvconn != NULL))
-    {
-      tcp_event_handler_dump(dev, pvconn, pvpriv, flags, conn);
-    }
-#endif
-
-  /* If pvconn is not NULL, make sure that pvconn refers to the same
-   * connection as the socket is bound to.
-   */
-
-  DEBUGASSERT(pvconn == conn || pvconn == NULL);
 
   /* The TCP socket is connected and, hence, should be bound to a device.
    * Make sure that the polling device is the one that we are bound to.

--- a/net/tcp/tcp_sendfile.c
+++ b/net/tcp/tcp_sendfile.c
@@ -110,7 +110,7 @@ struct sendfile_s
  *
  * Input Parameters:
  *   dev      The structure of the network driver that caused the event
- *   conn     The connection structure associated with the socket
+ *   pvpriv   An instance of struct sendfile_s cast to void*
  *   flags    Set of events describing why the callback was invoked
  *
  * Returned Value:
@@ -122,18 +122,9 @@ struct sendfile_s
  ****************************************************************************/
 
 static uint16_t sendfile_eventhandler(FAR struct net_driver_s *dev,
-                                      FAR void *pvconn, FAR void *pvpriv,
-                                      uint16_t flags)
+                                      FAR void *pvpriv, uint16_t flags)
 {
-  /* FAR struct tcp_conn_s *conn = (FAR struct tcp_conn_s *)pvconn;
-   *
-   * Do not use pvconn argument to get the TCP connection pointer (the above
-   * commented line) because pvconn is normally NULL for some events like
-   * NETDEV_DOWN. Instead, the TCP connection pointer can be reliably
-   * obtained from the corresponding TCP socket.
-   */
-
-  FAR struct sendfile_s *pstate = (FAR struct sendfile_s *)pvpriv;
+  FAR struct sendfile_s *pstate = pvpriv;
   FAR struct socket *psock;
   FAR struct tcp_conn_s *conn;
   int ret;
@@ -149,19 +140,6 @@ static uint16_t sendfile_eventhandler(FAR struct net_driver_s *dev,
 
   conn = psock->s_conn;
   DEBUGASSERT(conn != NULL);
-
-#ifdef CONFIG_DEBUG_NET_ERROR
-  if (conn->dev == NULL || (pvconn != conn && pvconn != NULL))
-    {
-      tcp_event_handler_dump(dev, pvconn, pvpriv, flags, conn);
-    }
-#endif
-
-  /* If pvconn is not NULL, make sure that pvconn refers to the same
-   * connection as the socket is bound to.
-   */
-
-  DEBUGASSERT(pvconn == conn || pvconn == NULL);
 
   /* The TCP socket is connected and, hence, should be bound to a device.
    * Make sure that the polling device is the own that we are bound to.

--- a/net/udp/udp_callback.c
+++ b/net/udp/udp_callback.c
@@ -316,7 +316,7 @@ uint16_t udp_callback(FAR struct net_driver_s *dev,
     {
       /* Perform the callback */
 
-      flags = devif_conn_event(dev, conn, flags, conn->sconn.list);
+      flags = devif_conn_event(dev, flags, conn->sconn.list);
 
       if ((flags & UDP_NEWDATA) != 0)
         {

--- a/net/udp/udp_netpoll.c
+++ b/net/udp/udp_netpoll.c
@@ -50,7 +50,7 @@
  *
  * Input Parameters:
  *   dev      The structure of the network driver that caused the event
- *   conn     The connection structure associated with the socket
+ *   pvpriv   An instance of struct udp_poll_s cast to void*
  *   flags    Set of events describing why the callback was invoked
  *
  * Returned Value:
@@ -62,10 +62,9 @@
  ****************************************************************************/
 
 static uint16_t udp_poll_eventhandler(FAR struct net_driver_s *dev,
-                                      FAR void *conn,
                                       FAR void *pvpriv, uint16_t flags)
 {
-  FAR struct udp_poll_s *info = (FAR struct udp_poll_s *)pvpriv;
+  FAR struct udp_poll_s *info = pvpriv;
 
   ninfo("flags: %04x\n", flags);
 

--- a/net/udp/udp_recvfrom.c
+++ b/net/udp/udp_recvfrom.c
@@ -411,7 +411,7 @@ static void udp_terminate(FAR struct udp_recvfrom_s *pstate, int result)
  *
  * Input Parameters:
  *   dev      The structure of the network driver that generated the event.
- *   pvconn   The connection structure associated with the socket
+ *   pvpriv   An instance of struct udp_recvfrom_s cast to void*
  *   flags    Set of events describing why the callback was invoked
  *
  * Returned Value:
@@ -423,10 +423,9 @@ static void udp_terminate(FAR struct udp_recvfrom_s *pstate, int result)
  ****************************************************************************/
 
 static uint16_t udp_eventhandler(FAR struct net_driver_s *dev,
-                                 FAR void *pvconn, FAR void *pvpriv,
-                                 uint16_t flags)
+                                 FAR void *pvpriv, uint16_t flags)
 {
-  FAR struct udp_recvfrom_s *pstate = (FAR struct udp_recvfrom_s *)pvpriv;
+  FAR struct udp_recvfrom_s *pstate = pvpriv;
 
   ninfo("flags: %04x\n", flags);
 

--- a/net/udp/udp_sendto_buffered.c
+++ b/net/udp/udp_sendto_buffered.c
@@ -97,8 +97,7 @@ static inline void sendto_ipselect(FAR struct net_driver_s *dev,
 #endif
 static int sendto_next_transfer(FAR struct udp_conn_s *conn);
 static uint16_t sendto_eventhandler(FAR struct net_driver_s *dev,
-                                    FAR void *pvconn, FAR void *pvpriv,
-                                    uint16_t flags);
+                                    FAR void *pvpriv, uint16_t flags);
 
 /****************************************************************************
  * Private Functions
@@ -352,10 +351,9 @@ static int sendto_next_transfer(FAR struct udp_conn_s *conn)
  ****************************************************************************/
 
 static uint16_t sendto_eventhandler(FAR struct net_driver_s *dev,
-                                    FAR void *pvconn, FAR void *pvpriv,
-                                    uint16_t flags)
+                                    FAR void *pvpriv, uint16_t flags)
 {
-  FAR struct udp_conn_s *conn = (FAR struct udp_conn_s *)pvpriv;
+  FAR struct udp_conn_s *conn = pvpriv;
 
   DEBUGASSERT(dev != NULL && conn != NULL);
 

--- a/net/udp/udp_sendto_unbuffered.c
+++ b/net/udp/udp_sendto_unbuffered.c
@@ -132,7 +132,6 @@ static inline void sendto_ipselect(FAR struct net_driver_s *dev,
  *
  * Input Parameters:
  *   dev        The structure of the network driver that caused the event
- *   conn       An instance of the UDP connection structure cast to void *
  *   pvpriv     An instance of struct sendto_s cast to void*
  *   flags      Set of events describing why the callback was invoked
  *
@@ -145,10 +144,9 @@ static inline void sendto_ipselect(FAR struct net_driver_s *dev,
  ****************************************************************************/
 
 static uint16_t sendto_eventhandler(FAR struct net_driver_s *dev,
-                                    FAR void *conn, FAR void *pvpriv,
-                                    uint16_t flags)
+                                    FAR void *pvpriv, uint16_t flags)
 {
-  FAR struct sendto_s *pstate = (FAR struct sendto_s *)pvpriv;
+  FAR struct sendto_s *pstate = pvpriv;
 
   DEBUGASSERT(pstate != NULL && pstate->st_dev != NULL);
   if (pstate != NULL)

--- a/net/usrsock/usrsock.h
+++ b/net/usrsock/usrsock.h
@@ -74,7 +74,7 @@ enum usrsock_conn_state_e
 
 struct usrsock_poll_s
 {
-  FAR struct socket *psock;        /* Needed to handle loss of connection */
+  FAR struct usrsock_conn_s *conn; /* Needed to handle loss of connection */
   struct pollfd *fds;              /* Needed to handle poll events */
   FAR struct devif_callback_s *cb; /* Needed to teardown the poll */
 };

--- a/net/usrsock/usrsock_accept.c
+++ b/net/usrsock/usrsock_accept.c
@@ -38,7 +38,7 @@
  * Private Functions
  ****************************************************************************/
 
-static uint16_t accept_event(FAR struct net_driver_s *dev, FAR void *pvconn,
+static uint16_t accept_event(FAR struct net_driver_s *dev,
                              FAR void *pvpriv, uint16_t flags)
 {
   FAR struct usrsock_data_reqstate_s *pstate = pvpriv;

--- a/net/usrsock/usrsock_accept.c
+++ b/net/usrsock/usrsock_accept.c
@@ -42,7 +42,7 @@ static uint16_t accept_event(FAR struct net_driver_s *dev, FAR void *pvconn,
                              FAR void *pvpriv, uint16_t flags)
 {
   FAR struct usrsock_data_reqstate_s *pstate = pvpriv;
-  FAR struct usrsock_conn_s *conn = pvconn;
+  FAR struct usrsock_conn_s *conn = pstate->reqstate.conn;
 
   if (flags & USRSOCK_EVENT_ABORT)
     {

--- a/net/usrsock/usrsock_bind.c
+++ b/net/usrsock/usrsock_bind.c
@@ -47,7 +47,7 @@ static uint16_t bind_event(FAR struct net_driver_s *dev, FAR void *pvconn,
                            FAR void *pvpriv, uint16_t flags)
 {
   FAR struct usrsock_reqstate_s *pstate = pvpriv;
-  FAR struct usrsock_conn_s *conn = pvconn;
+  FAR struct usrsock_conn_s *conn = pstate->conn;
 
   if (flags & USRSOCK_EVENT_ABORT)
     {

--- a/net/usrsock/usrsock_bind.c
+++ b/net/usrsock/usrsock_bind.c
@@ -43,7 +43,7 @@
  * Private Functions
  ****************************************************************************/
 
-static uint16_t bind_event(FAR struct net_driver_s *dev, FAR void *pvconn,
+static uint16_t bind_event(FAR struct net_driver_s *dev,
                            FAR void *pvpriv, uint16_t flags)
 {
   FAR struct usrsock_reqstate_s *pstate = pvpriv;

--- a/net/usrsock/usrsock_close.c
+++ b/net/usrsock/usrsock_close.c
@@ -47,7 +47,7 @@ static uint16_t close_event(FAR struct net_driver_s *dev, FAR void *pvconn,
                             FAR void *pvpriv, uint16_t flags)
 {
   FAR struct usrsock_reqstate_s *pstate = pvpriv;
-  FAR struct usrsock_conn_s *conn = pvconn;
+  FAR struct usrsock_conn_s *conn = pstate->conn;
 
   if (flags & USRSOCK_EVENT_ABORT)
     {

--- a/net/usrsock/usrsock_close.c
+++ b/net/usrsock/usrsock_close.c
@@ -43,7 +43,7 @@
  * Private Functions
  ****************************************************************************/
 
-static uint16_t close_event(FAR struct net_driver_s *dev, FAR void *pvconn,
+static uint16_t close_event(FAR struct net_driver_s *dev,
                             FAR void *pvpriv, uint16_t flags)
 {
   FAR struct usrsock_reqstate_s *pstate = pvpriv;

--- a/net/usrsock/usrsock_connect.c
+++ b/net/usrsock/usrsock_connect.c
@@ -47,7 +47,7 @@ static uint16_t connect_event(FAR struct net_driver_s *dev, FAR void *pvconn,
                               FAR void *pvpriv, uint16_t flags)
 {
   FAR struct usrsock_reqstate_s *pstate = pvpriv;
-  FAR struct usrsock_conn_s *conn = pvconn;
+  FAR struct usrsock_conn_s *conn = pstate->conn;
 
   if (flags & USRSOCK_EVENT_ABORT)
     {

--- a/net/usrsock/usrsock_connect.c
+++ b/net/usrsock/usrsock_connect.c
@@ -43,7 +43,7 @@
  * Private Functions
  ****************************************************************************/
 
-static uint16_t connect_event(FAR struct net_driver_s *dev, FAR void *pvconn,
+static uint16_t connect_event(FAR struct net_driver_s *dev,
                               FAR void *pvpriv, uint16_t flags)
 {
   FAR struct usrsock_reqstate_s *pstate = pvpriv;

--- a/net/usrsock/usrsock_event.c
+++ b/net/usrsock/usrsock_event.c
@@ -110,7 +110,7 @@ int usrsock_event(FAR struct usrsock_conn_s *conn, uint16_t events)
 
   /* Send events to callbacks */
 
-  devif_conn_event(NULL, conn, events, conn->sconn.list);
+  devif_conn_event(NULL, events, conn->sconn.list);
   net_unlock();
 
   return OK;

--- a/net/usrsock/usrsock_getpeername.c
+++ b/net/usrsock/usrsock_getpeername.c
@@ -44,7 +44,6 @@
  ****************************************************************************/
 
 static uint16_t getpeername_event(FAR struct net_driver_s *dev,
-                                  FAR void *pvconn,
                                   FAR void *pvpriv, uint16_t flags)
 {
   FAR struct usrsock_data_reqstate_s *pstate = pvpriv;

--- a/net/usrsock/usrsock_getpeername.c
+++ b/net/usrsock/usrsock_getpeername.c
@@ -48,7 +48,7 @@ static uint16_t getpeername_event(FAR struct net_driver_s *dev,
                                   FAR void *pvpriv, uint16_t flags)
 {
   FAR struct usrsock_data_reqstate_s *pstate = pvpriv;
-  FAR struct usrsock_conn_s *conn = pvconn;
+  FAR struct usrsock_conn_s *conn = pstate->reqstate.conn;
 
   if (flags & USRSOCK_EVENT_ABORT)
     {

--- a/net/usrsock/usrsock_getsockname.c
+++ b/net/usrsock/usrsock_getsockname.c
@@ -48,7 +48,7 @@ static uint16_t getsockname_event(FAR struct net_driver_s *dev,
                                   FAR void *pvpriv, uint16_t flags)
 {
   FAR struct usrsock_data_reqstate_s *pstate = pvpriv;
-  FAR struct usrsock_conn_s *conn = pvconn;
+  FAR struct usrsock_conn_s *conn = pstate->reqstate.conn;
 
   if (flags & USRSOCK_EVENT_ABORT)
     {

--- a/net/usrsock/usrsock_getsockname.c
+++ b/net/usrsock/usrsock_getsockname.c
@@ -44,7 +44,6 @@
  ****************************************************************************/
 
 static uint16_t getsockname_event(FAR struct net_driver_s *dev,
-                                  FAR void *pvconn,
                                   FAR void *pvpriv, uint16_t flags)
 {
   FAR struct usrsock_data_reqstate_s *pstate = pvpriv;

--- a/net/usrsock/usrsock_getsockopt.c
+++ b/net/usrsock/usrsock_getsockopt.c
@@ -49,7 +49,7 @@ static uint16_t getsockopt_event(FAR struct net_driver_s *dev,
                                  uint16_t flags)
 {
   FAR struct usrsock_data_reqstate_s *pstate = pvpriv;
-  FAR struct usrsock_conn_s *conn = pvconn;
+  FAR struct usrsock_conn_s *conn = pstate->reqstate.conn;
 
   if (flags & USRSOCK_EVENT_ABORT)
     {

--- a/net/usrsock/usrsock_getsockopt.c
+++ b/net/usrsock/usrsock_getsockopt.c
@@ -45,8 +45,7 @@
  ****************************************************************************/
 
 static uint16_t getsockopt_event(FAR struct net_driver_s *dev,
-                                 FAR void *pvconn, FAR void *pvpriv,
-                                 uint16_t flags)
+                                 FAR void *pvpriv, uint16_t flags)
 {
   FAR struct usrsock_data_reqstate_s *pstate = pvpriv;
   FAR struct usrsock_conn_s *conn = pstate->reqstate.conn;

--- a/net/usrsock/usrsock_ioctl.c
+++ b/net/usrsock/usrsock_ioctl.c
@@ -49,7 +49,7 @@ static uint16_t ioctl_event(FAR struct net_driver_s *dev,
                                   FAR void *pvpriv, uint16_t flags)
 {
   FAR struct usrsock_data_reqstate_s *pstate = pvpriv;
-  FAR struct usrsock_conn_s *conn = pvconn;
+  FAR struct usrsock_conn_s *conn = pstate->reqstate.conn;
 
   if (flags & USRSOCK_EVENT_ABORT)
     {

--- a/net/usrsock/usrsock_ioctl.c
+++ b/net/usrsock/usrsock_ioctl.c
@@ -45,8 +45,7 @@
  ****************************************************************************/
 
 static uint16_t ioctl_event(FAR struct net_driver_s *dev,
-                                  FAR void *pvconn,
-                                  FAR void *pvpriv, uint16_t flags)
+                            FAR void *pvpriv, uint16_t flags)
 {
   FAR struct usrsock_data_reqstate_s *pstate = pvpriv;
   FAR struct usrsock_conn_s *conn = pstate->reqstate.conn;

--- a/net/usrsock/usrsock_listen.c
+++ b/net/usrsock/usrsock_listen.c
@@ -38,7 +38,7 @@
  * Private Functions
  ****************************************************************************/
 
-static uint16_t listen_event(FAR struct net_driver_s *dev, FAR void *pvconn,
+static uint16_t listen_event(FAR struct net_driver_s *dev,
                              FAR void *pvpriv, uint16_t flags)
 {
   FAR struct usrsock_reqstate_s *pstate = pvpriv;

--- a/net/usrsock/usrsock_listen.c
+++ b/net/usrsock/usrsock_listen.c
@@ -42,7 +42,7 @@ static uint16_t listen_event(FAR struct net_driver_s *dev, FAR void *pvconn,
                              FAR void *pvpriv, uint16_t flags)
 {
   FAR struct usrsock_reqstate_s *pstate = pvpriv;
-  FAR struct usrsock_conn_s *conn = pvconn;
+  FAR struct usrsock_conn_s *conn = pstate->conn;
 
   if (flags & USRSOCK_EVENT_ABORT)
     {

--- a/net/usrsock/usrsock_poll.c
+++ b/net/usrsock/usrsock_poll.c
@@ -49,10 +49,10 @@ static uint16_t poll_event(FAR struct net_driver_s *dev, FAR void *pvconn,
                            FAR void *pvpriv, uint16_t flags)
 {
   FAR struct usrsock_poll_s *info = (FAR struct usrsock_poll_s *)pvpriv;
-  FAR struct usrsock_conn_s *conn = pvconn;
+  FAR struct usrsock_conn_s *conn = info->conn;
   pollevent_t eventset = 0;
 
-  DEBUGASSERT(!info || (info->psock && info->fds));
+  DEBUGASSERT(!info || info->fds);
 
   if (info == NULL)
     {
@@ -161,7 +161,7 @@ static int usrsock_pollsetup(FAR struct socket *psock,
   /* Find a container to hold the poll information */
 
   info = conn->pollinfo;
-  while (info->psock != NULL)
+  while (info->conn != NULL)
     {
       if (++info >= &conn->pollinfo[CONFIG_NET_USRSOCK_NPOLLWAITERS])
         {
@@ -181,9 +181,9 @@ static int usrsock_pollsetup(FAR struct socket *psock,
 
   /* Initialize the poll info container */
 
-  info->psock  = psock;
-  info->fds    = fds;
-  info->cb     = cb;
+  info->conn  = conn;
+  info->fds   = fds;
+  info->cb    = cb;
 
   /* Initialize the callback structure.  Save the reference to the info
    * structure as callback private data so that it will be available during
@@ -327,7 +327,7 @@ static int usrsock_pollteardown(FAR struct socket *psock,
 
       /* Then free the poll info container */
 
-      info->psock = NULL;
+      info->conn = NULL;
     }
 
   return OK;

--- a/net/usrsock/usrsock_poll.c
+++ b/net/usrsock/usrsock_poll.c
@@ -45,10 +45,10 @@
  * Private Functions
  ****************************************************************************/
 
-static uint16_t poll_event(FAR struct net_driver_s *dev, FAR void *pvconn,
+static uint16_t poll_event(FAR struct net_driver_s *dev,
                            FAR void *pvpriv, uint16_t flags)
 {
-  FAR struct usrsock_poll_s *info = (FAR struct usrsock_poll_s *)pvpriv;
+  FAR struct usrsock_poll_s *info = pvpriv;
   FAR struct usrsock_conn_s *conn = info->conn;
   pollevent_t eventset = 0;
 

--- a/net/usrsock/usrsock_recvmsg.c
+++ b/net/usrsock/usrsock_recvmsg.c
@@ -44,8 +44,7 @@
  ****************************************************************************/
 
 static uint16_t recvfrom_event(FAR struct net_driver_s *dev,
-                               FAR void *pvconn, FAR void *pvpriv,
-                               uint16_t flags)
+                               FAR void *pvpriv, uint16_t flags)
 {
   FAR struct usrsock_data_reqstate_s *pstate = pvpriv;
   FAR struct usrsock_conn_s *conn = pstate->reqstate.conn;

--- a/net/usrsock/usrsock_recvmsg.c
+++ b/net/usrsock/usrsock_recvmsg.c
@@ -48,7 +48,7 @@ static uint16_t recvfrom_event(FAR struct net_driver_s *dev,
                                uint16_t flags)
 {
   FAR struct usrsock_data_reqstate_s *pstate = pvpriv;
-  FAR struct usrsock_conn_s *conn = pvconn;
+  FAR struct usrsock_conn_s *conn = pstate->reqstate.conn;
 
   if (flags & USRSOCK_EVENT_ABORT)
     {

--- a/net/usrsock/usrsock_sendmsg.c
+++ b/net/usrsock/usrsock_sendmsg.c
@@ -43,7 +43,7 @@
  * Private Functions
  ****************************************************************************/
 
-static uint16_t sendto_event(FAR struct net_driver_s *dev, FAR void *pvconn,
+static uint16_t sendto_event(FAR struct net_driver_s *dev,
                              FAR void *pvpriv, uint16_t flags)
 {
   FAR struct usrsock_reqstate_s *pstate = pvpriv;

--- a/net/usrsock/usrsock_sendmsg.c
+++ b/net/usrsock/usrsock_sendmsg.c
@@ -47,7 +47,7 @@ static uint16_t sendto_event(FAR struct net_driver_s *dev, FAR void *pvconn,
                              FAR void *pvpriv, uint16_t flags)
 {
   FAR struct usrsock_reqstate_s *pstate = pvpriv;
-  FAR struct usrsock_conn_s *conn = pvconn;
+  FAR struct usrsock_conn_s *conn = pstate->conn;
 
   if (flags & USRSOCK_EVENT_ABORT)
     {

--- a/net/usrsock/usrsock_setsockopt.c
+++ b/net/usrsock/usrsock_setsockopt.c
@@ -45,8 +45,7 @@
  ****************************************************************************/
 
 static uint16_t setsockopt_event(FAR struct net_driver_s *dev,
-                                 FAR void *pvconn, FAR void *pvpriv,
-                                 uint16_t flags)
+                                 FAR void *pvpriv, uint16_t flags)
 {
   FAR struct usrsock_reqstate_s *pstate = pvpriv;
   FAR struct usrsock_conn_s *conn = pstate->conn;

--- a/net/usrsock/usrsock_setsockopt.c
+++ b/net/usrsock/usrsock_setsockopt.c
@@ -49,7 +49,7 @@ static uint16_t setsockopt_event(FAR struct net_driver_s *dev,
                                  uint16_t flags)
 {
   FAR struct usrsock_reqstate_s *pstate = pvpriv;
-  FAR struct usrsock_conn_s *conn = pvconn;
+  FAR struct usrsock_conn_s *conn = pstate->conn;
 
   if (flags & USRSOCK_EVENT_ABORT)
     {

--- a/net/usrsock/usrsock_socket.c
+++ b/net/usrsock/usrsock_socket.c
@@ -44,7 +44,7 @@
  * Private Functions
  ****************************************************************************/
 
-static uint16_t socket_event(FAR struct net_driver_s *dev, FAR void *pvconn,
+static uint16_t socket_event(FAR struct net_driver_s *dev,
                              FAR void *pvpriv, uint16_t flags)
 {
   FAR struct usrsock_reqstate_s *pstate = pvpriv;

--- a/net/usrsock/usrsock_socket.c
+++ b/net/usrsock/usrsock_socket.c
@@ -48,7 +48,7 @@ static uint16_t socket_event(FAR struct net_driver_s *dev, FAR void *pvconn,
                              FAR void *pvpriv, uint16_t flags)
 {
   FAR struct usrsock_reqstate_s *pstate = pvpriv;
-  FAR struct usrsock_conn_s *conn = pvconn;
+  FAR struct usrsock_conn_s *conn = pstate->conn;
 
   if (flags & USRSOCK_EVENT_ABORT)
     {


### PR DESCRIPTION
## Summary

net: cleanup pvconn reference to avoid confuse
net: remove pvconn reference from all devif callback

Do not use 'pvconn' argument to get the connection pointer since
pvconn is normally NULL for some events like NETDEV_DOWN.
Instead, the connection pointer can be reliably obtained from the
corresponding private pointer.

More reference:
@a-lunev 
https://github.com/apache/incubator-nuttx/pull/5252
https://github.com/apache/incubator-nuttx/pull/5434


## Impact

N/A

## Testing

tcp/udp/usrsock/icmp