### PR TITLE
s32k1xx: Allow building with debug features and no console.

### DIFF
--- a/arch/arm/src/s32k1xx/s32k1xx_lowputc.c
+++ b/arch/arm/src/s32k1xx/s32k1xx_lowputc.c
@@ -385,7 +385,7 @@ int s32k1xx_lpuart_configure(uint32_t base,
  *
  ****************************************************************************/
 
-#if defined(HAVE_LPUART_DEVICE) && defined(CONFIG_DEBUG_FEATURES)
+#if defined(HAVE_LPUART_CONSOLE) && defined(CONFIG_DEBUG_FEATURES)
 void s32k1xx_lowputc(int ch)
 {
   while ((getreg32(S32K1XX_CONSOLE_BASE + S32K1XX_LPUART_STAT_OFFSET) &

--- a/arch/arm/src/s32k1xx/s32k1xx_start.c
+++ b/arch/arm/src/s32k1xx/s32k1xx_start.c
@@ -98,7 +98,7 @@
  *
  ****************************************************************************/
 
-#ifdef CONFIG_DEBUG_FEATURES
+#if defined(HAVE_LPUART_CONSOLE) && defined(CONFIG_DEBUG_FEATURES)
 #  define showprogress(c) s32k1xx_lowputc(c)
 #else
 #  define showprogress(c)


### PR DESCRIPTION
## Summary
If no LPUART console is selected, but DEBUG_FEATURES is enabled, building fails for s32k1xx boards.

## Impact
This prevents using custom consoles different from LPUART based ones.

## Testing

1. `tools/configure.sh s32k148evb:nsh`
2. `make menuconfig`
- Device Drivers -> Serial Driver Support -> Serial console: select "No serial console"
- Build Setup -> Debug Options -> Enable Debug Features: check
3. make
Build fails:
```In file included from chip/s32k1xx_pin.h:37,
                 from chip/s32k1xx_lowputc.c:36:
chip/s32k1xx_lowputc.c: In function 's32k1xx_lowputc':
chip/s32k1xx_lowputc.c:391:20: error: 'S32K1XX_CONSOLE_BASE' undeclared (first use in this function); did you mean 'S32K1XX_GPIOE_BASE'?
  391 |   while ((getreg32(S32K1XX_CONSOLE_BASE + S32K1XX_LPUART_STAT_OFFSET) &
      |                    ^~~~~~~~~~~~~~~~~~~~```

After applying the PR, build succeeds with the same procedure.



