### PR TITLE
arch/sim: fix tx pipeline in netdriver to avoid delaying packets.

### DIFF
--- a/arch/sim/src/sim/up_netdriver.c
+++ b/arch/sim/src/sim/up_netdriver.c
@@ -73,6 +73,12 @@
 #include "up_internal.h"
 
 /****************************************************************************
+ * Private Function Prototypes
+ ****************************************************************************/
+
+static void netdriver_txdone_interrupt(void *priv);
+
+/****************************************************************************
  * Private Data
  ****************************************************************************/
 
@@ -289,6 +295,17 @@ static int netdriver_txpoll(struct net_driver_s *dev)
           NETDEV_TXPACKETS(dev);
           netdev_send(devidx, dev->d_buf, dev->d_len);
           NETDEV_TXDONE(dev);
+        }
+      else
+        {
+          /* Calling txdone callback after loopback. NETDEV_TXDONE macro is
+           * already called in devif_loopback.
+           *
+           * TODO: Maybe a unified interface with txdone callback registered
+           * is needed, then we can let devif_loopback call this callback.
+           */
+
+          netdriver_txdone_interrupt(dev);
         }
     }
 


### PR DESCRIPTION
## Summary
- arch/sim: calling txdone callback after devif_loopback in netdriver
  - When devif_loopback handles a packet (like a ping targeting at this dev), it does not call the txdone callback, breaking the tx pipeline and may left some packets unhandled, delayed until next transmit on the network interface.

- arch/sim: change g_avail_work and g_recv_work to array in netdriver
  - Share one worker between multiple simulated network devices may work most of the time, but sometimes breaks the tx pipeline when sending packets on more than one interface at the same time, and leaves some packets unprocessed in network stack, delayed until next transmit on the network interface. The rx process is likely delayed in packet processing under similar situation, so keep g_avail_work and g_recv_work the same number as interfaces.
```
dev0         tx1 avail              tx1 done
                v                      v
shared_work  dev0 tx1 -> dev0 tx1 -> empty -> dev1 tx2 -> dev1 tx3 -> empty
                            ^                    ^           ^          ^
dev1             tx2 avail (failed to queue)  tx3 avail   tx2 done   tx3 done
```

## Impact
Netdriver in sim.

## Testing
Tested on Ubuntu 22.04 x86_64
