### PR TITLE
time: Typedef time_t to uint64_t if CONFIG_SYSTEM_TIME64 is defined

### DIFF
--- a/arch/x86_64/src/intel64/intel64_tickless.c
+++ b/arch/x86_64/src/intel64/intel64_tickless.c
@@ -48,6 +48,7 @@
 #include <nuttx/config.h>
 
 #include <debug.h>
+#include <inttypes.h>
 #include <stdint.h>
 #include <stdbool.h>
 #include <time.h>
@@ -437,7 +438,7 @@ int up_alarm_start(const struct timespec *ts)
 
   up_tmr_sync_down();
 
-  tmrinfo("%d.%09ld\n", ts->tv_sec, ts->tv_nsec);
+  tmrinfo("%" PRIdMAX ".%09ld\n", (uintmax_t)ts->tv_sec, ts->tv_nsec);
   tmrinfo("start\n");
 
   return OK;

--- a/include/time.h
+++ b/include/time.h
@@ -98,7 +98,11 @@
 
 /* Scalar types */
 
+#ifdef CONFIG_SYSTEM_TIME64
+typedef int64_t   time_t;         /* Holds time in seconds */
+#else
 typedef uint32_t  time_t;         /* Holds time in seconds */
+#endif
 typedef uint8_t   clockid_t;      /* Identifies one time base source */
 typedef FAR void *timer_t;        /* Represents one POSIX timer */
 


### PR DESCRIPTION
## Summary
to handle 2038 problem correctly

## Impact
The type of time_t
 
## Testing
Pass CI
