### PR TITLE
NUCLEO-L496ZG:modify clock config

### DIFF
--- a/boards/arm/stm32l4/nucleo-l496zg/include/board.h
+++ b/boards/arm/stm32l4/nucleo-l496zg/include/board.h
@@ -58,7 +58,7 @@
 #define STM32L4_HSE_FREQUENCY     8000000ul  /* 8 MHz from MCO output */
 #define STM32L4_LSE_FREQUENCY     32768
 
-#define HSE_CLOCK_CONFIG
+#define MSI_CLOCK_CONFIG
 
 #if defined(HSI_CLOCK_CONFIG)
 


### PR DESCRIPTION
## Summary
Change the default clock source from HSE to MSI (which is kind of a default for the NUCLEO-L496ZG board).
## Impact
Solves issues of testing with a fresh NUCLEO-L496ZG unit (e.g. issue: #6566)
## Testing
The configuration was built and tested on the NUCLEO-L496ZG with the nucleo-l496zg:nsh example