### PR TITLE
imxrt: add support for ADC triggering by an external signal

### DIFF
--- a/Documentation/platforms/arm/imxrt/index.rst
+++ b/Documentation/platforms/arm/imxrt/index.rst
@@ -87,6 +87,18 @@ ADC
 ADC driver with the successive approximation analog/digital converter. The lower-half of
 this driver is initialize by calling :c:func:`imxrt_adcinitialize`.
 
+ADC module can use either continous trigger (next conversion is started as soon as the
+previous is finished) or hardware trigger. This option is selected by IMXRT_ADCx_ETC
+(x = 1, 2) config option. If IMXRT_ADCx_ETC = -1 then continous trigger is used. If
+corresponding XBAR number is put in IMXRT_ADCx_ETC then that signal is used to trigger
+the ADC conversion (for example PWM signal can be used as a source). For PWM XBAR options
+please refer to PWM chapter of this documentation.
+
+Hardware triggering is currently limited to maximum of 8 channels. HW trigger is automatically
+disabled if there are more than 8 channels.
+
+DMA is currently not supported for ADC modules.
+
 CAN
 ---
 

--- a/arch/arm/src/imxrt/Kconfig
+++ b/arch/arm/src/imxrt/Kconfig
@@ -1274,10 +1274,44 @@ menuconfig IMXRT_ADC1
 	default n
 	select IMXRT_ADC
 
+if IMXRT_ADC1
+
+config IMXRT_ADC1_ETC
+	int "ADC1 External Trigger"
+	range -1 130
+	default -1
+	---help---
+		ADC module can be triggered by an external source (timer, PWM, etc).
+		This config option selects the signal's source. The number in
+		IMXRT_ADC1_ETC corresponds with the XBAR number of the source (please
+		refer to the documentation for XBAR numbers).
+
+		-1 (default value) means the conversion is not to be triggered by an
+		external source.
+
+endif
+
 menuconfig IMXRT_ADC2
 	bool "ADC2"
 	default n
 	select IMXRT_ADC
+
+if IMXRT_ADC2
+
+config IMXRT_ADC2_ETC
+	int "ADC2 External Trigger"
+	range -1 130
+	default -1
+	---help---
+		ADC module can be triggered by an external source (timer, PWM, etc).
+		This config option selects the signal's source. The number in
+		IMXRT_ADC2_ETC corresponds with the XBAR number of the source (please
+		refer to the documentation for XBAR numbers).
+
+		-1 (default value) means the conversion is not to be triggered by an
+		external source.
+
+endif
 
 endmenu
 

--- a/arch/arm/src/imxrt/hardware/imxrt_adc_etc.h
+++ b/arch/arm/src/imxrt/hardware/imxrt_adc_etc.h
@@ -33,6 +33,7 @@
  ****************************************************************************/
 
 #define TRIG_OFFSET   0x28
+#define IRQ_OFFSET    0x10
 #define CHAIN_OFFSET  0x4
 #define RESULT_OFFSET 0x4
 


### PR DESCRIPTION
## Summary
Config option IMXRT_ADCx_ETC can now be used to select an external HW trigger to be used instead of continous trigger. Continous trigger is used if IMXRT_ADCx_ETC = -1 (default option). Otherwise the source signal is routed through XBAR and used as a trigger.

## Impact
iMXRT boards only, no impact in default configuration.

## Testing
The external triggering was tested with PWM signal as a source on Teensy 4.1 board.
