### PR TITLE
Fixes for GPT partition parsing

### DIFF
--- a/fs/partition/fs_gpt.c
+++ b/fs/partition/fs_gpt.c
@@ -390,6 +390,7 @@ int parse_gpt_partition(FAR struct partition_state_s *state,
   FAR struct gpt_header_s *gpt;
   FAR struct gpt_entry_s *ptes;
   struct partition_s pentry;
+  blkcnt_t lastlba;
   int nb_part;
   int count;
   int ret;
@@ -462,12 +463,20 @@ int parse_gpt_partition(FAR struct partition_state_s *state,
       goto err;
     }
 
+  lastlba = gpt_last_lba(state);
   nb_part = le32toh(gpt->num_partition_entries);
   for (pentry.index = 0; pentry.index < nb_part; pentry.index++)
     {
+      /* Skip the empty or invalid entries */
+
+      if (!gpt_pte_is_valid(&ptes[pentry.index], lastlba))
+        {
+          continue;
+        }
+
       pentry.firstblock = GPT_LBA_TO_BLOCK(ptes[pentry.index].starting_lba,
                                            state->blocksize);
-      pentry.nblocks = GPT_LBA_TO_BLOCK(ptes[pentry.index].ending_lba,
+      pentry.nblocks = GPT_LBA_TO_BLOCK(ptes[pentry.index].ending_lba + 1,
                                         state->blocksize) -
                        pentry.firstblock;
       pentry.blocksize = state->blocksize;


### PR DESCRIPTION
1. Don't handle invalid or empty pte entries

num_partition_entries field in GPT typically means number of maximum entries and not the number of used entries. Empty entries are indentified with "0" partition type guid. Loop through all the entries

2. Fix the GPT partition size calculation

"ending_lba" is included in the partition, it is not the start of the next one. Thus the correct size of the partition is end-start+1

Signed-off-by: Jukka Laitinen <jukkax@ssrc.tii.ae>

## Summary

## Impact

## Testing

