### PR TITLE
net/igmp: fix build warning on GCC 12.2.0

### DIFF
--- a/net/igmp/igmp_input.c
+++ b/net/igmp/igmp_input.c
@@ -198,7 +198,7 @@ void igmp_input(struct net_driver_s *dev)
              *    Query."
              */
 
-            if (igmp->grpaddr == 0)
+            if (net_ipv4addr_cmp(igmp->grpaddr, INADDR_ANY) != 0)
               {
                 FAR struct igmp_group_s *member;
 
@@ -233,7 +233,7 @@ void igmp_input(struct net_driver_s *dev)
                       }
                   }
               }
-            else /* if (igmp->grpaddr != 0) */
+            else /* if (net_ipv4addr_cmp(igmp->grpaddr, INADDR_ANY) == 0) */
               {
                 ninfo("Group-specific multicast query\n");
 
@@ -262,7 +262,7 @@ void igmp_input(struct net_driver_s *dev)
 
         /* Not sent to all systems -- Unicast query */
 
-        else if (group->grpaddr != 0)
+        else if (net_ipv4addr_cmp(igmp->grpaddr, INADDR_ANY) == 0)
           {
             ninfo("Unicast query\n");
             IGMP_STATINCR(g_netstats.igmp.ucast_query);


### PR DESCRIPTION


## Summary

net/igmp: fix build warning on GCC 12.2.0

```
igmp/igmp_input.c: In function 'igmp_input':
igmp/igmp_input.c:201:31: warning: the comparison will always evaluate as 'false' for the address of 'grpaddr' will never be NULL [-Waddress]
  201 |             if (igmp->grpaddr == 0)
      |                               ^~
In file included from nuttx/include/nuttx/net/netstats.h:67,
                 from igmp/igmp_input.c:53:
nuttx/include/nuttx/net/igmp.h:132:12: note: 'grpaddr' declared here
  132 |   uint16_t grpaddr[2];       /* 32-bit Group address */
      |            ^~~~~~~
```

Signed-off-by: chao an <anchao@xiaomi.com>

## Impact

N/A

## Testing

https://developer.arm.com/downloads/-/arm-gnu-toolchain-downloads

$ arm-none-eabi-gcc -v
gcc version 12.2.0 (Arm GNU Toolchain 12.2.MPACBTI-Bet1 (Build arm-12-mpacbti.16)) 
