### PR TITLE
boards/ucleo-h743zi: Remove CONFIG_ARMV7M_SYSTICK from stm32_boot_image.c

### DIFF
--- a/boards/arm/stm32h7/nucleo-h743zi/src/stm32_boot_image.c
+++ b/boards/arm/stm32h7/nucleo-h743zi/src/stm32_boot_image.c
@@ -57,9 +57,7 @@ struct arm_vector_table
  ****************************************************************************/
 
 static void cleanup_arm_nvic(void);
-#ifdef CONFIG_ARMV7M_SYSTICK
 static void systick_disable(void);
-#endif
 
 /****************************************************************************
  * Private Functions
@@ -103,7 +101,6 @@ static void cleanup_arm_nvic(void)
     }
 }
 
-#ifdef CONFIG_ARMV7M_SYSTICK
 /****************************************************************************
  * Name:  systick_disable
  *
@@ -124,7 +121,6 @@ static void systick_disable(void)
   putreg32(NVIC_SYSTICK_RELOAD_MASK, NVIC_SYSTICK_RELOAD);
   putreg32(0, NVIC_SYSTICK_CURRENT);
 }
-#endif
 
 /****************************************************************************
  * Public Functions
@@ -158,9 +154,7 @@ int board_boot_image(FAR const char *path, uint32_t hdr_size)
       return bytes < 0 ? bytes : -1;
     }
 
-#ifdef CONFIG_ARMV7M_SYSTICK
   systick_disable();
-#endif
 
   cleanup_arm_nvic();
 


### PR DESCRIPTION
## Summary
See the comment here:
https://github.com/apache/incubator-nuttx/pull/5406/files#r798493720

## Impact

## Testing
Pass CI
