### PR TITLE
net/wireless: add support for netdev private ioctl

### DIFF
--- a/include/nuttx/fs/ioctl.h
+++ b/include/nuttx/fs/ioctl.h
@@ -89,6 +89,8 @@
 #define _MTRIOBASE      (0x3100) /* Motor device ioctl commands */
 #define _MATHIOBASE     (0x3200) /* MATH device ioctl commands */
 #define _MMCSDIOBASE    (0x3300) /* MMCSD device ioctl commands */
+#define _BLUETOOTHBASE  (0x3400) /* Bluetooth ioctl commands */
+#define _PKTRADIOBASE   (0x3500) /* Packet radio ioctl commands */
 #define _WLIOCBASE      (0x8b00) /* Wireless modules ioctl network commands */
 
 /* boardctl() commands share the same number space */
@@ -580,6 +582,16 @@
 
 #define _MMCSDIOCVALID(c)   (_IOC_TYPE(c) == _MMCSDIOBASE)
 #define _MMCSDIOC(nr)       _IOC(_MMCSDIOBASE, nr)
+
+/* Bluetooth ioctl definitions **********************************************/
+
+#define _BLUETOOTHIOCVALID(c) (_IOC_TYPE(c)==_BLUETOOTHBASE)
+#define _BLUETOOTHIOC(nr)     _IOC(_BLUETOOTHBASE,nr)
+
+/* Packet radio ioctl definitions *******************************************/
+
+#define _PKRADIOIOCVALID(c) (_IOC_TYPE(c)==_PKTRADIOBASE)
+#define _PKRADIOIOC(nr)     _IOC(_PKTRADIOBASE,nr)
 
 /* Wireless driver network ioctl definitions ********************************/
 

--- a/include/nuttx/wireless/bluetooth/bt_ioctl.h
+++ b/include/nuttx/wireless/bluetooth/bt_ioctl.h
@@ -42,7 +42,7 @@
 
 #include <net/if.h>
 
-#include <nuttx/wireless/wireless.h>
+#include <nuttx/fs/ioctl.h>
 #include <nuttx/wireless/bluetooth/bt_core.h>
 #include <nuttx/wireless/bluetooth/bt_hci.h>
 #include <nuttx/wireless/bluetooth/bt_gatt.h>
@@ -67,10 +67,6 @@
 
 /* Bluetooth network device IOCTL commands. */
 
-#if !defined(WL_BLUETOOTHCMDS) || WL_BLUETOOTHCMDS != 28
-#  error Incorrect setting for number of Bluetooth IOCTL commands
-#endif
-
 /* IOCTL Commands ***********************************************************
  * Many derive from NetBSD, at least in name.
  * All of the following use an argument of type struct btreg_s:
@@ -91,9 +87,9 @@
  *   Thus, you can cycle through all devices in the system.
  */
 
-#define SIOCGBTINFO            _WLIOC(WL_BLUETOOTHFIRST + 0)
-#define SIOCGBTINFOA           _WLIOC(WL_BLUETOOTHFIRST + 1)
-#define SIOCNBTINFO            _WLIOC(WL_BLUETOOTHFIRST + 2)
+#define SIOCGBTINFO            _BLUETOOTHIOC(0)
+#define SIOCGBTINFOA           _BLUETOOTHIOC(1)
+#define SIOCNBTINFO            _BLUETOOTHIOC(2)
 
 /* Features
  *
@@ -105,8 +101,8 @@
  *   features.  Only page 0 is value.
  */
 
-#define SIOCGBTFEAT            _WLIOC(WL_BLUETOOTHFIRST + 3)
-#define SIOCGBTLEFEAT          _WLIOC(WL_BLUETOOTHFIRST + 4)
+#define SIOCGBTFEAT            _BLUETOOTHIOC(3)
+#define SIOCGBTLEFEAT          _BLUETOOTHIOC(4)
 
 /* Set Flags, Link Policy, and Packet Types
  *
@@ -119,9 +115,9 @@
  *   the device supports.
  */
 
-#define SIOCSBTFLAGS           _WLIOC(WL_BLUETOOTHFIRST + 5)
-#define SIOCSBTPOLICY          _WLIOC(WL_BLUETOOTHFIRST + 6)
-#define SIOCSBTPTYPE           _WLIOC(WL_BLUETOOTHFIRST + 7)
+#define SIOCSBTFLAGS           _BLUETOOTHIOC(5)
+#define SIOCSBTPOLICY          _BLUETOOTHIOC(6)
+#define SIOCSBTPTYPE           _BLUETOOTHIOC(7)
 
 /* Get Statistics:
  *
@@ -131,8 +127,8 @@
  *   Read device statistics, and zero them.
  */
 
-#define SIOCGBTSTATS           _WLIOC(WL_BLUETOOTHFIRST + 8)
-#define SIOCZBTSTATS           _WLIOC(WL_BLUETOOTHFIRST + 9)
+#define SIOCGBTSTATS           _BLUETOOTHIOC(8)
+#define SIOCZBTSTATS           _BLUETOOTHIOC(9)
 
 /* Advertisement
  *
@@ -143,8 +139,8 @@
  *   Stop advertising.
  */
 
-#define SIOCBTADVSTART         _WLIOC(WL_BLUETOOTHFIRST + 10)
-#define SIOCBTADVSTOP          _WLIOC(WL_BLUETOOTHFIRST + 11)
+#define SIOCBTADVSTART         _BLUETOOTHIOC(10)
+#define SIOCBTADVSTOP          _BLUETOOTHIOC(11)
 
 /* Scanning
  *
@@ -158,9 +154,9 @@
  *   Stop LE scanning and discard any buffered results.
  */
 
-#define SIOCBTSCANSTART        _WLIOC(WL_BLUETOOTHFIRST + 12)
-#define SIOCBTSCANGET          _WLIOC(WL_BLUETOOTHFIRST + 13)
-#define SIOCBTSCANSTOP         _WLIOC(WL_BLUETOOTHFIRST + 14)
+#define SIOCBTSCANSTART        _BLUETOOTHIOC(12)
+#define SIOCBTSCANGET          _BLUETOOTHIOC(13)
+#define SIOCBTSCANSTOP         _BLUETOOTHIOC(14)
 
 /* Security
  *
@@ -168,7 +164,7 @@
  *   Enable security for a connection.
  */
 
-#define SIOCBTSECURITY         _WLIOC(WL_BLUETOOTHFIRST + 15)
+#define SIOCBTSECURITY         _BLUETOOTHIOC(15)
 
 /* GATT
  *
@@ -182,20 +178,20 @@
  *   Write GATT data
  */
 
-#define SIOCBTEXCHANGE         _WLIOC(WL_BLUETOOTHFIRST + 16)
-#define SIOCBTDISCOVER         _WLIOC(WL_BLUETOOTHFIRST + 17)
-#define SIOCBTGATTRD           _WLIOC(WL_BLUETOOTHFIRST + 18)
-#define SIOCBTGATTWR           _WLIOC(WL_BLUETOOTHFIRST + 19)
+#define SIOCBTEXCHANGE         _BLUETOOTHIOC(16)
+#define SIOCBTDISCOVER         _BLUETOOTHIOC(17)
+#define SIOCBTGATTRD           _BLUETOOTHIOC(18)
+#define SIOCBTGATTWR           _BLUETOOTHIOC(19)
 
 /* Connect/diconnect from a peer */
 
-#define SIOCBTCONNECT          _WLIOC(WL_BLUETOOTHFIRST + 24)
-#define SIOCBTDISCONNECT       _WLIOC(WL_BLUETOOTHFIRST + 25)
+#define SIOCBTCONNECT          _BLUETOOTHIOC(24)
+#define SIOCBTDISCONNECT       _BLUETOOTHIOC(25)
 
 /* btsnoop open and close operations */
 
-#define SIOCBTSNOOPOPEN        _WLIOC(WL_BLUETOOTHFIRST + 26)
-#define SIOCBTSNOOPCLOSE       _WLIOC(WL_BLUETOOTHFIRST + 27)
+#define SIOCBTSNOOPOPEN        _BLUETOOTHIOC(26)
+#define SIOCBTSNOOPCLOSE       _BLUETOOTHIOC(27)
 
 /* Definitions associated with struct btreg_s *******************************/
 

--- a/include/nuttx/wireless/pktradio.h
+++ b/include/nuttx/wireless/pktradio.h
@@ -26,8 +26,8 @@
  ****************************************************************************/
 
 #include <nuttx/config.h>
+#include <nuttx/fs/ioctl.h>
 #include <nuttx/net/netdev.h>
-#include <nuttx/wireless/wireless.h>
 
 #ifdef CONFIG_WIRELESS_PKTRADIO
 
@@ -37,17 +37,13 @@
 
 /* Packet radio network device IOCTL commands. */
 
-#ifndef WL_NPKTRADIOCMDS != 3
-#  error Incorrect setting for number of PktRadio IOCTL commands
-#endif
-
 /* SIOCPKTRADIOGGPROPS
  *   Description:   Get the radio properties
  *   Input:         Pointer to read-write instance of struct pktradio_ifreq_s
  *   Output:        Properties returned in struct pktradio_ifreq_s instance
  */
 
-#define SIOCPKTRADIOGGPROPS  _WLIOC(WL_PKTRADIOFIRST)
+#define SIOCPKTRADIOGGPROPS  _PKRADIOIOC(0)
 
 /* SIOCPKTRADIOGSNODE
  *   Description:   Set the radio node address
@@ -55,7 +51,7 @@
  *   Output:        None
  */
 
-#define SIOCPKTRADIOSNODE    _WLIOC(WL_PKTRADIOFIRST + 1)
+#define SIOCPKTRADIOSNODE    _PKRADIOIOC(1)
 
 /* SIOCPKTRADIOGGNODE
  *   Description:   Get the radio node address
@@ -63,7 +59,7 @@
  *   Output:        Node address return in struct pktradio_ifreq_s instance
  */
 
-#define SIOCPKTRADIOGNODE    _WLIOC(WL_PKTRADIOFIRST + 2)
+#define SIOCPKTRADIOGNODE    _PKRADIOIOC(2)
 
 /* Memory Pools */
 

--- a/include/nuttx/wireless/wireless.h
+++ b/include/nuttx/wireless/wireless.h
@@ -165,33 +165,6 @@
 #define WL_NETFIRST         0x0000          /* First network command */
 #define WL_NNETCMDS         0x003b          /* Number of network commands */
 
-/* Reserved for Bluetooth network devices (see bt_ioctls.h) */
-
-#define WL_BLUETOOTHFIRST     (WL_NETFIRST + WL_NNETCMDS)
-#define WL_BLUETOOTHCMDS      (28)
-#define WL_IBLUETOOTHCMD(cmd) (_WLIOCVALID(cmd) && \
-                              _IOC_NR(cmd) >= WL_BLUETOOTHFIRST && \
-                              _IOC_NR(cmd) < (WL_BLUETOOTHFIRST + WL_BLUETOOTHCMDS))
-
-/* Reserved for IEEE802.15.4 wireless network devices
- * NOTE:  Not used.  Currently logic uses IOCTL commands from the IEEE802.15.4
- * character driver space.
- */
-
-#define WL_802154FIRST        (WL_BLUETOOTHFIRST + WL_BLUETOOTHCMDS)
-#define WL_N802154CMDS        (3)
-#define WL_IS802154CMD(cmd)   (_WLIOCVALID(cmd) && \
-                               _IOC_NR(cmd) >= WL_802154FIRST && \
-                               _IOC_NR(cmd) < (WL_802154FIRST + WL_N802154CMDS))
-
-/* Reserved for network packet radio network devices  */
-
-#define WL_PKTRADIOFIRST      (WL_802154FIRST + WL_N802154CMDS)
-#define WL_NPKTRADIOCMDS      (3)
-#define WL_ISPKTRADIOCMD(cmd) (_WLIOCVALID(cmd) && \
-                               _IOC_NR(cmd) >= WL_PKTRADIOFIRST && \
-                               _IOC_NR(cmd) < (WL_PKTRADIOFIRST + WL_NPKTRADIOCMDS))
-
 /* ------------------------------ WIRELESS EVENTS --------------------------------- */
 
 /* Those are *NOT* ioctls, do not issue request on them !!! */

--- a/include/nuttx/wireless/wireless.h
+++ b/include/nuttx/wireless/wireless.h
@@ -150,6 +150,31 @@
 #define SIOCSIWPTAPRIO      _WLIOC(0x0039)  /* Set PTA priority type */
 #define SIOCGIWPTAPRIO      _WLIOC(0x003a)  /* Get PTA priority type */
 
+/* -------------------- DEV PRIVATE IOCTL LIST -------------------- */
+
+/* These 32 ioctl are wireless device private, for 16 commands.
+ * Each driver is free to use them for whatever purpose it chooses,
+ * however the driver *must* export the description of those ioctls
+ * with SIOCGIWPRIV and *must* use arguments as defined below.
+ */
+
+#define SIOCIWFIRSTPRIV     _WLIOC(0x00e0)
+#define SIOCIWLASTPRIV      _WLIOC(0x00ff)
+
+/* ------------------------- IOCTL STUFF ------------------------- */
+
+/* The first and the last (range) */
+
+#define SIOCIWFIRST         _WLIOC(0x0000)  /* First network command */
+#define SIOCIWLAST          SIOCIWLASTPRIV  /* 0x8bff */
+
+#define IW_IOCTL_IDX(cmd)   ((cmd) - SIOCIWFIRST)
+
+/* Odd : get (world access), even : set (root access) */
+
+#define IW_IS_SET(cmd)      (!((cmd) & 0x1))
+#define IW_IS_GET(cmd)      ((cmd) & 0x1)
+
 #define WL_IS80211POINTERCMD(cmd) ((cmd) == SIOCGIWSCAN || \
                                    (cmd) == SIOCSIWSCAN || \
                                    (cmd) == SIOCSIWCOUNTRY || \
@@ -159,11 +184,6 @@
                                    (cmd) == SIOCGIWENCODEEXT || \
                                    (cmd) == SIOCGIWESSID || \
                                    (cmd) == SIOCSIWESSID)
-
-/* Device-specific network IOCTL commands *******************************************/
-
-#define WL_NETFIRST         0x0000          /* First network command */
-#define WL_NNETCMDS         0x003b          /* Number of network commands */
 
 /* ------------------------------ WIRELESS EVENTS --------------------------------- */
 

--- a/net/netdev/netdev_ioctl.c
+++ b/net/netdev/netdev_ioctl.c
@@ -386,7 +386,7 @@ static int netdev_bluetooth_ioctl(FAR struct socket *psock, int cmd,
 
   if (arg != 0ul)
     {
-      if (WL_IBLUETOOTHCMD(cmd))
+      if (_BLUETOOTHIOCVALID(cmd))
         {
           /* Get the name of the Bluetooth device to receive the IOCTL
            * command
@@ -510,7 +510,7 @@ static int netdev_pktradio_ioctl(FAR struct socket *psock, int cmd,
 
   if (arg != 0ul)
     {
-      if (WL_ISPKTRADIOCMD(cmd))
+      if (_PKRADIOIOCVALID(cmd))
         {
           /* Get the packet radio device to receive the radio IOCTL
            * command
@@ -571,7 +571,7 @@ static int netdev_wifr_ioctl(FAR struct socket *psock, int cmd,
 
   /* Verify that this is a valid wireless network IOCTL command */
 
-  if (_WLIOCVALID(cmd) && (unsigned)_IOC_NR(cmd) <= WL_NNETCMDS)
+  if (_WLIOCVALID(cmd))
     {
       /* Get the wireless device associated with the IOCTL command */
 
@@ -1566,7 +1566,7 @@ ssize_t net_ioctl_arglen(int cmd)
       default:
 #ifdef CONFIG_NETDEV_IOCTL
 #  ifdef CONFIG_NETDEV_WIRELESS_IOCTL
-        if (_WLIOCVALID(cmd) && _IOC_NR(cmd) <= WL_NNETCMDS)
+        if (_WLIOCVALID(cmd))
           {
             return sizeof(struct iwreq);
           }
@@ -1580,14 +1580,14 @@ ssize_t net_ioctl_arglen(int cmd)
 #  endif
 
 #  ifdef CONFIG_WIRELESS_PKTRADIO
-        if (WL_ISPKTRADIOCMD(cmd))
+        if (_PKRADIOIOCVALID(cmd))
           {
             return sizeof(struct pktradio_ifreq_s);
           }
 #  endif
 
 #  ifdef CONFIG_WIRELESS_BLUETOOTH
-        if (WL_IBLUETOOTHCMD(cmd))
+        if (_BLUETOOTHIOCVALID(cmd))
           {
             return sizeof(struct btreq_s);
           }


### PR DESCRIPTION
## Summary

1. net/wireless: add support for netdev private ioctl

2. net/wireless: separate command catagory of bt/pktradio from wireless ioctl

```
1. separate command catagory of bt/pktradio from wireless ioctl
2. Remove commoand count limit to support vendor command
```

## Impact

N/A

## Testing

CI check