### PR TITLE
arch/arm64/qemu/qemu_boot: fix wrong memory size

### DIFF
--- a/arch/arm64/src/qemu/qemu_boot.c
+++ b/arch/arm64/src/qemu/qemu_boot.c
@@ -52,11 +52,11 @@
 static const struct arm_mmu_region mmu_regions[] =
 {
   MMU_REGION_FLAT_ENTRY("DEVICE_REGION",
-                        CONFIG_DEVICEIO_BASEADDR, MB(512),
+                        CONFIG_DEVICEIO_BASEADDR, CONFIG_DEVICEIO_SIZE,
                         MT_DEVICE_NGNRNE | MT_RW | MT_SECURE),
 
   MMU_REGION_FLAT_ENTRY("DRAM0_S0",
-                        CONFIG_RAMBANK1_ADDR, MB(512),
+                        CONFIG_RAMBANK1_ADDR, CONFIG_RAMBANK1_SIZE,
                         MT_NORMAL | MT_RW | MT_SECURE),
 };
 


### PR DESCRIPTION
## Summary
Fixed wrong region size. The default memory size in QEMU system is 128MB, and the size specified in chip.h is also 128MB. However, the region size for MMU was 512MB.

## Impact
none

## Testing
Have confirmed that OS boots with QEMU.

Signed-off-by: Hidenori Matsubayashi <hidenori.matsubayashi@gmail.com>
