### PR TITLE
Added Kconfig option for ccache.

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -1999,6 +1999,14 @@ config DEBUG_LINK_MAP
 		and debugging magic section games, and for seeing which
 		pieces of code get eliminated with DEBUG_OPT_UNUSED_SECTIONS.
 
+config CCACHE
+	bool "Use ccache"
+	default n
+	---help---
+		If enabled, ccache will be used during the build.
+		Build artifacts will be cached to a local storage, considerably
+		reducing build times.
+
 endmenu # Build Setup
 
 menu "System Type"

--- a/tools/Config.mk
+++ b/tools/Config.mk
@@ -53,6 +53,12 @@ MODULECC ?= $(CC)
 MODULELD ?= $(LD)
 MODULESTRIP ?= $(STRIP)
 
+# ccache configuration.
+
+ifeq ($(CONFIG_CCACHE),y)
+  CCACHE ?= ccache
+endif
+
 # Define HOSTCC on the make command line if it differs from these defaults
 # Define HOSTCFLAGS with -g on the make command line to build debug versions
 
@@ -273,7 +279,7 @@ endef
 
 define COMPILE
 	@echo "CC: $1"
-	$(Q) $(CC) -c $(CFLAGS) $($(strip $1)_CFLAGS) $1 -o $2
+	$(Q) $(CCACHE) $(CC) -c $(CFLAGS) $($(strip $1)_CFLAGS) $1 -o $2
 endef
 
 # COMPILEXX - Default macro to compile one C++ file
@@ -291,7 +297,7 @@ endef
 
 define COMPILEXX
 	@echo "CXX: $1"
-	$(Q) $(CXX) -c $(CXXFLAGS) $($(strip $1)_CXXFLAGS) $1 -o $2
+	$(Q) $(CCACHE) $(CXX) -c $(CXXFLAGS) $($(strip $1)_CXXFLAGS) $1 -o $2
 endef
 
 # COMPILERUST - Default macro to compile one Rust file
@@ -352,7 +358,7 @@ endef
 
 define ASSEMBLE
 	@echo "AS: $1"
-	$(Q) $(CC) -c $(AFLAGS) $1 $($(strip $1)_AFLAGS) -o $2
+	$(Q) $(CCACHE) $(CC) -c $(AFLAGS) $1 $($(strip $1)_AFLAGS) -o $2
 endef
 
 # INSTALL_LIB - Install a library $1 into target $2


### PR DESCRIPTION
## Summary

Added a new Kconfig option, to enable ccache in builds.

## Impact

By default the option is disabled, so the previous behavior does not change.

## Testing

Build tests.

