### PR TITLE
net/usrsock: Change xid from uint64_t to uint32_t

### DIFF
--- a/net/usrsock/usrsock_dev.c
+++ b/net/usrsock/usrsock_dev.c
@@ -73,7 +73,7 @@ struct usrsockdev_s
     sem_t     sem;               /* Request semaphore (only one outstanding
                                   * request) */
     sem_t     acksem;            /* Request acknowledgment notification */
-    uint64_t  ackxid;            /* Exchange id for which waiting ack */
+    uint32_t  ackxid;            /* Exchange id for which waiting ack */
     uint16_t  nbusy;             /* Number of requests blocked from different
                                   * threads */
   } req;


### PR DESCRIPTION
## Summary

 net/usrsock: Change xid from uint64_t to uint32_t
 
 follow the below change:
   -----------------------------------------------
```
   commit 03348197429d10470ac42492263c409138d8fd0f
   Author: Xiang Xiao <xiaoxiang@xiaomi.com>
   Date:   Mon Aug 22 05:10:47 2022 +0800
 
       net/usrsock: Change xid from uint64_t to uint32_t
 
       by generating the new xid for each transaction
 
       Signed-off-by: Xiang Xiao <xiaoxiang@xiaomi.com>
 
 Signed-off-by: chao an <anchao@xiaomi.com>
```


## Impact

N/A

## Testing

Pass the usrsock test