### PR TITLE
Fixed ungetc behavior when EOF is passed.

### DIFF
--- a/libs/libc/stdio/lib_ungetc.c
+++ b/libs/libc/stdio/lib_ungetc.c
@@ -59,6 +59,13 @@ int ungetc(int c, FAR FILE *stream)
       return EOF;
     }
 
+  /* EOF cannot be unget */
+
+  if (c == EOF)
+    {
+      return EOF;
+    }
+
 #if CONFIG_NUNGET_CHARS > 0
   nungotten = stream->fs_nungotten;
   if (stream->fs_nungotten < CONFIG_NUNGET_CHARS)


### PR DESCRIPTION
## Summary

When `EOF` is passed to `ungetc()`, it should do nothing and return.

Related issue #7308.

## Impact

Bug fix.

## Testing

Tested on simulator with code that follows the problematic sequence in the linked issue.
