### PR TITLE
Stm32h7 kconfig

### DIFF
--- a/arch/arm/src/stm32h7/Kconfig
+++ b/arch/arm/src/stm32h7/Kconfig
@@ -694,11 +694,11 @@ config STM32H7_SPI6
 	select SPI
 	select STM32H7_SPI
 
+endmenu # STM32H7 SPI Selection
+
 config STM32H7_SYSCFG
 	bool "SYSCFG"
 	default y
-
-endmenu # STM32H7 SPI Selection
 
 menu "STM32H7 Timer Selection"
 

--- a/arch/arm/src/stm32h7/Kconfig
+++ b/arch/arm/src/stm32h7/Kconfig
@@ -655,42 +655,39 @@ menu "STM32H7 SPI Selection"
 config STM32H7_SPI1
 	bool "SPI1"
 	default n
-	depends on EXPERIMENTAL
 	select SPI
 	select STM32H7_SPI
 
 config STM32H7_SPI2
 	bool "SPI2"
 	default n
-	depends on EXPERIMENTAL
 	select SPI
 	select STM32H7_SPI
 
 config STM32H7_SPI3
 	bool "SPI3"
 	default n
-	depends on EXPERIMENTAL
 	select SPI
 	select STM32H7_SPI
 
 config STM32H7_SPI4
 	bool "SPI4"
 	default n
-	depends on STM32H7_HAVE_SPI4 && EXPERIMENTAL
+	depends on STM32H7_HAVE_SPI4
 	select SPI
 	select STM32H7_SPI
 
 config STM32H7_SPI5
 	bool "SPI5"
 	default n
-	depends on STM32H7_HAVE_SPI5 && EXPERIMENTAL
+	depends on STM32H7_HAVE_SPI5
 	select SPI
 	select STM32H7_SPI
 
 config STM32H7_SPI6
 	bool "SPI6"
 	default n
-	depends on STM32H7_HAVE_SPI6 && EXPERIMENTAL
+	depends on STM32H7_HAVE_SPI6
 	select SPI
 	select STM32H7_SPI
 


### PR DESCRIPTION
## Summary
* stm32h7 Kconfig menu imbrication was broken, preventing spi peripheral selection
* stm32h7 spi does not need to depend on EXPERIMENTAL

## Impact
* none

## Testing
* tested in my own working copy, I can now select SPI peripherals, it was impossible to do before that fix.