### PR TITLE
nuttx/sched: semaphore and mqueue task list optimize

### DIFF
--- a/include/nuttx/mqueue.h
+++ b/include/nuttx/mqueue.h
@@ -85,6 +85,9 @@
 # define nxmq_pollnotify(msgq, eventset)
 #endif
 
+# define MQ_WNELIST(mq)               (&((mq)->waitfornotempty))
+# define MQ_WNFLIST(mq)               (&((mq)->waitfornotfull))
+
 /****************************************************************************
  * Public Type Declarations
  ****************************************************************************/
@@ -94,6 +97,8 @@
 struct mqueue_inode_s
 {
   FAR struct inode *inode;    /* Containing inode */
+  dq_queue_t waitfornotempty; /* Task list waiting for not empty */
+  dq_queue_t waitfornotfull;  /* Task list waiting for not full */
   struct list_node msglist;   /* Prioritized message list */
   int16_t maxmsgs;            /* Maximum number of messages in the queue */
   int16_t nmsgs;              /* Number of message in the queue */

--- a/include/nuttx/semaphore.h
+++ b/include/nuttx/semaphore.h
@@ -40,15 +40,21 @@
 
 #ifdef CONFIG_PRIORITY_INHERITANCE
 # if CONFIG_SEM_PREALLOCHOLDERS > 0
+/* semcount, waitlist, flags, hhead */
+
 #  define NXSEM_INITIALIZER(c, f) \
-    {(c), (f), NULL}                    /* semcount, flags, hhead */
+    {(c), SEM_WAITLIST_INITIALIZER, (f), NULL}
 # else
+/* semcount, waitlist, flags, holder[2] */
+
 #  define NXSEM_INITIALIZER(c, f) \
-    {(c), (f), {SEMHOLDER_INITIALIZER, SEMHOLDER_INITIALIZER}}  /* semcount, flags, holder[2] */
+    {(c), SEM_WAITLIST_INITIALIZER, (f), {SEMHOLDER_INITIALIZER, SEMHOLDER_INITIALIZER}}
 # endif
 #else /* CONFIG_PRIORITY_INHERITANCE */
+/* semcount, waitlist */
+
 #  define NXSEM_INITIALIZER(c, f) \
-    {(c)}                               /* semcount, flags */
+    {(c), SEM_WAITLIST_INITIALIZER}
 #endif /* CONFIG_PRIORITY_INHERITANCE */
 
 /* Most internal nxsem_* interfaces are not available in the user space in

--- a/libs/libc/semaphore/sem_init.c
+++ b/libs/libc/semaphore/sem_init.c
@@ -73,6 +73,10 @@ int nxsem_init(FAR sem_t *sem, int pshared, unsigned int value)
 
       sem->semcount         = (int16_t)value;
 
+      /* Initialize semaphore wait list */
+
+      dq_init(&sem->waitlist);
+
       /* Initialize to support priority inheritance */
 
 #ifdef CONFIG_PRIORITY_INHERITANCE

--- a/sched/init/nx_start.c
+++ b/sched/init/nx_start.c
@@ -134,10 +134,6 @@ FAR struct tcb_s *g_running_tasks[CONFIG_SMP_NCPUS];
 
 dq_queue_t g_pendingtasks;
 
-/* This is the list of all tasks that are blocked waiting for a semaphore */
-
-dq_queue_t g_waitingforsemaphore;
-
 /* This is the list of all tasks that are blocked waiting for a signal */
 
 dq_queue_t g_waitingforsignal;
@@ -237,8 +233,8 @@ const struct tasklist_s g_tasklisttable[NUM_TASK_STATES] =
     0
   },
   {                                              /* TSTATE_WAIT_SEM */
-    &g_waitingforsemaphore,
-    TLIST_ATTR_PRIORITIZED
+    (FAR void *)offsetof(sem_t, waitlist),
+    TLIST_ATTR_PRIORITIZED | TLIST_ATTR_OFFSET
   },
   {                                              /* TSTATE_WAIT_SIG */
     &g_waitingforsignal,
@@ -429,9 +425,9 @@ void nx_start(void)
        */
 
 #ifdef CONFIG_SMP
-      tasklist = TLIST_HEAD(TSTATE_TASK_RUNNING, i);
+      tasklist = TLIST_HEAD(&g_idletcb[i].cmn, i);
 #else
-      tasklist = TLIST_HEAD(TSTATE_TASK_RUNNING);
+      tasklist = TLIST_HEAD(&g_idletcb[i].cmn);
 #endif
       dq_addfirst((FAR dq_entry_t *)&g_idletcb[i], tasklist);
 

--- a/sched/init/nx_start.c
+++ b/sched/init/nx_start.c
@@ -138,22 +138,6 @@ dq_queue_t g_pendingtasks;
 
 dq_queue_t g_waitingforsignal;
 
-#ifndef CONFIG_DISABLE_MQUEUE
-/* This is the list of all tasks that are blocked waiting for a message
- * queue to become non-empty.
- */
-
-dq_queue_t g_waitingformqnotempty;
-#endif
-
-#ifndef CONFIG_DISABLE_MQUEUE
-/* This is the list of all tasks that are blocked waiting for a message
- * queue to become non-full.
- */
-
-dq_queue_t g_waitingformqnotfull;
-#endif
-
 #ifdef CONFIG_PAGING
 /* This is the list of all tasks that are blocking waiting for a page fill */
 
@@ -243,12 +227,12 @@ const struct tasklist_s g_tasklisttable[NUM_TASK_STATES] =
 #ifndef CONFIG_DISABLE_MQUEUE
   ,
   {                                              /* TSTATE_WAIT_MQNOTEMPTY */
-    &g_waitingformqnotempty,
-    TLIST_ATTR_PRIORITIZED
+    (FAR void *)offsetof(struct mqueue_inode_s, waitfornotempty),
+    TLIST_ATTR_PRIORITIZED | TLIST_ATTR_OFFSET
   },
   {                                              /* TSTATE_WAIT_MQNOTFULL */
-    &g_waitingformqnotfull,
-    TLIST_ATTR_PRIORITIZED
+    (FAR void *)offsetof(struct mqueue_inode_s, waitfornotfull),
+    TLIST_ATTR_PRIORITIZED | TLIST_ATTR_OFFSET
   }
 #endif
 #ifdef CONFIG_PAGING

--- a/sched/mqueue/mq_msgqalloc.c
+++ b/sched/mqueue/mq_msgqalloc.c
@@ -101,6 +101,9 @@ int nxmq_alloc_msgq(FAR struct mq_attr *attr,
 #ifndef CONFIG_DISABLE_MQUEUE_NOTIFICATION
       msgq->ntpid = INVALID_PROCESS_ID;
 #endif
+
+      dq_init(&msgq->waitfornotempty);
+      dq_init(&msgq->waitfornotfull);
     }
   else
     {

--- a/sched/mqueue/mq_rcvinternal.c
+++ b/sched/mqueue/mq_rcvinternal.c
@@ -280,16 +280,12 @@ ssize_t nxmq_do_receive(FAR struct mqueue_inode_s *msgq,
   if (msgq->nwaitnotfull > 0)
     {
       /* Find the highest priority task that is waiting for
-       * this queue to be not-full in g_waitingformqnotfull list.
+       * this queue to be not-full in waitfornotfull list.
        * This must be performed in a critical section because
        * messages can be sent from interrupt handlers.
        */
 
-      for (btcb = (FAR struct tcb_s *)g_waitingformqnotfull.head;
-           btcb && btcb->waitobj != msgq;
-           btcb = btcb->flink)
-        {
-        }
+      btcb = (FAR struct tcb_s *)dq_peek(MQ_WNFLIST(msgq));
 
       /* If one was found, unblock it.  NOTE:  There is a race
        * condition here:  the queue might be full again by the

--- a/sched/mqueue/mq_sndinternal.c
+++ b/sched/mqueue/mq_sndinternal.c
@@ -389,17 +389,13 @@ int nxmq_do_send(FAR struct mqueue_inode_s *msgq,
   if (msgq->nwaitnotempty > 0)
     {
       /* Find the highest priority task that is waiting for
-       * this queue to be non-empty in g_waitingformqnotempty
+       * this queue to be non-empty in waitfornotempty
        * list. leave_critical_section() should give us sufficient
        * protection since interrupts should never cause a change
        * in this list
        */
 
-      for (btcb = (FAR struct tcb_s *)g_waitingformqnotempty.head;
-           btcb && btcb->waitobj != msgq;
-           btcb = btcb->flink)
-        {
-        }
+      btcb = (FAR struct tcb_s *)dq_peek(MQ_WNELIST(msgq));
 
       /* If one was found, unblock it */
 

--- a/sched/sched/sched.h
+++ b/sched/sched/sched.h
@@ -178,22 +178,6 @@ extern dq_queue_t g_pendingtasks;
 
 extern dq_queue_t g_waitingforsignal;
 
-/* This is the list of all tasks that are blocked waiting for a message
- * queue to become non-empty.
- */
-
-#ifndef CONFIG_DISABLE_MQUEUE
-extern dq_queue_t g_waitingformqnotempty;
-#endif
-
-/* This is the list of all tasks that are blocked waiting for a message
- * queue to become non-full.
- */
-
-#ifndef CONFIG_DISABLE_MQUEUE
-extern dq_queue_t g_waitingformqnotfull;
-#endif
-
 /* This is the list of all tasks that are blocking waiting for a page fill */
 
 #ifdef CONFIG_PAGING

--- a/sched/sched/sched_addblocked.c
+++ b/sched/sched/sched_addblocked.c
@@ -63,9 +63,13 @@ void nxsched_add_blocked(FAR struct tcb_s *btcb, tstate_t task_state)
   DEBUGASSERT(task_state >= FIRST_BLOCKED_STATE &&
               task_state <= LAST_BLOCKED_STATE);
 
+  /* Make sure the TCB's state corresponds to the list */
+
+  btcb->task_state = task_state;
+
   /* Add the TCB to the blocked task list associated with this state. */
 
-  tasklist = TLIST_BLOCKED(task_state);
+  tasklist = TLIST_BLOCKED(btcb);
 
   /* Determine if the task is to be added to a prioritized task list. */
 
@@ -81,8 +85,4 @@ void nxsched_add_blocked(FAR struct tcb_s *btcb, tstate_t task_state)
 
       dq_addlast((FAR dq_entry_t *)btcb, tasklist);
     }
-
-  /* Make sure the TCB's state corresponds to the list */
-
-  btcb->task_state = task_state;
 }

--- a/sched/sched/sched_removeblocked.c
+++ b/sched/sched/sched_removeblocked.c
@@ -66,7 +66,7 @@ void nxsched_remove_blocked(FAR struct tcb_s *btcb)
    * with this state
    */
 
-  dq_rem((FAR dq_entry_t *)btcb, TLIST_BLOCKED(task_state));
+  dq_rem((FAR dq_entry_t *)btcb, TLIST_BLOCKED(btcb));
 
   /* Indicate that the wait is over. */
 

--- a/sched/sched/sched_removereadytorun.c
+++ b/sched/sched/sched_removereadytorun.c
@@ -130,7 +130,7 @@ bool nxsched_remove_readytorun(FAR struct tcb_s *rtcb)
    */
 
   cpu      = rtcb->cpu;
-  tasklist = TLIST_HEAD(rtcb->task_state, cpu);
+  tasklist = TLIST_HEAD(rtcb, cpu);
 
   /* Check if the TCB to be removed is at the head of a ready-to-run list.
    * For the case of SMP, there are two lists involved:  (1) the

--- a/sched/sched/sched_setpriority.c
+++ b/sched/sched/sched_setpriority.c
@@ -278,7 +278,7 @@ static inline void nxsched_blocked_setpriority(FAR struct tcb_s *tcb,
 
   /* CASE 3a. The task resides in a prioritized list. */
 
-  tasklist = TLIST_BLOCKED(task_state);
+  tasklist = TLIST_BLOCKED(tcb);
   if (TLIST_ISPRIORITIZED(task_state))
     {
       /* Remove the TCB from the prioritized task list */

--- a/sched/semaphore/sem_post.c
+++ b/sched/semaphore/sem_post.c
@@ -139,9 +139,7 @@ int nxsem_post(FAR sem_t *sem)
            * that we want.
            */
 
-          for (stcb = (FAR struct tcb_s *)g_waitingforsemaphore.head;
-               (stcb && stcb->waitobj != sem);
-               stcb = stcb->flink);
+          stcb = (FAR struct tcb_s *)dq_peek(SEM_WAITLIST(sem));
 
           if (stcb != NULL)
             {

--- a/sched/task/task_restart.c
+++ b/sched/task/task_restart.c
@@ -133,9 +133,9 @@ int nxtask_restart(pid_t pid)
    */
 
 #ifdef CONFIG_SMP
-  tasklist = TLIST_HEAD(tcb->cmn.task_state, tcb->cmn.cpu);
+  tasklist = TLIST_HEAD(&tcb->cmn, tcb->cmn.cpu);
 #else
-  tasklist = TLIST_HEAD(tcb->cmn.task_state);
+  tasklist = TLIST_HEAD(&tcb->cmn);
 #endif
 
   dq_rem((FAR dq_entry_t *)tcb, tasklist);

--- a/sched/task/task_terminate.c
+++ b/sched/task/task_terminate.c
@@ -131,13 +131,13 @@ int nxtask_terminate(pid_t pid, bool nonblocking)
 
   /* Get the task list associated with the thread's state and CPU */
 
-  tasklist = TLIST_HEAD(dtcb->task_state, cpu);
+  tasklist = TLIST_HEAD(dtcb, cpu);
 #else
   /* In the non-SMP case, we can be assured that the task to be terminated
    * is not running.  get the task list associated with the task state.
    */
 
-  tasklist = TLIST_HEAD(dtcb->task_state);
+  tasklist = TLIST_HEAD(dtcb);
 #endif
 
   /* Remove the task from the task list */


### PR DESCRIPTION
## Summary

Semaphore and mqueue task list optimize:
1.  move waitingforsemaphore list to sem_s；
2.  move waitingformqnotempty and waitingformqnotfull list to mqueue_inode_s;

depends on https://github.com/apache/incubator-nuttx/pull/7185

## Impact

Code Size:

Before:
```
   text	   data	    bss	    dec	    hex	filename
 109692	    224	  24940	 134856	  20ec8	nuttx
```

After:
```
   text	   data	    bss	    dec	    hex	filename
 109924	    312	  25144	 135380	  210d4	nuttx
```

Performance:

20 semaphore and 20 threads with different priorities.
sem_post -> sem_wait (cycle count):
before:
`8179`

after:
`6988`

## Testing

sabre-6quad:nsh