### PR TITLE
arch/risc-v/src/mpfs/mpfs_ethernet.c: Set PHY speed advert after PHY …

### DIFF
--- a/arch/risc-v/src/mpfs/mpfs_ethernet.c
+++ b/arch/risc-v/src/mpfs/mpfs_ethernet.c
@@ -2355,29 +2355,6 @@ static int mpfs_autonegotiate(struct mpfs_ethmac_s *priv)
       goto errout;
     }
 
-#ifndef CONFIG_MPFS_MAC_AUTONEG_DISABLE_1000MBPS
-  /* Modify the 1000Base-T control register to advertise 1000Base-T full
-   * and half duplex support.
-   */
-
-  ret = mpfs_phyread(priv, priv->phyaddr, GMII_1000BTCR, &btcr);
-  if (ret < 0)
-    {
-      nerr("ERROR: Failed to read 1000BTCR register: %d\n", ret);
-      goto errout;
-    }
-
-  btcr |= GMII_1000BTCR_1000BASETFULL | GMII_1000BTCR_1000BASETHALF;
-
-  ret = mpfs_phywrite(priv, priv->phyaddr, GMII_1000BTCR, btcr);
-  if (ret < 0)
-    {
-      nerr("ERROR: Failed to write 1000BTCR register: %d\n", ret);
-      goto errout;
-    }
-
-#endif
-
   /* Restart Auto_negotiation */
 
   ret = mpfs_phyread(priv, priv->phyaddr, GMII_MCR, &phyval);
@@ -2450,6 +2427,13 @@ static int mpfs_autonegotiate(struct mpfs_ethmac_s *priv)
       if (ret < 0)
         {
           nerr("ERROR: Failed to read 1000BTSR register: %d\n", ret);
+          goto errout;
+        }
+
+      ret = mpfs_phyread(priv, priv->phyaddr, GMII_1000BTCR, &btcr);
+      if (ret < 0)
+        {
+          nerr("ERROR: Failed to read 1000BTCR register: %d\n", ret);
           goto errout;
         }
 
@@ -3410,6 +3394,7 @@ static int mpfs_phyreset(struct mpfs_ethmac_s *priv)
   uint16_t mcr;
   int timeout;
   int ret;
+  uint16_t btcr;
 
   ninfo(" mpfs_phyreset\n");
 
@@ -3443,6 +3428,27 @@ static int mpfs_phyreset(struct mpfs_ethmac_s *priv)
         {
           ret = OK;
           break;
+        }
+    }
+
+  /* For gigabit PHYs, set or disable the autonegotiation advertisement for
+   * 1G speed
+   */
+
+  if (mpfs_phyread(priv, priv->phyaddr, GMII_1000BTCR, &btcr) == OK)
+    {
+#if defined(CONFIG_MPFS_MAC_AUTONEG_DISABLE_1000MBPS) || \
+            (!defined(CONFIG_MPFS_MAC_AUTONEG) && \
+             !defined(CONFIG_MPFS_MAC_ETH1000MBPS))
+      btcr &= ~(GMII_1000BTCR_1000BASETFULL | GMII_1000BTCR_1000BASETHALF);
+#else
+      btcr |= GMII_1000BTCR_1000BASETFULL | GMII_1000BTCR_1000BASETHALF;
+#endif
+
+      ret = mpfs_phywrite(priv, priv->phyaddr, GMII_1000BTCR, btcr);
+      if (ret < 0)
+        {
+          nerr("ERROR: Failed to write 1000BTCR register: %d\n", ret);
         }
     }
 


### PR DESCRIPTION
…reset

This allows properly using 10/100Mbps also with 1G phy. Some gigabit PHYs come out of reset with 1G advertisement enabled, causing other devices to set up link with 1G. If, after this, the MAC is set to 10/100 on the mpfs, the link won't work.

Signed-off-by: Jukka Laitinen <jukkax@ssrc.tii.ae>

## Testing

Tested on Aries module + custom HW with 2 different phys:
- 4 modes (fixed 100Mbps, fixed 1000Mbps, autonegotiation w. 1000Mbps enabled, autonegotiation w. 1000 disabled) on a gigabit phy,
- fixed 100Mbps and autonegotiation w. 1000 disabled on a 10/100 PHY.
