### PR TITLE
driver/usersock_dev: Check CONFIG_NET_USRSOCK_DEVICE instead CONFIG_NET_USRSOCK

### DIFF
--- a/drivers/usrsock/usrsock_dev.c
+++ b/drivers/usrsock/usrsock_dev.c
@@ -23,7 +23,7 @@
  ****************************************************************************/
 
 #include <nuttx/config.h>
-#if defined(CONFIG_NET) && defined(CONFIG_NET_USRSOCK)
+#if defined(CONFIG_NET_USRSOCK_DEVICE)
 
 #include <sys/types.h>
 #include <inttypes.h>
@@ -566,4 +566,4 @@ void usrsock_register(void)
                   &g_usrsockdev);
 }
 
-#endif /* CONFIG_NET && CONFIG_NET_USRSOCK */
+#endif /* CONFIG_NET_USRSOCK_DEVICE */


### PR DESCRIPTION
## Summary
since after https://github.com/apache/incubator-nuttx/pull/6949, usrsock can have multiple implementation, we need check CONFIG_NET_USRSOCK_DEVICE for usrsock_dev.c

## Impact
Minor

## Testing
Pass CI
