### PR TITLE
sched: Optimize sched_note_begin/end

### DIFF
--- a/include/nuttx/sched_note.h
+++ b/include/nuttx/sched_note.h
@@ -125,9 +125,9 @@
 #  define SCHED_NOTE_BPRINTF(event, fmt, ...) \
           sched_note_bprintf(SCHED_NOTE_IP, event, fmt, ##__VA_ARGS__)
 #  define SCHED_NOTE_BEGIN() \
-          sched_note_begin(SCHED_NOTE_IP, __FUNCTION__)
+          sched_note_begin(SCHED_NOTE_IP)
 #  define SCHED_NOTE_END() \
-          sched_note_end(SCHED_NOTE_IP, __FUNCTION__)
+          sched_note_end(SCHED_NOTE_IP)
 #else
 #  define SCHED_NOTE_STRING(buf)
 #  define SCHED_NOTE_DUMP(event, buf, len)
@@ -553,8 +553,8 @@ void sched_note_printf(uintptr_t ip,
                        FAR const char *fmt, ...) printflike(2, 3);
 void sched_note_bprintf(uintptr_t ip, uint8_t event,
                         FAR const char *fmt, ...) printflike(3, 4);
-void sched_note_begin(uintptr_t ip, FAR const char *buf);
-void sched_note_end(uintptr_t ip, FAR const char *buf);
+void sched_note_begin(uintptr_t ip);
+void sched_note_end(uintptr_t ip);
 #else
 #  define sched_note_string(ip,b)
 #  define sched_note_dump(ip,e,b,l)
@@ -562,8 +562,8 @@ void sched_note_end(uintptr_t ip, FAR const char *buf);
 #  define sched_note_vbprintf(ip,e,f,v)
 #  define sched_note_printf(ip,f,...)
 #  define sched_note_bprintf(ip,e,f,...)
-#  define sched_note_begin(ip,f)
-#  define sched_note_end(ip,f)
+#  define sched_note_begin(ip)
+#  define sched_note_end(ip)
 #endif /* CONFIG_SCHED_INSTRUMENTATION_DUMP */
 
 #if defined(__KERNEL__) || defined(CONFIG_BUILD_FLAT)

--- a/sched/sched/sched_note.c
+++ b/sched/sched/sched_note.c
@@ -1161,14 +1161,14 @@ void sched_note_bprintf(uintptr_t ip, uint8_t event,
   va_end(va);
 }
 
-void sched_note_begin(uintptr_t ip, FAR const char *buf)
+void sched_note_begin(uintptr_t ip)
 {
-  sched_note_printf(ip, "B|%d|%s", getpid(), buf);
+  sched_note_string(ip, "B");
 }
 
-void sched_note_end(uintptr_t ip, FAR const char *buf)
+void sched_note_end(uintptr_t ip)
 {
-  sched_note_printf(ip, "E|%d|%s", getpid(), buf);
+  sched_note_string(ip, "E");
 }
 #endif /* CONFIG_SCHED_INSTRUMENTATION_DUMP */
 


### PR DESCRIPTION
## Summary
Optimize sched_note_begin/end, replace note_printf with note_string 
the time required changed from 50us to 1us

## Impact

## Testing

