### PR TITLE
nuttx/sched/sched: fix runtime error UBSan(division by zero)

### DIFF
--- a/sched/sched/sched_sysinfo.c
+++ b/sched/sched/sched_sysinfo.c
@@ -65,10 +65,17 @@ int sysinfo(FAR struct sysinfo *info)
 #ifdef CONFIG_SCHED_CPULOAD
   clock_cpuload(0, &cpuload);
 
-  info->loads[0] = ((cpuload.total - cpuload.active) <<
-                     SI_LOAD_SHIFT) / cpuload.total;
-  info->loads[1] = info->loads[0];
-  info->loads[2] = info->loads[0];
+  /* On the simulator, you may hit cpuload.total == 0, but probably never
+   * on real hardware.
+   */
+
+  if (cpuload.total)
+    {
+      info->loads[0] = ((cpuload.total - cpuload.active) <<
+                         SI_LOAD_SHIFT) / cpuload.total;
+      info->loads[1] = info->loads[0];
+      info->loads[2] = info->loads[0];
+    }
 #endif
 
 #ifdef MM_KERNEL_USRHEAP_INIT


### PR DESCRIPTION
## Summary

Fix runtime error Undefined Behavior Sanitizer(division by zero)

NuttShell (NSH) NuttX-10.3.0
ap>
ap>
ap> uptime
sched/sched_sysinfo.c:69:37: runtime error: division by zero
[1]    28220 floating point exception  sudo ./nuttx

Signed-off-by: Junbo Zheng <zhengjunbo1@xiaomi.com>

## Impact
N/A

## Testing
Local test pass

