### PR TITLE
compiler.h: Rename inline_function to always_inline_function

### DIFF
--- a/arch/arm/include/armv6-m/irq.h
+++ b/arch/arm/include/armv6-m/irq.h
@@ -215,7 +215,7 @@ struct xcptcontext
 
 /* Get/set the PRIMASK register */
 
-static inline uint8_t getprimask(void) inline_function;
+static inline uint8_t getprimask(void) always_inline_function;
 static inline uint8_t getprimask(void)
 {
   uint32_t primask;
@@ -229,7 +229,7 @@ static inline uint8_t getprimask(void)
   return (uint8_t)primask;
 }
 
-static inline void setprimask(uint32_t primask) inline_function;
+static inline void setprimask(uint32_t primask) always_inline_function;
 static inline void setprimask(uint32_t primask)
 {
   __asm__ __volatile__
@@ -242,7 +242,7 @@ static inline void setprimask(uint32_t primask)
 
 /* Disable IRQs */
 
-static inline void up_irq_disable(void) inline_function;
+static inline void up_irq_disable(void) always_inline_function;
 static inline void up_irq_disable(void)
 {
   __asm__ __volatile__ ("\tcpsid  i\n");
@@ -250,7 +250,7 @@ static inline void up_irq_disable(void)
 
 /* Save the current primask state & disable IRQs */
 
-static inline irqstate_t up_irq_save(void) inline_function;
+static inline irqstate_t up_irq_save(void) always_inline_function;
 static inline irqstate_t up_irq_save(void)
 {
   unsigned short primask;
@@ -272,7 +272,7 @@ static inline irqstate_t up_irq_save(void)
 
 /* Enable IRQs */
 
-static inline void up_irq_enable(void) inline_function;
+static inline void up_irq_enable(void) always_inline_function;
 static inline void up_irq_enable(void)
 {
   __asm__ __volatile__ ("\tcpsie  i\n");
@@ -280,7 +280,7 @@ static inline void up_irq_enable(void)
 
 /* Restore saved primask state */
 
-static inline void up_irq_restore(irqstate_t flags) inline_function;
+static inline void up_irq_restore(irqstate_t flags) always_inline_function;
 static inline void up_irq_restore(irqstate_t flags)
 {
   /* If bit 0 of the primask is 0, then we need to restore
@@ -297,7 +297,7 @@ static inline void up_irq_restore(irqstate_t flags)
 
 /* Get/set IPSR */
 
-static inline uint32_t getipsr(void) inline_function;
+static inline uint32_t getipsr(void) always_inline_function;
 static inline uint32_t getipsr(void)
 {
   uint32_t ipsr;
@@ -313,7 +313,7 @@ static inline uint32_t getipsr(void)
 
 /* Get/set CONTROL */
 
-static inline uint32_t getcontrol(void) inline_function;
+static inline uint32_t getcontrol(void) always_inline_function;
 static inline uint32_t getcontrol(void)
 {
   uint32_t control;
@@ -327,7 +327,7 @@ static inline uint32_t getcontrol(void)
   return control;
 }
 
-static inline void setcontrol(uint32_t control) inline_function;
+static inline void setcontrol(uint32_t control) always_inline_function;
 static inline void setcontrol(uint32_t control)
 {
   __asm__ __volatile__

--- a/arch/arm/include/armv7-m/irq.h
+++ b/arch/arm/include/armv7-m/irq.h
@@ -268,7 +268,7 @@ struct xcptcontext
 
 /* Get/set the PRIMASK register */
 
-static inline uint8_t getprimask(void) inline_function;
+static inline uint8_t getprimask(void) always_inline_function;
 static inline uint8_t getprimask(void)
 {
   uint32_t primask;
@@ -282,7 +282,7 @@ static inline uint8_t getprimask(void)
   return (uint8_t)primask;
 }
 
-static inline void setprimask(uint32_t primask) inline_function;
+static inline void setprimask(uint32_t primask) always_inline_function;
 static inline void setprimask(uint32_t primask)
 {
   __asm__ __volatile__
@@ -293,13 +293,13 @@ static inline void setprimask(uint32_t primask)
       : "memory");
 }
 
-static inline void cpsie(void) inline_function;
+static inline void cpsie(void) always_inline_function;
 static inline void cpsie(void)
 {
   __asm__ __volatile__ ("\tcpsie  i\n");
 }
 
-static inline void cpsid(void) inline_function;
+static inline void cpsid(void) always_inline_function;
 static inline void cpsid(void)
 {
   __asm__ __volatile__ ("\tcpsid  i\n");
@@ -311,7 +311,7 @@ static inline void cpsid(void)
  * lower priority level as the BASEPRI value.
  */
 
-static inline uint8_t getbasepri(void) inline_function;
+static inline uint8_t getbasepri(void) always_inline_function;
 static inline uint8_t getbasepri(void)
 {
   uint32_t basepri;
@@ -326,7 +326,7 @@ static inline uint8_t getbasepri(void)
   return (uint8_t)basepri;
 }
 
-static inline void setbasepri(uint32_t basepri) inline_function;
+static inline void setbasepri(uint32_t basepri) always_inline_function;
 static inline void setbasepri(uint32_t basepri)
 {
   __asm__ __volatile__
@@ -344,7 +344,7 @@ static inline void setbasepri(uint32_t basepri)
  * 837070 Workaround may be required if we are raising the priority.
  */
 
-static inline void raisebasepri(uint32_t basepri) inline_function;
+static inline void raisebasepri(uint32_t basepri) always_inline_function;
 static inline void raisebasepri(uint32_t basepri)
 {
   register uint32_t primask;
@@ -375,7 +375,7 @@ static inline void raisebasepri(uint32_t basepri)
 
 /* Disable IRQs */
 
-static inline void up_irq_disable(void) inline_function;
+static inline void up_irq_disable(void) always_inline_function;
 static inline void up_irq_disable(void)
 {
 #ifdef CONFIG_ARMV7M_USEBASEPRI
@@ -389,7 +389,7 @@ static inline void up_irq_disable(void)
 
 /* Save the current primask state & disable IRQs */
 
-static inline irqstate_t up_irq_save(void) inline_function;
+static inline irqstate_t up_irq_save(void) always_inline_function;
 static inline irqstate_t up_irq_save(void)
 {
 #ifdef CONFIG_ARMV7M_USEBASEPRI
@@ -421,7 +421,7 @@ static inline irqstate_t up_irq_save(void)
 
 /* Enable IRQs */
 
-static inline void up_irq_enable(void) inline_function;
+static inline void up_irq_enable(void) always_inline_function;
 static inline void up_irq_enable(void)
 {
   /* In this case, we are always retaining or lowering the priority value */
@@ -432,7 +432,7 @@ static inline void up_irq_enable(void)
 
 /* Restore saved primask state */
 
-static inline void up_irq_restore(irqstate_t flags) inline_function;
+static inline void up_irq_restore(irqstate_t flags) always_inline_function;
 static inline void up_irq_restore(irqstate_t flags)
 {
 #ifdef CONFIG_ARMV7M_USEBASEPRI
@@ -460,7 +460,7 @@ static inline void up_irq_restore(irqstate_t flags)
 
 /* Get/set IPSR */
 
-static inline uint32_t getipsr(void) inline_function;
+static inline uint32_t getipsr(void) always_inline_function;
 static inline uint32_t getipsr(void)
 {
   uint32_t ipsr;
@@ -476,7 +476,7 @@ static inline uint32_t getipsr(void)
 
 /* Get/set CONTROL */
 
-static inline uint32_t getcontrol(void) inline_function;
+static inline uint32_t getcontrol(void) always_inline_function;
 static inline uint32_t getcontrol(void)
 {
   uint32_t control;
@@ -490,7 +490,7 @@ static inline uint32_t getcontrol(void)
   return control;
 }
 
-static inline void setcontrol(uint32_t control) inline_function;
+static inline void setcontrol(uint32_t control) always_inline_function;
 static inline void setcontrol(uint32_t control)
 {
   __asm__ __volatile__

--- a/arch/arm/include/armv8-m/irq.h
+++ b/arch/arm/include/armv8-m/irq.h
@@ -279,7 +279,7 @@ struct xcptcontext
 
 /* Get/set the PRIMASK register */
 
-static inline uint8_t getprimask(void) inline_function;
+static inline uint8_t getprimask(void) always_inline_function;
 static inline uint8_t getprimask(void)
 {
   uint32_t primask;
@@ -293,7 +293,7 @@ static inline uint8_t getprimask(void)
   return (uint8_t)primask;
 }
 
-static inline void setprimask(uint32_t primask) inline_function;
+static inline void setprimask(uint32_t primask) always_inline_function;
 static inline void setprimask(uint32_t primask)
 {
   __asm__ __volatile__
@@ -304,13 +304,13 @@ static inline void setprimask(uint32_t primask)
       : "memory");
 }
 
-static inline void cpsie(void) inline_function;
+static inline void cpsie(void) always_inline_function;
 static inline void cpsie(void)
 {
   __asm__ __volatile__ ("\tcpsie  i\n");
 }
 
-static inline void cpsid(void) inline_function;
+static inline void cpsid(void) always_inline_function;
 static inline void cpsid(void)
 {
   __asm__ __volatile__ ("\tcpsid  i\n");
@@ -322,7 +322,7 @@ static inline void cpsid(void)
  * lower priority level as the BASEPRI value.
  */
 
-static inline uint8_t getbasepri(void) inline_function;
+static inline uint8_t getbasepri(void) always_inline_function;
 static inline uint8_t getbasepri(void)
 {
   uint32_t basepri;
@@ -337,7 +337,7 @@ static inline uint8_t getbasepri(void)
   return (uint8_t)basepri;
 }
 
-static inline void setbasepri(uint32_t basepri) inline_function;
+static inline void setbasepri(uint32_t basepri) always_inline_function;
 static inline void setbasepri(uint32_t basepri)
 {
   __asm__ __volatile__
@@ -352,7 +352,7 @@ static inline void setbasepri(uint32_t basepri)
 
 /* Disable IRQs */
 
-static inline void up_irq_disable(void) inline_function;
+static inline void up_irq_disable(void) always_inline_function;
 static inline void up_irq_disable(void)
 {
 #ifdef CONFIG_ARMV8M_USEBASEPRI
@@ -366,7 +366,7 @@ static inline void up_irq_disable(void)
 
 /* Save the current primask state & disable IRQs */
 
-static inline irqstate_t up_irq_save(void) inline_function;
+static inline irqstate_t up_irq_save(void) always_inline_function;
 static inline irqstate_t up_irq_save(void)
 {
 #ifdef CONFIG_ARMV8M_USEBASEPRI
@@ -398,7 +398,7 @@ static inline irqstate_t up_irq_save(void)
 
 /* Enable IRQs */
 
-static inline void up_irq_enable(void) inline_function;
+static inline void up_irq_enable(void) always_inline_function;
 static inline void up_irq_enable(void)
 {
   /* In this case, we are always retaining or lowering the priority value */
@@ -409,7 +409,7 @@ static inline void up_irq_enable(void)
 
 /* Restore saved primask state */
 
-static inline void up_irq_restore(irqstate_t flags) inline_function;
+static inline void up_irq_restore(irqstate_t flags) always_inline_function;
 static inline void up_irq_restore(irqstate_t flags)
 {
 #ifdef CONFIG_ARMV8M_USEBASEPRI
@@ -437,7 +437,7 @@ static inline void up_irq_restore(irqstate_t flags)
 
 /* Get/set IPSR */
 
-static inline uint32_t getipsr(void) inline_function;
+static inline uint32_t getipsr(void) always_inline_function;
 static inline uint32_t getipsr(void)
 {
   uint32_t ipsr;
@@ -453,7 +453,7 @@ static inline uint32_t getipsr(void)
 
 /* Get/set CONTROL */
 
-static inline uint32_t getcontrol(void) inline_function;
+static inline uint32_t getcontrol(void) always_inline_function;
 static inline uint32_t getcontrol(void)
 {
   uint32_t control;
@@ -467,7 +467,7 @@ static inline uint32_t getcontrol(void)
   return control;
 }
 
-static inline void setcontrol(uint32_t control) inline_function;
+static inline void setcontrol(uint32_t control) always_inline_function;
 static inline void setcontrol(uint32_t control)
 {
   __asm__ __volatile__

--- a/arch/arm/src/phy62xx/phy6222_irq.h
+++ b/arch/arm/src/phy62xx/phy6222_irq.h
@@ -215,7 +215,7 @@ struct xcptcontext
 
 /* Get/set the PRIMASK register */
 
-static inline uint8_t getprimask(void) inline_function;
+static inline uint8_t getprimask(void) always_inline_function;
 static inline uint8_t getprimask(void)
 {
   uint32_t primask;
@@ -229,7 +229,7 @@ static inline uint8_t getprimask(void)
   return (uint8_t)primask;
 }
 
-static inline void setprimask(uint32_t primask) inline_function;
+static inline void setprimask(uint32_t primask) always_inline_function;
 static inline void setprimask(uint32_t primask)
 {
   __asm__ __volatile__
@@ -242,7 +242,7 @@ static inline void setprimask(uint32_t primask)
 
 /* Disable IRQs */
 
-static inline void up_irq_disable(void) inline_function;
+static inline void up_irq_disable(void) always_inline_function;
 static inline void up_irq_disable(void)
 {
   __asm__ __volatile__ ("\tcpsid  i\n");
@@ -252,7 +252,7 @@ static inline void up_irq_disable(void)
 
 typedef void (*gpiowr_t)(int id, unsigned int en);
 #if 0
-static inline irqstate_t up_irq_save(void) inline_function;
+static inline irqstate_t up_irq_save(void) always_inline_function;
 static inline irqstate_t up_irq_save(void)
 {
   unsigned short primask;
@@ -276,7 +276,7 @@ static inline irqstate_t up_irq_save(void)
 #endif
 /* Enable IRQs */
 
-static inline void up_irq_enable(void) inline_function;
+static inline void up_irq_enable(void) always_inline_function;
 static inline void up_irq_enable(void)
 {
   __asm__ __volatile__ ("\tcpsie  i\n");
@@ -284,7 +284,7 @@ static inline void up_irq_enable(void)
 
 /* Restore saved primask state */
 #if 0
-static inline void up_irq_restore(irqstate_t flags) inline_function;
+static inline void up_irq_restore(irqstate_t flags) always_inline_function;
 static inline void up_irq_restore(irqstate_t flags)
 {
   /* If bit 0 of the primask is 0, then we need to restore
@@ -302,7 +302,7 @@ static inline void up_irq_restore(irqstate_t flags)
 #endif
 /* Get/set IPSR */
 
-static inline uint32_t getipsr(void) inline_function;
+static inline uint32_t getipsr(void) always_inline_function;
 static inline uint32_t getipsr(void)
 {
   uint32_t ipsr;
@@ -318,7 +318,7 @@ static inline uint32_t getipsr(void)
 
 /* Get/set CONTROL */
 
-static inline uint32_t getcontrol(void) inline_function;
+static inline uint32_t getcontrol(void) always_inline_function;
 static inline uint32_t getcontrol(void)
 {
   uint32_t control;
@@ -332,7 +332,7 @@ static inline uint32_t getcontrol(void)
   return control;
 }
 
-static inline void setcontrol(uint32_t control) inline_function;
+static inline void setcontrol(uint32_t control) always_inline_function;
 static inline void setcontrol(uint32_t control)
 {
   __asm__ __volatile__

--- a/arch/or1k/include/mor1kx/irq.h
+++ b/arch/or1k/include/mor1kx/irq.h
@@ -233,7 +233,7 @@ static inline void up_irq_restore(irqstate_t flags)
 
 /* Enable IRQs */
 
-static inline void up_irq_enable(void) inline_function;
+static inline void up_irq_enable(void) always_inline_function;
 static inline void up_irq_enable(void)
 {
   irqstate_t flags;

--- a/arch/xtensa/src/common/xtensa_backtrace.c
+++ b/arch/xtensa/src/common/xtensa_backtrace.c
@@ -57,7 +57,7 @@ struct xtensa_windowregs_s
  ****************************************************************************/
 
 static void inline get_window_regs(struct xtensa_windowregs_s *frame)
-inline_function;
+always_inline_function;
 
 /****************************************************************************
  * Private Functions

--- a/include/nuttx/compiler.h
+++ b/include/nuttx/compiler.h
@@ -179,12 +179,12 @@
 
 #  define naked_function __attribute__ ((naked,no_instrument_function))
 
-/* The inline_function attribute informs GCC that the function should always
- * be inlined, regardless of the level of optimization.  The
+/* The always_inline_function attribute informs GCC that the function should
+ * always be inlined, regardless of the level of optimization.  The
  * noinline_function indicates that the function should never be inlined.
  */
 
-#  define inline_function __attribute__ ((always_inline,no_instrument_function))
+#  define always_inline_function __attribute__ ((always_inline,no_instrument_function))
 #  define noinline_function __attribute__ ((noinline))
 
 /* The noinstrument_function attribute informs GCC don't instrument it */
@@ -465,7 +465,7 @@
 
 /* SDCC does not support forced inlining. */
 
-#  define inline_function
+#  define always_inline_function
 #  define noinline_function
 #  define noinstrument_function
 #  define nosanitize_address
@@ -598,7 +598,7 @@
 #  define begin_packed_struct
 #  define end_packed_struct
 #  define naked_function
-#  define inline_function
+#  define always_inline_function
 #  define noinline_function
 #  define noinstrument_function
 #  define nosanitize_address
@@ -700,7 +700,7 @@
 #  define end_packed_struct
 #  define reentrant_function
 #  define naked_function
-#  define inline_function
+#  define always_inline_function
 #  define noinline_function
 #  define noinstrument_function
 #  define nosanitize_address
@@ -768,7 +768,7 @@
 #  define end_packed_struct
 #  define reentrant_function
 #  define naked_function
-#  define inline_function
+#  define always_inline_function
 #  define noinline_function
 #  define noinstrument_function
 #  define nosanitize_address


### PR DESCRIPTION
## Summary
reserve inline_function macro for inline keyword

## Impact
Minor

## Testing
Pass CI
