### PR TITLE
fix typo big letter 'o' in hex value for zero.

### DIFF
--- a/arch/arm/src/rp2040/hardware/rp2040_pwm.h
+++ b/arch/arm/src/rp2040/hardware/rp2040_pwm.h
@@ -59,7 +59,7 @@
 #define RP2040_PWM_INTR_OFFSET    0x0000A4              /* PWM raw interrupt register */
 #define RP2040_PWM_INTE_OFFSET    0x0000A8              /* PWM interrupt enable register */
 #define RP2040_PWM_INTF_OFFSET    0x0000AC              /* PWM interrupt force register */
-#define RP2040_PWM_INTS_OFFSET    0x0000BO              /* PWM interrupt status register */
+#define RP2040_PWM_INTS_OFFSET    0x0000B0              /* PWM interrupt status register */
 
 /* Register definitions *****************************************************/
 


### PR DESCRIPTION
## Summary
Hex value contains letter O instead of number 0.

## Impact
compile error if the define is being used

## Testing

