### PR TITLE
fs/aio: fix typo ail

### DIFF
--- a/fs/aio/aio_read.c
+++ b/fs/aio/aio_read.c
@@ -165,7 +165,7 @@ static void aio_read_worker(FAR void *arg)
  *   The aio_read() function will return the value zero if the I/O operation
  *   is successfully queued; otherwise, the function will return the value
  *   -1 and set errno to indicate the error.  The aio_read() function will
- *   ail if:
+ *   fail if:
  *
  *   EAGAIN - The requested asynchronous I/O operation was not queued due to
  *     system resource limitations.

--- a/fs/aio/aio_write.c
+++ b/fs/aio/aio_write.c
@@ -195,7 +195,7 @@ errout:
  *   The aio_write() function will return the value zero if the I/O operation
  *   is successfully queued; otherwise, the function will return the value
  *   -1 and set errno to indicate the error.  The aio_write() function will
- *   ail if:
+ *   fail if:
  *
  *   EAGAIN - The requested asynchronous I/O operation was not queued due to
  *     system resource limitations.


### PR DESCRIPTION
## Summary

Fix typo in comment section.
Replace `ail` with `fail`

## Impact

No impact is expected.

## Testing

Local build ok.
