### PR TITLE
arch/arm: declare vector array default type to read-only

### DIFF
--- a/arch/arm/src/armv6-m/arm_vectors.c
+++ b/arch/arm/src/armv6-m/arm_vectors.c
@@ -81,7 +81,7 @@ extern void exception_common(void);
  * Note that the [ ... ] designated initialiser is a GCC extension.
  */
 
-const void *_vectors[] locate_data(".vectors") =
+const void * const _vectors[] locate_data(".vectors") =
 {
   /* Initial stack */
 

--- a/arch/arm/src/armv7-m/arm_vectors.c
+++ b/arch/arm/src/armv7-m/arm_vectors.c
@@ -76,7 +76,7 @@ extern void exception_common(void);
  * Note that the [ ... ] designated initializer is a GCC extension.
  */
 
-const void *_vectors[] locate_data(".vectors") =
+const void * const _vectors[] locate_data(".vectors") =
 {
   /* Initial stack */
 

--- a/arch/arm/src/armv8-m/arm_vectors.c
+++ b/arch/arm/src/armv8-m/arm_vectors.c
@@ -76,7 +76,7 @@ extern void exception_common(void);
  * Note that the [ ... ] designated initializer is a GCC extension.
  */
 
-const void *_vectors[] locate_data(".vectors") =
+const void * const _vectors[] locate_data(".vectors") =
 {
   /* Initial stack */
 

--- a/arch/arm/src/common/arm_internal.h
+++ b/arch/arm/src/common/arm_internal.h
@@ -301,7 +301,7 @@ uintptr_t arm_intstack_top(void);
 
 extern const void *__vector_table[];
 #else
-extern const void *_vectors[];
+extern const void * const _vectors[];
 #endif
 
 /* Interrupt acknowledge and dispatch */

--- a/arch/arm/src/rtl8720c/ameba_vectors.c
+++ b/arch/arm/src/rtl8720c/ameba_vectors.c
@@ -63,7 +63,7 @@ extern void exception_common(void);
  * Note that the [ ... ] designated initialiser is a GCC extension.
  */
 
-const void *_vectors[] locate_data(".vectors") aligned_data(0x100) =
+const void * const _vectors[] locate_data(".vectors") aligned_data(0x100) =
 {
   /* Initial stack */
 


### PR DESCRIPTION
## Summary

arch/arm: declare vector array default type to read-only

Reference:
https://developer.arm.com/documentation/dui0474/m/image-structure-and-generation/section-placement-with-the-linker/section-placement-with-the-first-and-last-attributes

CAUTION:
FIRST and LAST must not violate the basic attribute sorting order. For example, FIRST RW is placed after any read-only code or read-only data.

```
arm-none-eabi-readelf -aS arm_vectors.o
1. Without const: Section Headers:
  [Nr] Name              Type            Addr     Off    Size   ES Flg Lk Inf Al
  [ 3] .vectors          PROGBITS        00000000 000034 00011c 00  WA  0   0  4

2. const symbol:
  [ 3] .vectors          PROGBITS        00000000 000034 00011c 00   A  0   0  4
```

Regression by:

```
| commit 229b57d6cb1c87868e0ca86f6035e56226979fa5
|
|     arch/armv[6|7|8]-m: Move _vectors to arm_internal.h to avoid the duplication
|
|     and change the type of _vectors from uint32_t to const void *
|
|     Signed-off-by: Xiang Xiao <xiaoxiang@xiaomi.com>
```

Signed-off-by: chao an <anchao@xiaomi.com>


## Impact

N/A

## Testing

CONFIG_ARM_TOOLCHAIN_ARMCLANG
./tools/configure.sh  lm3s6965-ek/qemu-flat