### PR TITLE
Update the outdated work around from z80 README

### DIFF
--- a/boards/z80/ez80/ez80f910200kitg/README.txt
+++ b/boards/z80/ez80/ez80f910200kitg/README.txt
@@ -22,27 +22,6 @@ Version 4.11.0
   all ez80 boards.  However, it is the older version 4.11.0 that this code
   has been verified against.
 
-  Although it compiles without error, the 4.11.0 compiler generates
-  bad code on one of the files, mm/mm_initialize.c.  Below is a simple work-
-  around.
-
-    --- mm/mm_initialize.c.SAVE	2008-02-13 08:06:46.833857700 -0600
-    +++ mm/mm_initialize.c	2008-02-13 08:07:26.367608900 -0600
-    @@ -94,8 +94,11 @@
-    {
-       int i;
-
-    +#if 0 /* DO NOT CHECK IN */
-       CHECK_ALLOCNODE_SIZE;
-       CHECK_FREENODE_SIZE;
-    +#endif
-
-   /* Set up global variables */
-
-   UPDATE:  I don't know if 4.11.1 has this same problem (I bet not since
-   I submitted the bug to ZiLOG), but I have permanently worked around the
-   above problem for all ZiLOG compilers.
-
 Version 5.1.1
 
   On June 22, 2011 I verified that these configurations build successfully

--- a/boards/z80/ez80/ez80f910200zco/README.txt
+++ b/boards/z80/ez80/ez80f910200zco/README.txt
@@ -22,27 +22,6 @@ Version 4.11.0
   all ez80 boards.  However, it is the older version 4.11.0 that this code
   has been verified against.
 
-  Although it compiles without error, the 4.11.0 compiler generates
-  bad code on one of the files, mm/mm_initialize.c.  Below is a simple work-
-  around.
-
-    --- mm/mm_initialize.c.SAVE	2008-02-13 08:06:46.833857700 -0600
-    +++ mm/mm_initialize.c	2008-02-13 08:07:26.367608900 -0600
-    @@ -94,8 +94,11 @@
-    {
-       int i;
-
-    +#if 0 /* DO NOT CHECK IN */
-       CHECK_ALLOCNODE_SIZE;
-       CHECK_FREENODE_SIZE;
-    +#endif
-
-   /* Set up global variables */
-
-   UPDATE:  I don't know if 4.11.1 has this same problem (I bet not since
-   I submitted the bug to ZiLOG), but I have permanently worked around the
-   above problem for all ZiLOG compilers.
-
 Version 5.1.1
 
   On June 22, 2011 I verified that these configurations build successfully

--- a/boards/z80/z180/p112/README.txt
+++ b/boards/z80/z180/p112/README.txt
@@ -162,15 +162,3 @@ Status
   with the integration of address environments on the Cortex-A.  It is
   likely that there is some breakage due to incompatibilities with the
   Z180's mini-MMU.
-
-Known compilation problems with SDCC:
-
-Known compilation problems:
-
-    CC:  stdlib/lib_strtof.c
-    stdlib/lib_strtof.c:62:6: warning: #warning "Size of exponent is unknown"
-    stdlib/lib_strtof.c:76: error 122: dividing by ZERO
-    stdlib/lib_strtof.c:102: error 122: dividing by ZERO
-    stdlib/lib_strtof.c:76: error 122: dividing by ZERO
-
-  Workaround: Remove lib_strtof.c from libs/libc/stdlib/Make.defs

--- a/boards/z80/z8/z8encore000zco/README.txt
+++ b/boards/z80/z8/z8encore000zco/README.txt
@@ -5,23 +5,7 @@ ZDS-II Compiler Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
 Version 4.10.1
-  The ZDS-II version 4.10.2 will not compile NuttX.  It reports "internal
-  errors" on one of the files, mm/mm_initialize.c.  Below is a simple work-
-  around.  With this work-around in place, NuttX builds successfully with
-  the 4.10.1 compiler.
-
-    --- mm/mm_initialize.c.SAVE	2008-02-13 08:06:46.833857700 -0600
-    +++ mm/mm_initialize.c	2008-02-13 08:07:26.367608900 -0600
-    @@ -94,8 +94,11 @@
-    {
-       int i;
-
-    +#if 0 /* DO NOT CHECK IN */
-       CHECK_ALLOCNODE_SIZE;
-       CHECK_FREENODE_SIZE;
-    +#endif
-
-   /* Set up global variables */
+  NuttX builds successfully with the 4.10.1 compiler.
 
 Version 4.9.5
   This is the latest tool version listed on the ZiLOG site for the Z8F6403.

--- a/boards/z80/z8/z8f64200100kit/README.txt
+++ b/boards/z80/z8/z8f64200100kit/README.txt
@@ -5,23 +5,7 @@ ZDS-II Compiler Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
 4.10.1
-  The ZDS-II version 4.10.2 will not compile NuttX.  It reports "internal
-  errors" on one of the files, mm/mm_initialize.c.  Below is a simple work-
-  around.  With this work-around in place, NuttX builds successfully with
-  the 4.10.1 compiler.
-
-    --- mm/mm_initialize.c.SAVE	2008-02-13 08:06:46.833857700 -0600
-    +++ mm/mm_initialize.c	2008-02-13 08:07:26.367608900 -0600
-    @@ -94,8 +94,11 @@
-    {
-       int i;
-
-    +#if 0 /* DO NOT CHECK IN */
-       CHECK_ALLOCNODE_SIZE;
-       CHECK_FREENODE_SIZE;
-    +#endif
-
-   /* Set up global variables */
+  NuttX builds successfully with the 4.10.1 compiler.
 
 Version 4.9.5
   This is the latest tool version listed on the ZiLOG site for the Z8F6403.

--- a/boards/z80/z80/z80sim/README.txt
+++ b/boards/z80/z80/z80sim/README.txt
@@ -181,15 +181,3 @@ Then make the SDCC binaries
 and install SDCC:
 
   sudo make install
-
-Known compilation problems:
-
-    CC:  stdlib/lib_strtof.c
-    stdlib/lib_strtof.c:62:6: warning: #warning "Size of exponent is unknown"
-    stdlib/lib_strtof.c:76: error 122: dividing by ZERO
-    stdlib/lib_strtof.c:102: error 122: dividing by ZERO
-    stdlib/lib_strtof.c:76: error 122: dividing by ZERO
-
-  Workaround: Remove lib_strtof.c from libs/libc/stdlib/Make.defs
-
-  In arch/z80/src/z180:  error 26: '_cbr' not a structure/union member


### PR DESCRIPTION
## Summary

- borads/z80: Remove the known issue about lib_strtof.c
- borads/z80: Remove the woraround for CHECK_[ALLOC|FREE]NODE_SIZE

## Impact
Minor

## Testing
Pass CI
