### PR TITLE
Fix Kconfig  dependence

### DIFF
--- a/libs/libc/netdb/Kconfig
+++ b/libs/libc/netdb/Kconfig
@@ -11,6 +11,7 @@ menu "NETDB Support"
 
 config LIBC_GAISTRERROR
 	bool "Enable gai_strerror"
+	depends on LIBC_NETDB
 	default n
 	---help---
 		The gai_strerror() function shall return a text string describing an error
@@ -20,10 +21,12 @@ config LIBC_GAISTRERROR
 
 config NETDB_BUFSIZE
 	int "gethostbyname/gethostbyaddr buffer size"
+	depends on LIBC_NETDB
 	default 256
 
 config NETDB_MAX_IPADDR
 	int "Max number of IP addresses per host"
+	depends on LIBC_NETDB
 	default 2 if NET_IPv4 && NET_IPv6
 	default 1
 	---help---

--- a/libs/libc/stdio/Kconfig
+++ b/libs/libc/stdio/Kconfig
@@ -7,6 +7,7 @@ menu "Standard C I/O"
 
 config STDIO_DISABLE_BUFFERING
 	bool "Disable STDIO Buffering"
+	depends on FILE_STREAM
 	default n
 	---help---
 		Tiny systems may need to disable all support for I/O buffering in


### PR DESCRIPTION
## Summary

- libc/netdb: Let LIBC_GAISTRERROR/NETDB_BUFSIZE/NETDB_MAX_IPADDR depends on LIBC_NETDB
- libc/stdio: Let STDIO_DISABLE_BUFFERING depends on FILE_STREAM 

## Impact
Minor

## Testing

