### PR TITLE
net/usrsock: allow usrsock *DATA_ACK with no-preload data

### DIFF
--- a/net/usrsock/usrsock_dev.c
+++ b/net/usrsock/usrsock_dev.c
@@ -851,23 +851,26 @@ static ssize_t usrsockdev_write(FAR struct file *filep,
 
       /* Copy data from user-space. */
 
-      ret = iovec_put(conn->resp.datain.iov, conn->resp.datain.iovcnt,
-                      conn->resp.datain.pos, buffer, len);
-      if (ret < 0)
+      if (len != 0)
         {
-          /* Tried writing beyond buffer. */
+          ret = iovec_put(conn->resp.datain.iov, conn->resp.datain.iovcnt,
+                          conn->resp.datain.pos, buffer, len);
+          if (ret < 0)
+            {
+              /* Tried writing beyond buffer. */
 
-          ret = -EINVAL;
-          conn->resp.result = -EINVAL;
-          conn->resp.datain.pos =
-              conn->resp.datain.total;
-        }
-      else
-        {
-          conn->resp.datain.pos += ret;
-          buffer += ret;
-          len -= ret;
-          ret = origlen - len;
+              ret = -EINVAL;
+              conn->resp.result = -EINVAL;
+              conn->resp.datain.pos =
+                  conn->resp.datain.total;
+            }
+          else
+            {
+              conn->resp.datain.pos += ret;
+              buffer += ret;
+              len -= ret;
+              ret = origlen - len;
+            }
         }
 
       if (conn->resp.datain.pos == conn->resp.datain.total)


### PR DESCRIPTION

## Summary

net/usrsock: allow usrsock *DATA_ACK with no-preload data

allow usrsock USRSOCK_MESSAGE_RESPONSE_DATA_ACK with no-preload data
so addrlen could be updated to valuelen_nontrunc of usrsock_message_datareq_ack_s

```

nsh> usrsocktest
...
Testing group "basic_getsockname" =>
	[TEST ASSERT FAILED!]
		In function "basic_getsockname_open":
		line 170: Assertion `(ssize_t)((ret)) == (ssize_t)((0))' failed.
			got value: -1
			should be: 0
	Group "basic_getsockname": [FAILED]
```

Signed-off-by: chao an <anchao@xiaomi.com>


## Impact

## Testing

Pass the usrsock test:
https://github.com/apache/incubator-nuttx-apps/blob/master/examples/usrsocktest/usrsocktest_basic_getsockname.c#L168-L170