### PR TITLE
xtensa: Avoid including handlers when no coprocessor is available

### DIFF
--- a/arch/xtensa/src/common/xtensa_context.S
+++ b/arch/xtensa/src/common/xtensa_context.S
@@ -69,7 +69,10 @@
 #include "chip.h"
 #include "syscall.h"
 #include "xtensa_asm_utils.h"
-#include "xtensa_coproc.S"
+
+#if XCHAL_CP_NUM > 0
+#  include "xtensa_coproc.S"
+#endif
 
 /****************************************************************************
  * Public Functions


### PR DESCRIPTION
## Summary

This PR intends to fix the build for **ESP32-S2** chip. `xtensa_coproc.S` is being included even when no coprocessors are available, resulting in some missing definitions.

## Impact
Build fix for ESP32-S2 defconfigs.

## Testing
CI build pass.