### PR TITLE
net/procfs: add entry mapping table

### DIFF
--- a/net/procfs/procfs.h
+++ b/net/procfs/procfs.h
@@ -49,22 +49,6 @@
  * Public Type Definitions
  ****************************************************************************/
 
-/* Describes the /net directory entries */
-
-enum netprocfs_entry_e
-{
-  NETPROCFS_SUBDIR_DEV = 0           /* Multiple instances, e.g. /proc/net/eth0 */
-#ifdef CONFIG_NET_STATISTICS
-  , NETPROCFS_SUBDIR_STAT            /* /proc/net/stat */
-#ifdef CONFIG_NET_MLD
-  , NETPROCFS_SUBDIR_MLD             /* /proc/net/mld */
-#endif
-#endif
-#ifdef CONFIG_NET_ROUTE
-  , NETPROCFS_SUBDIR_ROUTE           /* /proc/net/route */
-#endif
-};
-
 /* This structure describes one open "file" */
 
 struct net_driver_s;                 /* Forward reference */
@@ -75,7 +59,7 @@ struct netprocfs_file_s
   uint8_t lineno;                    /* Line number */
   uint8_t linesize;                  /* Number of valid characters in line[] */
   uint8_t offset;                    /* Offset to first valid character in line[] */
-  uint8_t entry;                     /* See enum netprocfs_entry_e */
+  uint8_t entry;                     /* Entry index of netprocfs_entry_s */
   char line[NET_LINELEN];            /* Pre-allocated buffer for formatted lines */
 };
 


### PR DESCRIPTION
## Summary

net/procfs: add entry mapping table

add entry mapping table to simplify new component registration

Signed-off-by: chao an <anchao@xiaomi.com>

## Impact

N/A

## Testing

```
nsh> ifconfig
Joins: 0000 Leaves: 0000
Sent       Sched Sent
  Queries: 0000  0000
  Reports:
    Ver 1: ----  0000
    Ver 2: 0000  0000
  Done:    0000  0000
Received:
  Queries:
    Gen:   0000
    MAS:   0000
    MASS:  0000
    Ucast: 0000
    Bad:   0000
  Reports:
    Ver 1: 0000
    Ver 2: 0000
  Done:    0000
eth0	Link encap:Ethernet HWaddr 00:00:00:00:00:00 at DOWN
	inet addr:0.0.0.0 DRaddr:0.0.0.0 Mask:0.0.0.0
	inet6 addr: ::/0
	inet6 DRaddr: ::/0

             IPv4  IPv6   TCP   UDP  ICMP  ICMPv6
Received     0000  0000  0000  0000  0000  0000
Dropped      0000  0000  0000  0000  0000  0000
  IPv4        VHL: 0000   Frg: 0000
  IPv6        VHL: 0000
  Checksum   0000  ----  0000  0000  ----  ----
  TCP         ACK: 0000   SYN: 0000
              RST: 0000  0000
  Type       0000  0000  ----  ----  0000  0000
Sent         0000  0000  0000  0000  0000  0000
  Rexmit     ----  ----  0000  ----  ----  ----

```