### PR TITLE
pthread: fix typo with CONFIG_PTHREAD_MUTEX_DEFAULT_PRIO_INHERIT

### DIFF
--- a/libs/libc/pthread/pthread_mutexattr_init.c
+++ b/libs/libc/pthread/pthread_mutexattr_init.c
@@ -44,8 +44,6 @@
  * Returned Value:
  *   0 if successful.  Otherwise, an error code.
  *
- * Assumptions:
- *
  ****************************************************************************/
 
 int pthread_mutexattr_init(FAR pthread_mutexattr_t *attr)
@@ -63,7 +61,7 @@ int pthread_mutexattr_init(FAR pthread_mutexattr_t *attr)
       attr->pshared = 0;
 
 #ifdef CONFIG_PRIORITY_INHERITANCE
-#  ifdef PTHREAD_MUTEX_DEFAULT_PRIO_INHERIT
+#  ifdef CONFIG_PTHREAD_MUTEX_DEFAULT_PRIO_INHERIT
       attr->proto   = PTHREAD_PRIO_INHERIT;
 #  else
       attr->proto   = PTHREAD_PRIO_NONE;

--- a/sched/pthread/pthread_mutexinit.c
+++ b/sched/pthread/pthread_mutexinit.c
@@ -44,12 +44,11 @@
  *   Create a mutex
  *
  * Input Parameters:
- *   None
+ *   mutex - A reference to the mutex to be initialized
+ *   attr - Mutex attribute object to be used
  *
  * Returned Value:
- *   None
- *
- * Assumptions:
+ *   0 if successful.  Otherwise, an error code.
  *
  ****************************************************************************/
 
@@ -61,7 +60,7 @@ int pthread_mutex_init(FAR pthread_mutex_t *mutex,
   uint8_t type = PTHREAD_MUTEX_DEFAULT;
 #endif
 #ifdef CONFIG_PRIORITY_INHERITANCE
-#  ifdef PTHREAD_MUTEX_DEFAULT_PRIO_INHERIT
+#  ifdef CONFIG_PTHREAD_MUTEX_DEFAULT_PRIO_INHERIT
   uint8_t proto = PTHREAD_PRIO_INHERIT;
 #  else
   uint8_t proto = PTHREAD_PRIO_NONE;


### PR DESCRIPTION
## Summary
CONFIG_ prefix was missing from reference to Kconfig variable CONFIG_PTHREAD_MUTEX_DEFAULT_PRIO_INHERIT, resulting to #else branch been always selected.

Also update function comments a bit.

## Impact

## Testing
Not tested, found by accident during code reading. Should be likely tested by someone who is using this feature.
