### PR TITLE
openamp/libmetal: support other arch sim host

### DIFF
--- a/openamp/libmetal.defs
+++ b/openamp/libmetal.defs
@@ -21,7 +21,15 @@
 ifeq ($(CONFIG_OPENAMP),y)
 
 ifeq ($(CONFIG_ARCH), sim)
+ifeq ($(CONFIG_HOST_ARM64), y)
+LIBMETAL_ARCH = aarch64
+else ifeq ($(CONFIG_HOST_ARM), y)
+LIBMETAL_ARCH = arm
+else ifeq ($(CONFIG_HOST_X86), y)
+LIBMETAL_ARCH = x86
+else
 LIBMETAL_ARCH = x86_64
+endif
 else ifeq ($(CONFIG_ARCH), risc-v)
 LIBMETAL_ARCH = riscv
 else


### PR DESCRIPTION
## Summary
Add support to libmetal for x86, arm and arm64 host. 
## Impact
sim:rpserver config works on aarch64 host.
## Testing
Tested on M2 mac.
