### PR TITLE
tools/ci: Update gcc-arm-none-eabi to 11.3.Rel1 August 08, 2022

### DIFF
--- a/tools/ci/cibuild.sh
+++ b/tools/ci/cibuild.sh
@@ -176,17 +176,18 @@ function arm-gcc-toolchain {
     local flavor
     case ${os} in
       Darwin)
-        flavor=mac
+        flavor=-darwin
         ;;
       Linux)
-        flavor=x86_64-linux
+        flavor=
         ;;
     esac
     cd "${prebuilt}"
-    wget --quiet https://developer.arm.com/-/media/Files/downloads/gnu-rm/10.3-2021.10/gcc-arm-none-eabi-10.3-2021.10-${flavor}.tar.bz2
-    tar jxf gcc-arm-none-eabi-10.3-2021.10-${flavor}.tar.bz2
-    mv gcc-arm-none-eabi-10.3-2021.10 gcc-arm-none-eabi
-    rm gcc-arm-none-eabi-10.3-2021.10-${flavor}.tar.bz2
+    wget --quiet https://developer.arm.com/-/media/Files/downloads/gnu/11.3.rel1/binrel/arm-gnu-toolchain-11.3.rel1${flavor}-x86_64-arm-none-eabi.tar.xz
+    xz -d arm-gnu-toolchain-11.3.rel1${flavor}-x86_64-arm-none-eabi.tar.xz
+    tar xf arm-gnu-toolchain-11.3.rel1${flavor}-x86_64-arm-none-eabi.tar
+    mv arm-gnu-toolchain-11.3.rel1${flavor}-x86_64-arm-none-eabi gcc-arm-none-eabi
+    rm arm-gnu-toolchain-11.3.rel1${flavor}-x86_64-arm-none-eabi.tar
   fi
   arm-none-eabi-gcc --version
 }

--- a/tools/ci/cibuild.sh
+++ b/tools/ci/cibuild.sh
@@ -187,6 +187,7 @@ function arm-gcc-toolchain {
     xz -d arm-gnu-toolchain-11.3.rel1${flavor}-x86_64-arm-none-eabi.tar.xz
     tar xf arm-gnu-toolchain-11.3.rel1${flavor}-x86_64-arm-none-eabi.tar
     mv arm-gnu-toolchain-11.3.rel1${flavor}-x86_64-arm-none-eabi gcc-arm-none-eabi
+    patch -p0 < ${nuttx}/tools/ci/patch/arm-none-eabi-workaround-for-newlib-version-break.patch
     rm arm-gnu-toolchain-11.3.rel1${flavor}-x86_64-arm-none-eabi.tar
   fi
   arm-none-eabi-gcc --version

--- a/tools/ci/docker/linux/Dockerfile
+++ b/tools/ci/docker/linux/Dockerfile
@@ -84,8 +84,8 @@ WORKDIR /tools
 FROM nuttx-toolchain-base AS nuttx-toolchain-arm
 # Download the latest ARM GCC toolchain prebuilt by ARM
 RUN mkdir gcc-arm-none-eabi && \
-  curl -s -L  "https://developer.arm.com/-/media/Files/downloads/gnu-rm/10.3-2021.10/gcc-arm-none-eabi-10.3-2021.10-x86_64-linux.tar.bz2" \
-  | tar -C gcc-arm-none-eabi --strip-components 1 -xj
+  curl -s -L  "https://developer.arm.com/-/media/Files/downloads/gnu/11.3.rel1/binrel/arm-gnu-toolchain-11.3.rel1-x86_64-arm-none-eabi.tar.xz" \
+  | tar -C gcc-arm-none-eabi --strip-components 1 -xJ
 
 ###############################################################################
 # Build image for tool required by ARM64 builds

--- a/tools/ci/patch/arm-none-eabi-workaround-for-newlib-version-break.patch
+++ b/tools/ci/patch/arm-none-eabi-workaround-for-newlib-version-break.patch
@@ -1,0 +1,38 @@
+From 819ab4ac433b809fdaca33246e2bffa1426acc0f Mon Sep 17 00:00:00 2001
+From: chao an <anchao@xiaomi.com>
+Date: Tue, 11 Oct 2022 15:27:37 +0800
+Subject: [PATCH] arm-none-eabi: workaround for newlib version break
+
+Signed-off-by: chao an <anchao@xiaomi.com>
+---
+ arm-none-eabi/include/_newlib_version.h | 15 ++++-----------
+ 1 file changed, 4 insertions(+), 11 deletions(-)
+
+diff --git a/arm-none-eabi/include/_newlib_version.h gcc-arm-none-eabi/arm-none-eabi/include/_newlib_version.h
+index 0dbf962e..c5d2be6d 100644
+--- a/arm-none-eabi/include/_newlib_version.h
++++ gcc-arm-none-eabi/arm-none-eabi/include/_newlib_version.h
+@@ -3,16 +3,9 @@
+ #ifndef _NEWLIB_VERSION_H__
+ #define _NEWLIB_VERSION_H__ 1
+
+-/* The newlib version in string format. */
+-#define _NEWLIB_VERSION "@NEWLIB_VERSION@"
+-
+-/* The newlib major version number. */
+-#define __NEWLIB__ @NEWLIB_MAJOR_VERSION@
+-
+-/* The newlib minor version number. */
+-#define __NEWLIB_MINOR__ @NEWLIB_MINOR_VERSION@
+-
+-/* The newlib patch level. */
+-#define __NEWLIB_PATCHLEVEL__ @NEWLIB_PATCHLEVEL_VERSION@
++#define _NEWLIB_VERSION "4.2.0"
++#define __NEWLIB__ 4
++#define __NEWLIB_MINOR__ 2
++#define __NEWLIB_PATCHLEVEL__ 0
+
+ #endif /* !_NEWLIB_VERSION_H__ */
+--
+2.25.1
+


### PR DESCRIPTION
## Summary

tools/ci: Update gcc-arm-none-eabi to 11.3.Rel1 August 08, 2022

https://gcc.gnu.org/gcc-11/changes.html

## Impact

N/A

## Testing
Ci check