### PR TITLE
libc: Port strtod fixes to strtof, strtold and improve comments

### DIFF
--- a/libs/libc/stdlib/lib_strtod.c
+++ b/libs/libc/stdlib/lib_strtod.c
@@ -79,11 +79,15 @@ static inline int is_real(double x)
  * Public Functions
  ****************************************************************************/
 
-/***************************************************(************************
+/****************************************************************************
  * Name: strtod
  *
  * Description:
  *   Convert a string to a double value
+ *
+ *   NOTE: This implementation is limited as compared to POSIX:
+ *   - Hexadecimal input is not supported
+ *   - INF, INFINITY, NAN, and NAN(...) are not supported
  *
  ****************************************************************************/
 

--- a/libs/libc/stdlib/lib_strtof.c
+++ b/libs/libc/stdlib/lib_strtof.c
@@ -86,11 +86,15 @@ static inline int is_real(float x)
  * Public Functions
  ****************************************************************************/
 
-/***************************************************(************************
+/****************************************************************************
  * Name: strtof
  *
  * Description:
  *   Convert a string to a float value
+ *
+ *   NOTE: This implementation is limited as compared to POSIX:
+ *   - Hexadecimal input is not supported
+ *   - INF, INFINITY, NAN, and NAN(...) are not supported
  *
  ****************************************************************************/
 
@@ -173,6 +177,7 @@ float strtof(FAR const char *str, FAR char **endptr)
     {
       set_errno(ERANGE);
       number = 0.0F;
+      p = (FAR char *)str;
       goto errout;
     }
 
@@ -207,6 +212,14 @@ float strtof(FAR const char *str, FAR char **endptr)
         }
 
       /* Process string of digits */
+
+      if (!isdigit(*p))
+        {
+          set_errno(ERANGE);
+          number = 0.0F;
+          p = (FAR char *)str;
+          goto errout;
+        }
 
       n = 0;
       while (isdigit(*p))

--- a/libs/libc/stdlib/lib_strtold.c
+++ b/libs/libc/stdlib/lib_strtold.c
@@ -79,11 +79,15 @@ static inline int is_real(long double x)
  * Public Functions
  ****************************************************************************/
 
-/***************************************************(************************
+/****************************************************************************
  * Name: strtold
  *
  * Description:
  *   Convert a string to a long double value
+ *
+ *   NOTE: This implementation is limited as compared to POSIX:
+ *   - Hexadecimal input is not supported
+ *   - INF, INFINITY, NAN, and NAN(...) are not supported
  *
  ****************************************************************************/
 
@@ -160,6 +164,7 @@ long double strtold(FAR const char *str, FAR char **endptr)
     {
       set_errno(ERANGE);
       number = 0.0L;
+      p = (FAR char *)str;
       goto errout;
     }
 
@@ -194,6 +199,14 @@ long double strtold(FAR const char *str, FAR char **endptr)
         }
 
       /* Process string of digits */
+
+      if (!isdigit(*p))
+        {
+          set_errno(ERANGE);
+          number = 0.0L;
+          p = (FAR char *)str;
+          goto errout;
+        }
 
       n = 0;
       while (isdigit(*p))


### PR DESCRIPTION
## Summary

Port the changes of PR #6952 to strtof() and strtold().

Also add a note of our implementation's limitations compared to POSIX.

## Impact

Consistency between strtod(), strtof(), strtold().

Addresses Issue #6945 for strtof() and strtold().

Improved documentation.

## Testing

Build testing and nxstyle.
