### PR TITLE
net/getsockname: small addrlen should be a valid value

### DIFF
--- a/net/socket/getsockname.c
+++ b/net/socket/getsockname.c
@@ -88,7 +88,7 @@ int psock_getsockname(FAR struct socket *psock, FAR struct sockaddr *addr,
 
   /* Some sanity checking... */
 
-  if (addr == NULL || addrlen == NULL || *addrlen <= 0)
+  if (addr == NULL || addrlen == NULL)
     {
       return -EINVAL;
     }


### PR DESCRIPTION
## Summary

net/getsockname: small addrlen should be a valid value

fix usrsock getsockname fail

```
nsh> usrsocktest
...
Testing group "basic_getsockname" =>
        [TEST ASSERT FAILED!]
                In function "basic_getsockname_open":
                line 170: Assertion `(ssize_t)((ret)) == (ssize_t)((0))' failed.
                        got value: -1
                        should be: 0
        Group "basic_getsockname": [FAILED]
...
```

```
Reference:

GETSOCKNAME(2)

NAME
       getsockname - get socket name
...
DESCRIPTION
...
       The returned address is truncated if the buffer provided is too small;
       in this case, addrlen will return a value greater than was supplied to the call.
```


## Impact

N/A

## Testing

Pass the usrsock test:
https://github.com/apache/incubator-nuttx-apps/blob/master/examples/usrsocktest/usrsocktest_basic_getsockname.c#L168-L170