### PR TITLE
vfs/fs_poll: not clear POLLIN event if POLLHUP or POLLERR set

### DIFF
--- a/fs/vfs/fs_poll.c
+++ b/fs/vfs/fs_poll.c
@@ -312,9 +312,9 @@ void poll_notify(FAR struct pollfd **afds, int nfds, pollevent_t eventset)
           fds->revents |= eventset & (fds->events | POLLERR | POLLHUP);
           if ((fds->revents & (POLLERR | POLLHUP)) != 0)
             {
-              /* Error, clear POLLIN and POLLOUT event */
+              /* Error or Hung up, clear POLLOUT event */
 
-              fds->revents &= ~(POLLIN | POLLOUT);
+              fds->revents &= ~POLLOUT;
             }
 
           if (fds->revents != 0)


### PR DESCRIPTION
## Summary
Fix the regression by https://github.com/apache/incubator-nuttx/pull/7131
usrsocktest failed:
```
nsh> usrsocktest
Starting unit-tests...
Testing group "char_dev" =>
	Group "char_dev": [OK]
Testing group "no_daemon" =>
	Group "no_daemon": [OK]
Testing group "basic_daemon" =>
	Group "basic_daemon": [OK]
Testing group "basic_connect" =>
	Group "basic_connect": [OK]
Testing group "basic_connect_delay" =>
	Group "basic_connect_delay": [OK]
Testing group "no_block_connect" =>
	Group "no_block_connect": [OK]
Testing group "basic_send" =>
	Group "basic_send": [OK]
Testing group "no_block_send" =>
	Group "no_block_send": [OK]
Testing group "block_send" =>
	Group "block_send": [OK]
Testing group "no_block_recv" =>
	Group "no_block_recv": [OK]
Testing group "block_recv" =>
	Group "block_recv": [OK]
Testing group "remote_disconnect" =>
	[TEST ASSERT FAILED!]
		In function "remote_disconnect_poll":
		line 688: Assertion `(ssize_t)((pfd.revents & (0x01))) == (ssize_t)(((0x01)))' failed.
			got value: 0
			should be: 1
	Group "remote_disconnect": [FAILED]
Testing group "basic_setsockopt" =>
	Group "basic_setsockopt": [OK]
Testing group "basic_getsockopt" =>
	Group "basic_getsockopt": [OK]
Testing group "basic_getsockname" =>
	Group "basic_getsockname": [OK]
Testing group "wake_with_signal" =>
	Group "wake_with_signal": [OK]
Testing group "multithread" =>
	Group "multithread": [OK]
Unit-test groups done... OK:16, FAILED:1, TOTAL:17
```
In poll_nofity(), should't clear POLLIN if POLLERR or POLLOUT set.

## Impact
All the poll operation.

## Testing
sim:usrsocktest pss, sim:ostest pass.
