### PR TITLE
net/procfs: disable tcp/udp proc node if no stack available

### DIFF
--- a/net/procfs/net_procfs.c
+++ b/net/procfs/net_procfs.c
@@ -124,7 +124,7 @@ static const struct netprocfs_entry_s g_net_entries[] =
     }
   },
 #  endif
-#  ifdef CONFIG_NET_TCP
+#  if defined(CONFIG_NET_TCP) && !defined(CONFIG_NET_TCP_NO_STACK)
   {
     DTYPE_FILE, "tcp",
     {
@@ -132,7 +132,7 @@ static const struct netprocfs_entry_s g_net_entries[] =
     }
   },
 #  endif
-#  ifdef CONFIG_NET_UDP
+#  if defined(CONFIG_NET_UDP) && !defined(CONFIG_NET_UDP_NO_STACK)
   {
     DTYPE_FILE, "udp",
     {

--- a/net/procfs/net_tcp.c
+++ b/net/procfs/net_tcp.c
@@ -41,7 +41,7 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-#ifdef CONFIG_NET_TCP
+#if defined(CONFIG_NET_TCP) && !defined(CONFIG_NET_TCP_NO_STACK)
 
 #ifdef CONFIG_NET_IPv6
 #  define TCP_LINELEN 180
@@ -215,4 +215,4 @@ ssize_t netprocfs_read_tcpstats(FAR struct netprocfs_file_s *priv,
   return len;
 }
 
-#endif /* CONFIG_NET_TCP */
+#endif /* CONFIG_NET_TCP && !CONFIG_NET_TCP_NO_STACK */

--- a/net/procfs/net_udp.c
+++ b/net/procfs/net_udp.c
@@ -41,7 +41,7 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-#ifdef CONFIG_NET_UDP
+#if defined(CONFIG_NET_UDP) && !defined(CONFIG_NET_UDP_NO_STACK)
 
 #ifdef CONFIG_NET_IPv6
 #  define UDP_LINELEN 180
@@ -206,4 +206,4 @@ ssize_t netprocfs_read_udpstats(FAR struct netprocfs_file_s *priv,
   return len;
 }
 
-#endif /* CONFIG_NET_UDP */
+#endif /* CONFIG_NET_UDP && !CONFIG_NET_UDP_NO_STACK */

--- a/net/procfs/procfs.h
+++ b/net/procfs/procfs.h
@@ -182,7 +182,7 @@ ssize_t netprocfs_read_mldstats(FAR struct netprocfs_file_s *priv,
  *
  ****************************************************************************/
 
-#ifdef CONFIG_NET_TCP
+#if defined(CONFIG_NET_TCP) && !defined(CONFIG_NET_TCP_NO_STACK)
 ssize_t netprocfs_read_tcpstats(FAR struct netprocfs_file_s *priv,
                                 FAR char *buffer, size_t buflen);
 #endif
@@ -205,7 +205,7 @@ ssize_t netprocfs_read_tcpstats(FAR struct netprocfs_file_s *priv,
  *
  ****************************************************************************/
 
-#ifdef CONFIG_NET_UDP
+#if defined(CONFIG_NET_UDP) && !defined(CONFIG_NET_UDP_NO_STACK)
 ssize_t netprocfs_read_udpstats(FAR struct netprocfs_file_s *priv,
                                 FAR char *buffer, size_t buflen);
 #endif


### PR DESCRIPTION
## Summary

net/procfs: disable tcp/udp proc node if no stack available

```
CC:  procfs/net_tcp.c
procfs/net_tcp.c: In function ‘netprocfs_tcpstats’:
procfs/net_tcp.c:74:18: warning: implicit declaration of function ‘tcp_nextconn’ [-Wimplicit-function-declaration]
   74 |   while ((conn = tcp_nextconn(conn)) != NULL)
      |                  ^~~~~~~~~~~~
procfs/net_tcp.c:74:16: warning: assignment to ‘struct tcp_conn_s *’ from ‘int’ makes pointer from integer without a cast [-Wint-conversion]
   74 |   while ((conn = tcp_nextconn(conn)) != NULL)
      |                ^
procfs/net_tcp.c:98:24: error: invalid use of undefined type ‘struct tcp_conn_s’
   98 |           laddr = &conn->u.ipv4.laddr;
      |                        ^~
```


## Impact

N/A

## Testing

enable usrsock and bypass the tcp/udp stack

CONFIG_NET_USRSOCK_OTHER=y
CONFIG_NET_USRSOCK_TCP=y
CONFIG_NET_USRSOCK_UDP=y
CONFIG_NET_TCP_NO_STACK=y
CONFIG_NET_UDP_NO_STACK=y

enable net statistics

CONFIG_NET_STATISTICS=y