### PR TITLE
RISC-V address environments: Add basic sanity checks for section boundaries

### DIFF
--- a/arch/risc-v/src/common/riscv_addrenv.c
+++ b/arch/risc-v/src/common/riscv_addrenv.c
@@ -89,6 +89,11 @@
 
 #define ADDRENV_VBASE       (CONFIG_ARCH_DATA_VBASE)
 
+/* Make sure the address environment virtual address boundary is valid */
+
+static_assert((ADDRENV_VBASE & RV_MMU_SECTION_ALIGN) == 0,
+              "Addrenv start address is not aligned to section boundary");
+
 /****************************************************************************
  * Public Data
  ****************************************************************************/

--- a/arch/risc-v/src/common/riscv_mmu.h
+++ b/arch/risc-v/src/common/riscv_mmu.h
@@ -107,6 +107,10 @@
 #define RV_MMU_L1_PAGE_SIZE     (0x40000000) /* 1G */
 #define RV_MMU_L2_PAGE_SIZE     (0x200000)   /* 2M */
 #define RV_MMU_L3_PAGE_SIZE     (0x1000)     /* 4K */
+
+/* Minimum alignment requirement for any section of memory is 2MB */
+
+#define RV_MMU_SECTION_ALIGN    (RV_MMU_L2_PAGE_SIZE)
 #else
 #error "Unsupported RISC-V MMU implementation selected"
 #endif /* CONFIG_ARCH_MMU_TYPE_SV39 */

--- a/arch/risc-v/src/mpfs/mpfs_mm_init.c
+++ b/arch/risc-v/src/mpfs/mpfs_mm_init.c
@@ -58,6 +58,11 @@
 #define PGT_L2_SIZE     (512)  /* Enough to map 1 GiB */
 #define PGT_L3_SIZE     (1024) /* Enough to map 4 MiB */
 
+/* Calculate the minimum size for the L3 table */
+
+#define KMEM_SIZE       (KFLASH_SIZE + KSRAM_SIZE)
+#define PGT_L3_MIN_SIZE ((KMEM_SIZE + RV_MMU_PAGE_MASK) >> RV_MMU_PAGE_SHIFT)
+
 #define SLAB_COUNT      (sizeof(m_l3_pgtable) / RV_MMU_PAGE_SIZE)
 
 /****************************************************************************
@@ -213,6 +218,10 @@ void mpfs_kernel_mappings(void)
   ASSERT((KFLASH_START & RV_MMU_SECTION_ALIGN) == 0);
   ASSERT((KSRAM_START & RV_MMU_SECTION_ALIGN) == 0);
   ASSERT((PGPOOL_START & RV_MMU_SECTION_ALIGN) == 0);
+
+  /* Check that the L3 table is of sufficient size */
+
+  ASSERT(PGT_L3_SIZE >= PGT_L3_MIN_SIZE);
 
   /* Initialize slab allocator for L3 page tables */
 

--- a/arch/risc-v/src/mpfs/mpfs_mm_init.c
+++ b/arch/risc-v/src/mpfs/mpfs_mm_init.c
@@ -172,7 +172,7 @@ static void map_region(uintptr_t paddr, uintptr_t vaddr, size_t size,
           /* No, allocate 1 page, this must not fail */
 
           l3pbase = slab_alloc();
-          DEBUGASSERT(l3pbase);
+          ASSERT(l3pbase);
 
           /* Map it to the L3 table */
 
@@ -205,6 +205,15 @@ static void map_region(uintptr_t paddr, uintptr_t vaddr, size_t size,
 
 void mpfs_kernel_mappings(void)
 {
+  /* Ensure the sections are aligned properly, requirement is 2MB due to the
+   * L3 page table size (one table maps 2MB of memory). This mapping cannot
+   * handle unaligned L3 sections.
+   */
+
+  ASSERT((KFLASH_START & RV_MMU_SECTION_ALIGN) == 0);
+  ASSERT((KSRAM_START & RV_MMU_SECTION_ALIGN) == 0);
+  ASSERT((PGPOOL_START & RV_MMU_SECTION_ALIGN) == 0);
+
   /* Initialize slab allocator for L3 page tables */
 
   slab_init(PGT_L3_PBASE);

--- a/arch/risc-v/src/mpfs/mpfs_mm_init.c
+++ b/arch/risc-v/src/mpfs/mpfs_mm_init.c
@@ -181,7 +181,7 @@ static void map_region(uintptr_t paddr, uintptr_t vaddr, size_t size,
 
           /* Map it to the L3 table */
 
-          mmu_ln_setentry(2, PGT_L2_VBASE, l3pbase, vaddr, MMU_UPGT_FLAGS);
+          mmu_ln_setentry(2, PGT_L2_VBASE, l3pbase, vaddr, PTE_G);
         }
 
       /* Then add the L3 mappings */


### PR DESCRIPTION
## Summary
This adds some basic sanity checks for section boundaries, e.g. for Sv39 the mapped regions _must_ be 2MB aligned, due to the fact that a single L3 table maps 2MB of memory.

Also, change the L2 page table mapping to global, because it exists in every address environment.

Also, ensure the L3 page table's size is sufficient to hold all of the kernel mappings.

## Impact
Minor, kernel mode / RISC-V only

## Testing
icicle:knsh
