### PR TITLE
armv7-a: icache also need SMP cache coherency configuration

### DIFF
--- a/arch/arm/src/armv7-a/arm_cpuhead.S
+++ b/arch/arm/src/armv7-a/arm_cpuhead.S
@@ -318,7 +318,7 @@ __cpu3_start:
 	 * after SMP cache coherency has been setup.
 	 */
 
-#if 0 /* !defined(CPU_DCACHE_DISABLE) && !defined(CONFIG_SMP) */
+#if !defined(CPU_DCACHE_DISABLE) && !defined(CONFIG_SMP)
 	/* Dcache enable
 	 *
 	 *   SCTLR_C    Bit 2:  DCache enable
@@ -327,7 +327,7 @@ __cpu3_start:
 	orr		r0, r0, #(SCTLR_C)
 #endif
 
-#ifndef CPU_ICACHE_DISABLE
+#if !defined(CPU_ICACHE_DISABLE) && !defined(CONFIG_SMP)
 	/* Icache enable
 	 *
 	 *   SCTLR_I    Bit 12: ICache enable

--- a/arch/arm/src/armv7-a/arm_head.S
+++ b/arch/arm/src/armv7-a/arm_head.S
@@ -452,7 +452,7 @@ __start:
 	orr		r0, r0, #(SCTLR_C)
 #endif
 
-#ifndef CPU_ICACHE_DISABLE
+#if !defined(CPU_ICACHE_DISABLE) && !defined(CONFIG_SMP)
 	/* Icache enable
 	 *
 	 *   SCTLR_I    Bit 12: ICache enable

--- a/arch/arm/src/armv7-a/arm_pghead.S
+++ b/arch/arm/src/armv7-a/arm_pghead.S
@@ -434,7 +434,7 @@ __start:
 	orr		r0, r0, #(SCTLR_C)
 #endif
 
-#ifndef CPU_ICACHE_DISABLE
+#if !defined(CPU_ICACHE_DISABLE) && !defined(CONFIG_SMP)
 	/* Icache enable
 	 *
 	 *   SCTLR_I    Bit 12: ICache enable

--- a/arch/arm/src/armv7-a/arm_scu.c
+++ b/arch/arm/src/armv7-a/arm_scu.c
@@ -203,6 +203,6 @@ void arm_enable_smp(int cpu)
   arm_set_actlr(regval);
 
   regval  = arm_get_sctlr();
-  regval |= SCTLR_C;
+  regval |= SCTLR_C | SCTLR_I;
   arm_set_sctlr(regval);
 }


### PR DESCRIPTION

## Summary

armv7-a: icache also need SMP cache coherency configuration

## Impact

SMP

## Testing

VELA