### PR TITLE
Kconfig: use "default y if DEFAULT_SMALL" for readability

### DIFF
--- a/fs/Kconfig
+++ b/fs/Kconfig
@@ -66,7 +66,7 @@ config FS_NEPOLL_DESCRIPTORS
 
 config DISABLE_PSEUDOFS_OPERATIONS
 	bool "Disable pseudo-filesystem operations"
-	default DEFAULT_SMALL
+	default y if DEFAULT_SMALL
 	---help---
 		Disable certain operations on pseudo-file systems include mkdir,
 		rmdir, unlink, and rename.  These are necessary for the logical

--- a/sched/Kconfig
+++ b/sched/Kconfig
@@ -17,7 +17,7 @@ if DISABLE_OS_API
 
 config DISABLE_POSIX_TIMERS
 	bool "Disable POSIX timers"
-	default DEFAULT_SMALL
+	default y if DEFAULT_SMALL
 	---help---
 		Disable support for the the entire POSIX timer family
 		including timer_create(), timer_gettime(), timer_settime(),
@@ -28,15 +28,15 @@ config DISABLE_POSIX_TIMERS
 
 config DISABLE_PTHREAD
 	bool "Disable pthread support"
-	default DEFAULT_SMALL
+	default y if DEFAULT_SMALL
 
 config DISABLE_MQUEUE
 	bool "Disable POSIX message queue support"
-	default DEFAULT_SMALL
+	default y if DEFAULT_SMALL
 
 config DISABLE_ENVIRON
 	bool "Disable environment variable support"
-	default DEFAULT_SMALL
+	default y if DEFAULT_SMALL
 
 endif # DISABLE_OS_API
 
@@ -1598,7 +1598,7 @@ config MQ_MAXMSGSIZE
 
 config DISABLE_MQUEUE_NOTIFICATION
 	bool "Disable POSIX message queue notification"
-	default DEFAULT_SMALL
+	default y if DEFAULT_SMALL
 	---help---
 		Disable POSIX message queue notification
 


### PR DESCRIPTION
## Summary
Use "default y if DEFAULT_SMALL" for readability
## Impact
It is easier to realize the intention when using "if SYMBOL"
## Testing
N/A
