### PR TITLE
rpmsgfs/Make.defs: rpmsgfs_server.c given more than once

### DIFF
--- a/fs/rpmsgfs/Make.defs
+++ b/fs/rpmsgfs/Make.defs
@@ -24,7 +24,7 @@ DEPPATH += --dep-path rpmsgfs
 VPATH += :rpmsgfs
 
 ifeq ($(CONFIG_FS_RPMSGFS),y)
-CSRCS += rpmsgfs.c rpmsgfs_client.c rpmsgfs_server.c
+CSRCS += rpmsgfs.c rpmsgfs_client.c
 endif
 
 ifeq ($(CONFIG_FS_RPMSGFS_SERVER),y)


### PR DESCRIPTION
Signed-off-by: wangbowen6 <wangbowen6@xiaomi.com>

## Summary
Makefile:81: target 'rpmsgfs_server.o' given more than once in the same rule

## Impact
No impact

## Testing
Compile and run with config sim:rpserver and sim:rpproxy
