### PR TITLE
net/mld/route: fix build warning

### DIFF
--- a/net/mld/mld_timer.c
+++ b/net/mld/mld_timer.c
@@ -115,7 +115,7 @@ static void mld_gendog_work(FAR void *arg)
    * index.
    */
 
-  ifindex = (int)arg;
+  ifindex = (intptr_t)arg;
   DEBUGASSERT(ifindex > 0);
 
   net_lock();
@@ -234,7 +234,7 @@ static void mld_v1dog_work(FAR void *arg)
    * index.
    */
 
-  ifindex = (int)arg;
+  ifindex = (intptr_t)arg;
   DEBUGASSERT(ifindex > 0);
 
   net_lock();

--- a/net/route/net_del_ramroute.c
+++ b/net/route/net_del_ramroute.c
@@ -90,7 +90,7 @@ static int net_match_ipv4(FAR struct net_route_ipv4_s *route, FAR void *arg)
 
   net_ipv4_dumproute("Comparing", route);
   ninfo("With:\n");
-  ninfo("  target=%08lx netmask=%08lx\n",
+  ninfo("  target=%08" PRIu32 " netmask=%08" PRIu32 "\n",
         HTONL(match->target), HTONL(match->netmask));
 
   if (net_ipv4addr_maskcmp(route->target, match->target, match->netmask) &&


### PR DESCRIPTION

## Summary

net/mld/route: fix build warning

```
In file included from route/net_del_ramroute.c:30:
route/net_del_ramroute.c: In function ‘net_match_ipv4’:
route/net_del_ramroute.c:93:9: warning: format ‘%lx’ expects argument of type ‘long unsigned int’, but argument 3 has type ‘unsigned int’ [-Wformat=]
   93 |   ninfo("  target=%08lx netmask=%08lx\n",
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
route/net_del_ramroute.c:93:23: note: format string is defined here
   93 |   ninfo("  target=%08lx netmask=%08lx\n",
      |                   ~~~~^
      |                       |
      |                       long unsigned int
      |                   %08x

mld/mld_timer.c: In function ‘mld_gendog_work’:
mld/mld_timer.c:118:13: warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
  118 |   ifindex = (int)arg;
      |             ^
mld/mld_timer.c: In function ‘mld_v1dog_work’:
mld/mld_timer.c:237:13: warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
  237 |   ifindex = (int)arg;
      |             ^

```
Signed-off-by: chao an <anchao@xiaomi.com>

## Impact

N/A

## Testing

enable CONFIG_NET_ROUTE/CONFIG_NET_MLD