### PR TITLE
lcd: Fix npixels parameter in calls to `getrun`/`putrun`

### DIFF
--- a/drivers/lcd/lcd_dev.c
+++ b/drivers/lcd/lcd_dev.c
@@ -145,7 +145,7 @@ static int lcddev_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
               {
                 ret = priv->planeinfo.getrun(priv->lcd_ptr, row,
                                              lcd_area->col_start, buf,
-                                             row_size);
+                                             cols);
                 if (ret < 0)
                   {
                     break;
@@ -184,7 +184,7 @@ static int lcddev_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
               {
                 ret = priv->planeinfo.putrun(priv->lcd_ptr, row,
                                              lcd_area->col_start, buf,
-                                             row_size);
+                                             cols);
                 if (ret < 0)
                   {
                     break;


### PR DESCRIPTION
## Summary
This PR intends to fix a regression in LCD Character Device Driver introduced in #6837.
The `npixels` parameter in some calls to `getrun` and `putrun` was being passed in number of bytes, but the correct should be the number of pixels.

## Impact
Fix for applications relying on the LCD character device driver, e.g. LVGL demos.

## Testing
`esp32-wrover-kit:lvgl` now properly executing the `lvgldemo` application.

