### PR TITLE
net/usrsock: forward FIONBIO to socket level

### DIFF
--- a/net/usrsock/usrsock_ioctl.c
+++ b/net/usrsock/usrsock_ioctl.c
@@ -31,6 +31,7 @@
 #include <errno.h>
 #include <debug.h>
 
+#include <sys/ioctl.h>
 #include <sys/socket.h>
 #include <nuttx/net/net.h>
 #include <nuttx/net/usrsock.h>
@@ -172,6 +173,15 @@ int usrsock_ioctl(FAR struct socket *psock, int cmd, FAR void *arg,
   };
 
   int ret;
+
+  /* Bypass FIONBIO to socket level,
+   * since the usrsock server always put the socket in nonblocking mode.
+   */
+
+  if (cmd == FIONBIO)
+    {
+      return -ENOTTY;
+    }
 
   net_lock();
 


### PR DESCRIPTION
## Summary

net/usrsock: forward FIONBIO to socket level

fix usrsock nonblock connect test break:

```
apps/examples/usrsocktest/usrsocktest_noblock_connect.c:

...
157 TEST(no_block_connect, delayed_connect)
158 {
...
190   ret = fcntl(sd, F_SETFL, flags | O_NONBLOCK);
...
204   ret = connect(sd, (FAR const struct sockaddr *)&addr, sizeof(addr));
205   TEST_ASSERT_EQUAL(-1, ret);
206   TEST_ASSERT_EQUAL(EINPROGRESS, errno);
```

FIONBIO should goahead to socket level:

```
nuttx/net/netdev/netdev_ioctl.c:
...
1755 int psock_vioctl(FAR struct socket *psock, int cmd, va_list ap)
1756 {
...
1771   ret = netdev_ioctl(psock, cmd, arg);
...
1775   if (ret == -ENOTTY)
1776     {
1777       ret = netdev_file_ioctl(psock, cmd, arg);
1778     }
...
```

Signed-off-by: chao an <anchao@xiaomi.com>


## Impact

## Testing
Pass the usrsock test:
https://github.com/apache/incubator-nuttx-apps/blob/master/examples/usrsocktest/usrsocktest_noblock_connect.c#L190-L204