### PR TITLE
poll: Don't need monitor POLLERR or POLLHUP explicitly

### DIFF
--- a/fs/vfs/fs_epoll.c
+++ b/fs/vfs/fs_epoll.c
@@ -365,7 +365,7 @@ int epoll_ctl(int epfd, int op, int fd, struct epoll_event *ev)
         return -1;
     }
 
-  poll_notify(&eph->poll, 1, eph->poll[0].events);
+  poll_notify(&eph->poll, 1, POLLIN);
   return 0;
 }
 

--- a/fs/vfs/fs_epoll.c
+++ b/fs/vfs/fs_epoll.c
@@ -308,7 +308,7 @@ int epoll_ctl(int epfd, int op, int fd, struct epoll_event *ev)
           }
 
         eph->data[++eph->occupied]      = ev->data;
-        eph->poll[eph->occupied].events = ev->events | POLLERR | POLLHUP;
+        eph->poll[eph->occupied].events = ev->events;
         eph->poll[eph->occupied].fd     = fd;
 
         break;
@@ -347,7 +347,7 @@ int epoll_ctl(int epfd, int op, int fd, struct epoll_event *ev)
             if (eph->poll[i].fd == fd)
               {
                 eph->data[i]        = ev->data;
-                eph->poll[i].events = ev->events | POLLERR | POLLHUP;
+                eph->poll[i].events = ev->events;
                 break;
               }
           }
@@ -366,7 +366,6 @@ int epoll_ctl(int epfd, int op, int fd, struct epoll_event *ev)
     }
 
   poll_notify(&eph->poll, 1, eph->poll[0].events);
-
   return 0;
 }
 

--- a/fs/vfs/fs_poll.c
+++ b/fs/vfs/fs_poll.c
@@ -153,7 +153,6 @@ static inline int poll_setup(FAR struct pollfd *fds, nfds_t nfds,
       fds[i].cb      = poll_default_cb;
       fds[i].revents = 0;
       fds[i].priv    = NULL;
-      fds[i].events |= POLLERR | POLLHUP;
 
       /* Check for invalid descriptors. "If the value of fd is less than 0,
        * events shall be ignored, and revents shall be set to 0 in that entry
@@ -419,7 +418,6 @@ int file_poll(FAR struct file *filep, FAR struct pollfd *fds, bool setup)
   else
     {
       poll_notify(&fds, 1, POLLERR | POLLHUP);
-
       ret = OK;
     }
 


### PR DESCRIPTION
## Summary
since spec require the implementation always report POLLERR/POLLHUP:
https://pubs.opengroup.org/onlinepubs/9699919799/functions/poll.html

## Impact
Shouldn't

## Testing
Pass CI
