### PR TITLE
phy62xx:support MTDIOC_ERASESTATE

### DIFF
--- a/arch/arm/src/phy62xx/pplus_mtd_flash.c
+++ b/arch/arm/src/phy62xx/pplus_mtd_flash.c
@@ -44,6 +44,12 @@
 #include <nuttx/mtd/mtd.h>
 
 /****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define MTD_ERASED_STATE            (0xff)
+
+/****************************************************************************
  * Private Types
  ****************************************************************************/
 
@@ -311,6 +317,14 @@ static int pplus_fls_ioctl(struct mtd_dev_s *dev,
           ret = pplus_fls_erase_chip(priv);
           break;
         }
+
+      case MTDIOC_ERASESTATE:
+        {
+          uint8_t *result = (uint8_t *)arg;
+          *result = MTD_ERASED_STATE;
+          ret = OK;
+        }
+        break;
 
       default:
           ret = -ENOTTY; /* Bad/unsupported command */


### PR DESCRIPTION
Signed-off-by: 田昕 <tianxin7@xiaomi.com>

## Summary
support MTDIOC_ERASESTATE for arm/phy62xx

## Impact
phy62xx only

## Testing
tested on phy62xx
