### PR TITLE
nuttx/timer: add arch_alarm tick interface

### DIFF
--- a/arch/arm/src/stm32/stm32_tickless.c
+++ b/arch/arm/src/stm32/stm32_tickless.c
@@ -685,7 +685,7 @@ int up_timer_gettime(struct timespec *ts)
 #ifdef CONFIG_CLOCK_TIMEKEEPING
 
 /****************************************************************************
- * Name: up_timer_getcounter
+ * Name: up_timer_gettick
  *
  * Description:
  *   To be provided
@@ -698,9 +698,9 @@ int up_timer_gettime(struct timespec *ts)
  *
  ****************************************************************************/
 
-int up_timer_getcounter(uint64_t *cycles)
+int up_timer_gettick(clock_t *ticks)
 {
-  *cycles = (uint64_t)STM32_TIM_GETCOUNTER(g_tickless.tch);
+  *ticks = (clock_t)STM32_TIM_GETCOUNTER(g_tickless.tch);
   return OK;
 }
 
@@ -718,7 +718,7 @@ int up_timer_getcounter(uint64_t *cycles)
  *
  ****************************************************************************/
 
-void up_timer_getmask(uint64_t *mask)
+void up_timer_getmask(clock_t *mask)
 {
   DEBUGASSERT(mask != NULL);
 #ifdef HAVE_32BIT_TICKLESS

--- a/arch/arm/src/stm32f7/stm32_tickless.c
+++ b/arch/arm/src/stm32f7/stm32_tickless.c
@@ -743,7 +743,7 @@ int up_timer_gettime(struct timespec *ts)
 #ifdef CONFIG_CLOCK_TIMEKEEPING
 
 /****************************************************************************
- * Name: up_timer_getcounter
+ * Name: up_timer_gettick
  *
  * Description:
  *   To be provided
@@ -756,9 +756,9 @@ int up_timer_gettime(struct timespec *ts)
  *
  ****************************************************************************/
 
-int up_timer_getcounter(uint64_t *cycles)
+int up_timer_gettick(clock_t *ticks)
 {
-  *cycles = (uint64_t)STM32_TIM_GETCOUNTER(g_tickless.tch);
+  *ticks = (clock_t)STM32_TIM_GETCOUNTER(g_tickless.tch);
   return OK;
 }
 
@@ -776,7 +776,7 @@ int up_timer_getcounter(uint64_t *cycles)
  *
  ****************************************************************************/
 
-void up_timer_getmask(uint64_t *mask)
+void up_timer_getmask(clock_t *mask)
 {
   DEBUGASSERT(mask != NULL);
 #ifdef HAVE_32BIT_TICKLESS

--- a/arch/arm/src/stm32h7/stm32_tickless.c
+++ b/arch/arm/src/stm32h7/stm32_tickless.c
@@ -716,7 +716,7 @@ int up_timer_gettime(struct timespec *ts)
 #ifdef CONFIG_CLOCK_TIMEKEEPING
 
 /****************************************************************************
- * Name: up_timer_getcounter
+ * Name: up_timer_gettick
  *
  * Description:
  *   To be provided
@@ -729,9 +729,9 @@ int up_timer_gettime(struct timespec *ts)
  *
  ****************************************************************************/
 
-int up_timer_getcounter(uint64_t *cycles)
+int up_timer_gettick(clock_t *ticks)
 {
-  *cycles = (uint64_t)STM32_TIM_GETCOUNTER(g_tickless.tch);
+  *ticks = (clock_t)STM32_TIM_GETCOUNTER(g_tickless.tch);
   return OK;
 }
 
@@ -749,7 +749,7 @@ int up_timer_getcounter(uint64_t *cycles)
  *
  ****************************************************************************/
 
-void up_timer_getmask(uint64_t *mask)
+void up_timer_getmask(clock_t *mask)
 {
   DEBUGASSERT(mask != NULL);
 #ifdef HAVE_32BIT_TICKLESS

--- a/arch/arm/src/stm32wb/stm32wb_tickless.c
+++ b/arch/arm/src/stm32wb/stm32wb_tickless.c
@@ -559,7 +559,7 @@ int up_timer_gettime(struct timespec *ts)
 #ifdef CONFIG_CLOCK_TIMEKEEPING
 
 /****************************************************************************
- * Name: up_timer_getcounter
+ * Name: up_timer_gettick
  *
  * Description:
  *   To be provided
@@ -572,9 +572,9 @@ int up_timer_gettime(struct timespec *ts)
  *
  ****************************************************************************/
 
-int up_timer_getcounter(uint64_t *cycles)
+int up_timer_gettick(clock_t *ticks)
 {
-  *cycles = (uint64_t)STM32WB_TIM_GETCOUNTER(g_tickless.tch);
+  *ticks = (clock_t)STM32WB_TIM_GETCOUNTER(g_tickless.tch);
   return OK;
 }
 
@@ -592,7 +592,7 @@ int up_timer_getcounter(uint64_t *cycles)
  *
  ****************************************************************************/
 
-void up_timer_getmask(uint64_t *mask)
+void up_timer_getmask(clock_t *mask)
 {
   DEBUGASSERT(mask != NULL);
 #ifdef HAVE_32BIT_TICKLESS

--- a/drivers/timers/Kconfig
+++ b/drivers/timers/Kconfig
@@ -96,6 +96,7 @@ config ALARM_ARCH
 	select ARCH_HAVE_TIMEKEEPING
 	select SCHED_TICKLESS_ALARM if SCHED_TICKLESS
 	select SCHED_TICKLESS_LIMIT_MAX_SLEEP if SCHED_TICKLESS
+	select SCHED_TICKLESS_TICK_ARGUMENT if SCHED_TICKLESS
 	---help---
 		Implement alarm arch API on top of oneshot driver interface.
 

--- a/include/nuttx/arch.h
+++ b/include/nuttx/arch.h
@@ -1646,13 +1646,16 @@ void up_timer_initialize(void);
  *
  ****************************************************************************/
 
-#if defined(CONFIG_SCHED_TICKLESS)
+#if defined(CONFIG_SCHED_TICKLESS) && !defined(CONFIG_SCHED_TICKLESS_TICK_ARGUMENT)
 int up_timer_gettime(FAR struct timespec *ts);
 #endif
 
+#if defined(CONFIG_SCHED_TICKLESS_TICK_ARGUMENT) || defined(CONFIG_CLOCK_TIMEKEEPING)
+int up_timer_gettick(FAR clock_t *ticks);
+#endif
+
 #ifdef CONFIG_CLOCK_TIMEKEEPING
-int up_timer_getcounter(FAR uint64_t *cycles);
-void up_timer_getmask(FAR uint64_t *mask);
+void up_timer_getmask(FAR clock_t *mask);
 #endif
 
 /****************************************************************************
@@ -1690,7 +1693,11 @@ void up_timer_getmask(FAR uint64_t *mask);
  ****************************************************************************/
 
 #if defined(CONFIG_SCHED_TICKLESS) && defined(CONFIG_SCHED_TICKLESS_ALARM)
+#  ifndef CONFIG_SCHED_TICKLESS_TICK_ARGUMENT
 int up_alarm_cancel(FAR struct timespec *ts);
+#  else
+int up_alarm_tick_cancel(FAR clock_t *ticks);
+#  endif
 #endif
 
 /****************************************************************************
@@ -1719,7 +1726,11 @@ int up_alarm_cancel(FAR struct timespec *ts);
  ****************************************************************************/
 
 #if defined(CONFIG_SCHED_TICKLESS) && defined(CONFIG_SCHED_TICKLESS_ALARM)
+#  ifndef CONFIG_SCHED_TICKLESS_TICK_ARGUMENT
 int up_alarm_start(FAR const struct timespec *ts);
+#  else
+int up_alarm_tick_start(clock_t ticks);
+#  endif
 #endif
 
 /****************************************************************************
@@ -1759,7 +1770,11 @@ int up_alarm_start(FAR const struct timespec *ts);
  ****************************************************************************/
 
 #if defined(CONFIG_SCHED_TICKLESS) && !defined(CONFIG_SCHED_TICKLESS_ALARM)
+#  ifndef CONFIG_SCHED_TICKLESS_TICK_ARGUMENT
 int up_timer_cancel(FAR struct timespec *ts);
+#  else
+int up_timer_tick_cancel(FAR clock_t *ticks);
+#  endif
 #endif
 
 /****************************************************************************
@@ -1788,7 +1803,11 @@ int up_timer_cancel(FAR struct timespec *ts);
  ****************************************************************************/
 
 #if defined(CONFIG_SCHED_TICKLESS) && !defined(CONFIG_SCHED_TICKLESS_ALARM)
+#  ifndef CONFIG_SCHED_TICKLESS_TICK_ARGUMENT
 int up_timer_start(FAR const struct timespec *ts);
+#  else
+int up_timer_tick_start(clock_t ticks);
+#  endif
 #endif
 
 /****************************************************************************
@@ -2251,6 +2270,7 @@ void nxsched_timer_expiration(void);
 
 #if defined(CONFIG_SCHED_TICKLESS) && defined(CONFIG_SCHED_TICKLESS_ALARM)
 void nxsched_alarm_expiration(FAR const struct timespec *ts);
+void nxsched_alarm_tick_expiration(clock_t ticks);
 #endif
 
 /****************************************************************************

--- a/include/nuttx/clock.h
+++ b/include/nuttx/clock.h
@@ -251,6 +251,19 @@ EXTERN volatile clock_t g_system_ticks;
  * Public Function Prototypes
  ****************************************************************************/
 
+#define timespec_from_tick(ts, tick) \
+  do \
+    { \
+      clock_t _tick = (tick); \
+      (ts)->tv_sec = _tick / TICK_PER_SEC; \
+      _tick -= (clock_t)(ts)->tv_sec * TICK_PER_SEC; \
+      (ts)->tv_nsec = _tick * NSEC_PER_TICK; \
+    } \
+  while (0)
+
+#define timespec_to_tick(ts) \
+  ((clock_t)(ts)->tv_sec * TICK_PER_SEC + (ts)->tv_nsec / NSEC_PER_TICK)
+
 /****************************************************************************
  * Name: clock_timespec_compare
  *

--- a/sched/Kconfig
+++ b/sched/Kconfig
@@ -60,6 +60,26 @@ config SCHED_TICKLESS
 
 if SCHED_TICKLESS
 
+config SCHED_TICKLESS_TICK_ARGUMENT
+	bool "Scheduler use tick argument"
+	default n
+	---help---
+		Enables use of tick argument in scheduler. If enabled, then the
+		board-specific logic must provide the following functions:
+
+			int up_timer_gettick(FAR clock_t *ticks);
+
+		If SCHED_TICKLESS_ALARM is enabled, then these additional interfaces are
+		expected:
+
+			int up_alarm_tick_cancel(FAR clock_t *ticks);
+			int up_alarm_tick_start(clock_t ticks);
+
+		Otherwise, these additional interfaces are expected:
+
+			int up_timer_tick_cancel(FAR clock_t *ticks);
+			int up_timer_tick_start(FAR clock_t ticks);
+
 config SCHED_TICKLESS_ALARM
 	bool "Tickless alarm"
 	default n

--- a/sched/clock/clock_systime_timespec.c
+++ b/sched/clock/clock_systime_timespec.c
@@ -114,7 +114,16 @@ int clock_systime_timespec(FAR struct timespec *ts)
        * code.  Let the platform timer do the work.
        */
 
+#ifdef CONFIG_SCHED_TICKLESS_TICK_ARGUMENT
+      clock_t ticks;
+      int ret;
+
+      ret = up_timer_gettick(&ticks);
+      timespec_from_tick(ts, ticks);
+      return ret;
+#else
       return up_timer_gettime(ts);
+#endif
 
 #elif defined(CONFIG_HAVE_LONG_LONG) && (CONFIG_USEC_PER_TICK % 1000) != 0
       /* 64-bit microsecond calculations should improve our accuracy

--- a/sched/clock/clock_timekeeping.c
+++ b/sched/clock/clock_timekeeping.c
@@ -72,7 +72,7 @@ static int clock_get_current_time(FAR struct timespec *ts,
 
   flags = enter_critical_section();
 
-  ret = up_timer_getcounter(&counter);
+  ret = up_timer_gettick(&counter);
   if (ret < 0)
     {
       goto errout_in_critical_section;
@@ -123,7 +123,7 @@ int clock_timekeeping_set_wall_time(FAR const struct timespec *ts)
 
   flags = enter_critical_section();
 
-  ret = up_timer_getcounter(&counter);
+  ret = up_timer_gettick(&counter);
   if (ret < 0)
     {
       goto errout_in_critical_section;
@@ -217,7 +217,7 @@ void clock_update_wall_time(void)
 
   flags = enter_critical_section();
 
-  ret = up_timer_getcounter(&counter);
+  ret = up_timer_gettick(&counter);
   if (ret < 0)
     {
       goto errout_in_critical_section;
@@ -289,7 +289,7 @@ void clock_inittimekeeping(FAR const struct timespec *tp)
       clock_basetime(&g_clock_wall_time);
     }
 
-  up_timer_getcounter(&g_clock_last_counter);
+  up_timer_gettick(&g_clock_last_counter);
 }
 
 #endif /* CONFIG_CLOCK_TIMEKEEPING */


### PR DESCRIPTION
## Summary

1. Use tick count for sched timer expiration;
2. Adjust arch_alarm to support tick;

## Impact

NA

## Testing

sabre-6quad:nsh