### PR TITLE
Eliminate un-needed wait in rp2040 SMART filesystem

### DIFF
--- a/arch/arm/src/rp2040/rp2040_flash_mtd.c
+++ b/arch/arm/src/rp2040/rp2040_flash_mtd.c
@@ -256,8 +256,6 @@ static int     rp2040_flash_erase(struct mtd_dev_s *dev,
          nblocks,
          FLASH_BLOCK_SIZE * nblocks);
 
-  usleep(500000);
-
   ret = nxsem_wait(&(rp_dev->sem));
 
   if (ret < 0)


### PR DESCRIPTION
## Summary

Removed a spurious usleep that was left over from testing. 

## Impact

Makes erase faster.

## Testing

Built and run on RaspberryPi Pico W.
