### PR TITLE
boards: Change the linker generated symbols from uint32_t to uint8_t array

### DIFF
--- a/boards/arm/gd32f4/gd32f450zk-eval/src/gd32f4xx_romfs.c
+++ b/boards/arm/gd32f4/gd32f450zk-eval/src/gd32f4xx_romfs.c
@@ -75,14 +75,10 @@ __asm__ (
     "   .balign " STR(ROMFS_SECTOR_SIZE)           "\n"
     "   .globl   romfs_data_end                     \n"
     "romfs_data_end:                                \n"
-    "   .globl   romfs_data_size                    \n"
-    "romfs_data_size:                               \n"
-    "   .word romfs_data_end - romfs_data_begin     \n"
     );
 
-extern const char romfs_data_begin;
-extern const char romfs_data_end;
-extern const int  romfs_data_size;
+extern const uint8_t romfs_data_begin[];
+extern const uint8_t romfs_data_end[];
 
 /****************************************************************************
  * Public Functions
@@ -99,7 +95,7 @@ extern const int  romfs_data_size;
  *   Zero (OK) on success, a negated errno value on error.
  *
  * Assumptions/Limitations:
- *   Memory addresses [&romfs_data_begin .. &romfs_data_begin) should contain
+ *   Memory addresses [romfs_data_begin .. romfs_data_end) should contain
  *   ROMFS volume data, as included in the assembly snippet above.
  *
  ****************************************************************************/
@@ -111,9 +107,9 @@ int gd32_romfs_initialize(void)
 
   /* Create a ROM disk for the /etc filesystem */
 
-  romfs_data_len = (uintptr_t)&romfs_data_end - (uintptr_t)&romfs_data_begin;
+  romfs_data_len = romfs_data_end - romfs_data_begin;
 
-  ret = romdisk_register(CONFIG_GD32F4_ROMFS_DEV_MINOR, &romfs_data_begin,
+  ret = romdisk_register(CONFIG_GD32F4_ROMFS_DEV_MINOR, romfs_data_begin,
                          NSECTORS(romfs_data_len), ROMFS_SECTOR_SIZE);
   if (ret < 0)
     {

--- a/boards/arm/gd32f4/gd32f450zk-eval/src/gd32f4xx_romfs.h
+++ b/boards/arm/gd32f4/gd32f450zk-eval/src/gd32f4xx_romfs.h
@@ -49,7 +49,7 @@
  *   Zero (OK) on success, a negated errno value on error.
  *
  * Assumptions/Limitations:
- *   Memory addresses [&romfs_data_begin .. &romfs_data_begin) should contain
+ *   Memory addresses [romfs_data_begin .. romfs_data_end) should contain
  *   ROMFS volume data, as included in the assembly snippet in
  *   gd32f4xx_romfs.c.
  *

--- a/boards/arm/lpc17xx_40xx/pnev5180b/src/lpc17_40_romfs.c
+++ b/boards/arm/lpc17xx_40xx/pnev5180b/src/lpc17_40_romfs.c
@@ -75,14 +75,10 @@ __asm__ (
     \
     ".balign " STR(ROMFS_SECTOR_SIZE) "\n"
     ".globl   romfs_data_end\n"
-"romfs_data_end:\n"
-    ".globl   romfs_data_size\n"
-"romfs_data_size:\n"
-    ".word romfs_data_end - romfs_data_begin\n");
+"romfs_data_end:\n");
 
-extern const uint8_t romfs_data_begin;
-extern const uint8_t romfs_data_end;
-extern const int  romfs_data_size;
+extern const uint8_t romfs_data_begin[];
+extern const uint8_t romfs_data_end[];
 
 /****************************************************************************
  * Public Functions
@@ -99,21 +95,21 @@ extern const int  romfs_data_size;
  *   Zero (OK) on success, a negated errno value on error.
  *
  * Assumptions/Limitations:
- *   Memory addresses [&romfs_data_begin .. &romfs_data_en) should contain
+ *   Memory addresses [romfs_data_begin .. romfs_data_en) should contain
  *   ROMFS volume data, as included in the assembly snippet above.
  *
  ****************************************************************************/
 
 int lpc17_40_romfs_initialize(void)
 {
-  uintptr_t romfs_data_len;
+  size_t romfs_data_len;
   int  ret;
 
   /* Create a ROM disk for the /etc filesystem */
 
-  romfs_data_len = (uintptr_t)&romfs_data_end - (uintptr_t)&romfs_data_begin;
+  romfs_data_len = romfs_data_end - romfs_data_begin;
 
-  ret = romdisk_register(CONFIG_LPC17_40_ROMFS_DEV_MINOR, &romfs_data_begin,
+  ret = romdisk_register(CONFIG_LPC17_40_ROMFS_DEV_MINOR, romfs_data_begin,
                          NSECTORS(romfs_data_len), ROMFS_SECTOR_SIZE);
   if (ret < 0)
     {

--- a/boards/arm/lpc17xx_40xx/pnev5180b/src/lpc17_40_romfs.h
+++ b/boards/arm/lpc17xx_40xx/pnev5180b/src/lpc17_40_romfs.h
@@ -49,7 +49,7 @@
  *   Zero (OK) on success, a negated errno value on error.
  *
  * Assumptions/Limitations:
- *   Memory addresses [&romfs_data_begin .. &romfs_data_end) should contain
+ *   Memory addresses [romfs_data_begin .. romfs_data_end) should contain
  *   ROMFS volume data, as included in the assembly snippet in
  *   lpc17_40_romfs_initialize.c.
  *

--- a/boards/arm/stm32/nucleo-f429zi/src/stm32_romfs.h
+++ b/boards/arm/stm32/nucleo-f429zi/src/stm32_romfs.h
@@ -49,7 +49,7 @@
  *   Zero (OK) on success, a negated errno value on error.
  *
  * Assumptions/Limitations:
- *   Memory addresses [&romfs_data_begin .. &romfs_data_begin) should contain
+ *   Memory addresses [romfs_data_begin .. romfs_data_end) should contain
  *   ROMFS volume data, as included in the assembly snippet above (l. 84).
  *
  ****************************************************************************/

--- a/boards/arm/stm32/nucleo-f429zi/src/stm32_romfs_initialize.c
+++ b/boards/arm/stm32/nucleo-f429zi/src/stm32_romfs_initialize.c
@@ -77,14 +77,10 @@ __asm__ (
     "   .balign " STR(ROMFS_SECTOR_SIZE)           "\n"
     "   .globl   romfs_data_end                     \n"
     "romfs_data_end:                                \n"
-    "   .globl   romfs_data_size                    \n"
-    "romfs_data_size:                               \n"
-    "   .word romfs_data_end - romfs_data_begin     \n"
     );
 
-extern const char romfs_data_begin;
-extern const char romfs_data_end;
-extern const int  romfs_data_size;
+extern const uint8_t romfs_data_begin[];
+extern const uint8_t romfs_data_end[];
 
 /****************************************************************************
  * Public Functions
@@ -101,21 +97,21 @@ extern const int  romfs_data_size;
  *   Zero (OK) on success, a negated errno value on error.
  *
  * Assumptions/Limitations:
- *   Memory addresses [&romfs_data_begin .. &romfs_data_begin) should contain
+ *   Memory addresses [romfs_data_begin .. romfs_data_end) should contain
  *   ROMFS volume data, as included in the assembly snippet above (l. 84).
  *
  ****************************************************************************/
 
 int stm32_romfs_initialize(void)
 {
-  uintptr_t romfs_data_len;
+  size_t romfs_data_len;
   int  ret;
 
   /* Create a ROM disk for the /etc filesystem */
 
-  romfs_data_len = (uintptr_t)&romfs_data_end - (uintptr_t)&romfs_data_begin;
+  romfs_data_len = romfs_data_end - romfs_data_begin;
 
-  ret = romdisk_register(CONFIG_STM32_ROMFS_DEV_MINOR, &romfs_data_begin,
+  ret = romdisk_register(CONFIG_STM32_ROMFS_DEV_MINOR, romfs_data_begin,
                          NSECTORS(romfs_data_len), ROMFS_SECTOR_SIZE);
   if (ret < 0)
     {

--- a/boards/arm/stm32/omnibusf4/src/stm32_romfs.h
+++ b/boards/arm/stm32/omnibusf4/src/stm32_romfs.h
@@ -64,7 +64,7 @@
  *   Zero (OK) on success, a negated errno value on error.
  *
  * Assumptions/Limitations:
- *   Memory addresses [&romfs_data_begin .. &romfs_data_begin) should contain
+ *   Memory addresses [romfs_data_begin .. romfs_data_end) should contain
  *   ROMFS volume data, as included in the assembly snippet above (l. 84).
  *
  ****************************************************************************/

--- a/boards/arm/stm32/omnibusf4/src/stm32_romfs_initialize.c
+++ b/boards/arm/stm32/omnibusf4/src/stm32_romfs_initialize.c
@@ -91,14 +91,10 @@ __asm__ (
     \
     ".balign " STR(ROMFS_SECTOR_SIZE) "\n"
     ".globl   romfs_data_end\n"
-"romfs_data_end:\n"
-    ".globl   romfs_data_size\n"
-"romfs_data_size:\n"
-    ".word romfs_data_end - romfs_data_begin\n");
+"romfs_data_end:\n");
 
-extern const char romfs_data_begin;
-extern const char romfs_data_end;
-extern const int  romfs_data_size;
+extern const uint8_t romfs_data_begin[];
+extern const uint8_t romfs_data_end[];
 
 /****************************************************************************
  * Public Functions
@@ -115,21 +111,21 @@ extern const int  romfs_data_size;
  *   Zero (OK) on success, a negated errno value on error.
  *
  * Assumptions/Limitations:
- *   Memory addresses [&romfs_data_begin .. &romfs_data_begin) should contain
+ *   Memory addresses [romfs_data_begin .. romfs_data_end) should contain
  *   ROMFS volume data, as included in the assembly snippet above (l. 84).
  *
  ****************************************************************************/
 
 int stm32_romfs_initialize(void)
 {
-  uintptr_t romfs_data_len
+  size_t romfs_data_len
   int  ret;
 
   /* Create a ROM disk for the /etc filesystem */
 
-  romfs_data_len = (uintptr_t)&romfs_data_end - (uintptr_t)&romfs_data_begin;
+  romfs_data_len = romfs_data_end - romfs_data_begin;
 
-  ret = romdisk_register(CONFIG_STM32_ROMFS_DEV_MINOR, &romfs_data_begin,
+  ret = romdisk_register(CONFIG_STM32_ROMFS_DEV_MINOR, romfs_data_begin,
                          NSECTORS(romfs_data_len), ROMFS_SECTOR_SIZE);
   if (ret < 0)
     {

--- a/boards/arm/stm32/stm32f4discovery/src/stm32_romfs.h
+++ b/boards/arm/stm32/stm32f4discovery/src/stm32_romfs.h
@@ -64,7 +64,7 @@
  *   Zero (OK) on success, a negated errno value on error.
  *
  * Assumptions/Limitations:
- *   Memory addresses [&romfs_data_begin .. &romfs_data_begin) should contain
+ *   Memory addresses [romfs_data_begin .. romfs_data_end) should contain
  *   ROMFS volume data, as included in the assembly snippet above (l. 84).
  *
  ****************************************************************************/

--- a/boards/arm/stm32/stm32f4discovery/src/stm32_romfs_initialize.c
+++ b/boards/arm/stm32/stm32f4discovery/src/stm32_romfs_initialize.c
@@ -91,15 +91,10 @@ __asm__ (
     \
     ".balign " STR(ROMFS_SECTOR_SIZE) "\n"
     ".globl   romfs_data_end\n"
-"romfs_data_end:\n"
-    ".globl   romfs_data_size\n"
-"romfs_data_size:\n"
-    ".word romfs_data_end - romfs_data_begin\n"
-    ".previous\n");
+"romfs_data_end:\n");
 
-extern const char romfs_data_begin;
-extern const char romfs_data_end;
-extern const int  romfs_data_size;
+extern const uint8_t romfs_data_begin[];
+extern const uint8_t romfs_data_end[];
 
 /****************************************************************************
  * Public Functions
@@ -116,21 +111,21 @@ extern const int  romfs_data_size;
  *   Zero (OK) on success, a negated errno value on error.
  *
  * Assumptions/Limitations:
- *   Memory addresses [&romfs_data_begin .. &romfs_data_begin) should contain
+ *   Memory addresses [romfs_data_begin .. romfs_data_end) should contain
  *   ROMFS volume data, as included in the assembly snippet above (l. 84).
  *
  ****************************************************************************/
 
 int stm32_romfs_initialize(void)
 {
-  uintptr_t romfs_data_len;
+  size_t romfs_data_len;
   int  ret;
 
   /* Create a ROM disk for the /etc filesystem */
 
-  romfs_data_len = (uintptr_t)&romfs_data_end - (uintptr_t)&romfs_data_begin;
+  romfs_data_len = romfs_data_end - romfs_data_begin;
 
-  ret = romdisk_register(CONFIG_STM32_ROMFS_DEV_MINOR, &romfs_data_begin,
+  ret = romdisk_register(CONFIG_STM32_ROMFS_DEV_MINOR, romfs_data_begin,
                          NSECTORS(romfs_data_len), ROMFS_SECTOR_SIZE);
   if (ret < 0)
     {

--- a/boards/arm/stm32f7/nucleo-144/src/stm32_romfs.h
+++ b/boards/arm/stm32f7/nucleo-144/src/stm32_romfs.h
@@ -64,7 +64,7 @@
  *   Zero (OK) on success, a negated errno value on error.
  *
  * Assumptions/Limitations:
- *   Memory addresses [&romfs_data_begin .. &romfs_data_begin) should contain
+ *   Memory addresses [romfs_data_begin .. romfs_data_end) should contain
  *   ROMFS volume data, as included in the assembly snippet above (l. 84).
  *
  ****************************************************************************/

--- a/boards/arm/stm32f7/nucleo-144/src/stm32_romfs_initialize.c
+++ b/boards/arm/stm32f7/nucleo-144/src/stm32_romfs_initialize.c
@@ -91,14 +91,10 @@ __asm__ (
     \
     ".balign " STR(ROMFS_SECTOR_SIZE) "\n"
     ".globl   romfs_data_end\n"
-"romfs_data_end:\n"
-    ".globl   romfs_data_size\n"
-"romfs_data_size:\n"
-    ".word romfs_data_end - romfs_data_begin\n");
+"romfs_data_end:\n");
 
-extern const char romfs_data_begin;
-extern const char romfs_data_end;
-extern const int  romfs_data_size;
+extern const uint8_t romfs_data_begin[];
+extern const uint8_t romfs_data_end[];
 
 /****************************************************************************
  * Public Functions
@@ -115,21 +111,21 @@ extern const int  romfs_data_size;
  *   Zero (OK) on success, a negated errno value on error.
  *
  * Assumptions/Limitations:
- *   Memory addresses [&romfs_data_begin .. &romfs_data_begin) should contain
+ *   Memory addresses [romfs_data_begin .. romfs_data_end) should contain
  *   ROMFS volume data, as included in the assembly snippet above (l. 84).
  *
  ****************************************************************************/
 
 int stm32_romfs_initialize(void)
 {
-  uintptr_t romfs_data_len;
+  size_t romfs_data_len;
   int  ret;
 
   /* Create a ROM disk for the /etc filesystem */
 
-  romfs_data_len = (uintptr_t)&romfs_data_end - (uintptr_t)&romfs_data_begin;
+  romfs_data_len = romfs_data_end - romfs_data_begin;
 
-  ret = romdisk_register(CONFIG_STM32_ROMFS_DEV_MINOR, &romfs_data_begin,
+  ret = romdisk_register(CONFIG_STM32_ROMFS_DEV_MINOR, romfs_data_begin,
                          NSECTORS(romfs_data_len), ROMFS_SECTOR_SIZE);
   if (ret < 0)
     {

--- a/boards/arm/stm32h7/nucleo-h743zi/src/stm32_romfs.h
+++ b/boards/arm/stm32h7/nucleo-h743zi/src/stm32_romfs.h
@@ -49,7 +49,7 @@
  *   Zero (OK) on success, a negated errno value on error.
  *
  * Assumptions/Limitations:
- *   Memory addresses [&romfs_data_begin .. &romfs_data_begin) should contain
+ *   Memory addresses [romfs_data_begin .. romfs_data_end) should contain
  *   ROMFS volume data, as included in the assembly snippet above (l. 84).
  *
  ****************************************************************************/

--- a/boards/arm/stm32h7/nucleo-h743zi/src/stm32_romfs_initialize.c
+++ b/boards/arm/stm32h7/nucleo-h743zi/src/stm32_romfs_initialize.c
@@ -75,14 +75,10 @@ __asm__ (
     "   .balign " STR(ROMFS_SECTOR_SIZE)           "\n"
     "   .globl   romfs_data_end                     \n"
     "romfs_data_end:                                \n"
-    "   .globl   romfs_data_size                    \n"
-    "romfs_data_size:                               \n"
-    "   .word romfs_data_end - romfs_data_begin     \n"
     );
 
-extern const char romfs_data_begin;
-extern const char romfs_data_end;
-extern const int  romfs_data_size;
+extern const uint8_t romfs_data_begin[];
+extern const uint8_t romfs_data_end[];
 
 /****************************************************************************
  * Public Functions
@@ -99,21 +95,21 @@ extern const int  romfs_data_size;
  *   Zero (OK) on success, a negated errno value on error.
  *
  * Assumptions/Limitations:
- *   Memory addresses [&romfs_data_begin .. &romfs_data_begin) should contain
+ *   Memory addresses [romfs_data_begin .. romfs_data_end) should contain
  *   ROMFS volume data, as included in the assembly snippet above (l. 84).
  *
  ****************************************************************************/
 
 int stm32_romfs_initialize(void)
 {
-  uintptr_t romfs_data_len;
+  size_t romfs_data_len;
   int  ret;
 
   /* Create a ROM disk for the /etc filesystem */
 
-  romfs_data_len = (uintptr_t)&romfs_data_end - (uintptr_t)&romfs_data_begin;
+  romfs_data_len = romfs_data_end - romfs_data_begin;
 
-  ret = romdisk_register(CONFIG_STM32_ROMFS_DEV_MINOR, &romfs_data_begin,
+  ret = romdisk_register(CONFIG_STM32_ROMFS_DEV_MINOR, romfs_data_begin,
                          NSECTORS(romfs_data_len), ROMFS_SECTOR_SIZE);
   if (ret < 0)
     {


### PR DESCRIPTION
## Summary
since the symbol generated by linker is always used as an address not a value.
forgot in https://github.com/apache/incubator-nuttx/pull/7160.

## Impact
Code refactor only

## Testing
Pass CI
