### PR TITLE
sockopt:Change the flow of function psock_setsockopt and psock_getsockopt

### DIFF
--- a/net/socket/getsockopt.c
+++ b/net/socket/getsockopt.c
@@ -337,50 +337,51 @@ int psock_getsockopt(FAR struct socket *psock, int level, int option,
       return -EBADF;
     }
 
-  /* Handle retrieval of the socket option according to the level at which
-   * option should be applied.
-   */
-
-  switch (level)
-    {
-      case SOL_SOCKET:   /* Socket-level options (see include/sys/socket.h) */
-       ret = psock_socketlevel_option(psock, option, value, value_len);
-       break;
-
-#ifdef CONFIG_NET_TCPPROTO_OPTIONS
-      case IPPROTO_TCP:  /* TCP protocol socket options (see include/netinet/tcp.h) */
-       ret = tcp_getsockopt(psock, option, value, value_len);
-       break;
-#endif
-
-#ifdef CONFIG_NET_CANPROTO_OPTIONS
-      case SOL_CAN_RAW:/* CAN protocol socket options (see include/netpacket/can.h) */
-       ret = can_getsockopt(psock, option, value, value_len);
-       break;
-#endif
-
-      /* These levels are defined in sys/socket.h, but are not yet
-       * implemented.
-       */
-
-      case IPPROTO_IP:   /* TCP protocol socket options (see include/netinet/ip.h) */
-      case IPPROTO_IPV6: /* TCP protocol socket options (see include/netinet/ip6.h) */
-      case IPPROTO_UDP:  /* TCP protocol socket options (see include/netinit/udp.h) */
-      default:           /* The provided level is invalid */
-        ret = -ENOPROTOOPT;
-       break;
-    }
-
 #ifdef CONFIG_NET_USRSOCK
   /* Try usrsock further if the protocol not available */
 
-  if (ret == -ENOPROTOOPT && psock->s_type == SOCK_USRSOCK_TYPE)
+  if (psock->s_type == SOCK_USRSOCK_TYPE)
     {
       ret = usrsock_getsockopt(psock->s_conn, level,
                                option, value, value_len);
     }
+  else
+#endif
+    {
+      /* Handle retrieval of the socket option according to the level at which
+      * option should be applied.
+      */
+
+      switch (level)
+        {
+          case SOL_SOCKET:   /* Socket-level options (see include/sys/socket.h) */
+            ret = psock_socketlevel_option(psock, option, value, value_len);
+            break;
+
+#ifdef CONFIG_NET_TCPPROTO_OPTIONS
+          case IPPROTO_TCP:  /* TCP protocol socket options (see include/netinet/tcp.h) */
+            ret = tcp_getsockopt(psock, option, value, value_len);
+            break;
 #endif
 
+#ifdef CONFIG_NET_CANPROTO_OPTIONS
+          case SOL_CAN_RAW:/* CAN protocol socket options (see include/netpacket/can.h) */
+            ret = can_getsockopt(psock, option, value, value_len);
+            break;
+#endif
+
+          /* These levels are defined in sys/socket.h, but are not yet
+          * implemented.
+          */
+
+          case IPPROTO_IP:   /* TCP protocol socket options (see include/netinet/ip.h) */
+          case IPPROTO_IPV6: /* TCP protocol socket options (see include/netinet/ip6.h) */
+          case IPPROTO_UDP:  /* TCP protocol socket options (see include/netinit/udp.h) */
+          default:           /* The provided level is invalid */
+            ret = -ENOPROTOOPT;
+          break;
+        }
+    }
   return ret;
 }
 

--- a/net/socket/setsockopt.c
+++ b/net/socket/setsockopt.c
@@ -529,60 +529,62 @@ int psock_setsockopt(FAR struct socket *psock, int level, int option,
       return -EBADF;
     }
 
-  /* Handle setting of the socket option according to the level at which
-   * option should be applied.
-   */
-
-  switch (level)
-    {
-      case SOL_SOCKET: /* Socket-level options (see include/sys/socket.h) */
-        ret = psock_socketlevel_option(psock, option, value, value_len);
-        break;
-
-#ifdef CONFIG_NET_TCPPROTO_OPTIONS
-      case IPPROTO_TCP:/* TCP protocol socket options (see include/netinet/tcp.h) */
-        ret = tcp_setsockopt(psock, option, value, value_len);
-        break;
-#endif
-
-#ifdef CONFIG_NET_UDPPROTO_OPTIONS
-      case IPPROTO_UDP:/* UDP protocol socket options (see include/netinet/udp.h) */
-        ret = udp_setsockopt(psock, option, value, value_len);
-        break;
-#endif
-
-#ifdef CONFIG_NET_IPv4
-      case IPPROTO_IP:/* TCP protocol socket options (see include/netinet/in.h) */
-        ret = ipv4_setsockopt(psock, option, value, value_len);
-        break;
-#endif
-
-#ifdef CONFIG_NET_IPv6
-      case IPPROTO_IPV6:/* TCP protocol socket options (see include/netinet/in.h) */
-        ret = ipv6_setsockopt(psock, option, value, value_len);
-        break;
-#endif
-
-#ifdef CONFIG_NET_CANPROTO_OPTIONS
-      case SOL_CAN_RAW:   /* CAN protocol socket options (see include/netpacket/can.h) */
-        ret = can_setsockopt(psock, option, value, value_len);
-        break;
-#endif
-
-      default:         /* The provided level is invalid */
-        ret = -ENOPROTOOPT;
-        break;
-    }
-
 #ifdef CONFIG_NET_USRSOCK
-  /* Try usrsock further if the protocol not available */
-
-  if (ret == -ENOPROTOOPT && psock->s_type == SOCK_USRSOCK_TYPE)
+  if (psock->s_type == SOCK_USRSOCK_TYPE)
     {
+      /* Handle setting of the socket option with usrsock */
+
       ret = usrsock_setsockopt(psock->s_conn, level,
                                option, value, value_len);
     }
+  else
+#endif /* CONFIG_NET_USRSOCK */
+    {
+      /* Handle setting of the socket option according to the level at which
+      * option should be applied.
+      */
+
+      switch (level)
+        {
+          case SOL_SOCKET: /* Socket-level options (see include/sys/socket.h) */
+            ret = psock_socketlevel_option(psock, option, value, value_len);
+            break;
+
+#ifdef CONFIG_NET_TCPPROTO_OPTIONS
+          case IPPROTO_TCP:/* TCP protocol socket options (see include/netinet/tcp.h) */
+            ret = tcp_setsockopt(psock, option, value, value_len);
+            break;
 #endif
+
+#ifdef CONFIG_NET_UDPPROTO_OPTIONS
+          case IPPROTO_UDP:/* UDP protocol socket options (see include/netinet/udp.h) */
+            ret = udp_setsockopt(psock, option, value, value_len);
+            break;
+#endif
+
+#ifdef CONFIG_NET_IPv4
+          case IPPROTO_IP:/* TCP protocol socket options (see include/netinet/in.h) */
+            ret = ipv4_setsockopt(psock, option, value, value_len);
+            break;
+#endif
+
+#ifdef CONFIG_NET_IPv6
+          case IPPROTO_IPV6:/* TCP protocol socket options (see include/netinet/in.h) */
+            ret = ipv6_setsockopt(psock, option, value, value_len);
+            break;
+#endif
+
+#ifdef CONFIG_NET_CANPROTO_OPTIONS
+          case SOL_CAN_RAW:   /* CAN protocol socket options (see include/netpacket/can.h) */
+            ret = can_setsockopt(psock, option, value, value_len);
+            break;
+#endif
+
+          default:         /* The provided level is invalid */
+            ret = -ENOPROTOOPT;
+            break;
+        }
+    }
 
   return ret;
 }


### PR DESCRIPTION

## Summary
See the issue: #7082
## Impact
Prioritize to call usrsock_getsockopt / usrsock_setsockopt when enable CONFIG_NET_USRSOCK
## Testing

