### PR TITLE
arch: stm32h7: Add support for dual bank flash memory

### DIFF
--- a/arch/arm/src/stm32h7/stm32_flash.c
+++ b/arch/arm/src/stm32h7/stm32_flash.c
@@ -332,10 +332,10 @@ static inline
 struct stm32h7_flash_priv_s * stm32h7_flash_bank(size_t address)
 {
   struct stm32h7_flash_priv_s *priv = NULL;
-    
+ 
   uint32_t bank_size;
 #ifdef STM32_DUAL_BANK
-  bank_size = stm32h7_flash_size(priv)/2;
+  bank_size = stm32h7_flash_size(priv) / 2;
 #else
   bank_size = stm32h7_flash_size(priv);
 #endif
@@ -397,6 +397,7 @@ static int stm32h7_israngeerased(size_t startaddress, size_t size)
         {
           bwritten++;
         }
+
       baddr++;
       count++;
     }


### PR DESCRIPTION
Signed-off-by: Andrés Sánchez Pascual <tito97_sp@hotmail.com>

## Summary
stm32_flash.c not supports currently the dual bank flash memory layout. This commit contemplates this possible layout.

Also a bug in stm32h7_israngeerased function has been solved.

## Impact
stm32h7 arch and based boards.

## Testing
Tested with nucleo-h743zi with multiple MTD drivers in different memory banks:

- /dev/ota0 in bank1   (start_address  0x08040000, lenght 0xC0000)
- /dev/ota1 in bank2   (start_address  0x08100000, lenght 0xC0000)
- /dev/scratch in bank2 (start_address  0x081E0000, lenght 0x40000)

