### PR TITLE
net: Return -ENOPROTOOPT for unsupported/unknown socket option

### DIFF
--- a/net/socket/getsockopt.c
+++ b/net/socket/getsockopt.c
@@ -85,7 +85,7 @@ static int psock_socketlevel_option(FAR struct socket *psock, int option,
 
   /* Verify that the socket option if valid (but might not be supported ) */
 
-  if (!_SO_GETVALID(option) || !value || !value_len)
+  if (!value || !value_len)
     {
       return -EINVAL;
     }
@@ -338,14 +338,6 @@ static int psock_socketlevel_option(FAR struct socket *psock, int option,
           break;
         }
 #endif
-
-      /* The following are not yet implemented
-       * (return values other than {0,1})
-       */
-
-      case SO_LINGER:     /* Lingers on a close() if data is present */
-      case SO_RCVLOWAT:   /* Sets the minimum number of bytes to input */
-      case SO_SNDLOWAT:   /* Sets the minimum number of bytes to output */
 
       default:
         return -ENOPROTOOPT;

--- a/net/socket/setsockopt.c
+++ b/net/socket/setsockopt.c
@@ -80,7 +80,7 @@ static int psock_socketlevel_option(FAR struct socket *psock, int option,
 
   /* Verify that the socket option if valid (but might not be supported ) */
 
-  if (!_SO_SETVALID(option) || !value)
+  if (!value)
     {
       return -EINVAL;
     }
@@ -445,16 +445,12 @@ static int psock_socketlevel_option(FAR struct socket *psock, int option,
         }
 #endif
 
-      /* The following are not yet implemented */
-
-      case SO_RCVLOWAT:   /* Sets the minimum number of bytes to input */
-      case SO_SNDLOWAT:   /* Sets the minimum number of bytes to output */
-
       /* There options are only valid when used with getopt */
 
       case SO_ACCEPTCONN: /* Reports whether socket listening is enabled */
       case SO_ERROR:      /* Reports and clears error status. */
       case SO_TYPE:       /* Reports the socket type */
+        return -EINVAL;
 
       default:
         return -ENOPROTOOPT;


### PR DESCRIPTION
## Summary
so usrsock implementation could support more option than built-in stack

## Impact
usrsock implementor

## Testing
sim:usrsocktest
```
nsh> usrsocktest
Starting unit-tests...
Testing group "char_dev" =>
        Group "char_dev": [OK]
Testing group "no_daemon" =>
        Group "no_daemon": [OK]
Testing group "basic_daemon" =>
        Group "basic_daemon": [OK]
Testing group "basic_connect" =>
        Group "basic_connect": [OK]
Testing group "basic_connect_delay" =>
        Group "basic_connect_delay": [OK]
Testing group "no_block_connect" =>
        Group "no_block_connect": [OK]
Testing group "basic_send" =>
        Group "basic_send": [OK]
Testing group "no_block_send" =>
        Group "no_block_send": [OK]
Testing group "block_send" =>
        Group "block_send": [OK]
Testing group "no_block_recv" =>
        Group "no_block_recv": [OK]
Testing group "block_recv" =>
        Group "block_recv": [OK]
Testing group "remote_disconnect" =>
        Group "remote_disconnect": [OK]
Testing group "basic_setsockopt" =>
        Group "basic_setsockopt": [OK]
Testing group "basic_getsockopt" =>
        Group "basic_getsockopt": [OK]
Testing group "basic_getsockname" =>
        Group "basic_getsockname": [OK]
Testing group "wake_with_signal" =>
        Group "wake_with_signal": [OK]
Testing group "multithread" =>
        Group "multithread": [OK]
Unit-test groups done... OK:17, FAILED:0, TOTAL:17
 -- number of checks made: 3589
HEAP BEFORE TESTS:
             total       used       free    largest
Mem:      67108368     283120   66825248   66825184
HEAP AFTER TESTS:
             total       used       free    largest
Mem:      67108368     623440   66484928   66483328
```