### PR TITLE
arm/cortex-r: correct include path of chip.h

### DIFF
--- a/arch/arm/src/armv7-r/Kconfig
+++ b/arch/arm/src/armv7-r/Kconfig
@@ -54,7 +54,7 @@ if ARMV7R_HAVE_L2CC
 menu "L2 Cache Configuration"
 
 config ARMV7R_L2CC_PL310
-	bool "ARMv7-A L2CC P310 Support"
+	bool "ARMv7-R L2CC P310 Support"
 	default n
 	depends on ARMV7R_HAVE_L2CC_PL310
 	select ARCH_L2CACHE

--- a/arch/arm/src/armv7-r/l2cc_pl310.h
+++ b/arch/arm/src/armv7-r/l2cc_pl310.h
@@ -35,7 +35,7 @@
  * header file as L2CC_BASE.
  */
 
-#include "chip/chip.h"
+#include "chip.h"
 
 /****************************************************************************
  * Pre-processor Definitions


### PR DESCRIPTION
## Summary

arm/cortex-r: correct include path of chip.h

```
In file included from ./armv7-r/arm_l2cc_pl310.c:41: ./armv7-r/l2cc_pl310.h:38:10: fatal error: chip/chip.h: No such file or directory
   38 | #include "chip/chip.h"
      |          ^~~~~~~~~~~~~
```

Signed-off-by: chao an <anchao@xiaomi.com>

## Impact

N/A

## Testing

enable l2 cache:
CONFIG_ARMV7R_L2CC_PL310=y