### PR TITLE
armv7-r/tms570: fix build break

### DIFF
--- a/arch/arm/src/tms570/Make.defs
+++ b/arch/arm/src/tms570/Make.defs
@@ -23,7 +23,7 @@ include armv7-r/Make.defs
 # SAMA5-specific C source files
 
 CHIP_CSRCS  = tms570_boot.c tms570_clockconfig.c tms570_esm.c tms570_gio.c
-CHIP_CSRCS += tms570_irq.c tms570_lowputc.c tms570_serial.c tms570_spi.c
+CHIP_CSRCS += tms570_irq.c tms570_lowputc.c tms570_serial.c
 
 # Configuration dependent C and assembly language files
 
@@ -38,3 +38,5 @@ endif
 ifeq ($(CONFIG_TMS570_GIO_IRQ),y)
 CHIP_CSRCS += tms570_gioirq.c
 endif
+
+CMN_CSRCS := $(filter-out arm_gicv2.c, $(CMN_CSRCS))

--- a/arch/arm/src/tms570/tms570_clockconfig.c
+++ b/arch/arm/src/tms570/tms570_clockconfig.c
@@ -203,7 +203,7 @@ static uint32_t check_frequency(uint32_t cnt1_clksrc)
 
 uint32_t _errata_sswf021_45_both_plls(uint32_t count)
 {
-  uint32_t failcode;
+  uint32_t failcode = 0u;
   uint32_t retries;
   uint32_t clkcntrlsave;
   uint32_t regval;

--- a/arch/arm/src/tms570/tms570_esm.c
+++ b/arch/arm/src/tms570/tms570_esm.c
@@ -154,7 +154,7 @@ int tms570_esm_interrupt(int irq, void *context, void *arg)
 
   /* Crash -- possibly showing diagnostic debug information. */
 
-  _err("ERROR: ESM Interrupt. PC: %08x\n", CURRENT_REGS[REG_PC]);
+  _err("ERROR: ESM Interrupt. PC: %08" PRIx32 "\n", CURRENT_REGS[REG_PC]);
   PANIC();
   return OK; /* To keep the compiler happy */
 }

--- a/arch/arm/src/tms570/tms570_serial.c
+++ b/arch/arm/src/tms570/tms570_serial.c
@@ -128,7 +128,7 @@ static int  tms570_attach(struct uart_dev_s *dev);
 static void tms570_detach(struct uart_dev_s *dev);
 static int  tms570_interrupt(int irq, void *context, void *arg);
 static int  tms570_ioctl(struct file *filep, int cmd, unsigned long arg);
-static int  tms570_receive(struct uart_dev_s *dev, uint32_t *status);
+static int  tms570_receive(struct uart_dev_s *dev, unsigned int *status);
 static void tms570_rxint(struct uart_dev_s *dev, bool enable);
 static bool tms570_rxavailable(struct uart_dev_s *dev);
 static void tms570_send(struct uart_dev_s *dev, int ch);
@@ -692,7 +692,7 @@ static int tms570_ioctl(struct file *filep, int cmd, unsigned long arg)
  *
  ****************************************************************************/
 
-static int tms570_receive(struct uart_dev_s *dev, uint32_t *status)
+static int tms570_receive(struct uart_dev_s *dev, unsigned int *status)
 {
   struct tms570_dev_s *priv = (struct tms570_dev_s *)dev->priv;
 

--- a/boards/arm/tms570/launchxl-tms57004/scripts/Make.defs
+++ b/boards/arm/tms570/launchxl-tms57004/scripts/Make.defs
@@ -25,7 +25,6 @@ include $(TOPDIR)/arch/arm/src/armv7-r/Toolchain.defs
 LDSCRIPT = flash-sram.ld
 ARCHSCRIPT += $(BOARD_DIR)$(DELIM)scripts$(DELIM)$(LDSCRIPT)
 
-ARCHCPUFLAGS = -mcpu=cortex-r4 -mbig-endian
 ARCHPICFLAGS = -fpic -msingle-pic-base -mpic-register=r10
 
 CFLAGS := $(ARCHCFLAGS) $(ARCHOPTIMIZATION) $(ARCHCPUFLAGS) $(ARCHINCLUDES) $(ARCHDEFINES) $(EXTRAFLAGS) -pipe


### PR DESCRIPTION

## Summary

armv7-r/tms570: fix build break

1.
`make[1]: *** No rule to make target 'tms570_spi.c', needed by '.depend'.  Stop.`

2.
```
In file included from armv7-r/arm_gicv2.c:36:
armv7-r/gic.h: In function 'arm_gic_nlines':
armv7-r/mpcore.h:63:29: error: 'CHIP_MPCORE_VBASE' undeclared (first use in this function)
   63 | #define MPCORE_ICD_VBASE   (CHIP_MPCORE_VBASE+MPCORE_ICD_OFFSET)
      |                             ^~~~~~~~~~~~~~~~~
```

In file included from armv7-r/arm_gicv2.c:36:
armv7-r/gic.h: In function 'arm_gic_nlines':
armv7-r/mpcore.h:63:29: error: 'CHIP_MPCORE_VBASE' undeclared (first use in this function)
   63 | #define MPCORE_ICD_VBASE   (CHIP_MPCORE_VBASE+MPCORE_ICD_OFFSET)
      |                             ^~~~~~~~~~~~~~~~~



```
In file included from chip/tms570_esm.c:52:
chip/tms570_esm.c: In function 'tms570_esm_interrupt':
chip/tms570_esm.c:157:8: warning: format '%x' expects argument of type 'unsigned int', but argument 3 has type 'uint32_t' {aka 'volatile long unsigned int'} [-Wformat=]
  157 |   _err("ERROR: ESM Interrupt. PC: %08x\n", CURRENT_REGS[REG_PC]);
      |        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
chip/tms570_esm.c:157:38: note: format string is defined here
  157 |   _err("ERROR: ESM Interrupt. PC: %08x\n", CURRENT_REGS[REG_PC]);
      |                                   ~~~^
      |                                      |
      |                                      unsigned int
      |                                   %08lx
chip/tms570_serial.c:150:21: warning: initialization of 'int (*)(struct uart_dev_s *, unsigned int *)' from incompatible pointer type 'int (*)(struct uart_dev_s *, uint32_t *)' {aka 'int (*)(struct uart_dev_s *, long unsigned int *)'} [-Wincompatible-pointer-types]
  150 |   .receive        = tms570_receive,
      |                     ^~~~~~~~~~~~~~
chip/tms570_serial.c:150:21: note: (near initialization for 'g_sci_ops.receive')
chip/tms570_clockconfig.c: In function '_errata_sswf021_45_both_plls':
chip/tms570_clockconfig.c:319:10: warning: 'failcode' may be used uninitialized in this function [-Wmaybe-uninitialized]
  319 |   return failcode;
      |          ^~~~~~~~
```

Signed-off-by: chao an <anchao@xiaomi.com>

## Impact

N/A

## Testing

armv7-r  launchxl-tms57004/nsh