### PR TITLE
Kconfig: EXPERIMENTAL: Add help text and change prompt label

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -66,7 +66,12 @@ endmenu # License Setup
 menu "Build Setup"
 
 config EXPERIMENTAL
-	bool "Prompt for development and/or incomplete code/drivers"
+	bool "Show experimental options"
+	---help---
+		Some features and drivers are considered "experimental" or
+		development/work-in-progress status. By default, these options are
+		hidden in the Kconfig menus. Enabling "Show experimental options"
+		makes these options visible and makes it possible to enable them.
 
 config DEFAULT_SMALL
 	bool "Default to smallest size"


### PR DESCRIPTION
## Summary

This PR adds help text to the Kconfig entry `EXPERIMENTAL` and changes the label from "Prompt for development and/or incomplete code/drivers" to "Show experimental options" -- I think this is more clear because it contains the word "experimental" for associativity with `EXPERIMENTAL` and `CONFIG_EXPERIMENTAL` and it's shorter and easier to read.

## Impact

Hopefully makes the EXPERIMENTAL option easier to understand.

## Testing

`make menuconfig`.