### PR TITLE
net: Fix memcpy() size used by SIOCSIFHWADDR for radios

### DIFF
--- a/net/netdev/netdev_ioctl.c
+++ b/net/netdev/netdev_ioctl.c
@@ -950,8 +950,14 @@ static int netdev_ifr_ioctl(FAR struct socket *psock, int cmd,
             if (ret >= 0)
               {
                 dev->d_mac.radio.nv_addrlen = properties.sp_addrlen;
+
+                DEBUGASSERT(dev->d_mac.radio.nv_addrlen <=
+                            sizeof(dev->d_mac.radio.nv_addr));
+                DEBUGASSERT(dev->d_mac.radio.nv_addrlen <=
+                            sizeof(req->ifr_hwaddr.sa_data));
+
                 memcpy(dev->d_mac.radio.nv_addr,
-                       req->ifr_hwaddr.sa_data, NET_6LOWPAN_ADDRSIZE);
+                       req->ifr_hwaddr.sa_data, dev->d_mac.radio.nv_addrlen);
               }
           }
         else


### PR DESCRIPTION
## Summary

The ioctl `SIOCSIFHWADDR` sets the hardware address (e.g., Ethernet MAC, etc.) of a network interface.

Radio devices may have different lengths of hardware addresses, such as `NET_6LOWPAN_EADDRSIZE` (8), `NET_6LOWPAN_SADDRSIZE` (2), or `RADIO_MAX_ADDRLEN` (8). Also, Kconfig `CONFIG_PKTRADIO_ADDRLEN` allows the user to set any arbitrary size.

Note that while the sister ioctl `SIOCGIFHWADDR` "get hardware address" copies `dev->d_mac.radio.nv_addrlen` bytes, `SIOCSIFHWADDR` was copying NET_6LOWPAN_ADDRSIZE bytes unconditionally. Depending on which radio is used, this could be incorrect.

Fixing it to use `dev->d_mac.radio.nv_addrlen` for `SIOCSIFHWADDR` as well. Also adding `DEBUGASSERT` to ensure this is within bounds of source and destination of the copy.

## Impact

Fix `SIOCSIFHWADDR` for radios that have a different hardware address size than 6LoWPAN.

## Testing

I do not have hardware or an application to test this with.

Build testing and nxstyle only.
