### PR TITLE
arch: lc823450: Fix to boot

### DIFF
--- a/arch/arm/src/lc823450/lc823450_start.c
+++ b/arch/arm/src/lc823450/lc823450_start.c
@@ -170,10 +170,6 @@ void __start(void)
       *dest++ = *src++;
     }
 
-  /* run as interrupt context, before scheduler running */
-
-  CURRENT_REGS = (uint32_t *)1;
-
 #ifdef CONFIG_LASTKMSG_LOWOUTS
 
   if (g_lastksg_buf.sig == LASTKMSG_SIG_REBOOT)


### PR DESCRIPTION
## Summary

- I noticed that lc823450-xgevk does not boot due to the recent changes on g_current_regs
- This PR fixes this issue

## Impact

- None

## Testing

- Tested with lc823450-xgevk:rndis
