### PR TITLE
 fix runtime error by UBSan

### DIFF
--- a/libs/libc/time/lib_localtime.c
+++ b/libs/libc/time/lib_localtime.c
@@ -461,7 +461,7 @@ static int_fast64_t detzcode64(FAR const char *codep)
   result = (codep[0] & 0x80) ? -1 : 0;
   for (i = 0; i < 8; ++i)
     {
-      result = (result << 8) | (codep[i] & 0xff);
+      result = (result * 256) | (codep[i] & 0xff);
     }
 
   return result;


### PR DESCRIPTION
## Summary
fix runtimer error by UBSan
```
nsh> 
time/lib_localtime.c:463:24: runtime error: left shift of negative value -1
```
Signed-off-by: Junbo Zheng <zhengjunbo1@xiaomi.com>

## Impact
N/A

## Testing
Local build ok.
