### PR TITLE
stm32h7\stm32_fdcan_sock: fix the FDCAN_LOOPBACK config macros

### DIFF
--- a/arch/arm/src/stm32h7/stm32_fdcan_sock.c
+++ b/arch/arm/src/stm32h7/stm32_fdcan_sock.c
@@ -2075,14 +2075,14 @@ int fdcan_initialize(struct fdcan_driver_s *priv)
 
   /* Operation Configuration */
 
-#ifdef STM32H7_FDCAN_LOOPBACK
+#ifdef CONFIG_STM32H7_FDCAN_LOOPBACK
   /* Enable External Loopback Mode (Rx pin disconnected) (RM0433 pg 2494) */
 
   modifyreg32(priv->base + STM32_FDCAN_CCCR_OFFSET, 0, FDCAN_CCCR_TEST);
   modifyreg32(priv->base + STM32_FDCAN_TEST_OFFSET, 0, FDCAN_TEST_LBCK);
 #endif
 
-#ifdef STM32H7_FDCAN_LOOPBACK_INTERNAL
+#ifdef CONFIG_STM32H7_FDCAN_LOOPBACK_INTERNAL
   /* Enable Bus Monitoring / Restricted Op Mode (RM0433 pg 2492, 2494) */
 
   modifyreg32(priv->base + STM32_FDCAN_CCCR_OFFSET, 0, FDCAN_CCCR_MON);


### PR DESCRIPTION
## Summary
The names of the macros STM32H7_FDCAN_LOOPBACK and STM32H7_FDCAN_LOOPBACK_INTERNAL  do not match with the corresponding macro names in KConfig. As a result, when these macros are enabled in Kconfig, the enclosed code stay disabled.

## Impact
There's no way to enable the loopback mode on STM32H7 enclosed within the macros.

## Testing
Tested loopback functionality on STM32H7 board and loopback works fine after the fix.
