### PR TITLE
arch/arm: redefine the linker symbols as armlink style

### DIFF
--- a/arch/arm/include/arch.h
+++ b/arch/arm/include/arch.h
@@ -104,6 +104,13 @@ do { \
 #  endif
 #endif /* CONFIG_ARCH_ADDRENV */
 
+/* Redefine the linker symbols as armlink style */
+
+#ifdef CONFIG_ARM_TOOLCHAIN_ARMCLANG
+#  define _sinit   Image$$init_section$$Base
+#  define _einit   Image$$init_section$$Limit
+#endif
+
 /****************************************************************************
  * Inline functions
  ****************************************************************************/

--- a/arch/arm/src/common/Toolchain.defs
+++ b/arch/arm/src/common/Toolchain.defs
@@ -157,6 +157,22 @@ else ifeq ($(CONFIG_ARM_TOOLCHAIN_ARMCLANG),y)
   ARCHCPUFLAGS += -Wno-license-management
   LDFLAGS      += --diag_suppress=9931
 
+  # Input sections are specified even though there will be no such
+  # sections found in the libraries linked.
+  # Warning: L6314W: No section matches pattern *(xxx).
+
+  LDFLAGS      += --diag_suppress=6314
+
+  # Allow Empty Execution region declared on scatter
+  # Warning: L6312W: Empty Execution region description for region xxx
+
+  LDFLAGS      += --diag_suppress=6312
+
+  # Match pattern for an unused section that is being removed.
+  # Warning: L6329W: Pattern xxx only matches removed unused sections.
+
+  LDFLAGS      += --diag_suppress=6329
+
 # Default toolchain
 
 else

--- a/arch/arm/src/common/arm_internal.h
+++ b/arch/arm/src/common/arm_internal.h
@@ -148,6 +148,24 @@
 #define arm_switchcontext(saveregs, restoreregs) \
   sys_call2(SYS_switch_context, (uintptr_t)saveregs, (uintptr_t)restoreregs);
 
+/* Redefine the linker symbols as armlink style */
+
+#ifdef CONFIG_ARM_TOOLCHAIN_ARMCLANG
+#  define _stext   Image$$text$$Base
+#  define _etext   Image$$text$$Limit
+#  define _eronly  Image$$eronly$$Base
+#  define _sdata   Image$$data$$Base
+#  define _edata   Image$$data$$RW$$Limit
+#  define _sbss    Image$$bss$$Base
+#  define _ebss    Image$$bss$$ZI$$Limit
+#  define _stdata  Image$$tdata$$Base
+#  define _etdata  Image$$tdata$$Limit
+#  define _stbss   Image$$tbss$$Base
+#  define _etbss   Image$$tbss$$Limit
+#  define _snoinit Image$$noinit$$Base
+#  define _enoinit Image$$noinit$$Limit
+#endif
+
 /****************************************************************************
  * Public Types
  ****************************************************************************/


### PR DESCRIPTION
## Summary

arch/arm: redefine the linker symbols as armlink style

This is a simple implementation of https://github.com/apache/incubator-nuttx/pull/7121, seems redefine the symbol is better than steering file

## Impact

N/A

## Testing

CONFIG_ARM_TOOLCHAIN_ARMCLANG
./tools/configure.sh sabre-6quad/smp