### PR TITLE
fs: Run the default action of FIONBIO/FIOCLEX/FIONCLEX in success path

### DIFF
--- a/drivers/serial/pty.c
+++ b/drivers/serial/pty.c
@@ -757,16 +757,9 @@ static int pty_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
       case FIONBIO:
         {
           ret = file_ioctl(&dev->pd_src, cmd, arg);
-          if (ret >= 0 || ret == -ENOTTY)
-            {
-              ret = file_ioctl(&dev->pd_sink, cmd, arg);
-            }
-
-          /* Let the default handler set O_NONBLOCK flags for us. */
-
           if (ret >= 0)
             {
-              ret = -ENOTTY;
+              ret = file_ioctl(&dev->pd_sink, cmd, arg);
             }
         }
         break;

--- a/fs/vfs/fs_ioctl.c
+++ b/fs/vfs/fs_ioctl.c
@@ -67,45 +67,43 @@ int file_vioctl(FAR struct file *filep, int req, va_list ap)
       ret = inode->u.i_ops->ioctl(filep, req, arg);
     }
 
-  /* Check for File system IOCTL commands that can be implemented via
-   * fcntl()
-   */
-
-  if (ret != -ENOTTY)
-    {
-      return ret;
-    }
-
   switch (req)
     {
       case FIONBIO:
-        {
-          FAR int *nonblock = (FAR int *)(uintptr_t)arg;
-          if (nonblock && *nonblock)
-            {
-              filep->f_oflags |= O_NONBLOCK;
-            }
-          else
-            {
-              filep->f_oflags &= ~O_NONBLOCK;
-            }
+        if (ret == OK || ret == -ENOTTY)
+          {
+            FAR int *nonblock = (FAR int *)(uintptr_t)arg;
+            if (nonblock && *nonblock)
+              {
+                filep->f_oflags |= O_NONBLOCK;
+              }
+            else
+              {
+                filep->f_oflags &= ~O_NONBLOCK;
+              }
 
-          ret = OK;
-        }
+            ret = OK;
+          }
         break;
 
       case FIOCLEX:
-        filep->f_oflags |= O_CLOEXEC;
-        ret = OK;
+        if (ret == OK || ret == -ENOTTY)
+          {
+            filep->f_oflags |= O_CLOEXEC;
+            ret = OK;
+          }
         break;
 
       case FIONCLEX:
-        filep->f_oflags &= ~O_CLOEXEC;
-        ret = OK;
+        if (ret == OK || ret == -ENOTTY)
+          {
+            filep->f_oflags &= ~O_CLOEXEC;
+            ret = OK;
+          }
         break;
 
       case FIOC_FILEPATH:
-        if (!INODE_IS_MOUNTPT(inode))
+        if (ret == -ENOTTY && !INODE_IS_MOUNTPT(inode))
           {
             ret = inode_getpath(inode, (FAR char *)(uintptr_t)arg);
           }
@@ -113,7 +111,8 @@ int file_vioctl(FAR struct file *filep, int req, va_list ap)
 
 #ifndef CONFIG_DISABLE_MOUNTPOINT
       case BIOC_BLKSSZGET:
-        if (inode->u.i_ops != NULL && inode->u.i_ops->ioctl != NULL)
+        if (ret == -ENOTTY && inode->u.i_ops != NULL &&
+            inode->u.i_ops->ioctl != NULL)
           {
             struct geometry geo;
             ret = inode->u.i_ops->ioctl(filep, BIOC_GEOMETRY,

--- a/net/netdev/netdev_ioctl.c
+++ b/net/netdev/netdev_ioctl.c
@@ -1516,7 +1516,7 @@ static int netdev_rt_ioctl(FAR struct socket *psock, int cmd,
 static int netdev_file_ioctl(FAR struct socket *psock, int cmd,
                              unsigned long arg)
 {
-  int ret;
+  int ret = OK;
 
   switch (cmd)
     {
@@ -1545,8 +1545,6 @@ static int netdev_file_ioctl(FAR struct socket *psock, int cmd,
                  {
                    conn->s_flags &= ~_SF_NONBLOCK;
                  }
-
-               ret = -ENOTTY; /* let file_vioctl update f_oflags */
             }
           else
             {


### PR DESCRIPTION
## Summary
Avoid the FIONBIO/FIOCLEX/FIONCLEX handler in driver change the return value from OK to -NOTTY

## Impact

## Testing
usrsocktest
