### PR TITLE
net: Fix sa_family returned by SIOCGIFHWADDR

### DIFF
--- a/net/netdev/netdev_ioctl.c
+++ b/net/netdev/netdev_ioctl.c
@@ -901,7 +901,7 @@ static int netdev_ifr_ioctl(FAR struct socket *psock, int cmd,
         if (dev->d_lltype == NET_LL_ETHERNET ||
             dev->d_lltype == NET_LL_IEEE80211)
           {
-            req->ifr_hwaddr.sa_family = NET_SOCK_FAMILY;
+            req->ifr_hwaddr.sa_family = ARPHRD_ETHER;
             memcpy(req->ifr_hwaddr.sa_data,
                    dev->d_mac.ether.ether_addr_octet, IFHWADDRLEN);
           }
@@ -911,7 +911,7 @@ static int netdev_ifr_ioctl(FAR struct socket *psock, int cmd,
         if (dev->d_lltype == NET_LL_IEEE802154 ||
             dev->d_lltype == NET_LL_PKTRADIO)
           {
-            req->ifr_hwaddr.sa_family = NET_SOCK_FAMILY;
+            req->ifr_hwaddr.sa_family = ARPHRD_IEEE802154;
             memcpy(req->ifr_hwaddr.sa_data,
                    dev->d_mac.radio.nv_addr,
                    dev->d_mac.radio.nv_addrlen);


### PR DESCRIPTION
## Summary

The ioctl `SIOCGIFHWADDR` provides the hardware address (e.g., Ethernet MAC, etc.) of a network interface. It is based on Linux. (BSD-based systems don't have this ioctl.)

The Linux implementation sets `sa_family` to `ARPHRD_ETHER` for Ethernet and IEEE 802.11 interfaces [1].

NuttX was setting it to `NET_SOCK_FAMILY` for these interface types as well as 6LoWPAN and PKTRADIO; this was incorrect and also the value of `NET_SOCK_FAMILY` varies based on Kconfig settings. For example, in my build, `NET_SOCK_FAMILY` equals 2 while `ARPHRD_ETHER` equals 1, causing software to fail.

Correcting this to `ARPHRD_ETHER` for Ethernet and IEEE 802.11 and `ARPHRD_IEEE802154` for 6LoWPAN and PKTRADIO.

References:

[1] ['man 7 netdevice'](https://man7.org/linux/man-pages/man7/packet.7.html) on Linux: "SIOCGIFHWADDR... sa_family` contains the ARPHRD_* device type..."
[2] Mailing list thread "Bug - SIOCGIFHWADDR?" started 14 Sept 2022, archived: [https://lists.apache.org/thread/1m6nzv7xltfm1rpjgfcm486p57jgl2ct](https://lists.apache.org/thread/1m6nzv7xltfm1rpjgfcm486p57jgl2ct)

## Impact

Consistency with the expectations of software that uses this ioctl.

## Testing

Ported application running on custom board.
Build testing.
nxstyle.
