### PR TITLE
Fixes in strtod parser.

### DIFF
--- a/libs/libc/stdlib/lib_strtod.c
+++ b/libs/libc/stdlib/lib_strtod.c
@@ -160,6 +160,7 @@ double strtod(FAR const char *str, FAR char **endptr)
     {
       set_errno(ERANGE);
       number = 0.0;
+      p = (FAR char *)str;
       goto errout;
     }
 
@@ -194,6 +195,14 @@ double strtod(FAR const char *str, FAR char **endptr)
         }
 
       /* Process string of digits */
+
+      if (!isdigit(*p))
+        {
+          set_errno(ERANGE);
+          number = 0.0;
+          p = (FAR char *)str;
+          goto errout;
+        }
 
       n = 0;
       while (isdigit(*p))


### PR DESCRIPTION
## Summary

Fixes in `strtod()` as reported in issue #6945.

## Impact

`strtod()` behaves more correctly now.

## Testing

Tested all reported problematic strings.  
Errors were indicated (and the fix was verified) using the Lua tests suite too.
