### PR TITLE
Fixed NULL pointer use in tmpfs.

### DIFF
--- a/fs/tmpfs/fs_tmpfs.c
+++ b/fs/tmpfs/fs_tmpfs.c
@@ -1496,8 +1496,15 @@ static ssize_t tmpfs_read(FAR struct file *filep, FAR char *buffer,
 
   /* Copy data from the memory object to the user buffer */
 
-  memcpy(buffer, &tfo->tfo_data[startpos], nread);
-  filep->f_pos += nread;
+  if (tfo->tfo_data != NULL)
+    {
+      memcpy(buffer, &tfo->tfo_data[startpos], nread);
+      filep->f_pos += nread;
+    }
+  else
+    {
+      DEBUGASSERT(tfo->tfo_size == 0 && nread == 0);
+    }
 
   /* Release the lock on the file */
 
@@ -1553,8 +1560,15 @@ static ssize_t tmpfs_write(FAR struct file *filep, FAR const char *buffer,
 
   /* Copy data from the memory object to the user buffer */
 
-  memcpy(&tfo->tfo_data[startpos], buffer, nwritten);
-  filep->f_pos += nwritten;
+  if (tfo->tfo_data != NULL)
+    {
+      memcpy(&tfo->tfo_data[startpos], buffer, nwritten);
+      filep->f_pos += nwritten;
+    }
+  else
+    {
+      DEBUGASSERT(tfo->tfo_size == 0 && nwritten == 0);
+    }
 
   /* Release the lock on the file */
 


### PR DESCRIPTION
## Summary

When the file size is 0 and the data to be written is also 0 (in case of `tmpfs_write()`) then `tfo->tfo_data` will be NULL.

Previously, the code used this buffer unconditionally with `memcpy()` (albeit with 0 size), which is wrong.  
The `memcpy()` arguments must always be non-NULL, regardless of the size.

An UBSan warning was also triggered for this.

This PR fixes this, ensuring that only non-NULL arguments are provided to memcpy.

## Impact

UB fix.

## Testing

Tested by writing 0 bytes to an empty tmpfs file.  
No issues, no UBSan warnings.

