### PR TITLE
Minor fix backtrace config

### DIFF
--- a/arch/arm/Kconfig
+++ b/arch/arm/Kconfig
@@ -598,7 +598,6 @@ config ARCH_CHIP_PHY62XX
 config ARCH_CHIP_TLSR82
 	bool "Telink TLSR82XX"
 	select ARCH_ARMV6M
-	select ARCH_HAVE_BACKTRACE
 	select ARCH_HAVE_RESET
 	select LIBC_ARCH_ATOMIC
 	---help---

--- a/libs/libc/sched/sched_backtrace.c
+++ b/libs/libc/sched/sched_backtrace.c
@@ -24,14 +24,12 @@
 
 #include <nuttx/config.h>
 
+#ifndef CONFIG_ARCH_HAVE_BACKTRACE
+
 #include <sys/types.h>
 #include <unistd.h>
 #include <execinfo.h>
 #include <unwind.h>
-
-#include <nuttx/irq.h>
-
-#if !defined(CONFIG_ARCH_HAVE_BACKTRACE)
 
 /****************************************************************************
  * Private Data Types

--- a/sched/sched/Make.defs
+++ b/sched/sched/Make.defs
@@ -99,7 +99,7 @@ ifeq ($(CONFIG_SCHED_CRITMONITOR),y)
 CSRCS += sched_critmonitor.c
 endif
 
-ifeq ($(CONFIG_ARCH_HAVE_BACKTRACE),y)
+ifeq ($(CONFIG_SCHED_BACKTRACE),y)
 CSRCS += sched_backtrace.c
 endif
 

--- a/sched/sched/sched_backtrace.c
+++ b/sched/sched/sched_backtrace.c
@@ -40,6 +40,7 @@
  *
  ****************************************************************************/
 
+#ifdef CONFIG_ARCH_HAVE_BACKTRACE
 int sched_backtrace(pid_t tid, FAR void **buffer, int size, int skip)
 {
   FAR struct tcb_s *rtcb = NULL;
@@ -55,3 +56,4 @@ int sched_backtrace(pid_t tid, FAR void **buffer, int size, int skip)
 
   return up_backtrace(rtcb, buffer, size, skip);
 }
+#endif


### PR DESCRIPTION
## Summary

- arm/tlsr82xx: Don't select ARCH_HAVE_BACKTRACE 
- sched: Guard backtrace related code correctly 

## Impact
Minor

## Testing
Pass CI
