### PR TITLE
arch/arm/compiler: correct global symbol name

### DIFF
--- a/arch/arm/src/arm/arm_vectoraddrexcptn.S
+++ b/arch/arm/src/arm/arm_vectoraddrexcptn.S
@@ -35,7 +35,7 @@
  * Public Symbols
  ****************************************************************************/
 
-	.globl	arm_vectoraddrexcption
+	.globl	arm_vectoraddrexcptn
 
 /****************************************************************************
  * Assembly Macros
@@ -54,7 +54,7 @@
 	.text
 
 /****************************************************************************
- *  Name: arm_vectoraddrexcption
+ *  Name: arm_vectoraddrexcptn
  *
  * Description:
  *   Shouldn't happen.  This exception handler is in a separate file from

--- a/arch/arm/src/armv7-a/arm_vectoraddrexcptn.S
+++ b/arch/arm/src/armv7-a/arm_vectoraddrexcptn.S
@@ -35,7 +35,7 @@
  * Public Symbols
  ****************************************************************************/
 
-	.globl	arm_vectoraddrexcption
+	.globl	arm_vectoraddrexcptn
 
 /****************************************************************************
  * Assembly Macros
@@ -54,7 +54,7 @@
 	.text
 
 /****************************************************************************
- *  Name: arm_vectoraddrexcption
+ *  Name: arm_vectoraddrexcptn
  *
  * Description:
  *   Shouldn't happen.  This exception handler is in a separate file from

--- a/arch/arm/src/armv7-r/arm_vectoraddrexcptn.S
+++ b/arch/arm/src/armv7-r/arm_vectoraddrexcptn.S
@@ -35,7 +35,7 @@
  * Public Symbols
  ****************************************************************************/
 
-	.globl	arm_vectoraddrexcption
+	.globl	arm_vectoraddrexcptn
 
 /****************************************************************************
  * Assembly Macros
@@ -54,7 +54,7 @@
 	.text
 
 /****************************************************************************
- *  Name: arm_vectoraddrexcption
+ *  Name: arm_vectoraddrexcptn
  *
  * Description:
  *   Shouldn't happen.  This exception handler is in a separate file from


### PR DESCRIPTION

## Summary

arch/arm/compiler: correct global symbol name

Fix Compile error from Armclang compiler(AC6):
Error: L6218E: Undefined symbol arm_vectoraddrexcption (referred from arm_vectoraddrexcptn.o).

Signed-off-by: chao an <anchao@xiaomi.com>

## Impact

N/A

## Testing

armlink