### PR TITLE
arch: risc-v: Remove FPU support from qemu-rv

### DIFF
--- a/arch/risc-v/Kconfig
+++ b/arch/risc-v/Kconfig
@@ -134,8 +134,6 @@ config ARCH_CHIP_RV32M1
 
 config ARCH_CHIP_QEMU_RV
 	bool "QEMU RV"
-	select ARCH_HAVE_FPU
-	select ARCH_HAVE_DPFPU
 	select ARCH_HAVE_MULTICPU
 	select ARCH_HAVE_MPU
 	select ARCH_HAVE_MMU


### PR DESCRIPTION
## Summary

- Because a context switch issue still exists with FPU
   the configs should be removed until it works.

## Impact

- None

## Testing

- Tested with ostest
