### PR TITLE
arch: armv7-a: Remove the code for CONFIG_ARCH_PGPOOL_MAPPING=n

### DIFF
--- a/arch/arm/src/armv7-a/arm_pgalloc.c
+++ b/arch/arm/src/armv7-a/arm_pgalloc.c
@@ -56,9 +56,6 @@ static uintptr_t alloc_pgtable(void)
   irqstate_t flags;
   uintptr_t paddr;
   uint32_t *l2table;
-#ifndef CONFIG_ARCH_PGPOOL_MAPPING
-  uint32_t l1save;
-#endif
 
   /* Allocate one physical page for the L2 page table */
 
@@ -70,19 +67,9 @@ static uintptr_t alloc_pgtable(void)
 
       flags = enter_critical_section();
 
-#ifdef CONFIG_ARCH_PGPOOL_MAPPING
       /* Get the virtual address corresponding to the physical page address */
 
       l2table = (uint32_t *)arm_pgvaddr(paddr);
-#else
-      /* Temporarily map the page into the virtual address space */
-
-      l1save = mmu_l1_getentry(ARCH_SCRATCH_VBASE);
-      mmu_l1_setentry(paddr & ~SECTION_MASK, ARCH_SCRATCH_VBASE,
-                      MMU_MEMFLAGS);
-      l2table = (uint32_t *)(ARCH_SCRATCH_VBASE |
-                                 (paddr & SECTION_MASK));
-#endif
 
       /* Initialize the page table */
 
@@ -95,11 +82,6 @@ static uintptr_t alloc_pgtable(void)
       up_flush_dcache((uintptr_t)l2table,
                       (uintptr_t)l2table + MM_PGSIZE);
 
-#ifndef CONFIG_ARCH_PGPOOL_MAPPING
-      /* Restore the scratch section page table entry */
-
-      mmu_l1_restore(ARCH_SCRATCH_VBASE, l1save);
-#endif
       leave_critical_section(flags);
     }
 
@@ -205,9 +187,6 @@ uintptr_t pgalloc(uintptr_t brkaddr, unsigned int npages)
   uint32_t *l2table;
   irqstate_t flags;
   uintptr_t paddr;
-#ifndef CONFIG_ARCH_PGPOOL_MAPPING
-  uint32_t l1save;
-#endif
   unsigned int index;
 
   binfo("tcb->pid=%d tcb->group=%p\n", tcb->pid, tcb->group);
@@ -247,21 +226,9 @@ uintptr_t pgalloc(uintptr_t brkaddr, unsigned int npages)
 
       flags = enter_critical_section();
 
-#ifdef CONFIG_ARCH_PGPOOL_MAPPING
       /* Get the virtual address corresponding to the physical page address */
 
       l2table = (uint32_t *)arm_pgvaddr(paddr);
-#else
-      /* Temporarily map the level 2 page table into the "scratch" virtual
-       * address space
-       */
-
-      l1save = mmu_l1_getentry(ARCH_SCRATCH_VBASE);
-      mmu_l1_setentry(paddr & ~SECTION_MASK, ARCH_SCRATCH_VBASE,
-                      MMU_MEMFLAGS);
-      l2table = (uint32_t *)(ARCH_SCRATCH_VBASE |
-                                 (paddr & SECTION_MASK));
-#endif
 
       /* Back up L2 entry with physical memory */
 
@@ -269,9 +236,6 @@ uintptr_t pgalloc(uintptr_t brkaddr, unsigned int npages)
       binfo("a new page (paddr=%x)\n", paddr);
       if (paddr == 0)
         {
-#ifndef CONFIG_ARCH_PGPOOL_MAPPING
-          mmu_l1_restore(ARCH_SCRATCH_VBASE, l1save);
-#endif
           leave_critical_section(flags);
           return 0;
         }
@@ -296,11 +260,6 @@ uintptr_t pgalloc(uintptr_t brkaddr, unsigned int npages)
       up_flush_dcache((uintptr_t)&l2table[index],
                       (uintptr_t)&l2table[index] + sizeof(uint32_t));
 
-#ifndef CONFIG_ARCH_PGPOOL_MAPPING
-      /* Restore the scratch L1 page table entry */
-
-      mmu_l1_restore(ARCH_SCRATCH_VBASE, l1save);
-#endif
       leave_critical_section(flags);
     }
 

--- a/arch/arm/src/armv7-a/arm_virtpgaddr.c
+++ b/arch/arm/src/armv7-a/arm_virtpgaddr.c
@@ -26,7 +26,7 @@
 
 #include "pgalloc.h"
 
-#if defined(CONFIG_MM_PGALLOC) && defined(CONFIG_ARCH_PGPOOL_MAPPING)
+#ifdef CONFIG_MM_PGALLOC
 
 /****************************************************************************
  * Public Functions
@@ -58,4 +58,4 @@ uintptr_t arm_virtpgaddr(uintptr_t paddr)
   return 0;
 }
 
-#endif /* CONFIG_MM_PGALLOC && CONFIG_ARCH_PGPOOL_MAPPING */
+#endif /* CONFIG_MM_PGALLOC */

--- a/arch/arm/src/armv7-a/pgalloc.h
+++ b/arch/arm/src/armv7-a/pgalloc.h
@@ -41,6 +41,10 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
+#ifndef CONFIG_ARCH_PGPOOL_MAPPING
+#  error "ARMv7-A needs CONFIG_ARCH_PGPOOL_MAPPING"
+#endif
+
 /****************************************************************************
  * Public Data
  ****************************************************************************/
@@ -48,39 +52,6 @@
 /****************************************************************************
  * Inline Functions
  ****************************************************************************/
-
-/****************************************************************************
- * Name: arm_pgmap
- *
- * Description:
- *   Map one page to a temporary, scratch virtual memory address
- *
- ****************************************************************************/
-
-#if !defined(CONFIG_ARCH_PGPOOL_MAPPING) && defined(CONFIG_ARCH_USE_MMU)
-static inline uintptr_t arm_tmpmap(uintptr_t paddr, uint32_t *l1save)
-{
-  *l1save = mmu_l1_getentry(ARCH_SCRATCH_VBASE);
-  mmu_l1_setentry(paddr & ~SECTION_MASK, ARCH_SCRATCH_VBASE, MMU_MEMFLAGS);
-  return ((uintptr_t)ARCH_SCRATCH_VBASE | (paddr & SECTION_MASK));
-}
-#endif
-
-/****************************************************************************
- * Name: arm_pgrestore
- *
- * Description:
- *  Restore any previous L1 page table mapping that was in place when
- *  arm_tmpmap() was called
- *
- ****************************************************************************/
-
-#if !defined(CONFIG_ARCH_PGPOOL_MAPPING) && defined(CONFIG_ARCH_USE_MMU)
-static inline void arm_tmprestore(uint32_t l1save)
-{
-  mmu_l1_restore(ARCH_SCRATCH_VBASE, l1save);
-}
-#endif
 
 /****************************************************************************
  * Name: arm_pgvaddr
@@ -92,7 +63,6 @@ static inline void arm_tmprestore(uint32_t l1save)
  *
  ****************************************************************************/
 
-#ifdef CONFIG_ARCH_PGPOOL_MAPPING
 static inline uintptr_t arm_pgvaddr(uintptr_t paddr)
 {
   DEBUGASSERT(paddr >= CONFIG_ARCH_PGPOOL_PBASE &&
@@ -100,7 +70,6 @@ static inline uintptr_t arm_pgvaddr(uintptr_t paddr)
 
   return paddr - CONFIG_ARCH_PGPOOL_PBASE + CONFIG_ARCH_PGPOOL_VBASE;
 }
-#endif
 
 /****************************************************************************
  * Name: arm_uservaddr
@@ -228,9 +197,7 @@ uintptr_t arm_physpgaddr(uintptr_t vaddr);
  *
  ****************************************************************************/
 
-#ifdef CONFIG_ARCH_PGPOOL_MAPPING
 uintptr_t arm_virtpgaddr(uintptr_t paddr);
-#endif
 
 #endif /* CONFIG_MM_PGALLOC */
 #endif /* __ARCH_ARM_SRC_ARMV7_A_PGALLOC_H */


### PR DESCRIPTION
## Summary

- Currently, CONFIG_ARCH_PGPOOL_MAPPING=y is necessary for CONFIG_BUILD_KERNEL=y.
- This commit removes the code for CONFIG_ARCH_PGPOOL_MAPPING=n

## Impact

- None

## Testing

- Tested with sabre-6quad:netknsh_smp
