### PR TITLE
Fixed pow() for negative bases.

### DIFF
--- a/libs/libc/math/lib_pow.c
+++ b/libs/libc/math/lib_pow.c
@@ -41,6 +41,22 @@
 #ifdef CONFIG_HAVE_DOUBLE
 double pow(double b, double e)
 {
-  return exp(e * log(b));
+  if (b > 0)
+    {
+      return exp(e * log(b));
+    }
+  else if (b < 0 && e == (int)e)
+    {
+      if ((int)e % 2 == 0)
+        {
+          return exp(e * log(fabs(b)));
+        }
+      else
+        {
+          return -exp(e * log(fabs(b)));
+        }
+    }
+
+  return 0;
 }
 #endif


### PR DESCRIPTION
## Summary

Fixes `pow()` when negative numbers are used as a base.

See #6941 for more information.

## Impact

Correct calculations in `pow()` for all inputs.

## Testing

Tested a few sample cases in simulator.
The results seem correct.
