### PR TITLE
Revert "net/usrsock: read from the closed remote should return EOF"

### DIFF
--- a/net/usrsock/usrsock_recvmsg.c
+++ b/net/usrsock/usrsock_recvmsg.c
@@ -442,12 +442,6 @@ errout_unlock:
       *fromlen = outaddrlen;
     }
 
-  if (conn->flags & USRSOCK_EVENT_REMOTE_CLOSED &&
-      ret == -ENOTCONN)
-    {
-      ret = OK;
-    }
-
   return ret;
 }
 


### PR DESCRIPTION
Reverts apache/incubator-nuttx#6972