### PR TITLE
risc-v/mpfs: emmcsd: further enhance the clocking

### DIFF
--- a/boards/risc-v/mpfs/icicle/include/board.h
+++ b/boards/risc-v/mpfs/icicle/include/board.h
@@ -37,8 +37,12 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-#if defined(CONFIG_MMCSD_MMCSUPPORT) && defined(CONFIG_MPFS_EMMCSD)
-#define MPFS_EMMC_CLK_200MHZ
+#ifdef CONFIG_MMCSD_MMCSUPPORT
+#  define MPFS_EMMC_CLK_MODE MPFS_EMMCSD_MODE_HS200
+#endif
+
+#ifdef CONFIG_MMCSD_SDIO
+#  define MPFS_SD_CLOCK_4BIT MPFS_MMC_CLOCK_25MHZ
 #endif
 
 /* Clocking TODO: */

--- a/boards/risc-v/mpfs/m100pfsevp/include/board.h
+++ b/boards/risc-v/mpfs/m100pfsevp/include/board.h
@@ -37,8 +37,12 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-#if defined(CONFIG_MMCSD_MMCSUPPORT) && defined(CONFIG_MPFS_EMMCSD)
-#define MPFS_EMMC_CLK_26MHZ
+#ifdef CONFIG_MMCSD_MMCSUPPORT
+#  define MPFS_EMMC_CLK_MODE MPFS_EMMCSD_MODE_SDR
+#endif
+
+#ifdef CONFIG_MMCSD_SDIO
+#  define MPFS_SD_CLOCK_4BIT MPFS_MMC_CLOCK_25MHZ
 #endif
 
 #ifdef CONFIG_MPFS_EMMCSD_MUX_GPIO


### PR DESCRIPTION
Simplify the clock mode from the board.h -files. Also make the SD clock definable as well.

Co-authored-by: Petro Karashchenko <petro.karashchenko@gmail.com>
Signed-off-by: Eero Nurkkala <eero.nurkkala@offcode.fi>

## Summary

Simplify emmc/sd clocking for mpfs products

## Impact

N/A

## Testing

MPFS Polarfire, SD card and eMMC
