### PR TITLE
risc-v/esp32c3: Fix retrieval for linker-defined symbol

### DIFF
--- a/arch/risc-v/src/esp32c3/esp32c3_allocateheap.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_allocateheap.c
@@ -91,7 +91,7 @@ void up_allocate_heap(void **heap_start, size_t *heap_size)
    * Check boards/risc-v/esp32c3.
    */
 
-  extern uint8_t *_sheap;
+  extern uint8_t _sheap[];
   extern const struct esp32c3_rom_layout_s *ets_rom_layout_p;
 
   board_autoled_on(LED_HEAPALLOCATE);
@@ -123,7 +123,7 @@ void up_allocate_kheap(void **heap_start, size_t *heap_size)
    * Check boards/risc-v/esp32c3.
    */
 
-  extern uint8_t *_sheap;
+  extern uint8_t _sheap[];
 
   uintptr_t kbase = (uintptr_t)_sheap;
   uintptr_t ktop  = KDRAM_END;


### PR DESCRIPTION
## Summary
A recent change introduced in #7160 prevents the ESP32-C3 from booting into NSH.

## Impact
Platforms based on ESP32-C3 chip.

## Testing
`esp32c3-devkit:nsh` properly boots to NSH.
Build pass on internal CI.
