### PR TITLE
sched: Remove volatile from the task list

### DIFF
--- a/sched/init/nx_start.c
+++ b/sched/init/nx_start.c
@@ -84,7 +84,7 @@
  * task, is always the IDLE task.
  */
 
-volatile dq_queue_t g_readytorun;
+dq_queue_t g_readytorun;
 
 /* In order to support SMP, the function of the g_readytorun list changes,
  * The g_readytorun is still used but in the SMP case it will contain only:
@@ -117,7 +117,7 @@ volatile dq_queue_t g_readytorun;
  */
 
 #ifdef CONFIG_SMP
-volatile dq_queue_t g_assignedtasks[CONFIG_SMP_NCPUS];
+dq_queue_t g_assignedtasks[CONFIG_SMP_NCPUS];
 #endif
 
 /* g_running_tasks[] holds a references to the running task for each cpu.
@@ -132,22 +132,22 @@ FAR struct tcb_s *g_running_tasks[CONFIG_SMP_NCPUS];
  * currently active task has disabled pre-emption.
  */
 
-volatile dq_queue_t g_pendingtasks;
+dq_queue_t g_pendingtasks;
 
 /* This is the list of all tasks that are blocked waiting for a semaphore */
 
-volatile dq_queue_t g_waitingforsemaphore;
+dq_queue_t g_waitingforsemaphore;
 
 /* This is the list of all tasks that are blocked waiting for a signal */
 
-volatile dq_queue_t g_waitingforsignal;
+dq_queue_t g_waitingforsignal;
 
 #ifndef CONFIG_DISABLE_MQUEUE
 /* This is the list of all tasks that are blocked waiting for a message
  * queue to become non-empty.
  */
 
-volatile dq_queue_t g_waitingformqnotempty;
+dq_queue_t g_waitingformqnotempty;
 #endif
 
 #ifndef CONFIG_DISABLE_MQUEUE
@@ -155,13 +155,13 @@ volatile dq_queue_t g_waitingformqnotempty;
  * queue to become non-full.
  */
 
-volatile dq_queue_t g_waitingformqnotfull;
+dq_queue_t g_waitingformqnotfull;
 #endif
 
 #ifdef CONFIG_PAGING
 /* This is the list of all tasks that are blocking waiting for a page fill */
 
-volatile dq_queue_t g_waitingforfill;
+dq_queue_t g_waitingforfill;
 #endif
 
 #ifdef CONFIG_SIG_SIGSTOP_ACTION
@@ -169,14 +169,14 @@ volatile dq_queue_t g_waitingforfill;
  * via SIGSTOP or SIGTSTP
  */
 
-volatile dq_queue_t g_stoppedtasks;
+dq_queue_t g_stoppedtasks;
 #endif
 
 /* This the list of all tasks that have been initialized, but not yet
  * activated. NOTE:  This is the only list that is not prioritized.
  */
 
-volatile dq_queue_t g_inactivetasks;
+dq_queue_t g_inactivetasks;
 
 /* This is the value of the last process ID assigned to a task */
 

--- a/sched/paging/pg_worker.c
+++ b/sched/paging/pg_worker.c
@@ -223,8 +223,7 @@ static inline bool pg_dequeue(void)
     {
       /* Remove the TCB from the head of the list (if any) */
 
-      g_pftcb = (FAR struct tcb_s *)
-        dq_remfirst((FAR dq_queue_t *)&g_waitingforfill);
+      g_pftcb = (FAR struct tcb_s *)dq_remfirst(&g_waitingforfill);
       pginfo("g_pftcb: %p\n", g_pftcb);
       if (g_pftcb != NULL)
         {

--- a/sched/pthread/pthread_create.c
+++ b/sched/pthread/pthread_create.c
@@ -575,7 +575,7 @@ int nx_pthread_create(pthread_trampoline_t trampoline, FAR pthread_t *thread,
   else
     {
       sched_unlock();
-      dq_rem((FAR dq_entry_t *)ptcb, (FAR dq_queue_t *)&g_inactivetasks);
+      dq_rem((FAR dq_entry_t *)ptcb, &g_inactivetasks);
       nxsem_destroy(&pjoin->exit_sem);
 
       errcode = EIO;

--- a/sched/sched/sched.h
+++ b/sched/sched/sched.h
@@ -74,7 +74,7 @@
 #define TLIST_ISINDEXED(s)       ((__TLIST_ATTR(s) & TLIST_ATTR_INDEXED) != 0)
 #define TLIST_ISRUNNABLE(s)      ((__TLIST_ATTR(s) & TLIST_ATTR_RUNNABLE) != 0)
 
-#define __TLIST_HEAD(s)          (FAR dq_queue_t *)g_tasklisttable[s].list
+#define __TLIST_HEAD(s)          g_tasklisttable[s].list
 #define __TLIST_HEADINDEXED(s,c) (&(__TLIST_HEAD(s))[c])
 
 #ifdef CONFIG_SMP

--- a/sched/sched/sched.h
+++ b/sched/sched/sched.h
@@ -96,8 +96,8 @@
 
 struct tasklist_s
 {
-  DSEG volatile dq_queue_t *list; /* Pointer to the task list */
-  uint8_t attr;                   /* List attribute flags */
+  DSEG dq_queue_t *list; /* Pointer to the task list */
+  uint8_t attr;          /* List attribute flags */
 };
 
 /****************************************************************************
@@ -121,7 +121,7 @@ struct tasklist_s
  * task, is always the IDLE task.
  */
 
-extern volatile dq_queue_t g_readytorun;
+extern dq_queue_t g_readytorun;
 
 #ifdef CONFIG_SMP
 /* In order to support SMP, the function of the g_readytorun list changes,
@@ -154,7 +154,7 @@ extern volatile dq_queue_t g_readytorun;
  * always the CPU's IDLE task.
  */
 
-extern volatile dq_queue_t g_assignedtasks[CONFIG_SMP_NCPUS];
+extern dq_queue_t g_assignedtasks[CONFIG_SMP_NCPUS];
 #endif
 
 /* g_running_tasks[] holds a references to the running task for each cpu.
@@ -169,22 +169,22 @@ extern FAR struct tcb_s *g_running_tasks[CONFIG_SMP_NCPUS];
  * currently active task has disabled pre-emption.
  */
 
-extern volatile dq_queue_t g_pendingtasks;
+extern dq_queue_t g_pendingtasks;
 
 /* This is the list of all tasks that are blocked waiting for a semaphore */
 
-extern volatile dq_queue_t g_waitingforsemaphore;
+extern dq_queue_t g_waitingforsemaphore;
 
 /* This is the list of all tasks that are blocked waiting for a signal */
 
-extern volatile dq_queue_t g_waitingforsignal;
+extern dq_queue_t g_waitingforsignal;
 
 /* This is the list of all tasks that are blocked waiting for a message
  * queue to become non-empty.
  */
 
 #ifndef CONFIG_DISABLE_MQUEUE
-extern volatile dq_queue_t g_waitingformqnotempty;
+extern dq_queue_t g_waitingformqnotempty;
 #endif
 
 /* This is the list of all tasks that are blocked waiting for a message
@@ -192,20 +192,20 @@ extern volatile dq_queue_t g_waitingformqnotempty;
  */
 
 #ifndef CONFIG_DISABLE_MQUEUE
-extern volatile dq_queue_t g_waitingformqnotfull;
+extern dq_queue_t g_waitingformqnotfull;
 #endif
 
 /* This is the list of all tasks that are blocking waiting for a page fill */
 
 #ifdef CONFIG_PAGING
-extern volatile dq_queue_t g_waitingforfill;
+extern dq_queue_t g_waitingforfill;
 #endif
 
 /* This the list of all tasks that have been initialized, but not yet
  * activated. NOTE:  This is the only list that is not prioritized.
  */
 
-extern volatile dq_queue_t g_inactivetasks;
+extern dq_queue_t g_inactivetasks;
 
 /* This is the value of the last process ID assigned to a task */
 

--- a/sched/sched/sched_addreadytorun.c
+++ b/sched/sched/sched_addreadytorun.c
@@ -81,14 +81,14 @@ bool nxsched_add_readytorun(FAR struct tcb_s *btcb)
        * g_pendingtasks task list for now.
        */
 
-      nxsched_add_prioritized(btcb, (FAR dq_queue_t *)&g_pendingtasks);
+      nxsched_add_prioritized(btcb, &g_pendingtasks);
       btcb->task_state = TSTATE_TASK_PENDING;
       ret = false;
     }
 
   /* Otherwise, add the new task to the ready-to-run task list */
 
-  else if (nxsched_add_prioritized(btcb, (FAR dq_queue_t *)&g_readytorun))
+  else if (nxsched_add_prioritized(btcb, &g_readytorun))
     {
       /* The new btcb was added at the head of the ready-to-run list.  It
        * is now the new active task!
@@ -229,7 +229,7 @@ bool nxsched_add_readytorun(FAR struct tcb_s *btcb)
        * now.
        */
 
-      nxsched_add_prioritized(btcb, (FAR dq_queue_t *)&g_pendingtasks);
+      nxsched_add_prioritized(btcb, &g_pendingtasks);
       btcb->task_state = TSTATE_TASK_PENDING;
       doswitch = false;
     }
@@ -243,7 +243,7 @@ bool nxsched_add_readytorun(FAR struct tcb_s *btcb)
        * Add the task to the ready-to-run (but not running) task list
        */
 
-      nxsched_add_prioritized(btcb, (FAR dq_queue_t *)&g_readytorun);
+      nxsched_add_prioritized(btcb, &g_readytorun);
 
       btcb->task_state = TSTATE_TASK_READYTORUN;
       doswitch         = false;
@@ -263,7 +263,7 @@ bool nxsched_add_readytorun(FAR struct tcb_s *btcb)
        * and check if a context switch will occur
        */
 
-      tasklist = (FAR dq_queue_t *)&g_assignedtasks[cpu];
+      tasklist = &g_assignedtasks[cpu];
       switched = nxsched_add_prioritized(btcb, tasklist);
 
       /* If the selected task list was the g_assignedtasks[] list and if the
@@ -337,12 +337,12 @@ bool nxsched_add_readytorun(FAR struct tcb_s *btcb)
               if (nxsched_islocked_global())
                 {
                   next->task_state = TSTATE_TASK_PENDING;
-                  tasklist         = (FAR dq_queue_t *)&g_pendingtasks;
+                  tasklist         = &g_pendingtasks;
                 }
               else
                 {
                   next->task_state = TSTATE_TASK_READYTORUN;
-                  tasklist         = (FAR dq_queue_t *)&g_readytorun;
+                  tasklist         = &g_readytorun;
                 }
 
               nxsched_add_prioritized(next, tasklist);

--- a/sched/sched/sched_lock.c
+++ b/sched/sched/sched_lock.c
@@ -211,8 +211,8 @@ int sched_lock(void)
        * unlocked and nxsched_merge_pending() is called.
        */
 
-      nxsched_merge_prioritized((FAR dq_queue_t *)&g_readytorun,
-                                (FAR dq_queue_t *)&g_pendingtasks,
+      nxsched_merge_prioritized(&g_readytorun,
+                                &g_pendingtasks,
                                 TSTATE_TASK_PENDING);
 
       leave_critical_section(flags);

--- a/sched/sched/sched_mergepending.c
+++ b/sched/sched/sched_mergepending.c
@@ -195,7 +195,7 @@ bool nxsched_merge_pending(void)
     {
       /* Find the CPU that is executing the lowest priority task */
 
-      ptcb = (FAR struct tcb_s *)dq_peek((FAR dq_queue_t *)&g_pendingtasks);
+      ptcb = (FAR struct tcb_s *)dq_peek(&g_pendingtasks);
       if (ptcb == NULL)
         {
           /* The pending task list is empty */
@@ -219,8 +219,7 @@ bool nxsched_merge_pending(void)
         {
           /* Remove the task from the pending task list */
 
-          tcb = (FAR struct tcb_s *)
-            dq_remfirst((FAR dq_queue_t *)&g_pendingtasks);
+          tcb = (FAR struct tcb_s *)dq_remfirst(&g_pendingtasks);
 
           /* Add the pending task to the correct ready-to-run list. */
 
@@ -237,8 +236,8 @@ bool nxsched_merge_pending(void)
                * move them back to the pending task list.
                */
 
-              nxsched_merge_prioritized((FAR dq_queue_t *)&g_readytorun,
-                                        (FAR dq_queue_t *)&g_pendingtasks,
+              nxsched_merge_prioritized(&g_readytorun,
+                                        &g_pendingtasks,
                                         TSTATE_TASK_PENDING);
 
               /* And return with the scheduler locked and tasks in the
@@ -250,8 +249,7 @@ bool nxsched_merge_pending(void)
 
           /* Set up for the next time through the loop */
 
-          ptcb = (FAR struct tcb_s *)
-            dq_peek((FAR dq_queue_t *)&g_pendingtasks);
+          ptcb = (FAR struct tcb_s *)dq_peek(&g_pendingtasks);
           if (ptcb == NULL)
             {
               /* The pending task list is empty */
@@ -267,8 +265,8 @@ bool nxsched_merge_pending(void)
        * tasks in the pending task list to the ready-to-run task list.
        */
 
-      nxsched_merge_prioritized((FAR dq_queue_t *)&g_pendingtasks,
-                                (FAR dq_queue_t *)&g_readytorun,
+      nxsched_merge_prioritized(&g_pendingtasks,
+                                &g_readytorun,
                                 TSTATE_TASK_READYTORUN);
     }
 

--- a/sched/sched/sched_removereadytorun.c
+++ b/sched/sched/sched_removereadytorun.c
@@ -86,7 +86,7 @@ bool nxsched_remove_readytorun(FAR struct tcb_s *rtcb)
    * is always the g_readytorun list.
    */
 
-  dq_rem((FAR dq_entry_t *)rtcb, (FAR dq_queue_t *)&g_readytorun);
+  dq_rem((FAR dq_entry_t *)rtcb, &g_readytorun);
 
   /* Since the TCB is not in any list, it is now invalid */
 
@@ -214,7 +214,7 @@ bool nxsched_remove_readytorun(FAR struct tcb_s *rtcb)
            * list and add to the head of the g_assignedtasks[cpu] list.
            */
 
-          dq_rem((FAR dq_entry_t *)rtrtcb, (FAR dq_queue_t *)&g_readytorun);
+          dq_rem((FAR dq_entry_t *)rtrtcb, &g_readytorun);
           dq_addfirst((FAR dq_entry_t *)rtrtcb, tasklist);
 
           rtrtcb->cpu = cpu;

--- a/sched/task/task_init.c
+++ b/sched/task/task_init.c
@@ -218,7 +218,7 @@ void nxtask_uninit(FAR struct task_tcb_s *tcb)
    * nxtask_setup_scheduler().
    */
 
-  dq_rem((FAR dq_entry_t *)tcb, (FAR dq_queue_t *)&g_inactivetasks);
+  dq_rem((FAR dq_entry_t *)tcb, &g_inactivetasks);
 
   /* Release all resources associated with the TCB... Including the TCB
    * itself.

--- a/sched/task/task_restart.c
+++ b/sched/task/task_restart.c
@@ -178,7 +178,7 @@ int nxtask_restart(pid_t pid)
 
   /* Add the task to the inactive task list */
 
-  dq_addfirst((FAR dq_entry_t *)tcb, (FAR dq_queue_t *)&g_inactivetasks);
+  dq_addfirst((FAR dq_entry_t *)tcb, &g_inactivetasks);
   tcb->cmn.task_state = TSTATE_TASK_INACTIVE;
 
 #ifdef CONFIG_SMP

--- a/sched/task/task_setup.c
+++ b/sched/task/task_setup.c
@@ -454,7 +454,7 @@ static int nxthread_setup_scheduler(FAR struct tcb_s *tcb, int priority,
       /* Add the task to the inactive task list */
 
       sched_lock();
-      dq_addfirst((FAR dq_entry_t *)tcb, (FAR dq_queue_t *)&g_inactivetasks);
+      dq_addfirst((FAR dq_entry_t *)tcb, &g_inactivetasks);
       tcb->task_state = TSTATE_TASK_INACTIVE;
       sched_unlock();
     }

--- a/sched/task/task_vfork.c
+++ b/sched/task/task_vfork.c
@@ -335,7 +335,7 @@ void nxtask_abort_vfork(FAR struct task_tcb_s *child, int errcode)
 {
   /* The TCB was added to the active task list by nxtask_setup_scheduler() */
 
-  dq_rem((FAR dq_entry_t *)child, (FAR dq_queue_t *)&g_inactivetasks);
+  dq_rem((FAR dq_entry_t *)child, &g_inactivetasks);
 
   /* Release the TCB */
 


### PR DESCRIPTION
## Summary
it inappropriate to apply volatile to the task list:
1.The code access task list is already protected by critical section
2.The queue is complex struct, it isn't enough to protect by volatile

## Impact
The generated code is same before and after modification on sabre-6quad:smp:
before:
```
   text    data     bss     dec     hex filename
 129436     240   33484  163160   27d58 nuttx
```
after:
```
   text    data     bss     dec     hex filename
 129436     240   33484  163160   27d58 ../nuttx.list
```

## Testing
Pass CI
