### PR TITLE
arm/tlsr82: move peripherals pin config to board.h

### DIFF
--- a/arch/arm/src/tlsr82/tlsr82_adc.c
+++ b/arch/arm/src/tlsr82/tlsr82_adc.c
@@ -33,6 +33,7 @@
 #include <nuttx/analog/adc.h>
 #include <nuttx/analog/ioctl.h>
 #include <nuttx/semaphore.h>
+#include <arch/board/board.h>
 
 #include "tlsr82_adc.h"
 #include "tlsr82_gpio.h"
@@ -64,13 +65,6 @@
 #if (ADC_FILT_NUM & 0x3) != 0
 #  error "The filter number must be multiple of 4 !"
 #endif
-
-/* ADC Channel type definition */
-
-#define ADC_CHAN_TYPE_NONE   0
-#define ADC_CHAN_TYPE_BASE   1
-#define ADC_CHAN_TYPE_VBAT   2
-#define ADC_CHAN_TYPE_TEMP   3
 
 /****************************************************************************
  * Private Types
@@ -159,9 +153,9 @@ static const struct adc_ops_s g_adcops =
 static struct adc_chan_s g_adc_chan0 =
 {
   .info        = &g_adc_module0_info,
-  .channeltype = ADC_CHAN_TYPE_BASE,
-  .channel     = ADC_CHAN_0,
-  .pinset      = GPIO_PIN_PB2,
+  .channeltype = BOARD_ADC0_CHAN_TYPE,
+  .channel     = BOARD_ADC0_CHAN,
+  .pinset      = BOARD_ADC0_PIN,
 };
 
 static struct adc_dev_s g_adc_chan0_dev =
@@ -175,9 +169,9 @@ static struct adc_dev_s g_adc_chan0_dev =
 static struct adc_chan_s g_adc_chan1 =
 {
   .info        = &g_adc_module0_info,
-  .channeltype = ADC_CHAN_TYPE_BASE,
-  .channel     = ADC_CHAN_1,
-  .pinset      = GPIO_PIN_PB3,
+  .channeltype = BOARD_ADC1_CHAN_TYPE,
+  .channel     = BOARD_ADC1_CHAN,
+  .pinset      = BOARD_ADC1_PIN,
 };
 
 static struct adc_dev_s g_adc_chan1_dev =
@@ -191,9 +185,9 @@ static struct adc_dev_s g_adc_chan1_dev =
 static struct adc_chan_s g_adc_chan2 =
 {
   .info        = &g_adc_module0_info,
-  .channeltype = ADC_CHAN_TYPE_BASE,
-  .channel     = ADC_CHAN_2,
-  .pinset      = GPIO_PIN_PB5,
+  .channeltype = BOARD_ADC2_CHAN_TYPE,
+  .channel     = BOARD_ADC2_CHAN,
+  .pinset      = BOARD_ADC2_PIN,
 };
 
 static struct adc_dev_s g_adc_chan2_dev =
@@ -209,9 +203,9 @@ static struct adc_dev_s g_adc_chan2_dev =
 static struct adc_chan_s g_adc_chanbat =
 {
   .info        = &g_adc_module0_info,
-  .channeltype = ADC_CHAN_TYPE_VBAT,
-  .channel     = ADC_CHAN_VBAT,
-  .pinset      = GPIO_INVLD_CFG,
+  .channeltype = BOARD_ADCVBAT_CHAN_TYPE,
+  .channel     = BOARD_ADCVBAT_CHAN,
+  .pinset      = BOARD_ADCVBAT_PIN,
 };
 
 static struct adc_dev_s g_adc_chanbat_dev =

--- a/arch/arm/src/tlsr82/tlsr82_adc.h
+++ b/arch/arm/src/tlsr82/tlsr82_adc.h
@@ -45,6 +45,13 @@
 #define ADC_CHAN_VBAT            254
 #define ADC_CHAN_NONE            255
 
+/* ADC Channel type definition */
+
+#define ADC_CHAN_TYPE_NONE   0
+#define ADC_CHAN_TYPE_BASE   1
+#define ADC_CHAN_TYPE_VBAT   2
+#define ADC_CHAN_TYPE_TEMP   3
+
 /****************************************************************************
  * Public Function Prototypes
  ****************************************************************************/

--- a/arch/arm/src/tlsr82/tlsr82_pwm.c
+++ b/arch/arm/src/tlsr82/tlsr82_pwm.c
@@ -166,7 +166,7 @@ static const struct pwm_ops_s g_pwmops =
 static struct tlsr82_pwmtimer_s g_pwm0dev =
 {
   .ops         = &g_pwmops,
-  .pincfg      = GPIO_PIN_PD5 | GPIO_AF_MUX0,
+  .pincfg      = BOARD_PWM0_PIN,
   .id          = 0,
   .invert      = false,
   .started     = false,
@@ -180,7 +180,7 @@ static struct tlsr82_pwmtimer_s g_pwm0dev =
 static struct tlsr82_pwmtimer_s g_pwm1dev =
 {
   .ops         = &g_pwmops,
-  .pincfg      = GPIO_PIN_PD3 | GPIO_AF_MUX0,
+  .pincfg      = BOARD_PWM1_PIN,
   .id          = 1,
   .invert      = true,
   .started     = false,
@@ -191,7 +191,7 @@ static struct tlsr82_pwmtimer_s g_pwm1dev =
 static struct tlsr82_pwmtimer_s g_pwm2dev =
 {
   .ops         = &g_pwmops,
-  .pincfg      = GPIO_PIN_PD4 | GPIO_AF_MUX2,
+  .pincfg      = BOARD_PWM2_PIN,
   .id          = 2,
   .invert      = true,
   .started     = false,
@@ -202,7 +202,7 @@ static struct tlsr82_pwmtimer_s g_pwm2dev =
 static struct tlsr82_pwmtimer_s g_pwm3dev =
 {
   .ops         = &g_pwmops,
-  .pincfg      = GPIO_PIN_PB4 | GPIO_AF_MUX1,
+  .pincfg      = BOARD_PWM3_PIN,
   .id          = 3,
   .invert      = false,
   .started     = false,
@@ -213,7 +213,7 @@ static struct tlsr82_pwmtimer_s g_pwm3dev =
 static struct tlsr82_pwmtimer_s g_pwm4dev =
 {
   .ops         = &g_pwmops,
-  .pincfg      = GPIO_INVLD_CFG,
+  .pincfg      = BOARD_PWM4_PIN,
   .id          = 4,
   .invert      = false,
   .started     = false,
@@ -224,7 +224,7 @@ static struct tlsr82_pwmtimer_s g_pwm4dev =
 static struct tlsr82_pwmtimer_s g_pwm5dev =
 {
   .ops         = &g_pwmops,
-  .pincfg      = GPIO_INVLD_CFG,
+  .pincfg      = BOARD_PWM5_PIN,
   .id          = 5,
   .invert      = false,
   .started     = false,

--- a/arch/arm/src/tlsr82/tlsr82_serial.c
+++ b/arch/arm/src/tlsr82/tlsr82_serial.c
@@ -61,11 +61,11 @@
 #define CONSOLE_PRIV               g_uart0priv
 #define CONSOLE_DEV                g_uart0_dev
 
-#define UART0_PIN_TX_MUX           GPIO_AF_MUX1
-#define UART0_PIN_RX_MUX           GPIO_AF_MUX1
+#define UART0_PIN_TX_MUX           BOARD_UART0_TX_MUX
+#define UART0_PIN_RX_MUX           BOARD_UART0_RX_MUX
 
-#define UART0_PIN_TX               GPIO_PIN_PB1
-#define UART0_PIN_RX               GPIO_PIN_PB0
+#define UART0_PIN_TX               BOARD_UART0_TX_PIN
+#define UART0_PIN_RX               BOARD_UART0_RX_PIN
 
 #define UART0_TX_BUF_SIZE          CONFIG_TLSR82_UART0_TX_BUF_SIZE
 #define UART0_RX_BUF_SIZE          CONFIG_TLSR82_UART0_RX_BUF_SIZE

--- a/boards/arm/tlsr82/tlsr8278adk80d/include/board.h
+++ b/boards/arm/tlsr82/tlsr8278adk80d/include/board.h
@@ -22,6 +22,141 @@
 #define __BOARDS_ARM_TLSR82_TLSR8278ADK80D_INCLUDE_BOARD_H
 
 /****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+#include <nuttx/ioexpander/gpio.h>
+
+#include "tlsr82_adc.h"
+#include "tlsr82_gpio.h"
+#include "tlsr82_pwm.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/* Board GPIO PIN Configuration
+ * BOARD_NGPIO      : the gpio numbers, max 8
+ * BOARD_GPIOx_PIN  : define the gpio pin number, see tlsr82_gpio.h
+ * BOARD_GPIOx_TYPE : define the pio type, see enum gpio_pintype_e in
+ *                    nuttx/ioexpander/gpio.h
+ */
+
+#define BOARD_NGPIO                    4
+
+#if BOARD_NGPIO > 0
+#  define BOARD_GPIO0_PIN              GPIO_PIN_PD6
+#  define BOARD_GPIO0_TYPE             GPIO_INPUT_PIN_PULLDOWN
+#endif
+#if BOARD_NGPIO > 1
+#  define BOARD_GPIO1_PIN              GPIO_PIN_PD0
+#  define BOARD_GPIO1_TYPE             GPIO_OUTPUT_PIN
+#endif
+#if BOARD_NGPIO > 2
+#  define BOARD_GPIO2_PIN              GPIO_PIN_PD1
+#  define BOARD_GPIO2_TYPE             GPIO_OUTPUT_PIN
+#endif
+#if BOARD_NGPIO > 3
+#  define BOARD_GPIO3_PIN              GPIO_PIN_PB3
+#  define BOARD_GPIO3_TYPE             GPIO_INTERRUPT_FALLING_PIN
+#endif
+#if BOARD_NGPIO > 4
+#  define BOARD_GPIO4_PIN              GPIO_INVLD_CFG
+#  define BOARD_GPIO4_TYPE             GPIO_NPINTYPES
+#endif
+#if BOARD_NGPIO > 5
+#  define BOARD_GPIO5_PIN              GPIO_INVLD_CFG
+#  define BOARD_GPIO5_TYPE             GPIO_NPINTYPES
+#endif
+#if BOARD_NGPIO > 6
+#  define BOARD_GPIO6_PIN              GPIO_INVLD_CFG
+#  define BOARD_GPIO6_TYPE             GPIO_NPINTYPES
+#endif
+#if BOARD_NGPIO > 7
+#  define BOARD_GPIO7_PIN              GPIO_INVLD_CFG
+#  define BOARD_GPIO7_TYPE             GPIO_NPINTYPES
+#endif
+#if BOARD_NGPIO > 8
+#  error "BOARD_NGPIO max value is 8"
+#endif
+
+/* Board UART PIN Configuration
+ * BOARD_UARTx_RX/TX_PIN : define the uart pin number, see tlsr82_gpio.h
+ * BOARD_UARTx_RX/TX_MUX : define the gpio multiplex function, should be
+ *                         UART function, see the tlsr82 datasheet
+ */
+
+#define BOARD_UART0_RX_PIN             GPIO_PIN_PB0
+#define BOARD_UART0_RX_MUX             GPIO_AF_MUX1
+#define BOARD_UART0_TX_PIN             GPIO_PIN_PB1
+#define BOARD_UART0_TX_MUX             GPIO_AF_MUX1
+
+/* Board ADC PIN Configuration
+ * BOARD_ADCx_CHAN      : the ADC channel
+ * BOARD_ADCx_CHAN_TYPE : the ADC type,
+ * BOARD_ADCx_PIN       : the ADC input gpio pin, please see the datasheet to
+ *                        configure this pin
+ * Note: For ADC_CHAN_TYPE_VBAT and ADC_CHAN_TYPE_TEMP, do not need configure
+ *       the external sample pin, so configure it to GPIO_INVLD_CFG
+ *
+ */
+
+#ifdef CONFIG_TLSR82_ADC_CHAN0
+#  define BOARD_ADC0_CHAN              ADC_CHAN_0
+#  define BOARD_ADC0_CHAN_TYPE         ADC_CHAN_TYPE_BASE
+#  define BOARD_ADC0_PIN               GPIO_PIN_PB2
+#endif
+
+#ifdef CONFIG_TLSR82_ADC_CHAN1
+#  define BOARD_ADC1_CHAN              ADC_CHAN_1
+#  define BOARD_ADC1_CHAN_TYPE         ADC_CHAN_TYPE_BASE
+#  define BOARD_ADC1_PIN               GPIO_PIN_PB3
+#endif
+
+#ifdef CONFIG_TLSR82_ADC_CHAN2
+#  define BOARD_ADC2_CHAN              ADC_CHAN_2
+#  define BOARD_ADC2_CHAN_TYPE         ADC_CHAN_TYPE_BASE
+#  define BOARD_ADC2_PIN               GPIO_PIN_PB5
+#endif
+
+#ifdef CONFIG_TLSR82_ADC_VBAT
+#  define BOARD_ADCVBAT_CHAN           ADC_CHAN_VBAT
+#  define BOARD_ADCVBAT_CHAN_TYPE      ADC_CHAN_TYPE_VBAT
+#  define BOARD_ADCVBAT_PIN            GPIO_INVLD_CFG
+#endif
+
+/* Board PWM PIN Configuration
+ * BOARD_PWMx_PIN : define the gpio pin numbers and multiplex function,
+ *                  please refs the tlsr82 datasheet to configure the
+ *                  multiplex function.
+ */
+
+#ifdef CONFIG_TLSR82_PWM0
+#  define BOARD_PWM0_PIN               (GPIO_PIN_PD5 | GPIO_AF_MUX0)
+#endif
+
+#ifdef CONFIG_TLSR82_PWM1
+#  define BOARD_PWM1_PIN               (GPIO_PIN_PD3 | GPIO_AF_MUX0)
+#endif
+
+#ifdef CONFIG_TLSR82_PWM2
+#  define BOARD_PWM2_PIN               (GPIO_PIN_PD4 | GPIO_AF_MUX2)
+#endif
+
+#ifdef CONFIG_TLSR82_PWM3
+#  define BOARD_PWM3_PIN               (GPIO_PIN_PB4 | GPIO_AF_MUX1)
+#endif
+
+#ifdef CONFIG_TLSR82_PWM4
+#  define BOARD_PWM4_PIN               (GPIO_INVLD_CFG)
+#endif
+
+#ifdef CONFIG_TLSR82_PWM5
+#  define BOARD_PWM5_PIN               (GPIO_INVLD_CFG)
+#endif
+
+/****************************************************************************
  * Public Function Prototypes
  ****************************************************************************/
 

--- a/boards/arm/tlsr82/tlsr8278adk80d/src/tlsr8278_gpio.c
+++ b/boards/arm/tlsr82/tlsr8278adk80d/src/tlsr8278_gpio.c
@@ -41,6 +41,10 @@
 
 #if defined(CONFIG_DEV_GPIO) && !defined(CONFIG_GPIO_LOWER_HALF)
 
+#if BOARD_NGPIO == 0
+#  error "BOARD_NGPIO must > 0"
+#endif
+
 /****************************************************************************
  * Private Types
  ****************************************************************************/
@@ -82,22 +86,54 @@ static const struct gpio_operations_s gpio_ops =
 
 static struct tlsr82gpio_dev_s g_gpdevs[BOARD_NGPIO] =
 {
+#if BOARD_NGPIO > 0
   {
-    .pinset = GPIO_PIN_PD6,
-    .init_pintype = GPIO_INPUT_PIN_PULLDOWN,
+    .pinset = BOARD_GPIO0_PIN,
+    .init_pintype = BOARD_GPIO0_TYPE,
   },
+#endif
+#if BOARD_NGPIO > 1
   {
-    .pinset = GPIO_PIN_PD0,
-    .init_pintype = GPIO_OUTPUT_PIN,
+    .pinset = BOARD_GPIO1_PIN,
+    .init_pintype = BOARD_GPIO1_TYPE,
   },
+#endif
+#if BOARD_NGPIO > 2
   {
-    .pinset = GPIO_PIN_PD1,
-    .init_pintype = GPIO_OUTPUT_PIN,
+    .pinset = BOARD_GPIO2_PIN,
+    .init_pintype = BOARD_GPIO2_TYPE,
   },
+#endif
+#if BOARD_NGPIO > 3
   {
-    .pinset = GPIO_PIN_PB3,
-    .init_pintype = GPIO_INTERRUPT_FALLING_PIN,
+    .pinset = BOARD_GPIO3_PIN,
+    .init_pintype = BOARD_GPIO3_TYPE,
   }
+#endif
+#if BOARD_NGPIO > 4
+  {
+    .pinset = BOARD_GPIO4_PIN,
+    .init_pintype = BOARD_GPIO4_TYPE,
+  }
+#endif
+#if BOARD_NGPIO > 5
+  {
+    .pinset = BOARD_GPIO5_PIN,
+    .init_pintype = BOARD_GPIO5_TYPE,
+  }
+#endif
+#if BOARD_NGPIO > 6
+  {
+    .pinset = BOARD_GPIO6_PIN,
+    .init_pintype = BOARD_GPIO6_TYPE,
+  }
+#endif
+#if BOARD_NGPIO > 7
+  {
+    .pinset = BOARD_GPIO7_PIN,
+    .init_pintype = BOARD_GPIO7_TYPE,
+  }
+#endif
 };
 
 /****************************************************************************

--- a/boards/arm/tlsr82/tlsr8278adk80d/src/tlsr8278adk80d.h
+++ b/boards/arm/tlsr82/tlsr8278adk80d/src/tlsr8278adk80d.h
@@ -28,16 +28,6 @@
 #include <nuttx/config.h>
 
 /****************************************************************************
- * Pre-processor Definitions
- ****************************************************************************/
-
-#define BOARD_NGPIO 4
-
-#define GPIO_IN_CFG          (GPIO_AF_INPUT | GPIO_PUPD_NONE)
-#define GPIO_OUT_CFG         (GPIO_AF_OUTPUT | GPIO_PUPD_NONE)
-#define GPIO_INT_CFG         (GPIO_AF_INPUT | GPIO_IRQ_NORMAL | GPIO_POL_RISE)
-
-/****************************************************************************
  * Public Function Prototypes
  ****************************************************************************/
 


### PR DESCRIPTION
Signed-off-by: wangbowen6 <wangbowen6@xiaomi.com>

## Summary
Move the hard code driver pin config to board.h

## Impact
Only code refactor

## Testing
test with adc, gpio and pwm examples, all pass.
