### PR TITLE
bl602: Fix bug in lli functionality for dma.

### DIFF
--- a/arch/risc-v/src/bl602/bl602_dma.c
+++ b/arch/risc-v/src/bl602/bl602_dma.c
@@ -259,15 +259,14 @@ int bl602_dma_channel_start(uint8_t channel_id)
   /* Unmask interrupts for:
    *  - DMA_INT_TCOMPLETED
    *  - DMA_INT_ERR
-   * Enable Terminal Count interrupt.
+   * Note it is expected that the TC interupt to be enabled prior to this
+   * function call if needed as it is nominally controlled via the LLI
+   * mechanism.
    */
 
   modifyreg32(BL602_DMA_CH_N_REG(BL602_DMA_CONFIG_OFFSET, channel_id),
               DMA_C0CONFIG_ITC | DMA_C0CONFIG_IE,
               0);
-  modifyreg32(BL602_DMA_CH_N_REG(BL602_DMA_CONTROL_OFFSET, channel_id),
-              0,
-              DMA_C0CONTROL_I);
 
   /* Enable channel */
 

--- a/arch/risc-v/src/bl602/bl602_spi.c
+++ b/arch/risc-v/src/bl602/bl602_spi.c
@@ -933,7 +933,8 @@ static int lli_list_init(struct bl602_spi_priv_s *priv,
           (*tx_lli)[i].dma_ctrl = dma_ctrl;
           (*tx_lli)[i].dst_addr = BL602_SPI_FIFO_WDATA;
           (*tx_lli)[i].src_addr = \
-            (uint32_t)txbuffer + (dma_ctrl.src_width * i * LLI_BUFF_SIZE);
+            (uint32_t)txbuffer + \
+            ((dma_ctrl.src_width + 1) * i * LLI_BUFF_SIZE);
 
           /* Assume last entry, we will overwrite as needed. */
 
@@ -955,7 +956,8 @@ static int lli_list_init(struct bl602_spi_priv_s *priv,
           dma_ctrl.src_increment = 0;
           (*rx_lli)[i].dma_ctrl = dma_ctrl;
           (*rx_lli)[i].dst_addr = \
-            (uint32_t)rxbuffer + (dma_ctrl.dst_width * i * LLI_BUFF_SIZE);
+            (uint32_t)rxbuffer + \
+            ((dma_ctrl.dst_width + 1) * i * LLI_BUFF_SIZE);
           (*rx_lli)[i].src_addr = BL602_SPI_FIFO_RDATA;
           (*rx_lli)[i].next_lli = 0; /* Assume last entry, we will overwrite as needed. */
 
@@ -1006,7 +1008,6 @@ static void bl602_spi_dma_exchange(struct bl602_spi_priv_s *priv,
                                    void *rxbuffer, uint32_t nwords)
 {
   int err;
-
   #ifdef CONFIG_DEBUG_DMA_INFO
     struct bl602_dmaregs_s regs;
   #endif


### PR DESCRIPTION
## Summary
This fixes two bugs when using the DMA LLI functionality:
 * rx and tx buffer addresses were not properly offset for entries past the first.
 * The TC interrupt was enabled on the first LLI entry because it was set directly to the control register in the dma_channel_start function, which would cause the interrupt to fire before the full transaction was completed.

## Impact
Larger DMA transfers for SPI are now properly supported.

## Testing
Tested this against a display using transfers of 12800 bytes per transfer which is 7 LLI entries.

