### PR TITLE
Fixed format specifier in various prints.

### DIFF
--- a/fs/procfs/fs_procfsproc.c
+++ b/fs/procfs/fs_procfsproc.c
@@ -993,7 +993,7 @@ static ssize_t proc_heapcheck(FAR struct proc_file_s *procfile,
       heapcheck = 1;
     }
 
-  linesize = procfs_snprintf(procfile->line, STATUS_LINELEN, "%-12s%d\n",
+  linesize = procfs_snprintf(procfile->line, STATUS_LINELEN, "%-12s%zu\n",
                              "HeapCheck:", heapcheck);
 
   copysize = procfs_memcpy(procfile->line, linesize, buffer, remaining,

--- a/mm/kasan/kasan.c
+++ b/mm/kasan/kasan.c
@@ -101,7 +101,8 @@ static void kasan_report(FAR const void *addr, size_t size, bool is_write)
   if (++recursion == 1)
     {
       _alert("kasan detected a %s access error, address at %0#"PRIxPTR
-            ", size is %zu\n", is_write ? "write" : "read", addr, size);
+            ", size is %zu\n", is_write ? "write" : "read",
+            (uintptr_t)addr, size);
       PANIC();
     }
 

--- a/mm/ubsan/ubsan.c
+++ b/mm/ubsan/ubsan.c
@@ -284,18 +284,18 @@ void __ubsan_handle_alignment_assumption(FAR void *data, uintptr_t ptr,
 
   if (offset)
     {
-      _alert("assumption of %u byte alignment (with offset of %u byte) for "
-             "pointer of type %s failed",
+      _alert("assumption of %zu byte alignment (with offset of %zu byte) for"
+             " pointer of type %s failed",
              align, offset, info->type->type_name);
     }
   else
     {
-      _alert("assumption of %u byte alignment for pointer of type %s failed",
-             align, info->type->type_name);
+      _alert("assumption of %zu byte alignment for pointer of type %s "
+             "failed", align, info->type->type_name);
     }
 
   real_ptr = ptr - offset;
-  _alert("%saddress is %lu aligned, misalignment offset is %u bytes",
+  _alert("%saddress is %lu aligned, misalignment offset is %zu bytes",
          offset ? "offset " : "",
          1ul << (real_ptr ? ffsl(real_ptr) : 0),
          real_ptr & (align - 1));


### PR DESCRIPTION
## Summary

Various prints produced compiler warnings, because of wrong specifiers used, or wrong types.  
This PR fixes these warnings.

## Impact

Code builds without warnings.

## Testing

Build test.
