### PR TITLE
sched/wqueue: fix visual studio Compiler Error C2059

### DIFF
--- a/sched/wqueue/kwork_thread.c
+++ b/sched/wqueue/kwork_thread.c
@@ -79,7 +79,7 @@
 
 struct hp_wqueue_s g_hpwork =
 {
-  {},
+  {NULL, NULL},
   NXSEM_INITIALIZER(0, PRIOINHERIT_FLAGS_DISABLE),
 };
 
@@ -90,7 +90,7 @@ struct hp_wqueue_s g_hpwork =
 
 struct lp_wqueue_s g_lpwork =
 {
-  {},
+  {NULL, NULL},
   NXSEM_INITIALIZER(0, PRIOINHERIT_FLAGS_DISABLE),
 };
 


### PR DESCRIPTION
## Summary

sched/wqueue: fix visual studio Compiler Error C2059

Designated initializers are a C99 (or newer) feature, and Visual Studio doesn't (part) support C99 (or newer).

`D:\code\incubator-nuttx\sched\wqueue\kwork_thread.c(94,50): error C2059: syntax error : ','`

Reference:
https://docs.microsoft.com/en-us/cpp/overview/visual-cpp-language-conformance?view=msvc-160#c-standard-library-features-1
https://docs.microsoft.com/en-us/cpp/error-messages/compiler-errors-1/compiler-error-c2059?view=msvc-170

Signed-off-by: chao an <anchao@xiaomi.com>

## Impact

N/A

## Testing

visio studio + cmake