### PR TITLE
arch/armv7-[a|r]: Don't define fiq stack if CONFIG_ARMV7A_DECODEFIQ=n

### DIFF
--- a/arch/arm/src/armv7-a/arm_vectors.S
+++ b/arch/arm/src/armv7-a/arm_vectors.S
@@ -753,6 +753,7 @@ g_intstacktop:
  *  Name: g_fiqstackalloc/g_fiqstacktop
  ****************************************************************************/
 
+#ifdef CONFIG_ARMV7A_DECODEFIQ
 	.globl	g_fiqstackalloc
 	.type	g_fiqstackalloc, object
 	.globl	g_fiqstacktop
@@ -763,6 +764,7 @@ g_fiqstackalloc:
 g_fiqstacktop:
 	.size	g_fiqstacktop, 0
 	.size	g_fiqstackalloc, (CONFIG_ARCH_INTERRUPTSTACK & ~7)
+#endif
 
 #endif /* !CONFIG_SMP && CONFIG_ARCH_INTERRUPTSTACK > 7 */
 	.end

--- a/arch/arm/src/armv7-r/arm_vectors.S
+++ b/arch/arm/src/armv7-r/arm_vectors.S
@@ -707,6 +707,7 @@ g_intstacktop:
  *  Name: g_fiqstackalloc/g_fiqstacktop
  ****************************************************************************/
 
+#ifdef CONFIG_ARMV7A_DECODEFIQ
 	.globl	g_fiqstackalloc
 	.type	g_fiqstackalloc, object
 	.globl	g_fiqstacktop
@@ -717,6 +718,7 @@ g_fiqstackalloc:
 g_fiqstacktop:
 	.size	g_fiqstacktop, 0
 	.size	g_fiqstackalloc, (CONFIG_ARCH_INTERRUPTSTACK & ~7)
+#endif
 
 #endif /* CONFIG_ARCH_INTERRUPTSTACK > 7 */
 	.end


### PR DESCRIPTION
## Summary

## Impact
Remove the unused fiq stack

## Testing
Pass CI
