### PR TITLE
net/w5500: Fix small typo

### DIFF
--- a/drivers/net/w5500.c
+++ b/drivers/net/w5500.c
@@ -2134,7 +2134,7 @@ static int w5500_ioctl(FAR struct net_driver_s *dev, int cmd,
       /* Add cases here to support the IOCTL commands */
 
       default:
-        nerr("ERROR: Unrecognized IOCTL command: %d\n", command);
+        nerr("ERROR: Unrecognized IOCTL command: %d\n", cmd);
         return -ENOTTY;  /* Special return value for this case */
     }
 


### PR DESCRIPTION
## Summary
Fix small typo
## Impact
It will fix compilation error
## Testing
With external W5500 module
