### PR TITLE
arm/armlink: add support of link time optimization(lto)

### DIFF
--- a/arch/arm/src/common/Toolchain.defs
+++ b/arch/arm/src/common/Toolchain.defs
@@ -78,10 +78,16 @@ endif
 
 ifeq ($(CONFIG_LTO_THIN),y)
   ARCHOPTIMIZATION += -flto=thin
+  ifeq ($(CONFIG_ARM_TOOLCHAIN_ARMCLANG),y)
+    LDFLAGS += --lto
+  endif
 else ifeq ($(CONFIG_LTO_FULL),y)
   ARCHOPTIMIZATION += -flto
   ifeq ($(CONFIG_ARM_TOOLCHAIN_GNU_EABI),y)
     ARCHOPTIMIZATION += -fuse-linker-plugin
+  endif
+  ifeq ($(CONFIG_ARM_TOOLCHAIN_ARMCLANG),y)
+    LDFLAGS += --lto
   endif
 endif
 
@@ -220,9 +226,10 @@ ifneq ($(CONFIG_CXX_RTTI),y)
 endif
 
 ARCHOPTIMIZATION += -fno-common -Wall -Wshadow -Wundef
-ARCHOPTIMIZATION += -nostdlib
 
-ifeq ($(CONFIG_ARM_TOOLCHAIN_ARMCLANG),)
+ifeq ($(CONFIG_ARM_TOOLCHAIN_ARMCLANG),y)
+  ARCHOPTIMIZATION += -nostdlib
+else
   LDFLAGS += -nostdlib
 endif
 

--- a/boards/arm/imx6/sabre-6quad/scripts/dramboot.sct
+++ b/boards/arm/imx6/sabre-6quad/scripts/dramboot.sct
@@ -101,7 +101,7 @@ OSCRAM_SECTIONS DDR3_START DDR3_SIZE
       CONSTRUCTORS
     }
 
-  bss AlignExpr(ImageLimit(data), 0x8)
+  bss AlignExpr(ImageLimit(data), 0x10)
     {
       *(.bss)
       *(.bss.*)


### PR DESCRIPTION
## Summary

arm/armlink: add support of link time optimization(lto)

```
Optimization goal(Code size)

Smaller                           GCC(-Os) GCC(-flto -Os) CLANG(-flto -Oz) ARMCLANG(-flto -Oz/-Omin)
lm3s6965-ek/qemu-flat(Cortex-M3)   208662      193893           199525             195464
                                               -7.07%           -4.37%             -6.32%
sabre-6quad/smp(Cortex-A9)         131360      122500            N/A               123988
                                               -6.74%            N/A               -5.61%

Faster performance                GCC(-O3) GCC(-flto -O3) CLANG(-flto -Ofast) ARMCLANG(-flto -Ofast) ARMCLANG(-flto -Omax)
lm3s6965-ek/qemu-flat(Cortex-M3)   257502      296364           369465             346696                  384204
                                              +15.00%          +43.40%            +34.60%                 +49.20%
sabre-6quad/smp(Cortex-A9)         166520      196004             N/A              207908                  224140
                                              +17.70%             N/A             +24.85%                 +34.60%

```

Reference:
https://developer.arm.com/documentation/101754/0618/armclang-Reference/armclang-Command-line-Options/-O--armclang-

![img_v2_e028b23b-9bde-4934-93b8-d6bb9808d8bl](https://user-images.githubusercontent.com/758493/192206809-ca0c3423-8db7-4ce0-b533-2b6ba1265c3a.png)




Signed-off-by: chao an <anchao@xiaomi.com>


## Impact

N/A

## Testing

lm3s6965-ek/qemu-flat(Cortex-M3)
sabre-6quad/smp(Cortex-A9)      
