### PR TITLE
Fix in rename() when old file doesn't exist.

### DIFF
--- a/fs/vfs/fs_rename.c
+++ b/fs/vfs/fs_rename.c
@@ -457,6 +457,7 @@ errout_with_newsearch:
 
 int rename(FAR const char *oldpath, FAR const char *newpath)
 {
+  struct stat stat_buf;
   struct inode_search_s olddesc;
   FAR struct inode *oldinode;
   int ret;
@@ -469,6 +470,14 @@ int rename(FAR const char *oldpath, FAR const char *newpath)
       !newpath || *newpath == '\0')
     {
       ret = -EINVAL;
+      goto errout;
+    }
+
+  /* Ensure that oldpath actually exists */
+
+  ret = nx_stat(oldpath, &stat_buf, 0);
+  if (ret < 0)
+    {
       goto errout;
     }
 


### PR DESCRIPTION
## Summary

When `rename()` is called with an `oldpath` that refers to a non-existent file, it caused the file pointed by `newpath` to be deleted.

In this case, it should just fail without such side effects.  
This PR adds a check to ensure that the old file exists, and thus that rename can succeed.

Related issue: #7306.

## Impact

Bug fix.

## Testing

Tested on simulator with code exhibiting the behavior mentioned in the related issue.