### PR TITLE
wqueue: fix race-condition on work_queue

### DIFF
--- a/sched/wqueue/kwork_queue.c
+++ b/sched/wqueue/kwork_queue.c
@@ -110,15 +110,15 @@ int work_queue(int qid, FAR struct work_s *work, worker_t worker,
   irqstate_t flags;
   int ret = OK;
 
-  /* Remove the entry from the timer and work queue. */
-
-  work_cancel(qid, work);
-
   /* Interrupts are disabled so that this logic can be called from with
    * task logic or from interrupt handling logic.
    */
 
   flags = enter_critical_section();
+
+  /* Remove the entry from the timer and work queue. */
+
+  work_cancel(qid, work);
 
   /* Initialize the work structure. */
 


### PR DESCRIPTION

## Summary

wqueue: fix race-condition on work_queue

CPU0                     CPU1

work_queue(a)            work_queue(a)
                         -> work_cancel(a)
-> work_cancel(a)
-> enter_critical()
-> sq_addlast(a)
-> leave_critical()
                         -> enter_critical()
                         -> sq_addlast(a) // double add, wrong
                         -> leave_critical()

Also, this happens in mulit-threads in one CPU.

Fix:

work_cancel() should in critical section.

Change-Id: Icde312f8c0ae71f07c4231e140cb5c3fd3937425
Signed-off-by: ligd <liguiding1@xiaomi.com>


## Impact

wqeue

## Testing

VELA
