### PR TITLE
Fix chip/cxd56_gnss.c:2858:7: error: label 'err' used but not defined

### DIFF
--- a/arch/arm/src/cxd56xx/cxd56_gnss.c
+++ b/arch/arm/src/cxd56xx/cxd56_gnss.c
@@ -2746,7 +2746,7 @@ static ssize_t cxd56_gnss_read(struct file *filep, char *buffer,
   if (!buffer)
     {
       ret = -EINVAL;
-      goto err;
+      goto out;
     }
 
   if (len == 0)


### PR DESCRIPTION
## Summary
Fix the compiler error reported by #7234

## Impact
cxd56:gnss

## Testing
Pass CI
