### PR TITLE
arch: risc-v: Fix up_check_tcbstack() for CONFIG_ARCH_ADDRENV=y

### DIFF
--- a/arch/risc-v/src/common/riscv_checkstack.c
+++ b/arch/risc-v/src/common/riscv_checkstack.c
@@ -155,8 +155,30 @@ size_t riscv_stack_check(uintptr_t alloc, size_t size)
 
 size_t up_check_tcbstack(struct tcb_s *tcb)
 {
-  return riscv_stack_check((uintptr_t)tcb->stack_base_ptr,
+  size_t size;
+
+#ifdef CONFIG_ARCH_ADDRENV
+  save_addrenv_t oldenv;
+  bool saved = false;
+
+  if ((tcb->flags & TCB_FLAG_TTYPE_MASK) != TCB_FLAG_TTYPE_KERNEL)
+    {
+      up_addrenv_select(&tcb->group->tg_addrenv, &oldenv);
+      saved = true;
+    }
+#endif
+
+  size = riscv_stack_check((uintptr_t)tcb->stack_base_ptr,
                            tcb->adj_stack_size);
+
+#ifdef CONFIG_ARCH_ADDRENV
+  if (saved)
+    {
+      up_addrenv_restore(&oldenv);
+    }
+#endif
+
+  return size;
 }
 
 ssize_t up_check_tcbstack_remain(struct tcb_s *tcb)


### PR DESCRIPTION
## Summary

- I noticed that ps shows incorrect stack usage when running
  getprime in the background.
- With CONFIG_ARCH_ADDRENV=y, a user task including pthread
  allocates its stack in the user space that needs to be
  accessed with a correct address environment.
- This commit fixes this issue.

## Impact

- CONFIG_ARCH_ADDRENV=y only

## Testing

- Tested with rv-virt:knsh64 on qemu-6.2
