### PR TITLE
net/procfs: add tcp profs support

### DIFF
--- a/net/procfs/Make.defs
+++ b/net/procfs/Make.defs
@@ -36,6 +36,9 @@ endif
 ifeq ($(CONFIG_NET_TCP),y)
   NET_CSRCS += net_tcp.c
 endif
+ifeq ($(CONFIG_NET_UDP),y)
+  NET_CSRCS += net_udp.c
+endif
 endif
 
 # Routing table

--- a/net/procfs/Make.defs
+++ b/net/procfs/Make.defs
@@ -33,6 +33,9 @@ ifeq ($(CONFIG_NET_STATISTICS),y)
 ifeq ($(CONFIG_NET_MLD),y)
   NET_CSRCS += net_mld.c
 endif
+ifeq ($(CONFIG_NET_TCP),y)
+  NET_CSRCS += net_tcp.c
+endif
 endif
 
 # Routing table

--- a/net/procfs/net_procfs.c
+++ b/net/procfs/net_procfs.c
@@ -132,6 +132,14 @@ static const struct netprocfs_entry_s g_net_entries[] =
     }
   },
 #  endif
+#  ifdef CONFIG_NET_UDP
+  {
+    DTYPE_FILE, "udp",
+    {
+      netprocfs_read_udpstats
+    }
+  },
+#  endif
 #endif
 #ifdef CONFIG_NET_ROUTE
   {

--- a/net/procfs/net_procfs.c
+++ b/net/procfs/net_procfs.c
@@ -124,6 +124,14 @@ static const struct netprocfs_entry_s g_net_entries[] =
     }
   },
 #  endif
+#  ifdef CONFIG_NET_TCP
+  {
+    DTYPE_FILE, "tcp",
+    {
+      netprocfs_read_tcpstats
+    }
+  },
+#  endif
 #endif
 #ifdef CONFIG_NET_ROUTE
   {

--- a/net/procfs/net_tcp.c
+++ b/net/procfs/net_tcp.c
@@ -1,0 +1,218 @@
+/****************************************************************************
+ * net/procfs/net_tcp.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <sys/types.h>
+#include <stdio.h>
+#include <string.h>
+#include <debug.h>
+
+#include <arpa/inet.h>
+#include <netinet/in.h>
+
+#include <nuttx/net/netstats.h>
+
+#include "procfs/procfs.h"
+#include "tcp/tcp.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#ifdef CONFIG_NET_TCP
+
+#ifdef CONFIG_NET_IPv6
+#  define TCP_LINELEN 180
+#else
+#  define TCP_LINELEN 120
+#endif
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+static ssize_t netprocfs_tcpstats(FAR struct netprocfs_file_s *priv,
+                                  FAR char *buffer, size_t buflen,
+                                  uint8_t domain, int *skip)
+{
+  int addrlen = (domain == PF_INET) ?
+                INET_ADDRSTRLEN : INET6_ADDRSTRLEN;
+  FAR struct tcp_conn_s *conn = NULL;
+  char remote[addrlen + 1];
+  char local[addrlen + 1];
+  int len = 0;
+  void *laddr;
+  void *raddr;
+
+  net_lock();
+
+  local[addrlen] = '\0';
+  remote[addrlen] = '\0';
+
+  while ((conn = tcp_nextconn(conn)) != NULL)
+    {
+#if defined(CONFIG_NET_IPv4) && defined(CONFIG_NET_IPv6)
+      if (conn->domain != domain)
+        {
+          continue;
+        }
+#endif /* CONFIG_NET_IPv4 && CONFIG_NET_IPv6 */
+
+      if (++(*skip) <= priv->offset)
+        {
+          continue;
+        }
+
+      if (buflen - len < TCP_LINELEN)
+        {
+          break;
+        }
+
+#ifdef CONFIG_NET_IPv4
+#  ifdef CONFIG_NET_IPv6
+      if (domain == PF_INET)
+#  endif /* CONFIG_NET_IPv6 */
+        {
+          laddr = &conn->u.ipv4.laddr;
+          raddr = &conn->u.ipv4.raddr;
+        }
+#endif /* CONFIG_NET_IPv4 */
+
+#ifdef CONFIG_NET_IPv6
+#  ifdef CONFIG_NET_IPv4
+      else
+#  endif /* CONFIG_NET_IPv4 */
+        {
+          laddr = &conn->u.ipv6.laddr;
+          raddr = &conn->u.ipv6.raddr;
+        }
+#endif /* CONFIG_NET_IPv6 */
+
+      len += snprintf(buffer + len, buflen - len,
+                      "    %2" PRIu8
+                      ": %02" PRIx8
+                      " %3" PRIx8 " %3" PRIu8
+                      " %3" PRIu8
+                      " %4" PRIu32
+                      " %3" PRIu8
+#if CONFIG_NET_SEND_BUFSIZE > 0
+                      " %6" PRIu32
+#endif
+                      " %6u",
+                      priv->offset++,
+                      conn->tcpstateflags,
+                      conn->sconn.s_flags,
+                      conn->crefs,
+                      conn->timer,
+                      (uint32_t)conn->tx_unacked,
+                      conn->nrtx,
+#if CONFIG_NET_SEND_BUFSIZE > 0
+                      tcp_wrbuffer_inqueue_size(conn),
+#endif
+                      (conn->readahead) ? conn->readahead->io_pktlen : 0);
+
+      len += snprintf(buffer + len, buflen - len,
+                      " %*s:%-6" PRIu16 " %*s:%-6" PRIu16 "\n",
+                      (domain == PF_INET6) ? addrlen / 2 : addrlen,
+                      inet_ntop(domain, laddr, local, addrlen),
+                      ntohs(conn->lport),
+                      (domain == PF_INET6) ? addrlen / 2 : addrlen,
+                      inet_ntop(domain, raddr, remote, addrlen),
+                      ntohs(conn->rport));
+    }
+
+  net_unlock();
+
+  return len;
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: netprocfs_read_tcpstats
+ *
+ * Description:
+ *   Read and format TCP statistics.
+ *
+ * Input Parameters:
+ *   priv - A reference to the network procfs file structure
+ *   buffer - The user-provided buffer into which network status will be
+ *            returned.
+ *   bulen  - The size in bytes of the user provided buffer.
+ *
+ * Returned Value:
+ *   Zero (OK) is returned on success; a negated errno value is returned
+ *   on failure.
+ *
+ ****************************************************************************/
+
+ssize_t netprocfs_read_tcpstats(FAR struct netprocfs_file_s *priv,
+                                FAR char *buffer, size_t buflen)
+{
+  int skip = 1;
+  int len = 0;
+
+  net_lock();
+
+  if (tcp_nextconn(NULL) != NULL)
+    {
+      if (priv->offset == 0)
+        {
+          len = snprintf(buffer, buflen, "TCP sl  "
+                                         "st flg ref tmr uack nrt   "
+#if CONFIG_NET_SEND_BUFSIZE > 0
+                                          "txsz   "
+#endif
+                                          "rxsz "
+                                          "%-*s "
+                                          "%-*s\n"
+                                          ,
+                                          INET6_ADDRSTRLEN / 2,
+                                          "local_address",
+                                          INET6_ADDRSTRLEN / 2,
+                                          "remote_address"
+                                          );
+          priv->offset = 1;
+        }
+
+#ifdef CONFIG_NET_IPv4
+      len += netprocfs_tcpstats(priv, buffer + len,
+                                buflen - len, PF_INET, &skip);
+#endif /* CONFIG_NET_IPv4 */
+
+#ifdef CONFIG_NET_IPv6
+      len += netprocfs_tcpstats(priv, buffer + len,
+                                buflen - len, PF_INET6, &skip);
+#endif /* CONFIG_NET_IPv6 */
+    }
+
+  net_unlock();
+
+  return len;
+}
+
+#endif /* CONFIG_NET_TCP */

--- a/net/procfs/net_udp.c
+++ b/net/procfs/net_udp.c
@@ -1,0 +1,209 @@
+/****************************************************************************
+ * net/procfs/net_udp.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <sys/types.h>
+#include <stdio.h>
+#include <string.h>
+#include <debug.h>
+
+#include <arpa/inet.h>
+#include <netinet/in.h>
+
+#include <nuttx/net/netstats.h>
+
+#include "procfs/procfs.h"
+#include "udp/udp.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#ifdef CONFIG_NET_UDP
+
+#ifdef CONFIG_NET_IPv6
+#  define UDP_LINELEN 180
+#else
+#  define UDP_LINELEN 120
+#endif
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+static ssize_t netprocfs_udpstats(FAR struct netprocfs_file_s *priv,
+                                  FAR char *buffer, size_t buflen,
+                                  uint8_t domain, int *skip)
+{
+  int addrlen = (domain == PF_INET) ?
+                INET_ADDRSTRLEN : INET6_ADDRSTRLEN;
+  FAR struct udp_conn_s *conn = NULL;
+  char remote[addrlen + 1];
+  char local[addrlen + 1];
+  int len = 0;
+  void *laddr;
+  void *raddr;
+
+  net_lock();
+
+  local[addrlen] = '\0';
+  remote[addrlen] = '\0';
+
+  while ((conn = udp_nextconn(conn)) != NULL)
+    {
+#if defined(CONFIG_NET_IPv4) && defined(CONFIG_NET_IPv6)
+      if (conn->domain != domain)
+        {
+          continue;
+        }
+#endif /* CONFIG_NET_IPv4 && CONFIG_NET_IPv6 */
+
+      if (++(*skip) <= priv->offset)
+        {
+          continue;
+        }
+
+      if (buflen - len < UDP_LINELEN)
+        {
+          break;
+        }
+
+#ifdef CONFIG_NET_IPv4
+#  ifdef CONFIG_NET_IPv6
+      if (domain == PF_INET)
+#  endif /* CONFIG_NET_IPv6 */
+        {
+          laddr = &conn->u.ipv4.laddr;
+          raddr = &conn->u.ipv4.raddr;
+        }
+#endif /* CONFIG_NET_IPv4 */
+
+#ifdef CONFIG_NET_IPv6
+#  ifdef CONFIG_NET_IPv4
+      else
+#  endif /* CONFIG_NET_IPv4 */
+        {
+          laddr = &conn->u.ipv6.laddr;
+          raddr = &conn->u.ipv6.raddr;
+        }
+#endif /* CONFIG_NET_IPv6 */
+
+      len += snprintf(buffer + len, buflen - len,
+                      "    %2" PRIu8
+                      ": %3" PRIx8
+#if CONFIG_NET_SEND_BUFSIZE > 0
+                      " %6" PRIu32
+#endif
+                      " %6u",
+                      priv->offset++,
+                      conn->sconn.s_flags,
+#if CONFIG_NET_SEND_BUFSIZE > 0
+                      udp_wrbuffer_inqueue_size(conn),
+#endif
+                      iob_get_queue_size(&conn->readahead));
+
+      len += snprintf(buffer + len, buflen - len,
+                      " %*s:%-6" PRIu16 " %*s:%-6" PRIu16 "\n",
+                      (domain == PF_INET6) ? addrlen / 2 : addrlen,
+                      inet_ntop(domain, laddr, local, addrlen),
+                      ntohs(conn->lport),
+                      (domain == PF_INET6) ? addrlen / 2 : addrlen,
+                      inet_ntop(domain, raddr, remote, addrlen),
+                      ntohs(conn->rport));
+    }
+
+  net_unlock();
+
+  return len;
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: netprocfs_read_udpstats
+ *
+ * Description:
+ *   Read and format UDP statistics.
+ *
+ * Input Parameters:
+ *   priv - A reference to the network procfs file structure
+ *   buffer - The user-provided buffer into which network status will be
+ *            returned.
+ *   bulen  - The size in bytes of the user provided buffer.
+ *
+ * Returned Value:
+ *   Zero (OK) is returned on success; a negated errno value is returned
+ *   on failure.
+ *
+ ****************************************************************************/
+
+ssize_t netprocfs_read_udpstats(FAR struct netprocfs_file_s *priv,
+                                FAR char *buffer, size_t buflen)
+{
+  int skip = 1;
+  int len = 0;
+
+  net_lock();
+
+  if (udp_nextconn(NULL) != NULL)
+    {
+      if (priv->offset == 0)
+        {
+          len = snprintf(buffer, buflen, "UDP sl "
+                                         " flg   "
+#if CONFIG_NET_SEND_BUFSIZE > 0
+                                         "txsz   "
+#endif
+                                         "rxsz "
+                                          "%-*s "
+                                          "%-*s\n"
+                                          ,
+                                          INET6_ADDRSTRLEN / 2,
+                                          "local_address",
+                                          INET6_ADDRSTRLEN / 2,
+                                          "remote_address"
+                                          );
+          priv->offset = 1;
+        }
+
+#ifdef CONFIG_NET_IPv4
+      len += netprocfs_udpstats(priv, buffer + len,
+                                buflen - len, PF_INET, &skip);
+#endif /* CONFIG_NET_IPv4 */
+
+#ifdef CONFIG_NET_IPv6
+      len += netprocfs_udpstats(priv, buffer + len,
+                                buflen - len, PF_INET6, &skip);
+#endif /* CONFIG_NET_IPv6 */
+    }
+
+  net_unlock();
+
+  return len;
+}
+
+#endif /* CONFIG_NET_UDP */

--- a/net/procfs/procfs.h
+++ b/net/procfs/procfs.h
@@ -188,6 +188,29 @@ ssize_t netprocfs_read_tcpstats(FAR struct netprocfs_file_s *priv,
 #endif
 
 /****************************************************************************
+ * Name: netprocfs_read_udpstats
+ *
+ * Description:
+ *   Read and format UDP statistics.
+ *
+ * Input Parameters:
+ *   priv - A reference to the network procfs file structure
+ *   buffer - The user-provided buffer into which network status will be
+ *            returned.
+ *   bulen  - The size in bytes of the user provided buffer.
+ *
+ * Returned Value:
+ *   Zero (OK) is returned on success; a negated errno value is returned
+ *   on failure.
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_NET_UDP
+ssize_t netprocfs_read_udpstats(FAR struct netprocfs_file_s *priv,
+                                FAR char *buffer, size_t buflen);
+#endif
+
+/****************************************************************************
  * Name: netprocfs_read_routes
  *
  * Description:

--- a/net/procfs/procfs.h
+++ b/net/procfs/procfs.h
@@ -165,6 +165,29 @@ ssize_t netprocfs_read_mldstats(FAR struct netprocfs_file_s *priv,
 #endif
 
 /****************************************************************************
+ * Name: netprocfs_read_tcpstats
+ *
+ * Description:
+ *   Read and format TCP statistics.
+ *
+ * Input Parameters:
+ *   priv - A reference to the network procfs file structure
+ *   buffer - The user-provided buffer into which network status will be
+ *            returned.
+ *   bulen  - The size in bytes of the user provided buffer.
+ *
+ * Returned Value:
+ *   Zero (OK) is returned on success; a negated errno value is returned
+ *   on failure.
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_NET_TCP
+ssize_t netprocfs_read_tcpstats(FAR struct netprocfs_file_s *priv,
+                                FAR char *buffer, size_t buflen);
+#endif
+
+/****************************************************************************
  * Name: netprocfs_read_routes
  *
  * Description:


### PR DESCRIPTION
## Summary

net/procfs: add tcp profs support (IPv4 only)

add proc node /proc/net/tcp to show the active tcp connections from procfs

nuttx style:

```
server> cat /proc/net/tcp
TCP sl  st flg ref tmr uack nrt   rxsz local_address           remote_address
     1: 04  61   1  12    0   0   1024          0.0.0.0:4855      192.168.31.22:5001
     2: 04  61   1  12    0   0   1024          0.0.0.0:4856      192.168.31.22:5001
     3: 04  61   1   9    0   0      0                      :::4853   fe80::b27b:25ff:fe28:4011:8789
     4: 04  61   1   3    3   0      0                      :::4854   fe80::b27b:25ff:fe28:4011:8789

```

linux kernel:
https://www.kernel.org/doc/Documentation/networking/proc_net_tcp.txt


## Impact

N/A

## Testing

IPv4 tcp procfs