### PR TITLE
mm: Check the function result with suitable macro.

### DIFF
--- a/mm/mm_heap/mm_extend.c
+++ b/mm/mm_heap/mm_extend.c
@@ -56,6 +56,7 @@ void mm_extend(FAR struct mm_heap_s *heap, FAR void *mem, size_t size,
   FAR struct mm_allocnode_s *newnode;
   uintptr_t blockstart;
   uintptr_t blockend;
+  bool ret;
 
   /* Make sure that we were passed valid parameters */
 
@@ -77,7 +78,8 @@ void mm_extend(FAR struct mm_heap_s *heap, FAR void *mem, size_t size,
 
   /* Take the memory manager semaphore */
 
-  DEBUGVERIFY(mm_takesemaphore(heap));
+  ret = mm_takesemaphore(heap);
+  DEBUGASSERT(ret);
 
   /* Get the terminal node in the old heap.  The block to extend must
    * immediately follow this node.

--- a/mm/mm_heap/mm_initialize.c
+++ b/mm/mm_heap/mm_initialize.c
@@ -61,6 +61,7 @@ void mm_addregion(FAR struct mm_heap_s *heap, FAR void *heapstart,
   FAR struct mm_freenode_s *node;
   uintptr_t heapbase;
   uintptr_t heapend;
+  bool ret;
 #if CONFIG_MM_REGIONS > 1
   int IDX;
 
@@ -91,7 +92,8 @@ void mm_addregion(FAR struct mm_heap_s *heap, FAR void *heapstart,
 
   kasan_register(heapstart, &heapsize);
 
-  DEBUGVERIFY(mm_takesemaphore(heap));
+  ret = mm_takesemaphore(heap);
+  DEBUGASSERT(ret);
 
   /* Adjust the provided heap start and size.
    *

--- a/mm/mm_heap/mm_malloc.c
+++ b/mm/mm_heap/mm_malloc.c
@@ -108,6 +108,7 @@ FAR void *mm_malloc(FAR struct mm_heap_s *heap, size_t size)
   size_t alignsize;
   FAR void *ret = NULL;
   int ndx;
+  bool val;
 
   /* Free the delay list first */
 
@@ -137,7 +138,8 @@ FAR void *mm_malloc(FAR struct mm_heap_s *heap, size_t size)
 
   /* We need to hold the MM semaphore while we muck with the nodelist. */
 
-  DEBUGVERIFY(mm_takesemaphore(heap));
+  val = mm_takesemaphore(heap);
+  DEBUGASSERT(val);
 
   /* Get the location in the node list to start the search. Special case
    * really big allocations

--- a/mm/mm_heap/mm_memalign.c
+++ b/mm/mm_heap/mm_memalign.c
@@ -57,6 +57,7 @@ FAR void *mm_memalign(FAR struct mm_heap_s *heap, size_t alignment,
   size_t mask = (size_t)(alignment - 1);
   size_t allocsize;
   size_t newsize;
+  bool ret;
 
   /* Make sure that alignment is less than half max size_t */
 
@@ -118,7 +119,8 @@ FAR void *mm_memalign(FAR struct mm_heap_s *heap, size_t alignment,
    * nodelist.
    */
 
-  DEBUGVERIFY(mm_takesemaphore(heap));
+  ret = mm_takesemaphore(heap);
+  DEBUGASSERT(ret);
 
   /* Get the node associated with the allocation and the next node after
    * the allocation.

--- a/mm/mm_heap/mm_realloc.c
+++ b/mm/mm_heap/mm_realloc.c
@@ -72,6 +72,7 @@ FAR void *mm_realloc(FAR struct mm_heap_s *heap, FAR void *oldmem,
   size_t prevsize = 0;
   size_t nextsize = 0;
   FAR void *newmem;
+  bool ret;
 
   /* If oldmem is NULL, then realloc is equivalent to malloc */
 
@@ -108,7 +109,8 @@ FAR void *mm_realloc(FAR struct mm_heap_s *heap, FAR void *oldmem,
 
   /* We need to hold the MM semaphore while we muck with the nodelist. */
 
-  DEBUGVERIFY(mm_takesemaphore(heap));
+  ret = mm_takesemaphore(heap);
+  DEBUGASSERT(ret);
   DEBUGASSERT(oldnode->preceding & MM_ALLOC_BIT);
   DEBUGASSERT(mm_heapmember(heap, oldmem));
 


### PR DESCRIPTION
The return value of function mm_takesemaphore will never below
than zero, DEBUGVERIFY make no effect to check it, use DEBUGASSERT
instead.

Signed-off-by: xiangdong6 <xiangdong6@xiaomi.com>

## Summary

## Impact
None

## Testing
passed.
