### PR TITLE
libs/libc/stdio: fix ungetc operation

### DIFF
--- a/libs/libc/stdio/lib_ungetc.c
+++ b/libs/libc/stdio/lib_ungetc.c
@@ -43,11 +43,10 @@ int ungetc(int c, FAR FILE *stream)
   int nungotten;
 #endif
 
-  /* Verify that a non-NULL stream was provided */
+  /* Verify that a non-NULL stream was provided and c is not EOF */
 
-  if (!stream)
+  if (!stream || c == EOF)
     {
-      set_errno(EBADF);
       return EOF;
     }
 
@@ -55,7 +54,6 @@ int ungetc(int c, FAR FILE *stream)
 
   if ((stream->fs_fd < 0) || ((stream->fs_oflags & O_RDOK) == 0))
     {
-      set_errno(EBADF);
       return EOF;
     }
 
@@ -70,7 +68,6 @@ int ungetc(int c, FAR FILE *stream)
   else
 #endif
     {
-      set_errno(ENOMEM);
       return EOF;
     }
 }


### PR DESCRIPTION
## Summary
According to https://pubs.opengroup.org/onlinepubs/9699919799/functions/ungetc.html the `ungetc` should not set errno in case of failure. Also `If the value of c equals that of the macro EOF, the operation shall fail and the input stream shall be left unchanged.`

## Impact
Improve POSIX compliance

## Testing
Pass CI