### PR TITLE
mm: umm_heap: Do not register Umem if CONFIG_BUILD_KERNEL=y

### DIFF
--- a/fs/procfs/fs_procfsmeminfo.c
+++ b/fs/procfs/fs_procfsmeminfo.c
@@ -578,6 +578,11 @@ static int meminfo_stat(FAR const char *relpath, FAR struct stat *buf)
 
 void procfs_register_meminfo(FAR struct procfs_meminfo_entry_s *entry)
 {
+  if (NULL == entry->name)
+    {
+      return;
+    }
+
   entry->next = g_procfs_meminfo;
   g_procfs_meminfo = entry;
 }

--- a/mm/umm_heap/umm_initialize.c
+++ b/mm/umm_heap/umm_initialize.c
@@ -81,7 +81,11 @@
 
 void umm_initialize(FAR void *heap_start, size_t heap_size)
 {
+#ifdef CONFIG_BUILD_KERNEL
+  USR_HEAP = mm_initialize(NULL, heap_start, heap_size);
+#else
   USR_HEAP = mm_initialize("Umem", heap_start, heap_size);
+#endif
 }
 
 /****************************************************************************


### PR DESCRIPTION
## Summary

- In the case of CONFIG_BUILD_KERNEL=y, showing Kmem and Page
  info is enough for free command

## Impact

- CONFIG_BUILD_KERNEL=y only

## Testing

- Tested with sabre-6quad:netknsh
