### PR TITLE
bl602/dma: Fix possible call of null pointer

### DIFF
--- a/arch/risc-v/src/bl602/bl602_dma.c
+++ b/arch/risc-v/src/bl602/bl602_dma.c
@@ -120,7 +120,13 @@ static int bl602_dma_int_handler(int irq, void *context, void *arg)
         {
           dmainfo("CH %d Error Int fired\n", ch);
           putreg32((1 << ch), BL602_DMA_INTERRCLR);
-          g_dmach[ch].callback(ch, BL602_DMA_INT_EVT_ERR, g_dmach[ch].arg);
+          if (g_dmach[ch].callback != NULL)
+            {
+              g_dmach[ch].callback(
+                ch,
+                BL602_DMA_INT_EVT_ERR,
+                g_dmach[ch].arg);
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
In the error interrupt case for DMA there was a missing check to see if callback function was registered. If it was not a null pointer would be deferenced.
 
## Impact
Remove possible null-pointer dereference bug.

## Testing
This was audited by the clang-analyzer which caught this as https://clang.llvm.org/docs/analyzer/checkers.html#core-callandmessage-c-c-objc 
