### PR TITLE
drivers: wireless: Add SIOCGIFFLAGS support to gs2200m.c

### DIFF
--- a/drivers/wireless/gs2200m.c
+++ b/drivers/wireless/gs2200m.c
@@ -2896,6 +2896,11 @@ static int gs2200m_ioctl_ifreq(FAR struct gs2200m_dev_s *dev,
 
   switch (msg->cmd)
     {
+      case SIOCGIFFLAGS:
+        getreq = true;
+        msg->ifr.ifr_flags = dev->net_dev.d_flags;
+        break;
+
       case SIOCGIFHWADDR:
         getreq = true;
         memcpy(&msg->ifr.ifr_hwaddr.sa_data,


### PR DESCRIPTION
## Summary

- I noticed that the latest ifconfig command shows nothing
- Finally, I found that gs2200m.c needs to handle SIOCGIFFLAGS
- This commit fixes this issue

## Impact

- gs2200m only

## Testing

- Tested with spresense:wifi
- NOTE: gs2200m_main.c will be updated later

