### PR TITLE
Add check in roundx() functions for infinite or NaN cases

### DIFF
--- a/include/nuttx/lib/math.h
+++ b/include/nuttx/lib/math.h
@@ -81,11 +81,23 @@
 #define INFINITY_F  (1.0F/0.0F)
 #define NAN_F       (0.0F/0.0F)
 
-#define isnan(x)    ((x) != (x))
-#define isinf(x)    (((x) == INFINITY) || ((x) == -INFINITY))
-#define isfinite(x) (!(isinf(x) || isnan(x)))
+#define INFINITY_L  (1.0L/0.0L)
+#define NAN_L       (0.0L/0.0L)
 
-#define isinf_f(x)  (((x) == INFINITY_F) || ((x) == -INFINITY_F))
+#define isnan(x)   ((x) != (x))
+#define isnanf(x)  ((x) != (x))
+#define isnanl(x)  ((x) != (x))
+#define isinf(x)   (((x) == INFINITY) || ((x) == -INFINITY))
+#define isinff(x)  (((x) == INFINITY_F) || ((x) == -INFINITY_F))
+#define isinfl(x)  (((x) == INFINITY_L) || ((x) == -INFINITY_L))
+
+#define finite(x)  (!(isinf(x) || isnan(x)))
+#define finitef(x) (!(isinff(x) || isnanf(x)))
+#define finitel(x) (!(isinfl(x) || isnanl(x)))
+
+#define isfinite(x) \
+  (sizeof(x) == sizeof(float) ? finitef(x) : \
+   sizeof(x) == sizeof(double) ? finite(x) : finitel(x))
 
 /* Exponential and Logarithmic constants ************************************/
 

--- a/libs/libc/math/lib_asinf.c
+++ b/libs/libc/math/lib_asinf.c
@@ -70,7 +70,7 @@ float asinf(float x)
 
   /* Verify that the input value is in the domain of the function */
 
-  if (x < -1.0F || x > 1.0F || isnan(x))
+  if (x < -1.0F || x > 1.0F || isnanf(x))
     {
       return NAN_F;
     }

--- a/libs/libc/math/lib_asinl.c
+++ b/libs/libc/math/lib_asinl.c
@@ -70,9 +70,9 @@ long double asinl(long double x)
 
   /* Verify that the input value is in the domain of the function */
 
-  if (x < -1.0 || x > 1.0 || isnan(x))
+  if (x < -1.0 || x > 1.0 || isnanl(x))
     {
-      return NAN;
+      return NAN_L;
     }
 
   /* if x is > sqrt(2), use identity for faster convergence */

--- a/libs/libc/math/lib_logf.c
+++ b/libs/libc/math/lib_logf.c
@@ -102,12 +102,12 @@ float logf(float x)
 
   if (y == FLT_MAX_EXP_X)
     {
-      return INFINITY;
+      return INFINITY_F;
     }
 
   if (y == -FLT_MAX_EXP_X)
     {
-      return INFINITY;
+      return INFINITY_F;
     }
 
   return y;

--- a/libs/libc/math/lib_logl.c
+++ b/libs/libc/math/lib_logl.c
@@ -78,12 +78,12 @@ long double logl(long double x)
 
   if (y == LDBL_MAX_EXP_X)
     {
-      return INFINITY;
+      return INFINITY_L;
     }
 
   if (y == -LDBL_MAX_EXP_X)
     {
-      return INFINITY;
+      return INFINITY_L;
     }
 
   return y;

--- a/libs/libc/math/lib_round.c
+++ b/libs/libc/math/lib_round.c
@@ -34,7 +34,14 @@
 #ifdef CONFIG_HAVE_DOUBLE
 double round(double x)
 {
-  double f = modf(x, &x);
+  double f;
+
+  if (isinf(x) || isnan(x))
+    {
+      return x;
+    }
+
+  f = modf(x, &x);
   if (x <= 0.0 && f <= -0.5)
     {
       x -= 1.0;

--- a/libs/libc/math/lib_roundf.c
+++ b/libs/libc/math/lib_roundf.c
@@ -33,7 +33,14 @@
 
 float roundf(float x)
 {
-  float f = modff(x, &x);
+  float f;
+
+  if (isinff(x) || isnanf(x))
+    {
+      return x;
+    }
+
+  f = modff(x, &x);
   if (x <= 0.0f && f <= -0.5f)
     {
       x -= 1.0f;

--- a/libs/libc/math/lib_roundl.c
+++ b/libs/libc/math/lib_roundl.c
@@ -34,7 +34,14 @@
 #ifdef CONFIG_HAVE_LONG_DOUBLE
 long double roundl(long double x)
 {
-  long double f = modfl(x, &x);
+  long double f;
+
+  if (isinfl(x) || isnanl(x))
+    {
+      return x;
+    }
+
+  f = modfl(x, &x);
   if (x <= 0.0 && f <= -0.5)
     {
       x -= 1.0;

--- a/libs/libc/math/lib_sqrtf.c
+++ b/libs/libc/math/lib_sqrtf.c
@@ -54,12 +54,12 @@ float sqrtf(float x)
       return NAN_F;
     }
 
-  if (isnan(x))
+  if (isnanf(x))
     {
       return NAN_F;
     }
 
-  if (isinf_f(x))
+  if (isinff(x))
     {
       return INFINITY_F;
     }

--- a/libs/libc/math/lib_sqrtl.c
+++ b/libs/libc/math/lib_sqrtl.c
@@ -52,17 +52,17 @@ long double sqrtl(long double x)
   if (x < 0.0)
     {
       set_errno(EDOM);
-      return NAN;
+      return NAN_L;
     }
 
-  if (isnan(x))
+  if (isnanl(x))
     {
-      return NAN;
+      return NAN_L;
     }
 
-  if (isinf(x))
+  if (isinfl(x))
     {
-      return INFINITY;
+      return INFINITY_L;
     }
 
   if (x == 0.0)


### PR DESCRIPTION
## Summary
The round() functions do not return the correct value for infinite or NaN values. For example, round(NaN) returns 0 instead of NaN.

## Impact
Incorrect results for these two conditions.

Resolves #6767