### PR TITLE
arm/backtrace_fp: fix build warning 

### DIFF
--- a/arch/arm/src/common/arm_backtrace_fp.c
+++ b/arch/arm/src/common/arm_backtrace_fp.c
@@ -123,7 +123,7 @@ int up_backtrace(struct tcb_s *tcb,
         {
 #if CONFIG_ARCH_INTERRUPTSTACK > 7
 #  ifdef CONFIG_SMP
-          istacklimit = arm_intstack_top();
+          istacklimit = (void *)arm_intstack_top();
 #  else
           istacklimit = g_intstacktop;
 #  endif /* CONFIG_SMP */


### PR DESCRIPTION
## Summary

arm/backtrace_fp: fix build warning

```
common/arm_backtrace_fp.c: In function 'up_backtrace': common/arm_backtrace_fp.c:126:23: warning: assignment to 'void *' from 'uintptr_t' {aka 'unsigned int'} makes pointer from integer without a cast [-Wint-conversion]
  126 |           istacklimit = arm_intstack_top();
      |                       ^

```
Signed-off-by: chao an <anchao@xiaomi.com>


## Impact

N/A

## Testing

enable CONFIG_UNWINDER_FRAME_POINTER