### PR TITLE
sem: don't clear waitobj when do sem recover

### DIFF
--- a/sched/semaphore/sem_recover.c
+++ b/sched/semaphore/sem_recover.c
@@ -98,14 +98,6 @@ void nxsem_recover(FAR struct tcb_s *tcb)
        */
 
       sem->semcount++;
-
-      /* Clear the semaphore to assure that it is not reused.  But leave the
-       * state as TSTATE_WAIT_SEM.  This is necessary because this is a
-       * necessary indication that the TCB still resides in the waiting-for-
-       * semaphore list.
-       */
-
-      tcb->waitobj = NULL;
     }
 
   /* Release all semphore holders for the task */


### PR DESCRIPTION
## Summary

This commit fixed data abort issue when task restart in wait sem status.
If delete waitobj in the sem recover function, then we will get the wrong task list when remove the task from task list.

A new test case was added for this issue,  apply the following patch and run ostest can reproduce it.
https://github.com/apache/incubator-nuttx-apps/pull/1342

## Impact

NA

## Testing

ostest with sabre-6quad:nsh