### PR TITLE
libfread: Fixed error flag when reading a write-only file.

### DIFF
--- a/libs/libc/stdio/lib_libfread.c
+++ b/libs/libc/stdio/lib_libfread.c
@@ -55,8 +55,14 @@ ssize_t lib_fread(FAR void *ptr, size_t count, FAR FILE *stream)
 
   /* Make sure that reading from this stream is allowed */
 
-  if (!stream || (stream->fs_oflags & O_RDOK) == 0)
+  if (!stream)
     {
+      _NX_SETERRNO(EBADF);
+      return ERROR;
+    }
+  else if ((stream->fs_oflags & O_RDOK) == 0)
+    {
+      stream->fs_flags |= __FS_FLAG_ERROR;
       _NX_SETERRNO(EBADF);
       return ERROR;
     }


### PR DESCRIPTION
## Summary

When trying to read a write-only file, the error flag was not updated properly.  
Calling `ferror()` returned a wrong value of `0` instead of `1`.

## Impact

Bug fix.

## Testing

Tested on simulator using the following snippet:

```c
FILE * f = fopen("file.txt", "w");
assert(fgetc(f) == EOF);
assert(ferror(f));
```

Previously the last assertion was failing, now it is OK.
