### PR TITLE
arch/arm: declare vector array default type to read-only

### DIFF
--- a/arch/arm/src/armv6-m/arm_vectors.c
+++ b/arch/arm/src/armv6-m/arm_vectors.c
@@ -50,7 +50,7 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-#define IDLE_STACK      ((unsigned)&_ebss+CONFIG_IDLETHREAD_STACKSIZE)
+#define IDLE_STACK      ((unsigned int)&_ebss+CONFIG_IDLETHREAD_STACKSIZE)
 
 #ifndef ARMV6M_PERIPHERAL_INTERRUPTS
 #  error ARMV6M_PERIPHERAL_INTERRUPTS must be defined to the number of I/O interrupts to be supported
@@ -81,7 +81,7 @@ extern void exception_common(void);
  * Note that the [ ... ] designated initialiser is a GCC extension.
  */
 
-unsigned _vectors[] locate_data(".vectors") =
+const unsigned int _vectors[] locate_data(".vectors") =
 {
   /* Initial stack */
 
@@ -89,9 +89,10 @@ unsigned _vectors[] locate_data(".vectors") =
 
   /* Reset exception handler */
 
-  (unsigned)&__start,
+  (unsigned int)&__start,
 
   /* Vectors 2 - n point directly at the generic handler */
 
-  [2 ... (15 + ARMV6M_PERIPHERAL_INTERRUPTS)] = (unsigned)&exception_common
+  [2 ... (15 + ARMV6M_PERIPHERAL_INTERRUPTS)] = (unsigned int)
+                                                &exception_common
 };

--- a/arch/arm/src/armv7-m/arm_vectors.c
+++ b/arch/arm/src/armv7-m/arm_vectors.c
@@ -45,7 +45,7 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-#define IDLE_STACK      ((unsigned)&_ebss+CONFIG_IDLETHREAD_STACKSIZE)
+#define IDLE_STACK      ((unsigned int)&_ebss+CONFIG_IDLETHREAD_STACKSIZE)
 
 #ifndef ARMV7M_PERIPHERAL_INTERRUPTS
 #  error ARMV7M_PERIPHERAL_INTERRUPTS must be defined to the number of I/O interrupts to be supported
@@ -76,7 +76,7 @@ extern void exception_common(void);
  * Note that the [ ... ] designated initializer is a GCC extension.
  */
 
-unsigned _vectors[] locate_data(".vectors") =
+const unsigned int _vectors[] locate_data(".vectors") =
 {
   /* Initial stack */
 
@@ -84,9 +84,10 @@ unsigned _vectors[] locate_data(".vectors") =
 
   /* Reset exception handler */
 
-  (unsigned)&__start,
+  (unsigned int)&__start,
 
   /* Vectors 2 - n point directly at the generic handler */
 
-  [2 ... (15 + ARMV7M_PERIPHERAL_INTERRUPTS)] = (unsigned)&exception_common
+  [2 ... (15 + ARMV7M_PERIPHERAL_INTERRUPTS)] = (unsigned int)
+                                                &exception_common
 };

--- a/arch/arm/src/armv8-m/arm_vectors.c
+++ b/arch/arm/src/armv8-m/arm_vectors.c
@@ -45,7 +45,7 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-#define IDLE_STACK      ((unsigned)&_ebss+CONFIG_IDLETHREAD_STACKSIZE)
+#define IDLE_STACK      ((unsigned int)&_ebss+CONFIG_IDLETHREAD_STACKSIZE)
 
 #ifndef ARMV8M_PERIPHERAL_INTERRUPTS
 #  error ARMV8M_PERIPHERAL_INTERRUPTS must be defined to the number of I/O interrupts to be supported
@@ -76,7 +76,7 @@ extern void exception_common(void);
  * Note that the [ ... ] designated initializer is a GCC extension.
  */
 
-unsigned _vectors[] locate_data(".vectors") =
+const unsigned int _vectors[] locate_data(".vectors") =
 {
   /* Initial stack */
 
@@ -84,9 +84,10 @@ unsigned _vectors[] locate_data(".vectors") =
 
   /* Reset exception handler */
 
-  (unsigned)&__start,
+  (unsigned int)&__start,
 
   /* Vectors 2 - n point directly at the generic handler */
 
-  [2 ... (15 + ARMV8M_PERIPHERAL_INTERRUPTS)] = (unsigned)&exception_common
+  [2 ... (15 + ARMV8M_PERIPHERAL_INTERRUPTS)] = (unsigned int)
+                                                &exception_common
 };

--- a/arch/arm/src/rtl8720c/ameba_vectors.c
+++ b/arch/arm/src/rtl8720c/ameba_vectors.c
@@ -31,7 +31,7 @@
  ****************************************************************************/
 
 extern uint32_t __stack;
-#define IDLE_STACK      ((unsigned)&__stack - 4)
+#define IDLE_STACK      ((unsigned int)&__stack - 4)
 #ifndef ARMV8M_PERIPHERAL_INTERRUPTS
 #  error ARMV8M_PERIPHERAL_INTERRUPTS must be defined to the number of I/O interrupts to be supported
 #endif
@@ -63,7 +63,7 @@ extern void exception_common(void);
  * Note that the [ ... ] designated initialiser is a GCC extension.
  */
 
-unsigned _vectors[] locate_data(".vectors") \
+const unsigned int _vectors[] locate_data(".vectors") \
                     aligned_data(0x100) =
 {
   /* Initial stack */
@@ -72,10 +72,11 @@ unsigned _vectors[] locate_data(".vectors") \
 
   /* Reset exception handler */
 
-  (unsigned) &ram_start,
+  (unsigned int) &ram_start,
 
   /* Vectors 2 - n point directly at the generic handler */
 
-  [2 ...(15 + ARMV8M_PERIPHERAL_INTERRUPTS)] = (unsigned) &exception_common
+  [2 ...(15 + ARMV8M_PERIPHERAL_INTERRUPTS)] = (unsigned int)
+                                               &exception_common
 };
 


### PR DESCRIPTION
## Summary

arch/arm: declare vector array default type to read-only

Reference:
https://developer.arm.com/documentation/dui0474/m/image-structure-and-generation/section-placement-with-the-linker/section-placement-with-the-first-and-last-attributes
```

CAUTION:
FIRST and LAST must not violate the basic attribute sorting order. For example, FIRST RW is placed after any read-only code or read-only data.
```

```
arm-none-eabi-readelf -aS arm_vectors.o
1. Without const:
  Section Headers:
  [Nr] Name              Type            Addr     Off    Size   ES Flg Lk Inf Al
  [ 3] .vectors          PROGBITS        00000000 000034 00011c 00   A  0   0  4

2. const symbol:
  [ 3] .vectors          PROGBITS        00000000 000034 00011c 00  WA  0   0  4
```

Signed-off-by: chao an <anchao@xiaomi.com>

## Impact

N/A

## Testing

armlink