### PR TITLE
sched: fix kasan report error when open CONFIG_DEBUG_MM

### DIFF
--- a/sched/irq/irq_dispatch.c
+++ b/sched/irq/irq_dispatch.c
@@ -124,6 +124,9 @@
 
 void irq_dispatch(int irq, FAR void *context)
 {
+#ifdef CONFIG_DEBUG_MM
+  struct tcb_s *rtcb = this_task();
+#endif
   xcpt_t vector = irq_unexpected_isr;
   FAR void *arg = NULL;
   unsigned int ndx = irq;
@@ -175,7 +178,7 @@ void irq_dispatch(int irq, FAR void *context)
 #endif
 
 #ifdef CONFIG_DEBUG_MM
-  if ((g_running_tasks[this_cpu()]->flags & TCB_FLAG_HEAPCHECK) || \
+  if ((rtcb->flags & TCB_FLAG_HEAPCHECK) || \
        (this_task()->flags & TCB_FLAG_HEAPCHECK))
     {
       kmm_checkcorruption();


### PR DESCRIPTION

## Summary

sched: fix kasan report error when open CONFIG_DEBUG_MM

reason:
1. g_running_tasks = thread A
2. thread A exit (free thread A's tcb) -> thread B
3. thread B interrupt by irq
4. check g_running_tasks->flags -> kasan report used after free

rootcause:
g_running_tasks has't set completely when syscall hanppened

Resolve:
Use rtcb (get at ISR begining) instead

Signed-off-by: ligd <liguiding1@xiaomi.com>

## Impact

DEBUG_MM

## Testing

VELA

