### PR TITLE
mmcsd_spi:reinit spi sd when sd status is wrong.

### DIFF
--- a/drivers/mmcsd/Kconfig
+++ b/drivers/mmcsd/Kconfig
@@ -98,6 +98,12 @@ config MMCSD_IDMODE_CLOCK
 		SPI clock identify MMC/SD card.
 		Should be 400KHz or less.
 
+config MMCSD_SPIRETRY_COUNT
+	int "MMC/SD read/write fail retry max count"
+	default 0
+	---help---
+		Try to recovery MMCSD read/write fail.
+
 endif
 
 config SDIO_DMA


### PR DESCRIPTION
VELAOS-21

Change-Id: I0091d7743dc21a68a20ac1e3568055eb164c741b
Signed-off-by: licheng <chengli@bestechnic.com>

## Summary
some sd card will always in wrong status (example:allways busy after write/read), need recovery the sd card for read/write
## Impact
No
## Testing
bes m0 dev board test OK
