### PR TITLE
newlib/impure: sync with newlib(4.2.0) reent update

### DIFF
--- a/libs/libc/misc/lib_impure.c
+++ b/libs/libc/misc/lib_impure.c
@@ -44,10 +44,14 @@
  * Public Functions
  ****************************************************************************/
 
-#ifdef _REENT_SMALL
+#if defined(_REENT_SMALL) && \
+   (defined(__NEWLIB__) || __NEWLIB__ < 4 || \
+    __NEWLIB__ == 4 && __NEWLIB_MINOR__ < 2)
 extern struct __sFILE_fake __sf_fake_stdin _ATTRIBUTE((weak));
 extern struct __sFILE_fake __sf_fake_stdout _ATTRIBUTE((weak));
 extern struct __sFILE_fake __sf_fake_stderr _ATTRIBUTE((weak));
+#else
+extern __FILE __sf[3] _ATTRIBUTE((weak));
 #endif
 
 static struct _reent __ATTRIBUTE_IMPURE_DATA__


### PR DESCRIPTION
## Summary

newlib/impure: sync with newlib(4.2.0) reent update

```
arm-none-eabi-ld: nuttx/staging/libc.a(lib_impure.o):(.data.impure_data+0x4): undefined reference to `__sf'
arm-none-eabi-ld: nuttx/staging/libc.a(lib_impure.o):(.data.impure_data+0x8): undefined reference to `__sf'
arm-none-eabi-ld: nuttx/staging/libc.a(lib_impure.o):(.data.impure_data+0xc): undefined reference to `__sf'
```

Toolchain:
```
  Version: GNU Arm Embedded Toolchain to Version 11.3.Rel1(August 8, 2022)
  Tar:     arm-gnu-toolchain-11.3.rel1-x86_64-arm-none-eabi.tar.xz
```

Break change:
https://sourceware.org/git/gitweb.cgi?p=newlib-cygwin.git;h=b0cb9f85ca3626e0e68fd451c3090d253ceb4300

Signed-off-by: chao an <anchao@xiaomi.com>

## Impact

LLVM libcxx

## Testing

ci check