### PR TITLE
libc: Remove the reference of _stext/_etext from lib_cxx_initialize.c

### DIFF
--- a/include/nuttx/arch.h
+++ b/include/nuttx/arch.h
@@ -96,6 +96,7 @@
 
 typedef CODE void (*sig_deliver_t)(FAR struct tcb_s *tcb);
 typedef CODE void (*phy_enable_t)(bool enable);
+typedef CODE void (*initializer_t)(void);
 
 /****************************************************************************
  * Public Data
@@ -147,6 +148,15 @@ EXTERN volatile bool g_rtc_enabled;
 
 /* EXTERN const irq_mapped_t g_irqmap[NR_IRQS]; */
 
+#endif
+
+#ifdef CONFIG_HAVE_CXXINITIALIZE
+/* _sinit and _einit are symbols exported by the linker script that mark the
+ * beginning and the end of the C++ initialization section.
+ */
+
+extern initializer_t _sinit;
+extern initializer_t _einit;
 #endif
 
 /****************************************************************************

--- a/libs/libc/misc/lib_cxx_initialize.c
+++ b/libs/libc/misc/lib_cxx_initialize.c
@@ -50,13 +50,6 @@ typedef CODE void (*initializer_t)(void);
 extern initializer_t _sinit;
 extern initializer_t _einit;
 
-/* _stext and _etext are symbols exported by the linker script that mark the
- * beginning and the end of text.
- */
-
-extern uintptr_t _stext;
-extern uintptr_t _etext;
-
 #if defined(CONFIG_ARCH_SIM) && defined(CONFIG_HOST_MACOS)
 extern void macho_call_saved_init_funcs(void);
 #endif
@@ -93,8 +86,7 @@ void lib_cxx_initialize(void)
 #else
       initializer_t *initp;
 
-      sinfo("_sinit: %p _einit: %p _stext: %p _etext: %p\n",
-            &_sinit, &_einit, &_stext, &_etext);
+      sinfo("_sinit: %p _einit: %p\n", &_sinit, &_einit);
 
       /* Visit each entry in the initialization table */
 
@@ -103,13 +95,11 @@ void lib_cxx_initialize(void)
           initializer_t initializer = *initp;
           sinfo("initp: %p initializer: %p\n", initp, initializer);
 
-          /* Make sure that the address is non-NULL and lies in the text
-           * region defined by the linker script.  Some toolchains may put
+          /* Make sure that the address is non-NULL. Some toolchains may put
            * NULL values or counts in the initialization table.
            */
 
-          if ((FAR void *)initializer >= (FAR void *)&_stext &&
-              (FAR void *)initializer < (FAR void *)&_etext)
+          if (initializer)
             {
               sinfo("Calling %p\n", initializer);
               initializer();

--- a/libs/libc/misc/lib_cxx_initialize.c
+++ b/libs/libc/misc/lib_cxx_initialize.c
@@ -32,23 +32,8 @@
 #include "libc.h"
 
 /****************************************************************************
- * Private Types
- ****************************************************************************/
-
-/* This type defines one entry in initialization array */
-
-typedef CODE void (*initializer_t)(void);
-
-/****************************************************************************
  * External References
  ****************************************************************************/
-
-/* _sinit and _einit are symbols exported by the linker script that mark the
- * beginning and the end of the C++ initialization section.
- */
-
-extern initializer_t _sinit;
-extern initializer_t _einit;
 
 #if defined(CONFIG_ARCH_SIM) && defined(CONFIG_HOST_MACOS)
 extern void macho_call_saved_init_funcs(void);


### PR DESCRIPTION
## Summary
and make _sinit/_einit as an offical interface

## Impact
Remove the impossible condition

## Testing

