### PR TITLE
sim: fix signal crash in SMP mode

### DIFF
--- a/arch/sim/src/sim/up_interruptcontext.c
+++ b/arch/sim/src/sim/up_interruptcontext.c
@@ -89,10 +89,6 @@ void *up_doirq(int irq, void *context)
       CURRENT_REGS = NULL;
 
 #ifdef CONFIG_SMP
-      /* Handle signal */
-
-      sim_sigdeliver();
-
       /* Then switch contexts */
 
       longjmp(regs, 1);


### PR DESCRIPTION

## Summary

sim: fix signal crash in SMP mode

reproduce:
sim:smp
ostest

reason:
shouldn't do sim_sigdeliver() in irq handler

Signed-off-by: ligd <liguiding1@xiaomi.com>


## Impact

sim smp

## Testing

sim:smp
