### PR TITLE
btuart driver improvement

### DIFF
--- a/drivers/wireless/bluetooth/bt_uart.c
+++ b/drivers/wireless/bluetooth/bt_uart.c
@@ -306,3 +306,23 @@ void btuart_close(FAR struct bt_driver_s *dev)
 
   lower->rxattach(lower, NULL, NULL);
 }
+
+int btuart_ioctl(FAR struct bt_driver_s *dev,
+                 int cmd, unsigned long arg)
+{
+  FAR struct btuart_upperhalf_s *upper;
+  FAR const struct btuart_lowerhalf_s *lower;
+
+  upper = (FAR struct btuart_upperhalf_s *)dev;
+  DEBUGASSERT(upper != NULL && upper->lower != NULL);
+  lower = upper->lower;
+
+  if (lower->ioctl)
+    {
+      return lower->ioctl(lower, cmd, arg);
+    }
+  else
+    {
+      return -ENOTTY;
+    }
+}

--- a/drivers/wireless/bluetooth/bt_uart.c
+++ b/drivers/wireless/bluetooth/bt_uart.c
@@ -64,8 +64,7 @@ static ssize_t btuart_read(FAR struct btuart_upperhalf_s *upper,
   ssize_t ntotal = 0;
   ssize_t nread;
 
-  wlinfo("buflen %lu minread %lu\n",
-         (unsigned long)buflen, (unsigned long)minread);
+  wlinfo("buflen %zu minread %zu\n", buflen, minread);
 
   DEBUGASSERT(upper != NULL && upper->lower != NULL);
   lower = upper->lower;
@@ -86,12 +85,11 @@ static ssize_t btuart_read(FAR struct btuart_upperhalf_s *upper,
         }
       else if (nread < 0)
         {
-          wlwarn("Returned error %d\n", (int)nread);
+          wlwarn("Returned error %zd\n", nread);
           return nread;
         }
 
-      wlinfo("read %ld remaining %lu\n",
-             (long)nread, (unsigned long)(buflen - nread));
+      wlinfo("read %zd remaining %zu\n", nread, buflen - nread);
 
       buflen -= nread;
       ntotal += nread;
@@ -124,10 +122,9 @@ static void btuart_rxwork(FAR void *arg)
    */
 
   nread = btuart_read(upper, data, H4_HEADER_SIZE, 0);
-  if (nread != 1)
+  if (nread != H4_HEADER_SIZE)
     {
-      wlwarn("WARNING: Unable to read H4 packet type: %ld\n",
-             (long)nread);
+      wlwarn("WARNING: Unable to read H4 packet type: %zd\n", nread);
       goto errout_with_busy;
     }
 
@@ -149,8 +146,7 @@ static void btuart_rxwork(FAR void *arg)
                       hdrlen, hdrlen);
   if (nread != hdrlen)
     {
-      wlwarn("WARNING: Unable to read H4 packet header: %ld\n",
-          (long)nread);
+      wlwarn("WARNING: Unable to read H4 packet header: %zd\n", nread);
       goto errout_with_busy;
     }
 
@@ -176,8 +172,7 @@ static void btuart_rxwork(FAR void *arg)
                       pktlen, pktlen);
   if (nread != pktlen)
     {
-      wlwarn("WARNING: Unable to read H4 packet: %ld\n",
-          (long)nread);
+      wlwarn("WARNING: Unable to read H4 packet: %zd\n", nread);
       goto errout_with_busy;
     }
 

--- a/drivers/wireless/bluetooth/bt_uart.c
+++ b/drivers/wireless/bluetooth/bt_uart.c
@@ -275,10 +275,6 @@ int btuart_open(FAR struct bt_driver_s *dev)
   DEBUGASSERT(upper != NULL && upper->lower != NULL);
   lower = upper->lower;
 
-  /* Disable Rx callbacks */
-
-  lower->rxenable(lower, false);
-
   /* Drain any cached Rx data */
 
   lower->rxdrain(lower);
@@ -291,4 +287,22 @@ int btuart_open(FAR struct bt_driver_s *dev)
 
   lower->rxenable(lower, true);
   return OK;
+}
+
+void btuart_close(FAR struct bt_driver_s *dev)
+{
+  FAR struct btuart_upperhalf_s *upper;
+  FAR const struct btuart_lowerhalf_s *lower;
+
+  upper = (FAR struct btuart_upperhalf_s *)dev;
+  DEBUGASSERT(upper != NULL && upper->lower != NULL);
+  lower = upper->lower;
+
+  /* Disable Rx callbacks */
+
+  lower->rxenable(lower, false);
+
+  /* Detach the Rx event handler */
+
+  lower->rxattach(lower, NULL, NULL);
 }

--- a/drivers/wireless/bluetooth/bt_uart.h
+++ b/drivers/wireless/bluetooth/bt_uart.h
@@ -92,5 +92,7 @@ int btuart_send(FAR struct bt_driver_s *dev,
                 FAR void *data, size_t len);
 int btuart_open(FAR struct bt_driver_s *dev);
 void btuart_close(FAR struct bt_driver_s *dev);
+int btuart_ioctl(FAR struct bt_driver_s *dev,
+                 int cmd, unsigned long arg);
 
 #endif /* __DRIVER_WIRELESS_BLUETOOTH_BT_UART_H */

--- a/drivers/wireless/bluetooth/bt_uart.h
+++ b/drivers/wireless/bluetooth/bt_uart.h
@@ -91,5 +91,6 @@ int btuart_send(FAR struct bt_driver_s *dev,
                 enum bt_buf_type_e type,
                 FAR void *data, size_t len);
 int btuart_open(FAR struct bt_driver_s *dev);
+void btuart_close(FAR struct bt_driver_s *dev);
 
 #endif /* __DRIVER_WIRELESS_BLUETOOTH_BT_UART_H */

--- a/drivers/wireless/bluetooth/bt_uart_bcm4343x.c
+++ b/drivers/wireless/bluetooth/bt_uart_bcm4343x.c
@@ -423,6 +423,7 @@ int btuart_register(FAR const struct btuart_lowerhalf_s *lower)
   upper->dev.head_reserve = H4_HEADER_SIZE;
   upper->dev.open = btuart_open;
   upper->dev.send = btuart_send;
+  upper->dev.close = btuart_close;
   upper->lower = lower;
 
   /* Load firmware */

--- a/drivers/wireless/bluetooth/bt_uart_bcm4343x.c
+++ b/drivers/wireless/bluetooth/bt_uart_bcm4343x.c
@@ -424,6 +424,7 @@ int btuart_register(FAR const struct btuart_lowerhalf_s *lower)
   upper->dev.open = btuart_open;
   upper->dev.send = btuart_send;
   upper->dev.close = btuart_close;
+  upper->dev.ioctl = btuart_ioctl;
   upper->lower = lower;
 
   /* Load firmware */

--- a/drivers/wireless/bluetooth/bt_uart_cc2564.c
+++ b/drivers/wireless/bluetooth/bt_uart_cc2564.c
@@ -189,6 +189,7 @@ int btuart_register(FAR const struct btuart_lowerhalf_s *lower)
   upper->dev.head_reserve = H4_HEADER_SIZE;
   upper->dev.open         = btuart_open;
   upper->dev.send         = btuart_send;
+  upper->dev.close        = btuart_close;
   upper->lower            = lower;
 
   /* Load firmware */

--- a/drivers/wireless/bluetooth/bt_uart_cc2564.c
+++ b/drivers/wireless/bluetooth/bt_uart_cc2564.c
@@ -190,6 +190,7 @@ int btuart_register(FAR const struct btuart_lowerhalf_s *lower)
   upper->dev.open         = btuart_open;
   upper->dev.send         = btuart_send;
   upper->dev.close        = btuart_close;
+  upper->dev.ioctl        = btuart_ioctl;
   upper->lower            = lower;
 
   /* Load firmware */

--- a/drivers/wireless/bluetooth/bt_uart_generic.c
+++ b/drivers/wireless/bluetooth/bt_uart_generic.c
@@ -84,6 +84,7 @@ int btuart_register(FAR const struct btuart_lowerhalf_s *lower)
   upper->dev.open         = btuart_open;
   upper->dev.send         = btuart_send;
   upper->dev.close        = btuart_close;
+  upper->dev.ioctl        = btuart_ioctl;
   upper->lower            = lower;
 
   /* And register the driver with the network and the Bluetooth stack. */

--- a/drivers/wireless/bluetooth/bt_uart_generic.c
+++ b/drivers/wireless/bluetooth/bt_uart_generic.c
@@ -83,6 +83,7 @@ int btuart_register(FAR const struct btuart_lowerhalf_s *lower)
   upper->dev.head_reserve = H4_HEADER_SIZE;
   upper->dev.open         = btuart_open;
   upper->dev.send         = btuart_send;
+  upper->dev.close        = btuart_close;
   upper->lower            = lower;
 
   /* And register the driver with the network and the Bluetooth stack. */

--- a/drivers/wireless/bluetooth/bt_uart_shim.c
+++ b/drivers/wireless/bluetooth/bt_uart_shim.c
@@ -241,8 +241,7 @@ hciuart_read(FAR const struct btuart_lowerhalf_s *lower,
   FAR struct hciuart_config_s *config = (FAR struct hciuart_config_s *)lower;
   FAR struct hciuart_state_s *state = &config->state;
 
-  wlinfo("config %p buffer %p buflen %lu\n",
-         config, buffer, (unsigned long)buflen);
+  wlinfo("config %p buffer %p buflen %zu\n", config, buffer, buflen);
 
   /* NOTE: This assumes that the caller has exclusive access to the Rx
    * buffer, i.e., one lower half instance can server only one upper half!
@@ -272,8 +271,7 @@ hciuart_write(FAR const struct btuart_lowerhalf_s *lower,
   FAR struct hciuart_config_s *config = (FAR struct hciuart_config_s *)lower;
   FAR struct hciuart_state_s *state = &config->state;
 
-  wlinfo("config %p buffer %p buflen %lu\n",
-         config, buffer, (unsigned long)buflen);
+  wlinfo("config %p buffer %p buflen %zu\n", config, buffer, buflen);
 
   return file_write(&state->f, buffer, buflen);
 }

--- a/include/nuttx/wireless/bluetooth/bt_uart.h
+++ b/include/nuttx/wireless/bluetooth/bt_uart.h
@@ -137,6 +137,11 @@ struct btuart_lowerhalf_s
   /* Flush/drain all buffered RX data */
 
   CODE ssize_t (*rxdrain)(FAR const struct btuart_lowerhalf_s *lower);
+
+  /* Lower-half logic may support platform-specific ioctl commands */
+
+  CODE int (*ioctl)(FAR const struct btuart_lowerhalf_s *lower,
+                    int cmd, unsigned long arg);
 };
 
 /****************************************************************************


### PR DESCRIPTION
## Summary

- bluetooth: Remove the unnecessary cast in btuart driver 
- bluetooth: Implement btuart_close for btuart upperhalf driver
- bluetooth: Forward ioctl to btuart lowerhalf driver(#6901)
- bluetooth: Implement hciuart_ioctl for btuart lowerhalf shim driver(#6901)
- bluetooth: Remove hcicollecttask from btuart shim driver(#7207)

## Impact
Got more function ioctl/close, remove one work thread

## Testing
Pass CI
