### PR TITLE
esp32s2: Add missing ESP32S2 SPIRAM config

### DIFF
--- a/arch/xtensa/src/esp32s2/Kconfig
+++ b/arch/xtensa/src/esp32s2/Kconfig
@@ -272,6 +272,10 @@ config ESP32S2_SPIFLASH
 	bool "SPI Flash"
 	default n
 
+config ESP32S2_SPIRAM
+	bool "SPI RAM Support"
+	default n
+
 config ESP32S2_TIMER0
 	bool "64-bit Timer 0 (Group 0 Timer 0)"
 	default n


### PR DESCRIPTION
## Summary
Add missing ESP32S2 SPIRAM config
## Impact
Users will be able to select the SPIRAM support
## Testing
CI
