### PR TITLE
net/usrsock: read from the closed remote should return EOF

### DIFF
--- a/net/usrsock/usrsock_recvmsg.c
+++ b/net/usrsock/usrsock_recvmsg.c
@@ -442,6 +442,12 @@ errout_unlock:
       *fromlen = outaddrlen;
     }
 
+  if (conn->flags & USRSOCK_EVENT_REMOTE_CLOSED &&
+      ret == -ENOTCONN)
+    {
+      ret = OK;
+    }
+
   return ret;
 }
 


### PR DESCRIPTION

## Summary

net/usrsock: read from the closed remote should return EOF
    
fix usrsock remote_disconnect fail:
    
```
    nsh> usrsocktest
    ...
    Testing group "remote_disconnect" =>
            [TEST ASSERT FAILED!]
                    In function "receive":
                    line 497: Assertion `(ssize_t)((ret)) == (ssize_t)((0))' failed.
                            got value: -1
                            should be: 0
            Group "remote_disconnect": [FAILED]
    ...
```
    
    Reference:
    
```
    RECV(2)
    
    NAME
           recv, recvfrom, recvmsg - receive a message from a socket
    ...
    RETURN VALUE
    ...
           When a stream socket peer has performed an orderly shutdown,
           the return value will be 0 (the traditional "end-of-file" return).
    
           Datagram sockets in various domains (e.g., the UNIX and Internet domains)
           permit zero-length datagrams.  When such a datagram is received, the return value is 0.
```
    
    Signed-off-by: chao an <anchao@xiaomi.com>


## Impact

## Testing

Pass the usrsock test:
https://github.com/apache/incubator-nuttx-apps/blob/master/examples/usrsocktest/usrsocktest_remote_disconnect.c#L492-L497