### PR TITLE
fs/poll: using callback mechanism to implement poll notification

### DIFF
--- a/fs/vfs/fs_epoll.c
+++ b/fs/vfs/fs_epoll.c
@@ -365,10 +365,7 @@ int epoll_ctl(int epfd, int op, int fd, struct epoll_event *ev)
         return -1;
     }
 
-  if (eph->poll[0].sem)
-    {
-      poll_notify(&eph->poll, 1, eph->poll[0].events);
-    }
+  poll_notify(&eph->poll, 1, eph->poll[0].events);
 
   return 0;
 }

--- a/include/sys/poll.h
+++ b/include/sys/poll.h
@@ -97,6 +97,11 @@ typedef unsigned int nfds_t;
 
 typedef uint32_t pollevent_t;
 
+/* The poll callback type */
+
+struct pollfd;
+typedef CODE void (*pollcb_t)(FAR struct pollfd *fds);
+
 /* This is the NuttX variant of the standard pollfd structure.  The poll()
  * interfaces receive a variable length array of such structures.
  *
@@ -117,7 +122,8 @@ struct pollfd
   /* Non-standard fields used internally by NuttX. */
 
   FAR void    *ptr;     /* The psock or file being polled */
-  FAR sem_t   *sem;     /* Pointer to semaphore used to post output event */
+  FAR void    *arg;     /* The poll callback function argument */
+  pollcb_t     cb;      /* The poll callback function */
   FAR void    *priv;    /* For use by drivers */
 };
 


### PR DESCRIPTION
## Summary
Using callback mechanism to implement poll notification, the callback mechanism can only be used in kernal code.
Rpmsg device (#6869) need this mechanism to implement the poll operation.

## Impact
All poll operation.

## Testing
ostest, pipe, usrsocktest pass.
