### PR TITLE
netdev/ioctl: netlock/unlock() should in pairs

### DIFF
--- a/net/netdev/netdev_ioctl.c
+++ b/net/netdev/netdev_ioctl.c
@@ -763,6 +763,7 @@ static int netdev_ifr_ioctl(FAR struct socket *psock, int cmd,
 
   if (dev == NULL)
     {
+      net_unlock();
       return ret;
     }
 


### PR DESCRIPTION


## Summary

netdev/ioctl: netlock/unlock() should in pairs

fix regression by https://github.com/apache/incubator-nuttx/pull/7020

```
commit fd53db56b6a49311a807fbc8944fcb7b11f33b6f
Author: chao an <anchao@xiaomi.com>
Date:   Wed Sep 7 10:56:09 2022 +0800

    net/netdev: simplify handling of netdev ifr ioctl()

    1. call netdev_ifr_dev() only once
    2. unify the error code of ENODEV

```

Signed-off-by: chao an <anchao@xiaomi.com>


## Impact

N/A

## Testing

renew