### PR TITLE
include/threads.h: fix warning

### DIFF
--- a/include/threads.h
+++ b/include/threads.h
@@ -38,11 +38,11 @@
 
 /* Indicates thread error status */
 
-#define thrd_success  ((FAR void *)OK)
-#define thrd_timedout ((FAR void *)ETIMEDOUT)
-#define thrd_busy     ((FAR void *)EBUSY)
-#define thrd_nomem    ((FAR void *)ENOMEM)
-#define thrd_error    ((FAR void *)ERROR)
+#define thrd_success  (OK)
+#define thrd_timedout (ETIMEDOUT)
+#define thrd_busy     (EBUSY)
+#define thrd_nomem    (ENOMEM)
+#define thrd_error    (ERROR)
 
 /* Defines the type of a mutex */
 


### PR DESCRIPTION
## Summary
include/threads.h: return values should be integer type to prevent compiler warnings

## Impact
Eliminate `warning: comparison between pointer and integer` when we use threads interface in a standard way:
`if (thrd_create(&th1, func1, NULL) != thrd_success)`

## Testing
CI
