### PR TITLE
arch: qemu-rv: Refactor the entry point name for BUILD_KERNEL

### DIFF
--- a/arch/risc-v/src/qemu-rv/qemu_rv_head.S
+++ b/arch/risc-v/src/qemu-rv/qemu_rv_head.S
@@ -105,11 +105,7 @@ __start:
 
   /* Jump to qemu_rv_start */
 
-#ifdef CONFIG_ARCH_USE_S_MODE
-  jal  x1, qemu_rv_start_s
-#else
   jal  x1, qemu_rv_start
-#endif
 
   /* We shouldn't return from _start */
 

--- a/arch/risc-v/src/qemu-rv/qemu_rv_start.c
+++ b/arch/risc-v/src/qemu-rv/qemu_rv_start.c
@@ -95,7 +95,11 @@ uintptr_t g_idle_topstack = QEMU_RV_IDLESTACK_TOP;
  * Name: qemu_rv_start
  ****************************************************************************/
 
+#ifdef CONFIG_BUILD_KERNEL
+void qemu_rv_start_s(int mhartid)
+#else
 void qemu_rv_start(int mhartid)
+#endif
 {
   /* Configure FPU */
 
@@ -147,10 +151,10 @@ cpux:
 #ifdef CONFIG_BUILD_KERNEL
 
 /****************************************************************************
- * Name: qemu_rv_start_s
+ * Name: qemu_rv_start
  ****************************************************************************/
 
-void qemu_rv_start_s(int mhartid)
+void qemu_rv_start(int mhartid)
 {
   /* NOTE: still in M-mode */
 
@@ -202,7 +206,7 @@ void qemu_rv_start_s(int mhartid)
 
   /* Set mepc to the entry */
 
-  WRITE_CSR(mepc, (uintptr_t)qemu_rv_start);
+  WRITE_CSR(mepc, (uintptr_t)qemu_rv_start_s);
 
   /* Set a0 to mhartid explicitly and enter to S-mode */
 


### PR DESCRIPTION
## Summary

- This commit refactors the entry point name for BUILD_KERNEL to avoid misunderstanding the name

## Impact

- None

## Testing

- Tested with rv-virt:ksmp64
