### PR TITLE
mm/ubsan: UBSan option should be turned on if SIM_UBSAN enabled

### DIFF
--- a/mm/Kconfig
+++ b/mm/Kconfig
@@ -224,7 +224,7 @@ config MM_UBSAN_ALL
 
 config MM_UBSAN_OPTION
 	string "UBSan options"
-	depends on MM_UBSAN
+	depends on MM_UBSAN || SIM_UBSAN
 	default "-fsanitize=undefined"
 	---help---
 		This option activates specified UBSan instrumentation. Please


### PR DESCRIPTION
## Summary

mm/ubsan: UBSan option should be turned on if SIM_UBSAN enabled

## Impact

N/A

## Testing

enable CONFIG_SIM_UBSAN