### PR TITLE
rpmsgdev: forward all open/close to server to support complex driver

### DIFF
--- a/drivers/misc/Kconfig
+++ b/drivers/misc/Kconfig
@@ -25,11 +25,6 @@ config DEV_RPMSG_SERVER
 	default n
 	depends on RPTUN
 
-config DEV_RPMSG_NPOLLWAITERS
-	int "RPMSG Device Max Number of Poll Threads"
-	default 4
-	depends on DEV_RPMSG_SERVER
-
 config DRVR_MKRD
 	bool "RAM disk wrapper (mkrd)"
 	default n

--- a/drivers/misc/rpmsgdev.h
+++ b/drivers/misc/rpmsgdev.h
@@ -61,17 +61,20 @@ begin_packed_struct struct rpmsgdev_header_s
 begin_packed_struct struct rpmsgdev_open_s
 {
   struct rpmsgdev_header_s header;
+  uint64_t                 filep;
   int32_t                  flags;
 } end_packed_struct;
 
 begin_packed_struct struct rpmsgdev_close_s
 {
   struct rpmsgdev_header_s header;
+  uint64_t                 filep;
 } end_packed_struct;
 
 begin_packed_struct struct rpmsgdev_read_s
 {
   struct rpmsgdev_header_s header;
+  uint64_t                 filep;
   uint32_t                 count;
   char                     buf[1];
 } end_packed_struct;
@@ -81,6 +84,7 @@ begin_packed_struct struct rpmsgdev_read_s
 begin_packed_struct struct rpmsgdev_lseek_s
 {
   struct rpmsgdev_header_s header;
+  uint64_t                 filep;
   int32_t                  whence;
   int32_t                  offset;
 } end_packed_struct;
@@ -88,15 +92,17 @@ begin_packed_struct struct rpmsgdev_lseek_s
 begin_packed_struct struct rpmsgdev_ioctl_s
 {
   struct rpmsgdev_header_s header;
-  int32_t                  request;
+  uint64_t                 filep;
   uint64_t                 arg;
   uint32_t                 arglen;
+  int32_t                  request;
   char                     buf[1];
 } end_packed_struct;
 
 begin_packed_struct struct rpmsgdev_poll_s
 {
   struct rpmsgdev_header_s header;
+  uint64_t                 filep;
   uint32_t                 events;
   uint32_t                 setup;
   uint64_t                 fds;


### PR DESCRIPTION
## Summary
Before this commit, each rpmsgdev server only manages one file no matter how many times the client opened.

It can't work fine with some complex drivers, such as input driver (keyboard, touchscreen and button), because input driver will alloc a new private open structure for every open operation to make sure all the applications don't miss data when input driver is used by multiple applications.

This commit solves this problem by making the files in server and client be one-to-one.

## Impact
sim:rpserver and sim:rpproxy

## Testing
test with sim:rpserver and sim:rpproxy
