### PR TITLE
stm32h7\stm32_fdcan_sock: reserve space for timeval struct in the int…

### DIFF
--- a/arch/arm/src/stm32h7/stm32_fdcan_sock.c
+++ b/arch/arm/src/stm32h7/stm32_fdcan_sock.c
@@ -43,7 +43,7 @@
 #include <nuttx/net/can.h>
 #include <netpacket/can.h>
 
-#ifdef CONFIG_NET_CAN_RAW_TX_DEADLINE
+#if defined(CONFIG_NET_CAN_RAW_TX_DEADLINE) || defined(CONFIG_NET_TIMESTAMP)
 #include <sys/time.h>
 #endif
 
@@ -112,7 +112,7 @@
 
 #define POOL_SIZE           1
 
-#ifdef CONFIG_NET_CAN_RAW_TX_DEADLINE
+#if defined(CONFIG_NET_CAN_RAW_TX_DEADLINE) || defined(CONFIG_NET_TIMESTAMP)
 #define MSG_DATA            sizeof(struct timeval)
 #else
 #define MSG_DATA            0


### PR DESCRIPTION
…ermediate storage of tx and rx CAN frames when timestamp is enabled

## Summary

When CONFIG_NET_TIMESTAMP is enabled, can_callback() concatenates a timestamp timeval to the receive frame in the rx_pool buffer. stm32h7 does not reserve space for the extra timeval structure in the rx_pool when timestamp is enabled.

## Impact

This causes a buffer overflow in the receive buffer (rx_pool).

## Testing

Tested functionality on STM32H7 board with both CAN instances initialized and buffer overflow is fixed after the change.

