### PR TITLE
net/icmpv6: finetune the RA parsing procedure

### DIFF
--- a/net/icmpv6/icmpv6.h
+++ b/net/icmpv6/icmpv6.h
@@ -439,7 +439,7 @@ void icmpv6_setaddresses(FAR struct net_driver_s *dev,
                          const net_ipv6addr_t prefix,
                          unsigned int preflen);
 #else
-#  define icmpv6_setaddresses(d,d,p,p) (0)
+#  define icmpv6_setaddresses(dev,draddr,prefix,preflen) (0)
 #endif
 
 /****************************************************************************

--- a/net/icmpv6/icmpv6.h
+++ b/net/icmpv6/icmpv6.h
@@ -425,6 +425,24 @@ int icmpv6_autoconfig(FAR struct net_driver_s *dev);
 #endif
 
 /****************************************************************************
+ * Name: icmpv6_setaddresses
+ *
+ * Description:
+ *   We successfully obtained the Router Advertisement.  Set the new IPv6
+ *   addresses in the driver structure.
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_NET_ICMPv6_AUTOCONF
+void icmpv6_setaddresses(FAR struct net_driver_s *dev,
+                         const net_ipv6addr_t draddr,
+                         const net_ipv6addr_t prefix,
+                         unsigned int preflen);
+#else
+#  define icmpv6_setaddresses(d,d,p,p) (0)
+#endif
+
+/****************************************************************************
  * Name: icmpv6_rwait_setup
  *
  * Description:
@@ -502,12 +520,9 @@ int icmpv6_rwait(FAR struct icmpv6_rnotify_s *notify, unsigned int timeout);
  ****************************************************************************/
 
 #ifdef CONFIG_NET_ICMPv6_AUTOCONF
-void icmpv6_rnotify(FAR struct net_driver_s *dev,
-                    const net_ipv6addr_t draddr,
-                    const net_ipv6addr_t prefix,
-                    unsigned int preflen);
+void icmpv6_rnotify(FAR struct net_driver_s *dev);
 #else
-#  define icmpv6_rnotify(d,p,l)
+#  define icmpv6_rnotify(d) (0)
 #endif
 
 /****************************************************************************

--- a/net/icmpv6/icmpv6_input.c
+++ b/net/icmpv6/icmpv6_input.c
@@ -408,7 +408,7 @@ void icmpv6_input(FAR struct net_driver_s *dev, unsigned int iplen)
                   {
                     FAR struct icmpv6_mtu_s *mtuopt =
                                         (FAR struct icmpv6_mtu_s *)opt;
-                    dev->d_pktsize = mtuopt->mtu;
+                    dev->d_pktsize = NTOHL(mtuopt->mtu);
                   }
                   break;
 

--- a/net/icmpv6/icmpv6_input.c
+++ b/net/icmpv6/icmpv6_input.c
@@ -391,10 +391,14 @@ void icmpv6_input(FAR struct net_driver_s *dev, unsigned int iplen)
 
                     if ((prefixopt->flags & ICMPv6_PRFX_FLAG_A) != 0)
                       {
+                        /* Yes.. Set the new network addresses. */
+
+                        icmpv6_setaddresses(dev, ipv6->srcipaddr,
+                                    prefixopt->prefix, prefixopt->preflen);
+
                         /* Notify any waiting threads */
 
-                        icmpv6_rnotify(dev, ipv6->srcipaddr,
-                                    prefixopt->prefix, prefixopt->preflen);
+                        icmpv6_rnotify(dev);
                         prefix = true;
                       }
                   }

--- a/net/icmpv6/icmpv6_input.c
+++ b/net/icmpv6/icmpv6_input.c
@@ -369,29 +369,47 @@ void icmpv6_input(FAR struct net_driver_s *dev, unsigned int iplen)
 
         for (ndx = 0; ndx + sizeof(struct icmpv6_prefixinfo_s) <= optlen; )
           {
-            FAR struct icmpv6_srclladdr_s *sllopt =
-              (FAR struct icmpv6_srclladdr_s *)&options[ndx];
+           FAR struct icmpv6_generic_s *opt =
+                                (FAR struct icmpv6_generic_s *)&options[ndx];
 
-            if (sllopt->opttype == ICMPv6_OPT_SRCLLADDR)
+            switch (opt->opttype)
               {
-                neighbor_add(dev, ipv6->srcipaddr, sllopt->srclladdr);
-              }
+                case ICMPv6_OPT_SRCLLADDR:
+                  {
+                    FAR struct icmpv6_srclladdr_s *sllopt =
+                                      (FAR struct icmpv6_srclladdr_s *)opt;
+                    neighbor_add(dev, ipv6->srcipaddr, sllopt->srclladdr);
+                  }
+                  break;
 
-            FAR struct icmpv6_prefixinfo_s *opt =
-              (FAR struct icmpv6_prefixinfo_s *)&options[ndx];
+                case ICMPv6_OPT_PREFIX:
+                  {
+                    FAR struct icmpv6_prefixinfo_s *prefixopt =
+                                      (FAR struct icmpv6_prefixinfo_s *)opt;
 
-            /* Is this the sought for prefix? Is it the correct size? Is
-             * the "A" flag set?
-             */
+                    /* Is the "A" flag set? */
 
-            if (opt->opttype == ICMPv6_OPT_PREFIX &&
-               (opt->flags & ICMPv6_PRFX_FLAG_A) != 0)
-              {
-                /* Yes.. Notify any waiting threads */
+                    if ((prefixopt->flags & ICMPv6_PRFX_FLAG_A) != 0)
+                      {
+                        /* Notify any waiting threads */
 
-                icmpv6_rnotify(dev, ipv6->srcipaddr,
-                               opt->prefix, opt->preflen);
-                prefix = true;
+                        icmpv6_rnotify(dev, ipv6->srcipaddr,
+                                    prefixopt->prefix, prefixopt->preflen);
+                        prefix = true;
+                      }
+                  }
+                  break;
+
+                case ICMPv6_OPT_MTU:
+                  {
+                    FAR struct icmpv6_mtu_s *mtuopt =
+                                        (FAR struct icmpv6_mtu_s *)opt;
+                    dev->d_pktsize = mtuopt->mtu;
+                  }
+                  break;
+
+                default:
+                  break;
               }
 
             /* Skip to the next option (units of octets) */

--- a/net/icmpv6/icmpv6_rnotify.c
+++ b/net/icmpv6/icmpv6_rnotify.c
@@ -58,22 +58,22 @@
 static struct icmpv6_rnotify_s *g_icmpv6_rwaiters;
 
 /****************************************************************************
- * Private Functions
+ * Public Functions
  ****************************************************************************/
 
 /****************************************************************************
  * Name: icmpv6_setaddresses
  *
  * Description:
- *   We successfully obtained the Router Advertisement.  See the new IPv6
+ *   We successfully obtained the Router Advertisement.  Set the new IPv6
  *   addresses in the driver structure.
  *
  ****************************************************************************/
 
-static void icmpv6_setaddresses(FAR struct net_driver_s *dev,
-                                const net_ipv6addr_t draddr,
-                                const net_ipv6addr_t prefix,
-                                unsigned int preflen)
+void icmpv6_setaddresses(FAR struct net_driver_s *dev,
+                         const net_ipv6addr_t draddr,
+                         const net_ipv6addr_t prefix,
+                         unsigned int preflen)
 {
   unsigned int i;
 
@@ -138,10 +138,6 @@ static void icmpv6_setaddresses(FAR struct net_driver_s *dev,
 
   net_unlock();
 }
-
-/****************************************************************************
- * Public Functions
- ****************************************************************************/
 
 /****************************************************************************
  * Name: icmpv6_rwait_setup
@@ -287,9 +283,7 @@ int icmpv6_rwait(FAR struct icmpv6_rnotify_s *notify, unsigned int timeout)
  *
  ****************************************************************************/
 
-void icmpv6_rnotify(FAR struct net_driver_s *dev,
-                    const net_ipv6addr_t draddr, const net_ipv6addr_t prefix,
-                    unsigned int preflen)
+void icmpv6_rnotify(FAR struct net_driver_s *dev)
 {
   FAR struct icmpv6_rnotify_s *curr;
 
@@ -307,10 +301,6 @@ void icmpv6_rnotify(FAR struct net_driver_s *dev,
       if (curr->rn_result != OK &&
           strncmp(curr->rn_ifname, dev->d_ifname, IFNAMSIZ) == 0)
         {
-          /* Yes.. Set the new network addresses. */
-
-          icmpv6_setaddresses(dev, draddr, prefix, preflen);
-
           /* And signal the waiting, returning success */
 
           curr->rn_result = OK;


### PR DESCRIPTION
## Summary

icmpv6: finetune the RA parsing procedure
icmpv6: update IPv6 NIC parameters unconditionally when ICMPv6 RA is received
icmpv6: add NTOHL when parse ICMPV6 option MTU

## Impact

N/A

## Testing

icmpv6 ping6