### PR TITLE
encoder: add support for QEIOC_GETINDEX ioctl

### DIFF
--- a/arch/arm/src/imxrt/Kconfig
+++ b/arch/arm/src/imxrt/Kconfig
@@ -1025,6 +1025,10 @@ config ENC1_HNE
 
 endif # ENC1_HIP
 
+config ENC1_XIE
+	bool "INDEX signal position capture"
+	default n
+
 config ENC1_XIP
 	bool "INDEX signal initializes position counter"
 	default n
@@ -1099,6 +1103,10 @@ config ENC2_HNE
 	default n
 
 endif # ENC2_HIP
+
+config ENC2_XIE
+	bool "INDEX signal position capture"
+	default n
 
 config ENC2_XIP
 	bool "INDEX signal initializes position counter"
@@ -1177,6 +1185,10 @@ config ENC3_HNE
 
 endif # ENC3_HIP
 
+config ENC3_XIE
+	bool "INDEX signal position capture"
+	default n
+
 config ENC3_XIP
 	bool "INDEX signal initializes position counter"
 	default n
@@ -1251,6 +1263,10 @@ config ENC4_HNE
 	default n
 
 endif # ENC4_HIP
+
+config ENC4_XIE
+	bool "INDEX signal position capture"
+	default n
 
 config ENC4_XIP
 	bool "INDEX signal initializes position counter"

--- a/include/nuttx/sensors/qencoder.h
+++ b/include/nuttx/sensors/qencoder.h
@@ -54,15 +54,20 @@
  *   Argument: uint32_t maximum position
  * QEIOC_SETINDEX - Set the index position for the encoder.
  *   Argument: uint32_t index position
+ * QEIOC_GETINDEX - Get the index position and count of the encoder.
+ *   The structure also contains current position so QEIOC_POSITION
+ *   is not required when QEIOC_GETINDEX is used.
+ *   Argment: qe_index_s structure (refer below)
  */
 
 #define QEIOC_POSITION     _QEIOC(0x0001) /* Arg: int32_t* pointer */
 #define QEIOC_RESET        _QEIOC(0x0002) /* Arg: None */
 #define QEIOC_SETPOSMAX    _QEIOC(0x0003) /* Arg: uint32_t */
 #define QEIOC_SETINDEX     _QEIOC(0x0004) /* Arg: uint32_t */
+#define QEIOC_GETINDEX     _QEIOC(0x0005) /* Arg: qe_index_s struct */
 
 #define QE_FIRST           0x0001         /* First required command */
-#define QE_NCMDS           4              /* 4 required commands */
+#define QE_NCMDS           5              /* 5 required commands */
 
 /* User defined ioctl commands are also supported. These will be forwarded
  * by the upper-half QE driver to the lower-half QE driver via the ioctl()
@@ -136,6 +141,18 @@ struct qe_ops_s
 
   CODE int (*ioctl)(FAR struct qe_lowerhalf_s *lower,
                     int cmd, unsigned long arg);
+};
+
+/* Structure qe_index_s is used for QEIOC_GETINDEX call. This call returns
+ * current encoder position, the last index position and number of index
+ * occurances.
+ */
+
+struct qe_index_s
+{
+  int32_t qenc_pos;     /* Qencoder actual position */
+  int32_t indx_pos;     /* Index last position */
+  int16_t indx_cnt;     /* Number of index occurances */
 };
 
 /* This is the interface between the lower half quadrature encoder driver


### PR DESCRIPTION
## Summary

This IOCTL (QEIOC_GETINDEX) allows the application to get the actual encoder position, the index last position and the index count with one IOCTL call if supported by architecture specific level.

The position, index and count is passed to application level through qe_index_s structure.

The other commit enhances the iMXRT encoder driver with index capture and QEIOC_GETINDEX support.

## Impact

QEIOC_GETINDEX IOCTL offers more comfortable usage for motor control (where last index position might be required for motor control). The IOCTL is currently implemented only for iMXRT MCU.

## Testing
Tested with iMXRT based Teensy 4.1 board and PMSM control.
