### PR TITLE
arm/armv7-r: remove incorrect include header "addrenv.h"

### DIFF
--- a/arch/arm/src/armv7-r/arm_syscall.c
+++ b/arch/arm/src/armv7-r/arm_syscall.c
@@ -33,7 +33,6 @@
 #include <nuttx/arch.h>
 #include <nuttx/sched.h>
 
-#include "addrenv.h"
 #include "arm.h"
 #include "arm_internal.h"
 #include "signal/signal.h"


### PR DESCRIPTION
## Summary

arm/armv7-r: remove incorrect include header "addrenv.h"

since armv7-r does not support kernel mode

```
./armv7-r/arm_syscall.c:36:10: fatal error: addrenv.h: No such file or directory
   36 | #include "addrenv.h"
      |          ^~~~~~~~~~~
```

Signed-off-by: chao an <anchao@xiaomi.com>


## Impact

N/A

## Testing

ci-check