### PR TITLE
add include <nuttx/fs/ioctl.h> to esp32c3_usbserial.c

### DIFF
--- a/arch/risc-v/src/esp32c3/esp32c3_usbserial.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_usbserial.c
@@ -32,6 +32,7 @@
 
 #ifdef CONFIG_SERIAL_TERMIOS
 #  include <termios.h>
+#  include <nuttx/fs/ioctl.h>
 #endif
 
 #include <nuttx/arch.h>


### PR DESCRIPTION
undeclare TCGETS on esp32c3 when enable usbserial and termios error:
chip/esp32c3_usbserial.c: In function 'esp32c3_ioctl':
chip/esp32c3_usbserial.c:411:10: error: 'TCGETS' undeclared (first use in this function)
