### PR TITLE
tools/pic32: Add description, fix nxstyle, fix typos

### DIFF
--- a/tools/pic32/Config.mk
+++ b/tools/pic32/Config.mk
@@ -19,7 +19,7 @@
 ############################################################################
 
 # These are the macros that will be used in the NuttX make system to compile
-# and assembly source files and to insert the resulting object files into an
+# and assemble source files and to insert the resulting object files into an
 # archive.  These replace the default definitions at tools/Config.mk
 
 # POSTBUILD -- Perform post build operations

--- a/tools/pic32/mkpichex.c
+++ b/tools/pic32/mkpichex.c
@@ -1,5 +1,6 @@
 /****************************************************************************
  * tools/pic32/mkpichex.c
+ * Convert virtual addresses in nuttx.hex to physical addresses
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -205,14 +206,14 @@ static void adjust_extlin(struct hex_s *hexline)
   segment &= 0x1fff;
 
   /* Recalculate the checksum and make sure that there is a null terminator
-   * Since len=2, addr=0, type=4, the is a trivial calculation.
+   * Since len=2, addr=0, type=4, this is a trivial calculation.
    */
 
   chksum = (-(segment + (segment >> 8) + 6)) & 0xff;
 
   /* Then create the new output record */
 
-  snprintf(line, MAX_LINE-PAYLOAD_OFFSET, ":02000004%04X%02X\n",
+  snprintf(line, MAX_LINE - PAYLOAD_OFFSET, ":02000004%04X%02X\n",
            segment, chksum);
 }
 


### PR DESCRIPTION

## Summary

Add one-line description to `tools/pic32/mkpichex.c`.

Also fix nxstyle error and a couple of typos.

## Impact

Makes the purpose of mkpichex.c a bit more clear.

## Testing

nxstyle