### PR TITLE
boards/arm/ac6: add scatter linker script for sabre-6quad/lm3s6965-ek

### DIFF
--- a/boards/arm/imx6/sabre-6quad/scripts/Make.defs
+++ b/boards/arm/imx6/sabre-6quad/scripts/Make.defs
@@ -22,7 +22,11 @@ include $(TOPDIR)/.config
 include $(TOPDIR)/tools/Config.mk
 include $(TOPDIR)/arch/arm/src/armv7-a/Toolchain.defs
 
-LDSCRIPT = dramboot.ld
+ifeq ($(CONFIG_ARM_TOOLCHAIN_ARMCLANG),y)
+  LDSCRIPT = dramboot.sct
+else
+  LDSCRIPT = dramboot.ld
+endif
 ARCHSCRIPT += $(BOARD_DIR)$(DELIM)scripts$(DELIM)$(LDSCRIPT)
 
 ARCHPICFLAGS = -fpic -msingle-pic-base -mpic-register=r10

--- a/boards/arm/imx6/sabre-6quad/scripts/dramboot.sct
+++ b/boards/arm/imx6/sabre-6quad/scripts/dramboot.sct
@@ -1,0 +1,130 @@
+#! armclang -E --target=arm-arm-none-eabi -x c -mcpu=cortex-a9
+
+/****************************************************************************
+ * boards/arm/imx6/sabre-6quad/scripts/dramboot.sct
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/* The i.MX6 has 256 KB of OCRAM beginning at virtual address 0x0090:0000
+ * This memory configuration, however, loads into the 1GB DDR3 on board
+ * the Sabre 6Quad K which lies at 0x1000:0000.  Code is positioned at
+ * 0x10800000 which the standard load address of Linux when used with uBoot.
+ *
+ * Vectors in low memory are assumed and 16KB of OCRAM is reserved at the
+ * high end of OCRAM for the page table.
+ */
+
+#define DDR3_START   0x10800000
+#define DDR3_SIZE    0x000FE000
+
+OSCRAM_SECTIONS DDR3_START DDR3_SIZE
+{
+  text +0
+    {
+      *(.vectors,+FIRST)
+      *(.text)
+      *(.text.*)
+      aeabi_sdiv.o
+      dfixull.o
+      dnaninf.o
+      usenofp.o
+      *(.fixup)
+      *(.gnu.warning)
+      *(.rodata)
+      *(.rodata.*)
+      *(.gnu.linkonce.t.*)
+      *(.glue_7)
+      *(.glue_7t)
+      *(.got)
+      *(.gcc_except_table)
+      *(.gnu.linkonce.r.*)
+      *(.ARM.extab*)
+      *(.gnu.linkonce.armextab.*)
+    }
+
+  init_section AlignExpr(ImageLimit(text), 0x4)
+    {
+      *(.init_array)
+      *(.init_array.*)
+    }
+
+  ARM.extab AlignExpr(ImageLimit(init_section), 0x4)
+    {
+      *(.ARM.extab*)
+    }
+
+  ARM.exidx AlignExpr(ImageLimit(ARM.extab), 0x4)
+    {
+      *(.ARM.exidx*)
+      *(.gnu.linkonce.armexidx.*)
+    }
+
+  eronly AlignExpr(ImageLimit(ARM.exidx), 0x4)
+    {
+    }
+
+  tdata AlignExpr(ImageLimit(eronly), 0x4)
+    {
+      *(.tdata)
+      *(.tdata.*)
+      *(.gnu.linkonce.td.*)
+    }
+
+  tbss AlignExpr(ImageLimit(tdata), 0x4)
+    {
+      *(.tbss)
+      *(.tbss.*)
+      *(.gnu.linkonce.tb.*)
+      *(.tcommon);
+    }
+
+  data AlignExpr(ImageLimit(tbss), 0x4)
+    {
+      *(.data)
+      *(.data.*)
+      *(.gnu.linkonce.d.*)
+      CONSTRUCTORS
+    }
+
+  bss AlignExpr(ImageLimit(data), 0x8)
+    {
+      *(.bss)
+      *(.bss.*)
+      *(.gnu.linkonce.b.*)
+      *(COMMON)
+      *(+ZI)
+    }
+
+  noinit AlignExpr(ImageLimit(bss), 0x100)
+    {
+      *(.noinit*)
+    }
+
+  stab 0 { *(.stab) }
+  stabstr 0 { *(.stabstr) }
+  stab.excl 0 { *(.stab.excl) }
+  stab.exclstr 0 { *(.stab.exclstr) }
+  stab.index 0 { *(.stab.index) }
+  stab.indexstr 0 { *(.stab.indexstr) }
+  comment 0 { *(.comment) }
+  debug_abbrev 0 { *(.debug_abbrev) }
+  debug_info 0 { *(.debug_info) }
+  debug_line 0 { *(.debug_line) }
+  debug_pubnames 0 { *(.debug_pubnames) }
+  debug_aranges 0 { *(.debug_aranges) }
+}

--- a/boards/arm/tiva/lm3s6965-ek/scripts/Make.defs
+++ b/boards/arm/tiva/lm3s6965-ek/scripts/Make.defs
@@ -22,7 +22,11 @@ include $(TOPDIR)/.config
 include $(TOPDIR)/tools/Config.mk
 include $(TOPDIR)/arch/arm/src/armv7-m/Toolchain.defs
 
-ARCHSCRIPT += $(BOARD_DIR)$(DELIM)scripts$(DELIM)ld.script
+ifeq ($(CONFIG_ARM_TOOLCHAIN_ARMCLANG),y)
+  ARCHSCRIPT += $(BOARD_DIR)$(DELIM)scripts$(DELIM)ld.sct
+else
+  ARCHSCRIPT += $(BOARD_DIR)$(DELIM)scripts$(DELIM)ld.script
+endif
 
 ARCHPICFLAGS = -fpic -msingle-pic-base -mpic-register=r10
 ifeq ($(CONFIG_NXFLAT),y)

--- a/boards/arm/tiva/lm3s6965-ek/scripts/ld.sct
+++ b/boards/arm/tiva/lm3s6965-ek/scripts/ld.sct
@@ -1,0 +1,114 @@
+#! armclang -E --target=arm-arm-none-eabi -x c -mcpu=cortex-m3
+
+/****************************************************************************
+ * boards/arm/tiva/lm3s6965-ek/scripts/ld.sct
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#define FLASH_START 0x00000000
+#define FLASH_SIZE  0x00040000
+#define SRAM_START  0x20000000
+#define SRAM_SIZE   0x00010000
+
+SRAM_SECTIONS FLASH_START FLASH_SIZE
+{
+  text +0
+    {
+      *(.vectors,+FIRST)
+      *(.text)
+      *(.text.*)
+      *(.fixup)
+      *(.gnu.warning)
+      *(.rodata)
+      *(.rodata.*)
+      *(.gnu.linkonce.t.*)
+      *(.glue_7)
+      *(.glue_7t)
+      *(.got)
+      *(.gcc_except_table)
+      *(.gnu.linkonce.r.*)
+    }
+
+  init_section AlignExpr(ImageLimit(text), 0x4)
+    {
+      *(.init_array)
+      *(.init_array.*)
+    }
+
+  ARM.extab AlignExpr(ImageLimit(init_section), 0x4)
+    {
+      *(.ARM.extab*)
+    }
+
+  ARM.exidx AlignExpr(ImageLimit(ARM.extab), 0x4)
+    {
+      *(.ARM.exidx*)
+    }
+
+  ARM.Collect AlignExpr(ImageLimit(ARM.exidx), 0x4)
+    {
+      *(.ARM.Collect*)
+    }
+
+  eronly AlignExpr(ImageLimit(ARM.Collect), 0x4)
+    {
+    }
+
+  tdata SRAM_START SRAM_SIZE
+    {
+      *(.tdata)
+      *(.tdata.*)
+      *(.gnu.linkonce.td.*)
+    }
+
+  tbss AlignExpr(ImageLimit(tdata), 0x4)
+    {
+      *(.tbss)
+      *(.tbss.*)
+      *(.gnu.linkonce.tb.*)
+      *(.tcommon);
+    }
+
+  noinit AlignExpr(ImageLimit(tbss), 0x4)
+    {
+      *(.noinit*)
+    }
+
+  data AlignExpr(ImageLimit(noinit), 0x4)
+    {
+      *(+RW)
+    }
+
+  bss AlignExpr(ImageLimit(data), 0x8)
+    {
+      *(+ZI)
+    }
+
+  stab           0 { *(.stab) }
+  stabstr        0 { *(.stabstr) }
+  stab.excl      0 { *(.stab.excl) }
+  stab.exclstr   0 { *(.stab.exclstr) }
+  stab.index     0 { *(.stab.index) }
+  stab.indexstr  0 { *(.stab.indexstr) }
+  comment        0 { *(.comment) }
+  debug_abbrev   0 { *(.debug_abbrev) }
+  debug_info     0 { *(.debug_info) }
+  debug_line     0 { *(.debug_line) }
+  debug_pubnames 0 { *(.debug_pubnames) }
+  debug_aranges  0 { *(.debug_aranges) }
+}


### PR DESCRIPTION
## Summary

boards/arm/ac6: add scatter linker script for sabre-6quad/lm3s6965-ek

add armclang compiler(AC6) support for board sabre-6quad/lm3s6965-ek

Verified config:

enable **CONFIG_ARM_TOOLCHAIN_ARMCLANG=y**

1. lm3s6965-ek:qemu-flat (Disable file apps)

./tools/configure.sh lm3s6965-ek:qemu-flat
```
-CONFIG_BOARDCTL_APP_SYMTAB=y
-CONFIG_ELF=y
-CONFIG_EXAMPLES_ELF=y
-CONFIG_EXAMPLES_ELF_DEVPATH="/dev/ram5"
-CONFIG_EXAMPLES_HELLO=y
-CONFIG_EXAMPLES_MODULE=y
-CONFIG_EXAMPLES_MODULE_DEVPATH="/dev/ram6"
-CONFIG_EXAMPLES_NETTEST=m
-CONFIG_EXAMPLES_WGET=y
-CONFIG_HOST_MACOS=y
-CONFIG_LIBC_DLFCN=y
-CONFIG_NSH_FILE_APPS=y
```
2. sabre-6quad/smp
./tools/configure.sh sabre-6quad/smp

Signed-off-by: chao an <anchao@xiaomi.com>

## Impact

N/A

## Testing

 lm3s6965-ek:qemu-flat
sabre-6quad/smp