### PR TITLE
net/ipforward: fix typo in ipv4_dev_forward

### DIFF
--- a/net/ipforward/ipv4_forward.c
+++ b/net/ipforward/ipv4_forward.c
@@ -244,8 +244,8 @@ static int ipv4_dev_forward(FAR struct net_driver_s *dev,
   /* Initialize the easy stuff in the forwarding structure */
 
   fwd->f_dev    = fwddev;  /* Forwarding device */
-#ifdef CONFIG_NET_IPv5
-  fwd->f_domain = PF_INET; /* IPv64 address domain */
+#ifdef CONFIG_NET_IPv6
+  fwd->f_domain = PF_INET; /* IPv4 address domain */
 #endif
 
 #ifdef CONFIG_DEBUG_NET_WARN


### PR DESCRIPTION
## Summary
f_domain is used to determine protocol family when CONFIG_NET_IPv4 and CONFIG_NET_IPv6 are both defined, but not correctly used in ipv4_dev_forward because of typo (there's not a config named CONFIG_NET_IPv5) which may cause IPv4 packets to be forwarded as IPv6.

## Impact
Fix IPv4 forward logic when both IPv4 and IPv6 are enabled.

## Testing
Locally tested, forwarding ICMP ECHO with more than one network device.
