### PR TITLE
compiler.h: add MSVC(Microsoft Visual C++)-specific definitions

### DIFF
--- a/include/nuttx/compiler.h
+++ b/include/nuttx/compiler.h
@@ -745,6 +745,75 @@
 
 #  define no_builtin(n)
 
+/* MSVC(Microsoft Visual C++)-specific definitions **************************/
+
+#elif defined(_MSC_VER)
+
+/* Define these here and allow specific architectures to override as needed */
+
+#  define CONFIG_HAVE_LONG_LONG 1
+#  define CONFIG_HAVE_FLOAT 1
+#  define CONFIG_HAVE_DOUBLE 1
+#  define CONFIG_HAVE_LONG_DOUBLE 1
+
+/* Pre-processor */
+
+#  define CONFIG_CPP_HAVE_VARARGS 1 /* Supports variable argument macros */
+
+/* Intriniscs */
+
+#  define CONFIG_HAVE_FUNCTIONNAME 1 /* Has __FUNCTION__ */
+#  define CONFIG_HAVE_FILENAME     1 /* Has __FILE__ */
+
+#  undef  CONFIG_CPP_HAVE_WARNING
+#  undef  CONFIG_HAVE_WEAKFUNCTIONS
+#  define weak_alias(name, aliasname)
+#  define weak_data
+#  define weak_function
+#  define weak_const_function
+#  define restrict
+#  define noreturn_function
+#  define farcall_function
+#  define aligned_data(n)
+#  define locate_code(n)
+#  define locate_data(n)
+#  define begin_packed_struct
+#  define end_packed_struct
+#  define reentrant_function
+#  define naked_function
+#  define always_inline_function
+#  define noinline_function
+#  define noinstrument_function
+#  define nosanitize_address
+#  define nosanitize_undefined
+#  define nostackprotect_function
+#  define unused_code
+#  define unused_data
+#  define used_code
+#  define used_data
+#  define formatlike(a)
+#  define printflike(a, b)
+#  define sysloglike(a, b)
+#  define scanflike(a, b)
+#  define strftimelike(a)
+
+#  define FAR
+#  define NEAR
+#  define DSEG
+#  define CODE
+#  define IOBJ
+#  define IPTR
+
+#  undef  CONFIG_SMALL_MEMORY
+#  undef  CONFIG_LONG_IS_NOT_INT
+#  undef  CONFIG_PTR_IS_NOT_INT
+
+#  define UNUSED(a) ((void)(1 || &(a)))
+
+#  define offsetof(a, b) ((size_t)(&(((a *)(0))->b)))
+
+#  define no_builtin(n)
+
 /* Unknown compiler *********************************************************/
 
 #else


### PR DESCRIPTION

## Summary

compiler.h: add MSVC(Microsoft Visual C++)-specific definitions

Signed-off-by: chao an <anchao@xiaomi.com>

## Impact

N/A

## Testing

cmake + sim/windows