### PR TITLE
up_nputs: fix AddressSanitizer: global-buffer-overflow problem

### DIFF
--- a/arch/arm/src/common/arm_nputs.c
+++ b/arch/arm/src/common/arm_nputs.c
@@ -39,7 +39,7 @@
 
 void up_nputs(const char *str, size_t len)
 {
-  while (*str && len-- > 0)
+  while (len-- > 0 && *str)
     {
       up_putc(*str++);
     }

--- a/arch/arm64/src/common/arm64_nputs.c
+++ b/arch/arm64/src/common/arm64_nputs.c
@@ -39,7 +39,7 @@
 
 void up_nputs(const char *str, size_t len)
 {
-  while (*str && len-- > 0)
+  while (len-- > 0 && *str)
     {
       up_putc(*str++);
     }

--- a/arch/avr/src/common/up_nputs.c
+++ b/arch/avr/src/common/up_nputs.c
@@ -51,7 +51,7 @@
 
 void up_nputs(const char *str, size_t len)
 {
-  while (*str && len-- > 0)
+  while (len-- > 0 && *str)
     {
       up_putc(*str++);
     }

--- a/arch/ceva/src/common/up_nputs.c
+++ b/arch/ceva/src/common/up_nputs.c
@@ -39,7 +39,7 @@
 
 void up_nputs(const char *str, size_t len)
 {
-  while (*str && len-- > 0)
+  while (len-- > 0 && *str)
     {
       up_putc(*str++);
     }

--- a/arch/hc/src/common/up_nputs.c
+++ b/arch/hc/src/common/up_nputs.c
@@ -51,7 +51,7 @@
 
 void up_nputs(const char *str, size_t len)
 {
-  while (*str && len-- > 0)
+  while (len-- > 0 && *str)
     {
       up_putc(*str++);
     }

--- a/arch/mips/src/common/mips_nputs.c
+++ b/arch/mips/src/common/mips_nputs.c
@@ -51,7 +51,7 @@
 
 void up_nputs(const char *str, size_t len)
 {
-  while (*str && len-- > 0)
+  while (len-- > 0 && *str)
     {
       up_putc(*str++);
     }

--- a/arch/or1k/src/common/up_nputs.c
+++ b/arch/or1k/src/common/up_nputs.c
@@ -39,7 +39,7 @@
 
 void up_nputs(const char *str, size_t len)
 {
-  while (*str && len-- > 0)
+  while (len-- > 0 && *str)
     {
       up_putc(*str++);
     }

--- a/arch/renesas/src/common/up_nputs.c
+++ b/arch/renesas/src/common/up_nputs.c
@@ -51,7 +51,7 @@
 
 void up_nputs(const char *str, size_t len)
 {
-  while (*str && len-- > 0)
+  while (len-- > 0 && *str)
     {
       up_putc(*str++);
     }

--- a/arch/risc-v/src/common/riscv_nputs.c
+++ b/arch/risc-v/src/common/riscv_nputs.c
@@ -39,7 +39,7 @@
 
 void up_nputs(const char *str, size_t len)
 {
-  while (*str && len-- > 0)
+  while (len-- > 0 && *str)
     {
       up_putc(*str++);
     }

--- a/arch/sim/src/sim/up_nputs.c
+++ b/arch/sim/src/sim/up_nputs.c
@@ -51,7 +51,7 @@
 
 void up_nputs(const char *str, size_t len)
 {
-  while (*str && len-- > 0)
+  while (len-- > 0 && *str)
     {
       up_putc(*str++);
     }

--- a/arch/sparc/src/common/up_nputs.c
+++ b/arch/sparc/src/common/up_nputs.c
@@ -51,7 +51,7 @@
 
 void up_nputs(const char *str, size_t len)
 {
-  while (*str && len-- > 0)
+  while (len-- > 0 && *str)
     {
       up_putc(*str++);
     }

--- a/arch/x86/src/common/up_nputs.c
+++ b/arch/x86/src/common/up_nputs.c
@@ -51,7 +51,7 @@
 
 void up_nputs(const char *str, size_t len)
 {
-  while (*str && len-- > 0)
+  while (len-- > 0 && *str)
     {
       up_putc(*str++);
     }

--- a/arch/x86_64/src/common/up_nputs.c
+++ b/arch/x86_64/src/common/up_nputs.c
@@ -51,7 +51,7 @@
 
 void up_nputs(const char *str, size_t len)
 {
-  while (*str && len-- > 0)
+  while (len-- > 0 && *str)
     {
       up_putc(*str++);
     }

--- a/arch/xtensa/src/common/xtensa_nputs.c
+++ b/arch/xtensa/src/common/xtensa_nputs.c
@@ -39,7 +39,7 @@
 
 void up_nputs(const char *str, size_t len)
 {
-  while (*str && len-- > 0)
+  while (len-- > 0 && *str)
     {
       up_putc(*str++);
     }

--- a/arch/z16/src/common/z16_nputs.c
+++ b/arch/z16/src/common/z16_nputs.c
@@ -39,7 +39,7 @@
 
 void up_nputs(const char *str, size_t len)
 {
-  while (*str && len-- > 0)
+  while (len-- > 0 && *str)
     {
       up_putc(*str++);
     }

--- a/arch/z80/src/common/z80_nputs.c
+++ b/arch/z80/src/common/z80_nputs.c
@@ -51,7 +51,7 @@
 
 void up_nputs(const char *str, size_t len)
 {
-  while (*str && len-- > 0)
+  while (len-- > 0 && *str)
     {
       up_putc(*str++);
     }


### PR DESCRIPTION
Signed-off-by: wangbowen6 <wangbowen6@xiaomi.com>

## Summary
==2117790==ERROR: AddressSanitizer: global-buffer-overflow on address 0x64d9e3c0 at pc 0x59ac4e16 bp 0xcefe8058 sp 0xcefe8048
READ of size 1 at 0x64d9e3c0 thread T0
    #0 0x59ac4e15 in up_nputs sim/up_nputs.c:54
    #1 0x59a67e4c in syslog_default_write syslog/syslog_channel.c:220
    #2 0x59a67823 in syslog_default_write syslog/syslog_write.c:101
    #3 0x59a67f10 in syslog_write syslog/syslog_write.c:153
    #4 0x59a651c3 in syslogstream_flush syslog/syslog_stream.c:60
    #5 0x59a6564e in syslogstream_addchar syslog/syslog_stream.c:104
    #6 0x59a6576f in syslogstream_putc syslog/syslog_stream.c:140
    #7 0x5989fc4d in vsprintf_internal stdio/lib_libvsprintf.c:952
    #8 0x598a1298 in lib_vsprintf stdio/lib_libvsprintf.c:1379
    #9 0x59a64ea4 in nx_vsyslog syslog/vsyslog.c:223
    #10 0x598a601a in vsyslog syslog/lib_syslog.c:68
    #11 0x59b0e3dc in AIOTJS::logPrintf(int, char const*, ...) src/ajs_log.cpp:45
    #12 0x59b03d56 in jse_dump_obj src/jse/quickjs/jse_quickjs.cpp:569
    #13 0x59b03ea1 in jse_dump_error1(JSContext*, unsigned long long) src/jse/quickjs/jse_quickjs.cpp:602
    #14 0x59b03dd9 in jse_dump_error(JSContext*) src/jse/quickjs/jse_quickjs.cpp:591
    #15 0x59bed615 in ferry::DomComponent::callHook(char const*) src/framework/dom/component.cpp:65
    #16 0x59bfe0ff in ferry::DomComponent::initialize() src/framework/dom/component.cpp:645
    #17 0x59bb141d in dom_create_component(JSContext*, unsigned long long, unsigned long long, unsigned long long) (/home/wangbowen/project/central/vela_miot_bes_m0/bin/audio+0x365c41d)
    #18 0x59b4c0d3 in AIOTJS::__createComponent(JSContext*, unsigned long long, int, unsigned long long*) (/home/wangbowen/project/central/vela_miot_bes_m0/bin/audio+0x35f70d3)
    #19 0x5a56ec17 in js_call_c_function quickjs/quickjs.c:16108

## Impact
no impact

## Testing
Local test with sim env

