### PR TITLE
arch/armv7-r: Fix typo error in commit 4fab2b9501d583bc98b23bf293475b526496a936

### DIFF
--- a/arch/arm/src/armv7-r/arm_vectors.S
+++ b/arch/arm/src/armv7-r/arm_vectors.S
@@ -707,7 +707,7 @@ g_intstacktop:
  *  Name: g_fiqstackalloc/g_fiqstacktop
  ****************************************************************************/
 
-#ifdef CONFIG_ARMV7A_DECODEFIQ
+#ifdef CONFIG_ARMV7R_DECODEFIQ
 	.globl	g_fiqstackalloc
 	.type	g_fiqstackalloc, object
 	.globl	g_fiqstacktop


### PR DESCRIPTION
## Summary

## Impact
Minor

## Testing

