### PR TITLE
arm/armv7-r: fix build break on armlink

### DIFF
--- a/arch/arm/src/armv7-r/arm_head.S
+++ b/arch/arm/src/armv7-r/arm_head.S
@@ -27,6 +27,7 @@
 #include "arm.h"
 #include "cp15.h"
 #include "sctlr.h"
+#include "arm_internal.h"
 
 	.file	"arm_head.S"
 


### PR DESCRIPTION


## Summary

arm/armv7-r: redefine the linker symbols as armlink style

Fix build break:

```
Error: L6218E: Undefined symbol _sbss (referred from arm_head.o).
Error: L6218E: Undefined symbol _ebss (referred from arm_head.o).
Error: L6218E: Undefined symbol _eronly (referred from arm_head.o).
Error: L6218E: Undefined symbol _sdata (referred from arm_head.o).
Error: L6218E: Undefined symbol _edata (referred from arm_head.o).
```

Signed-off-by: chao an <anchao@xiaomi.com>

## Impact

N/A

## Testing

./tools/configure.sh launchxl-tms57004/nsh