### PR TITLE
fs/vfs/fs_open.c: Improve documentation blocks of functions

### DIFF
--- a/fs/vfs/fs_open.c
+++ b/fs/vfs/fs_open.c
@@ -47,6 +47,29 @@
  * Name: file_vopen
  ****************************************************************************/
 
+/****************************************************************************
+ * Name: file_vopen
+ *
+ * Description:
+ *   file_vopen() is similar to the standard 'open' interface except that it
+ *   populates an instance of 'struct file' rather than return a file
+ *   descriptor.  It also is not a cancellation point and does not modify
+ *   the errno variable.
+ *
+ * Input Parameters:
+ *   filep  - The caller provided location in which to return the 'struct
+ *            file' instance.
+ *   path   - The full path to the file to be opened.
+ *   oflags - open flags.
+ *   umask  - File mode creation mask. Overrides the open flags.
+ *   ap     - Variable argument list, may include 'mode_t mode'
+ *
+ * Returned Value:
+ *   Zero (OK) is returned on success.  On failure, a negated errno value is
+ *   returned.
+ *
+ ****************************************************************************/
+
 static int file_vopen(FAR struct file *filep, FAR const char *path,
                       int oflags, mode_t umask, va_list ap)
 {
@@ -134,7 +157,7 @@ static int file_vopen(FAR struct file *filep, FAR const char *path,
   filep->f_priv   = NULL;
 
   /* Perform the driver open operation.  NOTE that the open method may be
-   * called many times.  The driver/mountpoint logic should handled this
+   * called many times.  The driver/mountpoint logic should handle this
    * because it may also be closed that many times.
    */
 
@@ -182,6 +205,23 @@ errout_with_search:
 
 /****************************************************************************
  * Name: nx_vopen
+ *
+ * Description:
+ *   nx_vopen() is similar to the standard 'open' interface except that it
+ *   is not a cancellation point and it does not modify the errno variable.
+ *
+ *   nx_open() is an internal NuttX interface and should not be called from
+ *   applications.
+ *
+ * Input Parameters:
+ *   path   - The full path to the file to be opened.
+ *   oflags - open flags.
+ *   ap     - Variable argument list, may include 'mode_t mode'
+ *
+ * Returned Value:
+ *   The new file descriptor is returned on success; a negated errno value is
+ *   returned on any failure.
+ *
  ****************************************************************************/
 
 static int nx_vopen(FAR const char *path, int oflags, va_list ap)
@@ -221,6 +261,17 @@ static int nx_vopen(FAR const char *path, int oflags, va_list ap)
  * Description:
  *   Check if the access described by 'oflags' is supported on 'inode'
  *
+ *   inode_checkflags() is an internal NuttX interface and should not be
+ *   called from applications.
+ *
+ * Input Parameters:
+ *   inode  - The inode to check
+ *   oflags - open flags.
+ *
+ * Returned Value:
+ *   Zero (OK) is returned on success.  On failure, a negated errno value is
+ *   returned.
+ *
  ****************************************************************************/
 
 int inode_checkflags(FAR struct inode *inode, int oflags)
@@ -251,14 +302,15 @@ int inode_checkflags(FAR struct inode *inode, int oflags)
  *
  * Description:
  *   file_open() is similar to the standard 'open' interface except that it
- *   returns an instance of 'struct file' rather than a file descriptor.  It
- *   also is not a cancellation point and does not modify the errno variable.
+ *   populates an instance of 'struct file' rather than return a file
+ *   descriptor.  It also is not a cancellation point and does not modify
+ *   the errno variable.
  *
  * Input Parameters:
  *   filep  - The caller provided location in which to return the 'struct
  *            file' instance.
- *   path   - The full path to the file to be open.
- *   oflags - open flags
+ *   path   - The full path to the file to be opened.
+ *   oflags - open flags.
  *   ...    - Variable number of arguments, may include 'mode_t mode'
  *
  * Returned Value:
@@ -283,11 +335,16 @@ int file_open(FAR struct file *filep, FAR const char *path, int oflags, ...)
  * Name: nx_open
  *
  * Description:
- *   nx_open() is similar to the standard 'open' interface except that is is
+ *   nx_open() is similar to the standard 'open' interface except that it is
  *   not a cancellation point and it does not modify the errno variable.
  *
  *   nx_open() is an internal NuttX interface and should not be called from
  *   applications.
+ *
+ * Input Parameters:
+ *   path   - The full path to the file to be opened.
+ *   oflags - open flags.
+ *   ...    - Variable number of arguments, may include 'mode_t mode'
  *
  * Returned Value:
  *   The new file descriptor is returned on success; a negated errno value is
@@ -317,7 +374,7 @@ int nx_open(FAR const char *path, int oflags, ...)
  *
  * Returned Value:
  *   The new file descriptor is returned on success; -1 (ERROR) is returned
- *   on any failure the errno value set appropriately.
+ *   on any failure with the errno value set appropriately.
  *
  ****************************************************************************/
 


### PR DESCRIPTION
## Summary

Document the functions `file_vopen()`, `nx_vopen()`, `inode_checkflags()`, `file_open()`, and `nx_open()`. Also fix a few typos.

## Impact

Improved documentation.

## Testing

nxstyle