### PR TITLE
risc-v/mpfs: usb: fix cppcheck findings

### DIFF
--- a/arch/risc-v/src/mpfs/mpfs_usb.c
+++ b/arch/risc-v/src/mpfs/mpfs_usb.c
@@ -1090,7 +1090,7 @@ static int mpfs_req_read(struct mpfs_usbdev_s *priv,
           privreq = NULL;
         }
 
-      if ((privreq->inflight > 0) && (count != 0) &&
+      if ((privreq != NULL) && (privreq->inflight > 0) && (count != 0) &&
           (reg & RXCSRL_REG_EPN_RX_PKT_RDY_MASK) != 0)
         {
           /* Update the total number of bytes transferred */
@@ -1135,9 +1135,12 @@ static int mpfs_req_read(struct mpfs_usbdev_s *priv,
   /* Activate new read request from queue */
 
   privep->rxactive  = true;
-  privreq->req.xfrd = 0;
-  privreq->inflight = privreq->req.len;
-  priv->eplist[epno].descb[0]->addr = (uintptr_t)privreq->req.buf;
+  if (privreq != NULL)
+    {
+      privreq->req.xfrd = 0;
+      privreq->inflight = privreq->req.len;
+      priv->eplist[epno].descb[0]->addr = (uintptr_t)privreq->req.buf;
+    }
 
   return OK;
 }


### PR DESCRIPTION
Fix the following cppcheck findings. Privreq may be NULL,
thus perform checks before using its member variables.

Checking mpfs_usb.c ...
mpfs_usb.c:1093:12: warning: Possible null pointer dereference: privreq [nullPointer]
      if ((privreq->inflight > 0) && (count != 0) &&
           ^
mpfs_usb.c:1090:21: note: Assignment 'privreq=NULL', assigned value is 0
          privreq = NULL;
                    ^
mpfs_usb.c:1093:12: note: Null pointer dereference
      if ((privreq->inflight > 0) && (count != 0) &&
           ^
mpfs_usb.c:1138:3: warning: Possible null pointer dereference: privreq [nullPointer]
  privreq->req.xfrd = 0;
  ^
mpfs_usb.c:1130:21: note: Assignment 'privreq=NULL', assigned value is 0
          privreq = NULL;
                    ^
mpfs_usb.c:1138:3: note: Null pointer dereference
  privreq->req.xfrd = 0;
  ^
mpfs_usb.c:1139:3: warning: Possible null pointer dereference: privreq [nullPointer]
  privreq->inflight = privreq->req.len;
  ^
mpfs_usb.c:1130:21: note: Assignment 'privreq=NULL', assigned value is 0
          privreq = NULL;
                    ^
mpfs_usb.c:1139:3: note: Null pointer dereference
  privreq->inflight = privreq->req.len;
  ^
mpfs_usb.c:1140:50: warning: Possible null pointer dereference: privreq [nullPointer]
  priv->eplist[epno].descb[0]->addr = (uintptr_t)privreq->req.buf;
                                                 ^
mpfs_usb.c:1130:21: note: Assignment 'privreq=NULL', assigned value is 0
          privreq = NULL;
                    ^
mpfs_usb.c:1140:50: note: Null pointer dereference
  priv->eplist[epno].descb[0]->addr = (uintptr_t)privreq->req.buf;

Signed-off-by: Eero Nurkkala <eero.nurkkala@offcode.fi>

## Summary

Fix potential trouble found with cppcheck (static code analysis tool).

## Impact

MPFS USB

## Testing

Polarfire kit, NuttX with Ubuntu 22.04 and Windows 10 (CDCACM and Mass storage).
