### PR TITLE
wqueue: change single queue to double queue to improve speed

### DIFF
--- a/include/nuttx/wdog.h
+++ b/include/nuttx/wdog.h
@@ -61,17 +61,22 @@ typedef uint32_t  wdparm_t;
 
 typedef CODE void (*wdentry_t)(wdparm_t arg);
 
-/* This is the internal representation of the watchdog timer structure. */
+/* This is the internal representation of the watchdog timer structure.
+ * Notice !!!
+ * Carefully with the struct wdog_s order, you may not directly modify
+ * this. This struct will combine in struct work_s in union type, and,
+ * wqueue will modify/check this struct in kwork work_qcancel().
+ */
 
 struct wdog_s
 {
   FAR struct wdog_s *next;       /* Support for singly linked lists. */
+  wdparm_t           arg;        /* Callback argument */
   wdentry_t          func;       /* Function to execute when delay expires */
 #ifdef CONFIG_PIC
   FAR void          *picbase;    /* PIC base address */
 #endif
   sclock_t           lag;        /* Timer associated with the delay */
-  wdparm_t           arg;        /* Callback argument */
 };
 
 /****************************************************************************

--- a/include/nuttx/wqueue.h
+++ b/include/nuttx/wqueue.h
@@ -249,7 +249,7 @@ struct work_s
   {
     struct
     {
-      struct sq_entry_s sq; /* Implements a single linked list */
+      struct dq_entry_s dq; /* Implements a double linked list */
       clock_t qtime;        /* Time work queued */
     } s;
     struct wdog_s timer;    /* Delay expiry timer */

--- a/include/queue.h
+++ b/include/queue.h
@@ -312,11 +312,12 @@ void dq_addafter(FAR dq_entry_t *prev, FAR dq_entry_t *node,
 
 /* Remove nodes from queues */
 
-FAR  sq_entry_t *sq_remafter(FAR sq_entry_t *node, FAR sq_queue_t *queue);
-FAR  sq_entry_t *sq_remlast(FAR sq_queue_t *queue);
-FAR  dq_entry_t *dq_remlast(FAR dq_queue_t *queue);
-FAR  sq_entry_t *sq_remfirst(FAR sq_queue_t *queue);
-FAR  dq_entry_t *dq_remfirst(FAR dq_queue_t *queue);
+FAR sq_entry_t *sq_remafter(FAR sq_entry_t *node, FAR sq_queue_t *queue);
+FAR dq_entry_t *dq_remafter(FAR dq_entry_t *node, FAR dq_queue_t *queue);
+FAR sq_entry_t *sq_remlast(FAR sq_queue_t *queue);
+FAR dq_entry_t *dq_remlast(FAR dq_queue_t *queue);
+FAR sq_entry_t *sq_remfirst(FAR sq_queue_t *queue);
+FAR dq_entry_t *dq_remfirst(FAR dq_queue_t *queue);
 
 /* Count nodes in queues */
 

--- a/libs/libc/queue/Make.defs
+++ b/libs/libc/queue/Make.defs
@@ -21,7 +21,7 @@
 # Add the queue C files to the build
 
 CSRCS += sq_addafter.c sq_remlast.c sq_remfirst.c sq_remafter.c sq_count.c
-CSRCS += dq_addafter.c dq_remlast.c dq_remfirst.c dq_count.c
+CSRCS += dq_addafter.c dq_remlast.c dq_remfirst.c dq_remafter.c dq_count.c
 
 # Add the queue directory to the build
 

--- a/libs/libc/queue/dq_remafter.c
+++ b/libs/libc/queue/dq_remafter.c
@@ -1,0 +1,50 @@
+/****************************************************************************
+ * libs/libc/queue/dq_remafter.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <queue.h>
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: dq_remafter
+ *
+ * Description:
+ *   dq_remafter removes the entry following 'node' from the 'queue'.
+ *   Returns a reference to the removed entry.
+ *
+ ****************************************************************************/
+
+FAR dq_entry_t *dq_remafter(FAR dq_entry_t *node, FAR dq_queue_t *queue)
+{
+  FAR dq_entry_t *ret = node->flink;
+
+  if (queue->head != NULL && ret != NULL)
+    {
+      dq_rem(ret, queue);
+    }
+
+  return ret;
+}

--- a/libs/libc/wqueue/work_cancel.c
+++ b/libs/libc/wqueue/work_cancel.c
@@ -63,8 +63,8 @@
 static int work_qcancel(FAR struct usr_wqueue_s *wqueue,
                         FAR struct work_s *work)
 {
-  FAR sq_entry_t *prev = NULL;
-  FAR sq_entry_t *curr;
+  FAR dq_entry_t *prev = NULL;
+  FAR dq_entry_t *curr;
   int ret = -ENOENT;
   int semcount;
 
@@ -82,12 +82,12 @@ static int work_qcancel(FAR struct usr_wqueue_s *wqueue,
   if (work->worker != NULL)
     {
       /* Search the work activelist for the target work. We can't
-       * use sq_rem to do this because there are additional operations that
+       * use dq_rem to do this because there are additional operations that
        * need to be done.
        */
 
       curr = wqueue->q.head;
-      while (curr && curr != &work->u.s.sq)
+      while (curr && curr != &work->u.s.dq)
         {
           prev = curr;
           curr = curr->flink;
@@ -105,13 +105,13 @@ static int work_qcancel(FAR struct usr_wqueue_s *wqueue,
         {
           /* Remove the work from mid- or end-of-queue */
 
-          sq_remafter(prev, &wqueue->q);
+          dq_remafter(prev, &wqueue->q);
         }
       else
         {
           /* Remove the work at the head of the queue */
 
-          sq_remfirst(&wqueue->q);
+          dq_remfirst(&wqueue->q);
           _SEM_GETVALUE(&wqueue->wake, &semcount);
           if (semcount < 1)
             {

--- a/libs/libc/wqueue/work_queue.c
+++ b/libs/libc/wqueue/work_queue.c
@@ -75,8 +75,8 @@ static int work_qqueue(FAR struct usr_wqueue_s *wqueue,
                        FAR struct work_s *work, worker_t worker,
                        FAR void *arg, clock_t delay)
 {
-  FAR sq_entry_t *prev = NULL;
-  FAR sq_entry_t *curr;
+  FAR dq_entry_t *prev = NULL;
+  FAR dq_entry_t *curr;
   sclock_t delta;
   int semcount;
 
@@ -96,7 +96,7 @@ static int work_qqueue(FAR struct usr_wqueue_s *wqueue,
     {
       /* Add the watchdog to the head == tail of the queue. */
 
-      sq_addfirst(&work->u.s.sq, &wqueue->q);
+      dq_addfirst(&work->u.s.dq, &wqueue->q);
       _SEM_POST(&wqueue->wake);
     }
 
@@ -127,7 +127,7 @@ static int work_qqueue(FAR struct usr_wqueue_s *wqueue,
         {
           /* Insert the watchdog at the head of the list */
 
-          sq_addfirst(&work->u.s.sq, &wqueue->q);
+          dq_addfirst(&work->u.s.dq, &wqueue->q);
           _SEM_GETVALUE(&wqueue->wake, &semcount);
           if (semcount < 1)
             {
@@ -138,7 +138,7 @@ static int work_qqueue(FAR struct usr_wqueue_s *wqueue,
         {
           /* Insert the watchdog in mid- or end-of-queue */
 
-          sq_addafter(prev, &work->u.s.sq, &wqueue->q);
+          dq_addafter(prev, &work->u.s.dq, &wqueue->q);
         }
     }
 

--- a/libs/libc/wqueue/work_usrthread.c
+++ b/libs/libc/wqueue/work_usrthread.c
@@ -127,7 +127,7 @@ static void work_process(FAR struct usr_wqueue_s *wqueue)
         {
           /* Remove the ready-to-execute work from the list */
 
-          sq_remfirst(&wqueue->q);
+          dq_remfirst(&wqueue->q);
 
           /* Extract the work description from the entry (in case the work
            * instance by the re-used after it has been de-queued).
@@ -288,7 +288,7 @@ int work_usrstart(void)
 
   /* Initialize the work queue */
 
-  sq_init(&g_usrwork.q);
+  dq_init(&g_usrwork.q);
 
 #ifdef CONFIG_BUILD_PROTECTED
 

--- a/libs/libc/wqueue/wqueue.h
+++ b/libs/libc/wqueue/wqueue.h
@@ -46,7 +46,7 @@
 
 struct usr_wqueue_s
 {
-  struct sq_queue_s q;      /* The queue of pending work */
+  struct dq_queue_s q;      /* The queue of pending work */
   sem_t             lock;   /* exclusive access to user-mode work queue */
   sem_t             wake;   /* The wake-up semaphore of the  usrthread */
 };

--- a/sched/wqueue/kwork_cancel.c
+++ b/sched/wqueue/kwork_cancel.c
@@ -87,7 +87,7 @@ static int work_qcancel(FAR struct kwork_wqueue_s *wqueue,
         }
       else
         {
-          sq_rem((FAR sq_entry_t *)work, &wqueue->q);
+          dq_rem((FAR dq_entry_t *)work, &wqueue->q);
         }
 
       work->worker = NULL;

--- a/sched/wqueue/kwork_queue.c
+++ b/sched/wqueue/kwork_queue.c
@@ -50,7 +50,7 @@
 static void hp_work_timer_expiry(wdparm_t arg)
 {
   irqstate_t flags = enter_critical_section();
-  sq_addlast((FAR sq_entry_t *)arg, &g_hpwork.q);
+  dq_addlast((FAR dq_entry_t *)arg, &g_hpwork.q);
   nxsem_post(&g_hpwork.sem);
   leave_critical_section(flags);
 }
@@ -64,7 +64,7 @@ static void hp_work_timer_expiry(wdparm_t arg)
 static void lp_work_timer_expiry(wdparm_t arg)
 {
   irqstate_t flags = enter_critical_section();
-  sq_addlast((FAR sq_entry_t *)arg, &g_lpwork.q);
+  dq_addlast((FAR dq_entry_t *)arg, &g_lpwork.q);
   nxsem_post(&g_lpwork.sem);
   leave_critical_section(flags);
 }
@@ -134,7 +134,7 @@ int work_queue(int qid, FAR struct work_s *work, worker_t worker,
 
       if (!delay)
         {
-          sq_addlast((FAR sq_entry_t *)work, &g_hpwork.q);
+          dq_addlast((FAR dq_entry_t *)work, &g_hpwork.q);
           nxsem_post(&g_hpwork.sem);
         }
       else
@@ -152,7 +152,7 @@ int work_queue(int qid, FAR struct work_s *work, worker_t worker,
 
       if (!delay)
         {
-          sq_addlast((FAR sq_entry_t *)work, &g_lpwork.q);
+          dq_addlast((FAR dq_entry_t *)work, &g_lpwork.q);
           nxsem_post(&g_lpwork.sem);
         }
       else

--- a/sched/wqueue/kwork_thread.c
+++ b/sched/wqueue/kwork_thread.c
@@ -153,7 +153,7 @@ static int work_thread(int argc, FAR char *argv[])
 
       /* Remove the ready-to-execute work from the list */
 
-      work = (FAR struct work_s *)sq_remfirst(&wqueue->q);
+      work = (FAR struct work_s *)dq_remfirst(&wqueue->q);
       if (work && work->worker)
         {
           /* Extract the work description from the entry (in case the work

--- a/sched/wqueue/wqueue.h
+++ b/sched/wqueue/wqueue.h
@@ -58,7 +58,7 @@ struct kworker_s
 
 struct kwork_wqueue_s
 {
-  struct sq_queue_s q;         /* The queue of pending work */
+  struct dq_queue_s q;         /* The queue of pending work */
   sem_t             sem;       /* The counting semaphore of the wqueue */
   struct kworker_s  worker[1]; /* Describes a worker thread */
 };
@@ -70,7 +70,7 @@ struct kwork_wqueue_s
 #ifdef CONFIG_SCHED_HPWORK
 struct hp_wqueue_s
 {
-  struct sq_queue_s q;         /* The queue of pending work */
+  struct dq_queue_s q;         /* The queue of pending work */
   sem_t             sem;       /* The counting semaphore of the wqueue */
 
   /* Describes each thread in the high priority queue's thread pool */
@@ -86,7 +86,7 @@ struct hp_wqueue_s
 #ifdef CONFIG_SCHED_LPWORK
 struct lp_wqueue_s
 {
-  struct sq_queue_s q;         /* The queue of pending work */
+  struct dq_queue_s q;         /* The queue of pending work */
   sem_t             sem;       /* The counting semaphore of the wqueue */
 
   /* Describes each thread in the low priority queue's thread pool */


### PR DESCRIPTION
## Summary
wqueue: change single queue to double queue to improve speed
wqueue: fix work_qcancel() judge error caused by the union in struct work_s

    in struct work_s:
    union
    {
      struct
      {
        struct dq_entry_s dq; /* Implements a double linked list */
        clock_t qtime;        /* Time work queued */
      } s;
      struct wdog_s timer;    /* Delay expiry timer */
    }
    
    while we use WDOG_ISACTIVE(&work->timer) to decide use dq or timer,
    that is error, wd_cancel() maybe modify this area, dq_rem() also can
    modify this area.
    So we can't use the WDOG_ISACTIVE(&work->timer) to take as the judgement,
    when there is a union.
    
    Fix:
    swap the order in struct wdog_s, move the arg to the second 32bit



## Impact

wqueue

## Testing

vela

