### PR TITLE
arch: Change the linker generated symbols from uint32_t to uint8_t *

### DIFF
--- a/arch/arm/include/elf.h
+++ b/arch/arm/include/elf.h
@@ -18,7 +18,7 @@
  *
  ****************************************************************************/
 
-/* Reference: "ELF for the ARM® Architecture," ARM IHI 0044D, current through
+/* Reference: "ELF for the ARM Architecture," ARM IHI 0044D, current through
  *   ABI release 2.08, October 28, 2009, ARM Limited.
  */
 
@@ -248,6 +248,16 @@
 #define DT_ARM_PREEMPTMAP        0x70000002
 #define DT_ARM_RESERVED2         0x70000003
 
+/****************************************************************************
+ * Public Types
+ ****************************************************************************/
+
+typedef struct __EIT_entry
+{
+  unsigned long fnoffset;
+  unsigned long content;
+} __EIT_entry;
+
 /* ELF register definitions */
 
 /* Holds the general purpose registers $a1 * through to $pc
@@ -256,5 +266,25 @@
  */
 
 typedef unsigned long elf_gregset_t[18];
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+#ifdef __cplusplus
+#define EXTERN extern "C"
+extern "C"
+{
+#else
+#define EXTERN extern
+#endif
+
+extern __EIT_entry __exidx_start[];
+extern __EIT_entry __exidx_end[];
+
+#undef EXTERN
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __ARCH_ARM_INCLUDE_ELF_H */

--- a/arch/arm/src/a1x/a1x_boot.c
+++ b/arch/arm/src/a1x/a1x_boot.c
@@ -62,8 +62,8 @@
  * Public Data
  ****************************************************************************/
 
-extern uint32_t _vector_start; /* Beginning of vector block */
-extern uint32_t _vector_end;   /* End+1 of vector block */
+extern uint8_t _vector_start[]; /* Beginning of vector block */
+extern uint8_t _vector_end[];   /* End+1 of vector block */
 
 /****************************************************************************
  * Private Data
@@ -173,7 +173,7 @@ static void a1x_vectormapping(void)
 {
   uint32_t vector_paddr = A1X_VECTOR_PADDR & PTE_SMALL_PADDR_MASK;
   uint32_t vector_vaddr = A1X_VECTOR_VADDR & PTE_SMALL_PADDR_MASK;
-  uint32_t vector_size  = (uint32_t)&_vector_end - (uint32_t)&_vector_start;
+  uint32_t vector_size  = _vector_end - _vector_start;
   uint32_t end_paddr    = A1X_VECTOR_PADDR + vector_size;
 
   /* REVISIT:  Cannot really assert in this context */
@@ -239,8 +239,8 @@ static void a1x_copyvectorblock(void)
    *                      0xffff0000)
    */
 
-  src  = (uint32_t *)&_vector_start;
-  end  = (uint32_t *)&_vector_end;
+  src  = (uint32_t *)_vector_start;
+  end  = (uint32_t *)_vector_end;
   dest = (uint32_t *)(A1X_VECTOR_VSRAM + VECTOR_TABLE_OFFSET);
 
   while (src < end)

--- a/arch/arm/src/am335x/am335x_boot.c
+++ b/arch/arm/src/am335x/am335x_boot.c
@@ -91,8 +91,8 @@
 
 /* Symbols defined via the linker script */
 
-extern uint32_t _vector_start; /* Beginning of vector block */
-extern uint32_t _vector_end;   /* End+1 of vector block */
+extern uint8_t _vector_start[]; /* Beginning of vector block */
+extern uint8_t _vector_end[];   /* End+1 of vector block */
 
 #define SAMA5_LCDC_FBNSECTIONS \
   ((CONFIG_SAMA5_LCDC_FB_SIZE + 0x000fffff) >> 20)
@@ -237,13 +237,7 @@ static void am335x_vectorpermissions(uint32_t mmuflags)
 
 static inline size_t am335x_vectorsize(void)
 {
-  uintptr_t src;
-  uintptr_t end;
-
-  src = (uintptr_t)&_vector_start;
-  end = (uintptr_t)&_vector_end;
-
-  return (size_t)(end - src);
+  return _vector_end - _vector_start;
 }
 
 /****************************************************************************
@@ -264,7 +258,7 @@ static void am335x_vectormapping(void)
 {
   uint32_t vector_paddr = AM335X_VECTOR_PADDR & PTE_SMALL_PADDR_MASK;
   uint32_t vector_vaddr = AM335X_VECTOR_VADDR & PTE_SMALL_PADDR_MASK;
-  uint32_t vector_size  = (uint32_t)&_vector_end - (uint32_t)&_vector_start;
+  uint32_t vector_size  = _vector_end - _vector_start;
   uint32_t end_paddr    = AM335X_VECTOR_PADDR + vector_size;
 
   /* REVISIT:  Cannot really assert in this context */
@@ -331,9 +325,9 @@ static void am335x_copyvectorblock(void)
    *                         0xffff0000)
    */
 
-  src  = (uint32_t *)&_vector_start;
-  end  = (uint32_t *)&_vector_end;
-  dest = (uint32_t *)(AM335X_VECTOR_VSRAM);
+  src  = (uint32_t *)_vector_start;
+  end  = (uint32_t *)_vector_end;
+  dest = (uint32_t *)AM335X_VECTOR_VSRAM;
 
   while (src < end)
     {

--- a/arch/arm/src/am335x/am335x_irq.c
+++ b/arch/arm/src/am335x/am335x_irq.c
@@ -40,8 +40,8 @@
 
 /* Symbols defined via the linker script */
 
-extern uint32_t _vector_start; /* Beginning of vector block */
-extern uint32_t _vector_end;   /* End+1 of vector block */
+extern uint8_t _vector_start[]; /* Beginning of vector block */
+extern uint8_t _vector_end[];   /* End+1 of vector block */
 
 /****************************************************************************
  * Public Functions
@@ -78,8 +78,8 @@ void up_irqinitialize(void)
 
   /* Set the VBAR register to the address of the vector table */
 
-  DEBUGASSERT((((uintptr_t)&_vector_start) & ~VBAR_MASK) == 0);
-  cp15_wrvbar((uint32_t)&_vector_start);
+  DEBUGASSERT((((uintptr_t)_vector_start) & ~VBAR_MASK) == 0);
+  cp15_wrvbar((uint32_t)_vector_start);
 #endif /* CONFIG_ARCH_LOWVECTORS */
 
   /* The following operations need to be atomic, but since this function is

--- a/arch/arm/src/armv6-m/arm_hardfault.c
+++ b/arch/arm/src/armv6-m/arm_hardfault.c
@@ -82,15 +82,15 @@ int arm_hardfault(int irq, void *context, void *arg)
    * FLASH region or in the user FLASH region.
    */
 
-  if (((uintptr_t)pc >= (uintptr_t)&_stext &&
-       (uintptr_t)pc <  (uintptr_t)&_etext) ||
+  if (((uintptr_t)pc >= (uintptr_t)_stext &&
+       (uintptr_t)pc <  (uintptr_t)_etext) ||
       ((uintptr_t)pc >= (uintptr_t)USERSPACE->us_textstart &&
        (uintptr_t)pc <  (uintptr_t)USERSPACE->us_textend))
 #else
   /* SVCalls are expected only from the base, kernel FLASH region */
 
-  if ((uintptr_t)pc >= (uintptr_t)&_stext &&
-      (uintptr_t)pc <  (uintptr_t)&_etext)
+  if ((uintptr_t)pc >= (uintptr_t)_stext &&
+      (uintptr_t)pc <  (uintptr_t)_etext)
 #endif
     {
       /* Fetch the instruction that caused the Hard fault */

--- a/arch/arm/src/armv6-m/arm_vectors.c
+++ b/arch/arm/src/armv6-m/arm_vectors.c
@@ -50,7 +50,7 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-#define IDLE_STACK      ((const char *)&_ebss+CONFIG_IDLETHREAD_STACKSIZE)
+#define IDLE_STACK      (_ebss + CONFIG_IDLETHREAD_STACKSIZE)
 
 #ifndef ARMV6M_PERIPHERAL_INTERRUPTS
 #  error ARMV6M_PERIPHERAL_INTERRUPTS must be defined to the number of I/O interrupts to be supported

--- a/arch/arm/src/armv7-m/arm_vectors.c
+++ b/arch/arm/src/armv7-m/arm_vectors.c
@@ -45,7 +45,7 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-#define IDLE_STACK      ((const char *)&_ebss+CONFIG_IDLETHREAD_STACKSIZE)
+#define IDLE_STACK      (_ebss + CONFIG_IDLETHREAD_STACKSIZE)
 
 #ifndef ARMV7M_PERIPHERAL_INTERRUPTS
 #  error ARMV7M_PERIPHERAL_INTERRUPTS must be defined to the number of I/O interrupts to be supported

--- a/arch/arm/src/armv8-m/arm_vectors.c
+++ b/arch/arm/src/armv8-m/arm_vectors.c
@@ -45,7 +45,7 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-#define IDLE_STACK      ((const char *)&_ebss+CONFIG_IDLETHREAD_STACKSIZE)
+#define IDLE_STACK      (_ebss + CONFIG_IDLETHREAD_STACKSIZE)
 
 #ifndef ARMV8M_PERIPHERAL_INTERRUPTS
 #  error ARMV8M_PERIPHERAL_INTERRUPTS must be defined to the number of I/O interrupts to be supported

--- a/arch/arm/src/common/arm_assert.c
+++ b/arch/arm/src/common/arm_assert.c
@@ -418,7 +418,7 @@ static void arm_dumpstate(void)
 #  ifdef CONFIG_SMP
                  (uint32_t)arm_intstack_alloc(),
 #  else
-                 (uint32_t)&g_intstackalloc,
+                 (uint32_t)g_intstackalloc,
 #  endif
                  (CONFIG_ARCH_INTERRUPTSTACK & ~7),
                  !!CURRENT_REGS);

--- a/arch/arm/src/common/arm_backtrace_fp.c
+++ b/arch/arm/src/common/arm_backtrace_fp.c
@@ -127,7 +127,7 @@ int up_backtrace(struct tcb_s *tcb,
 #  ifdef CONFIG_SMP
           istacklimit = arm_intstack_top();
 #  else
-          istacklimit = &g_intstacktop;
+          istacklimit = g_intstacktop;
 #  endif /* CONFIG_SMP */
           ret = backtrace(istacklimit - (CONFIG_ARCH_INTERRUPTSTACK & ~7),
                           istacklimit,

--- a/arch/arm/src/common/arm_backtrace_thumb.c
+++ b/arch/arm/src/common/arm_backtrace_thumb.c
@@ -492,7 +492,7 @@ int up_backtrace(struct tcb_s *tcb,
 #  ifdef CONFIG_SMP
                                arm_intstack_top(),
 #  else
-                               &g_intstacktop,
+                               g_intstacktop,
 #  endif /* CONFIG_SMP */
                                &sp, (void *)up_backtrace + 10,
                                buffer, size, &skip);

--- a/arch/arm/src/common/arm_checkstack.c
+++ b/arch/arm/src/common/arm_checkstack.c
@@ -246,7 +246,7 @@ size_t up_check_intstack(void)
   return arm_stack_check((void *)arm_intstack_alloc(),
                          STACK_ALIGN_DOWN(CONFIG_ARCH_INTERRUPTSTACK));
 #else
-  return arm_stack_check((void *)&g_intstackalloc,
+  return arm_stack_check(g_intstackalloc,
                          STACK_ALIGN_DOWN(CONFIG_ARCH_INTERRUPTSTACK));
 #endif
 }

--- a/arch/arm/src/common/arm_initialize.c
+++ b/arch/arm/src/common/arm_initialize.c
@@ -59,7 +59,7 @@ static inline void arm_color_intstack(void)
 #ifdef CONFIG_SMP
   uint32_t *ptr = (uint32_t *)arm_intstack_alloc();
 #else
-  uint32_t *ptr = (uint32_t *)&g_intstackalloc;
+  uint32_t *ptr = (uint32_t *)g_intstackalloc;
 #endif
   ssize_t size;
 

--- a/arch/arm/src/common/arm_internal.h
+++ b/arch/arm/src/common/arm_internal.h
@@ -106,17 +106,17 @@
 #  define _START_DATA  __sfb(".data")
 #  define _END_DATA    __sfe(".data")
 #else
-#  define _START_TEXT  &_stext
-#  define _END_TEXT    &_etext
-#  define _START_BSS   &_sbss
-#  define _END_BSS     &_ebss
-#  define _DATA_INIT   &_eronly
-#  define _START_DATA  &_sdata
-#  define _END_DATA    &_edata
-#  define _START_TDATA &_stdata
-#  define _END_TDATA   &_etdata
-#  define _START_TBSS  &_stbss
-#  define _END_TBSS    &_etbss
+#  define _START_TEXT  _stext
+#  define _END_TEXT    _etext
+#  define _START_BSS   _sbss
+#  define _END_BSS     _ebss
+#  define _DATA_INIT   _eronly
+#  define _START_DATA  _sdata
+#  define _END_DATA    _edata
+#  define _START_TDATA _stdata
+#  define _END_TDATA   _etdata
+#  define _START_TBSS  _stbss
+#  define _END_TBSS    _etbss
 #endif
 
 /* This is the value used to mark the stack for subsequent stack monitoring
@@ -207,33 +207,23 @@ EXTERN const uintptr_t g_idle_topstack;
 /* Address of the saved user stack pointer */
 
 #if CONFIG_ARCH_INTERRUPTSTACK > 3
-EXTERN uint32_t g_intstackalloc; /* Allocated stack base */
-EXTERN uint32_t g_intstacktop;   /* Initial top of interrupt stack */
+EXTERN uint8_t g_intstackalloc[]; /* Allocated stack base */
+EXTERN uint8_t g_intstacktop[];   /* Initial top of interrupt stack */
 #endif
 
-/* These 'addresses' of these values are setup by the linker script.  They
- * are not actual uint32_t storage locations! They are only used
- * meaningfully in the following way:
- *
- *  - The linker script defines, for example, the symbol_sdata.
- *  - The declaration extern uint32_t _sdata; makes C happy.  C will believe
- *    that the value _sdata is the address of a uint32_t variable _data (it
- *    is not!).
- *  - We can recover the linker value then by simply taking the address of
- *    of _data.  like:  uint32_t *pdata = &_sdata;
- */
+/* These symbols are setup by the linker script. */
 
-EXTERN uint32_t _stext;           /* Start of .text */
-EXTERN uint32_t _etext;           /* End_1 of .text + .rodata */
-EXTERN const uint32_t _eronly;    /* End+1 of read only section (.text + .rodata) */
-EXTERN uint32_t _sdata;           /* Start of .data */
-EXTERN uint32_t _edata;           /* End+1 of .data */
-EXTERN uint32_t _sbss;            /* Start of .bss */
-EXTERN uint32_t _ebss;            /* End+1 of .bss */
-EXTERN uint32_t _stdata;          /* Start of .tdata */
-EXTERN uint32_t _etdata;          /* End+1 of .tdata */
-EXTERN uint32_t _stbss;           /* Start of .tbss */
-EXTERN uint32_t _etbss;           /* End+1 of .tbss */
+EXTERN uint8_t _stext[];           /* Start of .text */
+EXTERN uint8_t _etext[];           /* End_1 of .text + .rodata */
+EXTERN const uint8_t _eronly[];    /* End+1 of read only section (.text + .rodata) */
+EXTERN uint8_t _sdata[];           /* Start of .data */
+EXTERN uint8_t _edata[];           /* End+1 of .data */
+EXTERN uint8_t _sbss[];            /* Start of .bss */
+EXTERN uint8_t _ebss[];            /* End+1 of .bss */
+EXTERN uint8_t _stdata[];          /* Start of .tdata */
+EXTERN uint8_t _etdata[];          /* End+1 of .tdata */
+EXTERN uint8_t _stbss[];           /* Start of .tbss */
+EXTERN uint8_t _etbss[];           /* End+1 of .tbss */
 
 /* Sometimes, functions must be executed from RAM.  In this case, the
  * following macro may be used (with GCC!) to specify a function that will
@@ -257,9 +247,9 @@ EXTERN uint32_t _etbss;           /* End+1 of .tbss */
  * functions from flash to RAM.
  */
 
-EXTERN const uint32_t _framfuncs; /* Copy source address in FLASH */
-EXTERN uint32_t _sramfuncs;       /* Copy destination start address in RAM */
-EXTERN uint32_t _eramfuncs;       /* Copy destination end address in RAM */
+EXTERN const uint8_t _framfuncs[]; /* Copy source address in FLASH */
+EXTERN uint8_t _sramfuncs[];       /* Copy destination start address in RAM */
+EXTERN uint8_t _eramfuncs[];       /* Copy destination end address in RAM */
 
 #else /* CONFIG_ARCH_RAMFUNCS */
 

--- a/arch/arm/src/cxd56xx/cxd56_allocateheap.c
+++ b/arch/arm/src/cxd56xx/cxd56_allocateheap.c
@@ -51,7 +51,7 @@
  * aligned).
  */
 
-const uintptr_t g_idle_topstack = (uintptr_t)&_ebss +
+const uintptr_t g_idle_topstack = (uintptr_t)_ebss +
   CONFIG_IDLETHREAD_STACKSIZE;
 
 /****************************************************************************
@@ -67,7 +67,7 @@ const uintptr_t g_idle_topstack = (uintptr_t)&_ebss +
 
 /* __stack is the end of RAM address, it would be set by linker. */
 
-extern char __stack[];
+extern uint8_t __stack[];
 
 /****************************************************************************
  * Private Functions
@@ -115,7 +115,7 @@ void up_allocate_heap(void **heap_start, size_t *heap_size)
 
   board_autoled_on(LED_HEAPALLOCATE);
   *heap_start = (void *)g_idle_topstack;
-  *heap_size = (uint32_t)&__stack - g_idle_topstack;
+  *heap_size = (uint32_t)__stack - g_idle_topstack;
 
   /* Colorize the heap for debug */
 

--- a/arch/arm/src/cxd56xx/cxd56_farapi.c
+++ b/arch/arm/src/cxd56xx/cxd56_farapi.c
@@ -106,7 +106,7 @@ struct farmsg_s
  * Public Data
  ****************************************************************************/
 
-extern char _image_modlist_base[];
+extern struct modulelist_s _image_modlist_base[];
 
 /****************************************************************************
  * Private Data
@@ -230,7 +230,7 @@ void farapi_main(int id, void *arg, struct modulelist_s *mlist)
   api = &msg.u.api;
 
   msg.cpuid      = getreg32(CPU_ID);
-  msg.modid      = mlist - (struct modulelist_s *)&_image_modlist_base;
+  msg.modid      = mlist - _image_modlist_base;
 
   api->id        = id;
   api->arg       = arg;

--- a/arch/arm/src/cxd56xx/cxd56_start.c
+++ b/arch/arm/src/cxd56xx/cxd56_start.c
@@ -119,11 +119,9 @@ void __start(void)
   /* Set MSP/PSP to IDLE stack */
 
   __asm__ __volatile__("\tmsr msp, %0\n" :
-                       : "r" ((uint32_t)&_ebss +
-                              CONFIG_IDLETHREAD_STACKSIZE));
+                       : "r" (_ebss + CONFIG_IDLETHREAD_STACKSIZE));
   __asm__ __volatile__("\tmsr psp, %0\n" :
-                       : "r" ((uint32_t)&_ebss +
-                              CONFIG_IDLETHREAD_STACKSIZE));
+                       : "r" (_ebss + CONFIG_IDLETHREAD_STACKSIZE));
 
 #ifndef CONFIG_CXD56_SUBCORE
   cpuid = getreg32(CPU_ID);
@@ -161,7 +159,7 @@ void __start(void)
    * certain that there are no issues with the state of global variables.
    */
 
-  for (dest = &_sbss; dest < &_ebss; )
+  for (dest = (uint32_t *)_sbss; dest < (uint32_t *)_ebss; )
     {
       *dest++ = 0;
     }

--- a/arch/arm/src/dm320/dm320_boot.c
+++ b/arch/arm/src/dm320/dm320_boot.c
@@ -47,8 +47,8 @@ struct section_mapping_s
  * Public Data
  ****************************************************************************/
 
-extern uint32_t _vector_start; /* Beginning of vector block */
-extern uint32_t _vector_end;   /* End+1 of vector block */
+extern uint8_t _vector_start[]; /* Beginning of vector block */
+extern uint8_t _vector_end[];   /* End+1 of vector block */
 
 /****************************************************************************
  * Private Data
@@ -182,8 +182,8 @@ static void up_vectormapping(void)
 
 static void up_copyvectorblock(void)
 {
-  uint32_t *src  = (uint32_t *)&_vector_start;
-  uint32_t *end  = (uint32_t *)&_vector_end;
+  uint32_t *src  = (uint32_t *)_vector_start;
+  uint32_t *end  = (uint32_t *)_vector_end;
   uint32_t *dest = (uint32_t *)VECTOR_BASE;
 
   while (src < end)

--- a/arch/arm/src/efm32/efm32_start.c
+++ b/arch/arm/src/efm32/efm32_start.c
@@ -52,7 +52,7 @@
  * ARM EABI requires 64 bit stack alignment.
  */
 
-#define HEAP_BASE      ((uintptr_t)&_ebss + CONFIG_IDLETHREAD_STACKSIZE)
+#define HEAP_BASE      ((uintptr_t)_ebss + CONFIG_IDLETHREAD_STACKSIZE)
 
 /****************************************************************************
  * Public Data
@@ -122,7 +122,7 @@ void __start(void)
    * certain that there are no issues with the state of global variables.
    */
 
-  for (dest = &_sbss; dest < &_ebss; )
+  for (dest = (uint32_t *)_sbss; dest < (uint32_t *)_ebss; )
     {
       *dest++ = 0;
     }
@@ -135,7 +135,9 @@ void __start(void)
    * end of all of the other read-only data (.text, .rodata) at _eronly.
    */
 
-  for (src = &_eronly, dest = &_sdata; dest < &_edata; )
+  for (src = (const uint32_t *)_eronly,
+       dest = (uint32_t *)_sdata; dest < (uint32_t *)_edata;
+      )
     {
       *dest++ = *src++;
     }

--- a/arch/arm/src/eoss3/eoss3_start.c
+++ b/arch/arm/src/eoss3/eoss3_start.c
@@ -46,7 +46,7 @@
  * ARM EABI requires 64 bit stack alignment.
  */
 
-#define HEAP_BASE      ((uintptr_t)&_ebss + CONFIG_IDLETHREAD_STACKSIZE)
+#define HEAP_BASE      ((uintptr_t)_ebss + CONFIG_IDLETHREAD_STACKSIZE)
 
 /****************************************************************************
  * Public Data
@@ -130,7 +130,7 @@ void __start(void)
    * certain that there are no issues with the state of global variables.
    */
 
-  for (dest = _START_BSS; dest < _END_BSS; )
+  for (dest = (uint32_t *)_START_BSS; dest < (uint32_t *)_END_BSS; )
     {
       *dest++ = 0;
     }
@@ -143,7 +143,9 @@ void __start(void)
    * end of all of the other read-only data (.text, .rodata) at _eronly.
    */
 
-  for (src = _DATA_INIT, dest = _START_DATA; dest < _END_DATA; )
+  for (src = (const uint32_t *)_DATA_INIT,
+       dest = (uint32_t *)_START_DATA; dest < (uint32_t *)_END_DATA;
+      )
     {
       *dest++ = *src++;
     }

--- a/arch/arm/src/gd32f4/gd32f4xx_start.c
+++ b/arch/arm/src/gd32f4/gd32f4xx_start.c
@@ -48,7 +48,7 @@
  * ARM EABI requires 64 bit stack alignment.
  */
 
-#define HEAP_BASE      ((uintptr_t)&_ebss + CONFIG_IDLETHREAD_STACKSIZE)
+#define HEAP_BASE      ((uintptr_t)_ebss + CONFIG_IDLETHREAD_STACKSIZE)
 
 /****************************************************************************
  * Public Data
@@ -219,7 +219,7 @@ void __start(void)
    * certain that there are no issues with the state of global variables.
    */
 
-  for (dest = &_sbss; dest < &_ebss; )
+  for (dest = (uint32_t *)_sbss; dest < (uint32_t *)_ebss; )
     {
       *dest++ = 0;
     }
@@ -230,7 +230,9 @@ void __start(void)
    * end of all of the other read-only data (.text, .rodata) at _eronly.
    */
 
-  for (src = &_eronly, dest = &_sdata; dest < &_edata; )
+  for (src = (const uint32_t *)_eronly,
+       dest = (uint32_t *)_sdata; dest < (uint32_t *)_edata;
+      )
     {
       *dest++ = *src++;
     }

--- a/arch/arm/src/imx1/imx_boot.c
+++ b/arch/arm/src/imx1/imx_boot.c
@@ -50,8 +50,8 @@ struct section_mapping_s
  * Public Data
  ****************************************************************************/
 
-extern uint32_t _vector_start; /* Beginning of vector block */
-extern uint32_t _vector_end;   /* End+1 of vector block */
+extern uint8_t _vector_start; /* Beginning of vector block */
+extern uint8_t _vector_end;   /* End+1 of vector block */
 
 /****************************************************************************
  * Private Data
@@ -171,8 +171,8 @@ static void up_copyvectorblock(void)
    */
 
 #if !defined(CONFIG_BOOT_RUNFROMFLASH) && !defined(CONFIG_BOOT_COPYTORAM)
-  uint32_t *src  = (uint32_t *)&_vector_start;
-  uint32_t *end  = (uint32_t *)&_vector_end;
+  uint32_t *src  = (uint32_t *)_vector_start;
+  uint32_t *end  = (uint32_t *)_vector_end;
   uint32_t *dest = (uint32_t *)VECTOR_BASE;
 
   while (src < end)

--- a/arch/arm/src/imx6/imx_boot.c
+++ b/arch/arm/src/imx6/imx_boot.c
@@ -63,8 +63,8 @@
 
 /* Symbols defined via the linker script */
 
-extern uint32_t _vector_start; /* Beginning of vector block */
-extern uint32_t _vector_end;   /* End+1 of vector block */
+extern uint8_t _vector_start[]; /* Beginning of vector block */
+extern uint8_t _vector_end[];   /* End+1 of vector block */
 
 /****************************************************************************
  * Private Functions
@@ -148,13 +148,7 @@ static void imx_vectorpermissions(uint32_t mmuflags)
 
 static inline size_t imx_vectorsize(void)
 {
-  uintptr_t src;
-  uintptr_t end;
-
-  src  = (uintptr_t)&_vector_start;
-  end  = (uintptr_t)&_vector_end;
-
-  return (size_t)(end - src);
+  return _vector_end - _vector_start;
 }
 
 /****************************************************************************
@@ -171,7 +165,7 @@ static void imx_vectormapping(void)
 {
   uint32_t vector_paddr = IMX_VECTOR_PADDR & PTE_SMALL_PADDR_MASK;
   uint32_t vector_vaddr = IMX_VECTOR_VADDR & PTE_SMALL_PADDR_MASK;
-  uint32_t vector_size  = (uint32_t)&_vector_end - (uint32_t)&_vector_start;
+  uint32_t vector_size  = _vector_end - _vector_start;
   uint32_t end_paddr    = IMX_VECTOR_PADDR + vector_size;
 
   /* REVISIT:  Cannot really assert in this context */
@@ -238,8 +232,8 @@ static void imx_copyvectorblock(void)
    *                      0xffff0000)
    */
 
-  src  = (uint32_t *)&_vector_start;
-  end  = (uint32_t *)&_vector_end;
+  src  = (uint32_t *)_vector_start;
+  end  = (uint32_t *)_vector_end;
   dest = (uint32_t *)IMX_VECTOR_VSRAM;
 
   while (src < end)
@@ -410,7 +404,9 @@ void arm_boot(void)
    * at _framfuncs
    */
 
-  for (src = &_framfuncs, dest = &_sramfuncs; dest < &_eramfuncs; )
+  for (src = (const uint32_t *)_framfuncs,
+       dest = (uint32_t *)_sramfuncs; dest < (uint32_t *)_eramfuncs;
+      )
     {
       *dest++ = *src++;
     }
@@ -421,7 +417,7 @@ void arm_boot(void)
    * be available when fetched into the I-Cache.
    */
 
-  up_clean_dcache((uintptr_t)&_sramfuncs, (uintptr_t)&_eramfuncs)
+  up_clean_dcache((uintptr_t)_sramfuncs, (uintptr_t)_eramfuncs)
   PROGRESS('F');
 #endif
 

--- a/arch/arm/src/imx6/imx_cpuboot.c
+++ b/arch/arm/src/imx6/imx_cpuboot.c
@@ -115,7 +115,7 @@ static const cpu_start_t g_cpu_boot[CONFIG_SMP_NCPUS] =
 
 /* Symbols defined via the linker script */
 
-extern uint32_t _vector_start; /* Beginning of vector block */
+extern uint8_t _vector_start[]; /* Beginning of vector block */
 
 /****************************************************************************
  * Public Functions
@@ -281,8 +281,8 @@ void arm_cpu_boot(int cpu)
 
   /* Set the VBAR register to the address of the vector table */
 
-  DEBUGASSERT((((uintptr_t)&_vector_start) & ~VBAR_MASK) == 0);
-  cp15_wrvbar((uint32_t)&_vector_start);
+  DEBUGASSERT((((uintptr_t)_vector_start) & ~VBAR_MASK) == 0);
+  cp15_wrvbar((uint32_t)_vector_start);
 #endif /* CONFIG_ARCH_LOWVECTORS */
 
 #ifndef CONFIG_SUPPRESS_INTERRUPTS

--- a/arch/arm/src/imx6/imx_irq.c
+++ b/arch/arm/src/imx6/imx_irq.c
@@ -86,8 +86,8 @@ uintptr_t g_fiqstack_top[CONFIG_SMP_NCPUS] =
 
 /* Symbols defined via the linker script */
 
-extern uint32_t _vector_start; /* Beginning of vector block */
-extern uint32_t _vector_end;   /* End+1 of vector block */
+extern uint8_t _vector_start[]; /* Beginning of vector block */
+extern uint8_t _vector_end[];   /* End+1 of vector block */
 
 /****************************************************************************
  * Public Functions
@@ -132,8 +132,8 @@ void up_irqinitialize(void)
 
   /* Set the VBAR register to the address of the vector table */
 
-  DEBUGASSERT((((uintptr_t)&_vector_start) & ~VBAR_MASK) == 0);
-  cp15_wrvbar((uint32_t)&_vector_start);
+  DEBUGASSERT((((uintptr_t)_vector_start) & ~VBAR_MASK) == 0);
+  cp15_wrvbar((uint32_t)_vector_start);
 #endif /* CONFIG_ARCH_LOWVECTORS */
 
 #ifndef CONFIG_SUPPRESS_INTERRUPTS

--- a/arch/arm/src/imxrt/imxrt_allocateheap.c
+++ b/arch/arm/src/imxrt/imxrt_allocateheap.c
@@ -248,7 +248,7 @@
  * aligned).
  */
 
-const uintptr_t g_idle_topstack = (uintptr_t)&_ebss +
+const uintptr_t g_idle_topstack = (uintptr_t)_ebss +
                                   CONFIG_IDLETHREAD_STACKSIZE;
 
 /****************************************************************************

--- a/arch/arm/src/imxrt/imxrt_start.c
+++ b/arch/arm/src/imxrt/imxrt_start.c
@@ -153,7 +153,7 @@ void __start(void)
    * certain that there are no issues with the state of global variables.
    */
 
-  for (dest = &_sbss; dest < &_ebss; )
+  for (dest = (uint32_t *)_sbss; dest < (uint32_t *)_ebss; )
     {
       *dest++ = 0;
     }
@@ -164,7 +164,9 @@ void __start(void)
    * end of all of the other read-only data (.text, .rodata) at _eronly.
    */
 
-  for (src = &_eronly, dest = &_sdata; dest < &_edata; )
+  for (src = (const uint32_t *)_eronly,
+       dest = (uint32_t *)_sdata; dest < (uint32_t *)_edata;
+      )
     {
       *dest++ = *src++;
     }
@@ -177,7 +179,9 @@ void __start(void)
    */
 
 #ifdef CONFIG_ARCH_RAMFUNCS
-  for (src = &_framfuncs, dest = &_sramfuncs; dest < &_eramfuncs; )
+  for (src = (const uint32_t *)_framfuncs,
+       dest = (uint32_t *)_sramfuncs; dest < (uint32_t *)_eramfuncs;
+      )
     {
       *dest++ = *src++;
     }

--- a/arch/arm/src/kinetis/kinetis_start.c
+++ b/arch/arm/src/kinetis/kinetis_start.c
@@ -60,7 +60,7 @@
  * NOTE:  ARM EABI requires 64 bit stack alignment.
  */
 
-#define HEAP_BASE      ((uintptr_t)&_ebss + CONFIG_IDLETHREAD_STACKSIZE)
+#define HEAP_BASE      ((uintptr_t)_ebss + CONFIG_IDLETHREAD_STACKSIZE)
 
 /****************************************************************************
  * Public Data
@@ -120,7 +120,7 @@ void __start(void)
    * certain that there are no issues with the state of global variables.
    */
 
-  for (dest = &_sbss; dest < &_ebss; )
+  for (dest = (uint32_t *)_sbss; dest < (uint32_t *)_ebss; )
     {
       *dest++ = 0;
     }
@@ -131,7 +131,9 @@ void __start(void)
    * end of all of the other read-only data (.text, .rodata) at _eronly.
    */
 
-  for (src = &_eronly, dest = &_sdata; dest < &_edata; )
+  for (src = (const uint32_t *)_eronly,
+       dest = (uint32_t *)_sdata; dest < (uint32_t *)_edata;
+      )
     {
       *dest++ = *src++;
     }
@@ -143,7 +145,9 @@ void __start(void)
    */
 
 #ifdef CONFIG_ARCH_RAMFUNCS
-  for (src = &_framfuncs, dest = &_sramfuncs; dest < &_eramfuncs; )
+  for (src = (const uint32_t *)_framfuncs,
+       dest = (uint32_t *)_sramfuncs; dest < (uint32_t *)_eramfuncs;
+      )
     {
       *dest++ = *src++;
     }

--- a/arch/arm/src/kl/kl_start.c
+++ b/arch/arm/src/kl/kl_start.c
@@ -56,7 +56,7 @@
  * 0x2000:3fff - End of SRAM and end of heap (assuming 16KB of SRAM)
  */
 
-#define IDLE_STACK ((uint32_t)&_ebss+CONFIG_IDLETHREAD_STACKSIZE)
+#define IDLE_STACK ((uint32_t)_ebss + CONFIG_IDLETHREAD_STACKSIZE)
 
 /****************************************************************************
  * Public Data
@@ -113,7 +113,7 @@ void __start(void)
    * certain that there are no issues with the state of global variables.
    */
 
-  for (dest = &_sbss; dest < &_ebss; )
+  for (dest = (uint32_t *)_sbss; dest < (uint32_t *)_ebss; )
     {
       *dest++ = 0;
     }
@@ -126,7 +126,9 @@ void __start(void)
    * end of all of the other read-only data (.text, .rodata) at _eronly.
    */
 
-  for (src = &_eronly, dest = &_sdata; dest < &_edata; )
+  for (src = (const uint32_t *)_eronly,
+       dest = (uint32_t *)_sdata; dest < (uint32_t *)_edata;
+      )
     {
       *dest++ = *src++;
     }

--- a/arch/arm/src/lc823450/lc823450_allocateheap2.c
+++ b/arch/arm/src/lc823450/lc823450_allocateheap2.c
@@ -151,9 +151,9 @@ void up_allocate_heap(void **heap_start, size_t *heap_size)
   /* Return the heap settings */
 
 #ifdef CONFIG_LC823450_SPIFI_BOOT
-  *heap_start = (uintptr_t *)&_ebss + 4096; /* see ld-spif-boot.script */
+  *heap_start = _ebss + 4096; /* see ld-spif-boot.script */
 #else
-  *heap_start = (uintptr_t *)&_eronly; /* see ld.script */
+  *heap_start = (void *)_eronly; /* see ld.script */
 #endif
 
   *heap_size  = SRAM1_END - (int)*heap_start;
@@ -227,7 +227,7 @@ void arm_addregion(void)
 
   /* NOTE: add 1KB to avoid conflicts of initial stack */
 
-  region_start = (uintptr_t *)&_ebss + 1024;
+  region_start = _ebss + 1024;
   region_size  = 0x02040000 - (int)region_start;
 
   umm_addregion(region_start, region_size);

--- a/arch/arm/src/lc823450/lc823450_cpustart.c
+++ b/arch/arm/src/lc823450/lc823450_cpustart.c
@@ -91,7 +91,7 @@ static void cpu1_boot(void)
 
   if (cpu == 1)
     {
-      putreg32((uint32_t)&_stext, NVIC_VECTAB); /* use CPU0 vectors */
+      putreg32((uint32_t)_stext, NVIC_VECTAB); /* use CPU0 vectors */
 
 #if defined(CONFIG_BUILD_FLAT) && defined(CONFIG_ARM_MPU)
       lc823450_mpuinitialize();

--- a/arch/arm/src/lc823450/lc823450_mpuinit2.c
+++ b/arch/arm/src/lc823450/lc823450_mpuinit2.c
@@ -89,7 +89,7 @@ void lc823450_mpuinitialize(void)
 #endif
 
 #ifdef CONFIG_BUILD_FLAT
-  uint32_t size = (uint32_t)((uint32_t)&_eronly - (uint32_t)&_stext);
+  uint32_t size = _eronly - _stext;
 
   /* 128KB align */
 
@@ -97,7 +97,7 @@ void lc823450_mpuinitialize(void)
 
   /* Protect text area in SRAM as privileged flash */
 
-  mpu_priv_flash((uintptr_t)&_stext, size);
+  mpu_priv_flash((uintptr_t)_stext, size);
 #endif
 
   /* Then enable the MPU */

--- a/arch/arm/src/lc823450/lc823450_start.c
+++ b/arch/arm/src/lc823450/lc823450_start.c
@@ -75,7 +75,7 @@
  * ARM EABI requires 64 bit stack alignment.
  */
 
-#define HEAP_BASE      ((uintptr_t)&_ebss + CONFIG_IDLETHREAD_STACKSIZE)
+#define HEAP_BASE      ((uintptr_t)_ebss + CONFIG_IDLETHREAD_STACKSIZE)
 
 /****************************************************************************
  * Public Data
@@ -154,7 +154,7 @@ void __start(void)
     }
 #endif
 
-  for (dest = &_sbss; dest < &_ebss; )
+  for (dest = (uint32_t *)_sbss; dest < (uint32_t *)_ebss; )
     {
       *dest++ = 0;
     }
@@ -165,7 +165,9 @@ void __start(void)
    * end of all of the other read-only data (.text, .rodata) at _eronly.
    */
 
-  for (src = &_eronly, dest = &_sdata; dest < &_edata; )
+  for (src = (const uint32_t *)_eronly,
+       dest = (uint32_t *)_sdata; dest < (uint32_t *)_edata;
+      )
     {
       *dest++ = *src++;
     }
@@ -200,7 +202,9 @@ void __start(void)
    */
 
 #ifdef CONFIG_ARCH_RAMFUNCS
-  for (src = &_framfuncs, dest = &_sramfuncs; dest < &_eramfuncs; )
+  for (src = (const uint32_t *)_framfuncs,
+       dest = (uint32_t *)_sramfuncs; dest < (uint32_t *)_eramfuncs;
+       )
     {
       *dest++ = *src++;
     }

--- a/arch/arm/src/lpc17xx_40xx/lpc17_40_start.c
+++ b/arch/arm/src/lpc17xx_40xx/lpc17_40_start.c
@@ -50,7 +50,7 @@
  * ARM EABI requires 64 bit stack alignment.
  */
 
-#define HEAP_BASE      ((uintptr_t)&_ebss + CONFIG_IDLETHREAD_STACKSIZE)
+#define HEAP_BASE      ((uintptr_t)_ebss + CONFIG_IDLETHREAD_STACKSIZE)
 
 /****************************************************************************
  * Public Data
@@ -131,7 +131,7 @@ void __start(void)
    * certain that there are no issues with the state of global variables.
    */
 
-  for (dest = &_sbss; dest < &_ebss; )
+  for (dest = (uint32_t *)_sbss; dest < (uint32_t *)_ebss; )
     {
       *dest++ = 0;
     }
@@ -144,7 +144,9 @@ void __start(void)
    * end of all of the other read-only data (.text, .rodata) at _eronly.
    */
 
-  for (src = &_eronly, dest = &_sdata; dest < &_edata; )
+  for (src = (const uint32_t *)_eronly,
+       dest = (uint32_t *)_sdata; dest < (uint32_t *)_edata;
+      )
     {
       *dest++ = *src++;
     }

--- a/arch/arm/src/lpc31xx/lpc31_boot.c
+++ b/arch/arm/src/lpc31xx/lpc31_boot.c
@@ -55,8 +55,8 @@ struct section_mapping_s
  * Public Data
  ****************************************************************************/
 
-extern uint32_t _vector_start; /* Beginning of vector block */
-extern uint32_t _vector_end;   /* End+1 of vector block */
+extern uint8_t _vector_start[]; /* Beginning of vector block */
+extern uint8_t _vector_end[];   /* End+1 of vector block */
 
 /****************************************************************************
  * Private Data
@@ -295,8 +295,8 @@ static void up_copyvectorblock(void)
    *                        0xffff0000)
    */
 
-  src  = (uint32_t *)&_vector_start;
-  end  = (uint32_t *)&_vector_end;
+  src  = (uint32_t *)_vector_start;
+  end  = (uint32_t *)_vector_end;
   dest = (uint32_t *)LPC31_VECTOR_VSRAM;
 
   while (src < end)

--- a/arch/arm/src/lpc43xx/lpc43_allocateheap.c
+++ b/arch/arm/src/lpc43xx/lpc43_allocateheap.c
@@ -323,7 +323,7 @@
  * aligned).
  */
 
-const uintptr_t g_idle_topstack = (uintptr_t)&_ebss +
+const uintptr_t g_idle_topstack = (uintptr_t)_ebss +
     CONFIG_IDLETHREAD_STACKSIZE;
 
 #ifdef MM_HAVE_REGION

--- a/arch/arm/src/lpc43xx/lpc43_start.c
+++ b/arch/arm/src/lpc43xx/lpc43_start.c
@@ -203,7 +203,7 @@ void __start(void)
    * certain that there are no issues with the state of global variables.
    */
 
-  for (dest = &_sbss; dest < &_ebss; )
+  for (dest = (uint32_t *)_sbss; dest < (uint32_t *)_ebss; )
     {
       *dest++ = 0;
     }
@@ -216,7 +216,9 @@ void __start(void)
    * end of all of the other read-only data (.text, .rodata) at _eronly.
    */
 
-  for (src = &_eronly, dest = &_sdata; dest < &_edata; )
+  for (src = (const uint32_t *)_eronly,
+       dest = (uint32_t *)_sdata; dest < (uint32_t *)_edata;
+      )
     {
       *dest++ = *src++;
     }

--- a/arch/arm/src/lpc54xx/lpc54_allocateheap.c
+++ b/arch/arm/src/lpc54xx/lpc54_allocateheap.c
@@ -126,7 +126,7 @@
  * aligned).
  */
 
-const uintptr_t g_idle_topstack = (uintptr_t)&_ebss +
+const uintptr_t g_idle_topstack = (uintptr_t)_ebss +
     CONFIG_IDLETHREAD_STACKSIZE;
 
 /****************************************************************************

--- a/arch/arm/src/lpc54xx/lpc54_start.c
+++ b/arch/arm/src/lpc54xx/lpc54_start.c
@@ -121,7 +121,7 @@ void __start(void)
    * certain that there are no issues with the state of global variables.
    */
 
-  for (dest = &_sbss; dest < &_ebss; )
+  for (dest = (uint32_t *)_sbss; dest < (uint32_t *)_ebss; )
     {
       *dest++ = 0;
     }
@@ -134,7 +134,9 @@ void __start(void)
    * end of all of the other read-only data (.text, .rodata) at _eronly.
    */
 
-  for (src = &_eronly, dest = &_sdata; dest < &_edata; )
+  for (src = (const uint32_t *)_eronly,
+       dest = (uint32_t *)_sdata; dest < (uint32_t *)_edata;
+      )
     {
       *dest++ = *src++;
     }

--- a/arch/arm/src/max326xx/common/max326_start.c
+++ b/arch/arm/src/max326xx/common/max326_start.c
@@ -58,7 +58,7 @@
  * 0x2001:7fff - End of SRAM and end of heap (assuming 96KB of SRAM)
  */
 
-#define IDLE_STACK ((uint32_t)&_ebss + CONFIG_IDLETHREAD_STACKSIZE)
+#define IDLE_STACK ((uintptr_t)_ebss + CONFIG_IDLETHREAD_STACKSIZE)
 
 /****************************************************************************
  * Name: showprogress
@@ -124,7 +124,7 @@ void __start(void)
    * REVISIT: Consider using MAX326xx SRAM Zeroize hardware.
    */
 
-  for (dest = &_sbss; dest < &_ebss; )
+  for (dest = (uint32_t *)_sbss; dest < (uint32_t *)_ebss; )
     {
       *dest++ = 0;
     }
@@ -138,7 +138,9 @@ void __start(void)
    * end of all of the other read-only data (.text, .rodata) at _eronly.
    */
 
-  for (src = &_eronly, dest = &_sdata; dest < &_edata; )
+  for (src = (const uint32_t *)_eronly,
+       dest = (uint32_t *)_sdata; dest < (uint32_t *)_edata;
+      )
     {
       *dest++ = *src++;
     }

--- a/arch/arm/src/nrf52/nrf52_allocateheap.c
+++ b/arch/arm/src/nrf52/nrf52_allocateheap.c
@@ -80,7 +80,7 @@
  * aligned).
  */
 
-const uintptr_t g_idle_topstack = (uintptr_t)&_ebss +
+const uintptr_t g_idle_topstack = (uintptr_t)_ebss +
     CONFIG_IDLETHREAD_STACKSIZE;
 
 /****************************************************************************

--- a/arch/arm/src/nrf52/nrf52_nvmc.c
+++ b/arch/arm/src/nrf52/nrf52_nvmc.c
@@ -304,8 +304,7 @@ uint32_t nrf_nvmc_read_dev_id1(void)
 
 uint32_t system_image_start_address(void)
 {
-  extern uint32_t _stext;
-  return (uint32_t)&_stext;
+  return (uint32_t)_stext;
 }
 
 /****************************************************************************
@@ -324,7 +323,7 @@ uint32_t system_image_start_address(void)
 
 uint32_t system_image_ro_section_end(void)
 {
-  return (uint32_t)&_eronly;
+  return (uint32_t)_eronly;
 }
 
 /****************************************************************************
@@ -343,16 +342,7 @@ uint32_t system_image_ro_section_end(void)
 
 uint32_t system_image_data_section_size(void)
 {
-  extern uint32_t _edata;
-  extern uint32_t _sdata;
-  uint32_t data_size;
-  uint32_t start;
-  uint32_t end;
-
-  start     = (uint32_t)&_sdata;
-  end       = (uint32_t)&_edata;
-  data_size = end - start;
-  return data_size;
+  return _edata - _sdata;
 }
 
 /****************************************************************************

--- a/arch/arm/src/nrf52/nrf52_start.c
+++ b/arch/arm/src/nrf52/nrf52_start.c
@@ -112,7 +112,7 @@ void __start(void)
    * certain that there are no issues with the state of global variables.
    */
 
-  for (dest = &_sbss; dest < &_ebss; )
+  for (dest = (uint32_t *)_sbss; dest < (uint32_t *)_ebss; )
     {
       *dest++ = 0;
     }
@@ -125,7 +125,9 @@ void __start(void)
    * end of all of the other read-only data (.text, .rodata) at _eronly.
    */
 
-  for (src = &_eronly, dest = &_sdata; dest < &_edata; )
+  for (src = (const uint32_t *)_eronly,
+       dest = (uint32_t *)_sdata; dest < (uint32_t *)_edata;
+      )
     {
       *dest++ = *src++;
     }

--- a/arch/arm/src/nrf53/nrf53_allocateheap.c
+++ b/arch/arm/src/nrf53/nrf53_allocateheap.c
@@ -64,7 +64,7 @@
  * aligned).
  */
 
-const uintptr_t g_idle_topstack = (uintptr_t)&_ebss +
+const uintptr_t g_idle_topstack = (uintptr_t)_ebss +
     CONFIG_IDLETHREAD_STACKSIZE;
 
 /****************************************************************************

--- a/arch/arm/src/nrf53/nrf53_start.c
+++ b/arch/arm/src/nrf53/nrf53_start.c
@@ -111,7 +111,7 @@ void __start(void)
    * certain that there are no issues with the state of global variables.
    */
 
-  for (dest = &_sbss; dest < &_ebss; )
+  for (dest = (uint32_t *)_sbss; dest < (uint32_t *)_ebss; )
     {
       *dest++ = 0;
     }
@@ -124,7 +124,9 @@ void __start(void)
    * end of all of the other read-only data (.text, .rodata) at _eronly.
    */
 
-  for (src = &_eronly, dest = &_sdata; dest < &_edata; )
+  for (src = (const uint32_t *)_eronly,
+       dest = (uint32_t *)_sdata; dest < (uint32_t *)_edata;
+      )
     {
       *dest++ = *src++;
     }

--- a/arch/arm/src/nuc1xx/nuc_start.c
+++ b/arch/arm/src/nuc1xx/nuc_start.c
@@ -53,7 +53,7 @@
  * 0x2000:3fff - End of SRAM and end of heap (assuming 16KB of SRAM)
  */
 
-#define IDLE_STACK ((uint32_t)&_ebss+CONFIG_IDLETHREAD_STACKSIZE)
+#define IDLE_STACK ((uint32_t)_ebss + CONFIG_IDLETHREAD_STACKSIZE)
 
 /****************************************************************************
  * Public Data
@@ -106,7 +106,7 @@ void __start(void)
    * certain that there are no issues with the state of global variables.
    */
 
-  for (dest = &_sbss; dest < &_ebss; )
+  for (dest = (uint32_t *)_sbss; dest < (uint32_t *)_ebss; )
     {
       *dest++ = 0;
     }
@@ -119,7 +119,9 @@ void __start(void)
    * end of all of the other read-only data (.text, .rodata) at _eronly.
    */
 
-  for (src = &_eronly, dest = &_sdata; dest < &_edata; )
+  for (src = (const uint32_t *)_eronly,
+       dest = (uint32_t *)_sdata; dest < (uint32_t *)_edata;
+      )
     {
       *dest++ = *src++;
     }

--- a/arch/arm/src/phy62xx/phy62xx_hardfault.c
+++ b/arch/arm/src/phy62xx/phy62xx_hardfault.c
@@ -38,8 +38,8 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-extern uint32_t _stextram;
-extern uint32_t _etextram;
+extern uint8_t _stextram[];
+extern uint8_t _etextram[];
 
 #ifdef CONFIG_DEBUG_HARDFAULT_ALERT
 # define hfalert(format, ...)  _alert(format, ##__VA_ARGS__)
@@ -85,16 +85,16 @@ int arm_hardfault(int irq, void *context, void *arg)
    * FLASH region or in the user FLASH region.
    */
 
-  if (((uintptr_t)pc >= (uintptr_t)&_stext &&
-       (uintptr_t)pc <  (uintptr_t)&_etext) ||
+  if (((uintptr_t)pc >= (uintptr_t)_stext &&
+       (uintptr_t)pc <  (uintptr_t)_etext) ||
       ((uintptr_t)pc >= (uintptr_t)USERSPACE->us_textstart &&
        (uintptr_t)pc <  (uintptr_t)USERSPACE->us_textend))
 #else
   /* SVCalls are expected only from the base, kernel FLASH region */
 
-  if (((uintptr_t)pc >= (uintptr_t)&_stext && (uintptr_t)pc <
-      (uintptr_t)&_etext) || ((uintptr_t)pc >= (uintptr_t)&_stextram &&
-      (uintptr_t)pc <  (uintptr_t)&_etextram))
+  if (((uintptr_t)pc >= (uintptr_t)_stext && (uintptr_t)pc <
+      (uintptr_t)_etext) || ((uintptr_t)pc >= (uintptr_t)_stextram &&
+      (uintptr_t)pc <  (uintptr_t)_etextram))
 #endif
     {
       /* Fetch the instruction that caused the Hard fault */

--- a/arch/arm/src/phy62xx/start.c
+++ b/arch/arm/src/phy62xx/start.c
@@ -45,15 +45,15 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-extern const uint32_t _sramscttexts;
-extern const uint32_t _sramscttext;
-extern const uint32_t _eramscttext;
+extern const uint8_t _sramscttexts[];
+extern uint8_t _sramscttext[];
+extern uint8_t _eramscttext[];
 
-extern const uint32_t _sjtblss;
-extern const uint32_t _sjtbls;
-extern const uint32_t _ejtbls;
+extern const uint8_t _sjtblss[];
+extern uint8_t _sjtbls[];
+extern uint8_t _ejtbls[];
 
-#define IDLE_STACK ((uint32_t)&_ebss+CONFIG_IDLETHREAD_STACKSIZE)
+#define IDLE_STACK ((uintptr_t)_ebss + CONFIG_IDLETHREAD_STACKSIZE)
 const uintptr_t g_idle_topstack = IDLE_STACK;
 
 /****************************************************************************
@@ -98,10 +98,6 @@ extern void *osal_memcpy(void *dest, const void *src, size_t n);
 
 void c_start(void)
 {
-  const uint8_t *src;
-  uint8_t *dest;
-  uint8_t *edest;
-
   /* Configure the uart so that we can get debug output as soon as possible */
 
   /* set stack to main stack point */
@@ -123,11 +119,9 @@ void c_start(void)
    * certain that there are no issues with the state of global variables.
    */
 
-  dest = (uint8_t *)&_sbss;
-  edest = (uint8_t *)&_ebss;
-  osal_memset(dest, 0, edest - dest);
+  osal_memset(_sbss, 0, _ebss - _ebss);
 
-  /* for (dest = &_sbss; dest < &_ebss; )
+  /* for (dest = _sbss; dest < _ebss; )
    *  {
    *    *dest++ = 0;
    *  }
@@ -141,12 +135,9 @@ void c_start(void)
    * end of all of the other read-only data (.text, .rodata) at _eronly.
    */
 
-  src = (const uint8_t *)&_eronly;
-  dest = (uint8_t *)&_sdata;
-  edest = (uint8_t *)&_edata;
-  osal_memcpy(dest, src, edest - dest);
+  osal_memcpy(_sdata, _eronly, _edata - _sdata);
 
-  /* for (src = &_eronly, dest = &_sdata; dest < &_edata; )
+  /* for (src = _eronly, dest = _sdata; dest < _edata; )
    *  {
    *    *dest++ = *src++;
    *  }
@@ -154,19 +145,15 @@ void c_start(void)
 
   /* showprogress('C'); */
 
-  /* for (src = &_sramscttexts, dest = &_sramscttext; dest < &_eramscttext; )
+  /* for (src = _sramscttexts, dest = _sramscttext; dest < _eramscttext; )
    * {
    *   *dest++ = *src++;
    *  }
    */
 
-  src = (const uint8_t *)&_sjtblss;
-  dest = (uint8_t *)&_sjtbls;
-  edest = (uint8_t *)&_ejtbls;
-  osal_memcpy(dest, src, edest - dest);
+  osal_memcpy(_sjtbls, _sjtblss, _ejtbls - _sjtbls);
 
-  /* osal_memcpy(&_sjtbls, &_sjtblss, _ejtbls - _sjtbls);
-   * for (src = &_sjtblss, dest = &_sjtbls; dest < &_ejtbls; )
+  /* for (src = _sjtblss, dest = _sjtbls; dest < _ejtbls; )
    * {
    *  *dest++ = *src++;
    * }

--- a/arch/arm/src/rp2040/rp2040_start.c
+++ b/arch/arm/src/rp2040/rp2040_start.c
@@ -41,7 +41,7 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-#define IDLE_STACK ((uint32_t)&_ebss+CONFIG_IDLETHREAD_STACKSIZE)
+#define IDLE_STACK ((uint32_t)_ebss + CONFIG_IDLETHREAD_STACKSIZE)
 
 /****************************************************************************
  * Public Data
@@ -103,7 +103,7 @@ void __start(void)
    * certain that there are no issues with the state of global variables.
    */
 
-  for (dest = &_sbss; dest < &_ebss; )
+  for (dest = (uint32_t *)_sbss; dest < (uint32_t *)_ebss; )
     {
       *dest++ = 0;
     }
@@ -132,7 +132,9 @@ void __start(void)
    */
 
 #ifdef CONFIG_RP2040_FLASH_BOOT
-  for (src = &_eronly, dest = &_sdata; dest < &_edata; )
+  for (src = (const uint32_t *)_eronly,
+       dest = (uint32_t *)_sdata; dest < (uint32_t *)_edata;
+      )
     {
       *dest++ = *src++;
     }

--- a/arch/arm/src/rtl8720c/ameba_heap.c
+++ b/arch/arm/src/rtl8720c/ameba_heap.c
@@ -34,8 +34,8 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-#define _START_HEAP                     ((uintptr_t)&__bss_end__)
-#define _END_HEAP                       ((uintptr_t)&__sram_end__)
+#define _START_HEAP                     ((uintptr_t)__bss_end__)
+#define _END_HEAP                       ((uintptr_t)__sram_end__)
 #ifdef CONFIG_HEAP_COLORATION
 #  define song_heap_color(start, size)  memset(start, HEAP_COLOR, size)
 #else
@@ -46,9 +46,10 @@
  * Public Data
  ****************************************************************************/
 
-extern uint32_t __stack;
-extern uint32_t __bss_end__;
-extern uint32_t __sram_end__;
+extern uint8_t __stack[];
+extern uint8_t __bss_end__[];
+extern uint8_t __sram_end__[];
+
 /* g_idle_topstack: _sbss is the start of the BSS region as defined by the
  * linker script. _ebss lies at the end of the BSS region. The idle task
  * stack starts at the end of BSS and is of size CONFIG_IDLETHREAD_STACKSIZE.
@@ -60,7 +61,7 @@ extern uint32_t __sram_end__;
  */
 
 const uintptr_t weak_data g_idle_topstack =
-  ((uintptr_t)&__stack);
+  ((uintptr_t)__stack);
 
 /****************************************************************************
  * Public Functions

--- a/arch/arm/src/rtl8720c/ameba_nvic.c
+++ b/arch/arm/src/rtl8720c/ameba_nvic.c
@@ -316,7 +316,7 @@ void up_irqinitialize(void)
 
   /* Restore the NVIC vector location to local */
 
-  memcpy(&__vectors, (void *) * (volatile uint32_t *)(NVIC_VECTAB)
+  memcpy(__vectors, (void *) * (volatile uint32_t *)(NVIC_VECTAB)
          + NVIC_IRQ_FIRST * sizeof(uint32_t), sizeof(__vectors));
 
   /* Set the NVIC vector location in case _vectors not equal zero. */

--- a/arch/arm/src/rtl8720c/ameba_vectors.c
+++ b/arch/arm/src/rtl8720c/ameba_vectors.c
@@ -30,8 +30,8 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-extern uint32_t __stack;
-#define IDLE_STACK      ((const char *)&__stack - 4)
+extern uint8_t __stack[];
+#define IDLE_STACK      (__stack - 4)
 #ifndef ARMV8M_PERIPHERAL_INTERRUPTS
 #  error ARMV8M_PERIPHERAL_INTERRUPTS must be defined to the number of I/O interrupts to be supported
 #endif

--- a/arch/arm/src/s32k1xx/s32k1xx_start.c
+++ b/arch/arm/src/s32k1xx/s32k1xx_start.c
@@ -88,7 +88,7 @@
  * NOTE:  ARM EABI requires 64 bit stack alignment.
  */
 
-#define HEAP_BASE      ((uintptr_t)&_ebss + CONFIG_IDLETHREAD_STACKSIZE)
+#define HEAP_BASE      ((uintptr_t)_ebss + CONFIG_IDLETHREAD_STACKSIZE)
 
 /****************************************************************************
  * Name: showprogress
@@ -209,7 +209,7 @@ void __start(void)
    * certain that there are no issues with the state of global variables.
    */
 
-  for (dest = &_sbss; dest < &_ebss; )
+  for (dest = (uint32_t *)_sbss; dest < (uint32_t *)_ebss; )
     {
       *dest++ = 0;
     }
@@ -221,7 +221,9 @@ void __start(void)
    * end of all of the other read-only data (.text, .rodata) at _eronly.
    */
 
-  for (src = &_eronly, dest = &_sdata; dest < &_edata; )
+  for (src = (const uint32_t *)_eronly,
+       dest = (uint32_t *)_sdata; dest < (uint32_t *)_edata;
+      )
     {
       *dest++ = *src++;
     }
@@ -235,7 +237,9 @@ void __start(void)
    */
 
 #ifdef CONFIG_ARCH_RAMFUNCS
-  for (src = &_framfuncs, dest = &_sramfuncs; dest < &_eramfuncs; )
+  for (src = (const uint32_t *)_framfuncs,
+       dest = (uint32_t *)_sramfuncs; dest < (uint32_t *)_eramfuncs;
+      )
     {
       *dest++ = *src++;
     }

--- a/arch/arm/src/s32k3xx/s32k3xx_allocateheap.c
+++ b/arch/arm/src/s32k3xx/s32k3xx_allocateheap.c
@@ -101,8 +101,8 @@
  */
 
 #if defined(CONFIG_S32K3XX_DTCM_HEAP) && !defined(S32K3XX_DCTM_ASSIGNED)
-#  define REGION1_RAM_START    &DTCM_BASE_ADDR
-#  define REGION1_RAM_SIZE     ((size_t)(&DTCM_END_ADDR) - (size_t)(&DTCM_BASE_ADDR))
+#  define REGION1_RAM_START    DTCM_BASE_ADDR
+#  define REGION1_RAM_SIZE     (DTCM_END_ADDR - DTCM_BASE_ADDR)
 #  define S32K3XX_DCTM_ASSIGNED 1
 #else
 #  warning CONFIG_MM_REGIONS > 1 but no available memory region
@@ -115,14 +115,14 @@
  * Private Types
  ****************************************************************************/
 
-extern const uint32_t SRAM_BASE_ADDR;
-extern const uint32_t SRAM_END_ADDR;
-extern const uint32_t SRAM_STDBY_BASE_ADDR;
-extern const uint32_t SRAM_STDBY_END_ADDR;
-extern const uint32_t ITCM_BASE_ADDR;
-extern const uint32_t ITCM_END_ADDR;
-extern const uint32_t DTCM_BASE_ADDR;
-extern const uint32_t DTCM_END_ADDR;
+extern uint8_t SRAM_BASE_ADDR[];
+extern uint8_t SRAM_END_ADDR[];
+extern uint8_t SRAM_STDBY_BASE_ADDR[];
+extern uint8_t SRAM_STDBY_END_ADDR[];
+extern uint8_t ITCM_BASE_ADDR[];
+extern uint8_t ITCM_END_ADDR[];
+extern uint8_t DTCM_BASE_ADDR[];
+extern uint8_t DTCM_END_ADDR[];
 
 /****************************************************************************
  * Public Data
@@ -138,7 +138,7 @@ extern const uint32_t DTCM_END_ADDR;
  * aligned).
  */
 
-const uintptr_t g_idle_topstack = (uintptr_t)&_ebss +
+const uintptr_t g_idle_topstack = (uintptr_t)_ebss +
                                   CONFIG_IDLETHREAD_STACKSIZE;
 
 /****************************************************************************
@@ -198,7 +198,7 @@ void up_allocate_heap(void **heap_start, size_t *heap_size)
 
   uintptr_t ubase = (uintptr_t)USERSPACE->us_bssend +
                      CONFIG_MM_KERNEL_HEAPSIZE;
-  size_t    usize = SRAM_END_ADDR - ubase;
+  size_t    usize = (uintptr_t)SRAM_END_ADDR - ubase;
 
   DEBUGASSERT(ubase < (uintptr_t)SRAM_END_ADDR);
 
@@ -213,8 +213,7 @@ void up_allocate_heap(void **heap_start, size_t *heap_size)
 
   board_autoled_on(LED_HEAPALLOCATE);
   *heap_start = (void *)g_idle_topstack;
-  *heap_size  = (size_t)(&SRAM_END_ADDR) -
-                (((size_t)&_ebss) + CONFIG_IDLETHREAD_STACKSIZE);
+  *heap_size  = SRAM_END_ADDR - (_ebss + CONFIG_IDLETHREAD_STACKSIZE);
 #endif
 }
 

--- a/arch/arm/src/s32k3xx/s32k3xx_start.c
+++ b/arch/arm/src/s32k3xx/s32k3xx_start.c
@@ -112,12 +112,12 @@
  * Private Types
  ****************************************************************************/
 
-extern const uint32_t SRAM_BASE_ADDR;
-extern const uint32_t SRAM_END_ADDR;
-extern const uint32_t ITCM_BASE_ADDR;
-extern const uint32_t ITCM_END_ADDR;
-extern const uint32_t DTCM_BASE_ADDR;
-extern const uint32_t DTCM_END_ADDR;
+extern uint8_t SRAM_BASE_ADDR[];
+extern uint8_t SRAM_END_ADDR[];
+extern uint8_t ITCM_BASE_ADDR[];
+extern uint8_t ITCM_END_ADDR[];
+extern uint8_t DTCM_BASE_ADDR[];
+extern uint8_t DTCM_END_ADDR[];
 
 /****************************************************************************
  * Private Functions
@@ -173,24 +173,24 @@ void s32k3xx_start(void)
    * then on a cold boot we go into a bootloop somehow
    */
 
-  dest = (uint64_t *)&SRAM_BASE_ADDR;
-  while (dest < (uint64_t *)&SRAM_END_ADDR)
+  dest = (uint64_t *)SRAM_BASE_ADDR;
+  while (dest < (uint64_t *)SRAM_END_ADDR)
     {
       *dest++ = STARTUP_ECC_INITVALUE;
     }
 
   /* ITCM */
 
-  dest = (uint64_t *)&ITCM_BASE_ADDR;
-  while (dest < (uint64_t *)&ITCM_END_ADDR)
+  dest = (uint64_t *)ITCM_BASE_ADDR;
+  while (dest < (uint64_t *)ITCM_END_ADDR)
     {
       *dest++ = STARTUP_ECC_INITVALUE;
     }
 
   /* DTCM */
 
-  dest = (uint64_t *)&DTCM_BASE_ADDR;
-  while (dest < (uint64_t *)&DTCM_END_ADDR)
+  dest = (uint64_t *)DTCM_BASE_ADDR;
+  while (dest < (uint64_t *)DTCM_END_ADDR)
     {
       *dest++ = STARTUP_ECC_INITVALUE;
     }
@@ -199,7 +199,7 @@ void s32k3xx_start(void)
    * certain that there are no issues with the state of global variables.
    */
 
-  for (dest = (uint64_t *)&_sbss; dest < (uint64_t *)&_ebss; )
+  for (dest = (uint64_t *)_sbss; dest < (uint64_t *)_ebss; )
     {
       *dest++ = 0;
     }
@@ -211,8 +211,8 @@ void s32k3xx_start(void)
    * end of all of the other read-only data (.text, .rodata) at _eronly.
    */
 
-  for (src = (uint64_t *)&_eronly, dest = (uint64_t *)&_sdata;
-     dest < (uint64_t *)&_edata;
+  for (src = (uint64_t *)_eronly, dest = (uint64_t *)_sdata;
+     dest < (uint64_t *)_edata;
       )
     {
       *dest++ = *src++;
@@ -227,8 +227,8 @@ void s32k3xx_start(void)
    */
 
 #ifdef CONFIG_ARCH_RAMFUNCS
-  for (src = (uint64_t *)&_framfuncs, dest = (uint64_t *)&_sramfuncs;
-     dest < (uint64_t *)&_eramfuncs;
+  for (src = (uint64_t *)_framfuncs, dest = (uint64_t *)_sramfuncs;
+     dest < (uint64_t *)_eramfuncs;
       )
     {
       *dest++ = *src++;

--- a/arch/arm/src/sam34/sam4cm_cpustart.c
+++ b/arch/arm/src/sam34/sam4cm_cpustart.c
@@ -98,7 +98,7 @@ static void cpu1_boot(void)
     {
       /* Use CPU0 vectors */
 
-      putreg32((uint32_t)&_stext, NVIC_VECTAB);
+      putreg32((uint32_t)_stext, NVIC_VECTAB);
       sam_ipc1_enableclk();
 
       /* Clear : write-only */

--- a/arch/arm/src/sam34/sam_start.c
+++ b/arch/arm/src/sam34/sam_start.c
@@ -49,7 +49,7 @@
  * ARM EABI requires 64 bit stack alignment.
  */
 
-#define HEAP_BASE      ((uintptr_t)&_ebss + CONFIG_IDLETHREAD_STACKSIZE)
+#define HEAP_BASE      ((uintptr_t)_ebss + CONFIG_IDLETHREAD_STACKSIZE)
 
 /****************************************************************************
  * Public Data
@@ -130,7 +130,7 @@ void __start(void)
    * certain that there are no issues with the state of global variables.
    */
 
-  for (dest = &_sbss; dest < &_ebss; )
+  for (dest = (uint32_t *)_sbss; dest < (uint32_t *)_ebss; )
     {
       *dest++ = 0;
     }
@@ -141,7 +141,9 @@ void __start(void)
    * end of all of the other read-only data (.text, .rodata) at _eronly.
    */
 
-  for (src = &_eronly, dest = &_sdata; dest < &_edata; )
+  for (src = (const uint32_t *)_eronly,
+       dest = (uint32_t *)_sdata; dest < (uint32_t *)_edata;
+      )
     {
       *dest++ = *src++;
     }
@@ -154,7 +156,9 @@ void __start(void)
    */
 
 #ifdef CONFIG_ARCH_RAMFUNCS
-  for (src = &_framfuncs, dest = &_sramfuncs; dest < &_eramfuncs; )
+  for (src = (const uint32_t *)_framfuncs,
+       dest = (uint32_t *)_sramfuncs; dest < (uint32_t *)_eramfuncs;
+      )
     {
       *dest++ = *src++;
     }

--- a/arch/arm/src/sama5/sam_allocateheap.c
+++ b/arch/arm/src/sama5/sam_allocateheap.c
@@ -247,8 +247,8 @@ void up_allocate_heap(void **heap_start, size_t *heap_size)
    */
 
   board_autoled_on(LED_HEAPALLOCATE);
-  *heap_start = (void *)&_ebss;
-  *heap_size  = SAMA5_PRIMARY_HEAP_END - (size_t)&_ebss;
+  *heap_start = _ebss;
+  *heap_size  = SAMA5_PRIMARY_HEAP_END - (size_t)_ebss;
 
 #else
   /* Both data and the heap are in ISRAM.  The heap is then from the end of

--- a/arch/arm/src/sama5/sam_boot.c
+++ b/arch/arm/src/sama5/sam_boot.c
@@ -56,8 +56,8 @@
 
 /* Symbols defined via the linker script */
 
-extern uint32_t _vector_start; /* Beginning of vector block */
-extern uint32_t _vector_end;   /* End+1 of vector block */
+extern uint8_t _vector_start[]; /* Beginning of vector block */
+extern uint8_t _vector_end[];   /* End+1 of vector block */
 
 /****************************************************************************
  * Private Functions
@@ -142,8 +142,8 @@ static inline size_t sam_vectorsize(void)
   uintptr_t src;
   uintptr_t end;
 
-  src  = (uintptr_t)&_vector_start;
-  end  = (uintptr_t)&_vector_end;
+  src  = (uintptr_t)_vector_start;
+  end  = (uintptr_t)_vector_end;
 
   return (size_t)(end - src);
 }
@@ -166,7 +166,7 @@ static void sam_vectormapping(void)
 {
   uint32_t vector_paddr = SAM_VECTOR_PADDR & PTE_SMALL_PADDR_MASK;
   uint32_t vector_vaddr = SAM_VECTOR_VADDR & PTE_SMALL_PADDR_MASK;
-  uint32_t vector_size  = (uint32_t)&_vector_end - (uint32_t)&_vector_start;
+  uint32_t vector_size  = _vector_end - _vector_start;
   uint32_t end_paddr    = SAM_VECTOR_PADDR + vector_size;
 
   /* REVISIT:  Cannot really assert in this context */
@@ -234,8 +234,8 @@ static void sam_copyvectorblock(void)
    *                      0xffff0000)
    */
 
-  src  = (uint32_t *)&_vector_start;
-  end  = (uint32_t *)&_vector_end;
+  src  = (uint32_t *)_vector_start;
+  end  = (uint32_t *)_vector_end;
   dest = (uint32_t *)SAM_VECTOR_VSRAM;
 
   while (src < end)
@@ -418,7 +418,9 @@ void arm_boot(void)
    * at _framfuncs
    */
 
-  for (src = &_framfuncs, dest = &_sramfuncs; dest < &_eramfuncs; )
+  for (src = (const uint32_t *)_framfuncs,
+       dest = (uint32_t *)_sramfuncs; dest < (uint32_t *)_eramfuncs;
+      )
     {
       *dest++ = *src++;
     }
@@ -427,7 +429,7 @@ void arm_boot(void)
    * be available when fetched into the I-Cache.
    */
 
-  up_clean_dcache((uintptr_t)&_sramfuncs, (uintptr_t)&_eramfuncs)
+  up_clean_dcache((uintptr_t)_sramfuncs, (uintptr_t)_eramfuncs)
 #endif
 
   /* Setup up vector block.  _vector_start and _vector_end are exported from

--- a/arch/arm/src/sama5/sam_irq.c
+++ b/arch/arm/src/sama5/sam_irq.c
@@ -65,8 +65,8 @@ typedef uint32_t *(*doirq_t)(int irq, uint32_t *regs);
 
 /* Symbols defined via the linker script */
 
-extern uint32_t _vector_start; /* Beginning of vector block */
-extern uint32_t _vector_end;   /* End+1 of vector block */
+extern uint8_t _vector_start[]; /* Beginning of vector block */
+extern uint8_t _vector_end[];   /* End+1 of vector block */
 
 /****************************************************************************
  * Private Data
@@ -166,13 +166,7 @@ static void sam_dumpaic(const char *msg, uintptr_t base, int irq)
 
 static inline size_t sam_vectorsize(void)
 {
-  uintptr_t src;
-  uintptr_t end;
-
-  src  = (uintptr_t)&_vector_start;
-  end  = (uintptr_t)&_vector_end;
-
-  return (size_t)(end - src);
+  return _vector_end - _vector_start;
 }
 
 /****************************************************************************
@@ -523,8 +517,8 @@ void up_irqinitialize(void)
 #elif defined(CONFIG_SAMA5_BOOT_SDRAM)
   /* Set the VBAR register to the address of the vector table in SDRAM */
 
-  DEBUGASSERT((((uintptr_t)&_vector_start) & ~VBAR_MASK) == 0);
-  cp15_wrvbar((uint32_t)&_vector_start);
+  DEBUGASSERT((((uintptr_t)_vector_start) & ~VBAR_MASK) == 0);
+  cp15_wrvbar((uint32_t)_vector_start);
 
 #endif /* CONFIG_SAMA5_BOOT_ISRAM || CONFIG_SAMA5_BOOT_CS0FLASH */
 #endif /* CONFIG_ARCH_LOWVECTORS */

--- a/arch/arm/src/samd2l2/sam_start.c
+++ b/arch/arm/src/samd2l2/sam_start.c
@@ -53,7 +53,7 @@
  * 0x2000:ffff - End of SRAM and end of heap (assuming 64KB of SRAM)
  */
 
-#define IDLE_STACK ((uint32_t)&_ebss+CONFIG_IDLETHREAD_STACKSIZE)
+#define IDLE_STACK ((uint32_t)_ebss + CONFIG_IDLETHREAD_STACKSIZE)
 
 /****************************************************************************
  * Public Data
@@ -100,7 +100,7 @@ void __start(void)
    * certain that there are no issues with the state of global variables.
    */
 
-  for (dest = &_sbss; dest < &_ebss; )
+  for (dest = (uint32_t *)_sbss; dest < (uint32_t *)_ebss; )
     {
       *dest++ = 0;
     }
@@ -111,7 +111,9 @@ void __start(void)
    * end of all of the other read-only data (.text, .rodata) at _eronly.
    */
 
-  for (src = &_eronly, dest = &_sdata; dest < &_edata; )
+  for (src = (const uint32_t *)_eronly,
+       dest = (uint32_t *)_sdata; dest < (uint32_t *)_edata;
+      )
     {
       *dest++ = *src++;
     }

--- a/arch/arm/src/samd5e5/sam_start.c
+++ b/arch/arm/src/samd5e5/sam_start.c
@@ -51,7 +51,7 @@
  * ARM EABI requires 64 bit stack alignment.
  */
 
-#define HEAP_BASE      ((uintptr_t)&_ebss + CONFIG_IDLETHREAD_STACKSIZE)
+#define HEAP_BASE      ((uintptr_t)_ebss + CONFIG_IDLETHREAD_STACKSIZE)
 
 /****************************************************************************
  * Public Data
@@ -131,7 +131,7 @@ void __start(void)
    * certain that there are no issues with the state of global variables.
    */
 
-  for (dest = &_sbss; dest < &_ebss; )
+  for (dest = (uint32_t *)_sbss; dest < (uint32_t *)_ebss; )
     {
       *dest++ = 0;
     }
@@ -143,7 +143,9 @@ void __start(void)
    * end of all of the other read-only data (.text, .rodata) at _eronly.
    */
 
-  for (src = &_eronly, dest = &_sdata; dest < &_edata; )
+  for (src = (const uint32_t *)_eronly,
+       dest = (uint32_t *)_sdata; dest < (uint32_t *)_edata;
+      )
     {
       *dest++ = *src++;
     }
@@ -157,7 +159,9 @@ void __start(void)
    * called (at least for the SAM4L family).
    */
 
-  for (src = &_framfuncs, dest = &_sramfuncs; dest < &_eramfuncs; )
+  for (src = (const uint32_t *)_framfuncs,
+       dest = (uint32_t *)_sramfuncs; dest < (uint32_t *)_eramfuncs;
+      )
     {
       *dest++ = *src++;
     }

--- a/arch/arm/src/samv7/sam_start.c
+++ b/arch/arm/src/samv7/sam_start.c
@@ -60,7 +60,7 @@
  * 0x2005:ffff - End of internal SRAM and end of heap (a
  */
 
-#define HEAP_BASE  ((uintptr_t)&_ebss+CONFIG_IDLETHREAD_STACKSIZE)
+#define HEAP_BASE  ((uintptr_t)_ebss + CONFIG_IDLETHREAD_STACKSIZE)
 
 /****************************************************************************
  * Public Data
@@ -165,7 +165,7 @@ void __start(void)
    * certain that there are no issues with the state of global variables.
    */
 
-  for (dest = &_sbss; dest < &_ebss; )
+  for (dest = (uint32_t *)_sbss; dest < (uint32_t *)_ebss; )
     {
       *dest++ = 0;
     }
@@ -176,7 +176,9 @@ void __start(void)
    * end of all of the other read-only data (.text, .rodata) at _eronly.
    */
 
-  for (src = &_eronly, dest = &_sdata; dest < &_edata; )
+  for (src = (const uint32_t *)_eronly,
+       dest = (uint32_t *)_sdata; dest < (uint32_t *)_edata;
+      )
     {
       *dest++ = *src++;
     }
@@ -189,7 +191,9 @@ void __start(void)
    */
 
 #ifdef CONFIG_ARCH_RAMFUNCS
-  for (src = &_framfuncs, dest = &_sramfuncs; dest < &_eramfuncs; )
+  for (src = (const uint32_t *)_framfuncs,
+       dest = (uint32_t *)_sramfuncs; dest < (uint32_t *)_eramfuncs;
+      )
     {
       *dest++ = *src++;
     }

--- a/arch/arm/src/stm32/stm32_start.c
+++ b/arch/arm/src/stm32/stm32_start.c
@@ -49,7 +49,7 @@
  * ARM EABI requires 64 bit stack alignment.
  */
 
-#define HEAP_BASE      ((uintptr_t)&_ebss + CONFIG_IDLETHREAD_STACKSIZE)
+#define HEAP_BASE      ((uintptr_t)_ebss + CONFIG_IDLETHREAD_STACKSIZE)
 
 /****************************************************************************
  * Public Data
@@ -135,7 +135,7 @@ void __start(void)
    * certain that there are no issues with the state of global variables.
    */
 
-  for (dest = _START_BSS; dest < _END_BSS; )
+  for (dest = (uint32_t *)_START_BSS; dest < (uint32_t *)_END_BSS; )
     {
       *dest++ = 0;
     }
@@ -148,7 +148,9 @@ void __start(void)
    * end of all of the other read-only data (.text, .rodata) at _eronly.
    */
 
-  for (src = _DATA_INIT, dest = _START_DATA; dest < _END_DATA; )
+  for (src = (const uint32_t *)_DATA_INIT,
+       dest = (uint32_t *)_START_DATA; dest < (uint32_t *)_END_DATA;
+      )
     {
       *dest++ = *src++;
     }

--- a/arch/arm/src/stm32f0l0g0/stm32_start.c
+++ b/arch/arm/src/stm32f0l0g0/stm32_start.c
@@ -40,7 +40,7 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-#define IDLE_STACK ((uint32_t)&_ebss+CONFIG_IDLETHREAD_STACKSIZE)
+#define IDLE_STACK ((uint32_t)_ebss + CONFIG_IDLETHREAD_STACKSIZE)
 
 /****************************************************************************
  * Public Data
@@ -93,7 +93,7 @@ void __start(void)
    * certain that there are no issues with the state of global variables.
    */
 
-  for (dest = &_sbss; dest < &_ebss; )
+  for (dest = (uint32_t *)_sbss; dest < (uint32_t *)_ebss; )
     {
       *dest++ = 0;
     }
@@ -106,7 +106,9 @@ void __start(void)
    * end of all of the other read-only data (.text, .rodata) at _eronly.
    */
 
-  for (src = &_eronly, dest = &_sdata; dest < &_edata; )
+  for (src = (const uint32_t *)_eronly,
+       dest = (uint32_t *)_sdata; dest < (uint32_t *)_edata;
+      )
     {
       *dest++ = *src++;
     }

--- a/arch/arm/src/stm32f7/stm32_start.c
+++ b/arch/arm/src/stm32f7/stm32_start.c
@@ -61,7 +61,7 @@
  * 0x2005:ffff - End of internal SRAM and end of heap (a
  */
 
-#define HEAP_BASE  ((uintptr_t)&_ebss+CONFIG_IDLETHREAD_STACKSIZE)
+#define HEAP_BASE  ((uintptr_t)_ebss + CONFIG_IDLETHREAD_STACKSIZE)
 
 /****************************************************************************
  * Private Function prototypes
@@ -189,7 +189,7 @@ void __start(void)
    * certain that there are no issues with the state of global variables.
    */
 
-  for (dest = &_sbss; dest < &_ebss; )
+  for (dest = (uint32_t *)_sbss; dest < (uint32_t *)_ebss; )
     {
       *dest++ = 0;
     }
@@ -200,7 +200,9 @@ void __start(void)
    * end of all of the other read-only data (.text, .rodata) at _eronly.
    */
 
-  for (src = &_eronly, dest = &_sdata; dest < &_edata; )
+  for (src = (const uint32_t *)_eronly,
+       dest = (uint32_t *)_sdata; dest < (uint32_t *)_edata;
+      )
     {
       *dest++ = *src++;
     }
@@ -213,7 +215,9 @@ void __start(void)
    */
 
 #ifdef CONFIG_ARCH_RAMFUNCS
-  for (src = &_framfuncs, dest = &_sramfuncs; dest < &_eramfuncs; )
+  for (src = (const uint32_t *)_framfuncs,
+       dest = (uint32_t *)_sramfuncs; dest < (uint32_t *)_eramfuncs;
+      )
     {
       *dest++ = *src++;
     }

--- a/arch/arm/src/stm32h7/stm32_allocateheap.c
+++ b/arch/arm/src/stm32h7/stm32_allocateheap.c
@@ -113,7 +113,7 @@
 #  define SRAM4_START ((uint32_t)(STM32_SRAM4_BASE))
 #  define SRAM4_END   ((uint32_t)(SRAM4_START + STM32H7_SRAM4_SIZE))
 
-#  define SRAM4_HEAP_START ((uint32_t)(&_sram4_heap_start))
+#  define SRAM4_HEAP_START ((uint32_t)_sram4_heap_start)
 #endif
 
 /* The STM32 H7 has DTCM memory */
@@ -135,7 +135,7 @@
  ****************************************************************************/
 
 #ifdef HAVE_SRAM4
-extern const uint32_t _sram4_heap_start;
+extern const uint8_t _sram4_heap_start[];
 #endif
 
 /****************************************************************************

--- a/arch/arm/src/stm32h7/stm32_start.c
+++ b/arch/arm/src/stm32h7/stm32_start.c
@@ -62,7 +62,7 @@
  * 0x2005:ffff - End of internal SRAM and end of heap (a
  */
 
-#define HEAP_BASE  ((uintptr_t)&_ebss+CONFIG_IDLETHREAD_STACKSIZE)
+#define HEAP_BASE  ((uintptr_t)_ebss + CONFIG_IDLETHREAD_STACKSIZE)
 
 /****************************************************************************
  * Public Data
@@ -190,7 +190,7 @@ void __start(void)
    * certain that there are no issues with the state of global variables.
    */
 
-  for (dest = &_sbss; dest < &_ebss; )
+  for (dest = (uint32_t *)_sbss; dest < (uint32_t *)_ebss; )
     {
       *dest++ = 0;
     }
@@ -201,7 +201,9 @@ void __start(void)
    * end of all of the other read-only data (.text, .rodata) at _eronly.
    */
 
-  for (src = &_eronly, dest = &_sdata; dest < &_edata; )
+  for (src = (const uint32_t *)_eronly,
+       dest = (uint32_t *)_sdata; dest < (uint32_t *)_edata;
+      )
     {
       *dest++ = *src++;
     }
@@ -214,7 +216,9 @@ void __start(void)
    */
 
 #ifdef CONFIG_ARCH_RAMFUNCS
-  for (src = &_framfuncs, dest = &_sramfuncs; dest < &_eramfuncs; )
+  for (src = (const uint32_t *)_framfuncs,
+       dest = (uint32_t *)_sramfuncs; dest < (uint32_t *)_eramfuncs;
+      )
     {
       *dest++ = *src++;
     }

--- a/arch/arm/src/stm32l4/stm32l4_start.c
+++ b/arch/arm/src/stm32l4/stm32l4_start.c
@@ -61,7 +61,7 @@
 #define SRAM2_START  STM32L4_SRAM2_BASE
 #define SRAM2_END    (SRAM2_START + STM32L4_SRAM2_SIZE)
 
-#define HEAP_BASE  ((uintptr_t)&_ebss+CONFIG_IDLETHREAD_STACKSIZE)
+#define HEAP_BASE  ((uintptr_t)_ebss + CONFIG_IDLETHREAD_STACKSIZE)
 
 /* g_idle_topstack: _sbss is the start of the BSS region as defined by the
  * linker script. _ebss lies at the end of the BSS region. The idle task
@@ -157,7 +157,7 @@ void __start(void)
    * certain that there are no issues with the state of global variables.
    */
 
-  for (dest = &_sbss; dest < &_ebss; )
+  for (dest = (uint32_t *)_sbss; dest < (uint32_t *)_ebss; )
     {
       *dest++ = 0;
     }
@@ -170,7 +170,9 @@ void __start(void)
    * end of all of the other read-only data (.text, .rodata) at _eronly.
    */
 
-  for (src = &_eronly, dest = &_sdata; dest < &_edata; )
+  for (src = (const uint32_t *)_eronly,
+       dest = (uint32_t *)_sdata; dest < (uint32_t *)_edata;
+      )
     {
       *dest++ = *src++;
     }

--- a/arch/arm/src/stm32l5/stm32l5_start.c
+++ b/arch/arm/src/stm32l5/stm32l5_start.c
@@ -63,7 +63,7 @@
 #define SRAM2_START  STM32L5_SRAM2_BASE
 #define SRAM2_END    (SRAM2_START + STM32L5_SRAM2_SIZE)
 
-#define HEAP_BASE  ((uintptr_t)&_ebss + CONFIG_IDLETHREAD_STACKSIZE)
+#define HEAP_BASE  ((uintptr_t)_ebss + CONFIG_IDLETHREAD_STACKSIZE)
 
 /* g_idle_topstack: _sbss is the start of the BSS region as defined by the
  * linker script. _ebss lies at the end of the BSS region. The idle task
@@ -159,7 +159,7 @@ void __start(void)
    * certain that there are no issues with the state of global variables.
    */
 
-  for (dest = &_sbss; dest < &_ebss; )
+  for (dest = (uint32_t *)_sbss; dest < (uint32_t *)_ebss; )
     {
       *dest++ = 0;
     }
@@ -172,7 +172,9 @@ void __start(void)
    * end of all of the other read-only data (.text, .rodata) at _eronly.
    */
 
-  for (src = &_eronly, dest = &_sdata; dest < &_edata; )
+  for (src = (const uint32_t *)_eronly,
+       dest = (uint32_t *)_sdata; dest < (uint32_t *)_edata;
+      )
     {
       *dest++ = *src++;
     }

--- a/arch/arm/src/stm32u5/stm32_start.c
+++ b/arch/arm/src/stm32u5/stm32_start.c
@@ -63,7 +63,7 @@
 #define SRAM2_START  STM32U5_SRAM2_BASE
 #define SRAM2_END    (SRAM2_START + STM32U5_SRAM2_SIZE)
 
-#define HEAP_BASE  ((uintptr_t)&_ebss + CONFIG_IDLETHREAD_STACKSIZE)
+#define HEAP_BASE  ((uintptr_t)_ebss + CONFIG_IDLETHREAD_STACKSIZE)
 
 /* g_idle_topstack: _sbss is the start of the BSS region as defined by the
  * linker script. _ebss lies at the end of the BSS region. The idle task
@@ -159,7 +159,7 @@ void __start(void)
    * certain that there are no issues with the state of global variables.
    */
 
-  for (dest = &_sbss; dest < &_ebss; )
+  for (dest = (uint32_t *)_sbss; dest < (uint32_t *)_ebss; )
     {
       *dest++ = 0;
     }
@@ -172,7 +172,9 @@ void __start(void)
    * end of all of the other read-only data (.text, .rodata) at _eronly.
    */
 
-  for (src = &_eronly, dest = &_sdata; dest < &_edata; )
+  for (src = (const uint32_t *)_eronly,
+       dest = (uint32_t *)_sdata; dest < (uint32_t *)_edata;
+      )
     {
       *dest++ = *src++;
     }

--- a/arch/arm/src/stm32wb/stm32wb_start.c
+++ b/arch/arm/src/stm32wb/stm32wb_start.c
@@ -59,7 +59,7 @@
  *               the stack + 4;
  */
 
-#define HEAP_BASE  ((uintptr_t)&_ebss+CONFIG_IDLETHREAD_STACKSIZE)
+#define HEAP_BASE  ((uintptr_t)_ebss + CONFIG_IDLETHREAD_STACKSIZE)
 
 #ifdef CONFIG_STM32WB_SRAM2A_HEAP
 #  define SRAM2A_START  (STM32WB_SRAM2A_BASE + CONFIG_STM32WB_SRAM2A_USER_BASE_OFFSET)
@@ -177,7 +177,7 @@ void __start(void)
    * certain that there are no issues with the state of global variables.
    */
 
-  for (dest = &_sbss; dest < &_ebss; )
+  for (dest = (uint32_t *)_sbss; dest < (uint32_t *)_ebss; )
     {
       *dest++ = 0;
     }
@@ -190,7 +190,9 @@ void __start(void)
    * end of all of the other read-only data (.text, .rodata) at _eronly.
    */
 
-  for (src = &_eronly, dest = &_sdata; dest < &_edata; )
+  for (src = (const uint32_t *)_eronly,
+       dest = (uint32_t *)_sdata; dest < (uint32_t *)_edata;
+      )
     {
       *dest++ = *src++;
     }

--- a/arch/arm/src/stm32wl5/stm32wl5_start.c
+++ b/arch/arm/src/stm32wl5/stm32wl5_start.c
@@ -62,7 +62,7 @@
 #define SRAM2_START  STM32WL5_SRAM2_BASE
 #define SRAM2_END    (SRAM2_START + STM32WL5_SRAM2_SIZE)
 
-#define HEAP_BASE  ((uintptr_t)&_ebss+CONFIG_IDLETHREAD_STACKSIZE)
+#define HEAP_BASE  ((uintptr_t)_ebss + CONFIG_IDLETHREAD_STACKSIZE)
 
 /* g_idle_topstack: _sbss is the start of the BSS region as defined by the
  * linker script. _ebss lies at the end of the BSS region. The idle task
@@ -161,7 +161,7 @@ void __start(void)
    * certain that there are no issues with the state of global variables.
    */
 
-  for (dest = &_sbss; dest < &_ebss; )
+  for (dest = (uint32_t *)_sbss; dest < (uint32_t *)_ebss; )
     {
       *dest++ = 0;
     }
@@ -174,7 +174,9 @@ void __start(void)
    * end of all of the other read-only data (.text, .rodata) at _eronly.
    */
 
-  for (src = &_eronly, dest = &_sdata; dest < &_edata; )
+  for (src = (const uint32_t *)_eronly,
+       dest = (uint32_t *)_sdata; dest < (uint32_t *)_edata;
+      )
     {
       *dest++ = *src++;
     }

--- a/arch/arm/src/tiva/cc13xx/cc13xx_start.c
+++ b/arch/arm/src/tiva/cc13xx/cc13xx_start.c
@@ -52,7 +52,7 @@
  * ARM EABI requires 64 bit stack alignment.
  */
 
-#define HEAP_BASE      ((uintptr_t)&_ebss + CONFIG_IDLETHREAD_STACKSIZE)
+#define HEAP_BASE      ((uintptr_t)_ebss + CONFIG_IDLETHREAD_STACKSIZE)
 
 /****************************************************************************
  * Public Data
@@ -125,7 +125,7 @@ void __start(void)
    * certain that there are no issues with the state of global variables.
    */
 
-  for (dest = &_sbss; dest < &_ebss; )
+  for (dest = (uint32_t *)_sbss; dest < (uint32_t *)_ebss; )
     {
       *dest++ = 0;
     }
@@ -150,7 +150,9 @@ void __start(void)
    * end of all of the other read-only data (.text, .rodata) at _eronly.
    */
 
-  for (src = &_eronly, dest = &_sdata; dest < &_edata; )
+  for (src = (const uint32_t *)_eronly,
+       dest = (uint32_t *)_sdata; dest < (uint32_t *)_edata;
+      )
     {
       *dest++ = *src++;
     }

--- a/arch/arm/src/tiva/common/lmxx_tm4c_start.c
+++ b/arch/arm/src/tiva/common/lmxx_tm4c_start.c
@@ -51,7 +51,7 @@
  * ARM EABI requires 64 bit stack alignment.
  */
 
-#define HEAP_BASE      ((uintptr_t)&_ebss + CONFIG_IDLETHREAD_STACKSIZE)
+#define HEAP_BASE      ((uintptr_t)_ebss + CONFIG_IDLETHREAD_STACKSIZE)
 
 /****************************************************************************
  * Public Data
@@ -117,7 +117,7 @@ void __start(void)
    * certain that there are no issues with the state of global variables.
    */
 
-  for (dest = &_sbss; dest < &_ebss; )
+  for (dest = (uint32_t *)_sbss; dest < (uint32_t *)_ebss; )
     {
       *dest++ = 0;
     }
@@ -131,7 +131,9 @@ void __start(void)
    * end of all of the other read-only data (.text, .rodata) at _eronly.
    */
 
-  for (src = &_eronly, dest = &_sdata; dest < &_edata; )
+  for (src = (const uint32_t *)_eronly,
+       dest = (uint32_t *)_sdata; dest < (uint32_t *)_edata;
+      )
     {
       *dest++ = *src++;
     }

--- a/arch/arm/src/tlsr82/tc32/tc32_backtrace.c
+++ b/arch/arm/src/tlsr82/tc32/tc32_backtrace.c
@@ -471,7 +471,7 @@ int up_backtrace(struct tcb_s *tcb, void **buffer, int size, int skip)
 #  ifdef CONFIG_SMP
                                arm_intstack_top(),
 #  else
-                               &g_intstacktop,
+                               g_intstacktop,
 #  endif /* CONFIG_SMP */
                                &sp, (void *)up_backtrace + 10,
                                buffer, size, &skip);

--- a/arch/arm/src/tlsr82/tlsr82_start.c
+++ b/arch/arm/src/tlsr82/tlsr82_start.c
@@ -39,8 +39,12 @@
 #include "tlsr82_flash.h"
 
 /****************************************************************************
- * Pre-processor Definitions
+ * Public Function Prototypes
  ****************************************************************************/
+
+#ifdef CONFIG_SCHED_BACKTRACE
+extern void up_backtrace_init_code_regions(void **regions);
+#endif
 
 /****************************************************************************
  * Public Data
@@ -56,8 +60,26 @@
  * address.
  */
 
-const uintptr_t g_idle_topstack = (uintptr_t)(&_ebss) +
+const uintptr_t g_idle_topstack = (uintptr_t)_ebss +
                                   CONFIG_IDLETHREAD_STACKSIZE;
+
+#ifdef CONFIG_SCHED_BACKTRACE
+extern uint8_t _sramcode[];
+extern uint8_t _eramcode[];
+#endif
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+#ifdef CONFIG_SCHED_BACKTRACE
+static void *g_code_regions[] =
+{
+  _stext   , _etext,
+  _sramcode, _eramcode,
+  NULL     , NULL,
+};
+#endif
 
 /****************************************************************************
  * Private Types
@@ -84,16 +106,6 @@ void __tc32_start(void)
   tlsr82_clock_init();
 
 #ifdef CONFIG_SCHED_BACKTRACE
-  extern uint32_t _sramcode;
-  extern uint32_t _eramcode;
-  static void *g_code_regions[] =
-  {
-    &_stext   , &_etext,
-    &_sramcode, &_eramcode,
-    NULL      , NULL,
-  };
-
-  extern void up_backtrace_init_code_regions(void **regions);
   up_backtrace_init_code_regions(g_code_regions);
 #endif
 

--- a/arch/arm/src/xmc4/xmc4_start.c
+++ b/arch/arm/src/xmc4/xmc4_start.c
@@ -66,7 +66,7 @@ static inline void xmc4_flash_waitstates(void);
  * 0x2002:ffff - End of internal SRAM and end of heap (a
  */
 
-#define HEAP_BASE  ((uintptr_t)&_ebss+CONFIG_IDLETHREAD_STACKSIZE)
+#define HEAP_BASE  ((uintptr_t)_ebss + CONFIG_IDLETHREAD_STACKSIZE)
 
 /****************************************************************************
  * Public Data
@@ -187,7 +187,7 @@ void __start(void)
    * certain that there are no issues with the state of global variables.
    */
 
-  for (dest = &_sbss; dest < &_ebss; )
+  for (dest = (uint32_t *)_sbss; dest < (uint32_t *)_ebss; )
     {
       *dest++ = 0;
     }
@@ -198,7 +198,9 @@ void __start(void)
    * end of all of the other read-only data (.text, .rodata) at _eronly.
    */
 
-  for (src = &_eronly, dest = &_sdata; dest < &_edata; )
+  for (src = (const uint32_t *)_eronly,
+       dest = (uint32_t *)_sdata; dest < (uint32_t *)_edata;
+      )
     {
       *dest++ = *src++;
     }
@@ -210,7 +212,9 @@ void __start(void)
    */
 
 #ifdef CONFIG_ARCH_RAMFUNCS
-  for (src = &_framfuncs, dest = &_sramfuncs; dest < &_eramfuncs; )
+  for (src = (const uint32_t *)_framfuncs,
+       dest = (uint32_t *)_sramfuncs; dest < (uint32_t *)_eramfuncs;
+      )
     {
       *dest++ = *src++;
     }

--- a/arch/arm64/src/common/arm64_allocateheap.c
+++ b/arch/arm64/src/common/arm64_allocateheap.c
@@ -125,7 +125,7 @@ void up_allocate_heap(void **heap_start, size_t *heap_size)
 
   /* Return the heap settings */
 
-  *heap_start = (void *)g_idle_topstack;
+  *heap_start = g_idle_topstack;
   *heap_size  = CONFIG_RAM_END - (size_t)g_idle_topstack;
   sinfo("heap_start=0x%p, heap_size=0x%"PRIx64"\n", *heap_start, *heap_size);
 #endif

--- a/arch/arm64/src/common/arm64_cpustart.c
+++ b/arch/arm64/src/common/arm64_cpustart.c
@@ -153,7 +153,7 @@ static void arm64_start_cpu(int cpu_num, char *stack, int stack_sz,
   flush_end     = flush_start + sizeof(cpu_boot_params);
   up_flush_dcache(flush_start, flush_end);
 
-  if (pcsi_cpu_on(cpu_mpid, (uint64_t)&__start))
+  if (pcsi_cpu_on(cpu_mpid, (uint64_t)__start))
     {
       sinfo("Failed to boot secondary CPU core %d (MPID:%#lx)\n", cpu_num,
             cpu_mpid);

--- a/arch/arm64/src/common/arm64_internal.h
+++ b/arch/arm64/src/common/arm64_internal.h
@@ -171,22 +171,13 @@ INIT_STACK_DEFINE_EXTERN(g_interrupt_stack, INTSTACK_SIZE);
 /* Address of the saved user stack pointer */
 
 #if CONFIG_ARCH_INTERRUPTSTACK > 3
-EXTERN uint64_t g_intstackalloc; /* Allocated stack base */
-EXTERN uint64_t g_intstacktop;   /* Initial top of interrupt stack */
+EXTERN uint8_t g_intstackalloc[]; /* Allocated stack base */
+EXTERN uint8_t g_intstacktop[];   /* Initial top of interrupt stack */
 #else
 #  error CONFIG_ARCH_INTERRUPTSTACK must be defined (4096 at least) at arm64
 #endif
 
-/* These 'addresses' of these values are setup by the linker script.  They
- * are not actual uint64_t storage locations! They are only used
- * meaningfully in the following way:
- *
- *  - The linker script defines, for example, the symbol_sdata.
- *  - The declaration extern uint64_t _sdata; makes C happy.  C will believe
- *    that the value _sdata is the address of a uint64_t variable _data
- *    (it is not!).
- *  - We can recover the linker value then by simply taking the address of
- *    of _data.  like:  uint64_t *pdata = &_sdata;
+/* These symbols are setup by the linker script.
  *
  * Memory layout for Nuttx at arm64 for FLAT Build
  *
@@ -217,20 +208,20 @@ EXTERN uint64_t g_intstacktop;   /* Initial top of interrupt stack */
  * please check dramboot.ld at specified platform for more detail
  */
 
-EXTERN char _stext[];            /* Start of .text */
-EXTERN char _etext[];            /* End of .text */
-EXTERN char _sztext[];           /* Size of .text */
-EXTERN char _srodata[];          /* Start of .rodata */
-EXTERN char _erodata[];          /* End+1 of .rodata */
-EXTERN char _szrodata[];         /* Size of .rodata */
-EXTERN const char _eronly[];     /* End+1 of read only section (.text + .rodata) */
-EXTERN char _sdata[];            /* Start of .data */
-EXTERN char _edata[];            /* End+1 of .data */
-EXTERN char _sbss[];             /* Start of .bss */
-EXTERN char _ebss[];             /* End+1 of .bss */
-EXTERN char _szdata[];           /* Size of data(.data + .bss) */
-EXTERN char _e_initstack[];      /* End+1 of .initstack */
-EXTERN char g_idle_topstack[];   /* End+1 of heap */
+EXTERN uint8_t _stext[];            /* Start of .text */
+EXTERN uint8_t _etext[];            /* End of .text */
+EXTERN uint8_t _sztext[];           /* Size of .text */
+EXTERN uint8_t _srodata[];          /* Start of .rodata */
+EXTERN uint8_t _erodata[];          /* End+1 of .rodata */
+EXTERN uint8_t _szrodata[];         /* Size of .rodata */
+EXTERN const uint8_t _eronly[];     /* End+1 of read only section (.text + .rodata) */
+EXTERN uint8_t _sdata[];            /* Start of .data */
+EXTERN uint8_t _edata[];            /* End+1 of .data */
+EXTERN uint8_t _sbss[];             /* Start of .bss */
+EXTERN uint8_t _ebss[];             /* End+1 of .bss */
+EXTERN uint8_t _szdata[];           /* Size of data(.data + .bss) */
+EXTERN uint8_t _e_initstack[];      /* End+1 of .initstack */
+EXTERN uint8_t g_idle_topstack[];   /* End+1 of heap */
 
 #  define _START_TEXT  _stext
 #  define _END_TEXT    _etext

--- a/arch/avr/src/at32uc3/at32uc3_irq.c
+++ b/arch/avr/src/at32uc3/at32uc3_irq.c
@@ -47,20 +47,20 @@
 /* These symbols are exported from up_exceptions.S:
  */
 
-extern uint32_t vectortab;
-extern uint32_t avr32_int0;
-extern uint32_t avr32_int1;
-extern uint32_t avr32_int2;
-extern uint32_t avr32_int3;
+extern uint8_t vectortab[];
+extern uint8_t avr32_int0[];
+extern uint8_t avr32_int1[];
+extern uint8_t avr32_int2[];
+extern uint8_t avr32_int3[];
 
 /* The provide interrupt handling offsets relative to the EVBA
  * address (which should be vectortab).
  */
 
-#define AVR32_INT0_RADDR ((uint32_t)&avr32_int0 - (uint32_t)&vectortab)
-#define AVR32_INT1_RADDR ((uint32_t)&avr32_int1 - (uint32_t)&vectortab)
-#define AVR32_INT2_RADDR ((uint32_t)&avr32_int2 - (uint32_t)&vectortab)
-#define AVR32_INT3_RADDR ((uint32_t)&avr32_int3 - (uint32_t)&vectortab)
+#define AVR32_INT0_RADDR (avr32_int0 - vectortab)
+#define AVR32_INT1_RADDR (avr32_int1 - vectortab)
+#define AVR32_INT2_RADDR (avr32_int2 - vectortab)
+#define AVR32_INT3_RADDR (avr32_int3 - vectortab)
 
 /****************************************************************************
  * Private Types

--- a/arch/avr/src/avr/up_dumpstate.c
+++ b/arch/avr/src/avr/up_dumpstate.c
@@ -147,7 +147,7 @@ void up_dumpstate(void)
   /* Get the limits on the interrupt stack memory */
 
 #if CONFIG_ARCH_INTERRUPTSTACK > 0
-  istackbase = (uint16_t)&g_intstackalloc;
+  istackbase = (uint16_t)g_intstackalloc;
   istacksize = CONFIG_ARCH_INTERRUPTSTACK;
 
   /* Show interrupt stack info */

--- a/arch/avr/src/avr32/up_dumpstate.c
+++ b/arch/avr/src/avr32/up_dumpstate.c
@@ -119,7 +119,7 @@ void up_dumpstate(void)
   /* Get the limits on the interrupt stack memory */
 
 #if CONFIG_ARCH_INTERRUPTSTACK > 3
-  istackbase = (uint32_t)&g_intstackalloc;
+  istackbase = (uint32_t)g_intstackalloc;
   istacksize = (CONFIG_ARCH_INTERRUPTSTACK & ~3);
 
   /* Show interrupt stack info */

--- a/arch/avr/src/common/up_initialize.c
+++ b/arch/avr/src/common/up_initialize.c
@@ -87,7 +87,7 @@ volatile uint8_t *g_current_regs;
 #if defined(CONFIG_STACK_COLORATION) && CONFIG_ARCH_INTERRUPTSTACK > 3
 static inline void up_color_intstack(void)
 {
-  uint8_t *ptr = (uint8_t *)&g_intstackalloc;
+  uint8_t *ptr = g_intstackalloc;
   ssize_t size;
 
   for (size = (CONFIG_ARCH_INTERRUPTSTACK & ~3);

--- a/arch/avr/src/common/up_internal.h
+++ b/arch/avr/src/common/up_internal.h
@@ -80,29 +80,19 @@ typedef void (*up_vector_t)(void);
 /* Address of the saved user stack pointer */
 
 #if CONFIG_ARCH_INTERRUPTSTACK > 3
-extern void g_intstackalloc;
-extern void g_intstacktop;
+extern uint8_t g_intstackalloc[];
+extern uint8_t g_intstacktop[];
 #endif
 
-/* These 'addresses' of these values are setup by the linker script.  They
- * are not actual uint32_t storage locations! They are only used meaningfully
- * in the following way:
- *
- *  - The linker script defines, for example, the symbol_sdata.
- *  - The declaration extern uint32_t _sdata; makes C happy.  C will believe
- *    that the value _sdata is the address of a uint32_t variable _data
- *    (it is not!).
- *  - We can recover the linker value then by simply taking the address of
- *    of _data.  like:  uint32_t *pdata = &_sdata;
- */
+/* These symbols are setup by the linker script. */
 
-extern uint32_t _stext;           /* Start of .text */
-extern uint32_t _etext;           /* End_1 of .text + .rodata */
-extern const uint32_t _eronly;    /* End+1 of read only section (.text + .rodata) */
-extern uint32_t _sdata;           /* Start of .data */
-extern uint32_t _edata;           /* End+1 of .data */
-extern uint32_t _sbss;            /* Start of .bss */
-extern uint32_t _ebss;            /* End+1 of .bss */
+extern uint8_t _stext[];           /* Start of .text */
+extern uint8_t _etext[];           /* End_1 of .text + .rodata */
+extern const uint8_t _eronly[];    /* End+1 of read only section (.text + .rodata) */
+extern uint8_t _sdata[];           /* Start of .data */
+extern uint8_t _edata[];           /* End+1 of .data */
+extern uint8_t _sbss[];            /* Start of .bss */
+extern uint8_t _ebss[];            /* End+1 of .bss */
 
 #endif /* __ASSEMBLY__ */
 

--- a/arch/ceva/src/common/up_assert.c
+++ b/arch/ceva/src/common/up_assert.c
@@ -200,8 +200,8 @@ static void up_dumpstate(void)
 
   /* Get the limits on the interrupt stack memory */
 
-  istackbase = (uint32_t)&g_intstackbase;
-  istacksize = &g_intstackbase - &g_intstackalloc;
+  istackbase = (uint32_t)g_intstackbase;
+  istacksize = g_intstackbase - g_intstackalloc;
 
   /* Show interrupt stack info */
 

--- a/arch/ceva/src/common/up_checkstack.c
+++ b/arch/ceva/src/common/up_checkstack.c
@@ -160,13 +160,13 @@ ssize_t up_check_stack_remain(void)
 
 size_t up_check_intstack(void)
 {
-  return ceva_stack_check((uintptr_t)&g_intstackalloc,
-                          &g_intstackbase - &g_intstackalloc);
+  return ceva_stack_check((uintptr_t)g_intstackalloc,
+                          g_intstackbase - g_intstackalloc);
 }
 
 size_t up_check_intstack_remain(void)
 {
-  return &g_intstackbase - &g_intstackalloc - up_check_intstack();
+  return g_intstackbase - g_intstackalloc - up_check_intstack();
 }
 
 #endif /* CONFIG_STACK_COLORATION */

--- a/arch/ceva/src/common/up_heap.c
+++ b/arch/ceva/src/common/up_heap.c
@@ -57,8 +57,8 @@ static struct mm_heap_s g_mmheap1;
 static struct mm_heap_s g_mmheap2;
 #    define MM_HEAP2    &g_mmheap2
 #  endif
-#  define _END_BSS2     ((void *)&_ebss2)
-#  define _END_HEAP2    ((void *)&_eheap2)
+#  define _END_BSS2     _ebss2
+#  define _END_HEAP2    _eheap2
 #else
 #  define MM_HEAP2      NULL
 #  define _END_BSS2     NULL
@@ -72,8 +72,8 @@ static struct mm_heap_s g_mmheap2;
 static struct mm_heap_s g_mmheap3;
 #    define MM_HEAP3    &g_mmheap3
 #  endif
-#  define _END_BSS3     ((void *)&_ebss3)
-#  define _END_HEAP3    ((void *)&_eheap3)
+#  define _END_BSS3     _ebss3
+#  define _END_HEAP3    _eheap3
 #else
 #  define MM_HEAP3      NULL
 #  define _END_BSS3     NULL
@@ -87,8 +87,8 @@ static struct mm_heap_s g_mmheap3;
 static struct mm_heap_s g_mmheap4;
 #    define MM_HEAP4    &g_mmheap4
 #  endif
-#  define _END_BSS4     ((void *)&_ebss4)
-#  define _END_HEAP4    ((void *)&_eheap4)
+#  define _END_BSS4     _ebss4
+#  define _END_HEAP4    _eheap4
 #else
 #  define MM_HEAP4      NULL
 #  define _END_BSS4     NULL

--- a/arch/ceva/src/common/up_initialize.c
+++ b/arch/ceva/src/common/up_initialize.c
@@ -41,10 +41,10 @@
 
 static inline void up_color_intstack(void)
 {
-  uint32_t *ptr = (uint32_t *)&g_intstackalloc;
+  uint32_t *ptr = (uint32_t *)g_intstackalloc;
   ssize_t size;
 
-  for (size = &g_intstackbase - &g_intstackalloc;
+  for (size = g_intstackbase - g_intstackalloc;
        size > 0;
        size -= sizeof(uint32_t))
     {

--- a/arch/ceva/src/common/up_internal.h
+++ b/arch/ceva/src/common/up_internal.h
@@ -79,16 +79,16 @@
 
 /* Linker defined section addresses */
 
-#define _START_TEXT    ((const void *)&_stext)
-#define _END_TEXT      ((const void *)&_etext)
-#define _START_BSS     ((void *)&_sbss)
-#define _END_BSS       ((void *)&_ebss)
-#define _DATA_INIT     ((const void *)&_eronly)
-#define _START_DATA    ((void *)&_sdata)
-#define _END_DATA      ((void *)&_edata)
-#define _START_HEAP    ((void *)&_ebss + CONFIG_IDLETHREAD_STACKSIZE)
-#define _END_HEAP      ((void *)&_eheap)
-#define _END_MEM       ((void *)~0)
+#define _START_TEXT    _stext
+#define _END_TEXT      _etext
+#define _START_BSS     _sbss
+#define _END_BSS       _ebss
+#define _DATA_INIT     _eronly
+#define _START_DATA    _sdata
+#define _END_DATA      _edata
+#define _START_HEAP    (_ebss + CONFIG_IDLETHREAD_STACKSIZE)
+#define _END_HEAP      _eheap
+#define _END_MEM       ((char *)~0)
 
 /* This is the value used to mark the stack for subsequent stack monitoring
  * logic.
@@ -129,76 +129,66 @@ EXTERN void *g_idle_topstack;
 
 /* Address of the interrupt stack pointer */
 
-EXTERN char g_intstackalloc; /* Allocated stack base */
-EXTERN char g_intstackbase;  /* Initial top of interrupt stack */
+EXTERN uint8_t g_intstackalloc[]; /* Allocated stack base */
+EXTERN uint8_t g_intstackbase[];  /* Initial top of interrupt stack */
 
-/* These 'addresses' of these values are setup by the linker script.
- * They are not actual char storage locations! They are only used
- * meaningfully in the following way:
- *
- *  - The linker script defines, for example, the symbol _sdata.
- *  - The declareion extern char _sdata; makes C happy.  C will believe
- *    that the value _sdata is the address of a char variable _data (it is
- *    not!).
- *  - We can recover the linker value then by simply taking the address of
- *    of _data.  like:  char *pdata = &_sdata;
- */
+/* These symbols are setup by the linker script. */
 
 /* Start of .text */
 
-EXTERN const char _stext;
-EXTERN const char _stext2;
-EXTERN const char _stext3;
-EXTERN const char _stext4;
+EXTERN const uint8_t _stext[];
+EXTERN const uint8_t _stext2[];
+EXTERN const uint8_t _stext3[];
+EXTERN const uint8_t _stext4[];
 
 /* End+1 of .text */
 
-EXTERN const char _etext;
-EXTERN const char _etext2;
-EXTERN const char _etext3;
-EXTERN const char _etext4;
+EXTERN const uint8_t _etext[];
+EXTERN const uint8_t _etext2[];
+EXTERN const uint8_t _etext3[];
+EXTERN const uint8_t _etext4[];
 
 /* End+1 of read only section (.text + .rodata) */
 
-EXTERN const char _eronly;
-EXTERN const char _eronly2;
-EXTERN const char _eronly3;
-EXTERN const char _eronly4;
+EXTERN const uint8_t _eronly[];
+EXTERN const uint8_t _eronly2[];
+EXTERN const uint8_t _eronly3[];
+EXTERN const uint8_t _eronly4[];
 
 /* Start of .data */
 
-EXTERN char _sdata;
-EXTERN char _sdata2;
-EXTERN char _sdata3;
-EXTERN char _sdata4;
+EXTERN uint8_t _sdata[];
+EXTERN uint8_t _sdata2[];
+EXTERN uint8_t _sdata3[];
+EXTERN uint8_t _sdata4[];
 
 /* End+1 of .data */
 
-EXTERN char _edata;
-EXTERN char _edata2;
-EXTERN char _edata3;
-EXTERN char _edata4;
+EXTERN uint8_t _edata[];
+EXTERN uint8_t _edata2[];
+EXTERN uint8_t _edata3[];
+EXTERN uint8_t _edata4[];
 
 /* Start of .bss */
 
-EXTERN char _sbss;
-EXTERN char _sbss2;
-EXTERN char _sbss3;
-EXTERN char _sbss4;
+EXTERN uint8_t _sbss[];
+EXTERN uint8_t _sbss2[];
+EXTERN uint8_t _sbss3[];
+EXTERN uint8_t _sbss4[];
 
 /* End+1 of .bss */
 
-EXTERN char _ebss;
-EXTERN char _ebss2;
-EXTERN char _ebss3;
-EXTERN char _ebss4;
+EXTERN uint8_t _ebss[];
+EXTERN uint8_t _ebss2[];
+EXTERN uint8_t _ebss3[];
+EXTERN uint8_t _ebss4[];
 
 /* End+1 of the memory */
 
-EXTERN char _eheap;
-EXTERN char _eheap2;
-EXTERN char _eheap3;
-EXTERN char _eheap4;
+EXTERN uint8_t _eheap[];
+EXTERN uint8_t _eheap2[];
+EXTERN uint8_t _eheap3[];
+EXTERN uint8_t _eheap4[];
 
 #endif /* __ASSEMBLY__ */
 

--- a/arch/ceva/src/common/up_start.c
+++ b/arch/ceva/src/common/up_start.c
@@ -35,13 +35,13 @@
 #include "up_internal.h"
 
 #if CONFIG_ARCH_NR_MEMORY >= 2
-#  define _START_TEXT2  ((const void *)&_stext2)
-#  define _END_TEXT2    ((const void *)&_etext2)
-#  define _START_BSS2   ((void *)&_sbss2)
-#  define _END_BSS2     ((void *)&_ebss2)
-#  define _DATA_INIT2   ((const void *)&_eronly2)
-#  define _START_DATA2  ((void *)&_sdata2)
-#  define _END_DATA2    ((void *)&_edata2)
+#  define _START_TEXT2  _stext2
+#  define _END_TEXT2    _etext2
+#  define _START_BSS2   _sbss2
+#  define _END_BSS2     _ebss2
+#  define _DATA_INIT2   _eronly2
+#  define _START_DATA2  _sdata2
+#  define _END_DATA2    _edata2
 #else
 #  define _START_TEXT2  NULL
 #  define _END_TEXT2    NULL
@@ -53,13 +53,13 @@
 #endif
 
 #if CONFIG_ARCH_NR_MEMORY >= 3
-#  define _START_TEXT3  ((const void *)&_stext3)
-#  define _END_TEXT3    ((const void *)&_etext3)
-#  define _START_BSS3   ((void *)&_sbss3)
-#  define _END_BSS3     ((void *)&_ebss3)
-#  define _DATA_INIT3   ((const void *)&_eronly3)
-#  define _START_DATA3  ((void *)&_sdata3)
-#  define _END_DATA3    ((void *)&_edata3)
+#  define _START_TEXT3  _stext3
+#  define _END_TEXT3    _etext3
+#  define _START_BSS3   _sbss3
+#  define _END_BSS3     _ebss3
+#  define _DATA_INIT3   _eronly3
+#  define _START_DATA3  _sdata3
+#  define _END_DATA3    _edata3
 #else
 #  define _START_TEXT3  NULL
 #  define _END_TEXT3    NULL
@@ -71,13 +71,13 @@
 #endif
 
 #if CONFIG_ARCH_NR_MEMORY >= 4
-#  define _START_TEXT4  ((const void *)&_stext4)
-#  define _END_TEXT4    ((const void *)&_etext4)
-#  define _START_BSS4   ((void *)&_sbss4)
-#  define _END_BSS4     ((void *)&_ebss4)
-#  define _DATA_INIT4   ((const void *)&_eronly4)
-#  define _START_DATA4  ((void *)&_sdata4)
-#  define _END_DATA4    ((void *)&_edata4)
+#  define _START_TEXT4  _stext4
+#  define _END_TEXT4    _etext4
+#  define _START_BSS4   _sbss4
+#  define _END_BSS4     _ebss4
+#  define _DATA_INIT4   _eronly4
+#  define _START_DATA4  _sdata4
+#  define _END_DATA4    _edata4
 #else
 #  define _START_TEXT4  NULL
 #  define _END_TEXT4    NULL

--- a/arch/ceva/src/common/up_userspace.c
+++ b/arch/ceva/src/common/up_userspace.c
@@ -52,14 +52,14 @@ static struct mm_heap_s g_mmheap1;
 static struct mm_heap_s g_mmheap2;
 #    define MM_HEAP2    &g_mmheap2
 #  endif
-#  define _START_TEXT2  ((const void *)&_stext2)
-#  define _END_TEXT2    ((const void *)&_etext2)
-#  define _START_BSS2   ((void *)&_sbss2)
-#  define _END_BSS2     ((void *)&_ebss2)
-#  define _DATA_INIT2   ((const void *)&_eronly2)
-#  define _START_DATA2  ((void *)&_sdata2)
-#  define _END_DATA2    ((void *)&_edata2)
-#  define _END_HEAP2    ((void *)&_eheap2)
+#  define _START_TEXT2  _stext2
+#  define _END_TEXT2    _etext2
+#  define _START_BSS2   _sbss2
+#  define _END_BSS2     _ebss2
+#  define _DATA_INIT2   _eronly2
+#  define _START_DATA2  _sdata2
+#  define _END_DATA2    _edata2
+#  define _END_HEAP2    _eheap2
 #else
 #  define MM_HEAP2      NULL
 #  define _START_TEXT2  NULL
@@ -79,14 +79,14 @@ static struct mm_heap_s g_mmheap2;
 static struct mm_heap_s g_mmheap3;
 #    define MM_HEAP3    &g_mmheap3
 #  endif
-#  define _START_TEXT3  ((const void *)&_stext3)
-#  define _END_TEXT3    ((const void *)&_etext3)
-#  define _START_BSS3   ((void *)&_sbss3)
-#  define _END_BSS3     ((void *)&_ebss3)
-#  define _DATA_INIT3   ((const void *)&_eronly3)
-#  define _START_DATA3  ((void *)&_sdata3)
-#  define _END_DATA3    ((void *)&_edata3)
-#  define _END_HEAP3    ((void *)&_eheap3)
+#  define _START_TEXT3  _stext3
+#  define _END_TEXT3    _etext3
+#  define _START_BSS3   _sbss3
+#  define _END_BSS3     _ebss3
+#  define _DATA_INIT3   _eronly3
+#  define _START_DATA3  _sdata3
+#  define _END_DATA3    _edata3
+#  define _END_HEAP3    _eheap3
 #else
 #  define MM_HEAP3      NULL
 #  define _START_TEXT3  NULL
@@ -106,14 +106,14 @@ static struct mm_heap_s g_mmheap3;
 static struct mm_heap_s g_mmheap4;
 #    define MM_HEAP4    &g_mmheap4
 #  endif
-#  define _START_TEXT4  ((const void *)&_stext4)
-#  define _END_TEXT4    ((const void *)&_etext4)
-#  define _START_BSS4   ((void *)&_sbss4)
-#  define _END_BSS4     ((void *)&_ebss4)
-#  define _DATA_INIT4   ((const void *)&_eronly4)
-#  define _START_DATA4  ((void *)&_sdata4)
-#  define _END_DATA4    ((void *)&_edata4)
-#  define _END_HEAP4    ((void *)&_eheap4)
+#  define _START_TEXT4  _stext4
+#  define _END_TEXT4    _etext4
+#  define _START_BSS4   _sbss4
+#  define _END_BSS4     _ebss4
+#  define _DATA_INIT4   _eronly4
+#  define _START_DATA4  _sdata4
+#  define _END_DATA4    _edata4
+#  define _END_HEAP4    _eheap4
 #else
 #  define MM_HEAP4      NULL
 #  define _START_TEXT4  NULL

--- a/arch/ceva/src/xc5/up_relocate.c
+++ b/arch/ceva/src/xc5/up_relocate.c
@@ -51,13 +51,13 @@
 #define DDIR_EX2IN           (0 << MSS_DDTC_DDIR_SHIFT)
 #define DDIR_IN2EX           (1 << MSS_DDTC_DDIR_SHIFT)
 
-#define _START_INTTBL        ((void *)&_sinttbl)
+#define _START_INTTBL        ((void *)_sinttbl)
 
 /****************************************************************************
  * Public Data
  ****************************************************************************/
 
-extern char _sinttbl;
+extern uint8_t _sinttbl[];
 
 /****************************************************************************
  * Private Functions

--- a/arch/hc/src/common/up_internal.h
+++ b/arch/hc/src/common/up_internal.h
@@ -121,8 +121,8 @@ extern uint16_t g_idle_topstack;
 /* Address of the saved user stack pointer */
 
 #if CONFIG_ARCH_INTERRUPTSTACK > 1
-extern uint32_t g_intstackalloc;
-extern uint32_t g_intstacktop;
+extern uint8_t g_intstackalloc[];
+extern uint8_t g_intstacktop[];
 #endif
 
 /****************************************************************************

--- a/arch/hc/src/m9s12/m9s12_assert.c
+++ b/arch/hc/src/m9s12/m9s12_assert.c
@@ -186,7 +186,7 @@ static void up_dumpstate(void)
   /* Get the limits on the interrupt stack memory */
 
 #if CONFIG_ARCH_INTERRUPTSTACK > 3
-  istackbase = (uint16_t)&g_intstackalloc;
+  istackbase = (uint16_t)g_intstackalloc;
   istacksize = (CONFIG_ARCH_INTERRUPTSTACK & ~3);
 
   /* Show interrupt stack info */

--- a/arch/mips/src/common/mips_internal.h
+++ b/arch/mips/src/common/mips_internal.h
@@ -122,37 +122,27 @@ extern uint32_t g_idle_topstack;
 /* Address of the saved user stack pointer */
 
 #if CONFIG_ARCH_INTERRUPTSTACK > 3
-extern void g_intstackalloc;
-extern void g_intstacktop;
+extern uint8_t g_intstackalloc[];
+extern uint8_t g_intstacktop[];
 #endif
 
-/* These 'addresses' of these values are setup by the linker script. They are
- * not actual uint32_t storage locations! They are only used meaningfully in
- * the following way:
- *
- *  - The linker script defines, for example, the symbol_sdata.
- *  - The declaration extern uint32_t _sdata; makes C happy.  C will believe
- *    that the value _sdata is the address of a uint32_t variable _data (it
- *    is not!).
- *  - We can recover the linker value then by simply taking the address of
- *    of _data.  like:  uint32_t *pdata = &_sdata;
- */
+/* These symbols are setup by the linker script. */
 
-extern uint32_t _stext;             /* Start of .text */
-extern uint32_t _etext;             /* End+1 of .text + .rodata */
-extern const uint32_t _data_loaddr; /* Start of .data in FLASH */
-extern uint32_t _sdata;             /* Start of .data */
-extern uint32_t _edata;             /* End+1 of .data */
-extern uint32_t _sbss;              /* Start of .bss */
-extern uint32_t _ebss;              /* End+1 of .bss */
+extern uint8_t _stext[];             /* Start of .text */
+extern uint8_t _etext[];             /* End+1 of .text + .rodata */
+extern const uint8_t _data_loaddr[]; /* Start of .data in FLASH */
+extern uint8_t _sdata[];             /* Start of .data */
+extern uint8_t _edata[];             /* End+1 of .data */
+extern uint8_t _sbss[];              /* Start of .bss */
+extern uint8_t _ebss[];              /* End+1 of .bss */
 #ifdef CONFIG_ARCH_RAMFUNCS
-extern uint32_t _sramfunc;          /* Start of ramfuncs */
-extern uint32_t _eramfunc;          /* End+1 of ramfuncs */
-extern uint32_t _ramfunc_loadaddr;  /* Start of ramfuncs in FLASH */
-extern uint32_t _ramfunc_sizeof;    /* Size of ramfuncs */
-extern uint32_t _bmxdkpba_address;  /* BMX register setting */
-extern uint32_t _bmxdudba_address;  /* BMX register setting */
-extern uint32_t _bmxdupba_address;  /* BMX register setting */
+extern uint8_t _sramfunc[];          /* Start of ramfuncs */
+extern uint8_t _eramfunc[];          /* End+1 of ramfuncs */
+extern uint8_t _ramfunc_loadaddr[];  /* Start of ramfuncs in FLASH */
+extern uint8_t _ramfunc_sizeof[];    /* Size of ramfuncs */
+extern uint8_t _bmxdkpba_address[];  /* BMX register setting */
+extern uint8_t _bmxdudba_address[];  /* BMX register setting */
+extern uint8_t _bmxdupba_address[];  /* BMX register setting */
 #endif /* CONFIG_ARCH_RAMFUNCS */
 #endif /* __ASSEMBLY__ */
 

--- a/arch/mips/src/mips32/mips_dumpstate.c
+++ b/arch/mips/src/mips32/mips_dumpstate.c
@@ -149,7 +149,7 @@ void up_dumpstate(void)
   /* Get the limits on the interrupt stack memory */
 
 #if CONFIG_ARCH_INTERRUPTSTACK > 3
-  istackbase = (uint32_t)&g_intstackalloc;
+  istackbase = (uint32_t)g_intstackalloc;
   istacksize = (CONFIG_ARCH_INTERRUPTSTACK & ~3);
 
   /* Show interrupt stack info */

--- a/arch/misoc/src/lm32/lm32_dumpstate.c
+++ b/arch/misoc/src/lm32/lm32_dumpstate.c
@@ -135,7 +135,7 @@ void lm32_dumpstate(void)
   /* Get the limits on the interrupt stack memory */
 
 #if CONFIG_ARCH_INTERRUPTSTACK > 3
-  istackbase = (uint32_t)&g_intstackalloc;
+  istackbase = (uint32_t)g_intstackalloc;
   istacksize = (CONFIG_ARCH_INTERRUPTSTACK & ~3);
 
   /* Show interrupt stack info */

--- a/arch/misoc/src/minerva/minerva_dumpstate.c
+++ b/arch/misoc/src/minerva/minerva_dumpstate.c
@@ -139,7 +139,7 @@ void minerva_dumpstate(void)
   /* Get the limits on the interrupt stack memory */
 
 #if CONFIG_ARCH_INTERRUPTSTACK > 3
-  istackbase = (uint32_t) &g_intstackalloc;
+  istackbase = (uint32_t)g_intstackalloc;
   istacksize = (CONFIG_ARCH_INTERRUPTSTACK & ~3);
 
   /* Show interrupt stack info */

--- a/arch/or1k/src/common/up_assert.c
+++ b/arch/or1k/src/common/up_assert.c
@@ -215,7 +215,7 @@ static void up_dumpstate(void)
   /* Get the limits on the interrupt stack memory */
 
 #if CONFIG_ARCH_INTERRUPTSTACK > 3
-  istackbase = (uint32_t)&g_intstackalloc;
+  istackbase = (uint32_t)g_intstackalloc;
   istacksize = (CONFIG_ARCH_INTERRUPTSTACK & ~3);
 
   /* Show interrupt stack info */

--- a/arch/or1k/src/common/up_checkstack.c
+++ b/arch/or1k/src/common/up_checkstack.c
@@ -137,7 +137,7 @@ ssize_t up_check_stack_remain(void)
 #if CONFIG_ARCH_INTERRUPTSTACK > 3
 size_t up_check_intstack(void)
 {
-  return or1k_stack_check((uintptr_t)&g_intstackalloc,
+  return or1k_stack_check((uintptr_t)g_intstackalloc,
                           (CONFIG_ARCH_INTERRUPTSTACK & ~3));
 }
 

--- a/arch/or1k/src/common/up_internal.h
+++ b/arch/or1k/src/common/up_internal.h
@@ -87,13 +87,13 @@
 #define up_savestate(regs)  up_copyfullstate(regs, (uint32_t*)CURRENT_REGS)
 #define up_restorestate(regs) up_copyfullstate((uint32_t*)CURRENT_REGS, regs)
 
-#define _START_TEXT  &_stext
-#define _END_TEXT    &_etext
-#define _START_BSS   &_sbss
-#define _END_BSS     &_ebss
-#define _DATA_INIT   &_eronly
-#define _START_DATA  &_sdata
-#define _END_DATA    &_edata
+#define _START_TEXT  _stext
+#define _END_TEXT    _etext
+#define _START_BSS   _sbss
+#define _END_BSS     _ebss
+#define _DATA_INIT   _eronly
+#define _START_DATA  _sdata
+#define _END_DATA    _edata
 
 /* This is the value used to mark the stack for subsequent stack monitoring
  * logic.
@@ -142,29 +142,19 @@ EXTERN const uint32_t g_idle_topstack;
 /* Address of the saved user stack pointer */
 
 #if CONFIG_ARCH_INTERRUPTSTACK > 3
-EXTERN uint32_t g_intstackalloc; /* Allocated stack base */
-EXTERN uint32_t g_intstacktop;   /* Initial top of interrupt stack */
+EXTERN uint8_t g_intstackalloc[]; /* Allocated stack base */
+EXTERN uint8_t g_intstacktop[];   /* Initial top of interrupt stack */
 #endif
 
-/* These 'addresses' of these values are setup by the linker script.  They
- * are not actual uint32_t storage locations! They are only used meaningfully
- * in the following way:
- *
- *  - The linker script defines, for example, the symbol_sdata.
- *  - The declaration extern uint32_t _sdata; makes C happy.  C will believe
- *    that the value _sdata is the address of a uint32_t variable _data
- *    (it is not!).
- *  - We can recover the linker value then by simply taking the address of
- *    of _data.  like:  uint32_t *pdata = &_sdata;
- */
+/* These symbols are setup by the linker script. */
 
-EXTERN uint32_t _stext;           /* Start of .text */
-EXTERN uint32_t _etext;           /* End_1 of .text + .rodata */
-EXTERN const uint32_t _eronly;    /* End+1 of read only section (.text + .rodata) */
-EXTERN uint32_t _sdata;           /* Start of .data */
-EXTERN uint32_t _edata;           /* End+1 of .data */
-EXTERN uint32_t _sbss;            /* Start of .bss */
-EXTERN uint32_t _ebss;            /* End+1 of .bss */
+EXTERN uint8_t _stext[];           /* Start of .text */
+EXTERN uint8_t _etext[];           /* End_1 of .text + .rodata */
+EXTERN const uint8_t _eronly[];    /* End+1 of read only section (.text + .rodata) */
+EXTERN uint8_t _sdata[];           /* Start of .data */
+EXTERN uint8_t _edata[];           /* End+1 of .data */
+EXTERN uint8_t _sbss[];            /* Start of .bss */
+EXTERN uint8_t _ebss[];            /* End+1 of .bss */
 
 /* Sometimes, functions must be executed from RAM.  In this case, the
  * following macro may be used (with GCC!) to specify a function that will

--- a/arch/or1k/src/mor1kx/mor1kx_start.c
+++ b/arch/or1k/src/mor1kx/mor1kx_start.c
@@ -42,7 +42,7 @@
  * 0x0000:0000 - Beginning of DRAM.
  */
 
-#define IDLE_STACK ((uint32_t)&_ebss+CONFIG_IDLETHREAD_STACKSIZE)
+#define IDLE_STACK ((uint32_t)_ebss + CONFIG_IDLETHREAD_STACKSIZE)
 
 /****************************************************************************
  * Public Data
@@ -89,7 +89,7 @@ void __start(void)
    * certain that there are no issues with the state of global variables.
    */
 
-  for (dest = &_sbss; dest < &_ebss; )
+  for (dest = (uint32_t *)_sbss; dest < (uint32_t *)_ebss; )
     {
       *dest++ = 0;
     }
@@ -100,7 +100,9 @@ void __start(void)
    * end of all of the other read-only data (.text, .rodata) at _eronly.
    */
 
-  for (src = &_eronly, dest = &_sdata; dest < &_edata; )
+  for (src = (const uint32_t *)_eronly,
+       dest = (uint32_t *)_sdata; dest < (uint32_t *)_edata;
+      )
     {
       *dest++ = *src++;
     }

--- a/arch/renesas/src/m16c/chip.h
+++ b/arch/renesas/src/m16c/chip.h
@@ -257,8 +257,8 @@ extern uint32_t g_svarvect;      /* Start of variable vectors */
 
 #ifndef __ASSEMBLY__
 #  if CONFIG_ARCH_INTERRUPTSTACK > 3
-     extern uint16_t g_intstackalloc;
-     extern uint16_t g_intstacktop;
+     extern uint8_t g_intstackalloc[];
+     extern uint8_t g_intstacktop[];
 #  endif
 #endif
 

--- a/arch/renesas/src/sh1/chip.h
+++ b/arch/renesas/src/sh1/chip.h
@@ -48,8 +48,8 @@
 
 #ifndef __ASSEMBLY__
 #  if CONFIG_ARCH_INTERRUPTSTACK > 3
-     extern uint32_t g_intstackalloc;
-     extern uint32_t g_intstacktop;
+     extern uint8_t g_intstackalloc[];
+     extern uint8_t g_intstacktop[];
 #  endif
 #endif
 

--- a/arch/renesas/src/sh1/sh1_dumpstate.c
+++ b/arch/renesas/src/sh1/sh1_dumpstate.c
@@ -133,7 +133,7 @@ void up_dumpstate(void)
   /* Get the limits on the interrupt stack memory */
 
 #if CONFIG_ARCH_INTERRUPTSTACK > 3
-  istackbase = (uint32_t)&g_intstackalloc;
+  istackbase = (uint32_t)g_intstackalloc;
   istacksize = (CONFIG_ARCH_INTERRUPTSTACK & ~3);
 
   /* Show interrupt stack info */

--- a/arch/risc-v/src/bl602/bl602_allocateheap.c
+++ b/arch/risc-v/src/bl602/bl602_allocateheap.c
@@ -33,10 +33,10 @@
  * Public Variables
  ****************************************************************************/
 
-extern uint8_t _heap_start;
-extern uint8_t _heap_size;
-extern uint8_t _heap_wifi_start;
-extern uint8_t _heap_wifi_size;
+extern uint8_t _heap_start[];
+extern uint8_t _heap_size[];
+extern uint8_t _heap_wifi_start[];
+extern uint8_t _heap_wifi_size[];
 
 /****************************************************************************
  * Public Functions
@@ -59,8 +59,8 @@ extern uint8_t _heap_wifi_size;
 
 void up_allocate_heap(void **heap_start, size_t *heap_size)
 {
-  *heap_start = (void *)&_heap_start;
-  *heap_size  = (size_t)&_heap_size;
+  *heap_start = (void *)_heap_start;
+  *heap_size  = (size_t)_heap_size;
 }
 
 /****************************************************************************
@@ -75,7 +75,7 @@ void up_allocate_heap(void **heap_start, size_t *heap_size)
 #if CONFIG_MM_REGIONS > 1
 void riscv_addregion(void)
 {
-  kumm_addregion(&_heap_wifi_start, (uint32_t)(&_heap_wifi_size));
+  kumm_addregion(_heap_wifi_start, (uint32_t)_heap_wifi_size);
 }
 #endif
 

--- a/arch/risc-v/src/bl602/bl602_irq.c
+++ b/arch/risc-v/src/bl602/bl602_irq.c
@@ -79,7 +79,7 @@ void up_irqinitialize(void)
   /* Colorize the interrupt stack for debug purposes */
 
   size_t intstack_size = (CONFIG_ARCH_INTERRUPTSTACK & ~15);
-  riscv_stack_color((void *)&g_intstackalloc, intstack_size);
+  riscv_stack_color(g_intstackalloc, intstack_size);
 #endif
 
   /* Attach the common interrupt handler */

--- a/arch/risc-v/src/bl602/bl602_start.c
+++ b/arch/risc-v/src/bl602/bl602_start.c
@@ -97,9 +97,9 @@ extern void bl602_boardinitialize(void);
 
 uint32_t noinstrument_function boot2_get_flash_addr(void)
 {
-  extern uint8_t __boot2_flash_cfg_src;
+  extern uint8_t __boot2_flash_cfg_src[];
 
-  return (uint32_t)(&__boot2_flash_cfg_src +
+  return (uint32_t)(__boot2_flash_cfg_src +
                     (sizeof(g_boot2_partition_table.table.entries[0]) *
                      g_boot2_partition_table.table.table.entry_cnt));
 }

--- a/arch/risc-v/src/c906/c906_irq.c
+++ b/arch/risc-v/src/c906/c906_irq.c
@@ -67,7 +67,7 @@ void up_irqinitialize(void)
 
 #if defined(CONFIG_STACK_COLORATION) && CONFIG_ARCH_INTERRUPTSTACK > 15
   size_t intstack_size = (CONFIG_ARCH_INTERRUPTSTACK & ~15);
-  riscv_stack_color((void *)&g_intstackalloc, intstack_size);
+  riscv_stack_color(g_intstackalloc, intstack_size);
 #endif
 
   /* Set priority for all global interrupts to 1 (lowest) */

--- a/arch/risc-v/src/c906/c906_memorymap.h
+++ b/arch/risc-v/src/c906/c906_memorymap.h
@@ -39,7 +39,7 @@
 /* Idle thread stack starts from _ebss */
 
 #ifndef __ASSEMBLY__
-#define C906_IDLESTACK_BASE  (uintptr_t)&_ebss
+#define C906_IDLESTACK_BASE  (uintptr_t)_ebss
 #else
 #define C906_IDLESTACK_BASE  _ebss
 #endif

--- a/arch/risc-v/src/c906/c906_start.c
+++ b/arch/risc-v/src/c906/c906_start.c
@@ -86,7 +86,7 @@ void __c906_start(uint32_t mhartid)
    * certain that there are no issues with the state of global variables.
    */
 
-  for (dest = &_sbss; dest < &_ebss; )
+  for (dest = (uint32_t *)_sbss; dest < (uint32_t *)_ebss; )
     {
       *dest++ = 0;
     }
@@ -97,7 +97,9 @@ void __c906_start(uint32_t mhartid)
    * end of all of the other read-only data (.text, .rodata) at _eronly.
    */
 
-  for (src = &_eronly, dest = &_sdata; dest < &_edata; )
+  for (src = (const uint32_t *)_eronly,
+       dest = (uint32_t *)_sdata; dest < (uint32_t *)_edata;
+      )
     {
       *dest++ = *src++;
     }

--- a/arch/risc-v/src/common/crt0.c
+++ b/arch/risc-v/src/common/crt0.c
@@ -22,14 +22,13 @@
  * Included Files
  ****************************************************************************/
 
-#include <arch/arch.h>
-#include <arch/syscall.h>
-
+#include <nuttx/arch.h>
 #include <nuttx/addrenv.h>
 #include <nuttx/compiler.h>
 #include <nuttx/config.h>
 
 #include <sys/types.h>
+#include <syscall.h>
 #include <stdlib.h>
 
 #include "riscv_internal.h"
@@ -94,10 +93,10 @@ static void sig_trampoline(void)
 
 /* Linker defined symbols to .ctors and .dtors */
 
-extern void (*_sctors)(void);
-extern void (*_ectors)(void);
-extern void (*_sdtors)(void);
-extern void (*_edtors)(void);
+extern initializer_t _sctors[];
+extern initializer_t _ectors[];
+extern initializer_t _sdtors[];
+extern initializer_t _edtors[];
 
 /****************************************************************************
  * Private Functions
@@ -115,7 +114,7 @@ extern void (*_edtors)(void);
 
 static void exec_ctors(void)
 {
-  for (void (**ctor)(void) = &_sctors; ctor != &_ectors; ctor++)
+  for (initializer_t *ctor = _sctors; ctor != _ectors; ctor++)
     {
       (*ctor)();
     }
@@ -131,7 +130,7 @@ static void exec_ctors(void)
 
 static void exec_dtors(void)
 {
-  for (void (**dtor)(void) = &_sdtors; dtor != &_edtors; dtor++)
+  for (initializer_t *dtor = _sdtors; dtor != _edtors; dtor++)
     {
       (*dtor)();
     }

--- a/arch/risc-v/src/common/riscv_assert.c
+++ b/arch/risc-v/src/common/riscv_assert.c
@@ -392,7 +392,7 @@ static void riscv_dumpstate(void)
 
 #if CONFIG_ARCH_INTERRUPTSTACK > 15
   riscv_dump_stack("IRQ", sp,
-                   (uintptr_t)&g_intstackalloc,
+                   (uintptr_t)g_intstackalloc,
                    (CONFIG_ARCH_INTERRUPTSTACK & ~15),
                    !!CURRENT_REGS);
   if (CURRENT_REGS)

--- a/arch/risc-v/src/common/riscv_backtrace.c
+++ b/arch/risc-v/src/common/riscv_backtrace.c
@@ -141,9 +141,8 @@ int up_backtrace(struct tcb_s *tcb, void **buffer, int size, int skip)
       if (up_interrupt_context())
         {
 #if CONFIG_ARCH_INTERRUPTSTACK > 15
-          ret = backtrace((void *)&g_intstackalloc,
-                          (void *)((uintptr_t)&g_intstackalloc +
-                                   CONFIG_ARCH_INTERRUPTSTACK),
+          ret = backtrace(g_intstackalloc,
+                          g_intstackalloc + CONFIG_ARCH_INTERRUPTSTACK,
                           (void *)getfp(), NULL, buffer, size, &skip);
 #else
           ret = backtrace(rtcb->stack_base_ptr,

--- a/arch/risc-v/src/common/riscv_checkstack.c
+++ b/arch/risc-v/src/common/riscv_checkstack.c
@@ -199,7 +199,7 @@ ssize_t up_check_stack_remain(void)
 #if CONFIG_ARCH_INTERRUPTSTACK > 15
 size_t up_check_intstack(void)
 {
-  return riscv_stack_check((uintptr_t)&g_intstackalloc,
+  return riscv_stack_check((uintptr_t)g_intstackalloc,
                            (CONFIG_ARCH_INTERRUPTSTACK & ~15));
 }
 

--- a/arch/risc-v/src/common/riscv_common_memorymap.h
+++ b/arch/risc-v/src/common/riscv_common_memorymap.h
@@ -33,17 +33,17 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-#define _START_TEXT  &_stext
-#define _END_TEXT    &_etext
-#define _START_BSS   &_sbss
-#define _END_BSS     &_ebss
-#define _DATA_INIT   &_eronly
-#define _START_DATA  &_sdata
-#define _END_DATA    &_edata
-#define _START_TDATA &_stdata
-#define _END_TDATA   &_etdata
-#define _START_TBSS  &_stbss
-#define _END_TBSS    &_etbss
+#define _START_TEXT  _stext
+#define _END_TEXT    _etext
+#define _START_BSS   _sbss
+#define _END_BSS     _ebss
+#define _DATA_INIT   _eronly
+#define _START_DATA  _sdata
+#define _END_DATA    _edata
+#define _START_TDATA _stdata
+#define _END_TDATA   _etdata
+#define _START_TBSS  _stbss
+#define _END_TBSS    _etbss
 
 /****************************************************************************
  * Public Types
@@ -68,33 +68,23 @@ EXTERN const uint8_t * const g_cpu_basestack[CONFIG_SMP_NCPUS];
 /* Address of the saved user stack pointer */
 
 #if CONFIG_ARCH_INTERRUPTSTACK > 15
-EXTERN uint32_t g_intstackalloc; /* Allocated stack base */
-EXTERN uint32_t g_intstacktop;   /* Initial top of interrupt stack */
+EXTERN uint8_t g_intstackalloc[]; /* Allocated stack base */
+EXTERN uint8_t g_intstacktop[];   /* Initial top of interrupt stack */
 #endif
 
-/* These 'addresses' of these values are setup by the linker script.  They
- * are not actual uint32_t storage locations! They are only used meaningfully
- * in the following way:
- *
- *  - The linker script defines, for example, the symbol_sdata.
- *  - The declaration extern uint32_t _sdata; makes C happy.  C will believe
- *    that the value _sdata is the address of a uint32_t variable _data (it
- *    is not!).
- *  - We can recover the linker value then by simply taking the address of
- *    of _data.  like:  uint32_t *pdata = &_sdata;
- */
+/* These symbols are setup by the linker script. */
 
-EXTERN uint32_t _stext;           /* Start of .text */
-EXTERN uint32_t _etext;           /* End_1 of .text + .rodata */
-EXTERN const uint32_t _eronly;    /* End+1 of read only section (.text + .rodata) */
-EXTERN uint32_t _sdata;           /* Start of .data */
-EXTERN uint32_t _edata;           /* End+1 of .data */
-EXTERN uint32_t _sbss;            /* Start of .bss */
-EXTERN uint32_t _ebss;            /* End+1 of .bss */
-EXTERN uint32_t _stdata;          /* Start of .tdata */
-EXTERN uint32_t _etdata;          /* End+1 of .tdata */
-EXTERN uint32_t _stbss;           /* Start of .tbss */
-EXTERN uint32_t _etbss;           /* End+1 of .tbss */
+EXTERN uint8_t _stext[];           /* Start of .text */
+EXTERN uint8_t _etext[];           /* End_1 of .text + .rodata */
+EXTERN const uint8_t _eronly[];    /* End+1 of read only section (.text + .rodata) */
+EXTERN uint8_t _sdata[];           /* Start of .data */
+EXTERN uint8_t _edata[];           /* End+1 of .data */
+EXTERN uint8_t _sbss[];            /* Start of .bss */
+EXTERN uint8_t _ebss[];            /* End+1 of .bss */
+EXTERN uint8_t _stdata[];          /* Start of .tdata */
+EXTERN uint8_t _etdata[];          /* End+1 of .tdata */
+EXTERN uint8_t _stbss[];           /* Start of .tbss */
+EXTERN uint8_t _etbss[];           /* End+1 of .tbss */
 
 #endif /* __ASSEMBLY__ */
 

--- a/arch/risc-v/src/common/riscv_cpuidlestack.c
+++ b/arch/risc-v/src/common/riscv_cpuidlestack.c
@@ -85,7 +85,7 @@ static uint8_t aligned_data(16) cpu7_idlestack[CONFIG_IDLETHREAD_STACKSIZE];
 
 const uint8_t * const g_cpu_basestack[CONFIG_SMP_NCPUS] =
 {
-    (uint8_t *)&_ebss,
+    (uint8_t *)_ebss,
 #if CONFIG_SMP_NCPUS > 1
     cpu1_idlestack,
 #endif

--- a/arch/risc-v/src/common/riscv_initialize.c
+++ b/arch/risc-v/src/common/riscv_initialize.c
@@ -50,7 +50,7 @@ volatile uintptr_t *g_current_regs[CONFIG_SMP_NCPUS];
 #if defined(CONFIG_STACK_COLORATION) && CONFIG_ARCH_INTERRUPTSTACK > 15
 static inline void up_color_intstack(void)
 {
-  uint32_t *ptr = (uint32_t *)&g_intstackalloc;
+  uint32_t *ptr = (uint32_t *)g_intstackalloc;
   ssize_t size;
 
   for (size = (CONFIG_ARCH_INTERRUPTSTACK & ~15);

--- a/arch/risc-v/src/common/riscv_percpu.c
+++ b/arch/risc-v/src/common/riscv_percpu.c
@@ -96,7 +96,7 @@ static void riscv_percpu_init(void)
       /* Set interrupt stack (if any) */
 
 #if CONFIG_ARCH_INTERRUPTSTACK > 15
-      g_percpu[i].irq_stack = (uintptr_t)&g_intstacktop - i * STACK_SIZE;
+      g_percpu[i].irq_stack = (uintptr_t)g_intstacktop - i * STACK_SIZE;
 #endif
 
       sq_addlast((struct sq_entry_s *) &g_percpu[i], &g_freelist);

--- a/arch/risc-v/src/esp32c3/esp32c3_allocateheap.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_allocateheap.c
@@ -96,9 +96,9 @@ void up_allocate_heap(void **heap_start, size_t *heap_size)
 
   board_autoled_on(LED_HEAPALLOCATE);
 
-  *heap_start = (void *)&_sheap;
-  *heap_size  = (size_t)(ets_rom_layout_p->dram0_rtos_reserved_start -
-                        (uintptr_t)&_sheap);
+  *heap_start = _sheap;
+  *heap_size  = ets_rom_layout_p->dram0_rtos_reserved_start -
+                (uintptr_t)_sheap;
 #endif /* CONFIG_BUILD_PROTECTED && CONFIG_MM_KERNEL_HEAP */
 }
 
@@ -125,7 +125,7 @@ void up_allocate_kheap(void **heap_start, size_t *heap_size)
 
   extern uint8_t *_sheap;
 
-  uintptr_t kbase = (uintptr_t)&_sheap;
+  uintptr_t kbase = (uintptr_t)_sheap;
   uintptr_t ktop  = KDRAM_END;
   size_t    ksize = ktop - kbase;
 

--- a/arch/risc-v/src/esp32c3/esp32c3_rtcheap.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_rtcheap.c
@@ -58,11 +58,11 @@ void esp32c3_rtcheap_initialize(void)
    * Check boards/risc-v/esp32c3.
    */
 
-  extern uint8_t *_srtcheap;
-  extern uint8_t *_ertcheap;
+  extern uint8_t _srtcheap[];
+  extern uint8_t _ertcheap[];
 
-  start = (void *)&_srtcheap;
-  size  = (size_t)((uintptr_t)&_ertcheap - (uintptr_t)&_srtcheap);
+  start = (void *)_srtcheap;
+  size  = (size_t)(_ertcheap - _srtcheap);
   g_rtcheap = mm_initialize("rtcheap", start, size);
 }
 

--- a/arch/risc-v/src/esp32c3/esp32c3_start.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_start.c
@@ -80,13 +80,13 @@
  ****************************************************************************/
 
 #ifdef CONFIG_ESP32C3_APP_FORMAT_MCUBOOT
-extern uint32_t _image_irom_vma;
-extern uint32_t _image_irom_lma;
-extern uint32_t _image_irom_size;
+extern uint8_t _image_irom_vma[];
+extern uint8_t _image_irom_lma[];
+extern uint8_t _image_irom_size[];
 
-extern uint32_t _image_drom_vma;
-extern uint32_t _image_drom_lma;
-extern uint32_t _image_drom_size;
+extern uint8_t _image_drom_vma[];
+extern uint8_t _image_drom_lma[];
+extern uint8_t _image_drom_size[];
 #endif
 
 /****************************************************************************
@@ -119,7 +119,7 @@ IRAM_ATTR noreturn_function void __start(void);
  ****************************************************************************/
 
 #ifdef CONFIG_ESP32C3_APP_FORMAT_MCUBOOT
-HDR_ATTR static void (*_entry_point)(void) = &__start;
+HDR_ATTR static void (*_entry_point)(void) = __start;
 #endif
 
 /****************************************************************************
@@ -186,12 +186,12 @@ static int map_rom_segments(void)
   uint32_t irom_page_count;
 
   size_t partition_offset = PRIMARY_SLOT_OFFSET;
-  uint32_t app_irom_lma = partition_offset + (uint32_t)&_image_irom_lma;
-  uint32_t app_irom_size = (uint32_t)&_image_irom_size;
-  uint32_t app_irom_vma = (uint32_t)&_image_irom_vma;
-  uint32_t app_drom_lma = partition_offset + (uint32_t)&_image_drom_lma;
-  uint32_t app_drom_size = (uint32_t)&_image_drom_size;
-  uint32_t app_drom_vma = (uint32_t)&_image_drom_vma;
+  uint32_t app_irom_lma = partition_offset + (uint32_t)_image_irom_lma;
+  uint32_t app_irom_size = (uint32_t)_image_irom_size;
+  uint32_t app_irom_vma = (uint32_t)_image_irom_vma;
+  uint32_t app_drom_lma = partition_offset + (uint32_t)_image_drom_lma;
+  uint32_t app_drom_size = (uint32_t)_image_drom_size;
+  uint32_t app_drom_vma = (uint32_t)_image_drom_vma;
 
   uint32_t autoload = cache_suspend_icache();
   cache_invalidate_icache_all();
@@ -288,9 +288,9 @@ void __esp32c3_start(void)
    * certain that there are no issues with the state of global variables.
    */
 
-  for (uint32_t *dest = &_sbss; dest < &_ebss; dest++)
+  for (uint32_t *dest = (uint32_t *)_sbss; dest < (uint32_t *)_ebss; )
     {
-      *dest = 0;
+      *dest++ = 0;
     }
 
   showprogress('B');

--- a/arch/risc-v/src/fe310/fe310_irq.c
+++ b/arch/risc-v/src/fe310/fe310_irq.c
@@ -60,7 +60,7 @@ void up_irqinitialize(void)
 
 #if defined(CONFIG_STACK_COLORATION) && CONFIG_ARCH_INTERRUPTSTACK > 15
   size_t intstack_size = (CONFIG_ARCH_INTERRUPTSTACK & ~15);
-  riscv_stack_color((void *)&g_intstackalloc, intstack_size);
+  riscv_stack_color(g_intstackalloc, intstack_size);
 #endif
 
   /* Set priority for all global interrupts to 1 (lowest) */

--- a/arch/risc-v/src/fe310/fe310_memorymap.h
+++ b/arch/risc-v/src/fe310/fe310_memorymap.h
@@ -40,7 +40,7 @@
 /* Idle thread stack starts from _ebss */
 
 #ifndef __ASSEMBLY__
-#define FE310_IDLESTACK_BASE  (uintptr_t)&_ebss
+#define FE310_IDLESTACK_BASE  (uintptr_t)_ebss
 #else
 #define FE310_IDLESTACK_BASE  _ebss
 #endif

--- a/arch/risc-v/src/fe310/fe310_start.c
+++ b/arch/risc-v/src/fe310/fe310_start.c
@@ -76,7 +76,7 @@ void __fe310_start(void)
    * certain that there are no issues with the state of global variables.
    */
 
-  for (dest = &_sbss; dest < &_ebss; )
+  for (dest = (uint32_t *)_sbss; dest < (uint32_t *)_ebss; )
     {
       *dest++ = 0;
     }
@@ -87,7 +87,9 @@ void __fe310_start(void)
    * end of all of the other read-only data (.text, .rodata) at _eronly.
    */
 
-  for (src = &_eronly, dest = &_sdata; dest < &_edata; )
+  for (src = (const uint32_t *)_eronly,
+       dest = (uint32_t *)_sdata; dest < (uint32_t *)_edata;
+      )
     {
       *dest++ = *src++;
     }

--- a/arch/risc-v/src/k210/k210_irq.c
+++ b/arch/risc-v/src/k210/k210_irq.c
@@ -64,7 +64,7 @@ void up_irqinitialize(void)
 #if defined(CONFIG_STACK_COLORATION) && CONFIG_ARCH_INTERRUPTSTACK > 15
   size_t intstack_size = 0;
   intstack_size = ((CONFIG_ARCH_INTERRUPTSTACK * CONFIG_SMP_NCPUS) & ~15);
-  riscv_stack_color((void *)&g_intstackalloc, intstack_size);
+  riscv_stack_color(g_intstackalloc, intstack_size);
 #endif
 
   /* Set priority for all global interrupts to 1 (lowest) */

--- a/arch/risc-v/src/k210/k210_memorymap.h
+++ b/arch/risc-v/src/k210/k210_memorymap.h
@@ -39,7 +39,7 @@
 /* Idle thread stack starts from _ebss */
 
 #ifndef __ASSEMBLY__
-#define K210_IDLESTACK_BASE  (uintptr_t)&_ebss
+#define K210_IDLESTACK_BASE  (uintptr_t)_ebss
 #else
 #define K210_IDLESTACK_BASE  _ebss
 #endif

--- a/arch/risc-v/src/k210/k210_start.c
+++ b/arch/risc-v/src/k210/k210_start.c
@@ -80,7 +80,7 @@ void __k210_start(uint32_t mhartid)
    * certain that there are no issues with the state of global variables.
    */
 
-  for (dest = &_sbss; dest < &_ebss; )
+  for (dest = (uint32_t *)_sbss; dest < (uint32_t *)_ebss; )
     {
       *dest++ = 0;
     }
@@ -91,7 +91,9 @@ void __k210_start(uint32_t mhartid)
    * end of all of the other read-only data (.text, .rodata) at _eronly.
    */
 
-  for (src = &_eronly, dest = &_sdata; dest < &_edata; )
+  for (src = (const uint32_t *)_eronly,
+       dest = (uint32_t *)_sdata; dest < (uint32_t *)_edata;
+      )
     {
       *dest++ = *src++;
     }

--- a/arch/risc-v/src/litex/litex_irq.c
+++ b/arch/risc-v/src/litex/litex_irq.c
@@ -57,7 +57,7 @@ void up_irqinitialize(void)
 
 #if defined(CONFIG_STACK_COLORATION) && CONFIG_ARCH_INTERRUPTSTACK > 15
   size_t intstack_size = (CONFIG_ARCH_INTERRUPTSTACK & ~15);
-  riscv_stack_color((void *)&g_intstackalloc, intstack_size);
+  riscv_stack_color(g_intstackalloc, intstack_size);
 #endif
 
   /* litex vexriscv dont have priority and threshold control */

--- a/arch/risc-v/src/litex/litex_memorymap.h
+++ b/arch/risc-v/src/litex/litex_memorymap.h
@@ -37,7 +37,7 @@
 /* Idle thread stack starts from _ebss */
 
 #ifndef __ASSEMBLY__
-#define LITEX_IDLESTACK_BASE  (uint32_t)&_ebss
+#define LITEX_IDLESTACK_BASE  (uint32_t)_ebss
 #else
 #define LITEX_IDLESTACK_BASE  _ebss
 #endif

--- a/arch/risc-v/src/litex/litex_start.c
+++ b/arch/risc-v/src/litex/litex_start.c
@@ -76,7 +76,7 @@ void __litex_start(void)
    * certain that there are no issues with the state of global variables.
    */
 
-  for (dest = &_sbss; dest < &_ebss; )
+  for (dest = (uint32_t *)_sbss; dest < (uint32_t *)_ebss; )
     {
       *dest++ = 0;
     }
@@ -89,7 +89,9 @@ void __litex_start(void)
 
   /* for vexriscv the full image is loaded in ddr ram */
 
-  for (src = &_eronly, dest = &_sdata; dest < &_edata; )
+  for (src = (const uint32_t *)_eronly,
+       dest = (uint32_t *)_sdata; dest < (uint32_t *)_edata;
+      )
     {
       *dest++ = *src++;
     }

--- a/arch/risc-v/src/mpfs/mpfs_irq.c
+++ b/arch/risc-v/src/mpfs/mpfs_irq.c
@@ -71,7 +71,7 @@ void up_irqinitialize(void)
 
 #if defined(CONFIG_STACK_COLORATION) && CONFIG_ARCH_INTERRUPTSTACK > 15
   size_t intstack_size = (CONFIG_ARCH_INTERRUPTSTACK & ~15);
-  riscv_stack_color((void *)&g_intstackalloc, intstack_size);
+  riscv_stack_color(g_intstackalloc, intstack_size);
 #endif
 
   /* Set priority for all global interrupts to 1 (lowest) */

--- a/arch/risc-v/src/mpfs/mpfs_memorymap.h
+++ b/arch/risc-v/src/mpfs/mpfs_memorymap.h
@@ -39,7 +39,7 @@
 /* Idle thread stack starts from _ebss */
 
 #ifndef __ASSEMBLY__
-#define MPFS_IDLESTACK_BASE  (uintptr_t)&_ebss
+#define MPFS_IDLESTACK_BASE  (uintptr_t)_ebss
 #else
 #define MPFS_IDLESTACK_BASE  _ebss
 #endif

--- a/arch/risc-v/src/mpfs/mpfs_opensbi.c
+++ b/arch/risc-v/src/mpfs/mpfs_opensbi.c
@@ -85,8 +85,8 @@ typedef struct sbi_scratch_holder_s sbi_scratch_holder_t;
 
 /* Linker provided region start / end addresses */
 
-extern const uint64_t __mpfs_nuttx_start;
-extern const uint64_t __mpfs_nuttx_end;
+extern const uint8_t __mpfs_nuttx_start[];
+extern const uint8_t __mpfs_nuttx_end[];
 
 /****************************************************************************
  * Private Function Prototypes
@@ -480,9 +480,9 @@ static void mpfs_opensbi_scratch_setup(uint32_t hartid)
    * them so that OpenSBI has no chance override then.
    */
 
-  g_scratches[hartid].scratch.fw_start = (unsigned long)&__mpfs_nuttx_start;
-  g_scratches[hartid].scratch.fw_size  = (unsigned long)&__mpfs_nuttx_end -
-                                         (unsigned long)&__mpfs_nuttx_start;
+  g_scratches[hartid].scratch.fw_start = (unsigned long)__mpfs_nuttx_start;
+  g_scratches[hartid].scratch.fw_size  = (unsigned long)__mpfs_nuttx_end -
+                                         (unsigned long)__mpfs_nuttx_start;
 }
 
 /****************************************************************************

--- a/arch/risc-v/src/mpfs/mpfs_start.c
+++ b/arch/risc-v/src/mpfs/mpfs_start.c
@@ -93,7 +93,7 @@ void __mpfs_start(uint64_t mhartid)
    * certain that there are no issues with the state of global variables.
    */
 
-  for (dest = &_sbss; dest < &_ebss; )
+  for (dest = (uint32_t *)_sbss; dest < (uint32_t *)_ebss; )
     {
       *dest++ = 0;
     }
@@ -104,7 +104,9 @@ void __mpfs_start(uint64_t mhartid)
    * end of all of the other read-only data (.text, .rodata) at _eronly.
    */
 
-  for (src = &_eronly, dest = &_sdata; dest < &_edata; )
+  for (src = (const uint32_t *)_eronly,
+       dest = (uint32_t *)_sdata; dest < (uint32_t *)_edata;
+      )
     {
       *dest++ = *src++;
     }

--- a/arch/risc-v/src/qemu-rv/qemu_rv_irq.c
+++ b/arch/risc-v/src/qemu-rv/qemu_rv_irq.c
@@ -58,7 +58,7 @@ void up_irqinitialize(void)
 
 #if defined(CONFIG_STACK_COLORATION) && CONFIG_ARCH_INTERRUPTSTACK > 15
   size_t intstack_size = (CONFIG_ARCH_INTERRUPTSTACK & ~15);
-  riscv_stack_color((void *)&g_intstackalloc, intstack_size);
+  riscv_stack_color(g_intstackalloc, intstack_size);
 #endif
 
   /* Set priority for all global interrupts to 1 (lowest) */

--- a/arch/risc-v/src/qemu-rv/qemu_rv_memorymap.h
+++ b/arch/risc-v/src/qemu-rv/qemu_rv_memorymap.h
@@ -34,7 +34,7 @@
 /* Idle thread stack starts from _ebss */
 
 #ifndef __ASSEMBLY__
-#define QEMU_RV_IDLESTACK_BASE  (uintptr_t)&_ebss
+#define QEMU_RV_IDLESTACK_BASE  (uintptr_t)_ebss
 #else
 #define QEMU_RV_IDLESTACK_BASE  _ebss
 #endif

--- a/arch/risc-v/src/qemu-rv/qemu_rv_start.c
+++ b/arch/risc-v/src/qemu-rv/qemu_rv_start.c
@@ -84,7 +84,7 @@ void qemu_rv_start(int mhartid)
    * certain that there are no issues with the state of global variables.
    */
 
-  for (dest = &_sbss; dest < &_ebss; )
+  for (dest = (uint32_t *)_sbss; dest < (uint32_t *)_ebss; )
     {
       *dest++ = 0;
     }

--- a/arch/risc-v/src/rv32m1/rv32m1_irq.c
+++ b/arch/risc-v/src/rv32m1/rv32m1_irq.c
@@ -95,8 +95,7 @@ void up_irqinitialize(void)
 
 #if defined(CONFIG_STACK_COLORATION) && CONFIG_ARCH_INTERRUPTSTACK > 15
   size_t intstack_size = (CONFIG_ARCH_INTERRUPTSTACK & ~15);
-  riscv_stack_color((void *)((uintptr_t)&g_intstacktop - intstack_size),
-                 intstack_size);
+  riscv_stack_color(g_intstacktop - intstack_size, intstack_size);
 #endif
 
   /* Clear all pending flags */

--- a/arch/risc-v/src/rv32m1/rv32m1_linker.h
+++ b/arch/risc-v/src/rv32m1/rv32m1_linker.h
@@ -66,11 +66,11 @@ extern "C"
 #endif
 
 #ifdef CONFIG_RV32M1_ITCM
-  EXTERN uint32_t _slitcm;        /* Start of ITCM LMA */
-  EXTERN uint32_t _svitcm;        /* Start of ITCM VMA */
-  EXTERN uint32_t _evitcm;        /* End+1 of ITCM VMA */
-  EXTERN uint32_t _suvitcm;       /* Start of User ITCM VMA */
-  EXTERN uint32_t _euvitcm;       /* End+1 of User ITCM VMA */
+  EXTERN uint8_t _slitcm[];        /* Start of ITCM LMA */
+  EXTERN uint8_t _svitcm[];        /* Start of ITCM VMA */
+  EXTERN uint8_t _evitcm[];        /* End+1 of ITCM VMA */
+  EXTERN uint8_t _suvitcm[];       /* Start of User ITCM VMA */
+  EXTERN uint8_t _euvitcm[];       /* End+1 of User ITCM VMA */
 #endif
 
 #undef EXTERN

--- a/arch/risc-v/src/rv32m1/rv32m1_memorymap.h
+++ b/arch/risc-v/src/rv32m1/rv32m1_memorymap.h
@@ -34,7 +34,7 @@
 /* Idle thread stack starts from _ebss */
 
 #ifndef __ASSEMBLY__
-#define RV32M1_IDLESTACK_BASE  (uint32_t)&_ebss
+#define RV32M1_IDLESTACK_BASE  (uint32_t)_ebss
 #else
 #define RV32M1_IDLESTACK_BASE  _ebss
 #endif

--- a/arch/risc-v/src/rv32m1/rv32m1_start.c
+++ b/arch/risc-v/src/rv32m1/rv32m1_start.c
@@ -89,14 +89,14 @@ void __rv32m1_start(void)
 
 #ifdef CONFIG_RV32M1_ITCM
 
-  src = &_slitcm;
-  dest = &_svitcm;
+  src = (uint32_t *)_slitcm;
+  dest = (uint32_t *)_svitcm;
 
   if (src != dest)
     {
       /* Copy codes from Flash LMA Region to ITCM VMA Region */
 
-      for (; dest < &_evitcm; )
+      for (; dest < (uint32_t *)_evitcm; )
         {
           *dest++ = *src++;
         }
@@ -108,7 +108,7 @@ void __rv32m1_start(void)
    * certain that there are no issues with the state of global variables.
    */
 
-  for (dest = &_sbss; dest < &_ebss; )
+  for (dest = (uint32_t *)_sbss; dest < (uint32_t *)_ebss; )
     {
       *dest++ = 0;
     }
@@ -119,7 +119,9 @@ void __rv32m1_start(void)
    * end of all of the other read-only data (.text, .rodata) at _eronly.
    */
 
-  for (src = &_eronly, dest = &_sdata; dest < &_edata; )
+  for (src = (const uint32_t *)_eronly,
+       dest = (uint32_t *)_sdata; dest < (uint32_t *)_edata;
+      )
     {
       *dest++ = *src++;
     }

--- a/arch/sparc/src/bm3803/bm3803-lowinit.c
+++ b/arch/sparc/src/bm3803/bm3803-lowinit.c
@@ -94,7 +94,7 @@ void up_lowinit(void)
    * certain that there are no issues with the state of global variables.
    */
 
-  for (dest = &_bss_start; dest < &_end; )
+  for (dest = (uint32_t *)_bss_start; dest < (uint32_t *)_end; )
     {
       *dest++ = 0;
     }

--- a/arch/sparc/src/bm3823/bm3823-lowinit.c
+++ b/arch/sparc/src/bm3823/bm3823-lowinit.c
@@ -147,7 +147,7 @@ void up_lowinit(void)
    * certain that there are no issues with the state of global variables.
    */
 
-  for (dest = &_bss_start; dest < &_end; )
+  for (dest = (uint32_t *)_bss_start; dest < (uint32_t *)_end; )
     {
       *dest++ = 0;
     }

--- a/arch/sparc/src/common/up_checkstack.c
+++ b/arch/sparc/src/common/up_checkstack.c
@@ -221,7 +221,7 @@ ssize_t up_check_stack_remain(void)
 #if CONFIG_ARCH_INTERRUPTSTACK > 3
 size_t up_check_intstack(void)
 {
-  return sparc_stack_check((uintptr_t)&g_intstackalloc,
+  return sparc_stack_check((uintptr_t)g_intstackalloc,
                            STACK_ALIGN_DOWN(CONFIG_ARCH_INTERRUPTSTACK));
 }
 

--- a/arch/sparc/src/common/up_initialize.c
+++ b/arch/sparc/src/common/up_initialize.c
@@ -93,7 +93,7 @@ volatile uint32_t *g_current_regs;
 #if defined(CONFIG_STACK_COLORATION) && CONFIG_ARCH_INTERRUPTSTACK > 3
 static inline void up_color_intstack(void)
 {
-  uint8_t *ptr = (uint8_t *)&g_intstackalloc;
+  uint8_t *ptr = g_intstackalloc;
   ssize_t size;
 
   for (size = (CONFIG_ARCH_INTERRUPTSTACK & ~3);

--- a/arch/sparc/src/common/up_internal.h
+++ b/arch/sparc/src/common/up_internal.h
@@ -133,33 +133,23 @@ extern uint32_t g_idle_topstack;
 extern void g_intstackbase;
 #endif
 
-/* These 'addresses' of these values are setup by the linker script.They are
- * not actual uint32_t storage locations! They are only used meaningfully in
- * the following way:
- *
- *  - The linker script defines, for example, the symbol_sdata.
- *  - The declaration extern uint32_t _sdata; makes C happy.  C will believe
- *    that the value _sdata is the address of a uint32_t variable _data
- *    (it is not!).
- *  - We can recoved the linker value then by simply taking the address of
- *    of _data.  like:  uint32_t *pdata = &_sdata;
- */
+/* These symbols are setup by the linker script. */
 
-extern uint32_t _text_start;         /* Start of .text */
-extern uint32_t _etext;              /* End+1 of .text + .rodata */
-extern const uint32_t _rodata_start; /* Start of .data in FLASH */
-extern uint32_t _sdata;              /* Start of .data */
-extern uint32_t _edata;              /* End+1 of .data */
-extern uint32_t _bss_start;          /* Start of .bss */
-extern uint32_t _end;                /* End+1 of .bss */
+extern char _text_start[];         /* Start of .text */
+extern char _etext[];              /* End+1 of .text + .rodata */
+extern const char _rodata_start[]; /* Start of .data in FLASH */
+extern char _sdata[];              /* Start of .data */
+extern char _edata[];              /* End+1 of .data */
+extern char _bss_start[];          /* Start of .bss */
+extern char _end[];                /* End+1 of .bss */
 #ifdef CONFIG_ARCH_RAMFUNCS
-extern uint32_t _sramfunc;           /* Start of ramfuncs */
-extern uint32_t _eramfunc;           /* End+1 of ramfuncs */
-extern uint32_t _ramfunc_loadaddr;   /* Start of ramfuncs in FLASH */
-extern uint32_t _ramfunc_sizeof;     /* Size of ramfuncs */
-extern uint32_t _bmxdkpba_address;   /* BMX register setting */
-extern uint32_t _bmxdudba_address;   /* BMX register setting */
-extern uint32_t _bmxdupba_address;   /* BMX register setting */
+extern char _sramfunc[];           /* Start of ramfuncs */
+extern char _eramfunc[];           /* End+1 of ramfuncs */
+extern char _ramfunc_loadaddr[];   /* Start of ramfuncs in FLASH */
+extern char _ramfunc_sizeof[];     /* Size of ramfuncs */
+extern char _bmxdkpba_address[];   /* BMX register setting */
+extern char _bmxdudba_address[];   /* BMX register setting */
+extern char _bmxdupba_address[];   /* BMX register setting */
 #endif /* CONFIG_ARCH_RAMFUNCS */
 #endif /* __ASSEMBLY__ */
 

--- a/arch/sparc/src/sparc_v8/up_dumpstate.c
+++ b/arch/sparc/src/sparc_v8/up_dumpstate.c
@@ -122,7 +122,7 @@ void up_dumpstate(void)
   /* Get the limits on the interrupt stack memory */
 
 #if CONFIG_ARCH_INTERRUPTSTACK > 3
-  istackbase = (uint32_t)&g_intstackbase;
+  istackbase = (uint32_t)g_intstackbase;
   istacksize = (CONFIG_ARCH_INTERRUPTSTACK & ~3) - 4;
 
   /* Show interrupt stack info */

--- a/arch/x86/src/common/up_assert.c
+++ b/arch/x86/src/common/up_assert.c
@@ -152,7 +152,7 @@ static void up_dumpstate(void)
   /* Get the limits on the interrupt stack memory */
 
 #if CONFIG_ARCH_INTERRUPTSTACK > 3
-  istackbase = (uint32_t)&g_intstackalloc;
+  istackbase = (uint32_t)g_intstackalloc;
   istacksize = (CONFIG_ARCH_INTERRUPTSTACK & ~3);
 
   /* Show interrupt stack info */

--- a/arch/x86/src/common/up_internal.h
+++ b/arch/x86/src/common/up_internal.h
@@ -121,29 +121,19 @@ extern uint32_t g_idle_topstack;
 /* Address of the saved user stack pointer */
 
 #if CONFIG_ARCH_INTERRUPTSTACK > 3
-extern uint32_t g_intstackalloc;
-extern uint32_t g_intstacktop;
+extern uint8_t g_intstackalloc[];
+extern uint8_t g_intstacktop[];
 #endif
 
-/* These 'addresses' of these values are setup by the linker script.  They
- * are not actual uint32_t storage locations! They are only used meaningfully
- * in the following way:
- *
- *  - The linker script defines, for example, the symbol_sdata.
- *  - The declaration extern uint32_t _sdata; makes C happy.  C will believe
- *    that the value _sdata is the address of a uint32_t variable _data
- *    (it is not!).
- *  - We can recover the linker value then by simply taking the address of
- *    of _data.  like:  uint32_t *pdata = &_sdata;
- */
+/* These symbols are setup by the linker script. */
 
-extern uint32_t _stext;           /* Start of .text */
-extern uint32_t _etext;           /* End_1 of .text + .rodata */
-extern const uint32_t _eronly;    /* End+1 of read only section (.text + .rodata) */
-extern uint32_t _sdata;           /* Start of .data */
-extern uint32_t _edata;           /* End+1 of .data */
-extern uint32_t _sbss;            /* Start of .bss */
-extern uint32_t _ebss;            /* End+1 of .bss */
+extern uint8_t _stext[];           /* Start of .text */
+extern uint8_t _etext[];           /* End_1 of .text + .rodata */
+extern const uint8_t _eronly[];    /* End+1 of read only section (.text + .rodata) */
+extern uint8_t _sdata[];           /* Start of .data */
+extern uint8_t _edata[];           /* End+1 of .data */
+extern uint8_t _sbss[];            /* Start of .bss */
+extern uint8_t _ebss[];            /* End+1 of .bss */
 #endif
 
 /****************************************************************************

--- a/arch/x86_64/src/common/up_allocateheap.c
+++ b/arch/x86_64/src/common/up_allocateheap.c
@@ -49,7 +49,7 @@
  * Public Functions
  ****************************************************************************/
 
-const uintptr_t g_idle_topstack = (uintptr_t)&_ebss +
+const uintptr_t g_idle_topstack = (uintptr_t)_ebss +
   CONFIG_IDLETHREAD_STACKSIZE;
 
 /****************************************************************************

--- a/arch/x86_64/src/common/up_assert.c
+++ b/arch/x86_64/src/common/up_assert.c
@@ -132,7 +132,7 @@ static void up_dumpstate(void)
   /* Get the limits on the interrupt stack memory */
 
 #if CONFIG_ARCH_INTERRUPTSTACK > 3
-  istackbase = (uint64_t)&g_intstackalloc;
+  istackbase = (uint64_t)g_intstackalloc;
   istacksize = (CONFIG_ARCH_INTERRUPTSTACK & ~3);
 
   /* Show interrupt stack info */

--- a/arch/x86_64/src/common/up_internal.h
+++ b/arch/x86_64/src/common/up_internal.h
@@ -141,29 +141,19 @@ extern const uintptr_t g_idle_topstack;
 /* Address of the saved user stack pointer */
 
 #if CONFIG_ARCH_INTERRUPTSTACK > 3
-extern uint64_t g_intstackalloc;
-extern uint64_t g_intstacktop;
+extern uint8_t g_intstackalloc[];
+extern uint8_t g_intstacktop[];
 #endif
 
-/* These 'addresses' of these values are setup by the linker script.  They
- * are not actual uint32_t storage locations! They are only used
- * meaningfully in the following way:
- *
- *  - The linker script defines, for example, the symbol_sdata.
- *  - The declaration extern uint32_t _sdata; makes C happy.  C will believe
- *    that the value _sdata is the address of a uint32_t variable _data
- *    (it is not!).
- *  - We can recover the linker value then by simply taking the address of
- *    of _data.  like:  uint32_t *pdata = &_sdata;
- */
+/* These symbols are setup by the linker script. */
 
-extern uint64_t _stext;           /* Start of .text */
-extern uint64_t _etext;           /* End_1 of .text + .rodata */
-extern const uint64_t _eronly;    /* End+1 of read only section (.text + .rodata) */
-extern uint64_t _sdata;           /* Start of .data */
-extern uint64_t _edata;           /* End+1 of .data */
-extern uint64_t _sbss;            /* Start of .bss */
-extern uint64_t _ebss;            /* End+1 of .bss */
+extern uint8_t _stext[];           /* Start of .text */
+extern uint8_t _etext[];           /* End_1 of .text + .rodata */
+extern const uint8_t _eronly[];    /* End+1 of read only section (.text + .rodata) */
+extern uint8_t _sdata[];           /* Start of .data */
+extern uint8_t _edata[];           /* End+1 of .data */
+extern uint8_t _sbss[];            /* Start of .bss */
+extern uint8_t _ebss[];            /* End+1 of .bss */
 #endif
 
 /****************************************************************************

--- a/arch/xtensa/src/common/xtensa.h
+++ b/arch/xtensa/src/common/xtensa.h
@@ -165,39 +165,29 @@
 #if !defined(CONFIG_SMP) && CONFIG_ARCH_INTERRUPTSTACK > 15
 /* The (optional) interrupt stack */
 
-extern uint32_t g_intstackalloc; /* Allocated interrupt stack */
-extern uint32_t g_intstacktop;   /* Initial top of interrupt stack */
+extern uint8_t g_intstackalloc[]; /* Allocated interrupt stack */
+extern uint8_t g_intstacktop[];   /* Initial top of interrupt stack */
 #endif
 
 /* Address of the CPU0 IDLE thread */
 
 extern uint32_t g_idlestack[IDLETHREAD_STACKWORDS];
 
-/* These 'addresses' of these values are setup by the linker script.  They
- * are not actual uint32_t storage locations! They are only used meaningfully
- * in the following way:
- *
- *  - The linker script defines, for example, the symbol_sdata.
- *  - The declaration extern uint32_t _sdata; makes C happy.  C will believe
- *    that the value _sdata is the address of a uint32_t variable _data (it
- *    is not!).
- *  - We can recover the linker value then by simply taking the address of
- *    of _data.  like:  uint32_t *pdata = &_sdata;
- */
+/* These symbols are setup by the linker script. */
 
-extern uint32_t _init_start;        /* Start of initialization logic */
-extern uint32_t _stext;             /* Start of .text */
-extern uint32_t _etext;             /* End+1 of .text + .rodata */
-extern uint32_t _sdata;             /* Start of .data */
-extern uint32_t _edata;             /* End+1 of .data */
-extern uint32_t _srodata;           /* Start of .rodata */
-extern uint32_t _erodata;           /* End+1 of .rodata */
-extern uint32_t _sbss;              /* Start of .bss */
-extern uint32_t _ebss;              /* End+1 of .bss */
-extern uint32_t _sheap;             /* Start of heap */
-extern uint32_t _eheap;             /* End+1 of heap */
-extern uint32_t _sbss_extmem;       /* start of external memory bss */
-extern uint32_t _ebss_extmem;       /* End+1 of external memory bss */
+extern uint8_t _init_start[];        /* Start of initialization logic */
+extern uint8_t _stext[];             /* Start of .text */
+extern uint8_t _etext[];             /* End+1 of .text + .rodata */
+extern uint8_t _sdata[];             /* Start of .data */
+extern uint8_t _edata[];             /* End+1 of .data */
+extern uint8_t _srodata[];           /* Start of .rodata */
+extern uint8_t _erodata[];           /* End+1 of .rodata */
+extern uint8_t _sbss[];              /* Start of .bss */
+extern uint8_t _ebss[];              /* End+1 of .bss */
+extern uint8_t _sheap[];             /* Start of heap */
+extern uint8_t _eheap[];             /* End+1 of heap */
+extern uint8_t _sbss_extmem[];       /* start of external memory bss */
+extern uint8_t _ebss_extmem[];       /* End+1 of external memory bss */
 
 /****************************************************************************
  * Inline Functions

--- a/arch/xtensa/src/common/xtensa_backtrace.c
+++ b/arch/xtensa/src/common/xtensa_backtrace.c
@@ -237,7 +237,7 @@ int up_backtrace(struct tcb_s *tcb, void **buffer, int size, int skip)
 #ifdef CONFIG_SMP
           istackbase = xtensa_intstack_alloc();
 #else
-          istackbase = &g_intstackalloc;
+          istackbase = g_intstackalloc;
 #endif
           xtensa_window_spill();
 

--- a/arch/xtensa/src/common/xtensa_checkstack.c
+++ b/arch/xtensa/src/common/xtensa_checkstack.c
@@ -183,7 +183,7 @@ size_t up_check_intstack(void)
 #ifdef CONFIG_SMP
   return xtensa_stack_check(xtensa_intstack_alloc(), INTSTACK_SIZE);
 #else
-  return xtensa_stack_check((uintptr_t)&g_intstackalloc, INTSTACK_SIZE);
+  return xtensa_stack_check((uintptr_t)g_intstackalloc, INTSTACK_SIZE);
 #endif
 }
 

--- a/arch/xtensa/src/common/xtensa_dumpstate.c
+++ b/arch/xtensa/src/common/xtensa_dumpstate.c
@@ -371,7 +371,7 @@ void xtensa_dumpstate(void)
 #  ifdef CONFIG_SMP
                     (uint32_t)xtensa_intstack_alloc(),
 #  else
-                    (uint32_t)&g_intstackalloc,
+                    (uint32_t)g_intstackalloc,
 #  endif
                     INTSTACK_SIZE,
                     !!CURRENT_REGS);

--- a/arch/xtensa/src/common/xtensa_initialize.c
+++ b/arch/xtensa/src/common/xtensa_initialize.c
@@ -63,7 +63,7 @@ static inline void xtensa_color_intstack(void)
 #ifdef CONFIG_SMP
   uint32_t *ptr = (uint32_t *)xtensa_intstack_alloc();
 #else
-  uint32_t *ptr = (uint32_t *)&g_intstackalloc;
+  uint32_t *ptr = (uint32_t *)g_intstackalloc;
 #endif
   ssize_t size;
 

--- a/arch/xtensa/src/esp32/esp32_allocateheap.c
+++ b/arch/xtensa/src/esp32/esp32_allocateheap.c
@@ -90,7 +90,7 @@ void up_allocate_heap(void **heap_start, size_t *heap_size)
 #else
   board_autoled_on(LED_HEAPALLOCATE);
 
-  *heap_start = (void *)&_sheap;
+  *heap_start = (void *)_sheap;
   DEBUGASSERT(HEAP_REGION1_END > (uintptr_t)*heap_start);
   *heap_size = (size_t)(HEAP_REGION1_END - (uintptr_t)*heap_start);
 #endif /* CONFIG_BUILD_PROTECTED && CONFIG_MM_KERNEL_HEAP */
@@ -117,7 +117,7 @@ void up_allocate_kheap(void **heap_start, size_t *heap_size)
    * Check boards/xtensa/esp32.
    */
 
-  uintptr_t kbase = (uintptr_t)&_sheap;
+  uintptr_t kbase = (uintptr_t)_sheap;
   uintptr_t ktop  = KDRAM_0_END;
   size_t    ksize = ktop - kbase;
 
@@ -172,7 +172,7 @@ void xtensa_add_region(void)
 
 #ifndef CONFIG_SMP
   start = (void *)(HEAP_REGION2_START + XTENSA_IMEM_REGION_SIZE);
-  size  = (size_t)(uintptr_t)&_eheap - (size_t)start;
+  size  = (size_t)(uintptr_t)_eheap - (size_t)start;
 #ifdef CONFIG_BUILD_PROTECTED
   kmm_addregion(start, size);
 #else
@@ -188,7 +188,7 @@ void xtensa_add_region(void)
 #endif
 
   start = (void *)HEAP_REGION3_START + XTENSA_IMEM_REGION_SIZE;
-  size  = (size_t)(uintptr_t)&_eheap - (size_t)start;
+  size  = (size_t)(uintptr_t)_eheap - (size_t)start;
 #ifdef CONFIG_BUILD_PROTECTED
   kmm_addregion(start, size);
 #else
@@ -209,8 +209,8 @@ void xtensa_add_region(void)
 #ifdef CONFIG_ESP32_SPIRAM
 #  if defined(CONFIG_HEAP2_BASE) && defined(CONFIG_HEAP2_SIZE)
 #    ifdef CONFIG_XTENSA_EXTMEM_BSS
-      start = (void *)(&_ebss_extmem);
-      size = CONFIG_HEAP2_SIZE - (size_t)(&_ebss_extmem - &_sbss_extmem);
+      start = _ebss_extmem;
+      size = CONFIG_HEAP2_SIZE - (_ebss_extmem - _sbss_extmem);
 #    else
       start = (void *)CONFIG_HEAP2_BASE;
       size = CONFIG_HEAP2_SIZE;

--- a/arch/xtensa/src/esp32/esp32_ble_adapter.c
+++ b/arch/xtensa/src/esp32/esp32_ble_adapter.c
@@ -447,24 +447,24 @@ extern int coex_register_bt_cb(coex_func_cb_t cb);
 extern void coex_bb_reset_unlock(uint32_t restore);
 extern uint32_t coex_bb_reset_lock(void);
 
-extern char _bss_start_btdm;
-extern char _bss_end_btdm;
-extern char _data_start_btdm;
-extern char _data_end_btdm;
-extern uint32_t _data_start_btdm_rom;
-extern uint32_t _data_end_btdm_rom;
+extern uint8_t _bss_start_btdm[];
+extern uint8_t _bss_end_btdm[];
+extern uint8_t _data_start_btdm[];
+extern uint8_t _data_end_btdm[];
+extern const uint8_t _data_start_btdm_rom[];
+extern const uint8_t _data_end_btdm_rom[];
 
-extern uint32_t _bt_bss_start;
-extern uint32_t _bt_bss_end;
-extern uint32_t _btdm_bss_start;
-extern uint32_t _btdm_bss_end;
-extern uint32_t _bt_data_start;
-extern uint32_t _bt_data_end;
-extern uint32_t _btdm_data_start;
-extern uint32_t _btdm_data_end;
+extern uint8_t _bt_bss_start[];
+extern uint8_t _bt_bss_end[];
+extern uint8_t _btdm_bss_start[];
+extern uint8_t _btdm_bss_end[];
+extern uint8_t _bt_data_start[];
+extern uint8_t _bt_data_end[];
+extern uint8_t _btdm_data_start[];
+extern uint8_t _btdm_data_end[];
 
-extern char _bt_tmp_bss_start;
-extern char _bt_tmp_bss_end;
+extern uint8_t _bt_tmp_bss_start[];
+extern uint8_t _bt_tmp_bss_end[];
 
 void intr_matrix_set(int cpu_no, uint32_t model_num, uint32_t intr_num);
 
@@ -2027,11 +2027,11 @@ static void btdm_controller_mem_init(void)
 
   /* initialise .data section */
 
-  memcpy(&_data_start_btdm, (void *)_data_start_btdm_rom,
-         &_data_end_btdm - &_data_start_btdm);
+  memcpy(_data_start_btdm, _data_start_btdm_rom,
+         _data_end_btdm - _data_start_btdm);
 
   wlinfo(".data initialise [0x%08x] <== [0x%08x]\n",
-         (uint32_t)&_data_start_btdm, _data_start_btdm_rom);
+         (uint32_t)_data_start_btdm, (uint32_t)_data_start_btdm_rom);
 
   /* initial em, .bss section */
 

--- a/arch/xtensa/src/esp32/esp32_cpustart.c
+++ b/arch/xtensa/src/esp32/esp32_cpustart.c
@@ -160,7 +160,7 @@ void IRAM_ATTR xtensa_appcpu_start(void)
 
   /* Move CPU0 exception vectors to IRAM */
 
-  __asm__ __volatile__ ("wsr %0, vecbase\n"::"r" (&_init_start));
+  __asm__ __volatile__ ("wsr %0, vecbase\n"::"r" (_init_start));
 
   /* Make page 0 access raise an exception */
 

--- a/arch/xtensa/src/esp32/esp32_iramheap.c
+++ b/arch/xtensa/src/esp32/esp32_iramheap.c
@@ -55,11 +55,11 @@ void esp32_iramheap_initialize(void)
 
   /* These values come from the linker scripts. Check boards/xtensa/esp32. */
 
-  extern uint8_t *_siramheap;
-  extern uint8_t *_eiramheap;
+  extern uint8_t _siramheap[];
+  extern uint8_t _eiramheap[];
 
-  start = (void *)&_siramheap;
-  size  = (size_t)((uintptr_t)&_eiramheap - (uintptr_t)&_siramheap);
+  start = (void *)_siramheap;
+  size  = _eiramheap - _siramheap;
   g_iramheap = mm_initialize("iramheap", start, size);
 }
 

--- a/arch/xtensa/src/esp32/esp32_rtcheap.c
+++ b/arch/xtensa/src/esp32/esp32_rtcheap.c
@@ -55,11 +55,11 @@ void esp32_rtcheap_initialize(void)
 
   /* These values come from the linker scripts. Check boards/xtensa/esp32. */
 
-  extern uint8_t *_srtcheap;
-  extern uint8_t *_ertcheap;
+  extern uint8_t _srtcheap[];
+  extern uint8_t _ertcheap[];
 
-  start = (void *)&_srtcheap;
-  size  = (size_t)((uintptr_t)&_ertcheap - (uintptr_t)&_srtcheap);
+  start = (void *)_srtcheap;
+  size  = _ertcheap - _srtcheap;
   g_rtcheap = mm_initialize("rtcheap", start, size);
 }
 

--- a/arch/xtensa/src/esp32/esp32_start.c
+++ b/arch/xtensa/src/esp32/esp32_start.c
@@ -77,13 +77,13 @@
  ****************************************************************************/
 
 #ifdef CONFIG_ESP32_APP_FORMAT_MCUBOOT
-extern uint32_t _image_irom_vma;
-extern uint32_t _image_irom_lma;
-extern uint32_t _image_irom_size;
+extern uint8_t _image_irom_vma[];
+extern uint8_t _image_irom_lma[];
+extern uint8_t _image_irom_size[];
 
-extern uint32_t _image_drom_vma;
-extern uint32_t _image_drom_lma;
-extern uint32_t _image_drom_size;
+extern uint8_t _image_drom_vma[];
+extern uint8_t _image_drom_lma[];
+extern uint8_t _image_drom_size[];
 #endif
 
 /****************************************************************************
@@ -122,7 +122,7 @@ extern void esp32_lowsetup(void);
  ****************************************************************************/
 
 #ifdef CONFIG_ESP32_APP_FORMAT_MCUBOOT
-HDR_ATTR static void (*_entry_point)(void) = &__start;
+HDR_ATTR static void (*_entry_point)(void) = __start;
 #endif
 
 /****************************************************************************
@@ -172,7 +172,7 @@ static noreturn_function void __esp32_start(void)
    * So we configure CPU to use the VECBASE address in DPORT peripheral.
    */
 
-  regval = ((uint32_t)&_init_start) >> 10;
+  regval = ((uint32_t)_init_start) >> 10;
   putreg32(regval, DPORT_PRO_VECBASE_SET_REG);
 
   regval  = getreg32(DPORT_PRO_VECBASE_CTRL_REG);
@@ -181,12 +181,12 @@ static noreturn_function void __esp32_start(void)
 #else
   /* Move CPU0 exception vectors to IRAM */
 
-  __asm__ __volatile__ ("wsr %0, vecbase\n"::"r"(&_init_start));
+  __asm__ __volatile__ ("wsr %0, vecbase\n"::"r"(_init_start));
 #endif
 
   /* Set .bss to zero */
 
-  memset(&_sbss, 0, (&_ebss - &_sbss) * sizeof(_sbss));
+  memset(_sbss, 0, _ebss - _sbss);
 
 #ifndef CONFIG_SMP
   /* Make sure that the APP_CPU is disabled for now */
@@ -238,8 +238,7 @@ static noreturn_function void __esp32_start(void)
   /* Set external memory bss section to zero */
 
 #  ifdef CONFIG_XTENSA_EXTMEM_BSS
-     memset(&_sbss_extmem, 0,
-            (&_ebss_extmem - &_sbss_extmem) * sizeof(_sbss_extmem));
+     memset(_sbss_extmem, 0, _ebss_extmem - _sbss_extmem);
 #  endif
 
 #endif
@@ -317,12 +316,12 @@ static int map_rom_segments(void)
   uint32_t irom_page_count;
 
   size_t partition_offset = PRIMARY_SLOT_OFFSET;
-  uint32_t app_irom_lma = partition_offset + (uint32_t)&_image_irom_lma;
-  uint32_t app_irom_size = (uint32_t)&_image_irom_size;
-  uint32_t app_irom_vma = (uint32_t)&_image_irom_vma;
-  uint32_t app_drom_lma = partition_offset + (uint32_t)&_image_drom_lma;
-  uint32_t app_drom_size = (uint32_t)&_image_drom_size;
-  uint32_t app_drom_vma = (uint32_t)&_image_drom_vma;
+  uint32_t app_irom_lma = partition_offset + (uint32_t)_image_irom_lma;
+  uint32_t app_irom_size = (uint32_t)_image_irom_size;
+  uint32_t app_irom_vma = (uint32_t)_image_irom_vma;
+  uint32_t app_drom_lma = partition_offset + (uint32_t)_image_drom_lma;
+  uint32_t app_drom_size = (uint32_t)_image_drom_size;
+  uint32_t app_drom_vma = (uint32_t)_image_drom_vma;
 
   volatile uint32_t *pro_flash_mmu_table =
     (volatile uint32_t *)DPORT_PRO_FLASH_MMU_TABLE_REG;

--- a/arch/xtensa/src/esp32/esp32_user.c
+++ b/arch/xtensa/src/esp32/esp32_user.c
@@ -39,8 +39,8 @@
  ****************************************************************************/
 
 #ifdef CONFIG_ARCH_USE_TEXT_HEAP
-extern uint32_t _siramheap;
-extern uint32_t _eiramheap;
+extern uint8_t _siramheap[];
+extern uint8_t _eiramheap[];
 #endif
 
 /****************************************************************************
@@ -338,8 +338,8 @@ uint32_t *xtensa_user(int exccause, uint32_t *regs)
    */
 
   if (exccause == EXCCAUSE_LOAD_STORE_ERROR &&
-      (uintptr_t)&_siramheap <= regs[REG_EXCVADDR] &&
-      (uintptr_t)&_eiramheap > regs[REG_EXCVADDR])
+      (uintptr_t)_siramheap <= regs[REG_EXCVADDR] &&
+      (uintptr_t)_eiramheap > regs[REG_EXCVADDR])
     {
       uint8_t *pc = (uint8_t *)regs[REG_PC];
       uint8_t imm8;

--- a/arch/xtensa/src/esp32s2/esp32s2_allocateheap.c
+++ b/arch/xtensa/src/esp32s2/esp32s2_allocateheap.c
@@ -59,13 +59,12 @@
 
 void up_allocate_heap(void **heap_start, size_t *heap_size)
 {
-  extern uint32_t *_dram0_rtos_reserved_start;
+  extern uint8_t _dram0_rtos_reserved_start[];
 
   board_autoled_on(LED_HEAPALLOCATE);
 
-  *heap_start = (void *)&_sheap;
-  *heap_size = (size_t)((uintptr_t)&_dram0_rtos_reserved_start -
-                        (uintptr_t)&_sheap);
+  *heap_start = _sheap;
+  *heap_size = _dram0_rtos_reserved_start - _sheap;
 }
 
 /****************************************************************************

--- a/arch/xtensa/src/esp32s2/esp32s2_spiram.c
+++ b/arch/xtensa/src/esp32s2/esp32s2_spiram.c
@@ -279,8 +279,8 @@ bool esp_spiram_test(void)
 #if defined(CONFIG_ESP32S2_SPIRAM_RODATA)
 void rodata_flash_page_info_init(void)
 {
-  uint32_t rodata_page_cnt = ((uint32_t)&_rodata_reserved_end -
-                              ((uint32_t)&_rodata_reserved_start &
+  uint32_t rodata_page_cnt = ((uint32_t)_rodata_reserved_end -
+                              ((uint32_t)_rodata_reserved_start &
                               ~ (MMU_PAGE_SIZE - 1)) + MMU_PAGE_SIZE - 1) /
                               MMU_PAGE_SIZE;
 

--- a/arch/xtensa/src/esp32s2/esp32s2_spiram.h
+++ b/arch/xtensa/src/esp32s2/esp32s2_spiram.h
@@ -170,8 +170,8 @@ int instruction_flash2spiram_offset(void);
 
 #if defined(CONFIG_SPIRAM_RODATA)
 
-extern int _rodata_reserved_start;
-extern int _rodata_reserved_end;
+extern uint8_t _rodata_reserved_start[];
+extern uint8_t _rodata_reserved_end[];
 
 /**
  * @brief Get the start page number of the rodata in SPI flash

--- a/arch/xtensa/src/esp32s2/esp32s2_start.c
+++ b/arch/xtensa/src/esp32s2/esp32s2_start.c
@@ -74,13 +74,13 @@
  ****************************************************************************/
 
 #ifdef CONFIG_ESP32S2_APP_FORMAT_MCUBOOT
-extern uint32_t _image_irom_vma;
-extern uint32_t _image_irom_lma;
-extern uint32_t _image_irom_size;
+extern uint8_t _image_irom_vma[];
+extern uint8_t _image_irom_lma[];
+extern uint8_t _image_irom_size[];
 
-extern uint32_t _image_drom_vma;
-extern uint32_t _image_drom_lma;
-extern uint32_t _image_drom_size;
+extern uint8_t _image_drom_vma[];
+extern uint8_t _image_drom_lma[];
+extern uint8_t _image_drom_size[];
 #endif
 
 typedef enum
@@ -153,7 +153,7 @@ noreturn_function void __start(void);
  ****************************************************************************/
 
 #ifdef CONFIG_ESP32S2_APP_FORMAT_MCUBOOT
-HDR_ATTR static void (*_entry_point)(void) = &__start;
+HDR_ATTR static void (*_entry_point)(void) = __start;
 #endif
 
 /****************************************************************************
@@ -319,15 +319,15 @@ static void noreturn_function IRAM_ATTR __esp32s2_start(void)
 
   /* Move CPU0 exception vectors to IRAM */
 
-  __asm__ __volatile__ ("wsr %0, vecbase\n"::"r" (&_init_start));
+  __asm__ __volatile__ ("wsr %0, vecbase\n"::"r" (_init_start));
 
   /* Clear .bss.  We'll do this inline (vs. calling memset) just to be
    * certain that there are no issues with the state of global variables.
    */
 
-  for (uint32_t *dest = &_sbss; dest < &_ebss; dest++)
+  for (uint32_t *dest = (uint32_t *)_sbss; dest < (uint32_t *)_ebss; )
     {
-      *dest = 0;
+      *dest++ = 0;
     }
 
   /* The 2nd stage bootloader enables RTC WDT to check on startup sequence
@@ -433,12 +433,12 @@ static int map_rom_segments(void)
   uint32_t irom_page_count;
 
   size_t partition_offset = PRIMARY_SLOT_OFFSET;
-  uint32_t app_irom_lma = partition_offset + (uint32_t)&_image_irom_lma;
-  uint32_t app_irom_size = (uint32_t)&_image_irom_size;
-  uint32_t app_irom_vma = (uint32_t)&_image_irom_vma;
-  uint32_t app_drom_lma = partition_offset + (uint32_t)&_image_drom_lma;
-  uint32_t app_drom_size = (uint32_t)&_image_drom_size;
-  uint32_t app_drom_vma = (uint32_t)&_image_drom_vma;
+  uint32_t app_irom_lma = partition_offset + (uint32_t)_image_irom_lma;
+  uint32_t app_irom_size = (uint32_t)_image_irom_size;
+  uint32_t app_irom_vma = (uint32_t)_image_irom_vma;
+  uint32_t app_drom_lma = partition_offset + (uint32_t)_image_drom_lma;
+  uint32_t app_drom_size = (uint32_t)_image_drom_size;
+  uint32_t app_drom_vma = (uint32_t)_image_drom_vma;
 
   uint32_t autoload = cache_suspend_icache();
   cache_invalidate_icache_all();

--- a/arch/xtensa/src/esp32s2/esp32s2_user.c
+++ b/arch/xtensa/src/esp32s2/esp32s2_user.c
@@ -39,8 +39,8 @@
  ****************************************************************************/
 
 #ifdef CONFIG_ARCH_USE_TEXT_HEAP
-extern uint32_t _stextheap;
-extern uint32_t _etextheap;
+extern char _stextheap[];
+extern char _etextheap[];
 #endif
 
 /****************************************************************************
@@ -308,8 +308,8 @@ uint32_t *xtensa_user(int exccause, uint32_t *regs)
    */
 
   if (exccause == EXCCAUSE_LOAD_STORE_ERROR &&
-      (uintptr_t)&_stextheap <= regs[REG_EXCVADDR] &&
-      (uintptr_t)&_etextheap > regs[REG_EXCVADDR])
+      (uintptr_t)_stextheap <= regs[REG_EXCVADDR] &&
+      (uintptr_t)_etextheap > regs[REG_EXCVADDR])
     {
       uint8_t *pc = (uint8_t *)regs[REG_PC];
       uint8_t imm8;

--- a/arch/xtensa/src/esp32s3/esp32s3_allocateheap.c
+++ b/arch/xtensa/src/esp32s3/esp32s3_allocateheap.c
@@ -63,9 +63,9 @@ void up_allocate_heap(void **heap_start, size_t *heap_size)
 {
   board_autoled_on(LED_HEAPALLOCATE);
 
-  *heap_start = (void *)&_sheap;
+  *heap_start = (void *)_sheap;
   *heap_size = (size_t)(ets_rom_layout_p->dram0_rtos_reserved_start -
-                (uintptr_t)&_sheap);
+                (uintptr_t)_sheap);
 }
 
 /****************************************************************************

--- a/arch/xtensa/src/esp32s3/esp32s3_cpustart.c
+++ b/arch/xtensa/src/esp32s3/esp32s3_cpustart.c
@@ -140,7 +140,7 @@ void xtensa_appcpu_start(void)
 
   /* Move CPU0 exception vectors to IRAM */
 
-  __asm__ __volatile__ ("wsr %0, vecbase\n"::"r" (&_init_start));
+  __asm__ __volatile__ ("wsr %0, vecbase\n"::"r" (_init_start));
 
   /* Make page 0 access raise an exception */
 

--- a/arch/xtensa/src/esp32s3/esp32s3_spiram.c
+++ b/arch/xtensa/src/esp32s3/esp32s3_spiram.c
@@ -240,7 +240,7 @@ int esp_spiram_enable_rodata_access(void)
 #if defined(CONFIG_ESP32S3_SPIRAM_FETCH_INSTRUCTIONS)
 void instruction_flash_page_info_init(void)
 {
-  uint32_t instr_page_cnt = ((uint32_t)&_instruction_reserved_end -
+  uint32_t instr_page_cnt = ((uint32_t)_instruction_reserved_end -
                             SOC_IROM_LOW + MMU_PAGE_SIZE - 1) /
                             MMU_PAGE_SIZE;
 
@@ -269,8 +269,8 @@ int IRAM_ATTR instruction_flash2spiram_offset(void)
 #if defined(CONFIG_ESP32_SPIRAM_RODATA)
 void rodata_flash_page_info_init(void)
 {
-  uint32_t rodata_page_cnt = ((uint32_t)&_rodata_reserved_end -
-                              ((uint32_t)&_rodata_reserved_start &
+  uint32_t rodata_page_cnt = ((uint32_t)_rodata_reserved_end -
+                              ((uint32_t)_rodata_reserved_start &
                               ~ (MMU_PAGE_SIZE - 1)) + MMU_PAGE_SIZE - 1) /
                               MMU_PAGE_SIZE;
 

--- a/arch/xtensa/src/esp32s3/esp32s3_spiram.h
+++ b/arch/xtensa/src/esp32s3/esp32s3_spiram.h
@@ -139,8 +139,8 @@ bool esp_spiram_is_initialized(void);
 
 #if defined(CONFIG_ESP32S3_SPIRAM_FETCH_INSTRUCTIONS)
 
-extern int _instruction_reserved_start;
-extern int _instruction_reserved_end;
+extern uint8_t _instruction_reserved_start[];
+extern uint8_t _instruction_reserved_end[];
 
 /**
  * @brief Get the start page number of the instruction in SPI flash
@@ -170,8 +170,8 @@ int instruction_flash2spiram_offset(void);
 
 #if defined(CONFIG_SPIRAM_RODATA)
 
-extern int _rodata_reserved_start;
-extern int _rodata_reserved_end;
+extern uint8_t _rodata_reserved_start[];
+extern uint8_t _rodata_reserved_end[];
 
 /**
  * @brief Get the start page number of the rodata in SPI flash

--- a/arch/z80/src/ez80/ez80_emac.c
+++ b/arch/z80/src/ez80/ez80_emac.c
@@ -89,8 +89,8 @@
  * into that region.
  */
 
-extern uintptr_t _RAM_ADDR_U_INIT_PARAM;
-#define ETH_RAMADDR (((uintptr_t)&_RAM_ADDR_U_INIT_PARAM << 16) + 0x00c000)
+extern uint8_t _RAM_ADDR_U_INIT_PARAM[];
+#define ETH_RAMADDR (((uintptr_t)_RAM_ADDR_U_INIT_PARAM << 16) + 0x00c000)
 
 #if CONFIG_NET_ETH_PKTSIZE > 1518
 #  error "MAXF size too big for this device"

--- a/arch/z80/src/ez80/z80_mem.h
+++ b/arch/z80/src/ez80/z80_mem.h
@@ -42,13 +42,13 @@
  */
 
 #ifndef CONFIG_HEAP1_BASE
-  extern unsigned long _heapbot;
-#  define CONFIG_HEAP1_BASE ((uint24_t)&_heapbot)
+  extern uint8_t _heapbot[];
+#  define CONFIG_HEAP1_BASE ((uint24_t)_heapbot)
 #endif
 
 #ifndef CONFIG_HEAP1_END
-  extern unsigned long _stack;
-#  define CONFIG_HEAP1_END (((uint24_t)&_stack) - CONFIG_IDLETHREAD_STACKSIZE)
+  extern uint8_t _stack[];
+#  define CONFIG_HEAP1_END (((uint24_t)_stack) - CONFIG_IDLETHREAD_STACKSIZE)
 #endif
 
 /************************************************************************************

--- a/boards/arm/cxd56xx/common/src/cxd56_crashdump.c
+++ b/boards/arm/cxd56xx/common/src/cxd56_crashdump.c
@@ -190,7 +190,7 @@ void board_crashdump(uintptr_t currentsp, void *tcb,
 #ifdef CONFIG_SMP
   pdump->info.stacks.interrupt.top = (uint32_t)arm_intstack_top();
 #else
-  pdump->info.stacks.interrupt.top = (uint32_t)&g_intstacktop;
+  pdump->info.stacks.interrupt.top = (uint32_t)g_intstacktop;
 #endif
   pdump->info.stacks.interrupt.size = (CONFIG_ARCH_INTERRUPTSTACK & ~3);
 

--- a/boards/arm/imxrt/imxrt1050-evk/kernel/imxrt_userspace.c
+++ b/boards/arm/imxrt/imxrt1050-evk/kernel/imxrt_userspace.c
@@ -50,25 +50,15 @@
  * Public Data
  ****************************************************************************/
 
-/* These 'addresses' of these values are setup by the linker script.
- * They are not actual uint32_t storage locations!
- * They are only used meaningfully in the following way:
- *
- *  - The linker script defines, for example, the symbol_sdata.
- *  - The declaration extern uint32_t _sdata; makes C happy.  C will believe
- *    that the value _sdata is the address of a uint32_t variable _data (it
- *    is not!).
- *  - We can recover the linker value then by simply taking the address of
- *    of _data.  like:  uint32_t *pdata = &_sdata;
- */
+/* These 'addresses' of these values are setup by the linker script. */
 
-extern uint32_t _stext;           /* Start of .text */
-extern uint32_t _etext;           /* End_1 of .text + .rodata */
-extern const uint32_t _eronly;    /* End+1 of read only section (.text + .rodata) */
-extern uint32_t _sdata;           /* Start of .data */
-extern uint32_t _edata;           /* End+1 of .data */
-extern uint32_t _sbss;            /* Start of .bss */
-extern uint32_t _ebss;            /* End+1 of .bss */
+extern uint8_t _stext[];           /* Start of .text */
+extern uint8_t _etext[];           /* End_1 of .text + .rodata */
+extern const uint8_t _eronly[];    /* End+1 of read only section (.text + .rodata) */
+extern uint8_t _sdata[];           /* Start of .data */
+extern uint8_t _edata[];           /* End+1 of .data */
+extern uint8_t _sbss[];            /* Start of .bss */
+extern uint8_t _ebss[];            /* End+1 of .bss */
 
 /* This is the user space entry point */
 
@@ -79,13 +69,13 @@ const struct userspace_s userspace locate_data(".userspace") =
   /* General memory map */
 
   .us_entrypoint    = (main_t)CONFIG_INIT_ENTRYPOINT,
-  .us_textstart     = (uintptr_t)&_stext,
-  .us_textend       = (uintptr_t)&_etext,
-  .us_datasource    = (uintptr_t)&_eronly,
-  .us_datastart     = (uintptr_t)&_sdata,
-  .us_dataend       = (uintptr_t)&_edata,
-  .us_bssstart      = (uintptr_t)&_sbss,
-  .us_bssend        = (uintptr_t)&_ebss,
+  .us_textstart     = (uintptr_t)_stext,
+  .us_textend       = (uintptr_t)_etext,
+  .us_datasource    = (uintptr_t)_eronly,
+  .us_datastart     = (uintptr_t)_sdata,
+  .us_dataend       = (uintptr_t)_edata,
+  .us_bssstart      = (uintptr_t)_sbss,
+  .us_bssend        = (uintptr_t)_ebss,
 
   /* Memory manager heap structure */
 

--- a/boards/arm/imxrt/imxrt1060-evk/kernel/imxrt_userspace.c
+++ b/boards/arm/imxrt/imxrt1060-evk/kernel/imxrt_userspace.c
@@ -50,25 +50,15 @@
  * Public Data
  ****************************************************************************/
 
-/* These 'addresses' of these values are setup by the linker script.
- * They are not actual uint32_t storage locations!
- * They are only used meaningfully in the following way:
- *
- *  - The linker script defines, for example, the symbol_sdata.
- *  - The declaration extern uint32_t _sdata; makes C happy.  C will believe
- *    that the value _sdata is the address of a uint32_t variable _data (it
- *    is not!).
- *  - We can recover the linker value then by simply taking the address of
- *    of _data.  like:  uint32_t *pdata = &_sdata;
- */
+/* These 'addresses' of these values are setup by the linker script. */
 
-extern uint32_t _stext;           /* Start of .text */
-extern uint32_t _etext;           /* End_1 of .text + .rodata */
-extern const uint32_t _eronly;    /* End+1 of read only section (.text + .rodata) */
-extern uint32_t _sdata;           /* Start of .data */
-extern uint32_t _edata;           /* End+1 of .data */
-extern uint32_t _sbss;            /* Start of .bss */
-extern uint32_t _ebss;            /* End+1 of .bss */
+extern uint8_t _stext[];           /* Start of .text */
+extern uint8_t _etext[];           /* End_1 of .text + .rodata */
+extern const uint8_t _eronly[];    /* End+1 of read only section (.text + .rodata) */
+extern uint8_t _sdata[];           /* Start of .data */
+extern uint8_t _edata[];           /* End+1 of .data */
+extern uint8_t _sbss[];            /* Start of .bss */
+extern uint8_t _ebss[];            /* End+1 of .bss */
 
 /* This is the user space entry point */
 
@@ -79,13 +69,13 @@ const struct userspace_s userspace locate_data(".userspace") =
   /* General memory map */
 
   .us_entrypoint    = (main_t)CONFIG_INIT_ENTRYPOINT,
-  .us_textstart     = (uintptr_t)&_stext,
-  .us_textend       = (uintptr_t)&_etext,
-  .us_datasource    = (uintptr_t)&_eronly,
-  .us_datastart     = (uintptr_t)&_sdata,
-  .us_dataend       = (uintptr_t)&_edata,
-  .us_bssstart      = (uintptr_t)&_sbss,
-  .us_bssend        = (uintptr_t)&_ebss,
+  .us_textstart     = (uintptr_t)_stext,
+  .us_textend       = (uintptr_t)_etext,
+  .us_datasource    = (uintptr_t)_eronly,
+  .us_datastart     = (uintptr_t)_sdata,
+  .us_dataend       = (uintptr_t)_edata,
+  .us_bssstart      = (uintptr_t)_sbss,
+  .us_bssend        = (uintptr_t)_ebss,
 
   /* Memory manager heap structure */
 

--- a/boards/arm/imxrt/imxrt1060-evk/src/imxrt_boot.c
+++ b/boards/arm/imxrt/imxrt1060-evk/src/imxrt_boot.c
@@ -67,7 +67,7 @@ void imxrt_ocram_initialize(void)
   for (src = (uint32_t *)(LOCATE_IN_SRC(g_boot_data.start) +
        g_boot_data.size),
        dest = (uint32_t *)(g_boot_data.start + g_boot_data.size);
-       dest < (uint32_t *) &_etext;
+       dest < (uint32_t *)_etext;
       )
     {
       *dest++ = *src++;

--- a/boards/arm/imxrt/imxrt1064-evk/kernel/imxrt_userspace.c
+++ b/boards/arm/imxrt/imxrt1064-evk/kernel/imxrt_userspace.c
@@ -50,25 +50,15 @@
  * Public Data
  ****************************************************************************/
 
-/* These 'addresses' of these values are setup by the linker script.
- * They are not actual uint32_t storage locations!
- * They are only used meaningfully in the following way:
- *
- *  - The linker script defines, for example, the symbol_sdata.
- *  - The declaration extern uint32_t _sdata; makes C happy.  C will believe
- *    that the value _sdata is the address of a uint32_t variable _data (it
- *    is not!).
- *  - We can recover the linker value then by simply taking the address of
- *    of _data.  like:  uint32_t *pdata = &_sdata;
- */
+/* These 'addresses' of these values are setup by the linker script. */
 
-extern uint32_t _stext;           /* Start of .text */
-extern uint32_t _etext;           /* End_1 of .text + .rodata */
-extern const uint32_t _eronly;    /* End+1 of read only section (.text + .rodata) */
-extern uint32_t _sdata;           /* Start of .data */
-extern uint32_t _edata;           /* End+1 of .data */
-extern uint32_t _sbss;            /* Start of .bss */
-extern uint32_t _ebss;            /* End+1 of .bss */
+extern uint8_t _stext[];           /* Start of .text */
+extern uint8_t _etext[];           /* End_1 of .text + .rodata */
+extern const uint8_t _eronly[];    /* End+1 of read only section (.text + .rodata) */
+extern uint8_t _sdata[];           /* Start of .data */
+extern uint8_t _edata[];           /* End+1 of .data */
+extern uint8_t _sbss[];            /* Start of .bss */
+extern uint8_t _ebss[];            /* End+1 of .bss */
 
 /* This is the user space entry point */
 
@@ -79,13 +69,13 @@ const struct userspace_s userspace locate_data(".userspace") =
   /* General memory map */
 
   .us_entrypoint    = (main_t)CONFIG_INIT_ENTRYPOINT,
-  .us_textstart     = (uintptr_t)&_stext,
-  .us_textend       = (uintptr_t)&_etext,
-  .us_datasource    = (uintptr_t)&_eronly,
-  .us_datastart     = (uintptr_t)&_sdata,
-  .us_dataend       = (uintptr_t)&_edata,
-  .us_bssstart      = (uintptr_t)&_sbss,
-  .us_bssend        = (uintptr_t)&_ebss,
+  .us_textstart     = (uintptr_t)_stext,
+  .us_textend       = (uintptr_t)_etext,
+  .us_datasource    = (uintptr_t)_eronly,
+  .us_datastart     = (uintptr_t)_sdata,
+  .us_dataend       = (uintptr_t)_edata,
+  .us_bssstart      = (uintptr_t)_sbss,
+  .us_bssend        = (uintptr_t)_ebss,
 
   /* Memory manager heap structure */
 

--- a/boards/arm/imxrt/imxrt1064-evk/src/imxrt_boot.c
+++ b/boards/arm/imxrt/imxrt1064-evk/src/imxrt_boot.c
@@ -67,7 +67,7 @@ void imxrt_ocram_initialize(void)
   src = (uint32_t *) (LOCATE_IN_SRC(g_boot_data.start) + g_boot_data.size);
   dest = (uint32_t *) (g_boot_data.start + g_boot_data.size);
 
-  while (dest < (uint32_t *) &_etext)
+  while (dest < (uint32_t *)_etext)
     {
       *dest++ = *src++;
     }

--- a/boards/arm/imxrt/teensy-4.x/kernel/imxrt_userspace.c
+++ b/boards/arm/imxrt/teensy-4.x/kernel/imxrt_userspace.c
@@ -50,25 +50,15 @@
  * Public Data
  ****************************************************************************/
 
-/* These 'addresses' of these values are setup by the linker script.
- * They are not actual uint32_t storage locations!
- * They are only used meaningfully in the following way:
- *
- *  - The linker script defines, for example, the symbol_sdata.
- *  - The declaration extern uint32_t _sdata; makes C happy.  C will believe
- *    that the value _sdata is the address of a uint32_t variable _data (it
- *    is not!).
- *  - We can recover the linker value then by simply taking the address of
- *    of _data.  like:  uint32_t *pdata = &_sdata;
- */
+/* These 'addresses' of these values are setup by the linker script. */
 
-extern uint32_t _stext;           /* Start of .text */
-extern uint32_t _etext;           /* End_1 of .text + .rodata */
-extern const uint32_t _eronly;    /* End+1 of read only section (.text + .rodata) */
-extern uint32_t _sdata;           /* Start of .data */
-extern uint32_t _edata;           /* End+1 of .data */
-extern uint32_t _sbss;            /* Start of .bss */
-extern uint32_t _ebss;            /* End+1 of .bss */
+extern uint8_t _stext[];           /* Start of .text */
+extern uint8_t _etext[];           /* End_1 of .text + .rodata */
+extern const uint8_t _eronly[];    /* End+1 of read only section (.text + .rodata) */
+extern uint8_t _sdata[];           /* Start of .data */
+extern uint8_t _edata[];           /* End+1 of .data */
+extern uint8_t _sbss[];            /* Start of .bss */
+extern uint8_t _ebss[];            /* End+1 of .bss */
 
 /* This is the user space entry point */
 
@@ -79,13 +69,13 @@ const struct userspace_s userspace locate_data(".userspace") =
   /* General memory map */
 
   .us_entrypoint    = (main_t)CONFIG_INIT_ENTRYPOINT,
-  .us_textstart     = (uintptr_t)&_stext,
-  .us_textend       = (uintptr_t)&_etext,
-  .us_datasource    = (uintptr_t)&_eronly,
-  .us_datastart     = (uintptr_t)&_sdata,
-  .us_dataend       = (uintptr_t)&_edata,
-  .us_bssstart      = (uintptr_t)&_sbss,
-  .us_bssend        = (uintptr_t)&_ebss,
+  .us_textstart     = (uintptr_t)_stext,
+  .us_textend       = (uintptr_t)_etext,
+  .us_datasource    = (uintptr_t)_eronly,
+  .us_datastart     = (uintptr_t)_sdata,
+  .us_dataend       = (uintptr_t)_edata,
+  .us_bssstart      = (uintptr_t)_sbss,
+  .us_bssend        = (uintptr_t)_ebss,
 
   /* Memory manager heap structure */
 

--- a/boards/arm/lc823450/lc823450-xgevk/kernel/lc823450_userspace.c
+++ b/boards/arm/lc823450/lc823450-xgevk/kernel/lc823450_userspace.c
@@ -51,25 +51,15 @@
  * Public Data
  ****************************************************************************/
 
-/* These 'addresses' of these values are setup by the linker script. They are
- * not actual uint32_t storage locations! They are only used meaningfully in
- * the following way:
- *
- *  - The linker script defines, for example, the symbol_sdata.
- *  - The declaration extern uint32_t _sdata; makes C happy.  C will believe
- *    that the value _sdata is the address of a uint32_t variable _data (it
- *    is not!).
- *  - We can recover the linker value then by simply taking the address of
- *    of _data.  like:  uint32_t *pdata = &_sdata;
- */
+/* These 'addresses' of these values are setup by the linker script. */
 
-extern uint32_t _stext;           /* Start of .text */
-extern uint32_t _etext;           /* End_1 of .text + .rodata */
-extern const uint32_t _eronly;    /* End+1 of read only section (.text + .rodata) */
-extern uint32_t _sdata;           /* Start of .data */
-extern uint32_t _edata;           /* End+1 of .data */
-extern uint32_t _sbss;            /* Start of .bss */
-extern uint32_t _ebss;            /* End+1 of .bss */
+extern uint8_t _stext[];           /* Start of .text */
+extern uint8_t _etext[];           /* End_1 of .text + .rodata */
+extern const uint8_t _eronly[];    /* End+1 of read only section (.text + .rodata) */
+extern uint8_t _sdata[];           /* Start of .data */
+extern uint8_t _edata[];           /* End+1 of .data */
+extern uint8_t _sbss[];            /* Start of .bss */
+extern uint8_t _ebss[];            /* End+1 of .bss */
 
 /* This is the user space entry point */
 
@@ -80,13 +70,13 @@ const struct userspace_s userspace locate_data(".userspace") =
   /* General memory map */
 
   .us_entrypoint    = (main_t)CONFIG_INIT_ENTRYPOINT,
-  .us_textstart     = (uintptr_t)&_stext,
-  .us_textend       = (uintptr_t)&_etext,
-  .us_datasource    = (uintptr_t)&_eronly,
-  .us_datastart     = (uintptr_t)&_sdata,
-  .us_dataend       = (uintptr_t)&_edata,
-  .us_bssstart      = (uintptr_t)&_sbss,
-  .us_bssend        = (uintptr_t)&_ebss,
+  .us_textstart     = (uintptr_t)_stext,
+  .us_textend       = (uintptr_t)_etext,
+  .us_datasource    = (uintptr_t)_eronly,
+  .us_datastart     = (uintptr_t)_sdata,
+  .us_dataend       = (uintptr_t)_edata,
+  .us_bssstart      = (uintptr_t)_sbss,
+  .us_bssend        = (uintptr_t)_ebss,
 
   /* Memory manager heap structure */
 

--- a/boards/arm/lpc17xx_40xx/lpc4088-devkit/kernel/lpc17_40_userspace.c
+++ b/boards/arm/lpc17xx_40xx/lpc4088-devkit/kernel/lpc17_40_userspace.c
@@ -50,25 +50,15 @@
  * Public Data
  ****************************************************************************/
 
-/* These 'addresses' of these values are setup by the linker script.
- * They are not actual uint32_t storage locations!
- * They are only used meaningfully in the following way:
- *
- *  - The linker script defines, for example, the symbol_sdata.
- *  - The declaration extern uint32_t _sdata; makes C happy.  C will believe
- *    that the value _sdata is the address of a uint32_t variable _data
- *    (it is not!).
- *  - We can recover the linker value then by simply taking the address of
- *    of _data.  like:  uint32_t *pdata = &_sdata;
- */
+/* These 'addresses' of these values are setup by the linker script. */
 
-extern uint32_t _stext;           /* Start of .text */
-extern uint32_t _etext;           /* End_1 of .text + .rodata */
-extern const uint32_t _eronly;    /* End+1 of read only section (.text + .rodata) */
-extern uint32_t _sdata;           /* Start of .data */
-extern uint32_t _edata;           /* End+1 of .data */
-extern uint32_t _sbss;            /* Start of .bss */
-extern uint32_t _ebss;            /* End+1 of .bss */
+extern uint8_t _stext[];           /* Start of .text */
+extern uint8_t _etext[];           /* End_1 of .text + .rodata */
+extern const uint8_t _eronly[];    /* End+1 of read only section (.text + .rodata) */
+extern uint8_t _sdata[];           /* Start of .data */
+extern uint8_t _edata[];           /* End+1 of .data */
+extern uint8_t _sbss[];            /* Start of .bss */
+extern uint8_t _ebss[];            /* End+1 of .bss */
 
 /* This is the user space entry point */
 
@@ -79,13 +69,13 @@ const struct userspace_s userspace locate_data(".userspace") =
   /* General memory map */
 
   .us_entrypoint    = (main_t)CONFIG_INIT_ENTRYPOINT,
-  .us_textstart     = (uintptr_t)&_stext,
-  .us_textend       = (uintptr_t)&_etext,
-  .us_datasource    = (uintptr_t)&_eronly,
-  .us_datastart     = (uintptr_t)&_sdata,
-  .us_dataend       = (uintptr_t)&_edata,
-  .us_bssstart      = (uintptr_t)&_sbss,
-  .us_bssend        = (uintptr_t)&_ebss,
+  .us_textstart     = (uintptr_t)_stext,
+  .us_textend       = (uintptr_t)_etext,
+  .us_datasource    = (uintptr_t)_eronly,
+  .us_datastart     = (uintptr_t)_sdata,
+  .us_dataend       = (uintptr_t)_edata,
+  .us_bssstart      = (uintptr_t)_sbss,
+  .us_bssend        = (uintptr_t)_ebss,
 
   /* Memory manager heap structure */
 

--- a/boards/arm/lpc17xx_40xx/lpc4088-quickstart/kernel/lpc17_40_userspace.c
+++ b/boards/arm/lpc17xx_40xx/lpc4088-quickstart/kernel/lpc17_40_userspace.c
@@ -50,25 +50,15 @@
  * Public Data
  ****************************************************************************/
 
-/* These 'addresses' of these values are setup by the linker script.
- * They are not actual uint32_t storage locations!
- * They are only used meaningfully in the following way:
- *
- *  - The linker script defines, for example, the symbol_sdata.
- *  - The declaration extern uint32_t _sdata; makes C happy.  C will believe
- *    that the value _sdata is the address of a uint32_t variable _data
- *    (it is not!).
- *  - We can recover the linker value then by simply taking the address of
- *    of _data.  like:  uint32_t *pdata = &_sdata;
- */
+/* These 'addresses' of these values are setup by the linker script. */
 
-extern uint32_t _stext;           /* Start of .text */
-extern uint32_t _etext;           /* End_1 of .text + .rodata */
-extern const uint32_t _eronly;    /* End+1 of read only section (.text + .rodata) */
-extern uint32_t _sdata;           /* Start of .data */
-extern uint32_t _edata;           /* End+1 of .data */
-extern uint32_t _sbss;            /* Start of .bss */
-extern uint32_t _ebss;            /* End+1 of .bss */
+extern uint8_t _stext[];           /* Start of .text */
+extern uint8_t _etext[];           /* End_1 of .text + .rodata */
+extern const uint8_t _eronly[];    /* End+1 of read only section (.text + .rodata) */
+extern uint8_t _sdata[];           /* Start of .data */
+extern uint8_t _edata[];           /* End+1 of .data */
+extern uint8_t _sbss[];            /* Start of .bss */
+extern uint8_t _ebss[];            /* End+1 of .bss */
 
 /* This is the user space entry point */
 
@@ -79,13 +69,13 @@ const struct userspace_s userspace locate_data(".userspace") =
   /* General memory map */
 
   .us_entrypoint    = (main_t)CONFIG_INIT_ENTRYPOINT,
-  .us_textstart     = (uintptr_t)&_stext,
-  .us_textend       = (uintptr_t)&_etext,
-  .us_datasource    = (uintptr_t)&_eronly,
-  .us_datastart     = (uintptr_t)&_sdata,
-  .us_dataend       = (uintptr_t)&_edata,
-  .us_bssstart      = (uintptr_t)&_sbss,
-  .us_bssend        = (uintptr_t)&_ebss,
+  .us_textstart     = (uintptr_t)_stext,
+  .us_textend       = (uintptr_t)_etext,
+  .us_datasource    = (uintptr_t)_eronly,
+  .us_datastart     = (uintptr_t)_sdata,
+  .us_dataend       = (uintptr_t)_edata,
+  .us_bssstart      = (uintptr_t)_sbss,
+  .us_bssend        = (uintptr_t)_ebss,
 
   /* Memory manager heap structure */
 

--- a/boards/arm/lpc17xx_40xx/open1788/kernel/lpc17_40_userspace.c
+++ b/boards/arm/lpc17xx_40xx/open1788/kernel/lpc17_40_userspace.c
@@ -50,25 +50,15 @@
  * Public Data
  ****************************************************************************/
 
-/* These 'addresses' of these values are setup by the linker script. They are
- * not actual uint32_t storage locations! They are only used meaningfully in
- * the following way:
- *
- *  - The linker script defines, for example, the symbol_sdata.
- *  - The declaration extern uint32_t _sdata; makes C happy.  C will believe
- *    that the value _sdata is the address of a uint32_t variable _data (it
- *    is not!).
- *  - We can recover the linker value then by simply taking the address of
- *    of _data.  like:  uint32_t *pdata = &_sdata;
- */
+/* These 'addresses' of these values are setup by the linker script. */
 
-extern uint32_t _stext;           /* Start of .text */
-extern uint32_t _etext;           /* End_1 of .text + .rodata */
-extern const uint32_t _eronly;    /* End+1 of read only section (.text + .rodata) */
-extern uint32_t _sdata;           /* Start of .data */
-extern uint32_t _edata;           /* End+1 of .data */
-extern uint32_t _sbss;            /* Start of .bss */
-extern uint32_t _ebss;            /* End+1 of .bss */
+extern uint8_t _stext[];           /* Start of .text */
+extern uint8_t _etext[];           /* End_1 of .text + .rodata */
+extern const uint8_t _eronly[];    /* End+1 of read only section (.text + .rodata) */
+extern uint8_t _sdata[];           /* Start of .data */
+extern uint8_t _edata[];           /* End+1 of .data */
+extern uint8_t _sbss[];            /* Start of .bss */
+extern uint8_t _ebss[];            /* End+1 of .bss */
 
 /* This is the user space entry point */
 
@@ -79,13 +69,13 @@ const struct userspace_s userspace locate_data(".userspace") =
   /* General memory map */
 
   .us_entrypoint    = (main_t)CONFIG_INIT_ENTRYPOINT,
-  .us_textstart     = (uintptr_t)&_stext,
-  .us_textend       = (uintptr_t)&_etext,
-  .us_datasource    = (uintptr_t)&_eronly,
-  .us_datastart     = (uintptr_t)&_sdata,
-  .us_dataend       = (uintptr_t)&_edata,
-  .us_bssstart      = (uintptr_t)&_sbss,
-  .us_bssend        = (uintptr_t)&_ebss,
+  .us_textstart     = (uintptr_t)_stext,
+  .us_textend       = (uintptr_t)_etext,
+  .us_datasource    = (uintptr_t)_eronly,
+  .us_datastart     = (uintptr_t)_sdata,
+  .us_dataend       = (uintptr_t)_edata,
+  .us_bssstart      = (uintptr_t)_sbss,
+  .us_bssend        = (uintptr_t)_ebss,
 
   /* Memory manager heap structure */
 

--- a/boards/arm/lpc17xx_40xx/pnev5180b/kernel/lpc17_40_userspace.c
+++ b/boards/arm/lpc17xx_40xx/pnev5180b/kernel/lpc17_40_userspace.c
@@ -50,25 +50,15 @@
  * Public Data
  ****************************************************************************/
 
-/* These 'addresses' of these values are setup by the linker script. They are
- * not actual uint32_t storage locations! They are only used meaningfully in
- * the following way:
- *
- *  - The linker script defines, for example, the symbol_sdata.
- *  - The declaration extern uint32_t _sdata; makes C happy.  C will believe
- *    that the value _sdata is the address of a uint32_t variable _data (it
- *    is not!).
- *  - We can recover the linker value then by simply taking the address of
- *    of _data.  like:  uint32_t *pdata = &_sdata;
- */
+/* These 'addresses' of these values are setup by the linker script. */
 
-extern uint32_t _stext;           /* Start of .text */
-extern uint32_t _etext;           /* End_1 of .text + .rodata */
-extern const uint32_t _eronly;    /* End+1 of read only section (.text + .rodata) */
-extern uint32_t _sdata;           /* Start of .data */
-extern uint32_t _edata;           /* End+1 of .data */
-extern uint32_t _sbss;            /* Start of .bss */
-extern uint32_t _ebss;            /* End+1 of .bss */
+extern uint8_t _stext[];           /* Start of .text */
+extern uint8_t _etext[];           /* End_1 of .text + .rodata */
+extern const uint8_t _eronly[];    /* End+1 of read only section (.text + .rodata) */
+extern uint8_t _sdata[];           /* Start of .data */
+extern uint8_t _edata[];           /* End+1 of .data */
+extern uint8_t _sbss[];            /* Start of .bss */
+extern uint8_t _ebss[];            /* End+1 of .bss */
 
 /* This is the user space entry point */
 
@@ -79,13 +69,13 @@ const struct userspace_s userspace locate_data(".userspace") =
   /* General memory map */
 
   .us_entrypoint    = (main_t)CONFIG_INIT_ENTRYPOINT,
-  .us_textstart     = (uintptr_t)&_stext,
-  .us_textend       = (uintptr_t)&_etext,
-  .us_datasource    = (uintptr_t)&_eronly,
-  .us_datastart     = (uintptr_t)&_sdata,
-  .us_dataend       = (uintptr_t)&_edata,
-  .us_bssstart      = (uintptr_t)&_sbss,
-  .us_bssend        = (uintptr_t)&_ebss,
+  .us_textstart     = (uintptr_t)_stext,
+  .us_textend       = (uintptr_t)_etext,
+  .us_datasource    = (uintptr_t)_eronly,
+  .us_datastart     = (uintptr_t)_sdata,
+  .us_dataend       = (uintptr_t)_edata,
+  .us_bssstart      = (uintptr_t)_sbss,
+  .us_bssend        = (uintptr_t)_ebss,
 
   /* Memory manager heap structure */
 

--- a/boards/arm/lpc43xx/bambino-200e/kernel/lpc43_userspace.c
+++ b/boards/arm/lpc43xx/bambino-200e/kernel/lpc43_userspace.c
@@ -51,25 +51,15 @@
  * Public Data
  ****************************************************************************/
 
-/* These 'addresses' of these values are setup by the linker script. They are
- * not actual uint32_t storage locations! They are only used meaningfully in
- * the following way:
- *
- *  - The linker script defines, for example, the symbol_sdata.
- *  - The declaration extern uint32_t _sdata; makes C happy.  C will believe
- *    that the value _sdata is the address of a uint32_t variable _data (it
- *    is not!).
- *  - We can recover the linker value then by simply taking the address of
- *    of _data.  like:  uint32_t *pdata = &_sdata;
- */
+/* These 'addresses' of these values are setup by the linker script. */
 
-extern uint32_t _stext;           /* Start of .text */
-extern uint32_t _etext;           /* End_1 of .text + .rodata */
-extern const uint32_t _eronly;    /* End+1 of read only section (.text + .rodata) */
-extern uint32_t _sdata;           /* Start of .data */
-extern uint32_t _edata;           /* End+1 of .data */
-extern uint32_t _sbss;            /* Start of .bss */
-extern uint32_t _ebss;            /* End+1 of .bss */
+extern uint8_t _stext[];           /* Start of .text */
+extern uint8_t _etext[];           /* End_1 of .text + .rodata */
+extern const uint8_t _eronly[];    /* End+1 of read only section (.text + .rodata) */
+extern uint8_t _sdata[];           /* Start of .data */
+extern uint8_t _edata[];           /* End+1 of .data */
+extern uint8_t _sbss[];            /* Start of .bss */
+extern uint8_t _ebss[];            /* End+1 of .bss */
 
 /* This is the user space entry point */
 
@@ -80,13 +70,13 @@ const struct userspace_s userspace locate_data(".userspace") =
   /* General memory map */
 
   .us_entrypoint    = (main_t)CONFIG_INIT_ENTRYPOINT,
-  .us_textstart     = (uintptr_t)&_stext,
-  .us_textend       = (uintptr_t)&_etext,
-  .us_datasource    = (uintptr_t)&_eronly,
-  .us_datastart     = (uintptr_t)&_sdata,
-  .us_dataend       = (uintptr_t)&_edata,
-  .us_bssstart      = (uintptr_t)&_sbss,
-  .us_bssend        = (uintptr_t)&_ebss,
+  .us_textstart     = (uintptr_t)_stext,
+  .us_textend       = (uintptr_t)_etext,
+  .us_datasource    = (uintptr_t)_eronly,
+  .us_datastart     = (uintptr_t)_sdata,
+  .us_dataend       = (uintptr_t)_edata,
+  .us_bssstart      = (uintptr_t)_sbss,
+  .us_bssend        = (uintptr_t)_ebss,
 
   /* Memory manager heap structure */
 

--- a/boards/arm/sam34/sam3u-ek/kernel/sam_userspace.c
+++ b/boards/arm/sam34/sam3u-ek/kernel/sam_userspace.c
@@ -50,25 +50,15 @@
  * Public Data
  ****************************************************************************/
 
-/* These 'addresses' of these values are setup by the linker script.
- * They are not actual uint32_t storage locations!
- * They are only used meaningfully in the following way:
- *
- *  - The linker script defines, for example, the symbol_sdata.
- *  - The declaration extern uint32_t _sdata; makes C happy.  C will believe
- *    that the value _sdata is the address of a uint32_t variable _data (it
- *    is not!).
- *  - We can recover the linker value then by simply taking the address of
- *    of _data.  like:  uint32_t *pdata = &_sdata;
- */
+/* These 'addresses' of these values are setup by the linker script. */
 
-extern uint32_t _stext;           /* Start of .text */
-extern uint32_t _etext;           /* End_1 of .text + .rodata */
-extern const uint32_t _eronly;    /* End+1 of read only section (.text + .rodata) */
-extern uint32_t _sdata;           /* Start of .data */
-extern uint32_t _edata;           /* End+1 of .data */
-extern uint32_t _sbss;            /* Start of .bss */
-extern uint32_t _ebss;            /* End+1 of .bss */
+extern uint8_t _stext[];           /* Start of .text */
+extern uint8_t _etext[];           /* End_1 of .text + .rodata */
+extern const uint8_t _eronly[];    /* End+1 of read only section (.text + .rodata) */
+extern uint8_t _sdata[];           /* Start of .data */
+extern uint8_t _edata[];           /* End+1 of .data */
+extern uint8_t _sbss[];            /* Start of .bss */
+extern uint8_t _ebss[];            /* End+1 of .bss */
 
 /* This is the user space entry point */
 
@@ -79,13 +69,13 @@ const struct userspace_s userspace locate_data(".userspace") =
   /* General memory map */
 
   .us_entrypoint    = (main_t)CONFIG_INIT_ENTRYPOINT,
-  .us_textstart     = (uintptr_t)&_stext,
-  .us_textend       = (uintptr_t)&_etext,
-  .us_datasource    = (uintptr_t)&_eronly,
-  .us_datastart     = (uintptr_t)&_sdata,
-  .us_dataend       = (uintptr_t)&_edata,
-  .us_bssstart      = (uintptr_t)&_sbss,
-  .us_bssend        = (uintptr_t)&_ebss,
+  .us_textstart     = (uintptr_t)_stext,
+  .us_textend       = (uintptr_t)_etext,
+  .us_datasource    = (uintptr_t)_eronly,
+  .us_datastart     = (uintptr_t)_sdata,
+  .us_dataend       = (uintptr_t)_edata,
+  .us_bssstart      = (uintptr_t)_sbss,
+  .us_bssend        = (uintptr_t)_ebss,
 
   /* Memory manager heap structure */
 

--- a/boards/arm/samv7/same70-qmtech/kernel/sam_userspace.c
+++ b/boards/arm/samv7/same70-qmtech/kernel/sam_userspace.c
@@ -50,25 +50,15 @@
  * Public Data
  ****************************************************************************/
 
-/* These 'addresses' of these values are setup by the linker script.
- * They are not actual uint32_t storage locations!
- * They are only used meaningfully in the following way:
- *
- *  - The linker script defines, for example, the symbol_sdata.
- *  - The declaration extern uint32_t _sdata; makes C happy.  C will believe
- *    that the value _sdata is the address of a uint32_t variable _data (it
- *    is not!).
- *  - We can recover the linker value then by simply taking the address of
- *    of _data.  like:  uint32_t *pdata = &_sdata;
- */
+/* These 'addresses' of these values are setup by the linker script. */
 
-extern uint32_t _stext;           /* Start of .text */
-extern uint32_t _etext;           /* End_1 of .text + .rodata */
-extern const uint32_t _eronly;    /* End+1 of read only section (.text + .rodata) */
-extern uint32_t _sdata;           /* Start of .data */
-extern uint32_t _edata;           /* End+1 of .data */
-extern uint32_t _sbss;            /* Start of .bss */
-extern uint32_t _ebss;            /* End+1 of .bss */
+extern uint8_t _stext[];           /* Start of .text */
+extern uint8_t _etext[];           /* End_1 of .text + .rodata */
+extern const uint8_t _eronly[];    /* End+1 of read only section (.text + .rodata) */
+extern uint8_t _sdata[];           /* Start of .data */
+extern uint8_t _edata[];           /* End+1 of .data */
+extern uint8_t _sbss[];            /* Start of .bss */
+extern uint8_t _ebss[];            /* End+1 of .bss */
 
 /* This is the user space entry point */
 
@@ -79,13 +69,13 @@ const struct userspace_s userspace locate_data(".userspace") =
   /* General memory map */
 
   .us_entrypoint    = (main_t)CONFIG_INIT_ENTRYPOINT,
-  .us_textstart     = (uintptr_t)&_stext,
-  .us_textend       = (uintptr_t)&_etext,
-  .us_datasource    = (uintptr_t)&_eronly,
-  .us_datastart     = (uintptr_t)&_sdata,
-  .us_dataend       = (uintptr_t)&_edata,
-  .us_bssstart      = (uintptr_t)&_sbss,
-  .us_bssend        = (uintptr_t)&_ebss,
+  .us_textstart     = (uintptr_t)_stext,
+  .us_textend       = (uintptr_t)_etext,
+  .us_datasource    = (uintptr_t)_eronly,
+  .us_datastart     = (uintptr_t)_sdata,
+  .us_dataend       = (uintptr_t)_edata,
+  .us_bssstart      = (uintptr_t)_sbss,
+  .us_bssend        = (uintptr_t)_ebss,
 
   /* Memory manager heap structure */
 

--- a/boards/arm/samv7/same70-xplained/kernel/sam_userspace.c
+++ b/boards/arm/samv7/same70-xplained/kernel/sam_userspace.c
@@ -50,25 +50,15 @@
  * Public Data
  ****************************************************************************/
 
-/* These 'addresses' of these values are setup by the linker script.
- * They are not actual uint32_t storage locations!
- * They are only used meaningfully in the following way:
- *
- *  - The linker script defines, for example, the symbol_sdata.
- *  - The declaration extern uint32_t _sdata; makes C happy.  C will believe
- *    that the value _sdata is the address of a uint32_t variable _data (it
- *    is not!).
- *  - We can recover the linker value then by simply taking the address of
- *    of _data.  like:  uint32_t *pdata = &_sdata;
- */
+/* These 'addresses' of these values are setup by the linker script. */
 
-extern uint32_t _stext;           /* Start of .text */
-extern uint32_t _etext;           /* End_1 of .text + .rodata */
-extern const uint32_t _eronly;    /* End+1 of read only section (.text + .rodata) */
-extern uint32_t _sdata;           /* Start of .data */
-extern uint32_t _edata;           /* End+1 of .data */
-extern uint32_t _sbss;            /* Start of .bss */
-extern uint32_t _ebss;            /* End+1 of .bss */
+extern uint8_t _stext[];           /* Start of .text */
+extern uint8_t _etext[];           /* End_1 of .text + .rodata */
+extern const uint8_t _eronly[];    /* End+1 of read only section (.text + .rodata) */
+extern uint8_t _sdata[];           /* Start of .data */
+extern uint8_t _edata[];           /* End+1 of .data */
+extern uint8_t _sbss[];            /* Start of .bss */
+extern uint8_t _ebss[];            /* End+1 of .bss */
 
 /* This is the user space entry point */
 
@@ -79,13 +69,13 @@ const struct userspace_s userspace locate_data(".userspace") =
   /* General memory map */
 
   .us_entrypoint    = (main_t)CONFIG_INIT_ENTRYPOINT,
-  .us_textstart     = (uintptr_t)&_stext,
-  .us_textend       = (uintptr_t)&_etext,
-  .us_datasource    = (uintptr_t)&_eronly,
-  .us_datastart     = (uintptr_t)&_sdata,
-  .us_dataend       = (uintptr_t)&_edata,
-  .us_bssstart      = (uintptr_t)&_sbss,
-  .us_bssend        = (uintptr_t)&_ebss,
+  .us_textstart     = (uintptr_t)_stext,
+  .us_textend       = (uintptr_t)_etext,
+  .us_datasource    = (uintptr_t)_eronly,
+  .us_datastart     = (uintptr_t)_sdata,
+  .us_dataend       = (uintptr_t)_edata,
+  .us_bssstart      = (uintptr_t)_sbss,
+  .us_bssend        = (uintptr_t)_ebss,
 
   /* Memory manager heap structure */
 

--- a/boards/arm/samv7/samv71-xult/kernel/sam_userspace.c
+++ b/boards/arm/samv7/samv71-xult/kernel/sam_userspace.c
@@ -50,25 +50,15 @@
  * Public Data
  ****************************************************************************/
 
-/* These 'addresses' of these values are setup by the linker script. They are
- * not actual uint32_t storage locations! They are only used meaningfully in
- * the following way:
- *
- *  - The linker script defines, for example, the symbol_sdata.
- *  - The declaration extern uint32_t _sdata; makes C happy.  C will believe
- *    that the value _sdata is the address of a uint32_t variable _data (it
- *    is not!).
- *  - We can recover the linker value then by simply taking the address of
- *    of _data.  like:  uint32_t *pdata = &_sdata;
- */
+/* These 'addresses' of these values are setup by the linker script. */
 
-extern uint32_t _stext;           /* Start of .text */
-extern uint32_t _etext;           /* End_1 of .text + .rodata */
-extern const uint32_t _eronly;    /* End+1 of read only section (.text + .rodata) */
-extern uint32_t _sdata;           /* Start of .data */
-extern uint32_t _edata;           /* End+1 of .data */
-extern uint32_t _sbss;            /* Start of .bss */
-extern uint32_t _ebss;            /* End+1 of .bss */
+extern uint8_t _stext[];           /* Start of .text */
+extern uint8_t _etext[];           /* End_1 of .text + .rodata */
+extern const uint8_t _eronly[];    /* End+1 of read only section (.text + .rodata) */
+extern uint8_t _sdata[];           /* Start of .data */
+extern uint8_t _edata[];           /* End+1 of .data */
+extern uint8_t _sbss[];            /* Start of .bss */
+extern uint8_t _ebss[];            /* End+1 of .bss */
 
 /* This is the user space entry point */
 
@@ -79,13 +69,13 @@ const struct userspace_s userspace locate_data(".userspace") =
   /* General memory map */
 
   .us_entrypoint    = (main_t)CONFIG_INIT_ENTRYPOINT,
-  .us_textstart     = (uintptr_t)&_stext,
-  .us_textend       = (uintptr_t)&_etext,
-  .us_datasource    = (uintptr_t)&_eronly,
-  .us_datastart     = (uintptr_t)&_sdata,
-  .us_dataend       = (uintptr_t)&_edata,
-  .us_bssstart      = (uintptr_t)&_sbss,
-  .us_bssend        = (uintptr_t)&_ebss,
+  .us_textstart     = (uintptr_t)_stext,
+  .us_textend       = (uintptr_t)_etext,
+  .us_datasource    = (uintptr_t)_eronly,
+  .us_datastart     = (uintptr_t)_sdata,
+  .us_dataend       = (uintptr_t)_edata,
+  .us_bssstart      = (uintptr_t)_sbss,
+  .us_bssend        = (uintptr_t)_ebss,
 
   /* Memory manager heap structure */
 

--- a/boards/arm/stm32/clicker2-stm32/kernel/stm32_userspace.c
+++ b/boards/arm/stm32/clicker2-stm32/kernel/stm32_userspace.c
@@ -51,25 +51,15 @@
  * Public Data
  ****************************************************************************/
 
-/* These 'addresses' of these values are setup by the linker script. They are
- * not actual uint32_t storage locations! They are only used meaningfully in
- * the following way:
- *
- *  - The linker script defines, for example, the symbol_sdata.
- *  - The declaration extern uint32_t _sdata; makes C happy.  C will believe
- *    that the value _sdata is the address of a uint32_t variable _data (it
- *    is not!).
- *  - We can recover the linker value then by simply taking the address of
- *    of _data.  like:  uint32_t *pdata = &_sdata;
- */
+/* These 'addresses' of these values are setup by the linker script. */
 
-extern uint32_t _stext;           /* Start of .text */
-extern uint32_t _etext;           /* End_1 of .text + .rodata */
-extern const uint32_t _eronly;    /* End+1 of read only section (.text + .rodata) */
-extern uint32_t _sdata;           /* Start of .data */
-extern uint32_t _edata;           /* End+1 of .data */
-extern uint32_t _sbss;            /* Start of .bss */
-extern uint32_t _ebss;            /* End+1 of .bss */
+extern uint8_t _stext[];           /* Start of .text */
+extern uint8_t _etext[];           /* End_1 of .text + .rodata */
+extern const uint8_t _eronly[];    /* End+1 of read only section (.text + .rodata) */
+extern uint8_t _sdata[];           /* Start of .data */
+extern uint8_t _edata[];           /* End+1 of .data */
+extern uint8_t _sbss[];            /* Start of .bss */
+extern uint8_t _ebss[];            /* End+1 of .bss */
 
 /* This is the user space entry point */
 
@@ -80,13 +70,13 @@ const struct userspace_s userspace locate_data(".userspace") =
   /* General memory map */
 
   .us_entrypoint    = (main_t)CONFIG_INIT_ENTRYPOINT,
-  .us_textstart     = (uintptr_t)&_stext,
-  .us_textend       = (uintptr_t)&_etext,
-  .us_datasource    = (uintptr_t)&_eronly,
-  .us_datastart     = (uintptr_t)&_sdata,
-  .us_dataend       = (uintptr_t)&_edata,
-  .us_bssstart      = (uintptr_t)&_sbss,
-  .us_bssend        = (uintptr_t)&_ebss,
+  .us_textstart     = (uintptr_t)_stext,
+  .us_textend       = (uintptr_t)_etext,
+  .us_datasource    = (uintptr_t)_eronly,
+  .us_datastart     = (uintptr_t)_sdata,
+  .us_dataend       = (uintptr_t)_edata,
+  .us_bssstart      = (uintptr_t)_sbss,
+  .us_bssend        = (uintptr_t)_ebss,
 
   /* Memory manager heap structure */
 

--- a/boards/arm/stm32/mikroe-stm32f4/kernel/stm32_userspace.c
+++ b/boards/arm/stm32/mikroe-stm32f4/kernel/stm32_userspace.c
@@ -50,25 +50,15 @@
  * Public Data
  ****************************************************************************/
 
-/* These 'addresses' of these values are setup by the linker script. They are
- * not actual uint32_t storage locations! They are only used meaningfully in
- * the following way:
- *
- *  - The linker script defines, for example, the symbol_sdata.
- *  - The declaration extern uint32_t _sdata; makes C happy.  C will believe
- *    that the value _sdata is the address of a uint32_t variable _data (it
- *    is not!).
- *  - We can recover the linker value then by simply taking the address of
- *    of _data.  like:  uint32_t *pdata = &_sdata;
- */
+/* These 'addresses' of these values are setup by the linker script. */
 
-extern uint32_t _stext;           /* Start of .text */
-extern uint32_t _etext;           /* End_1 of .text + .rodata */
-extern const uint32_t _eronly;    /* End+1 of read only section (.text + .rodata) */
-extern uint32_t _sdata;           /* Start of .data */
-extern uint32_t _edata;           /* End+1 of .data */
-extern uint32_t _sbss;            /* Start of .bss */
-extern uint32_t _ebss;            /* End+1 of .bss */
+extern uint8_t _stext[];           /* Start of .text */
+extern uint8_t _etext[];           /* End_1 of .text + .rodata */
+extern const uint8_t _eronly[];    /* End+1 of read only section (.text + .rodata) */
+extern uint8_t _sdata[];           /* Start of .data */
+extern uint8_t _edata[];           /* End+1 of .data */
+extern uint8_t _sbss[];            /* Start of .bss */
+extern uint8_t _ebss[];            /* End+1 of .bss */
 
 /* This is the user space entry point */
 
@@ -79,13 +69,13 @@ const struct userspace_s userspace locate_data(".userspace") =
   /* General memory map */
 
   .us_entrypoint    = (main_t)CONFIG_INIT_ENTRYPOINT,
-  .us_textstart     = (uintptr_t)&_stext,
-  .us_textend       = (uintptr_t)&_etext,
-  .us_datasource    = (uintptr_t)&_eronly,
-  .us_datastart     = (uintptr_t)&_sdata,
-  .us_dataend       = (uintptr_t)&_edata,
-  .us_bssstart      = (uintptr_t)&_sbss,
-  .us_bssend        = (uintptr_t)&_ebss,
+  .us_textstart     = (uintptr_t)_stext,
+  .us_textend       = (uintptr_t)_etext,
+  .us_datasource    = (uintptr_t)_eronly,
+  .us_datastart     = (uintptr_t)_sdata,
+  .us_dataend       = (uintptr_t)_edata,
+  .us_bssstart      = (uintptr_t)_sbss,
+  .us_bssend        = (uintptr_t)_ebss,
 
   /* Memory manager heap structure */
 

--- a/boards/arm/stm32/nucleo-f429zi/src/stm32_bbsram.c
+++ b/boards/arm/stm32/nucleo-f429zi/src/stm32_bbsram.c
@@ -457,7 +457,7 @@ void board_crashdump(uintptr_t currentsp, void *tcb,
 #if CONFIG_ARCH_INTERRUPTSTACK > 3
   /* Get the limits on the interrupt stack memory */
 
-  pdump->info.stacks.interrupt.top = (uint32_t)&g_intstacktop;
+  pdump->info.stacks.interrupt.top = (uint32_t)g_intstacktop;
   pdump->info.stacks.interrupt.size = (CONFIG_ARCH_INTERRUPTSTACK & ~3);
 
   /* If In interrupt Context save the interrupt stack data centered

--- a/boards/arm/stm32/olimex-stm32-p407/kernel/stm32_userspace.c
+++ b/boards/arm/stm32/olimex-stm32-p407/kernel/stm32_userspace.c
@@ -51,25 +51,15 @@
  * Public Data
  ****************************************************************************/
 
-/* These 'addresses' of these values are setup by the linker script. They are
- * not actual uint32_t storage locations! They are only used meaningfully in
- * the following way:
- *
- *  - The linker script defines, for example, the symbol_sdata.
- *  - The declaration extern uint32_t _sdata; makes C happy.  C will believe
- *    that the value _sdata is the address of a uint32_t variable _data (it
- *    is not!).
- *  - We can recover the linker value then by simply taking the address of
- *    of _data.  like:  uint32_t *pdata = &_sdata;
- */
+/* These 'addresses' of these values are setup by the linker script. */
 
-extern uint32_t _stext;           /* Start of .text */
-extern uint32_t _etext;           /* End_1 of .text + .rodata */
-extern const uint32_t _eronly;    /* End+1 of read only section (.text + .rodata) */
-extern uint32_t _sdata;           /* Start of .data */
-extern uint32_t _edata;           /* End+1 of .data */
-extern uint32_t _sbss;            /* Start of .bss */
-extern uint32_t _ebss;            /* End+1 of .bss */
+extern uint8_t _stext[];           /* Start of .text */
+extern uint8_t _etext[];           /* End_1 of .text + .rodata */
+extern const uint8_t _eronly[];    /* End+1 of read only section (.text + .rodata) */
+extern uint8_t _sdata[];           /* Start of .data */
+extern uint8_t _edata[];           /* End+1 of .data */
+extern uint8_t _sbss[];            /* Start of .bss */
+extern uint8_t _ebss[];            /* End+1 of .bss */
 
 /* This is the user space entry point */
 
@@ -80,13 +70,13 @@ const struct userspace_s userspace locate_data(".userspace") =
   /* General memory map */
 
   .us_entrypoint    = (main_t)CONFIG_INIT_ENTRYPOINT,
-  .us_textstart     = (uintptr_t)&_stext,
-  .us_textend       = (uintptr_t)&_etext,
-  .us_datasource    = (uintptr_t)&_eronly,
-  .us_datastart     = (uintptr_t)&_sdata,
-  .us_dataend       = (uintptr_t)&_edata,
-  .us_bssstart      = (uintptr_t)&_sbss,
-  .us_bssend        = (uintptr_t)&_ebss,
+  .us_textstart     = (uintptr_t)_stext,
+  .us_textend       = (uintptr_t)_etext,
+  .us_datasource    = (uintptr_t)_eronly,
+  .us_datastart     = (uintptr_t)_sdata,
+  .us_dataend       = (uintptr_t)_edata,
+  .us_bssstart      = (uintptr_t)_sbss,
+  .us_bssend        = (uintptr_t)_ebss,
 
   /* Memory manager heap structure */
 

--- a/boards/arm/stm32/omnibusf4/kernel/stm32_userspace.c
+++ b/boards/arm/stm32/omnibusf4/kernel/stm32_userspace.c
@@ -51,25 +51,15 @@
  * Public Data
  ****************************************************************************/
 
-/* These 'addresses' of these values are setup by the linker script.  They
- * are ot actual uint32_t storage locations! They are only used meaningfully
- * in the following way:
- *
- *  - The linker script defines, for example, the symbol_sdata.
- *  - The declaration extern uint32_t _sdata; makes C happy.  C will believe
- *    that the value _sdata is the address of a uint32_t variable _data (it
- *    is not!).
- *  - We can recover the linker value then by simply taking the address of
- *    of _data.  like:  uint32_t *pdata = &_sdata;
- */
+/* These 'addresses' of these values are setup by the linker script. */
 
-extern uint32_t _stext;           /* Start of .text */
-extern uint32_t _etext;           /* End_1 of .text + .rodata */
-extern const uint32_t _eronly;    /* End+1 of read only section (.text + .rodata) */
-extern uint32_t _sdata;           /* Start of .data */
-extern uint32_t _edata;           /* End+1 of .data */
-extern uint32_t _sbss;            /* Start of .bss */
-extern uint32_t _ebss;            /* End+1 of .bss */
+extern uint8_t _stext[];           /* Start of .text */
+extern uint8_t _etext[];           /* End_1 of .text + .rodata */
+extern const uint8_t _eronly[];    /* End+1 of read only section (.text + .rodata) */
+extern uint8_t _sdata[];           /* Start of .data */
+extern uint8_t _edata[];           /* End+1 of .data */
+extern uint8_t _sbss[];            /* Start of .bss */
+extern uint8_t _ebss[];            /* End+1 of .bss */
 
 /* This is the user space entry point */
 
@@ -80,13 +70,13 @@ const struct userspace_s userspace locate_data(".userspace") =
   /* General memory map */
 
   .us_entrypoint    = (main_t)CONFIG_INIT_ENTRYPOINT,
-  .us_textstart     = (uintptr_t)&_stext,
-  .us_textend       = (uintptr_t)&_etext,
-  .us_datasource    = (uintptr_t)&_eronly,
-  .us_datastart     = (uintptr_t)&_sdata,
-  .us_dataend       = (uintptr_t)&_edata,
-  .us_bssstart      = (uintptr_t)&_sbss,
-  .us_bssend        = (uintptr_t)&_ebss,
+  .us_textstart     = (uintptr_t)_stext,
+  .us_textend       = (uintptr_t)_etext,
+  .us_datasource    = (uintptr_t)_eronly,
+  .us_datastart     = (uintptr_t)_sdata,
+  .us_dataend       = (uintptr_t)_edata,
+  .us_bssstart      = (uintptr_t)_sbss,
+  .us_bssend        = (uintptr_t)_ebss,
 
   /* Memory manager heap structure */
 

--- a/boards/arm/stm32/photon/src/dfu_signature.c
+++ b/boards/arm/stm32/photon/src/dfu_signature.c
@@ -43,8 +43,8 @@ begin_packed_struct struct dfu_signature
  * Public Data
  ****************************************************************************/
 
-extern uint32_t _firmware_start;
-extern uint32_t _firmware_end;
+extern uint8_t _firmware_start[];
+extern uint8_t _firmware_end[];
 
 /****************************************************************************
  * Private Data
@@ -53,12 +53,12 @@ extern uint32_t _firmware_end;
 __attribute__((externally_visible)) locate_data(".dfu_signature")
 const struct dfu_signature dfu_sign =
 {
-  (uint32_t)&_firmware_start, /* Flash image start address */
-  (uint32_t)&_firmware_end,   /* Flash image end address */
-  {0, 0, 0, 0},               /* reserved */
-  6,                          /* Current board is photon */
-  4, 1,                       /* Firmware is "system-part1" */
-  {0, 0, 0, 0, 0, 0, 0, 0},   /* reserved */
+  (uint32_t)_firmware_start, /* Flash image start address */
+  (uint32_t)_firmware_end,   /* Flash image end address */
+  {0, 0, 0, 0},              /* reserved */
+  6,                         /* Current board is photon */
+  4, 1,                      /* Firmware is "system-part1" */
+  {0, 0, 0, 0, 0, 0, 0, 0},  /* reserved */
 };
 
 /****************************************************************************

--- a/boards/arm/stm32/stm3240g-eval/kernel/stm32_userspace.c
+++ b/boards/arm/stm32/stm3240g-eval/kernel/stm32_userspace.c
@@ -50,25 +50,15 @@
  * Public Data
  ****************************************************************************/
 
-/* These 'addresses' of these values are setup by the linker script. They are
- * not actual uint32_t storage locations! They are only used meaningfully in
- * the following way:
- *
- *  - The linker script defines, for example, the symbol_sdata.
- *  - The declaration extern uint32_t _sdata; makes C happy.  C will believe
- *    that the value _sdata is the address of a uint32_t variable _data (it
- *    is not!).
- *  - We can recover the linker value then by simply taking the address of
- *    of _data.  like:  uint32_t *pdata = &_sdata;
- */
+/* These 'addresses' of these values are setup by the linker script. */
 
-extern uint32_t _stext;           /* Start of .text */
-extern uint32_t _etext;           /* End_1 of .text + .rodata */
-extern const uint32_t _eronly;    /* End+1 of read only section (.text + .rodata) */
-extern uint32_t _sdata;           /* Start of .data */
-extern uint32_t _edata;           /* End+1 of .data */
-extern uint32_t _sbss;            /* Start of .bss */
-extern uint32_t _ebss;            /* End+1 of .bss */
+extern uint8_t _stext[];           /* Start of .text */
+extern uint8_t _etext[];           /* End_1 of .text + .rodata */
+extern const uint8_t _eronly[];    /* End+1 of read only section (.text + .rodata) */
+extern uint8_t _sdata[];           /* Start of .data */
+extern uint8_t _edata[];           /* End+1 of .data */
+extern uint8_t _sbss[];            /* Start of .bss */
+extern uint8_t _ebss[];            /* End+1 of .bss */
 
 /* This is the user space entry point */
 
@@ -79,13 +69,13 @@ const struct userspace_s userspace locate_data(".userspace") =
   /* General memory map */
 
   .us_entrypoint    = (main_t)CONFIG_INIT_ENTRYPOINT,
-  .us_textstart     = (uintptr_t)&_stext,
-  .us_textend       = (uintptr_t)&_etext,
-  .us_datasource    = (uintptr_t)&_eronly,
-  .us_datastart     = (uintptr_t)&_sdata,
-  .us_dataend       = (uintptr_t)&_edata,
-  .us_bssstart      = (uintptr_t)&_sbss,
-  .us_bssend        = (uintptr_t)&_ebss,
+  .us_textstart     = (uintptr_t)_stext,
+  .us_textend       = (uintptr_t)_etext,
+  .us_datasource    = (uintptr_t)_eronly,
+  .us_datastart     = (uintptr_t)_sdata,
+  .us_dataend       = (uintptr_t)_edata,
+  .us_bssstart      = (uintptr_t)_sbss,
+  .us_bssend        = (uintptr_t)_ebss,
 
   /* Memory manager heap structure */
 

--- a/boards/arm/stm32/stm32f4discovery/kernel/stm32_userspace.c
+++ b/boards/arm/stm32/stm32f4discovery/kernel/stm32_userspace.c
@@ -51,25 +51,15 @@
  * Public Data
  ****************************************************************************/
 
-/* These 'addresses' of these values are setup by the linker script. They are
- * not actual uint32_t storage locations! They are only used meaningfully in
- * the following way:
- *
- *  - The linker script defines, for example, the symbol_sdata.
- *  - The declaration extern uint32_t _sdata; makes C happy.  C will believe
- *    that the value _sdata is the address of a uint32_t variable _data (it
- *    is not!).
- *  - We can recover the linker value then by simply taking the address of
- *    of _data.  like:  uint32_t *pdata = &_sdata;
- */
+/* These 'addresses' of these values are setup by the linker script. */
 
-extern uint32_t _stext;           /* Start of .text */
-extern uint32_t _etext;           /* End_1 of .text + .rodata */
-extern const uint32_t _eronly;    /* End+1 of read only section (.text + .rodata) */
-extern uint32_t _sdata;           /* Start of .data */
-extern uint32_t _edata;           /* End+1 of .data */
-extern uint32_t _sbss;            /* Start of .bss */
-extern uint32_t _ebss;            /* End+1 of .bss */
+extern uint8_t _stext[];           /* Start of .text */
+extern uint8_t _etext[];           /* End_1 of .text + .rodata */
+extern const uint8_t _eronly[];    /* End+1 of read only section (.text + .rodata) */
+extern uint8_t _sdata[];           /* Start of .data */
+extern uint8_t _edata[];           /* End+1 of .data */
+extern uint8_t _sbss[];            /* Start of .bss */
+extern uint8_t _ebss[];            /* End+1 of .bss */
 
 /* This is the user space entry point */
 
@@ -80,13 +70,13 @@ const struct userspace_s userspace locate_data(".userspace") =
   /* General memory map */
 
   .us_entrypoint    = (main_t)CONFIG_INIT_ENTRYPOINT,
-  .us_textstart     = (uintptr_t)&_stext,
-  .us_textend       = (uintptr_t)&_etext,
-  .us_datasource    = (uintptr_t)&_eronly,
-  .us_datastart     = (uintptr_t)&_sdata,
-  .us_dataend       = (uintptr_t)&_edata,
-  .us_bssstart      = (uintptr_t)&_sbss,
-  .us_bssend        = (uintptr_t)&_ebss,
+  .us_textstart     = (uintptr_t)_stext,
+  .us_textend       = (uintptr_t)_etext,
+  .us_datasource    = (uintptr_t)_eronly,
+  .us_datastart     = (uintptr_t)_sdata,
+  .us_dataend       = (uintptr_t)_edata,
+  .us_bssstart      = (uintptr_t)_sbss,
+  .us_bssend        = (uintptr_t)_ebss,
 
   /* Memory manager heap structure */
 

--- a/boards/arm/stm32f7/nucleo-144/src/stm32_bbsram.c
+++ b/boards/arm/stm32f7/nucleo-144/src/stm32_bbsram.c
@@ -457,7 +457,7 @@ void board_crashdump(uintptr_t currentsp, void *tcb,
 #if CONFIG_ARCH_INTERRUPTSTACK > 3
   /* Get the limits on the interrupt stack memory */
 
-  pdump->info.stacks.interrupt.top = (uint32_t)&g_intstacktop;
+  pdump->info.stacks.interrupt.top = (uint32_t)g_intstacktop;
   pdump->info.stacks.interrupt.size = (CONFIG_ARCH_INTERRUPTSTACK & ~3);
 
   /* If In interrupt Context save the interrupt stack data centered

--- a/boards/arm/stm32f7/stm32f746g-disco/kernel/stm32_userspace.c
+++ b/boards/arm/stm32f7/stm32f746g-disco/kernel/stm32_userspace.c
@@ -51,25 +51,15 @@
  * Public Data
  ****************************************************************************/
 
-/* These 'addresses' of these values are setup by the linker script. They are
- * not actual uint32_t storage locations! They are only used meaningfully in
- * the following way:
- *
- *  - The linker script defines, for example, the symbol_sdata.
- *  - The declaration extern uint32_t _sdata; makes C happy.  C will believe
- *    that the value _sdata is the address of a uint32_t variable _data (it
- *    is not!).
- *  - We can recover the linker value then by simply taking the address of
- *    of _data.  like:  uint32_t *pdata = &_sdata;
- */
+/* These 'addresses' of these values are setup by the linker script. */
 
-extern uint32_t _stext;           /* Start of .text */
-extern uint32_t _etext;           /* End_1 of .text + .rodata */
-extern const uint32_t _eronly;    /* End+1 of read only section (.text + .rodata) */
-extern uint32_t _sdata;           /* Start of .data */
-extern uint32_t _edata;           /* End+1 of .data */
-extern uint32_t _sbss;            /* Start of .bss */
-extern uint32_t _ebss;            /* End+1 of .bss */
+extern uint8_t _stext[];           /* Start of .text */
+extern uint8_t _etext[];           /* End_1 of .text + .rodata */
+extern const uint8_t _eronly[];    /* End+1 of read only section (.text + .rodata) */
+extern uint8_t _sdata[];           /* Start of .data */
+extern uint8_t _edata[];           /* End+1 of .data */
+extern uint8_t _sbss[];            /* Start of .bss */
+extern uint8_t _ebss[];            /* End+1 of .bss */
 
 /* This is the user space entry point */
 
@@ -80,13 +70,13 @@ const struct userspace_s userspace locate_data(".userspace") =
   /* General memory map */
 
   .us_entrypoint    = (main_t)CONFIG_INIT_ENTRYPOINT,
-  .us_textstart     = (uintptr_t)&_stext,
-  .us_textend       = (uintptr_t)&_etext,
-  .us_datasource    = (uintptr_t)&_eronly,
-  .us_datastart     = (uintptr_t)&_sdata,
-  .us_dataend       = (uintptr_t)&_edata,
-  .us_bssstart      = (uintptr_t)&_sbss,
-  .us_bssend        = (uintptr_t)&_ebss,
+  .us_textstart     = (uintptr_t)_stext,
+  .us_textend       = (uintptr_t)_etext,
+  .us_datasource    = (uintptr_t)_eronly,
+  .us_datastart     = (uintptr_t)_sdata,
+  .us_dataend       = (uintptr_t)_edata,
+  .us_bssstart      = (uintptr_t)_sbss,
+  .us_bssend        = (uintptr_t)_ebss,
 
   /* Memory manager heap structure */
 

--- a/boards/arm/stm32f7/stm32f769i-disco/kernel/stm32_userspace.c
+++ b/boards/arm/stm32f7/stm32f769i-disco/kernel/stm32_userspace.c
@@ -51,25 +51,15 @@
  * Public Data
  ****************************************************************************/
 
-/* These 'addresses' of these values are setup by the linker script. They are
- * not actual uint32_t storage locations! They are only used meaningfully in
- * the following way:
- *
- *  - The linker script defines, for example, the symbol_sdata.
- *  - The declaration extern uint32_t _sdata; makes C happy.  C will believe
- *    that the value _sdata is the address of a uint32_t variable _data (it
- *    is not!).
- *  - We can recover the linker value then by simply taking the address of
- *    of _data.  like:  uint32_t *pdata = &_sdata;
- */
+/* These 'addresses' of these values are setup by the linker script. */
 
-extern uint32_t _stext;           /* Start of .text */
-extern uint32_t _etext;           /* End_1 of .text + .rodata */
-extern const uint32_t _eronly;    /* End+1 of read only section (.text + .rodata) */
-extern uint32_t _sdata;           /* Start of .data */
-extern uint32_t _edata;           /* End+1 of .data */
-extern uint32_t _sbss;            /* Start of .bss */
-extern uint32_t _ebss;            /* End+1 of .bss */
+extern uint8_t _stext[];           /* Start of .text */
+extern uint8_t _etext[];           /* End_1 of .text + .rodata */
+extern const uint8_t _eronly[];    /* End+1 of read only section (.text + .rodata) */
+extern uint8_t _sdata[];           /* Start of .data */
+extern uint8_t _edata[];           /* End+1 of .data */
+extern uint8_t _sbss[];            /* Start of .bss */
+extern uint8_t _ebss[];            /* End+1 of .bss */
 
 /* This is the user space entry point */
 
@@ -80,13 +70,13 @@ const struct userspace_s userspace locate_data(".userspace") =
   /* General memory map */
 
   .us_entrypoint    = (main_t)CONFIG_INIT_ENTRYPOINT,
-  .us_textstart     = (uintptr_t)&_stext,
-  .us_textend       = (uintptr_t)&_etext,
-  .us_datasource    = (uintptr_t)&_eronly,
-  .us_datastart     = (uintptr_t)&_sdata,
-  .us_dataend       = (uintptr_t)&_edata,
-  .us_bssstart      = (uintptr_t)&_sbss,
-  .us_bssend        = (uintptr_t)&_ebss,
+  .us_textstart     = (uintptr_t)_stext,
+  .us_textend       = (uintptr_t)_etext,
+  .us_datasource    = (uintptr_t)_eronly,
+  .us_datastart     = (uintptr_t)_sdata,
+  .us_dataend       = (uintptr_t)_edata,
+  .us_bssstart      = (uintptr_t)_sbss,
+  .us_bssend        = (uintptr_t)_ebss,
 
   /* Memory manager heap structure */
 

--- a/boards/arm/stm32h7/nucleo-h743zi/kernel/stm32_userspace.c
+++ b/boards/arm/stm32h7/nucleo-h743zi/kernel/stm32_userspace.c
@@ -51,25 +51,15 @@
  * Public Data
  ****************************************************************************/
 
-/* These 'addresses' of these values are setup by the linker script. They are
- * not actual uint32_t storage locations! They are only used meaningfully in
- * the following way:
- *
- *  - The linker script defines, for example, the symbol_sdata.
- *  - The declaration extern uint32_t _sdata; makes C happy.  C will believe
- *    that the value _sdata is the address of a uint32_t variable _data (it
- *    is not!).
- *  - We can recover the linker value then by simply taking the address of
- *    of _data.  like:  uint32_t *pdata = &_sdata;
- */
+/* These 'addresses' of these values are setup by the linker script. */
 
-extern uint32_t _stext;           /* Start of .text */
-extern uint32_t _etext;           /* End_1 of .text + .rodata */
-extern const uint32_t _eronly;    /* End+1 of read only section (.text + .rodata) */
-extern uint32_t _sdata;           /* Start of .data */
-extern uint32_t _edata;           /* End+1 of .data */
-extern uint32_t _sbss;            /* Start of .bss */
-extern uint32_t _ebss;            /* End+1 of .bss */
+extern uint8_t _stext[];           /* Start of .text */
+extern uint8_t _etext[];           /* End_1 of .text + .rodata */
+extern const uint8_t _eronly[];    /* End+1 of read only section (.text + .rodata) */
+extern uint8_t _sdata[];           /* Start of .data */
+extern uint8_t _edata[];           /* End+1 of .data */
+extern uint8_t _sbss[];            /* Start of .bss */
+extern uint8_t _ebss[];            /* End+1 of .bss */
 
 /* This is the user space entry point */
 
@@ -80,13 +70,13 @@ const struct userspace_s userspace locate_data(".userspace") =
   /* General memory map */
 
   .us_entrypoint    = (main_t)CONFIG_INIT_ENTRYPOINT,
-  .us_textstart     = (uintptr_t)&_stext,
-  .us_textend       = (uintptr_t)&_etext,
-  .us_datasource    = (uintptr_t)&_eronly,
-  .us_datastart     = (uintptr_t)&_sdata,
-  .us_dataend       = (uintptr_t)&_edata,
-  .us_bssstart      = (uintptr_t)&_sbss,
-  .us_bssend        = (uintptr_t)&_ebss,
+  .us_textstart     = (uintptr_t)_stext,
+  .us_textend       = (uintptr_t)_etext,
+  .us_datasource    = (uintptr_t)_eronly,
+  .us_datastart     = (uintptr_t)_sdata,
+  .us_dataend       = (uintptr_t)_edata,
+  .us_bssstart      = (uintptr_t)_sbss,
+  .us_bssend        = (uintptr_t)_ebss,
 
   /* Memory manager heap structure */
 

--- a/boards/arm/stm32h7/stm32h747i-disco/kernel/stm32_userspace.c
+++ b/boards/arm/stm32h7/stm32h747i-disco/kernel/stm32_userspace.c
@@ -51,25 +51,15 @@
  * Public Data
  ****************************************************************************/
 
-/* These 'addresses' of these values are setup by the linker script. They are
- * not actual uint32_t storage locations! They are only used meaningfully in
- * the following way:
- *
- *  - The linker script defines, for example, the symbol_sdata.
- *  - The declaration extern uint32_t _sdata; makes C happy.  C will believe
- *    that the value _sdata is the address of a uint32_t variable _data (it
- *    is not!).
- *  - We can recover the linker value then by simply taking the address of
- *    of _data.  like:  uint32_t *pdata = &_sdata;
- */
+/* These 'addresses' of these values are setup by the linker script. */
 
-extern uint32_t _stext;           /* Start of .text */
-extern uint32_t _etext;           /* End_1 of .text + .rodata */
-extern const uint32_t _eronly;    /* End+1 of read only section (.text + .rodata) */
-extern uint32_t _sdata;           /* Start of .data */
-extern uint32_t _edata;           /* End+1 of .data */
-extern uint32_t _sbss;            /* Start of .bss */
-extern uint32_t _ebss;            /* End+1 of .bss */
+extern uint8_t _stext[];           /* Start of .text */
+extern uint8_t _etext[];           /* End_1 of .text + .rodata */
+extern const uint8_t _eronly[];    /* End+1 of read only section (.text + .rodata) */
+extern uint8_t _sdata[];           /* Start of .data */
+extern uint8_t _edata[];           /* End+1 of .data */
+extern uint8_t _sbss[];            /* Start of .bss */
+extern uint8_t _ebss[];            /* End+1 of .bss */
 
 /* This is the user space entry point */
 
@@ -80,13 +70,13 @@ const struct userspace_s userspace locate_data(".userspace") =
   /* General memory map */
 
   .us_entrypoint    = (main_t)CONFIG_INIT_ENTRYPOINT,
-  .us_textstart     = (uintptr_t)&_stext,
-  .us_textend       = (uintptr_t)&_etext,
-  .us_datasource    = (uintptr_t)&_eronly,
-  .us_datastart     = (uintptr_t)&_sdata,
-  .us_dataend       = (uintptr_t)&_edata,
-  .us_bssstart      = (uintptr_t)&_sbss,
-  .us_bssend        = (uintptr_t)&_ebss,
+  .us_textstart     = (uintptr_t)_stext,
+  .us_textend       = (uintptr_t)_etext,
+  .us_datasource    = (uintptr_t)_eronly,
+  .us_datastart     = (uintptr_t)_sdata,
+  .us_dataend       = (uintptr_t)_edata,
+  .us_bssstart      = (uintptr_t)_sbss,
+  .us_bssend        = (uintptr_t)_ebss,
 
   /* Memory manager heap structure */
 

--- a/boards/arm/stm32l4/stm32l476vg-disco/kernel/stm32l4_userspace.c
+++ b/boards/arm/stm32l4/stm32l476vg-disco/kernel/stm32l4_userspace.c
@@ -51,25 +51,15 @@
  * Public Data
  ****************************************************************************/
 
-/* These 'addresses' of these values are setup by the linker script. They are
- * not actual uint32_t storage locations! They are only used meaningfully in
- * the following way:
- *
- *  - The linker script defines, for example, the symbol_sdata.
- *  - The declaration extern uint32_t _sdata; makes C happy.  C will believe
- *    that the value _sdata is the address of a uint32_t variable _data (it
- *    is not!).
- *  - We can recover the linker value then by simply taking the address of
- *    of _data.  like:  uint32_t *pdata = &_sdata;
- */
+/* These 'addresses' of these values are setup by the linker script. */
 
-extern uint32_t _stext;           /* Start of .text */
-extern uint32_t _etext;           /* End_1 of .text + .rodata */
-extern const uint32_t _eronly;    /* End+1 of read only section (.text + .rodata) */
-extern uint32_t _sdata;           /* Start of .data */
-extern uint32_t _edata;           /* End+1 of .data */
-extern uint32_t _sbss;            /* Start of .bss */
-extern uint32_t _ebss;            /* End+1 of .bss */
+extern uint8_t _stext[];           /* Start of .text */
+extern uint8_t _etext[];           /* End_1 of .text + .rodata */
+extern const uint8_t _eronly[];    /* End+1 of read only section (.text + .rodata) */
+extern uint8_t _sdata[];           /* Start of .data */
+extern uint8_t _edata[];           /* End+1 of .data */
+extern uint8_t _sbss[];            /* Start of .bss */
+extern uint8_t _ebss[];            /* End+1 of .bss */
 
 /* This is the user space entry point */
 
@@ -80,13 +70,13 @@ const struct userspace_s userspace locate_data(".userspace") =
   /* General memory map */
 
   .us_entrypoint    = (main_t)CONFIG_INIT_ENTRYPOINT,
-  .us_textstart     = (uintptr_t)&_stext,
-  .us_textend       = (uintptr_t)&_etext,
-  .us_datasource    = (uintptr_t)&_eronly,
-  .us_datastart     = (uintptr_t)&_sdata,
-  .us_dataend       = (uintptr_t)&_edata,
-  .us_bssstart      = (uintptr_t)&_sbss,
-  .us_bssend        = (uintptr_t)&_ebss,
+  .us_textstart     = (uintptr_t)_stext,
+  .us_textend       = (uintptr_t)_etext,
+  .us_datasource    = (uintptr_t)_eronly,
+  .us_datastart     = (uintptr_t)_sdata,
+  .us_dataend       = (uintptr_t)_edata,
+  .us_bssstart      = (uintptr_t)_sbss,
+  .us_bssend        = (uintptr_t)_ebss,
 
   /* Memory manager heap structure */
 

--- a/boards/arm/stm32l4/stm32l4r9ai-disco/kernel/stm32l4_userspace.c
+++ b/boards/arm/stm32l4/stm32l4r9ai-disco/kernel/stm32l4_userspace.c
@@ -51,25 +51,15 @@
  * Public Data
  ****************************************************************************/
 
-/* These 'addresses' of these values are setup by the linker script.  They
- * are not actual uint32_t storage locations!  They are only used
- * meaningfully in the following way:
- *
- *  - The linker script defines, for example, the symbol_sdata.
- *  - The declaration extern uint32_t _sdata; makes C happy.  C will believe
- *    that the value _sdata is the address of a uint32_t variable _data (it
- *    is not!).
- *  - We can recover the linker value then by simply taking the address of
- *    of _data.  like:  uint32_t *pdata = &_sdata;
- */
+/* These 'addresses' of these values are setup by the linker script. */
 
-extern uint32_t _stext;           /* Start of .text */
-extern uint32_t _etext;           /* End_1 of .text + .rodata */
-extern const uint32_t _eronly;    /* End+1 of read only section (.text + .rodata) */
-extern uint32_t _sdata;           /* Start of .data */
-extern uint32_t _edata;           /* End+1 of .data */
-extern uint32_t _sbss;            /* Start of .bss */
-extern uint32_t _ebss;            /* End+1 of .bss */
+extern uint8_t _stext[];           /* Start of .text */
+extern uint8_t _etext[];           /* End_1 of .text + .rodata */
+extern const uint8_t _eronly[];    /* End+1 of read only section (.text + .rodata) */
+extern uint8_t _sdata[];           /* Start of .data */
+extern uint8_t _edata[];           /* End+1 of .data */
+extern uint8_t _sbss[];            /* Start of .bss */
+extern uint8_t _ebss[];            /* End+1 of .bss */
 
 /* This is the user space entry point */
 
@@ -80,13 +70,13 @@ const struct userspace_s userspace locate_data(".userspace") =
   /* General memory map */
 
   .us_entrypoint    = (main_t)CONFIG_INIT_ENTRYPOINT,
-  .us_textstart     = (uintptr_t)&_stext,
-  .us_textend       = (uintptr_t)&_etext,
-  .us_datasource    = (uintptr_t)&_eronly,
-  .us_datastart     = (uintptr_t)&_sdata,
-  .us_dataend       = (uintptr_t)&_edata,
-  .us_bssstart      = (uintptr_t)&_sbss,
-  .us_bssend        = (uintptr_t)&_ebss,
+  .us_textstart     = (uintptr_t)_stext,
+  .us_textend       = (uintptr_t)_etext,
+  .us_datasource    = (uintptr_t)_eronly,
+  .us_datastart     = (uintptr_t)_sdata,
+  .us_dataend       = (uintptr_t)_edata,
+  .us_bssstart      = (uintptr_t)_sbss,
+  .us_bssend        = (uintptr_t)_ebss,
 
   /* Memory manager heap structure */
 

--- a/boards/arm/tiva/lm3s6965-ek/kernel/lm_userspace.c
+++ b/boards/arm/tiva/lm3s6965-ek/kernel/lm_userspace.c
@@ -51,25 +51,15 @@
  * Public Data
  ****************************************************************************/
 
-/* These 'addresses' of these values are setup by the linker script. They are
- * not actual uint32_t storage locations! They are only used meaningfully in
- * the following way:
- *
- *  - The linker script defines, for example, the symbol_sdata.
- *  - The declaration extern uint32_t _sdata; makes C happy.  C will believe
- *    that the value _sdata is the address of a uint32_t variable _data (it
- *    is not!).
- *  - We can recover the linker value then by simply taking the address of
- *    of _data.  like:  uint32_t *pdata = &_sdata;
- */
+/* These 'addresses' of these values are setup by the linker script. */
 
-extern uint32_t _stext;           /* Start of .text */
-extern uint32_t _etext;           /* End_1 of .text + .rodata */
-extern const uint32_t _eronly;    /* End+1 of read only section (.text + .rodata) */
-extern uint32_t _sdata;           /* Start of .data */
-extern uint32_t _edata;           /* End+1 of .data */
-extern uint32_t _sbss;            /* Start of .bss */
-extern uint32_t _ebss;            /* End+1 of .bss */
+extern uint8_t _stext[];           /* Start of .text */
+extern uint8_t _etext[];           /* End_1 of .text + .rodata */
+extern const uint8_t _eronly[];    /* End+1 of read only section (.text + .rodata) */
+extern uint8_t _sdata[];           /* Start of .data */
+extern uint8_t _edata[];           /* End+1 of .data */
+extern uint8_t _sbss[];            /* Start of .bss */
+extern uint8_t _ebss[];            /* End+1 of .bss */
 
 /* This is the user space entry point */
 
@@ -80,13 +70,13 @@ const struct userspace_s userspace locate_data(".userspace") =
   /* General memory map */
 
   .us_entrypoint    = (main_t)CONFIG_INIT_ENTRYPOINT,
-  .us_textstart     = (uintptr_t)&_stext,
-  .us_textend       = (uintptr_t)&_etext,
-  .us_datasource    = (uintptr_t)&_eronly,
-  .us_datastart     = (uintptr_t)&_sdata,
-  .us_dataend       = (uintptr_t)&_edata,
-  .us_bssstart      = (uintptr_t)&_sbss,
-  .us_bssend        = (uintptr_t)&_ebss,
+  .us_textstart     = (uintptr_t)_stext,
+  .us_textend       = (uintptr_t)_etext,
+  .us_datasource    = (uintptr_t)_eronly,
+  .us_datastart     = (uintptr_t)_sdata,
+  .us_dataend       = (uintptr_t)_edata,
+  .us_bssstart      = (uintptr_t)_sbss,
+  .us_bssend        = (uintptr_t)_ebss,
 
   /* Memory manager heap structure */
 

--- a/boards/risc-v/c906/smartl-c906/kernel/c906_userspace.c
+++ b/boards/risc-v/c906/smartl-c906/kernel/c906_userspace.c
@@ -51,27 +51,17 @@
  * Public Data
  ****************************************************************************/
 
-/* These 'addresses' of these values are setup by the linker script.
- * They are not actual uint32_t storage locations!
- * They are only used meaningfully in the following way:
- *
- *  - The linker script defines, for example, the symbol_sdata.
- *  - The declaration extern uint32_t _sdata; makes C happy.  C will believe
- *    that the value _sdata is the address of a uint32_t variable _data
- *    (it is not!).
- *  - We can recover the linker value then by simply taking the address of
- *    of _data.  like:  uint32_t *pdata = &_sdata;
- */
+/* These 'addresses' of these values are setup by the linker script. */
 
-extern uint32_t _stext;           /* Start of .text */
-extern uint32_t _etext;           /* End_1 of .text + .rodata */
-extern const uint32_t _eronly;    /* End+1 of read only section */
-extern uint32_t _sdata;           /* Start of .data */
-extern uint32_t _edata;           /* End+1 of .data */
-extern uint32_t _sbss;            /* Start of .bss */
-extern uint32_t _ebss;            /* End+1 of .bss */
+extern uint8_t _stext[];           /* Start of .text */
+extern uint8_t _etext[];           /* End_1 of .text + .rodata */
+extern const uint8_t _eronly[];    /* End+1 of read only section (.text + .rodata) */
+extern uint8_t _sdata[];           /* Start of .data */
+extern uint8_t _edata[];           /* End+1 of .data */
+extern uint8_t _sbss[];            /* Start of .bss */
+extern uint8_t _ebss[];            /* End+1 of .bss */
 
-extern uintptr_t *__ld_usram_end; /* End+1 of user ram section */
+extern uint8_t __ld_usram_end[];   /* End+1 of user ram section */
 
 /* This is the user space entry point */
 
@@ -82,15 +72,15 @@ const struct userspace_s userspace locate_data(".userspace") =
   /* General memory map */
 
   .us_entrypoint    = (main_t)CONFIG_INIT_ENTRYPOINT,
-  .us_textstart     = (uintptr_t)&_stext,
-  .us_textend       = (uintptr_t)&_etext,
-  .us_datasource    = (uintptr_t)&_eronly,
-  .us_datastart     = (uintptr_t)&_sdata,
-  .us_dataend       = (uintptr_t)&_edata,
-  .us_bssstart      = (uintptr_t)&_sbss,
-  .us_bssend        = (uintptr_t)&_ebss,
+  .us_textstart     = (uintptr_t)_stext,
+  .us_textend       = (uintptr_t)_etext,
+  .us_datasource    = (uintptr_t)_eronly,
+  .us_datastart     = (uintptr_t)_sdata,
+  .us_dataend       = (uintptr_t)_edata,
+  .us_bssstart      = (uintptr_t)_sbss,
+  .us_bssend        = (uintptr_t)_ebss,
 
-  .us_heapend       = (uintptr_t)&__ld_usram_end,
+  .us_heapend       = (uintptr_t)__ld_usram_end,
 
   /* Memory manager heap structure */
 

--- a/boards/risc-v/esp32c3/esp32c3-devkit-rust-1/include/board_memorymap.h
+++ b/boards/risc-v/esp32c3/esp32c3-devkit-rust-1/include/board_memorymap.h
@@ -33,42 +33,42 @@
 
 /* Kernel ROM */
 
-#define KIROM_START     (uintptr_t)&__kirom_start
-#define KIROM_SIZE      (uintptr_t)&__kirom_size
-#define KDROM_START     (uintptr_t)&__kdrom_start
-#define KDROM_SIZE      (uintptr_t)&__kdrom_size
+#define KIROM_START     (uintptr_t)__kirom_start
+#define KIROM_SIZE      (uintptr_t)__kirom_size
+#define KDROM_START     (uintptr_t)__kdrom_start
+#define KDROM_SIZE      (uintptr_t)__kdrom_size
 
 /* Kernel RAM */
 
-#define KIRAM_START     (uintptr_t)&__kiram_start
-#define KIRAM_SIZE      (uintptr_t)&__kiram_size
-#define KIRAM_END       (uintptr_t)&__kiram_end
-#define KDRAM_START     (uintptr_t)&__kdram_start
-#define KDRAM_SIZE      (uintptr_t)&__kdram_size
-#define KDRAM_END       (uintptr_t)&__kdram_end
+#define KIRAM_START     (uintptr_t)__kiram_start
+#define KIRAM_SIZE      (uintptr_t)__kiram_size
+#define KIRAM_END       (uintptr_t)__kiram_end
+#define KDRAM_START     (uintptr_t)__kdram_start
+#define KDRAM_SIZE      (uintptr_t)__kdram_size
+#define KDRAM_END       (uintptr_t)__kdram_end
 
 /* Exception vectors */
 
-#define VECTORS_START   (uintptr_t)&__vectors_start
-#define VECTORS_END     (uintptr_t)&__vectors_end
+#define VECTORS_START   (uintptr_t)__vectors_start
+#define VECTORS_END     (uintptr_t)__vectors_end
 
 /* User ROM */
 
-#define UIROM_START     (uintptr_t)&__uirom_start
-#define UIROM_SIZE      (uintptr_t)&__uirom_size
-#define UIROM_END       (uintptr_t)&__uirom_end
-#define UDROM_START     (uintptr_t)&__udrom_start
-#define UDROM_SIZE      (uintptr_t)&__udrom_size
-#define UDROM_END       (uintptr_t)&__udrom_end
+#define UIROM_START     (uintptr_t)__uirom_start
+#define UIROM_SIZE      (uintptr_t)__uirom_size
+#define UIROM_END       (uintptr_t)__uirom_end
+#define UDROM_START     (uintptr_t)__udrom_start
+#define UDROM_SIZE      (uintptr_t)__udrom_size
+#define UDROM_END       (uintptr_t)__udrom_end
 
 /* User RAM */
 
-#define UIRAM_START     (uintptr_t)&__uiram_start
-#define UIRAM_SIZE      (uintptr_t)&__uiram_size
-#define UIRAM_END       (uintptr_t)&__uiram_end
-#define UDRAM_START     (uintptr_t)&__udram_start
-#define UDRAM_SIZE      (uintptr_t)&__udram_size
-#define UDRAM_END       (uintptr_t)&__udram_end
+#define UIRAM_START     (uintptr_t)__uiram_start
+#define UIRAM_SIZE      (uintptr_t)__uiram_size
+#define UIRAM_END       (uintptr_t)__uiram_end
+#define UDRAM_START     (uintptr_t)__udram_start
+#define UDRAM_SIZE      (uintptr_t)__udram_size
+#define UDRAM_END       (uintptr_t)__udram_end
 
 /****************************************************************************
  * Public Data
@@ -76,41 +76,41 @@
 
 /* Kernel ROM (RX)  */
 
-extern uintptr_t        __kirom_start;
-extern uintptr_t        __kirom_size;
-extern uintptr_t        __kdrom_start;
-extern uintptr_t        __kdrom_size;
+extern uint8_t          __kirom_start[];
+extern uint8_t          __kirom_size[];
+extern uint8_t          __kdrom_start[];
+extern uint8_t          __kdrom_size[];
 
 /* Kernel RAM (RW) */
 
-extern uintptr_t        __kiram_start;
-extern uintptr_t        __kiram_size;
-extern uintptr_t        __kiram_end;
-extern uintptr_t        __kdram_start;
-extern uintptr_t        __kdram_size;
-extern uintptr_t        __kdram_end;
+extern uint8_t          __kiram_start[];
+extern uint8_t          __kiram_size[];
+extern uint8_t          __kiram_end[];
+extern uint8_t          __kdram_start[];
+extern uint8_t          __kdram_size[];
+extern uint8_t          __kdram_end[];
 
 /* Exception vectors */
 
-extern uintptr_t        __vectors_start;
-extern uintptr_t        __vectors_end;
+extern uint8_t          __vectors_start[];
+extern uint8_t          __vectors_end[];
 
 /* User ROM (RX) */
 
-extern uintptr_t        __uirom_start;
-extern uintptr_t        __uirom_size;
-extern uintptr_t        __uirom_end;
-extern uintptr_t        __udrom_start;
-extern uintptr_t        __udrom_size;
-extern uintptr_t        __udrom_end;
+extern uint8_t          __uirom_start[];
+extern uint8_t          __uirom_size[];
+extern uint8_t          __uirom_end[];
+extern uint8_t          __udrom_start[];
+extern uint8_t          __udrom_size[];
+extern uint8_t          __udrom_end[];
 
 /* User RAM (RW) */
 
-extern uintptr_t        __uiram_start;
-extern uintptr_t        __uiram_size;
-extern uintptr_t        __uiram_end;
-extern uintptr_t        __udram_start;
-extern uintptr_t        __udram_size;
-extern uintptr_t        __udram_end;
+extern uint8_t          __uiram_start[];
+extern uint8_t          __uiram_size[];
+extern uint8_t          __uiram_end[];
+extern uint8_t          __udram_start[];
+extern uint8_t          __udram_size[];
+extern uint8_t          __udram_end[];
 
 #endif /* __BOARDS_RISCV_ESP32C3_ESP32C3_DEVKIT_RUST1_INCLUDE_BOARD_MEMORYMAP_H */

--- a/boards/risc-v/esp32c3/esp32c3-devkit/include/board_memorymap.h
+++ b/boards/risc-v/esp32c3/esp32c3-devkit/include/board_memorymap.h
@@ -33,42 +33,42 @@
 
 /* Kernel ROM */
 
-#define KIROM_START     (uintptr_t)&__kirom_start
-#define KIROM_SIZE      (uintptr_t)&__kirom_size
-#define KDROM_START     (uintptr_t)&__kdrom_start
-#define KDROM_SIZE      (uintptr_t)&__kdrom_size
+#define KIROM_START     (uintptr_t)__kirom_start
+#define KIROM_SIZE      (uintptr_t)__kirom_size
+#define KDROM_START     (uintptr_t)__kdrom_start
+#define KDROM_SIZE      (uintptr_t)__kdrom_size
 
 /* Kernel RAM */
 
-#define KIRAM_START     (uintptr_t)&__kiram_start
-#define KIRAM_SIZE      (uintptr_t)&__kiram_size
-#define KIRAM_END       (uintptr_t)&__kiram_end
-#define KDRAM_START     (uintptr_t)&__kdram_start
-#define KDRAM_SIZE      (uintptr_t)&__kdram_size
-#define KDRAM_END       (uintptr_t)&__kdram_end
+#define KIRAM_START     (uintptr_t)__kiram_start
+#define KIRAM_SIZE      (uintptr_t)__kiram_size
+#define KIRAM_END       (uintptr_t)__kiram_end
+#define KDRAM_START     (uintptr_t)__kdram_start
+#define KDRAM_SIZE      (uintptr_t)__kdram_size
+#define KDRAM_END       (uintptr_t)__kdram_end
 
 /* Exception vectors */
 
-#define VECTORS_START   (uintptr_t)&__vectors_start
-#define VECTORS_END     (uintptr_t)&__vectors_end
+#define VECTORS_START   (uintptr_t)__vectors_start
+#define VECTORS_END     (uintptr_t)__vectors_end
 
 /* User ROM */
 
-#define UIROM_START     (uintptr_t)&__uirom_start
-#define UIROM_SIZE      (uintptr_t)&__uirom_size
-#define UIROM_END       (uintptr_t)&__uirom_end
-#define UDROM_START     (uintptr_t)&__udrom_start
-#define UDROM_SIZE      (uintptr_t)&__udrom_size
-#define UDROM_END       (uintptr_t)&__udrom_end
+#define UIROM_START     (uintptr_t)__uirom_start
+#define UIROM_SIZE      (uintptr_t)__uirom_size
+#define UIROM_END       (uintptr_t)__uirom_end
+#define UDROM_START     (uintptr_t)__udrom_start
+#define UDROM_SIZE      (uintptr_t)__udrom_size
+#define UDROM_END       (uintptr_t)__udrom_end
 
 /* User RAM */
 
-#define UIRAM_START     (uintptr_t)&__uiram_start
-#define UIRAM_SIZE      (uintptr_t)&__uiram_size
-#define UIRAM_END       (uintptr_t)&__uiram_end
-#define UDRAM_START     (uintptr_t)&__udram_start
-#define UDRAM_SIZE      (uintptr_t)&__udram_size
-#define UDRAM_END       (uintptr_t)&__udram_end
+#define UIRAM_START     (uintptr_t)__uiram_start
+#define UIRAM_SIZE      (uintptr_t)__uiram_size
+#define UIRAM_END       (uintptr_t)__uiram_end
+#define UDRAM_START     (uintptr_t)__udram_start
+#define UDRAM_SIZE      (uintptr_t)__udram_size
+#define UDRAM_END       (uintptr_t)__udram_end
 
 /****************************************************************************
  * Public Data
@@ -76,41 +76,41 @@
 
 /* Kernel ROM (RX)  */
 
-extern uintptr_t        __kirom_start;
-extern uintptr_t        __kirom_size;
-extern uintptr_t        __kdrom_start;
-extern uintptr_t        __kdrom_size;
+extern uint8_t          __kirom_start[];
+extern uint8_t          __kirom_size[];
+extern uint8_t          __kdrom_start[];
+extern uint8_t          __kdrom_size[];
 
 /* Kernel RAM (RW) */
 
-extern uintptr_t        __kiram_start;
-extern uintptr_t        __kiram_size;
-extern uintptr_t        __kiram_end;
-extern uintptr_t        __kdram_start;
-extern uintptr_t        __kdram_size;
-extern uintptr_t        __kdram_end;
+extern uint8_t          __kiram_start[];
+extern uint8_t          __kiram_size[];
+extern uint8_t          __kiram_end[];
+extern uint8_t          __kdram_start[];
+extern uint8_t          __kdram_size[];
+extern uint8_t          __kdram_end[];
 
 /* Exception vectors */
 
-extern uintptr_t        __vectors_start;
-extern uintptr_t        __vectors_end;
+extern uint8_t          __vectors_start[];
+extern uint8_t          __vectors_end[];
 
 /* User ROM (RX) */
 
-extern uintptr_t        __uirom_start;
-extern uintptr_t        __uirom_size;
-extern uintptr_t        __uirom_end;
-extern uintptr_t        __udrom_start;
-extern uintptr_t        __udrom_size;
-extern uintptr_t        __udrom_end;
+extern uint8_t          __uirom_start[];
+extern uint8_t          __uirom_size[];
+extern uint8_t          __uirom_end[];
+extern uint8_t          __udrom_start[];
+extern uint8_t          __udrom_size[];
+extern uint8_t          __udrom_end[];
 
 /* User RAM (RW) */
 
-extern uintptr_t        __uiram_start;
-extern uintptr_t        __uiram_size;
-extern uintptr_t        __uiram_end;
-extern uintptr_t        __udram_start;
-extern uintptr_t        __udram_size;
-extern uintptr_t        __udram_end;
+extern uint8_t          __uiram_start[];
+extern uint8_t          __uiram_size[];
+extern uint8_t          __uiram_end[];
+extern uint8_t          __udram_start[];
+extern uint8_t          __udram_size[];
+extern uint8_t          __udram_end[];
 
 #endif /* __BOARDS_RISCV_ESP32C3_ESP32C3_DEVKIT_INCLUDE_BOARD_MEMORYMAP_H */

--- a/boards/risc-v/esp32c3/esp32c3-devkit/kernel/esp32c3_userspace.c
+++ b/boards/risc-v/esp32c3/esp32c3-devkit/kernel/esp32c3_userspace.c
@@ -47,27 +47,17 @@
  * Public Data
  ****************************************************************************/
 
-/* These 'addresses' of these values are setup by the linker script.
- * They are not actual uint32_t storage locations!
- * They are only used meaningfully in the following way:
- *
- *  - The linker script defines, for example, the symbol_sdata.
- *  - The declaration extern uint32_t _sdata; makes C happy.  C will believe
- *    that the value _sdata is the address of a uint32_t variable _data
- *    (it is not!).
- *  - We can recover the linker value then by simply taking the address of
- *    of _data.  like:  uint32_t *pdata = &_sdata;
- */
+/* These 'addresses' of these values are setup by the linker script. */
 
-extern uint32_t _stext;           /* Start of .text */
-extern uint32_t _etext;           /* End+1 of .text + .rodata */
-extern const uint32_t _eronly;    /* End+1 of read only section */
-extern uint32_t _sdata;           /* Start of .data */
-extern uint32_t _edata;           /* End+1 of .data */
-extern uint32_t _sbss;            /* Start of .bss */
-extern uint32_t _ebss;            /* End+1 of .bss */
+extern uint8_t _stext[];           /* Start of .text */
+extern uint8_t _etext[];           /* End_1 of .text + .rodata */
+extern const uint8_t _eronly[];    /* End+1 of read only section (.text + .rodata) */
+extern uint8_t _sdata[];           /* Start of .data */
+extern uint8_t _edata[];           /* End+1 of .data */
+extern uint8_t _sbss[];            /* Start of .bss */
+extern uint8_t _ebss[];            /* End+1 of .bss */
 
-extern uintptr_t *__ld_udram_end; /* End+1 of user ram section */
+extern uint8_t __ld_udram_end[];   /* End+1 of user ram section */
 
 /* This is the user space entry point */
 
@@ -78,15 +68,15 @@ const struct userspace_s userspace locate_data(".userspace") =
   /* General memory map */
 
   .us_entrypoint    = (main_t)CONFIG_INIT_ENTRYPOINT,
-  .us_textstart     = (uintptr_t)&_stext,
-  .us_textend       = (uintptr_t)&_etext,
-  .us_datasource    = (uintptr_t)&_eronly,
-  .us_datastart     = (uintptr_t)&_sdata,
-  .us_dataend       = (uintptr_t)&_edata,
-  .us_bssstart      = (uintptr_t)&_sbss,
-  .us_bssend        = (uintptr_t)&_ebss,
+  .us_textstart     = (uintptr_t)_stext,
+  .us_textend       = (uintptr_t)_etext,
+  .us_datasource    = (uintptr_t)_eronly,
+  .us_datastart     = (uintptr_t)_sdata,
+  .us_dataend       = (uintptr_t)_edata,
+  .us_bssstart      = (uintptr_t)_sbss,
+  .us_bssend        = (uintptr_t)_ebss,
 
-  .us_heapend       = (uintptr_t)&__ld_udram_end,
+  .us_heapend       = (uintptr_t)__ld_udram_end,
 
   /* Memory manager heap structure */
 

--- a/boards/risc-v/k210/maix-bit/kernel/k210_userspace.c
+++ b/boards/risc-v/k210/maix-bit/kernel/k210_userspace.c
@@ -51,25 +51,15 @@
  * Public Data
  ****************************************************************************/
 
-/* These 'addresses' of these values are setup by the linker script.
- * They are not actual uint32_t storage locations!
- * They are only used meaningfully in the following way:
- *
- *  - The linker script defines, for example, the symbol_sdata.
- *  - The declaration extern uint32_t _sdata; makes C happy.  C will believe
- *    that the value _sdata is the address of a uint32_t variable _data
- *    (it is not!).
- *  - We can recover the linker value then by simply taking the address of
- *    of _data.  like:  uint32_t *pdata = &_sdata;
- */
+/* These 'addresses' of these values are setup by the linker script. */
 
-extern uint32_t _stext;           /* Start of .text */
-extern uint32_t _etext;           /* End_1 of .text + .rodata */
-extern const uint32_t _eronly;    /* End+1 of read only section */
-extern uint32_t _sdata;           /* Start of .data */
-extern uint32_t _edata;           /* End+1 of .data */
-extern uint32_t _sbss;            /* Start of .bss */
-extern uint32_t _ebss;            /* End+1 of .bss */
+extern uint8_t _stext[];           /* Start of .text */
+extern uint8_t _etext[];           /* End_1 of .text + .rodata */
+extern const uint8_t _eronly[];    /* End+1 of read only section (.text + .rodata) */
+extern uint8_t _sdata[];           /* Start of .data */
+extern uint8_t _edata[];           /* End+1 of .data */
+extern uint8_t _sbss[];            /* Start of .bss */
+extern uint8_t _ebss[];            /* End+1 of .bss */
 
 /* This is the user space entry point */
 
@@ -80,13 +70,13 @@ const struct userspace_s userspace locate_data(".userspace") =
   /* General memory map */
 
   .us_entrypoint    = (main_t)CONFIG_INIT_ENTRYPOINT,
-  .us_textstart     = (uintptr_t)&_stext,
-  .us_textend       = (uintptr_t)&_etext,
-  .us_datasource    = (uintptr_t)&_eronly,
-  .us_datastart     = (uintptr_t)&_sdata,
-  .us_dataend       = (uintptr_t)&_edata,
-  .us_bssstart      = (uintptr_t)&_sbss,
-  .us_bssend        = (uintptr_t)&_ebss,
+  .us_textstart     = (uintptr_t)_stext,
+  .us_textend       = (uintptr_t)_etext,
+  .us_datasource    = (uintptr_t)_eronly,
+  .us_datastart     = (uintptr_t)_sdata,
+  .us_dataend       = (uintptr_t)_edata,
+  .us_bssstart      = (uintptr_t)_sbss,
+  .us_bssend        = (uintptr_t)_ebss,
 
   /* Memory manager heap structure */
 

--- a/boards/risc-v/mpfs/common/kernel/mpfs_userspace.c
+++ b/boards/risc-v/mpfs/common/kernel/mpfs_userspace.c
@@ -47,27 +47,17 @@
  * Public Data
  ****************************************************************************/
 
-/* These 'addresses' of these values are setup by the linker script.
- * They are not actual uint32_t storage locations!
- * They are only used meaningfully in the following way:
- *
- *  - The linker script defines, for example, the symbol_sdata.
- *  - The declaration extern uint32_t _sdata; makes C happy.  C will believe
- *    that the value _sdata is the address of a uint32_t variable _data
- *    (it is not!).
- *  - We can recover the linker value then by simply taking the address of
- *    of _data.  like:  uint32_t *pdata = &_sdata;
- */
+/* These 'addresses' of these values are setup by the linker script. */
 
-extern uint32_t _stext;           /* Start of .text */
-extern uint32_t _etext;           /* End_1 of .text + .rodata */
-extern const uint32_t _eronly;    /* End+1 of read only section */
-extern uint32_t _sdata;           /* Start of .data */
-extern uint32_t _edata;           /* End+1 of .data */
-extern uint32_t _sbss;            /* Start of .bss */
-extern uint32_t _ebss;            /* End+1 of .bss */
+extern uint8_t _stext[];           /* Start of .text */
+extern uint8_t _etext[];           /* End_1 of .text + .rodata */
+extern const uint8_t _eronly[];    /* End+1 of read only section (.text + .rodata) */
+extern uint8_t _sdata[];           /* Start of .data */
+extern uint8_t _edata[];           /* End+1 of .data */
+extern uint8_t _sbss[];            /* Start of .bss */
+extern uint8_t _ebss[];            /* End+1 of .bss */
 
-extern uintptr_t *__ld_usram_end; /* End+1 of user ram section */
+extern uint8_t __ld_usram_end[];   /* End+1 of user ram section */
 
 /* This is the user space entry point */
 
@@ -78,15 +68,15 @@ const struct userspace_s userspace locate_data(".userspace") =
   /* General memory map */
 
   .us_entrypoint    = (main_t)CONFIG_INIT_ENTRYPOINT,
-  .us_textstart     = (uintptr_t)&_stext,
-  .us_textend       = (uintptr_t)&_etext,
-  .us_datasource    = (uintptr_t)&_eronly,
-  .us_datastart     = (uintptr_t)&_sdata,
-  .us_dataend       = (uintptr_t)&_edata,
-  .us_bssstart      = (uintptr_t)&_sbss,
-  .us_bssend        = (uintptr_t)&_ebss,
+  .us_textstart     = (uintptr_t)_stext,
+  .us_textend       = (uintptr_t)_etext,
+  .us_datasource    = (uintptr_t)_eronly,
+  .us_datastart     = (uintptr_t)_sdata,
+  .us_dataend       = (uintptr_t)_edata,
+  .us_bssstart      = (uintptr_t)_sbss,
+  .us_bssend        = (uintptr_t)_ebss,
 
-  .us_heapend       = (uintptr_t)&__ld_usram_end,
+  .us_heapend       = (uintptr_t)__ld_usram_end,
 
   /* Memory manager heap structure */
 

--- a/boards/risc-v/mpfs/icicle/include/board_memorymap.h
+++ b/boards/risc-v/mpfs/icicle/include/board_memorymap.h
@@ -38,32 +38,32 @@
 
 /* Kernel code memory (RX) */
 
-#define KFLASH_START    (uintptr_t)&__kflash_start
-#define KFLASH_SIZE     (uintptr_t)&__kflash_size
-#define KSRAM_START     (uintptr_t)&__ksram_start
-#define KSRAM_SIZE      (uintptr_t)&__ksram_size
-#define KSRAM_END       (uintptr_t)&__ksram_end
+#define KFLASH_START    (uintptr_t)__kflash_start
+#define KFLASH_SIZE     (uintptr_t)__kflash_size
+#define KSRAM_START     (uintptr_t)__ksram_start
+#define KSRAM_SIZE      (uintptr_t)__ksram_size
+#define KSRAM_END       (uintptr_t)__ksram_end
 
 /* Kernel RAM (RW) */
 
-#define PGPOOL_START    (uintptr_t)&__pgheap_start
-#define PGPOOL_SIZE     (uintptr_t)&__pgheap_size
+#define PGPOOL_START    (uintptr_t)__pgheap_start
+#define PGPOOL_SIZE     (uintptr_t)__pgheap_size
 
 /* Page pool (RWX) */
 
-#define PGPOOL_START    (uintptr_t)&__pgheap_start
-#define PGPOOL_SIZE     (uintptr_t)&__pgheap_size
+#define PGPOOL_START    (uintptr_t)__pgheap_start
+#define PGPOOL_SIZE     (uintptr_t)__pgheap_size
 #define PGPOOL_END      (PGPOOL_START + PGPOOL_SIZE)
 
 /* User flash */
 
-#define UFLASH_START    (uintptr_t)&__uflash_start
-#define UFLASH_SIZE     (uintptr_t)&__uflash_size
+#define UFLASH_START    (uintptr_t)__uflash_start
+#define UFLASH_SIZE     (uintptr_t)__uflash_size
 
 /* User RAM */
 
-#define USRAM_START     (uintptr_t)&__usram_start
-#define USRAM_SIZE      (uintptr_t)&__usram_size
+#define USRAM_START     (uintptr_t)__usram_start
+#define USRAM_SIZE      (uintptr_t)__usram_size
 
 /****************************************************************************
  * Public Data
@@ -71,28 +71,28 @@
 
 /* Kernel code memory (RX)  */
 
-extern uintptr_t        __kflash_start;
-extern uintptr_t        __kflash_size;
+extern uint8_t          __kflash_start[];
+extern uint8_t          __kflash_size[];
 
 /* Kernel RAM (RW) */
 
-extern uintptr_t        __ksram_start;
-extern uintptr_t        __ksram_size;
-extern uintptr_t        __ksram_end;
+extern uint8_t          __ksram_start[];
+extern uint8_t          __ksram_size[];
+extern uint8_t          __ksram_end[];
 
 /* Page pool (RWX) */
 
-extern uintptr_t        __pgheap_start;
-extern uintptr_t        __pgheap_size;
+extern uint8_t          __pgheap_start[];
+extern uint8_t          __pgheap_size[];
 
 /* User code memory (RX) */
 
-extern uintptr_t        __uflash_start;
-extern uintptr_t        __uflash_size;
+extern uint8_t          __uflash_start[];
+extern uint8_t          __uflash_size[];
 
 /* User RAM (RW) */
 
-extern uintptr_t        __usram_start;
-extern uintptr_t        __usram_size;
+extern uint8_t          __usram_start[];
+extern uint8_t          __usram_size[];
 
 #endif /* __BOARDS_RISC_V_MPFS_ICICLE_INCLUDE_BOARD_MEMORYMAP_H */

--- a/boards/risc-v/qemu-rv/rv-virt/include/board_memorymap.h
+++ b/boards/risc-v/qemu-rv/rv-virt/include/board_memorymap.h
@@ -38,32 +38,32 @@
 
 /* Kernel code memory (RX) */
 
-#define KFLASH_START    (uintptr_t)&__kflash_start
-#define KFLASH_SIZE     (uintptr_t)&__kflash_size
-#define KSRAM_START     (uintptr_t)&__ksram_start
-#define KSRAM_SIZE      (uintptr_t)&__ksram_size
-#define KSRAM_END       (uintptr_t)&__ksram_end
+#define KFLASH_START    (uintptr_t)__kflash_start
+#define KFLASH_SIZE     (uintptr_t)__kflash_size
+#define KSRAM_START     (uintptr_t)__ksram_start
+#define KSRAM_SIZE      (uintptr_t)__ksram_size
+#define KSRAM_END       (uintptr_t)__ksram_end
 
 /* Kernel RAM (RW) */
 
-#define PGPOOL_START    (uintptr_t)&__pgheap_start
-#define PGPOOL_SIZE     (uintptr_t)&__pgheap_size
+#define PGPOOL_START    (uintptr_t)__pgheap_start
+#define PGPOOL_SIZE     (uintptr_t)__pgheap_size
 
 /* Page pool (RWX) */
 
-#define PGPOOL_START    (uintptr_t)&__pgheap_start
-#define PGPOOL_SIZE     (uintptr_t)&__pgheap_size
+#define PGPOOL_START    (uintptr_t)__pgheap_start
+#define PGPOOL_SIZE     (uintptr_t)__pgheap_size
 #define PGPOOL_END      (PGPOOL_START + PGPOOL_SIZE)
 
 /* User flash */
 
-#define UFLASH_START    (uintptr_t)&__uflash_start
-#define UFLASH_SIZE     (uintptr_t)&__uflash_size
+#define UFLASH_START    (uintptr_t)__uflash_start
+#define UFLASH_SIZE     (uintptr_t)__uflash_size
 
 /* User RAM */
 
-#define USRAM_START     (uintptr_t)&__usram_start
-#define USRAM_SIZE      (uintptr_t)&__usram_size
+#define USRAM_START     (uintptr_t)__usram_start
+#define USRAM_SIZE      (uintptr_t)__usram_size
 
 /****************************************************************************
  * Public Data
@@ -71,28 +71,28 @@
 
 /* Kernel code memory (RX)  */
 
-extern uintptr_t        __kflash_start;
-extern uintptr_t        __kflash_size;
+extern uint8_t          __kflash_start[];
+extern uint8_t          __kflash_size[];
 
 /* Kernel RAM (RW) */
 
-extern uintptr_t        __ksram_start;
-extern uintptr_t        __ksram_size;
-extern uintptr_t        __ksram_end;
+extern uint8_t          __ksram_start[];
+extern uint8_t          __ksram_size[];
+extern uint8_t          __ksram_end[];
 
 /* Page pool (RWX) */
 
-extern uintptr_t        __pgheap_start;
-extern uintptr_t        __pgheap_size;
+extern uint8_t          __pgheap_start[];
+extern uint8_t          __pgheap_size[];
 
 /* User code memory (RX) */
 
-extern uintptr_t        __uflash_start;
-extern uintptr_t        __uflash_size;
+extern uint8_t          __uflash_start[];
+extern uint8_t          __uflash_size[];
 
 /* User RAM (RW) */
 
-extern uintptr_t        __usram_start;
-extern uintptr_t        __usram_size;
+extern uint8_t          __usram_start[];
+extern uint8_t          __usram_size[];
 
 #endif /* __BOARDS_RISC_V_QEMURV_RVVIRT_INCLUDE_BOARD_MEMORYMAP_H */

--- a/boards/xtensa/esp32/common/kernel/esp32_userspace.c
+++ b/boards/xtensa/esp32/common/kernel/esp32_userspace.c
@@ -47,27 +47,17 @@
  * Public Data
  ****************************************************************************/
 
-/* These 'addresses' of these values are setup by the linker script.
- * They are not actual uint32_t storage locations!
- * They are only used meaningfully in the following way:
- *
- *  - The linker script defines, for example, the symbol_sdata.
- *  - The declaration extern uint32_t _sdata; makes C happy.  C will believe
- *    that the value _sdata is the address of a uint32_t variable _data
- *    (it is not!).
- *  - We can recover the linker value then by simply taking the address of
- *    of _data.  like:  uint32_t *pdata = &_sdata;
- */
+/* These 'addresses' of these values are setup by the linker script. */
 
-extern uint32_t _stext;           /* Start of .text */
-extern uint32_t _etext;           /* End+1 of .text + .rodata */
-extern const uint32_t _eronly;    /* End+1 of read only section */
-extern uint32_t _sdata;           /* Start of .data */
-extern uint32_t _edata;           /* End+1 of .data */
-extern uint32_t _sbss;            /* Start of .bss */
-extern uint32_t _ebss;            /* End+1 of .bss */
+extern uint8_t _stext[];           /* Start of .text */
+extern uint8_t _etext[];           /* End_1 of .text + .rodata */
+extern const uint8_t _eronly[];    /* End+1 of read only section (.text + .rodata) */
+extern uint8_t _sdata[];           /* Start of .data */
+extern uint8_t _edata[];           /* End+1 of .data */
+extern uint8_t _sbss[];            /* Start of .bss */
+extern uint8_t _ebss[];            /* End+1 of .bss */
 
-extern uintptr_t *__ld_udram_end; /* End+1 of user ram section */
+extern uint8_t __ld_udram_end[];   /* End+1 of user ram section */
 
 /* This is the user space entry point */
 
@@ -78,15 +68,15 @@ const struct userspace_s userspace locate_data(".userspace") =
   /* General memory map */
 
   .us_entrypoint    = (main_t)CONFIG_INIT_ENTRYPOINT,
-  .us_textstart     = (uintptr_t)&_stext,
-  .us_textend       = (uintptr_t)&_etext,
-  .us_datasource    = (uintptr_t)&_eronly,
-  .us_datastart     = (uintptr_t)&_sdata,
-  .us_dataend       = (uintptr_t)&_edata,
-  .us_bssstart      = (uintptr_t)&_sbss,
-  .us_bssend        = (uintptr_t)&_ebss,
+  .us_textstart     = (uintptr_t)_stext,
+  .us_textend       = (uintptr_t)_etext,
+  .us_datasource    = (uintptr_t)_eronly,
+  .us_datastart     = (uintptr_t)_sdata,
+  .us_dataend       = (uintptr_t)_edata,
+  .us_bssstart      = (uintptr_t)_sbss,
+  .us_bssend        = (uintptr_t)_ebss,
 
-  .us_heapend       = (uintptr_t)&__ld_udram_end,
+  .us_heapend       = (uintptr_t)__ld_udram_end,
 
   /* Memory manager heap structure */
 

--- a/boards/xtensa/esp32/esp32-devkitc/include/board_memorymap.h
+++ b/boards/xtensa/esp32/esp32-devkitc/include/board_memorymap.h
@@ -33,48 +33,48 @@
 
 /* Kernel ROM */
 
-#define KIROM_START     (uintptr_t)&__kirom_start
-#define KIROM_SIZE      (uintptr_t)&__kirom_size
-#define KDROM_START     (uintptr_t)&__kdrom_start
-#define KDROM_SIZE      (uintptr_t)&__kdrom_size
+#define KIROM_START     (uintptr_t)__kirom_start
+#define KIROM_SIZE      (uintptr_t)__kirom_size
+#define KDROM_START     (uintptr_t)__kdrom_start
+#define KDROM_SIZE      (uintptr_t)__kdrom_size
 
 /* Kernel RAM */
 
-#define KIRAM_0_START   (uintptr_t)&__kiram_0_start
-#define KIRAM_0_SIZE    (uintptr_t)&__kiram_0_size
-#define KIRAM_0_END     (uintptr_t)&__kiram_0_end
-#define KIRAM_1_START   (uintptr_t)&__kiram_1_start
-#define KIRAM_1_SIZE    (uintptr_t)&__kiram_1_size
-#define KIRAM_1_END     (uintptr_t)&__kiram_1_end
-#define KDRAM_0_START   (uintptr_t)&__kdram_0_start
-#define KDRAM_0_SIZE    (uintptr_t)&__kdram_0_size
-#define KDRAM_0_END     (uintptr_t)&__kdram_0_end
-#define KDRAM_1_START   (uintptr_t)&__kdram_1_start
-#define KDRAM_1_SIZE    (uintptr_t)&__kdram_1_size
-#define KDRAM_1_END     (uintptr_t)&__kdram_1_end
+#define KIRAM_0_START   (uintptr_t)__kiram_0_start
+#define KIRAM_0_SIZE    (uintptr_t)__kiram_0_size
+#define KIRAM_0_END     (uintptr_t)__kiram_0_end
+#define KIRAM_1_START   (uintptr_t)__kiram_1_start
+#define KIRAM_1_SIZE    (uintptr_t)__kiram_1_size
+#define KIRAM_1_END     (uintptr_t)__kiram_1_end
+#define KDRAM_0_START   (uintptr_t)__kdram_0_start
+#define KDRAM_0_SIZE    (uintptr_t)__kdram_0_size
+#define KDRAM_0_END     (uintptr_t)__kdram_0_end
+#define KDRAM_1_START   (uintptr_t)__kdram_1_start
+#define KDRAM_1_SIZE    (uintptr_t)__kdram_1_size
+#define KDRAM_1_END     (uintptr_t)__kdram_1_end
 
 /* Exception vectors */
 
-#define VECTORS_START   (uintptr_t)&__vectors_start
-#define VECTORS_END     (uintptr_t)&__vectors_end
+#define VECTORS_START   (uintptr_t)__vectors_start
+#define VECTORS_END     (uintptr_t)__vectors_end
 
 /* User ROM */
 
-#define UIROM_START     (uintptr_t)&__uirom_start
-#define UIROM_SIZE      (uintptr_t)&__uirom_size
-#define UIROM_END       (uintptr_t)&__uirom_end
-#define UDROM_START     (uintptr_t)&__udrom_start
-#define UDROM_SIZE      (uintptr_t)&__udrom_size
-#define UDROM_END       (uintptr_t)&__udrom_end
+#define UIROM_START     (uintptr_t)__uirom_start
+#define UIROM_SIZE      (uintptr_t)__uirom_size
+#define UIROM_END       (uintptr_t)__uirom_end
+#define UDROM_START     (uintptr_t)__udrom_start
+#define UDROM_SIZE      (uintptr_t)__udrom_size
+#define UDROM_END       (uintptr_t)__udrom_end
 
 /* User RAM */
 
-#define UIRAM_START     (uintptr_t)&__uiram_start
-#define UIRAM_SIZE      (uintptr_t)&__uiram_size
-#define UIRAM_END       (uintptr_t)&__uiram_end
-#define UDRAM_START     (uintptr_t)&__udram_start
-#define UDRAM_SIZE      (uintptr_t)&__udram_size
-#define UDRAM_END       (uintptr_t)&__udram_end
+#define UIRAM_START     (uintptr_t)__uiram_start
+#define UIRAM_SIZE      (uintptr_t)__uiram_size
+#define UIRAM_END       (uintptr_t)__uiram_end
+#define UDRAM_START     (uintptr_t)__udram_start
+#define UDRAM_SIZE      (uintptr_t)__udram_size
+#define UDRAM_END       (uintptr_t)__udram_end
 
 /****************************************************************************
  * Public Data
@@ -82,47 +82,47 @@
 
 /* Kernel ROM (RX)  */
 
-extern uintptr_t        __kirom_start;
-extern uintptr_t        __kirom_size;
-extern uintptr_t        __kdrom_start;
-extern uintptr_t        __kdrom_size;
+extern uint8_t          __kirom_start[];
+extern uint8_t          __kirom_size[];
+extern uint8_t          __kdrom_start[];
+extern uint8_t          __kdrom_size[];
 
 /* Kernel RAM (RW) */
 
-extern uintptr_t        __kiram_0_start;
-extern uintptr_t        __kiram_0_size;
-extern uintptr_t        __kiram_0_end;
-extern uintptr_t        __kiram_1_start;
-extern uintptr_t        __kiram_1_size;
-extern uintptr_t        __kiram_1_end;
-extern uintptr_t        __kdram_0_start;
-extern uintptr_t        __kdram_0_size;
-extern uintptr_t        __kdram_0_end;
-extern uintptr_t        __kdram_1_start;
-extern uintptr_t        __kdram_1_size;
-extern uintptr_t        __kdram_1_end;
+extern uint8_t          __kiram_0_start[];
+extern uint8_t          __kiram_0_size[];
+extern uint8_t          __kiram_0_end[];
+extern uint8_t          __kiram_1_start[];
+extern uint8_t          __kiram_1_size[];
+extern uint8_t          __kiram_1_end[];
+extern uint8_t          __kdram_0_start[];
+extern uint8_t          __kdram_0_size[];
+extern uint8_t          __kdram_0_end[];
+extern uint8_t          __kdram_1_start[];
+extern uint8_t          __kdram_1_size[];
+extern uint8_t          __kdram_1_end[];
 
 /* Exception vectors */
 
-extern uintptr_t        __vectors_start;
-extern uintptr_t        __vectors_end;
+extern uint8_t          __vectors_start[];
+extern uint8_t          __vectors_end[];
 
 /* User ROM (RX) */
 
-extern uintptr_t        __uirom_start;
-extern uintptr_t        __uirom_size;
-extern uintptr_t        __uirom_end;
-extern uintptr_t        __udrom_start;
-extern uintptr_t        __udrom_size;
-extern uintptr_t        __udrom_end;
+extern uint8_t          __uirom_start[];
+extern uint8_t          __uirom_size[];
+extern uint8_t          __uirom_end[];
+extern uint8_t          __udrom_start[];
+extern uint8_t          __udrom_size[];
+extern uint8_t          __udrom_end[];
 
 /* User RAM (RW) */
 
-extern uintptr_t        __uiram_start;
-extern uintptr_t        __uiram_size;
-extern uintptr_t        __uiram_end;
-extern uintptr_t        __udram_start;
-extern uintptr_t        __udram_size;
-extern uintptr_t        __udram_end;
+extern uint8_t          __uiram_start[];
+extern uint8_t          __uiram_size[];
+extern uint8_t          __uiram_end[];
+extern uint8_t          __udram_start[];
+extern uint8_t          __udram_size[];
+extern uint8_t          __udram_end[];
 
 #endif /* __BOARDS_XTENSA_ESP32_ESP32_DEVKITC_INCLUDE_BOARD_MEMORYMAP_H */

--- a/boards/xtensa/esp32/esp32-ethernet-kit/include/board_memorymap.h
+++ b/boards/xtensa/esp32/esp32-ethernet-kit/include/board_memorymap.h
@@ -33,48 +33,48 @@
 
 /* Kernel ROM */
 
-#define KIROM_START     (uintptr_t)&__kirom_start
-#define KIROM_SIZE      (uintptr_t)&__kirom_size
-#define KDROM_START     (uintptr_t)&__kdrom_start
-#define KDROM_SIZE      (uintptr_t)&__kdrom_size
+#define KIROM_START     (uintptr_t)__kirom_start
+#define KIROM_SIZE      (uintptr_t)__kirom_size
+#define KDROM_START     (uintptr_t)__kdrom_start
+#define KDROM_SIZE      (uintptr_t)__kdrom_size
 
 /* Kernel RAM */
 
-#define KIRAM_0_START   (uintptr_t)&__kiram_0_start
-#define KIRAM_0_SIZE    (uintptr_t)&__kiram_0_size
-#define KIRAM_0_END     (uintptr_t)&__kiram_0_end
-#define KIRAM_1_START   (uintptr_t)&__kiram_1_start
-#define KIRAM_1_SIZE    (uintptr_t)&__kiram_1_size
-#define KIRAM_1_END     (uintptr_t)&__kiram_1_end
-#define KDRAM_0_START   (uintptr_t)&__kdram_0_start
-#define KDRAM_0_SIZE    (uintptr_t)&__kdram_0_size
-#define KDRAM_0_END     (uintptr_t)&__kdram_0_end
-#define KDRAM_1_START   (uintptr_t)&__kdram_1_start
-#define KDRAM_1_SIZE    (uintptr_t)&__kdram_1_size
-#define KDRAM_1_END     (uintptr_t)&__kdram_1_end
+#define KIRAM_0_START   (uintptr_t)__kiram_0_start
+#define KIRAM_0_SIZE    (uintptr_t)__kiram_0_size
+#define KIRAM_0_END     (uintptr_t)__kiram_0_end
+#define KIRAM_1_START   (uintptr_t)__kiram_1_start
+#define KIRAM_1_SIZE    (uintptr_t)__kiram_1_size
+#define KIRAM_1_END     (uintptr_t)__kiram_1_end
+#define KDRAM_0_START   (uintptr_t)__kdram_0_start
+#define KDRAM_0_SIZE    (uintptr_t)__kdram_0_size
+#define KDRAM_0_END     (uintptr_t)__kdram_0_end
+#define KDRAM_1_START   (uintptr_t)__kdram_1_start
+#define KDRAM_1_SIZE    (uintptr_t)__kdram_1_size
+#define KDRAM_1_END     (uintptr_t)__kdram_1_end
 
 /* Exception vectors */
 
-#define VECTORS_START   (uintptr_t)&__vectors_start
-#define VECTORS_END     (uintptr_t)&__vectors_end
+#define VECTORS_START   (uintptr_t)__vectors_start
+#define VECTORS_END     (uintptr_t)__vectors_end
 
 /* User ROM */
 
-#define UIROM_START     (uintptr_t)&__uirom_start
-#define UIROM_SIZE      (uintptr_t)&__uirom_size
-#define UIROM_END       (uintptr_t)&__uirom_end
-#define UDROM_START     (uintptr_t)&__udrom_start
-#define UDROM_SIZE      (uintptr_t)&__udrom_size
-#define UDROM_END       (uintptr_t)&__udrom_end
+#define UIROM_START     (uintptr_t)__uirom_start
+#define UIROM_SIZE      (uintptr_t)__uirom_size
+#define UIROM_END       (uintptr_t)__uirom_end
+#define UDROM_START     (uintptr_t)__udrom_start
+#define UDROM_SIZE      (uintptr_t)__udrom_size
+#define UDROM_END       (uintptr_t)__udrom_end
 
 /* User RAM */
 
-#define UIRAM_START     (uintptr_t)&__uiram_start
-#define UIRAM_SIZE      (uintptr_t)&__uiram_size
-#define UIRAM_END       (uintptr_t)&__uiram_end
-#define UDRAM_START     (uintptr_t)&__udram_start
-#define UDRAM_SIZE      (uintptr_t)&__udram_size
-#define UDRAM_END       (uintptr_t)&__udram_end
+#define UIRAM_START     (uintptr_t)__uiram_start
+#define UIRAM_SIZE      (uintptr_t)__uiram_size
+#define UIRAM_END       (uintptr_t)__uiram_end
+#define UDRAM_START     (uintptr_t)__udram_start
+#define UDRAM_SIZE      (uintptr_t)__udram_size
+#define UDRAM_END       (uintptr_t)__udram_end
 
 /****************************************************************************
  * Public Data
@@ -82,47 +82,47 @@
 
 /* Kernel ROM (RX)  */
 
-extern uintptr_t        __kirom_start;
-extern uintptr_t        __kirom_size;
-extern uintptr_t        __kdrom_start;
-extern uintptr_t        __kdrom_size;
+extern uint8_t          __kirom_start[];
+extern uint8_t          __kirom_size[];
+extern uint8_t          __kdrom_start[];
+extern uint8_t          __kdrom_size[];
 
 /* Kernel RAM (RW) */
 
-extern uintptr_t        __kiram_0_start;
-extern uintptr_t        __kiram_0_size;
-extern uintptr_t        __kiram_0_end;
-extern uintptr_t        __kiram_1_start;
-extern uintptr_t        __kiram_1_size;
-extern uintptr_t        __kiram_1_end;
-extern uintptr_t        __kdram_0_start;
-extern uintptr_t        __kdram_0_size;
-extern uintptr_t        __kdram_0_end;
-extern uintptr_t        __kdram_1_start;
-extern uintptr_t        __kdram_1_size;
-extern uintptr_t        __kdram_1_end;
+extern uint8_t          __kiram_0_start[];
+extern uint8_t          __kiram_0_size[];
+extern uint8_t          __kiram_0_end[];
+extern uint8_t          __kiram_1_start[];
+extern uint8_t          __kiram_1_size[];
+extern uint8_t          __kiram_1_end[];
+extern uint8_t          __kdram_0_start[];
+extern uint8_t          __kdram_0_size[];
+extern uint8_t          __kdram_0_end[];
+extern uint8_t          __kdram_1_start[];
+extern uint8_t          __kdram_1_size[];
+extern uint8_t          __kdram_1_end[];
 
 /* Exception vectors */
 
-extern uintptr_t        __vectors_start;
-extern uintptr_t        __vectors_end;
+extern uint8_t          __vectors_start[];
+extern uint8_t          __vectors_end[];
 
 /* User ROM (RX) */
 
-extern uintptr_t        __uirom_start;
-extern uintptr_t        __uirom_size;
-extern uintptr_t        __uirom_end;
-extern uintptr_t        __udrom_start;
-extern uintptr_t        __udrom_size;
-extern uintptr_t        __udrom_end;
+extern uint8_t          __uirom_start[];
+extern uint8_t          __uirom_size[];
+extern uint8_t          __uirom_end[];
+extern uint8_t          __udrom_start[];
+extern uint8_t          __udrom_size[];
+extern uint8_t          __udrom_end[];
 
 /* User RAM (RW) */
 
-extern uintptr_t        __uiram_start;
-extern uintptr_t        __uiram_size;
-extern uintptr_t        __uiram_end;
-extern uintptr_t        __udram_start;
-extern uintptr_t        __udram_size;
-extern uintptr_t        __udram_end;
+extern uint8_t          __uiram_start[];
+extern uint8_t          __uiram_size[];
+extern uint8_t          __uiram_end[];
+extern uint8_t          __udram_start[];
+extern uint8_t          __udram_size[];
+extern uint8_t          __udram_end[];
 
 #endif /* __BOARDS_XTENSA_ESP32_ESP32_ETHERNET_KIT_INCLUDE_BOARD_MEMORYMAP_H */

--- a/boards/xtensa/esp32/esp32-wrover-kit/include/board_memorymap.h
+++ b/boards/xtensa/esp32/esp32-wrover-kit/include/board_memorymap.h
@@ -33,48 +33,48 @@
 
 /* Kernel ROM */
 
-#define KIROM_START     (uintptr_t)&__kirom_start
-#define KIROM_SIZE      (uintptr_t)&__kirom_size
-#define KDROM_START     (uintptr_t)&__kdrom_start
-#define KDROM_SIZE      (uintptr_t)&__kdrom_size
+#define KIROM_START     (uintptr_t)__kirom_start
+#define KIROM_SIZE      (uintptr_t)__kirom_size
+#define KDROM_START     (uintptr_t)__kdrom_start
+#define KDROM_SIZE      (uintptr_t)__kdrom_size
 
 /* Kernel RAM */
 
-#define KIRAM_0_START   (uintptr_t)&__kiram_0_start
-#define KIRAM_0_SIZE    (uintptr_t)&__kiram_0_size
-#define KIRAM_0_END     (uintptr_t)&__kiram_0_end
-#define KIRAM_1_START   (uintptr_t)&__kiram_1_start
-#define KIRAM_1_SIZE    (uintptr_t)&__kiram_1_size
-#define KIRAM_1_END     (uintptr_t)&__kiram_1_end
-#define KDRAM_0_START   (uintptr_t)&__kdram_0_start
-#define KDRAM_0_SIZE    (uintptr_t)&__kdram_0_size
-#define KDRAM_0_END     (uintptr_t)&__kdram_0_end
-#define KDRAM_1_START   (uintptr_t)&__kdram_1_start
-#define KDRAM_1_SIZE    (uintptr_t)&__kdram_1_size
-#define KDRAM_1_END     (uintptr_t)&__kdram_1_end
+#define KIRAM_0_START   (uintptr_t)__kiram_0_start
+#define KIRAM_0_SIZE    (uintptr_t)__kiram_0_size
+#define KIRAM_0_END     (uintptr_t)__kiram_0_end
+#define KIRAM_1_START   (uintptr_t)__kiram_1_start
+#define KIRAM_1_SIZE    (uintptr_t)__kiram_1_size
+#define KIRAM_1_END     (uintptr_t)__kiram_1_end
+#define KDRAM_0_START   (uintptr_t)__kdram_0_start
+#define KDRAM_0_SIZE    (uintptr_t)__kdram_0_size
+#define KDRAM_0_END     (uintptr_t)__kdram_0_end
+#define KDRAM_1_START   (uintptr_t)__kdram_1_start
+#define KDRAM_1_SIZE    (uintptr_t)__kdram_1_size
+#define KDRAM_1_END     (uintptr_t)__kdram_1_end
 
 /* Exception vectors */
 
-#define VECTORS_START   (uintptr_t)&__vectors_start
-#define VECTORS_END     (uintptr_t)&__vectors_end
+#define VECTORS_START   (uintptr_t)__vectors_start
+#define VECTORS_END     (uintptr_t)__vectors_end
 
 /* User ROM */
 
-#define UIROM_START     (uintptr_t)&__uirom_start
-#define UIROM_SIZE      (uintptr_t)&__uirom_size
-#define UIROM_END       (uintptr_t)&__uirom_end
-#define UDROM_START     (uintptr_t)&__udrom_start
-#define UDROM_SIZE      (uintptr_t)&__udrom_size
-#define UDROM_END       (uintptr_t)&__udrom_end
+#define UIROM_START     (uintptr_t)__uirom_start
+#define UIROM_SIZE      (uintptr_t)__uirom_size
+#define UIROM_END       (uintptr_t)__uirom_end
+#define UDROM_START     (uintptr_t)__udrom_start
+#define UDROM_SIZE      (uintptr_t)__udrom_size
+#define UDROM_END       (uintptr_t)__udrom_end
 
 /* User RAM */
 
-#define UIRAM_START     (uintptr_t)&__uiram_start
-#define UIRAM_SIZE      (uintptr_t)&__uiram_size
-#define UIRAM_END       (uintptr_t)&__uiram_end
-#define UDRAM_START     (uintptr_t)&__udram_start
-#define UDRAM_SIZE      (uintptr_t)&__udram_size
-#define UDRAM_END       (uintptr_t)&__udram_end
+#define UIRAM_START     (uintptr_t)__uiram_start
+#define UIRAM_SIZE      (uintptr_t)__uiram_size
+#define UIRAM_END       (uintptr_t)__uiram_end
+#define UDRAM_START     (uintptr_t)__udram_start
+#define UDRAM_SIZE      (uintptr_t)__udram_size
+#define UDRAM_END       (uintptr_t)__udram_end
 
 /****************************************************************************
  * Public Data
@@ -82,47 +82,47 @@
 
 /* Kernel ROM (RX)  */
 
-extern uintptr_t        __kirom_start;
-extern uintptr_t        __kirom_size;
-extern uintptr_t        __kdrom_start;
-extern uintptr_t        __kdrom_size;
+extern uint8_t          __kirom_start[];
+extern uint8_t          __kirom_size[];
+extern uint8_t          __kdrom_start[];
+extern uint8_t          __kdrom_size[];
 
 /* Kernel RAM (RW) */
 
-extern uintptr_t        __kiram_0_start;
-extern uintptr_t        __kiram_0_size;
-extern uintptr_t        __kiram_0_end;
-extern uintptr_t        __kiram_1_start;
-extern uintptr_t        __kiram_1_size;
-extern uintptr_t        __kiram_1_end;
-extern uintptr_t        __kdram_0_start;
-extern uintptr_t        __kdram_0_size;
-extern uintptr_t        __kdram_0_end;
-extern uintptr_t        __kdram_1_start;
-extern uintptr_t        __kdram_1_size;
-extern uintptr_t        __kdram_1_end;
+extern uint8_t          __kiram_0_start[];
+extern uint8_t          __kiram_0_size[];
+extern uint8_t          __kiram_0_end[];
+extern uint8_t          __kiram_1_start[];
+extern uint8_t          __kiram_1_size[];
+extern uint8_t          __kiram_1_end[];
+extern uint8_t          __kdram_0_start[];
+extern uint8_t          __kdram_0_size[];
+extern uint8_t          __kdram_0_end[];
+extern uint8_t          __kdram_1_start[];
+extern uint8_t          __kdram_1_size[];
+extern uint8_t          __kdram_1_end[];
 
 /* Exception vectors */
 
-extern uintptr_t        __vectors_start;
-extern uintptr_t        __vectors_end;
+extern uint8_t          __vectors_start[];
+extern uint8_t          __vectors_end[];
 
 /* User ROM (RX) */
 
-extern uintptr_t        __uirom_start;
-extern uintptr_t        __uirom_size;
-extern uintptr_t        __uirom_end;
-extern uintptr_t        __udrom_start;
-extern uintptr_t        __udrom_size;
-extern uintptr_t        __udrom_end;
+extern uint8_t          __uirom_start[];
+extern uint8_t          __uirom_size[];
+extern uint8_t          __uirom_end[];
+extern uint8_t          __udrom_start[];
+extern uint8_t          __udrom_size[];
+extern uint8_t          __udrom_end[];
 
 /* User RAM (RW) */
 
-extern uintptr_t        __uiram_start;
-extern uintptr_t        __uiram_size;
-extern uintptr_t        __uiram_end;
-extern uintptr_t        __udram_start;
-extern uintptr_t        __udram_size;
-extern uintptr_t        __udram_end;
+extern uint8_t          __uiram_start[];
+extern uint8_t          __uiram_size[];
+extern uint8_t          __uiram_end[];
+extern uint8_t          __udram_start[];
+extern uint8_t          __udram_size[];
+extern uint8_t          __udram_end[];
 
 #endif /* __BOARDS_XTENSA_ESP32_ESP32_WROVER_KIT_INCLUDE_BOARD_MEMORYMAP_H */

--- a/boards/xtensa/esp32/ttgo_eink5_v2/include/board_memorymap.h
+++ b/boards/xtensa/esp32/ttgo_eink5_v2/include/board_memorymap.h
@@ -33,48 +33,48 @@
 
 /* Kernel ROM */
 
-#define KIROM_START     (uintptr_t)&__kirom_start
-#define KIROM_SIZE      (uintptr_t)&__kirom_size
-#define KDROM_START     (uintptr_t)&__kdrom_start
-#define KDROM_SIZE      (uintptr_t)&__kdrom_size
+#define KIROM_START     (uintptr_t)__kirom_start
+#define KIROM_SIZE      (uintptr_t)__kirom_size
+#define KDROM_START     (uintptr_t)__kdrom_start
+#define KDROM_SIZE      (uintptr_t)__kdrom_size
 
 /* Kernel RAM */
 
-#define KIRAM_0_START   (uintptr_t)&__kiram_0_start
-#define KIRAM_0_SIZE    (uintptr_t)&__kiram_0_size
-#define KIRAM_0_END     (uintptr_t)&__kiram_0_end
-#define KIRAM_1_START   (uintptr_t)&__kiram_1_start
-#define KIRAM_1_SIZE    (uintptr_t)&__kiram_1_size
-#define KIRAM_1_END     (uintptr_t)&__kiram_1_end
-#define KDRAM_0_START   (uintptr_t)&__kdram_0_start
-#define KDRAM_0_SIZE    (uintptr_t)&__kdram_0_size
-#define KDRAM_0_END     (uintptr_t)&__kdram_0_end
-#define KDRAM_1_START   (uintptr_t)&__kdram_1_start
-#define KDRAM_1_SIZE    (uintptr_t)&__kdram_1_size
-#define KDRAM_1_END     (uintptr_t)&__kdram_1_end
+#define KIRAM_0_START   (uintptr_t)__kiram_0_start
+#define KIRAM_0_SIZE    (uintptr_t)__kiram_0_size
+#define KIRAM_0_END     (uintptr_t)__kiram_0_end
+#define KIRAM_1_START   (uintptr_t)__kiram_1_start
+#define KIRAM_1_SIZE    (uintptr_t)__kiram_1_size
+#define KIRAM_1_END     (uintptr_t)__kiram_1_end
+#define KDRAM_0_START   (uintptr_t)__kdram_0_start
+#define KDRAM_0_SIZE    (uintptr_t)__kdram_0_size
+#define KDRAM_0_END     (uintptr_t)__kdram_0_end
+#define KDRAM_1_START   (uintptr_t)__kdram_1_start
+#define KDRAM_1_SIZE    (uintptr_t)__kdram_1_size
+#define KDRAM_1_END     (uintptr_t)__kdram_1_end
 
 /* Exception vectors */
 
-#define VECTORS_START   (uintptr_t)&__vectors_start
-#define VECTORS_END     (uintptr_t)&__vectors_end
+#define VECTORS_START   (uintptr_t)__vectors_start
+#define VECTORS_END     (uintptr_t)__vectors_end
 
 /* User ROM */
 
-#define UIROM_START     (uintptr_t)&__uirom_start
-#define UIROM_SIZE      (uintptr_t)&__uirom_size
-#define UIROM_END       (uintptr_t)&__uirom_end
-#define UDROM_START     (uintptr_t)&__udrom_start
-#define UDROM_SIZE      (uintptr_t)&__udrom_size
-#define UDROM_END       (uintptr_t)&__udrom_end
+#define UIROM_START     (uintptr_t)__uirom_start
+#define UIROM_SIZE      (uintptr_t)__uirom_size
+#define UIROM_END       (uintptr_t)__uirom_end
+#define UDROM_START     (uintptr_t)__udrom_start
+#define UDROM_SIZE      (uintptr_t)__udrom_size
+#define UDROM_END       (uintptr_t)__udrom_end
 
 /* User RAM */
 
-#define UIRAM_START     (uintptr_t)&__uiram_start
-#define UIRAM_SIZE      (uintptr_t)&__uiram_size
-#define UIRAM_END       (uintptr_t)&__uiram_end
-#define UDRAM_START     (uintptr_t)&__udram_start
-#define UDRAM_SIZE      (uintptr_t)&__udram_size
-#define UDRAM_END       (uintptr_t)&__udram_end
+#define UIRAM_START     (uintptr_t)__uiram_start
+#define UIRAM_SIZE      (uintptr_t)__uiram_size
+#define UIRAM_END       (uintptr_t)__uiram_end
+#define UDRAM_START     (uintptr_t)__udram_start
+#define UDRAM_SIZE      (uintptr_t)__udram_size
+#define UDRAM_END       (uintptr_t)__udram_end
 
 /****************************************************************************
  * Public Data
@@ -82,47 +82,47 @@
 
 /* Kernel ROM (RX)  */
 
-extern uintptr_t        __kirom_start;
-extern uintptr_t        __kirom_size;
-extern uintptr_t        __kdrom_start;
-extern uintptr_t        __kdrom_size;
+extern uint8_t          __kirom_start[];
+extern uint8_t          __kirom_size[];
+extern uint8_t          __kdrom_start[];
+extern uint8_t          __kdrom_size[];
 
 /* Kernel RAM (RW) */
 
-extern uintptr_t        __kiram_0_start;
-extern uintptr_t        __kiram_0_size;
-extern uintptr_t        __kiram_0_end;
-extern uintptr_t        __kiram_1_start;
-extern uintptr_t        __kiram_1_size;
-extern uintptr_t        __kiram_1_end;
-extern uintptr_t        __kdram_0_start;
-extern uintptr_t        __kdram_0_size;
-extern uintptr_t        __kdram_0_end;
-extern uintptr_t        __kdram_1_start;
-extern uintptr_t        __kdram_1_size;
-extern uintptr_t        __kdram_1_end;
+extern uint8_t          __kiram_0_start[];
+extern uint8_t          __kiram_0_size[];
+extern uint8_t          __kiram_0_end[];
+extern uint8_t          __kiram_1_start[];
+extern uint8_t          __kiram_1_size[];
+extern uint8_t          __kiram_1_end[];
+extern uint8_t          __kdram_0_start[];
+extern uint8_t          __kdram_0_size[];
+extern uint8_t          __kdram_0_end[];
+extern uint8_t          __kdram_1_start[];
+extern uint8_t          __kdram_1_size[];
+extern uint8_t          __kdram_1_end[];
 
 /* Exception vectors */
 
-extern uintptr_t        __vectors_start;
-extern uintptr_t        __vectors_end;
+extern uint8_t          __vectors_start[];
+extern uint8_t          __vectors_end[];
 
 /* User ROM (RX) */
 
-extern uintptr_t        __uirom_start;
-extern uintptr_t        __uirom_size;
-extern uintptr_t        __uirom_end;
-extern uintptr_t        __udrom_start;
-extern uintptr_t        __udrom_size;
-extern uintptr_t        __udrom_end;
+extern uint8_t          __uirom_start[];
+extern uint8_t          __uirom_size[];
+extern uint8_t          __uirom_end[];
+extern uint8_t          __udrom_start[];
+extern uint8_t          __udrom_size[];
+extern uint8_t          __udrom_end[];
 
 /* User RAM (RW) */
 
-extern uintptr_t        __uiram_start;
-extern uintptr_t        __uiram_size;
-extern uintptr_t        __uiram_end;
-extern uintptr_t        __udram_start;
-extern uintptr_t        __udram_size;
-extern uintptr_t        __udram_end;
+extern uint8_t          __uiram_start[];
+extern uint8_t          __uiram_size[];
+extern uint8_t          __uiram_end[];
+extern uint8_t          __udram_start[];
+extern uint8_t          __udram_size[];
+extern uint8_t          __udram_end[];
 
 #endif /* __BOARDS_XTENSA_ESP32_TTGO_EINK_5_V2_INCLUDE_BOARD_MEMORYMAP_H */

--- a/boards/xtensa/esp32/ttgo_lora_esp32/include/board_memorymap.h
+++ b/boards/xtensa/esp32/ttgo_lora_esp32/include/board_memorymap.h
@@ -33,48 +33,48 @@
 
 /* Kernel ROM */
 
-#define KIROM_START     (uintptr_t)&__kirom_start
-#define KIROM_SIZE      (uintptr_t)&__kirom_size
-#define KDROM_START     (uintptr_t)&__kdrom_start
-#define KDROM_SIZE      (uintptr_t)&__kdrom_size
+#define KIROM_START     (uintptr_t)__kirom_start
+#define KIROM_SIZE      (uintptr_t)__kirom_size
+#define KDROM_START     (uintptr_t)__kdrom_start
+#define KDROM_SIZE      (uintptr_t)__kdrom_size
 
 /* Kernel RAM */
 
-#define KIRAM_0_START   (uintptr_t)&__kiram_0_start
-#define KIRAM_0_SIZE    (uintptr_t)&__kiram_0_size
-#define KIRAM_0_END     (uintptr_t)&__kiram_0_end
-#define KIRAM_1_START   (uintptr_t)&__kiram_1_start
-#define KIRAM_1_SIZE    (uintptr_t)&__kiram_1_size
-#define KIRAM_1_END     (uintptr_t)&__kiram_1_end
-#define KDRAM_0_START   (uintptr_t)&__kdram_0_start
-#define KDRAM_0_SIZE    (uintptr_t)&__kdram_0_size
-#define KDRAM_0_END     (uintptr_t)&__kdram_0_end
-#define KDRAM_1_START   (uintptr_t)&__kdram_1_start
-#define KDRAM_1_SIZE    (uintptr_t)&__kdram_1_size
-#define KDRAM_1_END     (uintptr_t)&__kdram_1_end
+#define KIRAM_0_START   (uintptr_t)__kiram_0_start
+#define KIRAM_0_SIZE    (uintptr_t)__kiram_0_size
+#define KIRAM_0_END     (uintptr_t)__kiram_0_end
+#define KIRAM_1_START   (uintptr_t)__kiram_1_start
+#define KIRAM_1_SIZE    (uintptr_t)__kiram_1_size
+#define KIRAM_1_END     (uintptr_t)__kiram_1_end
+#define KDRAM_0_START   (uintptr_t)__kdram_0_start
+#define KDRAM_0_SIZE    (uintptr_t)__kdram_0_size
+#define KDRAM_0_END     (uintptr_t)__kdram_0_end
+#define KDRAM_1_START   (uintptr_t)__kdram_1_start
+#define KDRAM_1_SIZE    (uintptr_t)__kdram_1_size
+#define KDRAM_1_END     (uintptr_t)__kdram_1_end
 
 /* Exception vectors */
 
-#define VECTORS_START   (uintptr_t)&__vectors_start
-#define VECTORS_END     (uintptr_t)&__vectors_end
+#define VECTORS_START   (uintptr_t)__vectors_start
+#define VECTORS_END     (uintptr_t)__vectors_end
 
 /* User ROM */
 
-#define UIROM_START     (uintptr_t)&__uirom_start
-#define UIROM_SIZE      (uintptr_t)&__uirom_size
-#define UIROM_END       (uintptr_t)&__uirom_end
-#define UDROM_START     (uintptr_t)&__udrom_start
-#define UDROM_SIZE      (uintptr_t)&__udrom_size
-#define UDROM_END       (uintptr_t)&__udrom_end
+#define UIROM_START     (uintptr_t)__uirom_start
+#define UIROM_SIZE      (uintptr_t)__uirom_size
+#define UIROM_END       (uintptr_t)__uirom_end
+#define UDROM_START     (uintptr_t)__udrom_start
+#define UDROM_SIZE      (uintptr_t)__udrom_size
+#define UDROM_END       (uintptr_t)__udrom_end
 
 /* User RAM */
 
-#define UIRAM_START     (uintptr_t)&__uiram_start
-#define UIRAM_SIZE      (uintptr_t)&__uiram_size
-#define UIRAM_END       (uintptr_t)&__uiram_end
-#define UDRAM_START     (uintptr_t)&__udram_start
-#define UDRAM_SIZE      (uintptr_t)&__udram_size
-#define UDRAM_END       (uintptr_t)&__udram_end
+#define UIRAM_START     (uintptr_t)__uiram_start
+#define UIRAM_SIZE      (uintptr_t)__uiram_size
+#define UIRAM_END       (uintptr_t)__uiram_end
+#define UDRAM_START     (uintptr_t)__udram_start
+#define UDRAM_SIZE      (uintptr_t)__udram_size
+#define UDRAM_END       (uintptr_t)__udram_end
 
 /****************************************************************************
  * Public Data
@@ -82,47 +82,47 @@
 
 /* Kernel ROM (RX)  */
 
-extern uintptr_t        __kirom_start;
-extern uintptr_t        __kirom_size;
-extern uintptr_t        __kdrom_start;
-extern uintptr_t        __kdrom_size;
+extern uint8_t          __kirom_start[];
+extern uint8_t          __kirom_size[];
+extern uint8_t          __kdrom_start[];
+extern uint8_t          __kdrom_size[];
 
 /* Kernel RAM (RW) */
 
-extern uintptr_t        __kiram_0_start;
-extern uintptr_t        __kiram_0_size;
-extern uintptr_t        __kiram_0_end;
-extern uintptr_t        __kiram_1_start;
-extern uintptr_t        __kiram_1_size;
-extern uintptr_t        __kiram_1_end;
-extern uintptr_t        __kdram_0_start;
-extern uintptr_t        __kdram_0_size;
-extern uintptr_t        __kdram_0_end;
-extern uintptr_t        __kdram_1_start;
-extern uintptr_t        __kdram_1_size;
-extern uintptr_t        __kdram_1_end;
+extern uint8_t          __kiram_0_start[];
+extern uint8_t          __kiram_0_size[];
+extern uint8_t          __kiram_0_end[];
+extern uint8_t          __kiram_1_start[];
+extern uint8_t          __kiram_1_size[];
+extern uint8_t          __kiram_1_end[];
+extern uint8_t          __kdram_0_start[];
+extern uint8_t          __kdram_0_size[];
+extern uint8_t          __kdram_0_end[];
+extern uint8_t          __kdram_1_start[];
+extern uint8_t          __kdram_1_size[];
+extern uint8_t          __kdram_1_end[];
 
 /* Exception vectors */
 
-extern uintptr_t        __vectors_start;
-extern uintptr_t        __vectors_end;
+extern uint8_t          __vectors_start[];
+extern uint8_t          __vectors_end[];
 
 /* User ROM (RX) */
 
-extern uintptr_t        __uirom_start;
-extern uintptr_t        __uirom_size;
-extern uintptr_t        __uirom_end;
-extern uintptr_t        __udrom_start;
-extern uintptr_t        __udrom_size;
-extern uintptr_t        __udrom_end;
+extern uint8_t          __uirom_start[];
+extern uint8_t          __uirom_size[];
+extern uint8_t          __uirom_end[];
+extern uint8_t          __udrom_start[];
+extern uint8_t          __udrom_size[];
+extern uint8_t          __udrom_end[];
 
 /* User RAM (RW) */
 
-extern uintptr_t        __uiram_start;
-extern uintptr_t        __uiram_size;
-extern uintptr_t        __uiram_end;
-extern uintptr_t        __udram_start;
-extern uintptr_t        __udram_size;
-extern uintptr_t        __udram_end;
+extern uint8_t          __uiram_start[];
+extern uint8_t          __uiram_size[];
+extern uint8_t          __uiram_end[];
+extern uint8_t          __udram_start[];
+extern uint8_t          __udram_size[];
+extern uint8_t          __udram_end[];
 
 #endif /* __BOARDS_XTENSA_ESP32_TTGO_LORA_ESP32_INCLUDE_BOARD_MEMORYMAP_H */

--- a/boards/xtensa/esp32/ttgo_t_display_esp32/include/board_memorymap.h
+++ b/boards/xtensa/esp32/ttgo_t_display_esp32/include/board_memorymap.h
@@ -33,48 +33,48 @@
 
 /* Kernel ROM */
 
-#define KIROM_START     (uintptr_t)&__kirom_start
-#define KIROM_SIZE      (uintptr_t)&__kirom_size
-#define KDROM_START     (uintptr_t)&__kdrom_start
-#define KDROM_SIZE      (uintptr_t)&__kdrom_size
+#define KIROM_START     (uintptr_t)__kirom_start
+#define KIROM_SIZE      (uintptr_t)__kirom_size
+#define KDROM_START     (uintptr_t)__kdrom_start
+#define KDROM_SIZE      (uintptr_t)__kdrom_size
 
 /* Kernel RAM */
 
-#define KIRAM_0_START   (uintptr_t)&__kiram_0_start
-#define KIRAM_0_SIZE    (uintptr_t)&__kiram_0_size
-#define KIRAM_0_END     (uintptr_t)&__kiram_0_end
-#define KIRAM_1_START   (uintptr_t)&__kiram_1_start
-#define KIRAM_1_SIZE    (uintptr_t)&__kiram_1_size
-#define KIRAM_1_END     (uintptr_t)&__kiram_1_end
-#define KDRAM_0_START   (uintptr_t)&__kdram_0_start
-#define KDRAM_0_SIZE    (uintptr_t)&__kdram_0_size
-#define KDRAM_0_END     (uintptr_t)&__kdram_0_end
-#define KDRAM_1_START   (uintptr_t)&__kdram_1_start
-#define KDRAM_1_SIZE    (uintptr_t)&__kdram_1_size
-#define KDRAM_1_END     (uintptr_t)&__kdram_1_end
+#define KIRAM_0_START   (uintptr_t)__kiram_0_start
+#define KIRAM_0_SIZE    (uintptr_t)__kiram_0_size
+#define KIRAM_0_END     (uintptr_t)__kiram_0_end
+#define KIRAM_1_START   (uintptr_t)__kiram_1_start
+#define KIRAM_1_SIZE    (uintptr_t)__kiram_1_size
+#define KIRAM_1_END     (uintptr_t)__kiram_1_end
+#define KDRAM_0_START   (uintptr_t)__kdram_0_start
+#define KDRAM_0_SIZE    (uintptr_t)__kdram_0_size
+#define KDRAM_0_END     (uintptr_t)__kdram_0_end
+#define KDRAM_1_START   (uintptr_t)__kdram_1_start
+#define KDRAM_1_SIZE    (uintptr_t)__kdram_1_size
+#define KDRAM_1_END     (uintptr_t)__kdram_1_end
 
 /* Exception vectors */
 
-#define VECTORS_START   (uintptr_t)&__vectors_start
-#define VECTORS_END     (uintptr_t)&__vectors_end
+#define VECTORS_START   (uintptr_t)__vectors_start
+#define VECTORS_END     (uintptr_t)__vectors_end
 
 /* User ROM */
 
-#define UIROM_START     (uintptr_t)&__uirom_start
-#define UIROM_SIZE      (uintptr_t)&__uirom_size
-#define UIROM_END       (uintptr_t)&__uirom_end
-#define UDROM_START     (uintptr_t)&__udrom_start
-#define UDROM_SIZE      (uintptr_t)&__udrom_size
-#define UDROM_END       (uintptr_t)&__udrom_end
+#define UIROM_START     (uintptr_t)__uirom_start
+#define UIROM_SIZE      (uintptr_t)__uirom_size
+#define UIROM_END       (uintptr_t)__uirom_end
+#define UDROM_START     (uintptr_t)__udrom_start
+#define UDROM_SIZE      (uintptr_t)__udrom_size
+#define UDROM_END       (uintptr_t)__udrom_end
 
 /* User RAM */
 
-#define UIRAM_START     (uintptr_t)&__uiram_start
-#define UIRAM_SIZE      (uintptr_t)&__uiram_size
-#define UIRAM_END       (uintptr_t)&__uiram_end
-#define UDRAM_START     (uintptr_t)&__udram_start
-#define UDRAM_SIZE      (uintptr_t)&__udram_size
-#define UDRAM_END       (uintptr_t)&__udram_end
+#define UIRAM_START     (uintptr_t)__uiram_start
+#define UIRAM_SIZE      (uintptr_t)__uiram_size
+#define UIRAM_END       (uintptr_t)__uiram_end
+#define UDRAM_START     (uintptr_t)__udram_start
+#define UDRAM_SIZE      (uintptr_t)__udram_size
+#define UDRAM_END       (uintptr_t)__udram_end
 
 /****************************************************************************
  * Public Data
@@ -82,47 +82,47 @@
 
 /* Kernel ROM (RX)  */
 
-extern uintptr_t        __kirom_start;
-extern uintptr_t        __kirom_size;
-extern uintptr_t        __kdrom_start;
-extern uintptr_t        __kdrom_size;
+extern uint8_t          __kirom_start[];
+extern uint8_t          __kirom_size[];
+extern uint8_t          __kdrom_start[];
+extern uint8_t          __kdrom_size[];
 
 /* Kernel RAM (RW) */
 
-extern uintptr_t        __kiram_0_start;
-extern uintptr_t        __kiram_0_size;
-extern uintptr_t        __kiram_0_end;
-extern uintptr_t        __kiram_1_start;
-extern uintptr_t        __kiram_1_size;
-extern uintptr_t        __kiram_1_end;
-extern uintptr_t        __kdram_0_start;
-extern uintptr_t        __kdram_0_size;
-extern uintptr_t        __kdram_0_end;
-extern uintptr_t        __kdram_1_start;
-extern uintptr_t        __kdram_1_size;
-extern uintptr_t        __kdram_1_end;
+extern uint8_t          __kiram_0_start[];
+extern uint8_t          __kiram_0_size[];
+extern uint8_t          __kiram_0_end[];
+extern uint8_t          __kiram_1_start[];
+extern uint8_t          __kiram_1_size[];
+extern uint8_t          __kiram_1_end[];
+extern uint8_t          __kdram_0_start[];
+extern uint8_t          __kdram_0_size[];
+extern uint8_t          __kdram_0_end[];
+extern uint8_t          __kdram_1_start[];
+extern uint8_t          __kdram_1_size[];
+extern uint8_t          __kdram_1_end[];
 
 /* Exception vectors */
 
-extern uintptr_t        __vectors_start;
-extern uintptr_t        __vectors_end;
+extern uint8_t          __vectors_start[];
+extern uint8_t          __vectors_end[];
 
 /* User ROM (RX) */
 
-extern uintptr_t        __uirom_start;
-extern uintptr_t        __uirom_size;
-extern uintptr_t        __uirom_end;
-extern uintptr_t        __udrom_start;
-extern uintptr_t        __udrom_size;
-extern uintptr_t        __udrom_end;
+extern uint8_t          __uirom_start[];
+extern uint8_t          __uirom_size[];
+extern uint8_t          __uirom_end[];
+extern uint8_t          __udrom_start[];
+extern uint8_t          __udrom_size[];
+extern uint8_t          __udrom_end[];
 
 /* User RAM (RW) */
 
-extern uintptr_t        __uiram_start;
-extern uintptr_t        __uiram_size;
-extern uintptr_t        __uiram_end;
-extern uintptr_t        __udram_start;
-extern uintptr_t        __udram_size;
-extern uintptr_t        __udram_end;
+extern uint8_t          __uiram_start[];
+extern uint8_t          __uiram_size[];
+extern uint8_t          __uiram_end[];
+extern uint8_t          __udram_start[];
+extern uint8_t          __udram_size[];
+extern uint8_t          __udram_end[];
 
 #endif /* __BOARDS_XTENSA_ESP32_TTGO_T_DISPLAY_ESP32_INCLUDE_BOARD_MEMORYMAP_H */

--- a/boards/z80/ez80/z20x/src/z20x.h
+++ b/boards/z80/ez80/z20x/src/z20x.h
@@ -106,27 +106,27 @@
  * 0bffff _progend     End of RAM
  */
 
-extern unsigned long _vecstart;
-#define VECSTART     ((uintptr_t)&_vecstart)
+extern uint8_t _vecstart[];
+#define VECSTART     ((uintptr_t)_vecstart)
 
-extern unsigned long _vecend;
-#define VECEND       ((uintptr_t)&_vecend)
+extern uint8_t _vecend[];
+#define VECEND       ((uintptr_t)_vecend)
 
 #define VECSIZE      (VECEND - VECSTART + 1)
 
-extern unsigned long _loaderstart;
-#define LOADERSTART  ((uintptr_t)&_loaderstart)
+extern uint8_t _loaderstart[];
+#define LOADERSTART  ((uintptr_t)_loaderstart)
 
-extern unsigned long _loaderend;
-#define LOADEREND    ((uintptr_t)&_loaderend)
+extern uint8_t _loaderend[];
+#define LOADEREND    ((uintptr_t)_loaderend)
 
 #define LOADERSIZE   (LOADEREND - LOADERSTART + 1)
 
-extern unsigned long _progstart;
-#define PROGSTART    ((uintptr_t)&_progstart)
+extern uint8_t _progstart[];
+#define PROGSTART    ((uintptr_t)_progstart)
 
-extern unsigned long _progend;
-#define PROGEND      ((uintptr_t)&_progend)
+extern uint8_t _progend[];
+#define PROGEND      ((uintptr_t)_progend)
 
 #define PROGSIZE     (PROGEND - PROGSTART + 1)
 

--- a/include/nuttx/arch.h
+++ b/include/nuttx/arch.h
@@ -155,8 +155,8 @@ EXTERN volatile bool g_rtc_enabled;
  * beginning and the end of the C++ initialization section.
  */
 
-extern initializer_t _sinit;
-extern initializer_t _einit;
+extern initializer_t _sinit[];
+extern initializer_t _einit[];
 #endif
 
 /****************************************************************************

--- a/libs/libc/machine/arm/gnu_unwind_find_exidx.c
+++ b/libs/libc/machine/arm/gnu_unwind_find_exidx.c
@@ -26,28 +26,11 @@
 #include <unwind.h>
 
 /****************************************************************************
- * Private Types
- ****************************************************************************/
-
-typedef struct __EIT_entry
-{
-  _uw fnoffset;
-  _uw content;
-} __EIT_entry;
-
-/****************************************************************************
  * Private Data
  ****************************************************************************/
 
 static __EIT_entry *__exidx_start_elf;
 static __EIT_entry *__exidx_end_elf;
-
-/****************************************************************************
- * Public Data
- ****************************************************************************/
-
-extern __EIT_entry __exidx_start;
-extern __EIT_entry __exidx_end;
 
 /****************************************************************************
  * Public Functions
@@ -95,8 +78,8 @@ _Unwind_Ptr __gnu_Unwind_Find_exidx(_Unwind_Ptr return_address, int *nrecp)
 {
   if (return_address < 0x20000000)
     {
-      *nrecp = &__exidx_end - &__exidx_start;
-      return (_Unwind_Ptr)&__exidx_start;
+      *nrecp = __exidx_end - __exidx_start;
+      return (_Unwind_Ptr)__exidx_start;
     }
   else
     {

--- a/libs/libc/misc/lib_cxx_initialize.c
+++ b/libs/libc/misc/lib_cxx_initialize.c
@@ -71,11 +71,11 @@ void lib_cxx_initialize(void)
 #else
       initializer_t *initp;
 
-      sinfo("_sinit: %p _einit: %p\n", &_sinit, &_einit);
+      sinfo("_sinit: %p _einit: %p\n", _sinit, _einit);
 
       /* Visit each entry in the initialization table */
 
-      for (initp = &_sinit; initp != &_einit; initp++)
+      for (initp = _sinit; initp < _einit; initp++)
         {
           initializer_t initializer = *initp;
           sinfo("initp: %p initializer: %p\n", initp, initializer);


### PR DESCRIPTION
## Summary
The symbol generated by linker is always used as an address not a value.

## Impact
Code refactor

## Testing
Pass CI
