### PR TITLE
arch: arm: tlsr: Use flase_read ins of memcpy

### DIFF
--- a/arch/arm/src/tlsr82/tlsr82_flash.c
+++ b/arch/arm/src/tlsr82/tlsr82_flash.c
@@ -729,7 +729,10 @@ void tlsr82_flash_calibrate(uint32_t mid)
 {
 #if defined(CONFIG_ARCH_CHIP_TLSR8278)
 
-  uint16_t cali_data = *(uint16_t *)CONFIG_TLSR82_FLASH_CALI_PARA_ADDR;
+  uint16_t cali_data;
+
+  tlsr82_flash_read_data(CONFIG_TLSR82_FLASH_CALI_PARA_ADDR, cali_data,
+                         sizeof(cali_data));
 
   finfo("cali_data=0x%x\n");
 
@@ -769,7 +772,10 @@ void tlsr82_flash_calibrate(uint32_t mid)
 
 #elif defined(CONFIG_ARCH_CHIP_TLSR8258)
 
-  uint8_t cali_data = *(uint8_t *)CONFIG_TLSR82_FLASH_CALI_PARA_ADDR;
+  uint8_t cali_data;
+
+  tlsr82_flash_read_data(CONFIG_TLSR82_FLASH_CALI_PARA_ADDR, cali_data,
+                         sizeof(cali_data));
 
   finfo("cali_data=0x%x\n");
 


### PR DESCRIPTION
Since tlsr arch support A/B bank, the hardware support relative addr to load or store, but for flash read, must use absolute addr. also combine with flash_<*>_method.

Signed-off-by: Lingao Meng <menglingao@xiaomi.com>

## Summary

## Impact

## Testing

