### PR TITLE
allow to enable LIBC_NETDB directly from menuconfig

### DIFF
--- a/libs/libc/netdb/Kconfig
+++ b/libs/libc/netdb/Kconfig
@@ -4,7 +4,7 @@
 #
 
 config LIBC_NETDB
-	bool
+	bool "netdb support"
 	default n
 
 menu "NETDB Support"


### PR DESCRIPTION
## Summary
libs/libc/netdb/Kconfig: allow to enable LIBC_NETDB directly from menuconfig

I'm porting the Lely CANopen stack to Nuttx and for a clean build with a CAN character driver I need gai_strerror() function.
With this PR we can enable LIBC_NETDB and then LIBC_GAISTRERROR without additional networking support.

## Impact

## Testing
CI
