### PR TITLE
poll: add poll_notify() api and call it in all drivers.

### DIFF
--- a/arch/arm/src/cxd56xx/cxd56_geofence.c
+++ b/arch/arm/src/cxd56xx/cxd56_geofence.c
@@ -433,7 +433,6 @@ static void cxd56_geofence_sighandler(uint32_t data, void *userdata)
 {
   struct cxd56_geofence_dev_s *priv =
     (struct cxd56_geofence_dev_s *)userdata;
-  int i;
   int ret;
 
   ret = nxsem_wait(&priv->devsem);
@@ -442,16 +441,7 @@ static void cxd56_geofence_sighandler(uint32_t data, void *userdata)
       return;
     }
 
-  for (i = 0; i < CONFIG_GEOFENCE_NPOLLWAITERS; i++)
-    {
-      struct pollfd *fds = priv->fds[i];
-      if (fds)
-        {
-          fds->revents |= POLLIN;
-          gnssinfo("Report events: %08" PRIx32 "\n", fds->revents);
-          nxsem_post(fds->sem);
-        }
-    }
+  poll_notify(priv->fds, CONFIG_GEOFENCE_NPOLLWAITERS, POLLIN);
 
   nxsem_post(&priv->devsem);
 }

--- a/arch/arm/src/cxd56xx/cxd56_gnss.c
+++ b/arch/arm/src/cxd56xx/cxd56_gnss.c
@@ -2318,7 +2318,6 @@ static void cxd56_gnss_default_sighandler(uint32_t data, void *userdata)
 {
   struct cxd56_gnss_dev_s *priv =
                           (struct cxd56_gnss_dev_s *)userdata;
-  int                      i;
   int                      ret;
   int                      dtype = CXD56_CPU1_GET_DATA(data);
 
@@ -2385,16 +2384,7 @@ static void cxd56_gnss_default_sighandler(uint32_t data, void *userdata)
       return;
     }
 
-  for (i = 0; i < CONFIG_CXD56_GNSS_NPOLLWAITERS; i++)
-    {
-      struct pollfd *fds = priv->fds[i];
-      if (fds)
-        {
-          fds->revents |= POLLIN;
-          gnssinfo("Report events: %08" PRIx32 "\n", fds->revents);
-          nxsem_post(fds->sem);
-        }
-    }
+  poll_notify(priv->fds, CONFIG_CXD56_GNSS_NPOLLWAITERS, POLLIN);
 
   nxsem_post(&priv->devsem);
 

--- a/arch/arm/src/sama5/sam_tsd.c
+++ b/arch/arm/src/sama5/sam_tsd.c
@@ -257,24 +257,13 @@ static struct sam_tsd_s g_tsd;
 
 static void sam_tsd_notify(struct sam_tsd_s *priv)
 {
-  int i;
-
   /* If there are threads waiting on poll() for touchscreen data to become
    * available, then wake them up now.  NOTE: we wake up all waiting threads
    * because we do not know that they are going to do.  If they all try to
    * read the data, then some make end up blocking after all.
    */
 
-  for (i = 0; i < CONFIG_SAMA5_TSD_NPOLLWAITERS; i++)
-    {
-      struct pollfd *fds = priv->fds[i];
-      if (fds)
-        {
-          fds->revents |= POLLIN;
-          iinfo("Report events: %08" PRIx32 "\n", fds->revents);
-          nxsem_post(fds->sem);
-        }
-    }
+  poll_notify(priv->fds, CONFIG_SAMA5_TSD_NPOLLWAITERS, POLLIN);
 
   /* If there are threads waiting for read data, then signal one of them
    * that the read data is available.

--- a/arch/arm/src/stm32/stm32_bbsram.c
+++ b/arch/arm/src/stm32/stm32_bbsram.c
@@ -544,11 +544,7 @@ static int stm32_bbsram_poll(struct file *filep, struct pollfd *fds,
 {
   if (setup)
     {
-      fds->revents |= (fds->events & (POLLIN | POLLOUT));
-      if (fds->revents != 0)
-        {
-          nxsem_post(fds->sem);
-        }
+      poll_notify(&fds, 1, POLLIN | POLLOUT);
     }
 
   return OK;

--- a/arch/arm/src/stm32f7/stm32_bbsram.c
+++ b/arch/arm/src/stm32f7/stm32_bbsram.c
@@ -544,11 +544,7 @@ static int stm32_bbsram_poll(struct file *filep, struct pollfd *fds,
 {
   if (setup)
     {
-      fds->revents |= (fds->events & (POLLIN | POLLOUT));
-      if (fds->revents != 0)
-        {
-          nxsem_post(fds->sem);
-        }
+      poll_notify(&fds, 1, POLLIN | POLLOUT);
     }
 
   return OK;

--- a/arch/arm/src/stm32h7/stm32_bbsram.c
+++ b/arch/arm/src/stm32h7/stm32_bbsram.c
@@ -591,11 +591,7 @@ static int stm32_bbsram_poll(struct file *filep, struct pollfd *fds,
 {
   if (setup)
     {
-      fds->revents |= (fds->events & (POLLIN | POLLOUT));
-      if (fds->revents != 0)
-        {
-          nxsem_post(fds->sem);
-        }
+      poll_notify(&fds, 1, POLLIN | POLLOUT);
     }
 
   return OK;

--- a/arch/renesas/src/rx65n/rx65n_sbram.c
+++ b/arch/renesas/src/rx65n/rx65n_sbram.c
@@ -488,11 +488,7 @@ static int rx65n_sbram_poll(FAR struct file *filep, FAR struct pollfd *fds,
 {
   if (setup)
     {
-      fds->revents |= (fds->events & (POLLIN | POLLOUT));
-      if (fds->revents != 0)
-        {
-          nxsem_post(fds->sem);
-        }
+      poll_notify(&fds, 1, POLLIN | POLLOUT);
     }
 
   return OK;

--- a/boards/arm/sam34/sam4l-xplained/src/sam_slcd.c
+++ b/boards/arm/sam34/sam4l-xplained/src/sam_slcd.c
@@ -1168,11 +1168,7 @@ static int slcd_poll(struct file *filep, struct pollfd *fds,
     {
       /* Data is always available to be read / Data can always be written */
 
-      fds->revents |= (fds->events & (POLLIN | POLLOUT));
-      if (fds->revents != 0)
-        {
-          nxsem_post(fds->sem);
-        }
+      poll_notify(&fds, 1, POLLIN | POLLOUT);
     }
 
   return OK;

--- a/boards/arm/stm32/stm32ldiscovery/src/stm32_lcd.c
+++ b/boards/arm/stm32/stm32ldiscovery/src/stm32_lcd.c
@@ -1502,11 +1502,7 @@ static int slcd_poll(struct file *filep, struct pollfd *fds,
     {
       /* Data is always available to be read / Data can always be written */
 
-      fds->revents |= (fds->events & (POLLIN | POLLOUT));
-      if (fds->revents != 0)
-        {
-          nxsem_post(fds->sem);
-        }
+      poll_notify(&fds, 1, POLLIN | POLLOUT);
     }
 
   return OK;

--- a/boards/mips/pic32mx/sure-pic32mx/src/pic32mx_lcd1602.c
+++ b/boards/mips/pic32mx/sure-pic32mx/src/pic32mx_lcd1602.c
@@ -1024,11 +1024,7 @@ static int lcd_poll(struct file *filep, struct pollfd *fds,
     {
       /* Data is always available to be read */
 
-      fds->revents |= (fds->events & (POLLIN | POLLOUT));
-      if (fds->revents != 0)
-        {
-          nxsem_post(fds->sem);
-        }
+      poll_notify(&fds, 1, POLLIN | POLLOUT);
     }
 
   return OK;

--- a/drivers/bch/bchdev_driver.c
+++ b/drivers/bch/bchdev_driver.c
@@ -97,11 +97,7 @@ static int bch_poll(FAR struct file *filep, FAR struct pollfd *fds,
 {
   if (setup)
     {
-      fds->revents |= (fds->events & (POLLIN | POLLOUT));
-      if (fds->revents != 0)
-        {
-          nxsem_post(fds->sem);
-        }
+      poll_notify(&fds, 1, POLLIN | POLLOUT);
     }
 
   return OK;

--- a/drivers/can/can.c
+++ b/drivers/can/can.c
@@ -100,11 +100,6 @@
 
 static int            can_takesem(FAR sem_t *sem);
 
-/* Poll helpers */
-
-static void           can_pollnotify(FAR struct can_dev_s *dev,
-                                     pollevent_t eventset);
-
 /* CAN helpers */
 
 static uint8_t        can_dlc2bytes(uint8_t dlc);
@@ -168,30 +163,6 @@ static int can_takesem(FAR sem_t *sem)
  ****************************************************************************/
 
 #define can_givesem(sem) nxsem_post(sem)
-
-/****************************************************************************
- * Name: can_pollnotify
- ****************************************************************************/
-
-static void can_pollnotify(FAR struct can_dev_s *dev, pollevent_t eventset)
-{
-  FAR struct pollfd *fds;
-  int i;
-
-  for (i = 0; i < CONFIG_CAN_NPOLLWAITERS; i++)
-    {
-      fds = dev->cd_fds[i];
-      if (fds != NULL)
-        {
-          fds->revents |= fds->events & eventset;
-          if (fds->revents != 0)
-            {
-              caninfo("Report events: %08" PRIx32 "\n", fds->revents);
-              nxsem_post(fds->sem);
-            }
-        }
-    }
-}
 
 /****************************************************************************
  * Name: can_dlc2bytes
@@ -1154,7 +1125,7 @@ static int can_poll(FAR struct file *filep, FAR struct pollfd *fds,
 
       if (ndx != dev->cd_xmit.tx_head)
         {
-          eventset |= fds->events & POLLOUT;
+          eventset |= POLLOUT;
         }
 
       can_givesem(&dev->cd_xmit.tx_sem);
@@ -1174,7 +1145,7 @@ static int can_poll(FAR struct file *filep, FAR struct pollfd *fds,
             {
               /* No need to wait, just notify the application immediately */
 
-              eventset |= fds->events & POLLIN;
+              eventset |= POLLIN;
             }
           else
             {
@@ -1182,10 +1153,7 @@ static int can_poll(FAR struct file *filep, FAR struct pollfd *fds,
             }
         }
 
-      if (eventset != 0)
-        {
-          can_pollnotify(dev, eventset);
-        }
+      poll_notify(dev->cd_fds, CONFIG_CAN_NPOLLWAITERS, eventset);
     }
   else if (fds->priv != NULL)
     {
@@ -1401,7 +1369,7 @@ int can_receive(FAR struct can_dev_s *dev, FAR struct can_hdr_s *hdr,
            * cd_recv buffer
            */
 
-          can_pollnotify(dev, POLLIN);
+          poll_notify(dev->cd_fds, CONFIG_CAN_NPOLLWAITERS, POLLIN);
 
           sval = 0;
           if (nxsem_get_value(&fifo->rx_sem, &sval) < 0)
@@ -1546,7 +1514,7 @@ int can_txdone(FAR struct can_dev_s *dev)
        * buffer
        */
 
-      can_pollnotify(dev, POLLOUT);
+      poll_notify(dev->cd_fds, CONFIG_CAN_NPOLLWAITERS, POLLOUT);
 
       /* Are there any threads waiting for space in the TX FIFO? */
 

--- a/drivers/crypto/dev_urandom.c
+++ b/drivers/crypto/dev_urandom.c
@@ -292,11 +292,7 @@ static int devurand_poll(FAR struct file *filep, FAR struct pollfd *fds,
 {
   if (setup)
     {
-      fds->revents |= (fds->events & (POLLIN | POLLOUT));
-      if (fds->revents != 0)
-        {
-          nxsem_post(fds->sem);
-        }
+      poll_notify(&fds, 1, POLLIN | POLLOUT);
     }
 
   return OK;

--- a/drivers/input/ads7843e.c
+++ b/drivers/input/ads7843e.c
@@ -279,24 +279,13 @@ static uint16_t ads7843e_sendcmd(FAR struct ads7843e_dev_s *priv,
 
 static void ads7843e_notify(FAR struct ads7843e_dev_s *priv)
 {
-  int i;
-
   /* If there are threads waiting on poll() for ADS7843E data to become
    * available, then wake them up now.  NOTE: we wake up all waiting threads
    * because we do not know that they are going to do.  If they all try to
    * read the data, then some make end up blocking after all.
    */
 
-  for (i = 0; i < CONFIG_ADS7843E_NPOLLWAITERS; i++)
-    {
-      struct pollfd *fds = priv->fds[i];
-      if (fds)
-        {
-          fds->revents |= POLLIN;
-          iinfo("Report events: %08" PRIx32 "\n", fds->revents);
-          nxsem_post(fds->sem);
-        }
-    }
+  poll_notify(priv->fds, CONFIG_ADS7843E_NPOLLWAITERS, POLLIN);
 
   /* If there are threads waiting for read data, then signal one of them
    * that the read data is available.

--- a/drivers/input/ajoystick.c
+++ b/drivers/input/ajoystick.c
@@ -223,7 +223,6 @@ static void ajoy_sample(FAR struct ajoy_upperhalf_s *priv)
   ajoy_buttonset_t press;
   ajoy_buttonset_t release;
   irqstate_t flags;
-  int i;
 
   DEBUGASSERT(priv);
   lower = priv->au_lower;
@@ -265,19 +264,8 @@ static void ajoy_sample(FAR struct ajoy_upperhalf_s *priv)
 
           /* Yes.. Notify all waiters */
 
-          for (i = 0; i < CONFIG_INPUT_AJOYSTICK_NPOLLWAITERS; i++)
-            {
-              FAR struct pollfd *fds = opriv->ao_fds[i];
-              if (fds)
-                {
-                  fds->revents |= (fds->events & POLLIN);
-                  if (fds->revents != 0)
-                    {
-                      iinfo("Report events: %08" PRIx32 "\n", fds->revents);
-                      nxsem_post(fds->sem);
-                    }
-                }
-            }
+          poll_notify(opriv->ao_fds, CONFIG_INPUT_AJOYSTICK_NPOLLWAITERS,
+                      POLLIN);
         }
 
       /* Have any signal events occurred? */
@@ -635,12 +623,7 @@ static int ajoy_poll(FAR struct file *filep, FAR struct pollfd *fds,
 
               if (opriv->ao_pollpending)
                 {
-                  fds->revents |= (fds->events & POLLIN);
-                  if (fds->revents != 0)
-                    {
-                      iinfo("Report events: %08" PRIx32 "\n", fds->revents);
-                      nxsem_post(fds->sem);
-                    }
+                  poll_notify(&fds, 1, POLLIN);
                 }
 
               break;

--- a/drivers/input/button_upper.c
+++ b/drivers/input/button_upper.c
@@ -230,7 +230,6 @@ static void btn_sample(FAR struct btn_upperhalf_s *priv)
   btn_buttonset_t change;
   btn_buttonset_t press;
   btn_buttonset_t release;
-  int i;
 
   DEBUGASSERT(priv && priv->bu_lower);
   lower = priv->bu_lower;
@@ -267,19 +266,8 @@ static void btn_sample(FAR struct btn_upperhalf_s *priv)
         {
           /* Yes.. Notify all waiters */
 
-          for (i = 0; i < CONFIG_INPUT_BUTTONS_NPOLLWAITERS; i++)
-            {
-              FAR struct pollfd *fds = opriv->bo_fds[i];
-              if (fds)
-                {
-                  fds->revents |= (fds->events & POLLIN);
-                  if (fds->revents != 0)
-                    {
-                      iinfo("Report events: %08" PRIx32 "\n", fds->revents);
-                      nxsem_post(fds->sem);
-                    }
-                }
-            }
+          poll_notify(opriv->bo_fds, CONFIG_INPUT_BUTTONS_NPOLLWAITERS,
+                      POLLIN);
         }
 
       /* Have any signal events occurred? */
@@ -687,12 +675,7 @@ static int btn_poll(FAR struct file *filep, FAR struct pollfd *fds,
 
               if (opriv->bo_pending)
                 {
-                  fds->revents |= (fds->events & POLLIN);
-                  if (fds->revents != 0)
-                    {
-                      iinfo("Report events: %08" PRIx32 "\n", fds->revents);
-                      nxsem_post(fds->sem);
-                    }
+                  poll_notify(&fds, 1, POLLIN);
                 }
 
               break;

--- a/drivers/input/djoystick.c
+++ b/drivers/input/djoystick.c
@@ -223,7 +223,6 @@ static void djoy_sample(FAR struct djoy_upperhalf_s *priv)
   djoy_buttonset_t press;
   djoy_buttonset_t release;
   irqstate_t flags;
-  int i;
 
   DEBUGASSERT(priv);
   lower = priv->du_lower;
@@ -265,19 +264,8 @@ static void djoy_sample(FAR struct djoy_upperhalf_s *priv)
 
           /* Yes.. Notify all waiters */
 
-          for (i = 0; i < CONFIG_INPUT_DJOYSTICK_NPOLLWAITERS; i++)
-            {
-              FAR struct pollfd *fds = opriv->do_fds[i];
-              if (fds)
-                {
-                  fds->revents |= (fds->events & POLLIN);
-                  if (fds->revents != 0)
-                    {
-                      iinfo("Report events: %08" PRIx32 "\n", fds->revents);
-                      nxsem_post(fds->sem);
-                    }
-                }
-            }
+          poll_notify(opriv->do_fds, CONFIG_INPUT_DJOYSTICK_NPOLLWAITERS,
+                      POLLIN);
         }
 
       /* Have any signal events occurred? */
@@ -629,12 +617,7 @@ static int djoy_poll(FAR struct file *filep, FAR struct pollfd *fds,
 
               if (opriv->do_pollpending)
                 {
-                  fds->revents |= (fds->events & POLLIN);
-                  if (fds->revents != 0)
-                    {
-                      iinfo("Report events: %08" PRIx32 "\n", fds->revents);
-                      nxsem_post(fds->sem);
-                    }
+                  poll_notify(&fds, 1, POLLIN);
                 }
 
               break;

--- a/drivers/input/ft5x06.c
+++ b/drivers/input/ft5x06.c
@@ -201,24 +201,13 @@ static const uint8_t g_event_map[4] =
 
 static void ft5x06_notify(FAR struct ft5x06_dev_s *priv)
 {
-  int i;
-
   /* If there are threads waiting on poll() for FT5x06 data to become
    * available, then wake them up now.  NOTE: we wake up all waiting threads
    * because we do not know that they are going to do.  If they all try to
    * read the data, then some make end up blocking after all.
    */
 
-  for (i = 0; i < CONFIG_FT5X06_NPOLLWAITERS; i++)
-    {
-      struct pollfd *fds = priv->fds[i];
-      if (fds)
-        {
-          fds->revents |= POLLIN;
-          iinfo("Report events: %08" PRIx32 "\n", fds->revents);
-          nxsem_post(fds->sem);
-        }
-    }
+  poll_notify(priv->fds, CONFIG_FT5X06_NPOLLWAITERS, POLLIN);
 
   /* If there are threads waiting for read data, then signal one of them
    * that the read data is available.

--- a/drivers/input/max11802.c
+++ b/drivers/input/max11802.c
@@ -236,24 +236,13 @@ static uint16_t max11802_sendcmd(FAR struct max11802_dev_s *priv,
 
 static void max11802_notify(FAR struct max11802_dev_s *priv)
 {
-  int i;
-
   /* If there are threads waiting on poll() for MAX11802 data to become
    * available, then wake them up now.  NOTE: we wake up all waiting
    * threads because we do not know that they are going to do.  If they
    * all try to read the data, then some make end up blocking after all.
    */
 
-  for (i = 0; i < CONFIG_MAX11802_NPOLLWAITERS; i++)
-    {
-      struct pollfd *fds = priv->fds[i];
-      if (fds)
-        {
-          fds->revents |= POLLIN;
-          iinfo("Report events: %08" PRIx32 "\n", fds->revents);
-          nxsem_post(fds->sem);
-        }
-    }
+  poll_notify(priv->fds, CONFIG_MAX11802_NPOLLWAITERS, POLLIN);
 
   /* If there are threads waiting for read data, then signal one of them
    * that the read data is available.

--- a/drivers/input/mxt.c
+++ b/drivers/input/mxt.c
@@ -584,24 +584,13 @@ static int mxt_flushmsgs(FAR struct mxt_dev_s *priv)
 
 static void mxt_notify(FAR struct mxt_dev_s *priv)
 {
-  int i;
-
   /* If there are threads waiting on poll() for maXTouch data to become
    * available, then wake them up now.  NOTE: we wake up all waiting threads
    * because we do not know that they are going to do.  If they all try to
    * read the data, then some make end up blocking after all.
    */
 
-  for (i = 0; i < CONFIG_MXT_NPOLLWAITERS; i++)
-    {
-      struct pollfd *fds = priv->fds[i];
-      if (fds)
-        {
-          fds->revents |= POLLIN;
-          iinfo("Report events: %08" PRIx32 "\n", fds->revents);
-          nxsem_post(fds->sem);
-        }
-    }
+  poll_notify(priv->fds, CONFIG_MXT_NPOLLWAITERS, POLLIN);
 
   /* If there are threads waiting for read data, then signal one of them
    * that the read data is available.

--- a/drivers/input/spq10kbd.c
+++ b/drivers/input/spq10kbd.c
@@ -441,29 +441,6 @@ static int spq10kbd_interrupt(int irq, FAR void *context, FAR void *arg)
 }
 
 /****************************************************************************
- * Name: spq10kbd_pollnotify
- ****************************************************************************/
-
-static void spq10kbd_pollnotify(FAR struct spq10kbd_dev_s *priv)
-{
-  int i;
-
-  for (i = 0; i < CONFIG_SPQ10KBD_NPOLLWAITERS; i++)
-    {
-      struct pollfd *fds = priv->fds[i];
-      if (fds)
-        {
-          fds->revents |= (fds->events & POLLIN);
-          if (fds->revents != 0)
-            {
-              uinfo("Report events: %08" PRIx32 "\n", fds->revents);
-              nxsem_post(fds->sem);
-            }
-        }
-    }
-}
-
-/****************************************************************************
  * Name: spq10kbd_open
  *
  * Description:
@@ -676,7 +653,7 @@ static int spq10kbd_poll(FAR struct file *filep, FAR struct pollfd *fds,
 
       if (priv->headndx != priv->tailndx)
         {
-          spq10kbd_pollnotify(priv);
+          poll_notify(priv->fds, CONFIG_SPQ10KBD_NPOLLWAITERS, POLLIN);
         }
     }
   else

--- a/drivers/input/stmpe811_tsc.c
+++ b/drivers/input/stmpe811_tsc.c
@@ -145,24 +145,13 @@ static const struct file_operations g_stmpe811fops =
 
 static void stmpe811_notify(FAR struct stmpe811_dev_s *priv)
 {
-  int i;
-
   /* If there are threads waiting on poll() for STMPE811 data to become
    * available, then wake them up now.  NOTE: we wake up all waiting threads
    * because we do not know that they are going to do.  If they all try to
    * read the data, then some make end up blocking after all.
    */
 
-  for (i = 0; i < CONFIG_STMPE811_NPOLLWAITERS; i++)
-    {
-      struct pollfd *fds = priv->fds[i];
-      if (fds)
-        {
-          fds->revents |= POLLIN;
-          iinfo("Report events: %08" PRIx32 "\n", fds->revents);
-          nxsem_post(fds->sem);
-        }
-    }
+  poll_notify(priv->fds, CONFIG_STMPE811_NPOLLWAITERS, POLLIN);
 
   /* If there are threads waiting for read data, then signal one of them
    * that the read data is available.

--- a/drivers/input/tsc2007.c
+++ b/drivers/input/tsc2007.c
@@ -237,24 +237,13 @@ static struct tsc2007_dev_s *g_tsc2007list;
 
 static void tsc2007_notify(FAR struct tsc2007_dev_s *priv)
 {
-  int i;
-
   /* If there are threads waiting on poll() for TSC2007 data to become
    * available, then wake them up now.  NOTE: we wake up all waiting
    * threads because we do not know that they are going to do.  If they
    * all try to read the data, then some make end up blocking after all.
    */
 
-  for (i = 0; i < CONFIG_TSC2007_NPOLLWAITERS; i++)
-    {
-      struct pollfd *fds = priv->fds[i];
-      if (fds)
-        {
-          fds->revents |= POLLIN;
-          iinfo("Report events: %08" PRIx32 "\n", fds->revents);
-          nxsem_post(fds->sem);
-        }
-    }
+  poll_notify(priv->fds, CONFIG_TSC2007_NPOLLWAITERS, POLLIN);
 
   /* If there are threads waiting for read data, then signal one of them
    * that the read data is available.

--- a/drivers/lcd/pcf8574_lcd_backpack.c
+++ b/drivers/lcd/pcf8574_lcd_backpack.c
@@ -1558,11 +1558,7 @@ static int pcf8574_lcd_poll(FAR struct file *filep, FAR struct pollfd *fds,
     {
       /* Data is always available to be read */
 
-      fds->revents |= (fds->events & (POLLIN | POLLOUT));
-      if (fds->revents != 0)
-        {
-          nxsem_post(fds->sem);
-        }
+      poll_notify(&fds, 1, POLLIN | POLLOUT);
     }
 
   return OK;

--- a/drivers/lcd/tda19988.c
+++ b/drivers/lcd/tda19988.c
@@ -1180,11 +1180,7 @@ static int tda19988_poll(FAR struct file *filep, FAR struct pollfd *fds,
 
   if (setup)
     {
-      fds->revents |= (fds->events & (POLLIN | POLLOUT));
-      if (fds->revents != 0)
-        {
-          nxsem_post(fds->sem);
-        }
+      poll_notify(&fds, 1, POLLIN | POLLOUT);
     }
 
   nxsem_post(&priv->exclsem);

--- a/drivers/misc/dev_null.c
+++ b/drivers/misc/dev_null.c
@@ -105,11 +105,7 @@ static int devnull_poll(FAR struct file *filep, FAR struct pollfd *fds,
 
   if (setup)
     {
-      fds->revents |= (fds->events & (POLLIN | POLLOUT));
-      if (fds->revents != 0)
-        {
-          nxsem_post(fds->sem);
-        }
+      poll_notify(&fds, 1, POLLIN | POLLOUT);
     }
 
   return OK;

--- a/drivers/misc/dev_zero.c
+++ b/drivers/misc/dev_zero.c
@@ -104,11 +104,7 @@ static int devzero_poll(FAR struct file *filep, FAR struct pollfd *fds,
 
   if (setup)
     {
-      fds->revents |= (fds->events & (POLLIN | POLLOUT));
-      if (fds->revents != 0)
-        {
-          nxsem_post(fds->sem);
-        }
+      poll_notify(&fds, 1, POLLIN | POLLOUT);
     }
 
   return OK;

--- a/drivers/modem/u-blox.c
+++ b/drivers/modem/u-blox.c
@@ -260,11 +260,7 @@ static int ubxmdm_poll(FAR struct file * filep,
 {
   if (setup)
     {
-      fds->revents |= (fds->events & (POLLIN | POLLOUT));
-      if (fds->revents != 0)
-        {
-          nxsem_post(fds->sem);
-        }
+      poll_notify(&fds, 1, POLLIN | POLLOUT);
     }
 
   return OK;

--- a/drivers/mtd/mtd_config.c
+++ b/drivers/mtd/mtd_config.c
@@ -1713,11 +1713,7 @@ static int mtdconfig_poll(FAR struct file *filep, FAR struct pollfd *fds,
 {
   if (setup)
     {
-      fds->revents |= (fds->events & (POLLIN | POLLOUT));
-      if (fds->revents != 0)
-        {
-          nxsem_post(fds->sem);
-        }
+      poll_notify(&fds, 1, POLLIN | POLLOUT);
     }
 
   return OK;

--- a/drivers/mtd/mtd_config_fs.c
+++ b/drivers/mtd/mtd_config_fs.c
@@ -1985,11 +1985,7 @@ static int mtdconfig_poll(FAR struct file *filep, FAR struct pollfd *fds,
 {
   if (setup)
     {
-      fds->revents |= fds->events & (POLLIN | POLLOUT);
-      if (fds->revents != 0)
-        {
-          nxsem_post(fds->sem);
-        }
+      poll_notify(&fds, 1, POLLIN | POLLOUT);
     }
 
   return OK;

--- a/drivers/net/telnet.c
+++ b/drivers/net/telnet.c
@@ -1247,11 +1247,7 @@ static int telnet_poll(FAR struct file *filep, FAR struct pollfd *fds,
     {
       /* Yes.. then signal the poll logic */
 
-      fds->revents |= (POLLRDNORM & fds->events);
-      if (fds->revents)
-        {
-          nxsem_post(fds->sem);
-        }
+      poll_notify(&fds, 1, POLLRDNORM);
     }
 
   /* Then let psock_poll() do the heavy lifting */

--- a/drivers/net/tun.c
+++ b/drivers/net/tun.c
@@ -295,13 +295,7 @@ static void tun_pollnotify(FAR struct tun_device_s *priv,
       return;
     }
 
-  eventset &= fds->events;
-
-  if (eventset != 0)
-    {
-      fds->revents |= eventset;
-      nxsem_post(fds->sem);
-    }
+  poll_notify(&fds, 1, eventset);
 }
 
 /****************************************************************************
@@ -1261,7 +1255,7 @@ int tun_poll(FAR struct file *filep, FAR struct pollfd *fds, bool setup)
 
       if (priv->write_d_len == 0)
         {
-          eventset |= (fds->events & POLLOUT);
+          eventset |= POLLOUT;
         }
 
       /* The write buffer sometimes could be used for TX.
@@ -1270,13 +1264,10 @@ int tun_poll(FAR struct file *filep, FAR struct pollfd *fds, bool setup)
 
       if (priv->read_d_len != 0 || priv->write_d_len != 0)
         {
-          eventset |= (fds->events & POLLIN);
+          eventset |= POLLIN;
         }
 
-      if (eventset)
-        {
-          tun_pollnotify(priv, eventset);
-        }
+      tun_pollnotify(priv, eventset);
     }
   else
     {

--- a/drivers/power/battery/battery_charger.c
+++ b/drivers/power/battery/battery_charger.c
@@ -122,12 +122,7 @@ static int battery_charger_notify(FAR struct battery_charger_priv_s *priv,
   priv->mask |= mask;
   if (priv->mask)
     {
-      fd->revents |= POLLIN;
-      nxsem_get_value(fd->sem, &semcnt);
-      if (semcnt < 1)
-        {
-          nxsem_post(fd->sem);
-        }
+      poll_notify(&fd, 1, POLLIN);
 
       nxsem_get_value(&priv->wait, &semcnt);
       if (semcnt < 1)

--- a/drivers/power/battery/battery_gauge.c
+++ b/drivers/power/battery/battery_gauge.c
@@ -124,12 +124,7 @@ static int battery_gauge_notify(FAR struct battery_gauge_priv_s *priv,
   priv->mask |= mask;
   if (priv->mask)
     {
-      fd->revents |= POLLIN;
-      nxsem_get_value(fd->sem, &semcnt);
-      if (semcnt < 1)
-        {
-          nxsem_post(fd->sem);
-        }
+      poll_notify(&fd, 1, POLLIN);
 
       nxsem_get_value(&priv->wait, &semcnt);
       if (semcnt < 1)

--- a/drivers/power/battery/battery_monitor.c
+++ b/drivers/power/battery/battery_monitor.c
@@ -123,12 +123,7 @@ static int battery_monitor_notify(FAR struct battery_monitor_priv_s *priv,
   priv->mask |= mask;
   if (priv->mask)
     {
-      fd->revents |= POLLIN;
-      nxsem_get_value(fd->sem, &semcnt);
-      if (semcnt < 1)
-        {
-          nxsem_post(fd->sem);
-        }
+      poll_notify(&fd, 1, POLLIN);
 
       nxsem_get_value(&priv->wait, &semcnt);
       if (semcnt < 1)

--- a/drivers/sensors/hts221.c
+++ b/drivers/sensors/hts221.c
@@ -1054,30 +1054,6 @@ static bool hts221_sample(FAR struct hts221_dev_s *priv)
   return status.is_humid_ready || status.is_temp_ready;
 }
 
-static void hts221_notify(FAR struct hts221_dev_s *priv)
-{
-  DEBUGASSERT(priv != NULL);
-
-  int i;
-
-  /* If there are threads waiting on poll() for data to become available,
-   * then wake them up now.  NOTE: we wake up all waiting threads because we
-   * do not know that they are going to do.  If they all try to read the
-   * data, then some make end up blocking after all.
-   */
-
-  for (i = 0; i < CONFIG_HTS221_NPOLLWAITERS; i++)
-    {
-      FAR struct pollfd *fds = priv->fds[i];
-      if (fds)
-        {
-          fds->revents |= POLLIN;
-          hts221_dbg("Report events: %08" PRIx32 "\n", fds->revents);
-          nxsem_post(fds->sem);
-        }
-    }
-}
-
 static int hts221_poll(FAR struct file *filep, FAR struct pollfd *fds,
                        bool setup)
 {
@@ -1139,7 +1115,7 @@ static int hts221_poll(FAR struct file *filep, FAR struct pollfd *fds,
       flags = enter_critical_section();
       if (priv->int_pending || hts221_sample(priv))
         {
-          hts221_notify(priv);
+          poll_notify(priv->fds, CONFIG_HTS221_NPOLLWAITERS, POLLIN);
         }
 
       leave_critical_section(flags);
@@ -1170,7 +1146,7 @@ static int hts221_int_handler(int irq, FAR void *context, FAR void *arg)
 
   priv->int_pending = true;
   hts221_dbg("Hts221 interrupt\n");
-  hts221_notify(priv);
+  poll_notify(priv->fds, CONFIG_HTS221_NPOLLWAITERS, POLLIN);
 
   return OK;
 }

--- a/drivers/sensors/max44009.c
+++ b/drivers/sensors/max44009.c
@@ -769,9 +769,7 @@ static void max44009_notify(FAR struct max44009_dev_s *priv)
       FAR struct pollfd *fds = priv->fds[i];
       if (fds)
         {
-          fds->revents |= POLLIN;
-          max44009_dbg("Report events: %08" PRIx32 "\n", fds->revents);
-          nxsem_post(fds->sem);
+          poll_notify(&fds, 1, POLLIN);
           priv->int_pending = false;
         }
     }

--- a/drivers/sensors/sensor.c
+++ b/drivers/sensors/sensor.c
@@ -488,28 +488,12 @@ static ssize_t sensor_do_samples(FAR struct sensor_upperhalf_s *upper,
 static void sensor_pollnotify_one(FAR struct sensor_user_s *user,
                                   pollevent_t eventset)
 {
-  int semcount;
-
   if (eventset == POLLPRI)
     {
       user->changed = true;
     }
 
-  if (!user->fds)
-    {
-      return;
-    }
-
-  user->fds->revents |= (user->fds->events & eventset);
-  if (user->fds->revents != 0)
-    {
-      sninfo("Report events: %08" PRIx32 "\n", user->fds->revents);
-      nxsem_get_value(user->fds->sem, &semcount);
-      if (semcount < 1)
-        {
-          nxsem_post(user->fds->sem);
-        }
-    }
+  poll_notify(&user->fds, 1, eventset);
 }
 
 static void sensor_pollnotify(FAR struct sensor_upperhalf_s *upper,
@@ -899,31 +883,28 @@ static int sensor_poll(FAR struct file *filep,
 
           if (filep->f_oflags & O_NONBLOCK)
             {
-              eventset |= (fds->events & POLLIN);
+              eventset |= POLLIN;
             }
           else
             {
               nxsem_get_value(&user->buffersem, &semcount);
               if (semcount > 0)
                 {
-                  eventset |= (fds->events & POLLIN);
+                  eventset |= POLLIN;
                 }
             }
         }
       else if (sensor_is_updated(upper, user))
         {
-          eventset |= (fds->events & POLLIN);
+          eventset |= POLLIN;
         }
 
       if (user->changed)
         {
-          eventset |= (fds->events & POLLPRI);
+          eventset |= POLLPRI;
         }
 
-      if (eventset)
-        {
-          sensor_pollnotify_one(user, eventset);
-        }
+        sensor_pollnotify_one(user, eventset);
     }
   else
     {

--- a/drivers/syslog/ramlog.c
+++ b/drivers/syslog/ramlog.c
@@ -199,7 +199,6 @@ static int ramlog_readnotify(FAR struct ramlog_dev_s *priv)
 static void ramlog_pollnotify(FAR struct ramlog_dev_s *priv,
                               pollevent_t eventset)
 {
-  FAR struct pollfd *fds;
   irqstate_t flags;
   int i;
 
@@ -208,16 +207,7 @@ static void ramlog_pollnotify(FAR struct ramlog_dev_s *priv,
   for (i = 0; i < CONFIG_RAMLOG_NPOLLWAITERS; i++)
     {
       flags = enter_critical_section();
-      fds = priv->rl_fds[i];
-      if (fds)
-        {
-          fds->revents |= (fds->events & eventset);
-          if (fds->revents != 0)
-            {
-              nxsem_post(fds->sem);
-            }
-        }
-
+      poll_notify(&priv->rl_fds[i], 1, eventset);
       leave_critical_section(flags);
     }
 }
@@ -741,10 +731,7 @@ static int ramlog_file_poll(FAR struct file *filep, FAR struct pollfd *fds,
 
       leave_critical_section(flags);
 
-      if (eventset)
-        {
-          ramlog_pollnotify(priv, eventset);
-        }
+      ramlog_pollnotify(priv, eventset);
     }
   else if (fds->priv)
     {

--- a/drivers/usbhost/usbhost_hidmouse.c
+++ b/drivers/usbhost/usbhost_hidmouse.c
@@ -292,10 +292,6 @@ static int usbhost_takesem(FAR sem_t *sem);
 static void usbhost_forcetake(FAR sem_t *sem);
 #define usbhost_givesem(s) nxsem_post(s);
 
-/* Polling support */
-
-static void usbhost_pollnotify(FAR struct usbhost_state_s *dev);
-
 /* Memory allocation services */
 
 static inline FAR struct usbhost_state_s *usbhost_allocclass(void);
@@ -465,29 +461,6 @@ static void usbhost_forcetake(FAR sem_t *sem)
       DEBUGASSERT(ret == OK || ret == -ECANCELED);
     }
   while (ret < 0);
-}
-
-/****************************************************************************
- * Name: usbhost_pollnotify
- ****************************************************************************/
-
-static void usbhost_pollnotify(FAR struct usbhost_state_s *priv)
-{
-  int i;
-
-  for (i = 0; i < CONFIG_HIDMOUSE_NPOLLWAITERS; i++)
-    {
-      struct pollfd *fds = priv->fds[i];
-      if (fds)
-        {
-          fds->revents |= (fds->events & POLLIN);
-          if (fds->revents != 0)
-            {
-              uinfo("Report events: %08" PRIx32 "\n", fds->revents);
-              nxsem_post(fds->sem);
-            }
-        }
-    }
 }
 
 /****************************************************************************
@@ -677,8 +650,6 @@ static void usbhost_destroy(FAR void *arg)
 
 static void usbhost_notify(FAR struct usbhost_state_s *priv)
 {
-  int i;
-
   /* If there are threads waiting for read data, then signal one of them
    * that the read data is available.
    */
@@ -694,16 +665,7 @@ static void usbhost_notify(FAR struct usbhost_state_s *priv)
    * all try to read the data, then some make end up blocking after all.
    */
 
-  for (i = 0; i < CONFIG_HIDMOUSE_NPOLLWAITERS; i++)
-    {
-      struct pollfd *fds = priv->fds[i];
-      if (fds)
-        {
-          fds->revents |= POLLIN;
-          iinfo("Report events: %08" PRIx32 "\n", fds->revents);
-          nxsem_post(fds->sem);
-        }
-    }
+  poll_notify(priv->fds, CONFIG_HIDMOUSE_NPOLLWAITERS, POLLIN);
 }
 
 /****************************************************************************
@@ -2558,7 +2520,7 @@ static int usbhost_poll(FAR struct file *filep, FAR struct pollfd *fds,
 
       if (priv->valid)
         {
-          usbhost_pollnotify(priv);
+          poll_notify(priv->fds, CONFIG_HIDMOUSE_NPOLLWAITERS, POLLIN);
         }
     }
   else

--- a/drivers/usbhost/usbhost_xboxcontroller.c
+++ b/drivers/usbhost/usbhost_xboxcontroller.c
@@ -561,8 +561,6 @@ static void usbhost_destroy(FAR void *arg)
 
 static void usbhost_pollnotify(FAR struct usbhost_state_s *priv)
 {
-  int i;
-
   /* If there are threads waiting for read data, then signal one of them
    * that the read data is available.
    */
@@ -578,16 +576,7 @@ static void usbhost_pollnotify(FAR struct usbhost_state_s *priv)
    * read the data, then some make end up blocking after all.
    */
 
-  for (i = 0; i < CONFIG_XBOXCONTROLLER_NPOLLWAITERS; i++)
-    {
-      FAR struct pollfd *fds = priv->fds[i];
-      if (fds)
-        {
-          fds->revents |= POLLIN;
-          iinfo("Report events: %08" PRIx32 "\n", fds->revents);
-          nxsem_post(fds->sem);
-        }
-    }
+  poll_notify(priv->fds, CONFIG_XBOXCONTROLLER_NPOLLWAITERS, POLLIN);
 }
 
 /****************************************************************************

--- a/drivers/wireless/cc1101.c
+++ b/drivers/wireless/cc1101.c
@@ -92,6 +92,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <fcntl.h>
+#include <poll.h>
 #include <assert.h>
 #include <errno.h>
 #include <debug.h>
@@ -638,8 +639,7 @@ static int cc1101_file_poll(FAR struct file *filep, FAR struct pollfd *fds,
       cc1101_takesem(&dev->sem_rx_buffer);
       if (dev->fifo_len > 0)
         {
-          dev->pfd->revents |= POLLIN; /* Data available for input */
-          nxsem_post(dev->pfd->sem);
+          poll_notify(&dev->pfd, 1, POLLIN);
         }
 
       nxsem_post(&dev->sem_rx_buffer);
@@ -1540,9 +1540,7 @@ void cc1101_isr_process(FAR void *arg)
 
           if (dev->pfd)
             {
-              dev->pfd->revents |= POLLIN; /* Data available for input */
-              wlinfo("Wake up polled fd\n");
-              nxsem_post(dev->pfd->sem);
+              poll_notify(&dev->pfd, 1, POLLIN);
             }
         }
         break;

--- a/drivers/wireless/gs2200m.c
+++ b/drivers/wireless/gs2200m.c
@@ -423,8 +423,7 @@ static void _notif_q_push(FAR struct gs2200m_dev_s *dev, char cid)
     {
       /* If poll() waits and cid has been pushed to the queue, notify  */
 
-      dev->pfd->revents |= POLLIN;
-      nxsem_post(dev->pfd->sem);
+      poll_notify(&dev->pfd, 1, POLLIN);
     }
 
   wlinfo("+++ pushed %c count=%d\n", cid, dev->notif_q.count);
@@ -3187,9 +3186,7 @@ static int gs2200m_poll(FAR struct file *filep, FAR struct pollfd *fds,
 
       if (0 < n)
         {
-          dev->pfd->revents |= POLLIN;
-          nxsem_post(dev->pfd->sem);
-          wlinfo("==== _notif_q_count=%d\n", n);
+          poll_notify(&dev->pfd, 1, POLLIN);
         }
     }
   else

--- a/drivers/wireless/lpwan/sx127x/sx127x.c
+++ b/drivers/wireless/lpwan/sx127x/sx127x.c
@@ -1229,8 +1229,7 @@ static int sx127x_poll(FAR struct file *filep, FAR struct pollfd *fds,
         {
           /* Data available for input */
 
-          dev->pfd->revents |= POLLIN;
-          nxsem_post(dev->pfd->sem);
+          poll_notify(&dev->pfd, 1, POLLIN);
         }
 
       nxsem_post(&dev->rx_buffer_sem);
@@ -1313,10 +1312,7 @@ static int sx127x_lora_isr0_process(FAR struct sx127x_dev_s *dev)
                     {
                       /* Data available for input */
 
-                      dev->pfd->revents |= POLLIN;
-
-                      wlinfo("Wake up polled fd\n");
-                      nxsem_post(dev->pfd->sem);
+                      poll_notify(&dev->pfd, 1, POLLIN);
                     }
 
                   /* Wake-up any thread waiting in recv */
@@ -1448,10 +1444,7 @@ static int sx127x_fskook_isr0_process(FAR struct sx127x_dev_s *dev)
                     {
                       /* Data available for input */
 
-                      dev->pfd->revents |= POLLIN;
-
-                      wlinfo("Wake up polled fd\n");
-                      nxsem_post(dev->pfd->sem);
+                      poll_notify(&dev->pfd, 1, POLLIN);
                     }
 
                   /* Wake-up any thread waiting in recv */

--- a/drivers/wireless/nrf24l01.c
+++ b/drivers/wireless/nrf24l01.c
@@ -714,10 +714,7 @@ static void nrf24l01_worker(FAR void *arg)
 
       if (dev->pfd && has_data)
         {
-          dev->pfd->revents |= POLLIN;  /* Data available for input */
-
-          wlinfo("Wake up polled fd\n");
-          nxsem_post(dev->pfd->sem);
+          poll_notify(&dev->pfd, 1, POLLIN);
         }
 
       /* Clear interrupt sources */
@@ -1410,8 +1407,7 @@ static int nrf24l01_poll(FAR struct file *filep, FAR struct pollfd *fds,
       nxsem_wait(&dev->sem_fifo);
       if (dev->fifo_len > 0)
         {
-          dev->pfd->revents |= POLLIN;  /* Data available for input */
-          nxsem_post(dev->pfd->sem);
+          poll_notify(&dev->pfd, 1, POLLIN);
         }
 
       nxsem_post(&dev->sem_fifo);

--- a/fs/mqueue/mq_open.c
+++ b/fs/mqueue/mq_open.c
@@ -127,18 +127,15 @@ static int nxmq_file_poll(FAR struct file *filep,
 
       if (msgq->nmsgs < msgq->maxmsgs)
         {
-          eventset |= (fds->events & POLLOUT);
+          eventset |= POLLOUT;
         }
 
       if (msgq->nmsgs)
         {
-          eventset |= (fds->events & POLLIN);
+          eventset |= POLLIN;
         }
 
-      if (eventset)
-        {
-          nxmq_pollnotify(msgq, eventset);
-        }
+      nxmq_pollnotify(msgq, eventset);
     }
   else if (fds->priv != NULL)
     {
@@ -369,34 +366,6 @@ static mqd_t nxmq_vopen(FAR const char *mq_name, int oflags, va_list ap)
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
-
-#if CONFIG_FS_MQUEUE_NPOLLWAITERS > 0
-void nxmq_pollnotify(FAR struct mqueue_inode_s *msgq, pollevent_t eventset)
-{
-  int i;
-
-  for (i = 0; i < CONFIG_FS_MQUEUE_NPOLLWAITERS; i++)
-    {
-      FAR struct pollfd *fds = msgq->fds[i];
-
-      if (fds)
-        {
-          fds->revents |= (fds->events & eventset);
-
-          if (fds->revents != 0)
-            {
-              int semcount;
-
-              nxsem_get_value(fds->sem, &semcount);
-              if (semcount < 1)
-                {
-                  nxsem_post(fds->sem);
-                }
-            }
-        }
-    }
-}
-#endif
 
 /****************************************************************************
  * Name: file_mq_open

--- a/fs/vfs/fs_epoll.c
+++ b/fs/vfs/fs_epoll.c
@@ -367,8 +367,7 @@ int epoll_ctl(int epfd, int op, int fd, struct epoll_event *ev)
 
   if (eph->poll[0].sem)
     {
-      eph->poll[0].revents |= eph->poll[0].events;
-      nxsem_post(eph->poll[0].sem);
+      poll_notify(&eph->poll, 1, eph->poll[0].events);
     }
 
   return 0;

--- a/graphics/nxterm/nxterm_kbdin.c
+++ b/graphics/nxterm/nxterm_kbdin.c
@@ -49,7 +49,6 @@
 static void nxterm_pollnotify(FAR struct nxterm_state_s *priv,
                               pollevent_t eventset)
 {
-  FAR struct pollfd *fds;
   irqstate_t flags;
   int i;
 
@@ -58,16 +57,7 @@ static void nxterm_pollnotify(FAR struct nxterm_state_s *priv,
   for (i = 0; i < CONFIG_NXTERM_NPOLLWAITERS; i++)
     {
       flags = enter_critical_section();
-      fds   = priv->fds[i];
-      if (fds)
-        {
-          fds->revents |= (fds->events & eventset);
-          if (fds->revents != 0)
-            {
-              nxsem_post(fds->sem);
-            }
-        }
-
+      poll_notify(&priv->fds[i], 1, eventset);
       leave_critical_section(flags);
     }
 }
@@ -304,10 +294,7 @@ int nxterm_poll(FAR struct file *filep, FAR struct pollfd *fds, bool setup)
           eventset |= POLLIN;
         }
 
-      if (eventset)
-        {
-          nxterm_pollnotify(priv, eventset);
-        }
+      nxterm_pollnotify(priv, eventset);
     }
   else if (fds->priv)
     {

--- a/include/nuttx/mqueue.h
+++ b/include/nuttx/mqueue.h
@@ -79,6 +79,13 @@
 #  define _MQ_TIMEDRECEIVE(d,m,l,p,t) mq_timedreceive(d,m,l,p,t)
 #endif
 
+#if CONFIG_FS_MQUEUE_NPOLLWAITERS > 0
+# define nxmq_pollnotify(msgq, eventset) \
+  poll_notify(msgq->fds, CONFIG_FS_MQUEUE_NPOLLWAITERS, eventset)
+#else
+# define nxmq_pollnotify(msgq, eventset)
+#endif
+
 /****************************************************************************
  * Public Type Declarations
  ****************************************************************************/
@@ -403,28 +410,6 @@ void nxmq_free_msgq(FAR struct mqueue_inode_s *msgq);
 
 int nxmq_alloc_msgq(FAR struct mq_attr *attr,
                     FAR struct mqueue_inode_s **pmsgq);
-
-/****************************************************************************
- * Name: nxmq_pollnotify
- *
- * Description:
- *   pollnotify, used for notifying the poll
- *
- * Input Parameters:
- *   msgq     - Named message queue
- *   eventset - evnet
- *
- * Returned Value:
- *   The allocated and initialized message queue structure or NULL in the
- *   event of a failure.
- *
- ****************************************************************************/
-
-#if CONFIG_FS_MQUEUE_NPOLLWAITERS > 0
-void nxmq_pollnotify(FAR struct mqueue_inode_s *msgq, pollevent_t eventset);
-#else
-# define nxmq_pollnotify(msgq, eventset)
-#endif
 
 /****************************************************************************
  * Name: file_mq_open

--- a/include/sys/poll.h
+++ b/include/sys/poll.h
@@ -144,6 +144,8 @@ int ppoll(FAR struct pollfd *fds, nfds_t nfds,
           FAR const struct timespec *timeout_ts,
           FAR const sigset_t *sigmask);
 
+void poll_notify(FAR struct pollfd **afds, int nfds, pollevent_t eventset);
+
 #undef EXTERN
 #if defined(__cplusplus)
 }

--- a/net/can/can_sockif.c
+++ b/net/can/can_sockif.c
@@ -128,7 +128,7 @@ static uint16_t can_poll_eventhandler(FAR struct net_driver_s *dev,
 
       if ((flags & CAN_NEWDATA) != 0)
         {
-          eventset |= (POLLIN & info->fds->events);
+          eventset |= POLLIN;
         }
 
       /* Check for loss of connection events. */
@@ -143,16 +143,12 @@ static uint16_t can_poll_eventhandler(FAR struct net_driver_s *dev,
       else if ((flags & CAN_POLL) != 0 &&
                  psock_can_cansend(info->psock) >= 0)
         {
-          eventset |= (POLLOUT & info->fds->events);
+          eventset |= POLLOUT;
         }
 
       /* Awaken the caller of poll() is requested event occurred. */
 
-      if (eventset)
-        {
-          info->fds->revents |= eventset;
-          nxsem_post(info->fds->sem);
-        }
+      poll_notify(&info->fds, 1, eventset);
     }
 
   return flags;
@@ -542,6 +538,7 @@ static int can_poll_local(FAR struct socket *psock, FAR struct pollfd *fds,
   FAR struct can_conn_s *conn;
   FAR struct can_poll_s *info;
   FAR struct devif_callback_s *cb;
+  pollevent_t eventset = 0;
   int ret = OK;
 
   DEBUGASSERT(psock != NULL && psock->s_conn != NULL);
@@ -602,24 +599,19 @@ static int can_poll_local(FAR struct socket *psock, FAR struct pollfd *fds,
         {
           /* Normal data may be read without blocking. */
 
-          fds->revents |= (POLLRDNORM & fds->events);
+          eventset |= POLLRDNORM;
         }
 
       if (psock_can_cansend(psock) >= 0)
         {
           /* A CAN frame may be sent without blocking. */
 
-          fds->revents |= (POLLWRNORM & fds->events);
+          eventset |= POLLWRNORM;
         }
 
       /* Check if any requested events are already in effect */
 
-      if (fds->revents != 0)
-        {
-          /* Yes.. then signal the poll logic */
-
-          nxsem_post(fds->sem);
-        }
+      poll_notify(&fds, 1, eventset);
 
 errout_with_lock:
       net_unlock();

--- a/net/icmp/icmp_netpoll.c
+++ b/net/icmp/icmp_netpoll.c
@@ -97,7 +97,7 @@ static uint16_t icmp_poll_eventhandler(FAR struct net_driver_s *dev,
       eventset = 0;
       if ((flags & ICMP_NEWDATA) != 0)
         {
-          eventset |= (POLLIN & info->fds->events);
+          eventset |= POLLIN;
         }
 
       /* Check for loss of connection events. */
@@ -109,11 +109,7 @@ static uint16_t icmp_poll_eventhandler(FAR struct net_driver_s *dev,
 
       /* Awaken the caller of poll() is requested event occurred. */
 
-      if (eventset)
-        {
-          info->fds->revents |= eventset;
-          nxsem_post(info->fds->sem);
-        }
+      poll_notify(&info->fds, 1, eventset);
     }
 
   return flags;
@@ -144,6 +140,7 @@ int icmp_pollsetup(FAR struct socket *psock, FAR struct pollfd *fds)
   FAR struct icmp_conn_s *conn;
   FAR struct icmp_poll_s *info;
   FAR struct devif_callback_s *cb;
+  pollevent_t eventset = 0;
   int ret = OK;
 
   /* Some of the following must be atomic */
@@ -213,23 +210,18 @@ int icmp_pollsetup(FAR struct socket *psock, FAR struct pollfd *fds)
     {
       /* Normal data may be read without blocking. */
 
-      fds->revents |= (POLLRDNORM & fds->events);
+      eventset |= POLLRDNORM;
     }
 
   /* Always report POLLWRNORM if caller request it because we don't utilize
    * IOB buffer for sending.
    */
 
-  fds->revents |= (POLLWRNORM & fds->events);
+  eventset |= POLLWRNORM;
 
   /* Check if any requested events are already in effect */
 
-  if (fds->revents != 0)
-    {
-      /* Yes.. then signal the poll logic */
-
-      nxsem_post(fds->sem);
-    }
+  poll_notify(&fds, 1, eventset);
 
 errout_with_lock:
   net_unlock();

--- a/net/netlink/netlink.h
+++ b/net/netlink/netlink.h
@@ -73,8 +73,7 @@ struct netlink_conn_s
   /* poll() support */
 
   int key;                           /* used to cancel notifications */
-  FAR sem_t *pollsem;                /* Used to wakeup poll() */
-  FAR pollevent_t *pollevent;        /* poll() wakeup event */
+  FAR struct pollfd *fds;            /* Used to wakeup poll() */
 
   /* Queued response data */
 

--- a/net/rpmsg/rpmsg_sockif.c
+++ b/net/rpmsg/rpmsg_sockif.c
@@ -205,27 +205,6 @@ static inline void rpmsg_socket_post(FAR sem_t *sem)
     }
 }
 
-static void rpmsg_socket_pollnotify(FAR struct rpmsg_socket_conn_s *conn,
-                                    pollevent_t eventset)
-{
-  int i;
-
-  for (i = 0; i < CONFIG_NET_RPMSG_NPOLLWAITERS; i++)
-    {
-      FAR struct pollfd *fds = conn->fds[i];
-
-      if (fds)
-        {
-          fds->revents |= ((fds->events | POLLERR | POLLHUP) & eventset);
-
-          if (fds->revents != 0)
-            {
-              rpmsg_socket_post(fds->sem);
-            }
-        }
-    }
-}
-
 static FAR struct rpmsg_socket_conn_s *rpmsg_socket_alloc(void)
 {
   FAR struct rpmsg_socket_conn_s *conn;
@@ -314,7 +293,7 @@ static int rpmsg_socket_ept_cb(FAR struct rpmsg_endpoint *ept,
         }
 
       rpmsg_socket_post(&conn->sendsem);
-      rpmsg_socket_pollnotify(conn, POLLOUT);
+      poll_notify(conn->fds, CONFIG_NET_RPMSG_NPOLLWAITERS, POLLOUT);
       rpmsg_socket_unlock(&conn->recvlock);
     }
   else
@@ -329,7 +308,7 @@ static int rpmsg_socket_ept_cb(FAR struct rpmsg_endpoint *ept,
       if (rpmsg_socket_get_space(conn) > 0)
         {
           rpmsg_socket_post(&conn->sendsem);
-          rpmsg_socket_pollnotify(conn, POLLOUT);
+          poll_notify(conn->fds, CONFIG_NET_RPMSG_NPOLLWAITERS, POLLOUT);
         }
 
       rpmsg_socket_unlock(&conn->sendlock);
@@ -379,7 +358,7 @@ static int rpmsg_socket_ept_cb(FAR struct rpmsg_endpoint *ept,
                   nerr("circbuf_write overflow, %zu, %zu\n", written, len);
                 }
 
-              rpmsg_socket_pollnotify(conn, POLLIN);
+              poll_notify(conn->fds, CONFIG_NET_RPMSG_NPOLLWAITERS, POLLIN);
             }
 
           rpmsg_socket_unlock(&conn->recvlock);
@@ -411,7 +390,8 @@ static inline void rpmsg_socket_destroy_ept(
       rpmsg_destroy_ept(&conn->ept);
       rpmsg_socket_post(&conn->sendsem);
       rpmsg_socket_post(&conn->recvsem);
-      rpmsg_socket_pollnotify(conn, POLLIN | POLLOUT);
+      poll_notify(conn->fds, CONFIG_NET_RPMSG_NPOLLWAITERS,
+                  POLLIN | POLLOUT);
     }
 
   rpmsg_socket_unlock(&conn->recvlock);
@@ -553,7 +533,7 @@ static void rpmsg_socket_ns_bind(FAR struct rpmsg_device *rdev,
   rpmsg_socket_ns_bound(&new->ept);
 
   rpmsg_socket_post(&server->recvsem);
-  rpmsg_socket_pollnotify(server, POLLIN);
+  poll_notify(server->fds, CONFIG_NET_RPMSG_NPOLLWAITERS, POLLIN);
 }
 
 static int rpmsg_socket_getaddr(FAR struct rpmsg_socket_conn_s *conn,
@@ -868,7 +848,7 @@ static int rpmsg_socket_poll(FAR struct socket *psock,
 
           if (conn->next)
             {
-              eventset |= (fds->events & POLLIN);
+              eventset |= POLLIN;
             }
         }
       else if (_SS_ISCONNECTED(conn->sconn.s_flags))
@@ -883,7 +863,7 @@ static int rpmsg_socket_poll(FAR struct socket *psock,
 
               if (rpmsg_socket_get_space(conn) > 0)
                 {
-                  eventset |= (fds->events & POLLOUT);
+                  eventset |= POLLOUT;
                 }
 
               rpmsg_socket_unlock(&conn->sendlock);
@@ -892,7 +872,7 @@ static int rpmsg_socket_poll(FAR struct socket *psock,
 
               if (!circbuf_is_empty(&conn->recvbuf))
                 {
-                  eventset |= (fds->events & POLLIN);
+                  eventset |= POLLIN;
                 }
 
               rpmsg_socket_unlock(&conn->recvlock);
@@ -908,10 +888,7 @@ static int rpmsg_socket_poll(FAR struct socket *psock,
           eventset |= POLLERR;
         }
 
-      if (eventset)
-        {
-          rpmsg_socket_pollnotify(conn, eventset);
-        }
+      poll_notify(conn->fds, CONFIG_NET_RPMSG_NPOLLWAITERS, eventset);
     }
   else if (fds->priv != NULL)
     {

--- a/net/tcp/tcp_netpoll.c
+++ b/net/tcp/tcp_netpoll.c
@@ -83,14 +83,14 @@ static uint16_t tcp_poll_eventhandler(FAR struct net_driver_s *dev,
 
       if ((flags & (TCP_NEWDATA | TCP_BACKLOG)) != 0)
         {
-          eventset |= POLLIN & info->fds->events;
+          eventset |= POLLIN;
         }
 
       /* Non-blocking connection */
 
       if ((flags & TCP_CONNECTED) != 0)
         {
-          eventset |= POLLOUT & info->fds->events;
+          eventset |= POLLOUT;
         }
 
       /* Check for a loss of connection events. */
@@ -154,21 +154,20 @@ static uint16_t tcp_poll_eventhandler(FAR struct net_driver_s *dev,
 #endif
               )
         {
-          eventset |= (POLLOUT & info->fds->events);
+          eventset |= POLLOUT;
         }
 
       /* Awaken the caller of poll() if requested event occurred. */
 
-      if (eventset != 0)
+      poll_notify(&info->fds, 1, eventset);
+
+      if (info->fds->revents != 0)
         {
           /* Stop further callbacks */
 
           info->cb->flags   = 0;
           info->cb->priv    = NULL;
           info->cb->event   = NULL;
-
-          info->fds->revents |= eventset;
-          nxsem_post(info->fds->sem);
         }
     }
 
@@ -200,6 +199,7 @@ int tcp_pollsetup(FAR struct socket *psock, FAR struct pollfd *fds)
   FAR struct tcp_conn_s *conn;
   FAR struct tcp_poll_s *info;
   FAR struct devif_callback_s *cb;
+  pollevent_t eventset = 0;
   bool nonblock_conn;
   int ret = OK;
 
@@ -291,7 +291,7 @@ int tcp_pollsetup(FAR struct socket *psock, FAR struct pollfd *fds)
     {
       /* Normal data may be read without blocking. */
 
-      fds->revents |= (POLLRDNORM & fds->events);
+      eventset |= POLLRDNORM;
     }
 
   /* Check for a loss of connection events.  We need to be careful here.
@@ -342,22 +342,17 @@ int tcp_pollsetup(FAR struct socket *psock, FAR struct pollfd *fds)
        * exceptional event.
        */
 
-      fds->revents |= (POLLERR | POLLHUP);
+      eventset |= POLLERR | POLLHUP;
     }
   else if (_SS_ISCONNECTED(conn->sconn.s_flags) &&
            psock_tcp_cansend(conn) >= 0)
     {
-      fds->revents |= (POLLWRNORM & fds->events);
+      eventset |= POLLWRNORM;
     }
 
   /* Check if any requested events are already in effect */
 
-  if (fds->revents != 0)
-    {
-      /* Yes.. then signal the poll logic */
-
-      nxsem_post(fds->sem);
-    }
+  poll_notify(&fds, 1, eventset);
 
 errout_with_lock:
   net_unlock();

--- a/net/udp/udp_netpoll.c
+++ b/net/udp/udp_netpoll.c
@@ -80,7 +80,7 @@ static uint16_t udp_poll_eventhandler(FAR struct net_driver_s *dev,
 
       if ((flags & UDP_NEWDATA) != 0)
         {
-          eventset |= (POLLIN & info->fds->events);
+          eventset |= POLLIN;
         }
 
       /* Check for loss of connection events. */
@@ -94,16 +94,12 @@ static uint16_t udp_poll_eventhandler(FAR struct net_driver_s *dev,
 
       else if (psock_udp_cansend(info->conn) >= 0)
         {
-          eventset |= (POLLOUT & info->fds->events);
+          eventset |= POLLOUT;
         }
 
       /* Awaken the caller of poll() is requested event occurred. */
 
-      if (eventset)
-        {
-          info->fds->revents |= eventset;
-          nxsem_post(info->fds->sem);
-        }
+      poll_notify(&info->fds, 1, eventset);
     }
 
   return flags;
@@ -134,6 +130,7 @@ int udp_pollsetup(FAR struct socket *psock, FAR struct pollfd *fds)
   FAR struct udp_conn_s *conn;
   FAR struct udp_poll_s *info;
   FAR struct devif_callback_s *cb;
+  pollevent_t eventset = 0;
   int ret = OK;
 
   /* Some of the following must be atomic */
@@ -215,24 +212,19 @@ int udp_pollsetup(FAR struct socket *psock, FAR struct pollfd *fds)
     {
       /* Normal data may be read without blocking. */
 
-      fds->revents |= (POLLRDNORM & fds->events);
+      eventset |= POLLRDNORM;
     }
 
   if (psock_udp_cansend(conn) >= 0)
     {
       /* Normal data may be sent without blocking (at least one byte). */
 
-      fds->revents |= (POLLWRNORM & fds->events);
+      eventset |= POLLWRNORM;
     }
 
   /* Check if any requested events are already in effect */
 
-  if (fds->revents != 0)
-    {
-      /* Yes.. then signal the poll logic */
-
-      nxsem_post(fds->sem);
-    }
+  poll_notify(&fds, 1, eventset);
 
 errout_with_lock:
   net_unlock();


### PR DESCRIPTION
## Summary
1. add `poll_notify()` api for poll notification;
2. call `poll_notify()` in all drivers;

This patch modify some drivers' original logic:
1. Some drivers poll notify operation do not check the `fds->events` when set the `fds->revents`, that is wrong, because the app may poll success but the `fds->revents` is not the app wants. The `poll_notify()` always check the `fds->events` before set the `fds->revents`;
2. Most drivers poll notify operation do not check the count of `fds->sem`, the `poll_nofity()` always check the count of `fds->sem`, and only post it when count < 1, because there is one and only one thread is waiting for the sem (`*fds->sem` is a local variable);
3. In `poll_notify()`, always check `POLLERR `and `POLLHUP `event, and when `POLLERR `or `POLLHUP `are set, clear the `POLLIN` and `POLLOUT `event;
4. Call `poll_notify()` to do the poll notify operation, so do not need check the `fds->events` in driver when set event to eventset (eg: `eventset |= (fds->events & POLLIN)`) (this thing has been done in `poll_notify()`) , so i remove all the check code, eg: `eventset |= (fds->events & POLLIN) ==> event |= POLLIN`;   

## Impact
Only code refactor

## Testing
Pass CI
