### PR TITLE
xtensa: Fix allocation of FPU registers in exception context

### DIFF
--- a/arch/arm/src/armv7-a/arm_fpucmp.c
+++ b/arch/arm/src/armv7-a/arm_fpucmp.c
@@ -44,7 +44,14 @@
  * Name: up_fpucmp
  *
  * Description:
- *   compare FPU areas from thread context
+ *   Compare FPU areas from thread context.
+ *
+ * Input Parameters:
+ *   saveregs1 - Pointer to the saved FPU registers.
+ *   saveregs2 - Pointer to the saved FPU registers.
+ *
+ * Returned Value:
+ *   True if FPU areas compare equal, False otherwise.
  *
  ****************************************************************************/
 

--- a/arch/arm/src/armv7-m/arm_fpucmp.c
+++ b/arch/arm/src/armv7-m/arm_fpucmp.c
@@ -44,7 +44,14 @@
  * Name: up_fpucmp
  *
  * Description:
- *   compare FPU areas from thread context
+ *   Compare FPU areas from thread context.
+ *
+ * Input Parameters:
+ *   saveregs1 - Pointer to the saved FPU registers.
+ *   saveregs2 - Pointer to the saved FPU registers.
+ *
+ * Returned Value:
+ *   True if FPU areas compare equal, False otherwise.
  *
  ****************************************************************************/
 

--- a/arch/arm/src/armv7-r/arm_fpucmp.c
+++ b/arch/arm/src/armv7-r/arm_fpucmp.c
@@ -44,7 +44,14 @@
  * Name: up_fpucmp
  *
  * Description:
- *   compare FPU areas from thread context
+ *   Compare FPU areas from thread context.
+ *
+ * Input Parameters:
+ *   saveregs1 - Pointer to the saved FPU registers.
+ *   saveregs2 - Pointer to the saved FPU registers.
+ *
+ * Returned Value:
+ *   True if FPU areas compare equal, False otherwise.
  *
  ****************************************************************************/
 

--- a/arch/arm/src/armv8-m/arm_fpucmp.c
+++ b/arch/arm/src/armv8-m/arm_fpucmp.c
@@ -44,7 +44,14 @@
  * Name: up_fpucmp
  *
  * Description:
- *   compare FPU areas from thread context
+ *   Compare FPU areas from thread context.
+ *
+ * Input Parameters:
+ *   saveregs1 - Pointer to the saved FPU registers.
+ *   saveregs2 - Pointer to the saved FPU registers.
+ *
+ * Returned Value:
+ *   True if FPU areas compare equal, False otherwise.
  *
  ****************************************************************************/
 

--- a/arch/arm64/src/common/arm64_fpu.c
+++ b/arch/arm64/src/common/arm64_fpu.c
@@ -229,7 +229,14 @@ void arm64_fpu_disable(void)
  * Name: up_fpucmp
  *
  * Description:
- *   compare FPU areas from thread context
+ *   Compare FPU areas from thread context.
+ *
+ * Input Parameters:
+ *   saveregs1 - Pointer to the saved FPU registers.
+ *   saveregs2 - Pointer to the saved FPU registers.
+ *
+ * Returned Value:
+ *   True if FPU areas compare equal, False otherwise.
  *
  ***************************************************************************/
 

--- a/arch/risc-v/src/common/riscv_fpucmp.c
+++ b/arch/risc-v/src/common/riscv_fpucmp.c
@@ -44,7 +44,14 @@
  * Name: up_fpucmp
  *
  * Description:
- *   compare FPU areas from thread context
+ *   Compare FPU areas from thread context.
+ *
+ * Input Parameters:
+ *   saveregs1 - Pointer to the saved FPU registers.
+ *   saveregs2 - Pointer to the saved FPU registers.
+ *
+ * Returned Value:
+ *   True if FPU areas compare equal, False otherwise.
  *
  ****************************************************************************/
 

--- a/arch/xtensa/include/irq.h
+++ b/arch/xtensa/include/irq.h
@@ -144,12 +144,16 @@
 #if XCHAL_CP_NUM > 0
   /* FPU first address must align to CP align size. */
 
-#  define XCPTCONTEXT_REGS  ALIGN_UP(_REG_CP_START, XCHAL_TOTAL_SA_ALIGN / 4)
-#  define XCPTCONTEXT_SIZE  ((4 * XCPTCONTEXT_REGS) + XTENSA_CP_SA_SIZE + 0x20)
+#  define COMMON_CTX_REGS   ALIGN_UP(_REG_CP_START, XCHAL_TOTAL_SA_ALIGN / 4)
+#  define COPROC_CTX_REGS   (XTENSA_CP_SA_SIZE / 4)
+#  define RESERVE_REGS      8
+#  define XCPTCONTEXT_REGS  (COMMON_CTX_REGS + COPROC_CTX_REGS + RESERVE_REGS)
 #else
-#  define XCPTCONTEXT_REGS  _REG_CP_START
-#  define XCPTCONTEXT_SIZE  ((4 * XCPTCONTEXT_REGS) + 0x20)
+#  define RESERVE_REGS      8
+#  define XCPTCONTEXT_REGS  (_REG_CP_START + RESERVE_REGS)
 #endif
+
+#define XCPTCONTEXT_SIZE    (4 * XCPTCONTEXT_REGS)
 
 /****************************************************************************
  * Public Types

--- a/arch/xtensa/src/common/xtensa_coproc.S
+++ b/arch/xtensa/src/common/xtensa_coproc.S
@@ -105,7 +105,7 @@ _xtensa_coproc_saoffsets:
 	* ---------------------------------------------------| <- SP
 	*/
 
-	addi		a3, sp, (4 * XCPTCONTEXT_REGS)
+	addi		a3, sp, (4 * COMMON_CTX_REGS)
 
 	/* CPENABLE should show which CPs are enabled. */
 
@@ -216,7 +216,7 @@ Ldone1:
 	* ---------------------------------------------------| <- SP
 	*/
 
-	addi		a3, a2, (4 * XCPTCONTEXT_REGS)
+	addi		a3, a2, (4 * COMMON_CTX_REGS)
 
 	rsr		a8, CPENABLE			/* a8 = which CPs are enabled */
 	beqz		a8, Ldone2			/* Quick exit if none */

--- a/arch/xtensa/src/common/xtensa_fpucmp.c
+++ b/arch/xtensa/src/common/xtensa_fpucmp.c
@@ -54,6 +54,6 @@ bool up_fpucmp(const void *saveregs1, const void *saveregs2)
   const uint32_t *regs2 = saveregs2;
 
   return memcmp(&regs1[XCPTCONTEXT_REGS], &regs2[XCPTCONTEXT_REGS],
-                XTENSA_CP_SA_SIZE);
+                XTENSA_CP_SA_SIZE) == 0;
 }
 #endif /* CONFIG_ARCH_FPU */

--- a/arch/xtensa/src/common/xtensa_fpucmp.c
+++ b/arch/xtensa/src/common/xtensa_fpucmp.c
@@ -44,7 +44,14 @@
  * Name: up_fpucmp
  *
  * Description:
- *   compare FPU areas from thread context
+ *   Compare FPU areas from thread context.
+ *
+ * Input Parameters:
+ *   saveregs1 - Pointer to the saved FPU registers.
+ *   saveregs2 - Pointer to the saved FPU registers.
+ *
+ * Returned Value:
+ *   True if FPU areas compare equal, False otherwise.
  *
  ****************************************************************************/
 

--- a/arch/xtensa/src/common/xtensa_fpucmp.c
+++ b/arch/xtensa/src/common/xtensa_fpucmp.c
@@ -60,7 +60,7 @@ bool up_fpucmp(const void *saveregs1, const void *saveregs2)
   const uint32_t *regs1 = saveregs1;
   const uint32_t *regs2 = saveregs2;
 
-  return memcmp(&regs1[XCPTCONTEXT_REGS], &regs2[XCPTCONTEXT_REGS],
+  return memcmp(&regs1[COMMON_CTX_REGS], &regs2[COMMON_CTX_REGS],
                 XTENSA_CP_SA_SIZE) == 0;
 }
 #endif /* CONFIG_ARCH_FPU */

--- a/arch/xtensa/src/common/xtensa_tcbinfo.c
+++ b/arch/xtensa/src/common/xtensa_tcbinfo.c
@@ -64,7 +64,7 @@ const struct tcbinfo_s g_tcbinfo =
   .pri_off   = TCB_PRI_OFF,
   .name_off  = TCB_NAME_OFF,
   .regs_off  = TCB_REGS_OFF,
-  .basic_num = XCPTCONTEXT_REGS,
+  .basic_num = COMMON_CTX_REGS,
   .total_num = XCPTCONTEXT_REGS,
   {
     .p = g_reg_offs,

--- a/include/nuttx/arch.h
+++ b/include/nuttx/arch.h
@@ -2594,7 +2594,14 @@ int up_saveusercontext(FAR void *saveregs);
  * Name: up_fpucmp
  *
  * Description:
- *   compare FPU areas from thread context
+ *   Compare FPU areas from thread context.
+ *
+ * Input Parameters:
+ *   saveregs1 - Pointer to the saved FPU registers.
+ *   saveregs2 - Pointer to the saved FPU registers.
+ *
+ * Returned Value:
+ *   True if FPU areas compare equal, False otherwise.
  *
  ****************************************************************************/
 


### PR DESCRIPTION
## Summary
This PR intends to fix the allocation of FPU (and other coprocessors) registers in exception context.

## Impact
Fix `FPU Test` in `ostest` for Xtensa chips.

Solved memory corruption reported in #6914:
```sh
user_main: FPU test       
Starting task FPU#1       
fpu_test: Started task FPU#1 at PID=4
FPU#1: pass 1                                                         
Starting task FPU#2       
fpu_test: Started task FPU#2 at PID=5
FPU#2: pass 1             
FPU#1: pass 2             
FPU#2: pass 2             
FPU#1: pass 3                                     
FPU#2: pass 3                                      
FPU#1: pass 4                                      
FPU#2: pass 4                                                         
FPU#1: pass 5               
FPU#2: pass 5                                                         
FPU#1: pass 6                                 
FPU#2: pass 6                                
FPU#1: pass 7                               
FPU#2: pass 7                               
FPU#1: pass 8                                           
FPU#2: pass 8                                  
FPU#1: pass 9                                                      
FPU#2: pass 9                                                                                                                                
FPU#1: pass 10                                   
FPU#2: pass 10               
FPU#1: pass 11               
FPU#2: pass 11                   
FPU#1: pass 12                
FPU#2: pass 12                            
FPU#1: pass 13                         
FPU#2: pass 13                                  
FPU#1: pass 14                                   
FPU#2: pass 14       
FPU#1: pass 15                                                        
FPU#2: pass 15           
FPU#1: pass 16          
FPU#2: pass 16            
FPU#1: Succeeded               
FPU#2: Succeeded          
fpu_test: Returning
```

## Testing
Successful execution of `ostest` in the following targets:
- `esp32-devkitc:nsh`
- `esp32-devkitc:smp`
- `esp32s3-devkit:nsh` (`CONFIG_XTENSA_CP_INITSET=0x001` and `CONFIG_XTENSA_CP_INITSET=0x009`)
- `esp32s3-devkit:smp` (`CONFIG_XTENSA_CP_INITSET=0x001` and `CONFIG_XTENSA_CP_INITSET=0x009`)