### PR TITLE
armv7-a/r: only primary can do invalidate_dcache_all() at startting

### DIFF
--- a/arch/arm/src/armv7-a/arm_scu.c
+++ b/arch/arm/src/armv7-a/arm_scu.c
@@ -90,7 +90,7 @@ void arm_enable_smp(int cpu)
        * coherent L2.
        */
 
-      cp15_invalidate_dcache_all();
+      cp15_dcache_op_level(0, CP15_CACHE_INVALIDATE);
       ARM_DSB();
 
       /* Wait for the SCU to be enabled by the primary processor -- should

--- a/arch/arm/src/armv7-a/cp15_cacheops.h
+++ b/arch/arm/src/armv7-a/cp15_cacheops.h
@@ -63,6 +63,10 @@
 
 /* Cache definitions ********************************************************/
 
+#define CP15_CACHE_INVALIDATE       0
+#define CP15_CACHE_CLEAN            1
+#define CP15_CACHE_CLEANINVALIDATE  2
+
 /* L1 Memory */
 
 #define CP15_L1_LINESIZE 32
@@ -897,6 +901,23 @@ extern "C"
 /****************************************************************************
  * Public Function Prototypes
  ****************************************************************************/
+
+/****************************************************************************
+ * Name: cp15_dcache_op_level
+ *
+ * Description:
+ *   Dcache operation from level
+ *
+ * Input Parameters:
+ *   level - cache level
+ *   op    - CP15_CACHE_XX
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+void cp15_dcache_op_level(uint32_t level, int op);
 
 /****************************************************************************
  * Name: cp15_coherent_dcache

--- a/arch/arm/src/armv7-r/cp15_cacheops.h
+++ b/arch/arm/src/armv7-r/cp15_cacheops.h
@@ -61,6 +61,10 @@
 
 /* Cache definitions ********************************************************/
 
+#define CP15_CACHE_INVALIDATE       0
+#define CP15_CACHE_CLEAN            1
+#define CP15_CACHE_CLEANINVALIDATE  2
+
 /* L1 Memory */
 
 #define CP15_L1_LINESIZE 32
@@ -904,6 +908,23 @@ extern "C"
 /****************************************************************************
  * Public Function Prototypes
  ****************************************************************************/
+
+/****************************************************************************
+ * Name: cp15_dcache_op_level
+ *
+ * Description:
+ *   Dcache operation from level
+ *
+ * Input Parameters:
+ *   level - cache level
+ *   op    - CP15_CACHE_XX
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+void cp15_dcache_op_level(uint32_t level, int op);
 
 /****************************************************************************
  * Name: cp15_coherent_dcache


### PR DESCRIPTION
## Summary

armv7-a/r: NON-primary core should invalidate dacache level1

NON-primary cpu will invalidate cpu0's cache L2, that will caused cpu0's data mismatch, and then system crash

## Impact

SMP

## Testing

VELA
