### PR TITLE
net/procfs: fix runtime error AddressSanitizer(global-buffer-overflow) 

### DIFF
--- a/net/procfs/net_procfs.c
+++ b/net/procfs/net_procfs.c
@@ -393,20 +393,23 @@ static int netprocfs_opendir(FAR const char *relpath,
 
   /* Subdirectory ?  */
 
-  for (i = 0; i < ARRAY_SIZE(g_net_entries); i++)
+  if (strlen(relpath) > 4)
     {
-      if (strncmp(relpath + 4, g_net_entries[i].name,
-                  strlen(g_net_entries[i].name)))
+      for (i = 0; i < ARRAY_SIZE(g_net_entries); i++)
         {
-          continue;
-        }
+          if (strncmp(relpath + 4, g_net_entries[i].name,
+                      strlen(g_net_entries[i].name)))
+            {
+              continue;
+            }
 
-      if (g_net_entries[i].type == DTYPE_DIRECTORY)
-        {
-          return g_net_entries[i].u.ops->opendir(relpath, dir);
-        }
+          if (g_net_entries[i].type == DTYPE_DIRECTORY)
+            {
+              return g_net_entries[i].u.ops->opendir(relpath, dir);
+            }
 
-      break;
+          break;
+        }
     }
 
   /* Assume that path refers to the 1st level subdirectory.  Allocate the


### PR DESCRIPTION


## Summary

net/procfs: fix runtime error AddressSanitizer(global-buffer-overflow)

```
NuttShell (NSH) NuttX-10.3.0
ap> ifconfig
=================================================================
Program received signal SIGSEGV, Segmentation fault.
==3920365==ERROR: AddressSanitizer: global-buffer-overflow on address 0x57fb4f2a at pc 0x57177067 bp 0xf1ffebb8 sp 0xf1ffeba8
READ of size 1 at 0x57fb4f2a thread T0

...................
| #10 0xf7ac4339 in __asan::__asan_report_load1 (addr=1476087594) at ../../../../../src/libsanitizer/asan/asan_rtl.cpp:117
| #11 0x57177067 in strncmp (cs=0x57fb4f2a "", ct=0x582d36e0 "stat", nb=4) at string/lib_strncmp.c:40
| #12 0x57f3b467 in netprocfs_opendir (relpath=0x57fb4f26 "net", dir=0xf1ffed80) at procfs/net_procfs.c:398
| #13 0x572b3ae1 in procfs_opendir (mountpt=0xf4602c20, relpath=0x57fb4f26 "net", dir=0xf1ffed80) at procfs/fs_procfs.c:625
| #14 0x572879ff in open_mountpoint (inode=0xf4602c20, relpath=0x57fb4f26 "net", dir=0xf1ffed80) at vfs/fs_dir.c:127
...................
```

Signed-off-by: chao an <anchao@xiaomi.com>

## Impact

N/A

## Testing

enable address sanitizer:
CONFIG_SIM_ASAN=y
CONFIG_SIM_UBSAN=y