### PR TITLE
arch/sparc add support of spin_lock for LEON3 and LEON4

### DIFF
--- a/arch/sparc/Kconfig
+++ b/arch/sparc/Kconfig
@@ -48,7 +48,6 @@ config ARCH_CHIP
 	default "bm3803"	if ARCH_CHIP_BM3803
 	default "bm3823"	if ARCH_CHIP_BM3823
 
-source arch/sparc/src/common/Kconfig
 source arch/sparc/src/sparc_v8/Kconfig
 source arch/sparc/src/bm3803/Kconfig
 source arch/sparc/src/bm3823/Kconfig

--- a/arch/sparc/include/spinlock.h
+++ b/arch/sparc/include/spinlock.h
@@ -44,7 +44,7 @@
 
 /* The Type of a spinlock.
  *
- * This must be a uint32_ becaue it will be set using CASA instruction.
+ * This must be a uint32_ because it will be set using CASA instruction.
  * That instruction atomically Compare the 32-bitvalues in the register
  * and memory, if its current value is the expected one. swap the values
  * of second register with the memory.

--- a/arch/sparc/include/spinlock.h
+++ b/arch/sparc/include/spinlock.h
@@ -44,12 +44,10 @@
 
 /* The Type of a spinlock.
  *
- * This must be a uint32_ becaue it will be set using S32C1I instruction.
- * That instruction atomically stores to a memory location only if its
- * current value is the expected one.  The state register (SCOMPARE1) is
- * used to provide the additional comparison operand. Some implementations
- * also have a state register (ATOMCTL) for further control of the atomic
- * operation in cache and on the PIF bus.
+ * This must be a uint32_ becaue it will be set using CASA instruction.
+ * That instruction atomically Compare the 32-bitvalues in the register
+ * and memory, if its current value is the expected one. swap the values
+ * of second register with the memory.
  */
 
 typedef uint32_t spinlock_t;

--- a/arch/sparc/src/bm3823/Make.defs
+++ b/arch/sparc/src/bm3823/Make.defs
@@ -18,20 +18,11 @@
 #
 ############################################################################
 
+include common/Make.defs
+
 # The start-up, "head", file
 
-HEAD_ASRC = bm3823_head.S
-
-# Common SPARC files
-
-CMN_ASRCS  = up_syscall.S
-CMN_CSRCS  = up_allocateheap.c up_assert.c up_blocktask.c up_copystate.c
-CMN_CSRCS += up_createstack.c up_doirq.c up_exit.c  up_idle.c up_initialize.c
-CMN_CSRCS += up_initialstate.c up_irq.c up_lowputs.c
-CMN_CSRCS += up_mdelay.c up_modifyreg8.c up_modifyreg16.c up_modifyreg32.c
-CMN_CSRCS += up_nputs.c up_releasepending.c up_releasestack.c
-CMN_CSRCS += up_reprioritizertr.c up_schedulesigaction.c up_sigdeliver.c
-CMN_CSRCS += up_stackframe.c up_swint1.c up_udelay.c up_unblocktask.c up_usestack.c
+HEAD_ASRC += bm3823_head.S
 
 # Configuration-dependent common files
 

--- a/arch/sparc/src/common/Kconfig
+++ b/arch/sparc/src/common/Kconfig
@@ -1,7 +1,0 @@
-#
-# For a description of the syntax of this configuration file,
-# see the file kconfig-language.txt in the NuttX tools repository.
-#
-
-if ARCH_SPARC
-endif

--- a/arch/sparc/src/common/Make.defs
+++ b/arch/sparc/src/common/Make.defs
@@ -1,5 +1,5 @@
 ############################################################################
-# arch/sparc/src/bm3803/Make.defs
+# arch/sparc/src/common/Make.defs
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
@@ -18,41 +18,27 @@
 #
 ############################################################################
 
-include common/Make.defs
+# Common Sparc files (arch/sparc/src/common)
 
-# The start-up, "head", file
+CMN_ASRCS  = up_syscall.S
+CMN_CSRCS  = up_allocateheap.c up_assert.c up_blocktask.c up_copystate.c up_systemreset.c
+CMN_CSRCS += up_createstack.c up_doirq.c up_exit.c  up_idle.c up_initialize.c
+CMN_CSRCS += up_initialstate.c up_irq.c up_lowputs.c
+CMN_CSRCS += up_mdelay.c up_modifyreg8.c up_modifyreg16.c up_modifyreg32.c
+CMN_CSRCS += up_nputs.c up_releasepending.c up_releasestack.c
+CMN_CSRCS += up_reprioritizertr.c up_schedulesigaction.c up_sigdeliver.c
+CMN_CSRCS += up_stackframe.c up_swint1.c up_udelay.c up_unblocktask.c up_usestack.c
 
-HEAD_ASRC += bm3803_head.S
+# Configuration-dependent common files
 
-# Required BM3803 files
-
-CHIP_ASRCS = bm3803_exceptions.S
-CHIP_CSRCS = bm3803-lowconsole.c bm3803-lowinit.c bm3803-serial.c bm3803-irq.c bm3803_tim.c
-
-ifeq ($(CONFIG_TIMER),y)
-CHIP_CSRCS += bm3803_tim_lowerhalf.c
+ifeq ($(CONFIG_ARCH_STACKDUMP),y)
+CMN_CSRCS += up_dumpstate.c
 endif
 
-ifeq ($(CONFIG_BM3803_WDG),y)
-CHIP_CSRCS += bm3803_wdg.c
+ifeq ($(CONFIG_STACK_COLORATION),y)
+CMN_CSRCS += up_checkstack.c
 endif
 
-ifneq ($(CONFIG_SCHED_TICKLESS),y)
-CHIP_CSRCS += bm3803-timerisr.c
-else
-CHIP_CSRCS += bm3803_tickless.c
-endif
-
-ifeq ($(CONFIG_BM3803_ONESHOT),y)
-CHIP_CSRCS += bm3803_oneshot.c bm3803_oneshot_lowerhalf.c
-endif
-
-ifeq ($(CONFIG_BM3803_FREERUN),y)
-CHIP_CSRCS += bm3803_freerun.c
-endif
-
-# Configuration-dependent files
-
-ifeq ($(CONFIG_BM3803_GPIOIRQ),y)
-CHIP_CSRCS += bm3803_exti_gpio.c
+ifeq ($(CONFIG_SPINLOCK),y)
+  CMN_CSRCS += up_testset.c
 endif

--- a/arch/sparc/src/common/up_modifyreg16.c
+++ b/arch/sparc/src/common/up_modifyreg16.c
@@ -29,7 +29,7 @@
 
 #include <nuttx/irq.h>
 #include <nuttx/arch.h>
-
+#include <nuttx/spinlock.h>
 #include "up_internal.h"
 
 /****************************************************************************
@@ -61,11 +61,11 @@ void modifyreg16(unsigned int addr, uint16_t clearbits, uint16_t setbits)
   irqstate_t flags;
   uint16_t   regval;
 
-  flags   = enter_critical_section();
+  flags   = spin_lock_irqsave(NULL);
   regval  = getreg16(addr);
   regval &= ~clearbits;
   regval |= setbits;
   putreg16(regval, addr);
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(NULL, flags);
 }
 

--- a/arch/sparc/src/common/up_modifyreg32.c
+++ b/arch/sparc/src/common/up_modifyreg32.c
@@ -29,7 +29,7 @@
 
 #include <nuttx/irq.h>
 #include <nuttx/arch.h>
-
+#include <nuttx/spinlock.h>
 #include "up_internal.h"
 
 /****************************************************************************
@@ -61,11 +61,11 @@ void modifyreg32(unsigned int addr, uint32_t clearbits, uint32_t setbits)
   irqstate_t flags;
   uint32_t   regval;
 
-  flags   = enter_critical_section();
+  flags   = spin_lock_irqsave(NULL);
   regval  = getreg32(addr);
   regval &= ~clearbits;
   regval |= setbits;
   putreg32(regval, addr);
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(NULL, flags);
 }
 

--- a/arch/sparc/src/common/up_modifyreg8.c
+++ b/arch/sparc/src/common/up_modifyreg8.c
@@ -29,7 +29,7 @@
 
 #include <nuttx/irq.h>
 #include <nuttx/arch.h>
-
+#include <nuttx/spinlock.h>
 #include "up_internal.h"
 
 /****************************************************************************
@@ -61,11 +61,11 @@ void modifyreg8(unsigned int addr, uint8_t clearbits, uint8_t setbits)
   irqstate_t flags;
   uint8_t    regval;
 
-  flags   = enter_critical_section();
+  flags   = spin_lock_irqsave(NULL);
   regval  = getreg8(addr);
   regval &= ~clearbits;
   regval |= setbits;
   putreg8(regval, addr);
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(NULL, flags);
 }
 

--- a/arch/sparc/src/common/up_testset.c
+++ b/arch/sparc/src/common/up_testset.c
@@ -1,0 +1,104 @@
+/****************************************************************************
+ * arch/sparc/src/common/up_testset.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <nuttx/spinlock.h>
+
+#ifdef CONFIG_SPINLOCK
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: sparc_compareset
+ *
+ * Description:
+ *   Wrapper for the Sparc compare-and-swap instruction. This function will
+ *   atomically compare *addr to compare, and if it's the same, will swap
+ *   *addr with set. It will return the value of set which is the old value
+ *   of *addr.
+ *
+ * Note: The ldstub and swap instructions are available in all LEON
+ * processors, while casa is optional. The CASA is a SPARC-V9 Compare and
+ * Swap Alternative instruction but LEON3(GR712R) and LEON4 implements the
+ * SPARC V9 Compare and Swap Alternative (CASA) instruction. The CASA
+ * operates as described in the SPARC-V9 manual. This instruction is
+ * privileged, except when setting ASI = 0xA (user data). All multi-core
+ * LEON based components from Cobham Gaisler have casa. According to BCC
+ * User's Manual the GCC option -mcpu=leon3 is required to generate SPARC-V8
+ * code but support for the casa instruction.
+ *
+ ****************************************************************************/
+
+static inline uint32_t sparc_compareset(volatile uint32_t *addr,
+                                        uint32_t compare,
+                                        uint32_t set)
+{
+  __asm__ __volatile__
+  (
+    "casa [%2] 0xb, %3, %0\n" /* Atomically compare [%2] to %3, and swap
+                               * [%2] with %0 if the lock is the same as
+                               * compare, otherwise, no write-access.
+                               */
+    : "=&r" (set) : "0" (set), "r" (addr), "r" (compare) : "memory"
+  );
+
+  return set;
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: up_testset
+ *
+ * Description:
+ *   Perform an atomic compare and swap operation on the provided spinlock.
+ *
+ *   This function must be provided via the architecture-specific logic.
+ *
+ * Input Parameters:
+ *   lock  - A reference to the spinlock object.
+ *
+ * Returned Value:
+ *   The spinlock is always locked upon return.  The previous value of the
+ *   spinlock variable is returned, either SP_LOCKED if the spinlock was
+ *   previously locked (meaning that the test-and-set operation failed to
+ *   obtain the lock) or SP_UNLOCKED if the spinlock was previously unlocked
+ *   (meaning that we successfully obtained the lock).
+ *
+ ****************************************************************************/
+
+spinlock_t up_testset(volatile spinlock_t *lock)
+{
+  /* Perform the 32-bit compare and set operation */
+
+  return sparc_compareset((volatile uint32_t *)lock,
+                           SP_UNLOCKED, SP_LOCKED);
+}
+
+#endif /* CONFIG_SPINLOCK */


### PR DESCRIPTION
## Summary
1、Add support of spin_lock for LEON3 and LEON4
2、Build CMN_SRCS in common directory to keep up with other arch
## Impact
sparc
## Testing
ci
