### PR TITLE
boards/b-g474e-dpow1: Fix 'openocd' incantation in README.txt

### DIFF
--- a/boards/arm/stm32/b-g474e-dpow1/README.txt
+++ b/boards/arm/stm32/b-g474e-dpow1/README.txt
@@ -55,6 +55,12 @@ Development Environment
     $ openocd -f interface/stlink.cfg -f target/stm32g4x.cfg -c init \
       -c "reset halt" -c "flash write_image erase nuttx.bin 0x08000000"
 
+    NOTE: The above command might fail unless either: udev rules have been
+    configured on the development system (preferred) or the command is run as
+    root with 'sudo' (not encouraged). See:
+    - https://openocd.org/doc/html/Running.html
+    - https://forgge.github.io/theCore/guides/running-openocd-without-sudo.html
+
   * Start GDB with:
     $ arm-nuttx-eabi-gdb -tui nuttx
 


### PR DESCRIPTION
## Summary

boards/arm/stm32/b-g474e-dpow1/README.txt:

Apparently `sudo` is required for `openocd` to FLASH-program the microcontroller properly.

## Impact

Improves documentation.

## Testing

This is how I got the nuttx image onto the board to test the above release as mentioned in my vote email for NuttX-11.0.0-RC2 on the incubator general mailing list: https://lists.apache.org/thread/zm62l2b21wpbbo1b1r12krpsvvm7rw2n
