### PR TITLE
net/local: unified formatting name function 

### DIFF
--- a/net/local/local_fifo.c
+++ b/net/local/local_fifo.c
@@ -56,6 +56,32 @@
  ****************************************************************************/
 
 /****************************************************************************
+ * Name: local_format_name
+ *
+ * Description:
+ *   Format the name of the half duplex FIFO.
+ *
+ ****************************************************************************/
+
+static void local_format_name(FAR const char *inpath, FAR char *outpath,
+                              FAR const char *suffix, int32_t id)
+{
+  if (id < 0)
+    {
+      snprintf(outpath, LOCAL_FULLPATH_LEN - 1,
+               CONFIG_NET_LOCAL_VFS_PATH "/%s%s", inpath, suffix);
+    }
+  else
+    {
+      snprintf(outpath, LOCAL_FULLPATH_LEN - 1,
+               CONFIG_NET_LOCAL_VFS_PATH "/%s%s%" PRIx32,
+               inpath, suffix, id);
+    }
+
+  outpath[LOCAL_FULLPATH_LEN - 1] = '\0';
+}
+
+/****************************************************************************
  * Name: local_cs_name
  *
  * Description:
@@ -64,23 +90,10 @@
  ****************************************************************************/
 
 #ifdef CONFIG_NET_LOCAL_STREAM
-static inline void local_cs_name(FAR struct local_conn_s *conn,
-                                 FAR char *path)
+static void local_cs_name(FAR struct local_conn_s *conn, FAR char *path)
 {
-  if (conn->lc_instance_id < 0)
-    {
-      snprintf(path, LOCAL_FULLPATH_LEN - 1,
-               CONFIG_NET_LOCAL_VFS_PATH "/%s" LOCAL_CS_SUFFIX,
-               conn->lc_path);
-    }
-  else
-    {
-      snprintf(path, LOCAL_FULLPATH_LEN - 1,
-               CONFIG_NET_LOCAL_VFS_PATH "/%s" LOCAL_CS_SUFFIX "%" PRIx32,
-               conn->lc_path, conn->lc_instance_id);
-    }
-
-  path[LOCAL_FULLPATH_LEN - 1] = '\0';
+  local_format_name(conn->lc_path, path,
+                    LOCAL_CS_SUFFIX, conn->lc_instance_id);
 }
 #endif /* CONFIG_NET_LOCAL_STREAM */
 
@@ -93,23 +106,10 @@ static inline void local_cs_name(FAR struct local_conn_s *conn,
  ****************************************************************************/
 
 #ifdef CONFIG_NET_LOCAL_STREAM
-static inline void local_sc_name(FAR struct local_conn_s *conn,
-                                 FAR char *path)
+static void local_sc_name(FAR struct local_conn_s *conn, FAR char *path)
 {
-  if (conn->lc_instance_id < 0)
-    {
-      snprintf(path, LOCAL_FULLPATH_LEN - 1,
-               CONFIG_NET_LOCAL_VFS_PATH "/%s" LOCAL_SC_SUFFIX,
-               conn->lc_path);
-    }
-  else
-    {
-      snprintf(path, LOCAL_FULLPATH_LEN - 1,
-               CONFIG_NET_LOCAL_VFS_PATH "/%s" LOCAL_SC_SUFFIX "%" PRIx32,
-               conn->lc_path, conn->lc_instance_id);
-    }
-
-  path[LOCAL_FULLPATH_LEN - 1] = '\0';
+  local_format_name(conn->lc_path, path,
+                    LOCAL_SC_SUFFIX, conn->lc_instance_id);
 }
 #endif /* CONFIG_NET_LOCAL_STREAM */
 
@@ -122,11 +122,9 @@ static inline void local_sc_name(FAR struct local_conn_s *conn,
  ****************************************************************************/
 
 #ifdef CONFIG_NET_LOCAL_DGRAM
-static inline void local_hd_name(FAR const char *inpath, FAR char *outpath)
+static void local_hd_name(FAR const char *inpath, FAR char *outpath)
 {
-  snprintf(outpath, LOCAL_FULLPATH_LEN - 1,
-           CONFIG_NET_LOCAL_VFS_PATH "/%s" LOCAL_HD_SUFFIX, inpath);
-  outpath[LOCAL_FULLPATH_LEN - 1] = '\0';
+  local_format_name(inpath, outpath, LOCAL_HD_SUFFIX, -1);
 }
 #endif /* CONFIG_NET_LOCAL_DGRAM */
 


### PR DESCRIPTION


## Summary

net/local: unified formatting name function 

fix build warning on GCC 12.2.0

```
In file included from local/local_fifo.c:25:
In function 'local_hd_name',
    inlined from 'local_open_receiver' at local/local_fifo.c:593:3:
local/local_fifo.c:128:12: warning: '%s' directive output may be truncated writing up to 107 bytes into a region of size 97 [-Wformat-truncation=]
  128 |            CONFIG_NET_LOCAL_VFS_PATH "/%s" LOCAL_HD_SUFFIX, inpath);
      |            ^~~~~~~~~~~~~~~~~~~~~~~~~
local/local_fifo.c: In function 'local_open_receiver':
local/local_fifo.c:128:40: note: format string is defined here
  128 |            CONFIG_NET_LOCAL_VFS_PATH "/%s" LOCAL_HD_SUFFIX, inpath);
      |                                        ^~
In function 'local_hd_name',
    inlined from 'local_open_receiver' at local/local_fifo.c:593:3:
local/local_fifo.c:127:3: note: 'snprintf' output between 15 and 122 bytes into a destination of size 109
  127 |   snprintf(outpath, LOCAL_FULLPATH_LEN - 1,
      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  128 |            CONFIG_NET_LOCAL_VFS_PATH "/%s" LOCAL_HD_SUFFIX, inpath);
      |            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

Signed-off-by: chao an <anchao@xiaomi.com>

## Impact

N/A

## Testing

https://developer.arm.com/downloads/-/arm-gnu-toolchain-downloads

$ arm-none-eabi-gcc -v
gcc version 12.2.0 (Arm GNU Toolchain 12.2.MPACBTI-Bet1 (Build arm-12-mpacbti.16))