### PR TITLE
libs: fix visual studio Compiler Error C2124

### DIFF
--- a/libs/libc/stdlib/lib_strtod.c
+++ b/libs/libc/stdlib/lib_strtod.c
@@ -71,7 +71,12 @@
 
 static inline int is_real(double x)
 {
-  const double infinite = 1.0 / 0.0;
+  /* NOTE: Windows MSVC restrictions, MSVC doesn't allow division through a
+   * zero literal, but allows it through non-const variable set to zero
+   */
+
+  const double divzero = 0.0;
+  const double infinite = 1.0 / divzero;
   return (x < infinite) && (x >= -infinite);
 }
 
@@ -101,7 +106,13 @@ double strtod(FAR const char *str, FAR char **endptr)
   int n;
   int num_digits;
   int num_decimals;
-  const double infinite = 1.0 / 0.0;
+
+  /* NOTE: Windows MSVC restrictions, MSVC doesn't allow division through a
+   * zero literal, but allows it through non-const variable set to zero
+   */
+
+  const double divzero = 0.0;
+  const double infinite = 1.0 / divzero;
 
   /* Skip leading whitespace */
 

--- a/libs/libc/stdlib/lib_strtold.c
+++ b/libs/libc/stdlib/lib_strtold.c
@@ -71,7 +71,12 @@
 
 static inline int is_real(long double x)
 {
-  const long double infinite = 1.0L / 0.0L;
+  /* NOTE: Windows MSVC restrictions, MSVC doesn't allow division through a
+   * zero literal, but allows it through non-const variable set to zero
+   */
+
+  const long double divzero = 0.0L;
+  const long double infinite = 1.0L / divzero;
   return (x < infinite) && (x >= -infinite);
 }
 
@@ -101,7 +106,13 @@ long double strtold(FAR const char *str, FAR char **endptr)
   int n;
   int num_digits;
   int num_decimals;
-  const long double infinite = 1.0L / 0.0L;
+
+  /* NOTE: Windows MSVC restrictions, MSVC doesn't allow division through a
+   * zero literal, but allows it through non-const variable set to zero
+   */
+
+  const long double divzero = 0.0L;
+  const long double infinite = 1.0L / divzero;
 
   /* Skip leading whitespace */
 


### PR DESCRIPTION

## Summary

libs: fix visual studio Compiler Error C2124

D:\code\incubator-nuttx\libs\libc\stdlib\lib_strtod.c: error C2124: divide or mod by zero

Windows MSVC restrictions, MSVC doesn't allow division through a
zero literal, but allows it through non-const variable set to zero

Reference:
https://docs.microsoft.com/en-us/cpp/error-messages/compiler-errors-1/compiler-error-c2124?view=msvc-170

Signed-off-by: chao an <anchao@xiaomi.com>


## Impact

N/A

## Testing

cmake + sim/windows