### PR TITLE
Avoid assertion violation in case of kmm_free(NULL)

### DIFF
--- a/mm/kmm_heap/kmm_free.c
+++ b/mm/kmm_heap/kmm_free.c
@@ -52,7 +52,7 @@
 
 void kmm_free(FAR void *mem)
 {
-  DEBUGASSERT(kmm_heapmember(mem));
+  DEBUGASSERT((mem == NULL) || kmm_heapmember(mem));
   mm_free(g_kmmheap, mem);
 }
 


### PR DESCRIPTION
## Summary

It is ok to call kmm_free with a NULL pointer.  Thus adopt the
DEBUGASSERT statement to cover this case.

## Impact

None

## Testing

Tested on Nucleo-144 STM32U585 board.

