### PR TITLE
list.h: Change inline function to macro as much as possbile

### DIFF
--- a/include/nuttx/list.h
+++ b/include/nuttx/list.h
@@ -37,8 +37,36 @@
 #define LIST_INITIAL_VALUE(list) { &(list), &(list) }
 #define LIST_INITIAL_CLEARED_VALUE { NULL, NULL }
 
-#define list_add_after(entry, new_entry) list_add_head(entry, new_entry)
-#define list_add_before(entry, new_entry) list_add_tail(entry, new_entry)
+#define list_in_list(item) ((item)->prev || (item)->next)
+#define list_is_empty(list) ((list)->next == list)
+#define list_is_clear(list) ((list)->next == NULL)
+
+#define list_initialize(list) \
+  do \
+    { \
+      (list)->prev = (list)->next = (list); \
+    } \
+  while(0)
+
+#define list_clear_node(item) \
+  do \
+    { \
+      (item)->prev = (item)->next = NULL; \
+    } \
+  while (0)
+
+#define list_peek_head(list) ((list)->next != (list) ? (list)->next : NULL)
+#define list_peek_tail(list) ((list)->prev != (list) ? (list)->prev : NULL)
+
+#define list_prev(list, item) ((item)->prev != (list) ? (item)->prev : NULL)
+#define list_prev_wrap(list, item) \
+  ((item)->prev != (list) ? (item)->prev : \
+   (item)->prev->prev != (list) ? (item)->prev->prev : NULL)
+
+#define list_next(list, item) ((item)->next != (list) ? (item)->next : NULL)
+#define list_next_wrap(list, item) \
+  ((item)->next != (list) ? (item)->next : \
+   (item)->next->next != (list) ? (item)->next->next : NULL)
 
 /**
  * list_entry - get the struct for this entry
@@ -71,140 +99,171 @@
 #define list_last_entry(ptr, type, member) \
            list_entry((ptr)->prev, type, member)
 
-#define list_remove_head_type(list, type, element) (\
+#define list_add_after(entry, new_entry) list_add_head(entry, new_entry)
+#define list_add_head(list, item) \
+  do \
+    { \
+      (item)->next       = (list)->next; \
+      (item)->prev       = (list); \
+      (list)->next->prev = (item); \
+      (list)->next       = (item); \
+    } \
+  while (0)
+
+#define list_add_before(entry, new_entry) list_add_tail(entry, new_entry)
+#define list_add_tail(list, item) \
+  do \
+    { \
+      (item)->prev       = (list)->prev; \
+      (item)->next       = (list); \
+      (list)->prev->next = (item); \
+      (list)->prev       = (item); \
+    } \
+  while (0)
+
+#define list_delete(item) \
+  do \
+    { \
+      (item)->next->prev = (item)->prev; \
+      (item)->prev->next = (item)->next; \
+      (item)->prev       = (item)->next = NULL; \
+    } \
+  while (0)
+
+#define list_remove_head_type(list, type, element) ( \
 {\
-  FAR struct list_node *__nod = list_remove_head(list);\
-  FAR type *__t;\
+  FAR struct list_node *__nod = list_remove_head(list); \
+  FAR type *__t; \
 \
-  if(__nod)\
+  if(__nod) \
+    { \
+      __t = container_of(__nod, type, element); \
+    } \
+  else \
     {\
-      __t = container_of(__nod, type, element);\
-    }\
-  else\
-    {\
-      __t = (type *)0;\
-    }\
+      __t = (FAR type *)NULL; \
+    } \
 \
-  __t;\
+  __t; \
 })
 
-#define list_remove_tail_type(list, type, element) (\
+#define list_remove_tail_type(list, type, element) ( \
 {\
-  FAR struct list_node *__nod = list_remove_tail(list);\
-  FAR type *__t;\
+  FAR struct list_node *__nod = list_remove_tail(list); \
+  FAR type *__t; \
 \
-  if(__nod)\
-    {\
-      __t = container_of(__nod, type, element);\
-    }\
+  if(__nod) \
+    { \
+      __t = container_of(__nod, type, element); \
+    } \
   else\
-    {\
-      __t = (type *)0;\
-    }\
+    { \
+      __t = (FAR type *)NULL; \
+    } \
 \
-  __t;\
+  __t; \
 })
 
-#define list_peek_head_type(list, type, element) (\
+#define list_peek_head_type(list, type, element) ( \
 {\
-  FAR struct list_node *__nod = list_peek_head(list);\
-  FAR type *__t;\
+  FAR struct list_node *__nod = list_peek_head(list); \
+  FAR type *__t; \
 \
-  if(__nod)\
-    {\
-      __t = container_of(__nod, type, element);\
-    }\
-  else\
-    {\
-      __t = (type *)0;\
-    }\
+  if(__nod) \
+    { \
+      __t = container_of(__nod, type, element); \
+    } \
+  else \
+    { \
+      __t = (FAR type *)NULL; \
+    } \
 \
-  __t;\
+  __t; \
 })
 
-#define list_peek_tail_type(list, type, element) (\
-{\
-  FAR struct list_node *__nod = list_peek_tail(list);\
-  FAR type *__t;\
+#define list_peek_tail_type(list, type, element) ( \
+{ \
+  FAR struct list_node *__nod = list_peek_tail(list); \
+  FAR type *__t; \
 \
-  if(__nod)\
-    {\
-      __t = container_of(__nod, type, element);\
-    }\
+  if(__nod) \
+    { \
+      __t = container_of(__nod, type, element); \
+    } \
   else\
-    {\
-      __t = (type *)0;\
-    }\
+    { \
+      __t = (FAR type *)NULL; \
+    } \
 \
-  __t;\
+  __t; \
 })
 
-#define list_prev_type(list, item, type, element) (\
-{\
-  FAR struct list_node *__nod = list_prev(list, item);\
-  FAR type *__t;\
+#define list_prev_type(list, item, type, element) ( \
+{ \
+  FAR struct list_node *__nod = list_prev(list, item); \
+  FAR type *__t; \
 \
-  if(__nod)\
-    {\
-      __t = container_of(__nod, type, element);\
-    }\
-  else\
-    {\
-      __t = (type *)0;\
-    }\
+  if(__nod) \
+    { \
+      __t = container_of(__nod, type, element); \
+    } \
+  else \
+    { \
+      __t = (FAR type *)NULL; \
+    } \
 \
-  __t;\
+  __t; \
 })
 
-#define list_prev_wrap_type(list, item, type, element) (\
-{\
-  FAR struct list_node *__nod = list_prev_wrap(list, item);\
-  FAR type *__t;\
+#define list_prev_wrap_type(list, item, type, element) ( \
+{ \
+  FAR struct list_node *__nod = list_prev_wrap(list, item); \
+  FAR type *__t; \
 \
-  if(__nod)\
-    {\
-      __t = container_of(__nod, type, element);\
-    }\
-  else\
-    {\
-      __t = (type *)0;\
-    }\
+  if(__nod) \
+    { \
+      __t = container_of(__nod, type, element); \
+    } \
+  else \
+    { \
+      __t = (FAR type *)NULL; \
+    } \
 \
-  __t;\
+  __t; \
 })
 
-#define list_next_type(list, item, type, element) (\
-{\
-  FAR struct list_node *__nod = list_next(list, item);\
-  FAR type *__t;\
+#define list_next_type(list, item, type, element) ( \
+{ \
+  FAR struct list_node *__nod = list_next(list, item); \
+  FAR type *__t; \
 \
-  if(__nod)\
-    {\
-      __t = container_of(__nod, type, element);\
-    }\
-  else\
-    {\
-      __t = (type *)0;\
-    }\
+  if(__nod) \
+    { \
+      __t = container_of(__nod, type, element); \
+    } \
+  else \
+    { \
+      __t = (FAR type *)NULL; \
+    } \
 \
-  __t;\
+  __t; \
 })
 
-#define list_next_wrap_type(list, item, type, element) (\
+#define list_next_wrap_type(list, item, type, element) ( \
 {\
-  FAR struct list_node *__nod = list_next_wrap(list, item);\
-  FAR type *__t;\
+  FAR struct list_node *__nod = list_next_wrap(list, item); \
+  FAR type *__t; \
 \
-  if(__nod)\
-    {\
-      __t = container_of(__nod, type, element);\
-    }\
-  else\
-    {\
-      __t = (type *)0;\
-    }\
+  if(__nod) \
+    { \
+      __t = container_of(__nod, type, element); \
+    } \
+  else \
+    { \
+      __t = (FAR type *)NULL; \
+    } \
 \
-  __t;\
+  __t; \
 })
 
 /* iterates over the list, node should be struct list_node* */
@@ -217,15 +276,15 @@
  */
 
 #define list_for_every_safe(list, node, temp_node) \
-  for(node = (list)->next, temp_node = (node)->next;\
-      node != (list);\
+  for(node = (list)->next, temp_node = (node)->next; \
+      node != (list); \
       node = temp_node, temp_node = (node)->next)
 
 /* iterates over the list, entry should be the container structure type */
 
 #define list_for_every_entry(list, entry, type, member) \
-  for((entry) = container_of((list)->next, type, member);\
-      &(entry)->member != (list);\
+  for((entry) = container_of((list)->next, type, member); \
+      &(entry)->member != (list); \
       (entry) = container_of((entry)->member.next, type, member))
 
 /* iterates over the list in a safe way for deletion of current node
@@ -233,9 +292,9 @@
  */
 
 #define list_for_every_entry_safe(list, entry, temp_entry, type, member) \
-  for(entry = container_of((list)->next, type, member),\
-      temp_entry = container_of((entry)->member.next, type, member);\
-      &(entry)->member != (list);\
+  for(entry = container_of((list)->next, type, member), \
+      temp_entry = container_of((entry)->member.next, type, member); \
+      &(entry)->member != (list); \
       entry = temp_entry, \
       temp_entry = container_of((temp_entry)->member.next, type, member))
 
@@ -252,53 +311,6 @@ struct list_node
 /****************************************************************************
  * Inline Functions
  ****************************************************************************/
-
-static inline void list_initialize(FAR struct list_node *list)
-{
-  list->prev = list->next = list;
-}
-
-static inline void list_clear_node(FAR struct list_node *item)
-{
-  item->prev = item->next = 0;
-}
-
-static inline bool list_in_list(FAR struct list_node *item)
-{
-  if (item->prev == 0 && item->next == 0)
-    {
-      return false;
-    }
-  else
-    {
-      return true;
-    }
-}
-
-static inline void list_add_head(FAR struct list_node *list,
-                                 FAR struct list_node *item)
-{
-  item->next       = list->next;
-  item->prev       = list;
-  list->next->prev = item;
-  list->next       = item;
-}
-
-static inline void list_add_tail(FAR struct list_node *list,
-                                 FAR struct list_node *item)
-{
-  item->prev       = list->prev;
-  item->next       = list;
-  list->prev->next = item;
-  list->prev       = item;
-}
-
-static inline void list_delete(struct list_node *item)
-{
-  item->next->prev = item->prev;
-  item->prev->next = item->next;
-  item->prev       = item->next = 0;
-}
 
 static inline FAR struct list_node *
 list_remove_head(FAR struct list_node *list)
@@ -328,102 +340,6 @@ list_remove_tail(FAR struct list_node *list)
     {
       return NULL;
     }
-}
-
-static inline FAR struct list_node *
-list_peek_head(FAR struct list_node *list)
-{
-  if (list->next != list)
-    {
-      return list->next;
-    }
-  else
-    {
-      return NULL;
-    }
-}
-
-static inline FAR struct list_node *
-list_peek_tail(FAR struct list_node *list)
-{
-  if (list->prev != list)
-    {
-      return list->prev;
-    }
-  else
-    {
-      return NULL;
-    }
-}
-
-static inline FAR struct list_node *list_prev(FAR struct list_node *list,
-                                              FAR struct list_node *item)
-{
-  if (item->prev != list)
-    {
-      return item->prev;
-    }
-  else
-    {
-      return NULL;
-    }
-}
-
-static inline FAR struct list_node *
-list_prev_wrap(FAR struct list_node *list, FAR struct list_node *item)
-{
-  if (item->prev != list)
-    {
-      return item->prev;
-    }
-  else if (item->prev->prev != list)
-    {
-      return item->prev->prev;
-    }
-  else
-    {
-      return NULL;
-    }
-}
-
-static inline FAR struct list_node *list_next(FAR struct list_node *list,
-                                              FAR struct list_node *item)
-{
-  if (item->next != list)
-    {
-      return item->next;
-    }
-  else
-    {
-      return NULL;
-    }
-}
-
-static inline FAR struct list_node *
-list_next_wrap(FAR struct list_node *list, FAR struct list_node *item)
-{
-  if (item->next != list)
-    {
-      return item->next;
-    }
-  else if (item->next->next != list)
-    {
-      return item->next->next;
-    }
-  else
-    {
-      return NULL;
-    }
-}
-
-static inline bool list_is_empty(FAR struct list_node *list)
-{
-  return list->next == list;
-}
-
-static inline bool list_is_clear(FAR struct list_node *list)
-{
-  return list->next == NULL;
 }
 
 static inline size_t list_length(FAR struct list_node *list)

--- a/include/nuttx/list.h
+++ b/include/nuttx/list.h
@@ -40,6 +40,37 @@
 #define list_add_after(entry, new_entry) list_add_head(entry, new_entry)
 #define list_add_before(entry, new_entry) list_add_tail(entry, new_entry)
 
+/**
+ * list_entry - get the struct for this entry
+ * @ptr: the &struct list_head pointer.
+ * @type: the type of the struct this is embedded in.
+ * @member: the name of the list_head within the struct.
+ */
+#define list_entry(ptr, type, member) \
+           container_of(ptr, type, member)
+
+/**
+ * list_first_entry - get the first element from a list
+ * @ptr: the list head to take the element from.
+ * @type: the type of the struct this is embedded in.
+ * @member: the name of the list_head within the struct.
+ *
+ * Note, that list is expected to be not empty.
+ */
+#define list_first_entry(ptr, type, member) \
+             list_entry((ptr)->next, type, member)
+
+/**
+ * list_last_entry - get the last element from a list
+ * @ptr: the list head to take the element from.
+ * @type: the type of the struct this is embedded in.
+ * @member: the name of the list_head within the struct.
+ *
+ * Note, that list is expected to be not empty.
+ */
+#define list_last_entry(ptr, type, member) \
+           list_entry((ptr)->prev, type, member)
+
 #define list_remove_head_type(list, type, element) (\
 {\
   FAR struct list_node *__nod = list_remove_head(list);\


### PR DESCRIPTION
## Summary
since C89 doesn't support inline keyword: https://github.com/apache/incubator-nuttx/issues/6896

## Impact
Minor

## Testing
Pass CI
