### PR TITLE
boards/arm/stm32f7/nucleo-144/src/stm32_usb.c: fix CONFIG_STM32F4DISC…

### DIFF
--- a/boards/arm/stm32f7/nucleo-144/src/stm32_usb.c
+++ b/boards/arm/stm32f7/nucleo-144/src/stm32_usb.c
@@ -225,8 +225,8 @@ int stm32_usbhost_initialize(void)
 
       uinfo("Start usbhost_waiter\n");
 
-      ret = kthread_create("usbhost", CONFIG_STM32F4DISCO_USBHOST_PRIO,
-                           CONFIG_STM32F4DISCO_USBHOST_STACKSIZE,
+      ret = kthread_create("usbhost", CONFIG_NUCLEO144_USBHOST_PRIO,
+                           CONFIG_NUCLEO_USBHOST_STACKSIZE,
                            (main_t)usbhost_waiter, (char * const *)NULL);
       return ret < 0 ? -ENOEXEC : OK;
     }


### PR DESCRIPTION
## Summary

I guess the `CONFIG_STM32F4DISCO_USBHOST_PRIO`  and 
`CONFIG_STM32F4DISCO_USBHOST_STACKSIZE` should be
`CONFIG_NUCLEO144_USBHOST_PRIO` and `CONFIG_NUCLEO_USBHOST_STACKSIZE` .

Without this patch, enable `CONFIG_STM32F7_OTGFS` the compiling will failed.

## Impact

No impact is expected.

## Testing

This changes was tested compile `nucleo-144:f746-nsh` config file with `CONFIG_STM32F7_OTGFS` enabled.
Need more patches, compile ok, but OTG not work yet.

