### PR TITLE
arch/armv7[a|r]: Implement up_affinity_irq

### DIFF
--- a/arch/arm/src/armv7-a/Kconfig
+++ b/arch/arm/src/armv7-a/Kconfig
@@ -7,6 +7,7 @@ comment "ARMv7-A Configuration Options"
 
 config ARMV7A_HAVE_GICv2
 	bool
+	select ARCH_HAVE_IRQTRIGGER
 	default n
 	---help---
 		Selected by the configuration tool if the architecture supports the

--- a/arch/arm/src/armv7-a/arm_cpupause.c
+++ b/arch/arm/src/armv7-a/arm_cpupause.c
@@ -241,8 +241,6 @@ int arm_pause_handler(int irq, void *context, void *arg)
 
 int up_cpu_pause(int cpu)
 {
-  int ret;
-
   DEBUGASSERT(cpu >= 0 && cpu < CONFIG_SMP_NCPUS && cpu != this_cpu());
 
 #ifdef CONFIG_SCHED_INSTRUMENTATION
@@ -267,22 +265,13 @@ int up_cpu_pause(int cpu)
 
   /* Execute SGI2 */
 
-  ret = arm_cpu_sgi(GIC_IRQ_SGI2, (1 << cpu));
-  if (ret < 0)
-    {
-      /* What happened?  Unlock the g_cpu_wait spinlock */
+  arm_cpu_sgi(GIC_IRQ_SGI2, (1 << cpu));
 
-      spin_unlock(&g_cpu_wait[cpu]);
-    }
-  else
-    {
-      /* Wait for the other CPU to unlock g_cpu_paused meaning that
-       * it is fully paused and ready for up_cpu_resume();
-       */
+  /* Wait for the other CPU to unlock g_cpu_paused meaning that
+   * it is fully paused and ready for up_cpu_resume();
+   */
 
-      spin_lock(&g_cpu_paused[cpu]);
-    }
-
+  spin_lock(&g_cpu_paused[cpu]);
   spin_unlock(&g_cpu_paused[cpu]);
 
   /* On successful return g_cpu_wait will be locked, the other CPU will be
@@ -290,7 +279,7 @@ int up_cpu_pause(int cpu)
    * called.  g_cpu_paused will be unlocked in any case.
    */
 
-  return ret;
+  return OK;
 }
 
 /****************************************************************************

--- a/arch/arm/src/armv7-a/arm_cpustart.c
+++ b/arch/arm/src/armv7-a/arm_cpustart.c
@@ -160,7 +160,8 @@ int up_cpu_start(int cpu)
 
   /* Execute SGI1 */
 
-  return arm_cpu_sgi(GIC_IRQ_SGI1, (1 << cpu));
+  arm_cpu_sgi(GIC_IRQ_SGI1, (1 << cpu));
+  return OK;
 }
 
 #endif /* CONFIG_SMP */

--- a/arch/arm/src/armv7-a/arm_gicv2.c
+++ b/arch/arm/src/armv7-a/arm_gicv2.c
@@ -523,7 +523,21 @@ int up_prioritize_irq(int irq, int priority)
 
 void up_trigger_irq(int irq, cpu_set_t cpuset)
 {
-  arm_cpu_sgi(irq, cpuset);
+  if (irq >= 0 && irq <= GIC_IRQ_SGI15)
+    {
+      arm_cpu_sgi(irq, cpuset);
+    }
+  else if (irq >= 0 && irq < NR_IRQS)
+    {
+      uintptr_t regaddr;
+
+      /* Write '1' to the corresponding bit in the distributor Interrupt
+       * Set-Pending (ICDISPR)
+       */
+
+      regaddr = GIC_ICDISPR(irq);
+      putreg32(GIC_ICDISPR_INT(irq), regaddr);
+    }
 }
 
 /****************************************************************************

--- a/arch/arm/src/armv7-a/arm_gicv2.c
+++ b/arch/arm/src/armv7-a/arm_gicv2.c
@@ -505,6 +505,28 @@ int up_prioritize_irq(int irq, int priority)
 }
 
 /****************************************************************************
+ * Name: up_trigger_irq
+ *
+ * Description:
+ *   Perform a Software Generated Interrupt (SGI).  If CONFIG_SMP is
+ *   selected, then the SGI is sent to all CPUs specified in the CPU set.
+ *   That set may include the current CPU.
+ *
+ *   If CONFIG_SMP is not selected, the cpuset is ignored and SGI is sent
+ *   only to the current CPU.
+ *
+ * Input Parameters
+ *   irq    - The SGI interrupt ID (0-15)
+ *   cpuset - The set of CPUs to receive the SGI
+ *
+ ****************************************************************************/
+
+void up_trigger_irq(int irq, cpu_set_t cpuset)
+{
+  arm_cpu_sgi(irq, cpuset);
+}
+
+/****************************************************************************
  * Name: arm_gic_irq_trigger
  *
  * Description:

--- a/arch/arm/src/armv7-a/arm_gicv2.c
+++ b/arch/arm/src/armv7-a/arm_gicv2.c
@@ -505,6 +505,33 @@ int up_prioritize_irq(int irq, int priority)
 }
 
 /****************************************************************************
+ * Name: up_affinity_irq
+ *
+ * Description:
+ *   Set an IRQ affinity by software.
+ *
+ ****************************************************************************/
+
+void up_affinity_irq(int irq, cpu_set_t cpuset)
+{
+  if (irq >= GIC_IRQ_SPI && irq < NR_IRQS)
+    {
+      uintptr_t regaddr;
+      uint32_t regval;
+
+      /* Write the new cpuset to the corresponding field in the in the
+       * distributor Interrupt Processor Target Register (GIC_ICDIPTR).
+       */
+
+      regaddr = GIC_ICDIPTR(irq);
+      regval  = getreg32(regaddr);
+      regval &= ~GIC_ICDIPTR_ID_MASK(irq);
+      regval |= GIC_ICDIPTR_ID(irq, cpuset);
+      putreg32(regval, regaddr);
+    }
+}
+
+/****************************************************************************
  * Name: up_trigger_irq
  *
  * Description:

--- a/arch/arm/src/armv7-a/gic.h
+++ b/arch/arm/src/armv7-a/gic.h
@@ -681,7 +681,7 @@ static inline unsigned int arm_gic_nlines(void)
  *
  ****************************************************************************/
 
-static inline int arm_cpu_sgi(int sgi, unsigned int cpuset)
+static inline void arm_cpu_sgi(int sgi, unsigned int cpuset)
 {
   uint32_t regval;
 
@@ -694,7 +694,6 @@ static inline int arm_cpu_sgi(int sgi, unsigned int cpuset)
 #endif
 
   putreg32(regval, GIC_ICDSGIR);
-  return OK;
 }
 
 /****************************************************************************

--- a/arch/arm/src/armv7-m/arm_trigger_irq.c
+++ b/arch/arm/src/armv7-m/arm_trigger_irq.c
@@ -47,7 +47,7 @@
  *
  ****************************************************************************/
 
-void up_trigger_irq(int irq)
+void up_trigger_irq(int irq, cpu_set_t cpuset)
 {
   uint32_t pend_bit = 0;
 

--- a/arch/arm/src/armv7-r/Kconfig
+++ b/arch/arm/src/armv7-r/Kconfig
@@ -7,6 +7,7 @@ comment "ARMv7-R Configuration Options"
 
 config ARMV7R_HAVE_GICv2
 	bool "ARMV7R_GICv2 support"
+	select ARCH_HAVE_IRQTRIGGER
 	default y
 	---help---
 		Selected by the configuration tool if the architecture supports the

--- a/arch/arm/src/armv7-r/arm_gicv2.c
+++ b/arch/arm/src/armv7-r/arm_gicv2.c
@@ -504,6 +504,33 @@ int up_prioritize_irq(int irq, int priority)
 }
 
 /****************************************************************************
+ * Name: up_affinity_irq
+ *
+ * Description:
+ *   Set an IRQ affinity by software.
+ *
+ ****************************************************************************/
+
+void up_affinity_irq(int irq, cpu_set_t cpuset)
+{
+  if (irq >= GIC_IRQ_SPI && irq < NR_IRQS)
+    {
+      uintptr_t regaddr;
+      uint32_t regval;
+
+      /* Write the new cpuset to the corresponding field in the in the
+       * distributor Interrupt Processor Target Register (GIC_ICDIPTR).
+       */
+
+      regaddr = GIC_ICDIPTR(irq);
+      regval  = getreg32(regaddr);
+      regval &= ~GIC_ICDIPTR_ID_MASK(irq);
+      regval |= GIC_ICDIPTR_ID(irq, cpuset);
+      putreg32(regval, regaddr);
+    }
+}
+
+/****************************************************************************
  * Name: up_trigger_irq
  *
  * Description:

--- a/arch/arm/src/armv7-r/arm_gicv2.c
+++ b/arch/arm/src/armv7-r/arm_gicv2.c
@@ -504,7 +504,7 @@ int up_prioritize_irq(int irq, int priority)
 }
 
 /****************************************************************************
- * Name: arm_cpu_sgi
+ * Name: up_trigger_irq
  *
  * Description:
  *   Perform a Software Generated Interrupt (SGI).  If CONFIG_SMP is
@@ -515,30 +515,14 @@ int up_prioritize_irq(int irq, int priority)
  *   only to the current CPU.
  *
  * Input Parameters
- *   sgi    - The SGI interrupt ID (0-15)
+ *   irq    - The SGI interrupt ID (0-15)
  *   cpuset - The set of CPUs to receive the SGI
- *
- * Returned Value:
- *   OK is always returned at present.
  *
  ****************************************************************************/
 
-int arm_cpu_sgi(int sgi, unsigned int cpuset)
+void up_trigger_irq(int irq, cpu_set_t cpuset)
 {
-  uint32_t regval;
-
-#ifdef CONFIG_SMP
-  regval = GIC_ICDSGIR_INTID(sgi)        |
-           GIC_ICDSGIR_CPUTARGET(cpuset) |
-           GIC_ICDSGIR_TGTFILTER_LIST;
-#else
-  regval = GIC_ICDSGIR_INTID(sgi)   |
-           GIC_ICDSGIR_CPUTARGET(0) |
-           GIC_ICDSGIR_TGTFILTER_THIS;
-#endif
-
-  putreg32(regval, GIC_ICDSGIR);
-  return OK;
+  arm_cpu_sgi(irq, cpuset);
 }
 
-#endif							/* CONFIG_ARMV7R_HAVE_GICv2 */
+#endif /* CONFIG_ARMV7R_HAVE_GICv2 */

--- a/arch/arm/src/armv7-r/arm_gicv2.c
+++ b/arch/arm/src/armv7-r/arm_gicv2.c
@@ -522,7 +522,21 @@ int up_prioritize_irq(int irq, int priority)
 
 void up_trigger_irq(int irq, cpu_set_t cpuset)
 {
-  arm_cpu_sgi(irq, cpuset);
+  if (irq >= 0 && irq <= GIC_IRQ_SGI15)
+    {
+      arm_cpu_sgi(irq, cpuset);
+    }
+  else if (irq >= 0 && irq < NR_IRQS)
+    {
+      uintptr_t regaddr;
+
+      /* Write '1' to the corresponding bit in the distributor Interrupt
+       * Set-Pending (ICDISPR)
+       */
+
+      regaddr = GIC_ICDISPR(irq);
+      putreg32(GIC_ICDISPR_INT(irq), regaddr);
+    }
 }
 
 #endif /* CONFIG_ARMV7R_HAVE_GICv2 */

--- a/arch/arm/src/armv8-m/arm_trigger_irq.c
+++ b/arch/arm/src/armv8-m/arm_trigger_irq.c
@@ -47,7 +47,7 @@
  *
  ****************************************************************************/
 
-void up_trigger_irq(int irq)
+void up_trigger_irq(int irq, cpu_set_t cpuset)
 {
   uint32_t pend_bit = 0;
 

--- a/arch/arm/src/rtl8720c/ameba_nvic.c
+++ b/arch/arm/src/rtl8720c/ameba_nvic.c
@@ -260,45 +260,6 @@ void up_enable_irq(int irq)
 }
 
 /****************************************************************************
- * Name: up_trigger_irq
- *
- * Description:
- *   Trigger an IRQ by software.
- *
- ****************************************************************************/
-
-void up_trigger_irq(int irq)
-{
-  uint32_t pend_bit = 0;
-  DEBUGASSERT(irq >= NVIC_IRQ_NMI && irq < NR_IRQS);
-  if (irq >= NVIC_IRQ_FIRST)
-    {
-      putreg32(irq - NVIC_IRQ_FIRST, NVIC_STIR);
-    }
-
-  else
-    {
-      switch (irq)
-        {
-        case NVIC_IRQ_PENDSV:
-          pend_bit = NVIC_INTCTRL_PENDSVSET;
-          break;
-        case NVIC_IRQ_NMI:
-          pend_bit = NVIC_INTCTRL_NMIPENDSET;
-          break;
-        case NVIC_IRQ_SYSTICK:
-          pend_bit = NVIC_INTCTRL_PENDSTSET;
-          break;
-        }
-
-      if (pend_bit)
-        {
-          modifyreg32(NVIC_INTCTRL, 0, pend_bit);
-        }
-    }
-}
-
-/****************************************************************************
  * Name: up_prioritize_irq
  *
  * Description:

--- a/arch/ceva/src/xc5/up_intc.c
+++ b/arch/ceva/src/xc5/up_intc.c
@@ -162,7 +162,7 @@ int up_prioritize_irq(int irq, int priority)
  ****************************************************************************/
 
 #ifdef CONFIG_ARCH_HAVE_IRQTRIGGER
-void up_trigger_irq(int irq)
+void up_trigger_irq(int irq, cpu_set_t cpuset)
 {
   if (irq >= IRQ_VINT_FIRST)
     {

--- a/arch/ceva/src/xm6/up_intc.c
+++ b/arch/ceva/src/xm6/up_intc.c
@@ -170,7 +170,7 @@ int up_prioritize_irq(int irq, int priority)
  ****************************************************************************/
 
 #ifdef CONFIG_ARCH_HAVE_IRQTRIGGER
-void up_trigger_irq(int irq)
+void up_trigger_irq(int irq, cpu_set_t cpuset)
 {
   if (irq >= IRQ_VINT_FIRST)
     {

--- a/fs/vfs/fs_eventfd.c
+++ b/fs/vfs/fs_eventfd.c
@@ -491,8 +491,8 @@ static int eventfd_do_poll(FAR struct file *filep, FAR struct pollfd *fds,
 
       /* Remove all memory of the poll setup */
 
-      *slot                = NULL;
-      fds->priv            = NULL;
+      *slot     = NULL;
+      fds->priv = NULL;
       goto out;
     }
 

--- a/include/nuttx/arch.h
+++ b/include/nuttx/arch.h
@@ -1490,6 +1490,18 @@ void up_disable_irq(int irq);
 #endif
 
 /****************************************************************************
+ * Name: up_affinity_irq
+ *
+ * Description:
+ *   Set an IRQ affinity by software.
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_SMP
+void up_affinity_irq(int irq, cpu_set_t cpuset);
+#endif
+
+/****************************************************************************
  * Name: up_trigger_irq
  *
  * Description:

--- a/include/nuttx/arch.h
+++ b/include/nuttx/arch.h
@@ -1498,7 +1498,7 @@ void up_disable_irq(int irq);
  ****************************************************************************/
 
 #ifdef CONFIG_ARCH_HAVE_IRQTRIGGER
-void up_trigger_irq(int irq);
+void up_trigger_irq(int irq, cpu_set_t cpuset);
 #endif
 
 /****************************************************************************


### PR DESCRIPTION
## Summary
and make up_trigger_irq consistent between armv7-a/r and armv7/8-m

- arm/rtl8720c: Remove up_trigger_irq since it is implemented in arm_trigger_irq.c
- arch/arm: Unify arm_cpu_sgi to up_trigger_irq
- arch/armv7[a|r]: Support non SGI in up_trigger_irq
- arch/armv7[a|r]: Implement up_affinity_irq 

## Impact
New API

## Testing
Pass CI
