### PR TITLE
drivers/sensors/as5048b.c: change initialization of struct to C89 standard

### DIFF
--- a/drivers/sensors/as5048b.c
+++ b/drivers/sensors/as5048b.c
@@ -91,13 +91,13 @@ static int as5048b_ioctl(FAR struct qe_lowerhalf_s *lower, int cmd,
 
 static const struct qe_ops_s g_qeops =
 {
-  .setup     = as5048b_setup,
-  .shutdown  = as5048b_shutdown,
-  .position  = as5048b_position,
-  .setposmax = NULL,            /* not supported yet */
-  .reset     = as5048b_reset,
-  .setindex  = NULL,            /* not supported yet */
-  .ioctl     = as5048b_ioctl
+  as5048b_setup,    /* setup */
+  as5048b_shutdown, /* shutdown */
+  as5048b_position, /* position */
+  NULL,             /* setposmax */
+  as5048b_reset,    /* reset */
+  NULL,             /* setindex */
+  as5048b_ioctl     /* ioctl */
 };
 
 /****************************************************************************


### PR DESCRIPTION
## Summary
as5048b.c: change initialization of struct to C89 standard
## Impact
as5048b driver build with -std=c89
## Testing
CI
