### PR TITLE
sim: Added gcov dump on application exit.

### DIFF
--- a/arch/sim/src/sim/posix/up_hostmisc.c
+++ b/arch/sim/src/sim/posix/up_hostmisc.c
@@ -27,6 +27,14 @@
 #include "up_internal.h"
 
 /****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
+
+#ifdef CONFIG_ARCH_COVERAGE
+void __gcov_dump(void);
+#endif
+
+/****************************************************************************
  * Public Functions
  ****************************************************************************/
 
@@ -42,6 +50,12 @@
 
 void host_abort(int status)
 {
+#ifdef CONFIG_ARCH_COVERAGE
+  /* Dump gcov data. */
+
+  __gcov_dump();
+#endif
+
   /* exit the simulation */
 
   exit(status);


### PR DESCRIPTION
## Summary

Added gcov data dumping when the simulator exits.

## Impact

Gcov can be used without NSH and the gcov app.

## Testing

Tested that the simulator indeed creates the `.gcda` files on exit.
The `tools/gcov.sh` script creates a correct report.
