### PR TITLE
fs: Fix symbol name in comments

### DIFF
--- a/include/nuttx/fs/fs.h
+++ b/include/nuttx/fs/fs.h
@@ -208,7 +208,7 @@ struct file_operations
   int     (*open)(FAR struct file *filep);
 
   /* The following methods must be identical in signature and position
-   * because the struct file_operations and struct mountp_operations are
+   * because the struct file_operations and struct mountpt_operations are
    * treated like unions.
    */
 

--- a/include/nuttx/fs/procfs.h
+++ b/include/nuttx/fs/procfs.h
@@ -48,7 +48,7 @@ struct procfs_operations
                   int oflags, mode_t mode);
 
   /* The following methods must be identical in signature and position
-   * because the struct file_operations and struct mountp_operations are
+   * because the struct file_operations and struct mountpt_operations are
    * treated like unions.
    */
 


### PR DESCRIPTION
## Summary

The comments in `struct file_operations` and `struct procfs_operations` mention `struct mountpt_operations` but it was misspelled, making it hard to grep. This PR fixes the typo.

## Impact

Makes it greppable.

## Testing

nxstyle