### PR TITLE
add SAMA5D2 support for SAMA5 xdma driver

### DIFF
--- a/arch/arm/src/sama5/hardware/sam_xdmac.h
+++ b/arch/arm/src/sama5/hardware/sam_xdmac.h
@@ -385,6 +385,59 @@
 
 /* XDMA Controller 0 Channel Definitions (always secure) */
 
+#if defined(ATSAMA5D2)
+#define XDMAC0_CH_TWI0_TX           0  /* TWI0 Transmit */
+#define XDMAC0_CH_TWI0_RX           1  /* TWI0 Receive */
+#define XDMAC0_CH_TWI1_TX           2  /* TWI1 Transmit */
+#define XDMAC0_CH_TWI1_RX           3  /* TWI1 Receive */
+#define XDMAC0_CH_QSPI0_TX          4  /* QSPI0 Transmit */
+#define XDMAC0_CH_QSPI0_RX          5  /* QSPI0 Receive */
+#define XDMAC0_CH_SPI0_TX           6  /* SPI0 Transmit */
+#define XDMAC0_CH_SPI0_RX           7  /* SPI0 Receive */
+#define XDMAC0_CH_SPI1_TX           8  /* SPI1 Transmit */
+#define XDMAC0_CH_SPI1_RX           9  /* SPI1 Receive */
+#define XDMAC0_CH_PWM_TX            10 /* PWM Transmit */
+#define XDMAC0_CH_FLEXCOM0_TX       11 /* FLEXCOM0 Transmit */
+#define XDMAC0_CH_FLEXCOM0_RX       12 /* FLEXCOM0 Receive */
+#define XDMAC0_CH_FLEXCOM1_TX       13 /* FLEXCOM1 Transmit */
+#define XDMAC0_CH_FLEXCOM1_RX       14 /* FLEXCOM1 Receive */
+#define XDMAC0_CH_FLEXCOM2_TX       15 /* FLEXCOM2 Transmit */
+#define XDMAC0_CH_FLEXCOM2_RX       16 /* FLEXCOM2 Receive */
+#define XDMAC0_CH_FLEXCOM3_TX       17 /* FLEXCOM3 Transmit */
+#define XDMAC0_CH_FLEXCOM3_RX       18 /* FLEXCOM3 Receive */
+#define XDMAC0_CH_FLEXCOM4_TX       19 /* FLEXCOM4 Transmit */
+#define XDMAC0_CH_FLEXCOM4_RX       20 /* FLEXCOM4 Receive */
+#define XDMAC0_CH_SSC0_TX           21 /* SSC0 Transmit */
+#define XDMAC0_CH_SSC0_RX           22 /* SSC0 Receive */
+#define XDMAC0_CH_SSC1_TX           23 /* SSC1 Transmit */
+#define XDMAC0_CH_SSC1_RX           24 /* SSC1 Receive */
+#define XDMAC0_CH_ADC_RX            25 /* ADC Receive */
+#define XDMAC0_CH_AES_TX            26 /* AES Receive */
+#define XDMAC0_CH_AES_RX            27 /* AES Transmit */
+#define XDMAC0_CH_TDES_TX           28 /* TDES Transmit */
+#define XDMAC0_CH_TDES_RX           29 /* TDES Receive */
+#define XDMAC0_CH_SHA_TX            30 /* SHA Transmit */
+#define XDMAC0_CH_I2SC0_TX          31 /* I2SC0 Transmit */
+#define XDMAC0_CH_I2SC0_RX          32 /* I2SC0 Receive */
+#define XDMAC0_CH_I2SC1_TX          33 /* I2SC1 Transmit */
+#define XDMAC0_CH_I2SC1_RX          34 /* I2SC1 Receive */
+#define XDMAC0_CH_UART0_TX          35 /* UART0 Transmit */
+#define XDMAC0_CH_UART0_RX          36 /* UART0 Receive */
+#define XDMAC0_CH_UART1_TX          37 /* UART1 Transmit */
+#define XDMAC0_CH_UART1_RX          38 /* UART1 Receive */
+#define XDMAC0_CH_UART2_TX          39 /* UART2 Transmit */
+#define XDMAC0_CH_UART2_RX          40 /* UART2 Receive */
+#define XDMAC0_CH_UART3_TX          41 /* UART3 Transmit */
+#define XDMAC0_CH_UART3_RX          42 /* UART3 Receive */
+#define XDMAC0_CH_UART4_TX          43 /* UART4 Transmit */
+#define XDMAC0_CH_UART4_RX          44 /* UART4 Receive */
+#define XDMAC0_CH_TC0_RX            45 /* TC0 Receive */
+#define XDMAC0_CH_TC1_RX            46 /* TC1 Receive */
+#define XDMAC0_CH_CLASSD_TX         47 /* CLASSD Transmit */
+#define XDMAC0_CH_QSPI1_TX          48 /* QSPI1 Transmit */
+#define XDMAC0_CH_QSPI1_RX          49 /* QSPI1 Receive */
+#define XDMAC0_CH_PDMIC_RX          50 /* PDMIC Receive */
+#elif defined(ATSAMA5D4)
 #define XDMAC0_CH_HSMCI0            0  /* HSMCI0 Receive/Transmit */
 #define XDMAC0_CH_HSMCI1            1  /* HSMCI1 Receive/Transmit */
 #define XDMAC0_CH_TWI0_TX           2  /* TWI0 Transmit */
@@ -431,9 +484,63 @@
 #define XDMAC0_CH_SHA_TX            44 /* SHA Transmit */
 #define XDMAC0_CH_CATB_TX           46 /* CATB Transmit */
 #define XDMAC0_CH_CATB_RX           47 /* CATB Receive */
+#endif
 
 /* XDMA Controller 1 Channel Definitions (never secure) */
 
+#if defined(ATSAMA5D2)
+#define XDMAC1_CH_TWI0_TX           0  /* TWI0 Transmit */
+#define XDMAC1_CH_TWI0_RX           1  /* TWI0 Receive */
+#define XDMAC1_CH_TWI1_TX           2  /* TWI1 Transmit */
+#define XDMAC1_CH_TWI1_RX           3  /* TWI1 Receive */
+#define XDMAC1_CH_QSPI0_TX          4  /* QSPI0 Transmit */
+#define XDMAC1_CH_QSPI0_RX          5  /* QSPI0 Receive */
+#define XDMAC1_CH_SPI0_TX           6  /* SPI0 Transmit */
+#define XDMAC1_CH_SPI0_RX           7  /* SPI0 Receive */
+#define XDMAC1_CH_SPI1_TX           8  /* SPI1 Transmit */
+#define XDMAC1_CH_SPI1_RX           9  /* SPI1 Receive */
+#define XDMAC1_CH_PWM_TX            10 /* PWM Transmit */
+#define XDMAC1_CH_FLEXCOM0_TX       11 /* FLEXCOM0 Transmit */
+#define XDMAC1_CH_FLEXCOM0_RX       12 /* FLEXCOM0 Receive */
+#define XDMAC1_CH_FLEXCOM1_TX       13 /* FLEXCOM1 Transmit */
+#define XDMAC1_CH_FLEXCOM1_RX       14 /* FLEXCOM1 Receive */
+#define XDMAC1_CH_FLEXCOM2_TX       15 /* FLEXCOM2 Transmit */
+#define XDMAC1_CH_FLEXCOM2_RX       16 /* FLEXCOM2 Receive */
+#define XDMAC1_CH_FLEXCOM3_TX       17 /* FLEXCOM3 Transmit */
+#define XDMAC1_CH_FLEXCOM3_RX       18 /* FLEXCOM3 Receive */
+#define XDMAC1_CH_FLEXCOM4_TX       19 /* FLEXCOM4 Transmit */
+#define XDMAC1_CH_FLEXCOM4_RX       20 /* FLEXCOM4 Receive */
+#define XDMAC1_CH_SSC0_TX           21 /* SSC0 Transmit */
+#define XDMAC1_CH_SSC0_RX           22 /* SSC0 Receive */
+#define XDMAC1_CH_SSC1_TX           23 /* SSC1 Transmit */
+#define XDMAC1_CH_SSC1_RX           24 /* SSC1 Receive */
+#define XDMAC1_CH_ADC_RX            25 /* ADC Receive */
+#define XDMAC1_CH_AES_TX            26 /* AES Receive */
+#define XDMAC1_CH_AES_RX            27 /* AES Transmit */
+#define XDMAC1_CH_TDES_TX           28 /* TDES Transmit */
+#define XDMAC1_CH_TDES_RX           29 /* TDES Receive */
+#define XDMAC1_CH_SHA_TX            30 /* SHA Transmit */
+#define XDMAC1_CH_I2SC0_TX          31 /* I2SC0 Transmit */
+#define XDMAC1_CH_I2SC0_RX          32 /* I2SC0 Receive */
+#define XDMAC1_CH_I2SC1_TX          33 /* I2SC1 Transmit */
+#define XDMAC1_CH_I2SC1_RX          34 /* I2SC1 Receive */
+#define XDMAC1_CH_UART0_TX          35 /* UART0 Transmit */
+#define XDMAC1_CH_UART0_RX          36 /* UART0 Receive */
+#define XDMAC1_CH_UART1_TX          37 /* UART1 Transmit */
+#define XDMAC1_CH_UART1_RX          38 /* UART1 Receive */
+#define XDMAC1_CH_UART2_TX          39 /* UART2 Transmit */
+#define XDMAC1_CH_UART2_RX          40 /* UART2 Receive */
+#define XDMAC1_CH_UART3_TX          41 /* UART3 Transmit */
+#define XDMAC1_CH_UART3_RX          42 /* UART3 Receive */
+#define XDMAC1_CH_UART4_TX          43 /* UART4 Transmit */
+#define XDMAC1_CH_UART4_RX          44 /* UART4 Receive */
+#define XDMAC1_CH_TC0_RX            45 /* TC0 Receive */
+#define XDMAC1_CH_TC1_RX            46 /* TC1 Receive */
+#define XDMAC1_CH_CLASSD_TX         47 /* CLASSD Transmit */
+#define XDMAC1_CH_QSPI1_TX          48 /* QSPI1 Transmit */
+#define XDMAC1_CH_QSPI1_RX          49 /* QSPI1 Receive */
+#define XDMAC1_CH_PDMIC_RX          50 /* PDMIC Receive */
+#elif defined(ATSAMA5D4)
 #define XDMAC1_CH_HSMCI0            0  /* HSMCI0 Receive/Transmit */
 #define XDMAC1_CH_HSMCI1            1  /* HSMCI1 Receive/Transmit */
 #define XDMAC1_CH_TWI0_TX           2  /* TWI0 Transmit */
@@ -469,6 +576,7 @@
 #define XDMAC1_CH_ADC_RX            32 /* ADC Receive */
 #define XDMAC1_CH_SMD_TX            33 /* SMD Transmit */
 #define XDMAC1_CH_SMD_RX            34 /* SMD Receive */
+#endif
 
 /* Descriptor structure member definitions **********************************/
 

--- a/arch/arm/src/sama5/sam_xdmac.c
+++ b/arch/arm/src/sama5/sam_xdmac.c
@@ -155,30 +155,58 @@ struct sam_xdmac_s
 
 static const struct sam_pidmap_s g_xdmac0_rxchan[] =
 {
-  { SAM_PID_HSMCI0, XDMAC0_CH_HSMCI0    }, /* HSMCI0 Receive/Transmit */
-  { SAM_PID_HSMCI1, XDMAC0_CH_HSMCI1    }, /* HSMCI1 Receive/Transmit */
-  { SAM_PID_TWI0,   XDMAC0_CH_TWI0_RX   }, /* TWI0 Receive */
-  { SAM_PID_TWI1,   XDMAC0_CH_TWI1_RX   }, /* TWI1 Receive */
-  { SAM_PID_TWI2,   XDMAC0_CH_TWI2_RX   }, /* TWI2 Receive */
-  { SAM_PID_TWI3,   XDMAC0_CH_TWI3_RX   }, /* TWI3 Receive */
-  { SAM_PID_SPI0,   XDMAC0_CH_SPI0_RX   }, /* SPI0 Receive */
-  { SAM_PID_SPI1,   XDMAC0_CH_SPI1_RX   }, /* SPI1 Receive */
-  { SAM_PID_SPI2,   XDMAC0_CH_SPI2_RX   }, /* SPI2 Receive */
-  { SAM_PID_USART2, XDMAC0_CH_USART2_RX }, /* USART2 Receive */
-  { SAM_PID_USART3, XDMAC0_CH_USART3_RX }, /* USART3 Receive */
-  { SAM_PID_USART4, XDMAC0_CH_USART4_RX }, /* USART4 Receive */
-  { SAM_PID_UART0,  XDMAC0_CH_UART0_RX  }, /* UART0 Receive */
-  { SAM_PID_UART1,  XDMAC0_CH_UART1_RX  }, /* UART1 Receive */
-  { SAM_PID_SSC0,   XDMAC0_CH_SSC0_RX   }, /* SSC0 Receive */
-  { SAM_PID_SSC1,   XDMAC0_CH_SSC1_RX   }, /* SSC1 Receive */
-  { SAM_PID_DBGU,   XDMAC0_CH_DBGU_RX   }, /* DBGU Receive */
-  { SAM_PID_ADC,    XDMAC0_CH_ADC_RX    }, /* ADC Receive */
-  { SAM_PID_SMD,    XDMAC0_CH_SMD_RX    }, /* SMD Receive */
-  { SAM_PID_USART0, XDMAC0_CH_USART0_RX }, /* USART0 Receive */
-  { SAM_PID_USART1, XDMAC0_CH_USART1_RX }, /* USART1 Receive */
-  { SAM_PID_AES,    XDMAC0_CH_AES_RX    }, /* AES Receive */
-  { SAM_PID_TDES,   XDMAC0_CH_TDES_RX   }, /* TDES Receive */
-  { SAM_PID_CATB,   XDMAC0_CH_CATB_RX   }, /* CATB Receive */
+#if defined(ATSAMA5D2)
+  { SAM_PID_TWI0,     XDMAC0_CH_TWI0_RX     }, /* TWI0  Receive */
+  { SAM_PID_TWI1,     XDMAC0_CH_TWI1_RX     }, /* TWI1  Receive */
+  { SAM_PID_QSPI0,    XDMAC0_CH_QSPI0_RX    }, /* QSPI0 Receive */
+  { SAM_PID_SPI0,     XDMAC0_CH_SPI0_RX     }, /* SPI0  Receive */
+  { SAM_PID_SPI1,     XDMAC0_CH_SPI1_RX     }, /* SPI1  Receive */
+  { SAM_PID_FLEXCOM0, XDMAC0_CH_FLEXCOM0_RX }, /* FLEXCOM0 Receive */
+  { SAM_PID_FLEXCOM1, XDMAC0_CH_FLEXCOM1_RX }, /* FLEXCOM1 Receive */
+  { SAM_PID_FLEXCOM2, XDMAC0_CH_FLEXCOM2_RX }, /* FLEXCOM2 Receive */
+  { SAM_PID_FLEXCOM3, XDMAC0_CH_FLEXCOM3_RX }, /* FLEXCOM3 Receive */
+  { SAM_PID_FLEXCOM4, XDMAC0_CH_FLEXCOM4_RX }, /* FLEXCOM4 Receive */
+  { SAM_PID_SSC0,     XDMAC0_CH_SSC0_RX     }, /* SSC0  Receive */
+  { SAM_PID_SSC1,     XDMAC0_CH_SSC1_RX     }, /* SSC1  Receive */
+  { SAM_PID_ADC,      XDMAC0_CH_ADC_RX      }, /* ADC   Receive */
+  { SAM_PID_AES,      XDMAC0_CH_AES_RX      }, /* AES   Receive */
+  { SAM_PID_TDES,     XDMAC0_CH_TDES_RX     }, /* TDES  Receive */
+  { SAM_PID_I2SC0,    XDMAC0_CH_I2SC0_RX    }, /* I2SC0 Receive */
+  { SAM_PID_I2SC1,    XDMAC0_CH_I2SC1_RX    }, /* I2SC1 Receive */
+  { SAM_PID_UART0,    XDMAC0_CH_UART0_RX    }, /* UART0 Receive */
+  { SAM_PID_UART1,    XDMAC0_CH_UART1_RX    }, /* UART1 Receive */
+  { SAM_PID_UART2,    XDMAC0_CH_UART2_RX    }, /* UART2 Receive */
+  { SAM_PID_UART3,    XDMAC0_CH_UART3_RX    }, /* UART3 Receive */
+  { SAM_PID_UART4,    XDMAC0_CH_UART4_RX    }, /* UART4 Receive */
+  { SAM_PID_TC0,      XDMAC0_CH_TC0_RX      }, /* TC0   Receive */
+  { SAM_PID_TC1,      XDMAC0_CH_TC1_RX      }, /* TC1   Receive */
+  { SAM_PID_QSPI1,    XDMAC0_CH_QSPI1_RX    }, /* QSPI1 Receive */
+  { SAM_PID_PDMIC,    XDMAC0_CH_PDMIC_RX    }, /* PDMIC Receive */
+#elif defined(ATSAMA5D4)
+  { SAM_PID_HSMCI0,   XDMAC0_CH_HSMCI0      }, /* HSMCI0 Receive/Transmit */
+  { SAM_PID_HSMCI1,   XDMAC0_CH_HSMCI1      }, /* HSMCI1 Receive/Transmit */
+  { SAM_PID_TWI0,     XDMAC0_CH_TWI0_RX     }, /* TWI0 Receive */
+  { SAM_PID_TWI1,     XDMAC0_CH_TWI1_RX     }, /* TWI1 Receive */
+  { SAM_PID_TWI2,     XDMAC0_CH_TWI2_RX     }, /* TWI2 Receive */
+  { SAM_PID_TWI3,     XDMAC0_CH_TWI3_RX     }, /* TWI3 Receive */
+  { SAM_PID_SPI0,     XDMAC0_CH_SPI0_RX     }, /* SPI0 Receive */
+  { SAM_PID_SPI1,     XDMAC0_CH_SPI1_RX     }, /* SPI1 Receive */
+  { SAM_PID_SPI2,     XDMAC0_CH_SPI2_RX     }, /* SPI2 Receive */
+  { SAM_PID_USART2,   XDMAC0_CH_USART2_RX   }, /* USART2 Receive */
+  { SAM_PID_USART3,   XDMAC0_CH_USART3_RX   }, /* USART3 Receive */
+  { SAM_PID_USART4,   XDMAC0_CH_USART4_RX   }, /* USART4 Receive */
+  { SAM_PID_UART0,    XDMAC0_CH_UART0_RX    }, /* UART0 Receive */
+  { SAM_PID_UART1,    XDMAC0_CH_UART1_RX    }, /* UART1 Receive */
+  { SAM_PID_SSC0,     XDMAC0_CH_SSC0_RX     }, /* SSC0 Receive */
+  { SAM_PID_SSC1,     XDMAC0_CH_SSC1_RX     }, /* SSC1 Receive */
+  { SAM_PID_DBGU,     XDMAC0_CH_DBGU_RX     }, /* DBGU Receive */
+  { SAM_PID_ADC,      XDMAC0_CH_ADC_RX      }, /* ADC  Receive */
+  { SAM_PID_SMD,      XDMAC0_CH_SMD_RX      }, /* SMD  Receive */
+  { SAM_PID_USART0,   XDMAC0_CH_USART0_RX   }, /* USART0 Receive */
+  { SAM_PID_USART1,   XDMAC0_CH_USART1_RX   }, /* USART1 Receive */
+  { SAM_PID_AES,      XDMAC0_CH_AES_RX      }, /* AES  Receive */
+  { SAM_PID_TDES,     XDMAC0_CH_TDES_RX     }, /* TDES Receive */
+#endif
 };
 #define NXDMAC0_RXCHANNELS (sizeof(g_xdmac0_rxchan) / sizeof(struct sam_pidmap_s))
 
@@ -186,30 +214,57 @@ static const struct sam_pidmap_s g_xdmac0_rxchan[] =
 
 static const struct sam_pidmap_s g_xdmac0_txchan[] =
 {
-  { SAM_PID_HSMCI0, XDMAC0_CH_HSMCI0    }, /* HSMCI0 Receive/Transmit */
-  { SAM_PID_HSMCI1, XDMAC0_CH_HSMCI1    }, /* HSMCI1 Receive/Transmit */
-  { SAM_PID_TWI0,   XDMAC0_CH_TWI0_TX   }, /* TWI0 Transmit */
-  { SAM_PID_TWI1,   XDMAC0_CH_TWI1_TX   }, /* TWI1 Transmit */
-  { SAM_PID_TWI2,   XDMAC0_CH_TWI2_TX   }, /* TWI2 Transmit */
-  { SAM_PID_TWI3,   XDMAC0_CH_TWI3_TX   }, /* TWI3 Transmit */
-  { SAM_PID_SPI0,   XDMAC0_CH_SPI0_TX   }, /* SPI0 Transmit */
-  { SAM_PID_SPI1,   XDMAC0_CH_SPI1_TX   }, /* SPI1 Transmit */
-  { SAM_PID_SPI2,   XDMAC0_CH_SPI2_TX   }, /* SPI2 Transmit */
-  { SAM_PID_USART2, XDMAC0_CH_USART2_TX }, /* USART2 Transmit */
-  { SAM_PID_USART3, XDMAC0_CH_USART3_TX }, /* USART3 Transmit */
-  { SAM_PID_USART4, XDMAC0_CH_USART4_TX }, /* USART4 Transmit */
-  { SAM_PID_UART0,  XDMAC0_CH_UART0_TX  }, /* UART0 Transmit */
-  { SAM_PID_UART1,  XDMAC0_CH_UART1_TX  }, /* UART1 Transmit */
-  { SAM_PID_SSC0,   XDMAC0_CH_SSC0_TX   }, /* SSC0 Transmit */
-  { SAM_PID_SSC1,   XDMAC0_CH_SSC1_TX   }, /* SSC1 Transmit */
-  { SAM_PID_DBGU,   XDMAC0_CH_DBGU_TX   }, /* DBGU Transmit */
-  { SAM_PID_SMD,    XDMAC0_CH_SMD_TX    }, /* SMD Transmit */
-  { SAM_PID_USART0, XDMAC0_CH_USART0_TX }, /* USART0 Transmit */
-  { SAM_PID_USART1, XDMAC0_CH_USART1_TX }, /* USART1 Transmit */
-  { SAM_PID_AES,    XDMAC0_CH_AES_TX    }, /* AES Transmit */
-  { SAM_PID_TDES,   XDMAC0_CH_TDES_TX   }, /* TDES Transmit */
-  { SAM_PID_SHA,    XDMAC0_CH_SHA_TX    }, /* SHA Transmit */
-  { SAM_PID_CATB,   XDMAC0_CH_CATB_TX   }, /* CATB Transmit */
+#if defined(ATSAMA5D2)
+  { SAM_PID_TWI0,     XDMAC0_CH_TWI0_TX     }, /* TWI0  Transmit */
+  { SAM_PID_TWI1,     XDMAC0_CH_TWI1_TX     }, /* TWI1  Transmit */
+  { SAM_PID_QSPI0,    XDMAC0_CH_QSPI0_TX    }, /* QSPI0 Transmit */
+  { SAM_PID_SPI0,     XDMAC0_CH_SPI0_TX     }, /* SPI0  Transmit */
+  { SAM_PID_SPI1,     XDMAC0_CH_SPI1_TX     }, /* SPI1  Transmit */
+  { SAM_PID_PWM,      XDMAC0_CH_PWM_TX      }, /* PWM   Transmit */
+  { SAM_PID_FLEXCOM0, XDMAC0_CH_FLEXCOM0_TX }, /* FLEXCOM0 Transmit */
+  { SAM_PID_FLEXCOM1, XDMAC0_CH_FLEXCOM1_TX }, /* FLEXCOM1 Transmit */
+  { SAM_PID_FLEXCOM2, XDMAC0_CH_FLEXCOM2_TX }, /* FLEXCOM2 Transmit */
+  { SAM_PID_FLEXCOM3, XDMAC0_CH_FLEXCOM3_TX }, /* FLEXCOM3 Transmit */
+  { SAM_PID_FLEXCOM4, XDMAC0_CH_FLEXCOM4_TX }, /* FLEXCOM4 Transmit */
+  { SAM_PID_SSC0,     XDMAC0_CH_SSC0_TX     }, /* SSC0 Transmit */
+  { SAM_PID_SSC1,     XDMAC0_CH_SSC1_TX     }, /* SSC1 Transmit */
+  { SAM_PID_AES,      XDMAC0_CH_AES_TX      }, /* AES  Transmit */
+  { SAM_PID_TDES,     XDMAC0_CH_TDES_TX     }, /* TDES Transmit */
+  { SAM_PID_SHA,      XDMAC0_CH_SHA_TX      }, /* SHA  Transmit */
+  { SAM_PID_I2SC0,    XDMAC0_CH_I2SC0_TX    }, /* I2SC0  Transmit */
+  { SAM_PID_I2SC1,    XDMAC0_CH_I2SC1_TX    }, /* I2SC1  Transmit */
+  { SAM_PID_UART0,    XDMAC0_CH_UART0_TX    }, /* UART0  Transmit */
+  { SAM_PID_UART1,    XDMAC0_CH_UART1_TX    }, /* UART1  Transmit */
+  { SAM_PID_UART2,    XDMAC0_CH_UART2_TX    }, /* UART2  Transmit */
+  { SAM_PID_UART3,    XDMAC0_CH_UART3_TX    }, /* UART3  Transmit */
+  { SAM_PID_UART4,    XDMAC0_CH_UART4_TX    }, /* UART4  Transmit */
+  { SAM_PID_CLASSD,   XDMAC0_CH_CLASSD_TX   }, /* CLASSD Transmit */
+  { SAM_PID_QSPI1,    XDMAC0_CH_QSPI1_TX    }, /* QSPI1  Transmit */
+#elif defined(ATSAMA5D4)
+  { SAM_PID_HSMCI0,   XDMAC0_CH_HSMCI0      }, /* HSMCI0 Receive/Transmit */
+  { SAM_PID_HSMCI1,   XDMAC0_CH_HSMCI1      }, /* HSMCI1 Receive/Transmit */
+  { SAM_PID_TWI0,     XDMAC0_CH_TWI0_TX     }, /* TWI0 Transmit */
+  { SAM_PID_TWI1,     XDMAC0_CH_TWI1_TX     }, /* TWI1 Transmit */
+  { SAM_PID_TWI2,     XDMAC0_CH_TWI2_TX     }, /* TWI2 Transmit */
+  { SAM_PID_TWI3,     XDMAC0_CH_TWI3_TX     }, /* TWI3 Transmit */
+  { SAM_PID_SPI0,     XDMAC0_CH_SPI0_TX     }, /* SPI0 Transmit */
+  { SAM_PID_SPI1,     XDMAC0_CH_SPI1_TX     }, /* SPI1 Transmit */
+  { SAM_PID_SPI2,     XDMAC0_CH_SPI2_TX     }, /* SPI2 Transmit */
+  { SAM_PID_USART2,   XDMAC0_CH_USART2_TX   }, /* USART2 Transmit */
+  { SAM_PID_USART3,   XDMAC0_CH_USART3_TX   }, /* USART3 Transmit */
+  { SAM_PID_USART4,   XDMAC0_CH_USART4_TX   }, /* USART4 Transmit */
+  { SAM_PID_UART0,    XDMAC0_CH_UART0_TX    }, /* UART0 Transmit */
+  { SAM_PID_UART1,    XDMAC0_CH_UART1_TX    }, /* UART1 Transmit */
+  { SAM_PID_SSC0,     XDMAC0_CH_SSC0_TX     }, /* SSC0 Transmit */
+  { SAM_PID_SSC1,     XDMAC0_CH_SSC1_TX     }, /* SSC1 Transmit */
+  { SAM_PID_DBGU,     XDMAC0_CH_DBGU_TX     }, /* DBGU Transmit */
+  { SAM_PID_SMD,      XDMAC0_CH_SMD_TX      }, /* SMD  Transmit */
+  { SAM_PID_USART0,   XDMAC0_CH_USART0_TX   }, /* USART0 Transmit */
+  { SAM_PID_USART1,   XDMAC0_CH_USART1_TX   }, /* USART1 Transmit */
+  { SAM_PID_AES,      XDMAC0_CH_AES_TX      }, /* AES  Transmit */
+  { SAM_PID_TDES,     XDMAC0_CH_TDES_TX     }, /* TDES Transmit */
+  { SAM_PID_SHA,      XDMAC0_CH_SHA_TX      }, /* SHA  Transmit */
+#endif
 };
 #define NXDMAC0_TXCHANNELS (sizeof(g_xdmac0_txchan) / sizeof(struct sam_pidmap_s))
 #endif
@@ -219,25 +274,54 @@ static const struct sam_pidmap_s g_xdmac0_txchan[] =
 
 static const struct sam_pidmap_s g_xdmac1_rxchan[] =
 {
-  { SAM_PID_HSMCI0, XDMAC1_CH_HSMCI0    }, /* HSMCI0 Receive/Transmit */
-  { SAM_PID_HSMCI1, XDMAC1_CH_HSMCI1    }, /* HSMCI1 Receive/Transmit */
-  { SAM_PID_TWI0,   XDMAC1_CH_TWI0_RX   }, /* TWI0 Receive */
-  { SAM_PID_TWI1,   XDMAC1_CH_TWI1_RX   }, /* TWI1 Receive */
-  { SAM_PID_TWI2,   XDMAC1_CH_TWI2_RX   }, /* TWI2 Receive */
-  { SAM_PID_TWI3,   XDMAC1_CH_TWI3_RX   }, /* TWI3 Receive */
-  { SAM_PID_SPI0,   XDMAC1_CH_SPI0_RX   }, /* SPI0 Receive */
-  { SAM_PID_SPI1,   XDMAC1_CH_SPI1_RX   }, /* SPI1 Receive */
-  { SAM_PID_SPI2,   XDMAC1_CH_SPI2_RX   }, /* SPI2 Receive */
-  { SAM_PID_USART2, XDMAC1_CH_USART2_RX }, /* USART2 Receive */
-  { SAM_PID_USART3, XDMAC1_CH_USART3_RX }, /* USART3 Receive */
-  { SAM_PID_USART4, XDMAC1_CH_USART4_RX }, /* USART4 Receive */
-  { SAM_PID_UART0,  XDMAC1_CH_UART0_RX  }, /* UART0 Receive */
-  { SAM_PID_UART1,  XDMAC1_CH_UART1_RX  }, /* UART1 Receive */
-  { SAM_PID_SSC0,   XDMAC1_CH_SSC0_RX   }, /* SSC0 Receive */
-  { SAM_PID_SSC1,   XDMAC1_CH_SSC1_RX   }, /* SSC1 Receive */
-  { SAM_PID_DBGU,   XDMAC1_CH_DBGU_RX   }, /* DBGU Receive */
-  { SAM_PID_ADC,    XDMAC1_CH_ADC_RX    }, /* ADC Receive */
-  { SAM_PID_SMD,    XDMAC1_CH_SMD_RX    }, /* SMD Receive */
+#if defined(ATSAMA5D2)
+  { SAM_PID_TWI0,     XDMAC1_CH_TWI0_RX     }, /* TWI0  Receive */
+  { SAM_PID_TWI1,     XDMAC1_CH_TWI1_RX     }, /* TWI1  Receive */
+  { SAM_PID_QSPI0,    XDMAC1_CH_QSPI0_RX    }, /* QSPI0 Receive */
+  { SAM_PID_SPI0,     XDMAC1_CH_SPI0_RX     }, /* SPI0  Receive */
+  { SAM_PID_SPI1,     XDMAC1_CH_SPI1_RX     }, /* SPI1  Receive */
+  { SAM_PID_FLEXCOM0, XDMAC1_CH_FLEXCOM0_RX }, /* FLEXCOM0 Receive */
+  { SAM_PID_FLEXCOM1, XDMAC1_CH_FLEXCOM1_RX }, /* FLEXCOM1 Receive */
+  { SAM_PID_FLEXCOM2, XDMAC1_CH_FLEXCOM2_RX }, /* FLEXCOM2 Receive */
+  { SAM_PID_FLEXCOM3, XDMAC1_CH_FLEXCOM3_RX }, /* FLEXCOM3 Receive */
+  { SAM_PID_FLEXCOM4, XDMAC1_CH_FLEXCOM4_RX }, /* FLEXCOM4 Receive */
+  { SAM_PID_SSC0,     XDMAC1_CH_SSC0_RX     }, /* SSC0  Receive */
+  { SAM_PID_SSC1,     XDMAC1_CH_SSC1_RX     }, /* SSC1  Receive */
+  { SAM_PID_ADC,      XDMAC1_CH_ADC_RX      }, /* ADC   Receive */
+  { SAM_PID_AES,      XDMAC1_CH_AES_RX      }, /* AES   Receive */
+  { SAM_PID_TDES,     XDMAC1_CH_TDES_RX     }, /* TDES  Receive */
+  { SAM_PID_I2SC0,    XDMAC1_CH_I2SC0_RX    }, /* I2SC0 Receive */
+  { SAM_PID_I2SC1,    XDMAC1_CH_I2SC1_RX    }, /* I2SC1 Receive */
+  { SAM_PID_UART0,    XDMAC1_CH_UART0_RX    }, /* UART0 Receive */
+  { SAM_PID_UART1,    XDMAC1_CH_UART1_RX    }, /* UART1 Receive */
+  { SAM_PID_UART2,    XDMAC1_CH_UART2_RX    }, /* UART2 Receive */
+  { SAM_PID_UART3,    XDMAC1_CH_UART3_RX    }, /* UART3 Receive */
+  { SAM_PID_UART4,    XDMAC1_CH_UART4_RX    }, /* UART4 Receive */
+  { SAM_PID_TC0,      XDMAC1_CH_TC0_RX      }, /* TC0   Receive */
+  { SAM_PID_TC1,      XDMAC1_CH_TC1_RX      }, /* TC1   Receive */
+  { SAM_PID_QSPI1,    XDMAC1_CH_QSPI1_RX    }, /* QSPI1 Receive */
+  { SAM_PID_PDMIC,    XDMAC1_CH_PDMIC_RX    }, /* PDMIC Receive */
+#elif defined(ATSAMA5D4)
+  { SAM_PID_HSMCI0,   XDMAC1_CH_HSMCI0      }, /* HSMCI0 Receive/Transmit */
+  { SAM_PID_HSMCI1,   XDMAC1_CH_HSMCI1      }, /* HSMCI1 Receive/Transmit */
+  { SAM_PID_TWI0,     XDMAC1_CH_TWI0_RX     }, /* TWI0 Receive */
+  { SAM_PID_TWI1,     XDMAC1_CH_TWI1_RX     }, /* TWI1 Receive */
+  { SAM_PID_TWI2,     XDMAC1_CH_TWI2_RX     }, /* TWI2 Receive */
+  { SAM_PID_TWI3,     XDMAC1_CH_TWI3_RX     }, /* TWI3 Receive */
+  { SAM_PID_SPI0,     XDMAC1_CH_SPI0_RX     }, /* SPI0 Receive */
+  { SAM_PID_SPI1,     XDMAC1_CH_SPI1_RX     }, /* SPI1 Receive */
+  { SAM_PID_SPI2,     XDMAC1_CH_SPI2_RX     }, /* SPI2 Receive */
+  { SAM_PID_USART2,   XDMAC1_CH_USART2_RX   }, /* USART2 Receive */
+  { SAM_PID_USART3,   XDMAC1_CH_USART3_RX   }, /* USART3 Receive */
+  { SAM_PID_USART4,   XDMAC1_CH_USART4_RX   }, /* USART4 Receive */
+  { SAM_PID_UART0,    XDMAC1_CH_UART0_RX    }, /* UART0 Receive */
+  { SAM_PID_UART1,    XDMAC1_CH_UART1_RX    }, /* UART1 Receive */
+  { SAM_PID_SSC0,     XDMAC1_CH_SSC0_RX     }, /* SSC0  Receive */
+  { SAM_PID_SSC1,     XDMAC1_CH_SSC1_RX     }, /* SSC1  Receive */
+  { SAM_PID_DBGU,     XDMAC1_CH_DBGU_RX     }, /* DBGU  Receive */
+  { SAM_PID_ADC,      XDMAC1_CH_ADC_RX      }, /* ADC   Receive */
+  { SAM_PID_SMD,      XDMAC1_CH_SMD_RX      }, /* SMD   Receive */
+#endif
 };
 #define NXDMAC1_RXCHANNELS (sizeof(g_xdmac1_rxchan) / sizeof(struct sam_pidmap_s))
 
@@ -245,24 +329,52 @@ static const struct sam_pidmap_s g_xdmac1_rxchan[] =
 
 static const struct sam_pidmap_s g_xdmac1_txchan[] =
 {
-  { SAM_PID_HSMCI0, XDMAC1_CH_HSMCI0    }, /* HSMCI0 Receive/Transmit */
-  { SAM_PID_HSMCI1, XDMAC1_CH_HSMCI1    }, /* HSMCI1 Receive/Transmit */
-  { SAM_PID_TWI0,   XDMAC1_CH_TWI0_TX   }, /* TWI0 Transmit */
-  { SAM_PID_TWI1,   XDMAC1_CH_TWI1_TX   }, /* TWI1 Transmit */
-  { SAM_PID_TWI2,   XDMAC1_CH_TWI2_TX   }, /* TWI2 Transmit */
-  { SAM_PID_TWI3,   XDMAC1_CH_TWI3_TX   }, /* TWI3 Transmit */
-  { SAM_PID_SPI0,   XDMAC1_CH_SPI0_TX   }, /* SPI0 Transmit */
-  { SAM_PID_SPI1,   XDMAC1_CH_SPI1_TX   }, /* SPI1 Transmit */
-  { SAM_PID_SPI2,   XDMAC1_CH_SPI2_TX   }, /* SPI2 Transmit */
-  { SAM_PID_USART2, XDMAC1_CH_USART2_TX }, /* USART2 Transmit */
-  { SAM_PID_USART3, XDMAC1_CH_USART3_TX }, /* USART3 Transmit */
-  { SAM_PID_USART4, XDMAC1_CH_USART4_TX }, /* USART4 Transmit */
-  { SAM_PID_UART0,  XDMAC1_CH_UART0_TX  }, /* UART0 Transmit */
-  { SAM_PID_UART1,  XDMAC1_CH_UART1_TX  }, /* UART1 Transmit */
-  { SAM_PID_SSC0,   XDMAC1_CH_SSC0_TX   }, /* SSC0 Transmit */
-  { SAM_PID_SSC1,   XDMAC1_CH_SSC1_TX   }, /* SSC1 Transmit */
-  { SAM_PID_DBGU,   XDMAC1_CH_DBGU_TX   }, /* DBGU Transmit */
-  { SAM_PID_SMD,    XDMAC1_CH_SMD_TX    }, /* SMD Transmit */
+#if defined(ATSAMA5D2)
+  { SAM_PID_TWI0,     XDMAC1_CH_TWI0_TX     }, /* TWI0  Transmit */
+  { SAM_PID_TWI1,     XDMAC1_CH_TWI1_TX     }, /* TWI1  Transmit */
+  { SAM_PID_QSPI0,    XDMAC1_CH_QSPI0_TX    }, /* QSPI0 Transmit */
+  { SAM_PID_SPI0,     XDMAC1_CH_SPI0_TX     }, /* SPI0  Transmit */
+  { SAM_PID_SPI1,     XDMAC1_CH_SPI1_TX     }, /* SPI1  Transmit */
+  { SAM_PID_PWM,      XDMAC1_CH_PWM_TX      }, /* PWM   Transmit */
+  { SAM_PID_FLEXCOM0, XDMAC1_CH_FLEXCOM0_TX }, /* FLEXCOM0 Transmit */
+  { SAM_PID_FLEXCOM1, XDMAC1_CH_FLEXCOM1_TX }, /* FLEXCOM1 Transmit */
+  { SAM_PID_FLEXCOM2, XDMAC1_CH_FLEXCOM2_TX }, /* FLEXCOM2 Transmit */
+  { SAM_PID_FLEXCOM3, XDMAC1_CH_FLEXCOM3_TX }, /* FLEXCOM3 Transmit */
+  { SAM_PID_FLEXCOM4, XDMAC1_CH_FLEXCOM4_TX }, /* FLEXCOM4 Transmit */
+  { SAM_PID_SSC0,     XDMAC1_CH_SSC0_TX     }, /* SSC0 Transmit */
+  { SAM_PID_SSC1,     XDMAC1_CH_SSC1_TX     }, /* SSC1 Transmit */
+  { SAM_PID_AES,      XDMAC1_CH_AES_TX      }, /* AES  Transmit */
+  { SAM_PID_TDES,     XDMAC1_CH_TDES_TX     }, /* TDES Transmit */
+  { SAM_PID_SHA,      XDMAC1_CH_SHA_TX      }, /* SHA  Transmit */
+  { SAM_PID_I2SC0,    XDMAC1_CH_I2SC0_TX    }, /* I2SC0  Transmit */
+  { SAM_PID_I2SC1,    XDMAC1_CH_I2SC1_TX    }, /* I2SC1  Transmit */
+  { SAM_PID_UART0,    XDMAC1_CH_UART0_TX    }, /* UART0  Transmit */
+  { SAM_PID_UART1,    XDMAC1_CH_UART1_TX    }, /* UART1  Transmit */
+  { SAM_PID_UART2,    XDMAC1_CH_UART2_TX    }, /* UART2  Transmit */
+  { SAM_PID_UART3,    XDMAC1_CH_UART3_TX    }, /* UART3  Transmit */
+  { SAM_PID_UART4,    XDMAC1_CH_UART4_TX    }, /* UART4  Transmit */
+  { SAM_PID_CLASSD,   XDMAC1_CH_CLASSD_TX   }, /* CLASSD Transmit */
+  { SAM_PID_QSPI1,    XDMAC1_CH_QSPI1_TX    }, /* QSPI1  Transmit */
+#elif defined(ATSAMA5D4)
+  { SAM_PID_HSMCI0,   XDMAC1_CH_HSMCI0      }, /* HSMCI0 Receive/Transmit */
+  { SAM_PID_HSMCI1,   XDMAC1_CH_HSMCI1      }, /* HSMCI1 Receive/Transmit */
+  { SAM_PID_TWI0,     XDMAC1_CH_TWI0_TX     }, /* TWI0 Transmit */
+  { SAM_PID_TWI1,     XDMAC1_CH_TWI1_TX     }, /* TWI1 Transmit */
+  { SAM_PID_TWI2,     XDMAC1_CH_TWI2_TX     }, /* TWI2 Transmit */
+  { SAM_PID_TWI3,     XDMAC1_CH_TWI3_TX     }, /* TWI3 Transmit */
+  { SAM_PID_SPI0,     XDMAC1_CH_SPI0_TX     }, /* SPI0 Transmit */
+  { SAM_PID_SPI1,     XDMAC1_CH_SPI1_TX     }, /* SPI1 Transmit */
+  { SAM_PID_SPI2,     XDMAC1_CH_SPI2_TX     }, /* SPI2 Transmit */
+  { SAM_PID_USART2,   XDMAC1_CH_USART2_TX   }, /* USART2 Transmit */
+  { SAM_PID_USART3,   XDMAC1_CH_USART3_TX   }, /* USART3 Transmit */
+  { SAM_PID_USART4,   XDMAC1_CH_USART4_TX   }, /* USART4 Transmit */
+  { SAM_PID_UART0,    XDMAC1_CH_UART0_TX    }, /* UART0 Transmit */
+  { SAM_PID_UART1,    XDMAC1_CH_UART1_TX    }, /* UART1 Transmit */
+  { SAM_PID_SSC0,     XDMAC1_CH_SSC0_TX     }, /* SSC0 Transmit */
+  { SAM_PID_SSC1,     XDMAC1_CH_SSC1_TX     }, /* SSC1 Transmit */
+  { SAM_PID_DBGU,     XDMAC1_CH_DBGU_TX     }, /* DBGU Transmit */
+  { SAM_PID_SMD,      XDMAC1_CH_SMD_TX      }, /* SMD Transmit */
+#endif
 };
 #define NXDMAC1_TXCHANNELS (sizeof(g_xdmac1_txchan) / sizeof(struct sam_pidmap_s))
 #endif
@@ -1090,7 +1202,7 @@ static inline uint32_t sam_txcc(struct sam_xdmach_s *xdmach)
       /* Look up the DMA channel code for TX:  Peripheral is the sink. */
 
       field   = sam_sink_channel(xdmach, pid);
-      regval |= (field << XDMACH_CC_CSIZE_SHIFT);
+      regval |= (field << XDMACH_CC_PERID_SHIFT);
 
 #if 0 /* Not supported */
       /* 10. Set SWREQ to use software request (only relevant for a
@@ -1221,7 +1333,7 @@ static inline uint32_t sam_rxcc(struct sam_xdmach_s *xdmach)
    */
 
   if ((xdmach->flags & DMACH_FLAG_PERIPHAHB_MASK) ==
-      DMACH_FLAG_PERIPHAHB_AHB_IF1)
+       DMACH_FLAG_PERIPHAHB_AHB_IF1)
     {
       regval |= XDMACH_CC_SIF;
     }
@@ -1249,7 +1361,7 @@ static inline uint32_t sam_rxcc(struct sam_xdmach_s *xdmach)
       /* Look up the DMA channel code for RX:  Peripheral is the source. */
 
       field   = sam_source_channel(xdmach, pid);
-      regval |= (field << XDMACH_CC_CSIZE_SHIFT);
+      regval |= (field << XDMACH_CC_PERID_SHIFT);
 
 #if 0 /* Not supported */
       /* 10. Set SWREQ to use software request (only relevant for a
@@ -1368,12 +1480,12 @@ sam_allocdesc(struct sam_xdmach_s *xdmach, struct chnext_view1_s *prev,
               xdmach->lltail = descr;
 
               /* Assume that we will be doing multiple buffer transfers and
-               * that that hardware will be accessing the descriptor via DMA.
+               * that hardware will be accessing the descriptor via DMA.
                */
 
               up_clean_dcache((uintptr_t)descr,
                               (uintptr_t)descr +
-                              sizeof(struct chnext_view1_s));
+                               sizeof(struct chnext_view1_s));
               break;
             }
         }
@@ -1890,6 +2002,12 @@ void sam_dmainitialize(struct sam_xdmac_s *xdmac)
 
   nxsem_init(&xdmac->chsem, 0, 1);
   nxsem_init(&xdmac->dsem, 0, SAM_NDMACHAN);
+
+  /* The 'dsem' is used for signaling rather than mutual exclusion and,
+   * hence, should not have priority inheritance enabled.
+   */
+
+  nxsem_set_protocol(&xdmac->dsem, SEM_PRIO_NONE);
 }
 
 /****************************************************************************
@@ -2310,12 +2428,22 @@ int sam_dmastart(DMA_HANDLE handle, dma_callback_t callback, void *arg)
 
   if (xdmach->llhead)
     {
-      /* Save the callback info.  This will be invoked whent the DMA
+      /* Save the callback info.  This will be invoked when the DMA
        * completes
        */
 
       xdmach->callback = callback;
       xdmach->arg      = arg;
+
+      /* If this is an RX DMA (peripheral-to-memory), then flush and
+       * invalidate the data cache to force reloading from memory when the
+       * DMA completes.
+       */
+
+      if (xdmach->rx)
+        {
+          up_flush_dcache(xdmach->rxaddr, xdmach->rxaddr + xdmach->rxsize);
+        }
 
       /* Is this a single block transfer?  Or a multiple block transfer? */
 


### PR DESCRIPTION
## Summary
1. add SAMA5D2 support for SAMA5 xdma driver.
2. fix xdma configuration bug and some typo 
## Impact
N/A
## Testing
Verified on SAMA5D2 platform
