### PR TITLE
sem:remove sem default protocl

### DIFF
--- a/arch/arm/src/cxd56xx/cxd56_emmc.c
+++ b/arch/arm/src/cxd56xx/cxd56_emmc.c
@@ -942,7 +942,6 @@ int cxd56_emmcinitialize(void)
   memset(priv, 0, sizeof(struct cxd56_emmc_state_s));
   nxmutex_init(&priv->lock);
   nxsem_init(&g_waitsem, 0, 0);
-  nxsem_set_protocol(&g_waitsem, SEM_PRIO_NONE);
 
   ret = emmc_hwinitialize();
   if (ret != OK)

--- a/arch/arm/src/cxd56xx/cxd56_farapi.c
+++ b/arch/arm/src/cxd56xx/cxd56_farapi.c
@@ -292,7 +292,6 @@ void cxd56_farapiinitialize(void)
 #endif
   nxmutex_init(&g_farlock);
   nxsem_init(&g_farwait, 0, 0);
-  nxsem_set_protocol(&g_farwait, SEM_PRIO_NONE);
 
   cxd56_iccinit(CXD56_PROTO_MBX);
   cxd56_iccinit(CXD56_PROTO_FLG);

--- a/arch/arm/src/cxd56xx/cxd56_ge2d.c
+++ b/arch/arm/src/cxd56xx/cxd56_ge2d.c
@@ -186,7 +186,6 @@ int cxd56_ge2dinitialize(const char *devname)
 
   nxmutex_init(&g_lock);
   nxsem_init(&g_wait, 0, 0);
-  nxsem_set_protocol(&g_wait, SEM_PRIO_NONE);
 
   ret = register_driver(devname, &g_ge2dfops, 0666, NULL);
   if (ret != 0)

--- a/arch/arm/src/cxd56xx/cxd56_gnss.c
+++ b/arch/arm/src/cxd56xx/cxd56_gnss.c
@@ -2609,8 +2609,6 @@ static int cxd56_gnss_open(struct file *filep)
           goto err0;
         }
 
-      nxsem_set_protocol(&priv->syncsem, SEM_PRIO_NONE);
-
       /* Prohibit the clock change during loading image */
 
       up_pm_acquire_freqlock(&g_hold_lock);
@@ -3028,8 +3026,6 @@ static int cxd56_gnss_register(const char *devpath)
       gnsserr("Failed to initialize gnss apiwait!\n");
       goto err0;
     }
-
-  nxsem_set_protocol(&priv->apiwait, SEM_PRIO_NONE);
 
   ret = nxmutex_init(&priv->ioctllock);
   if (ret < 0)

--- a/arch/arm/src/cxd56xx/cxd56_hostif.c
+++ b/arch/arm/src/cxd56xx/cxd56_hostif.c
@@ -442,7 +442,6 @@ static int hif_initialize(struct hostif_buff_s *buffer)
   cxd56_iccinit(CXD56_PROTO_HOSTIF);
 
   nxsem_init(&drv->sync, 0, 0);
-  nxsem_set_protocol(&drv->sync, SEM_PRIO_NONE);
 
   ret = cxd56_iccregisterhandler(CXD56_PROTO_HOSTIF, hif_rxhandler, NULL);
 

--- a/arch/arm/src/cxd56xx/cxd56_icc.c
+++ b/arch/arm/src/cxd56xx/cxd56_icc.c
@@ -348,7 +348,6 @@ static struct iccdev_s *icc_devnew(void)
   memset(priv, 0, sizeof(struct iccdev_s));
 
   nxsem_init(&priv->rxwait, 0, 0);
-  nxsem_set_protocol(&priv->rxwait, SEM_PRIO_NONE);
 
   /* Initialize receive queue and free list */
 

--- a/arch/arm/src/cxd56xx/cxd56_powermgr.c
+++ b/arch/arm/src/cxd56xx/cxd56_powermgr.c
@@ -837,14 +837,12 @@ int cxd56_pm_initialize(void)
     }
 
   ret = nxsem_init(&g_freqlockwait, 0, 0);
-  nxsem_set_protocol(&g_freqlockwait, SEM_PRIO_NONE);
   if (ret < 0)
     {
       return ret;
     }
 
   ret = nxsem_init(&g_bootsync, 0, 0);
-  nxsem_set_protocol(&g_bootsync, SEM_PRIO_NONE);
   if (ret < 0)
     {
       return ret;

--- a/arch/arm/src/cxd56xx/cxd56_scu.c
+++ b/arch/arm/src/cxd56xx/cxd56_scu.c
@@ -1990,7 +1990,6 @@ static int seq_fifoinit(struct seq_s *seq, int fifoid, uint16_t fsize)
   /* Initialize DMA done wait semaphore */
 
   nxsem_init(&fifo->dmawait, 0, 0);
-  nxsem_set_protocol(&fifo->dmawait, SEM_PRIO_NONE);
 
   fifo->dmaresult = -1;
 #endif
@@ -3429,12 +3428,10 @@ void scu_initialize(void)
 
   nxmutex_init(&priv->synclock);
   nxsem_init(&priv->syncwait, 0, 0);
-  nxsem_set_protocol(&priv->syncwait, SEM_PRIO_NONE);
 
   for (i = 0; i < 3; i++)
     {
       nxsem_init(&priv->oneshotwait[i], 0, 0);
-      nxsem_set_protocol(&priv->oneshotwait[i], SEM_PRIO_NONE);
     }
 
   scufifo_initialize();

--- a/arch/arm/src/cxd56xx/cxd56_sdhci.c
+++ b/arch/arm/src/cxd56xx/cxd56_sdhci.c
@@ -1319,12 +1319,6 @@ static void cxd56_sdio_sdhci_reset(struct sdio_dev_s *dev)
 
   nxsem_init(&priv->waitsem, 0, 0);
 
-  /* The waitsem semaphore is used for signaling and, hence, should not have
-   * priority inheritance enabled.
-   */
-
-  nxsem_set_protocol(&priv->waitsem, SEM_PRIO_NONE);
-
   /* The next phase of the hardware reset would be to set the SYSCTRL INITA
    * bit to send 80 clock ticks for card to power up and then reset the card
    * with CMD0.  This is done elsewhere.

--- a/arch/arm/src/cxd56xx/cxd56_sph.c
+++ b/arch/arm/src/cxd56xx/cxd56_sph.c
@@ -231,7 +231,6 @@ static inline int cxd56_sphdevinit(const char *devname, int num)
     }
 
   nxsem_init(&priv->wait, 0, 0);
-  nxsem_set_protocol(&priv->wait, SEM_PRIO_NONE);
   priv->id = num;
 
   irq_attach(CXD56_IRQ_SPH0 + num, cxd56_sphirqhandler, NULL);

--- a/arch/arm/src/cxd56xx/cxd56_spi.c
+++ b/arch/arm/src/cxd56xx/cxd56_spi.c
@@ -1332,7 +1332,6 @@ void cxd56_spi_dmaconfig(int port, int chtype, DMA_HANDLE handle,
           if (!priv->dmaenable)
             {
               nxsem_init(&priv->dmasem, 0, 0);
-              nxsem_set_protocol(&priv->dmasem, SEM_PRIO_NONE);
               priv->dmaenable = true;
             }
         }
@@ -1346,7 +1345,6 @@ void cxd56_spi_dmaconfig(int port, int chtype, DMA_HANDLE handle,
           if (!priv->dmaenable)
             {
               nxsem_init(&priv->dmasem, 0, 0);
-              nxsem_set_protocol(&priv->dmasem, SEM_PRIO_NONE);
               priv->dmaenable = true;
             }
         }

--- a/arch/arm/src/cxd56xx/cxd56_sysctl.c
+++ b/arch/arm/src/cxd56xx/cxd56_sysctl.c
@@ -162,7 +162,6 @@ void cxd56_sysctlinitialize(void)
 
   nxmutex_init(&g_lock);
   nxsem_init(&g_sync, 0, 0);
-  nxsem_set_protocol(&g_sync, SEM_PRIO_NONE);
 
   cxd56_iccregisterhandler(CXD56_PROTO_SYSCTL, sysctl_rxhandler, NULL);
 

--- a/arch/arm/src/efm32/efm32_spi.c
+++ b/arch/arm/src/efm32/efm32_spi.c
@@ -1607,12 +1607,6 @@ static int spi_portinitialize(struct efm32_spidev_s *priv)
   nxsem_init(&priv->rxdmasem, 0, 0);
   nxsem_init(&priv->txdmasem, 0, 0);
 
-  /* These semaphores are used for signaling and, hence, should not have
-   * priority inheritance enabled.
-   */
-
-  nxsem_set_protocol(&priv->rxdmasem, SEM_PRIO_NONE);
-  nxsem_set_protocol(&priv->txdmasem, SEM_PRIO_NONE);
 #endif
 
   /* Enable SPI */

--- a/arch/arm/src/efm32/efm32_usbhost.c
+++ b/arch/arm/src/efm32/efm32_usbhost.c
@@ -5264,12 +5264,6 @@ static inline void efm32_sw_initialize(struct efm32_usbhost_s *priv)
   nxsem_init(&priv->pscsem,  0, 0);
   nxmutex_init(&priv->lock);
 
-  /* The pscsem semaphore is used for signaling and, hence, should not have
-   * priority inheritance enabled.
-   */
-
-  nxsem_set_protocol(&priv->pscsem, SEM_PRIO_NONE);
-
   /* Initialize the driver state data */
 
   priv->smstate   = SMSTATE_DETACHED;
@@ -5287,13 +5281,7 @@ static inline void efm32_sw_initialize(struct efm32_usbhost_s *priv)
       struct efm32_chan_s *chan = &priv->chan[i];
 
       chan->chidx = i;
-
-      /* The waitsem semaphore is used for signaling and, hence, should not
-       * have priority inheritance enabled.
-       */
-
       nxsem_init(&chan->waitsem,  0, 0);
-      nxsem_set_protocol(&chan->waitsem, SEM_PRIO_NONE);
     }
 }
 

--- a/arch/arm/src/gd32f4/gd32f4xx_spi.c
+++ b/arch/arm/src/gd32f4/gd32f4xx_spi.c
@@ -2129,9 +2129,6 @@ static void spi_bus_initialize(struct gd32_spidev_s *priv)
           nxsem_init(&priv->rxsem, 0, 0);
           nxsem_init(&priv->txsem, 0, 0);
 
-          nxsem_set_protocol(&priv->rxsem, SEM_PRIO_NONE);
-          nxsem_set_protocol(&priv->txsem, SEM_PRIO_NONE);
-
           /* Get DMA channels */
 
           priv->rxdma = gd32_dma_channel_alloc(priv->rxch);

--- a/arch/arm/src/imx1/imx_spi.c
+++ b/arch/arm/src/imx1/imx_spi.c
@@ -1109,13 +1109,7 @@ struct spi_dev_s *imx_spibus_initialize(int port)
   /* Initialize the state structure */
 
 #ifndef CONFIG_SPI_POLLWAIT
-  /* Initialize the semaphore that is used to wake up the waiting
-   * thread when the DMA transfer completes.  This semaphore is used for
-   * signaling and, hence, should not have priority inheritance enabled.
-   */
-
   nxsem_init(&priv->waitsem, 0, 0);
-  nxsem_set_protocol(&priv->waitsem, SEM_PRIO_NONE);
 #endif
   nxmutex_init(&priv->lock);
 

--- a/arch/arm/src/imx6/imx_ecspi.c
+++ b/arch/arm/src/imx6/imx_ecspi.c
@@ -1285,13 +1285,7 @@ struct spi_dev_s *imx_spibus_initialize(int port)
   /* Initialize Semaphores */
 
 #ifndef CONFIG_SPI_POLLWAIT
-  /* Initialize the semaphore that is used to wake up the waiting
-   * thread when the DMA transfer completes.  This semaphore is used for
-   * signaling and, hence, should not have priority inheritance enabled.
-   */
-
   nxsem_init(&priv->waitsem, 0, 0);
-  nxsem_set_protocol(&priv->waitsem, SEM_PRIO_NONE);
 #endif
   nxmutex_init(&priv->lock);
 

--- a/arch/arm/src/imxrt/imxrt_edma.c
+++ b/arch/arm/src/imxrt/imxrt_edma.c
@@ -752,12 +752,6 @@ void weak_function arm_dma_initialize(void)
 #if CONFIG_IMXRT_EDMA_NTCD > 0
   nxsem_init(&g_edma.dsem, 0, CONFIG_IMXRT_EDMA_NTCD);
 
-  /* The 'dsem' is used for signaling rather than mutual exclusion and,
-   * hence, should not have priority inheritance enabled.
-   */
-
-  nxsem_set_protocol(&g_edma.dsem, SEM_PRIO_NONE);
-
   /* Initialize the list of free TCDs from the pool of pre-allocated TCDs. */
 
   imxrt_tcd_initialize();

--- a/arch/arm/src/imxrt/imxrt_ehci.c
+++ b/arch/arm/src/imxrt/imxrt_ehci.c
@@ -3968,12 +3968,7 @@ static int imxrt_epalloc(struct usbhost_driver_s *drvr,
   epinfo->xfrtype   = epdesc->xfrtype;
   epinfo->speed     = hport->speed;
 
-  /* The iocsem semaphore is used for signaling and, hence, should not have
-   * priority inheritance enabled.
-   */
-
   nxsem_init(&epinfo->iocsem, 0, 0);
-  nxsem_set_protocol(&epinfo->iocsem, SEM_PRIO_NONE);
 
   /* Success.. return an opaque reference to the endpoint information
    * structure instance
@@ -5003,12 +4998,6 @@ struct usbhost_connection_s *imxrt_ehci_initialize(int controller)
   nxmutex_init(&g_ehci.lock);
   nxsem_init(&g_ehci.pscsem, 0, 0);
 
-  /* The pscsem semaphore is used for signaling and, hence, should not have
-   * priority inheritance enabled.
-   */
-
-  nxsem_set_protocol(&g_ehci.pscsem, SEM_PRIO_NONE);
-
   /* Initialize EP0 */
 
   nxsem_init(&g_ehci.ep0.iocsem, 0, 1);
@@ -5045,13 +5034,7 @@ struct usbhost_connection_s *imxrt_ehci_initialize(int controller)
       rhport->ep0.xfrtype = USB_EP_ATTR_XFER_CONTROL;
       rhport->ep0.speed = USB_SPEED_FULL;
       rhport->ep0.maxpacket = 8;
-
-      /* The EP0 iocsem semaphore is used for signaling and, hence, should
-       * not have priority inheritance enabled.
-       */
-
       nxsem_init(&rhport->ep0.iocsem, 0, 0);
-      nxsem_set_protocol(&rhport->ep0.iocsem, SEM_PRIO_NONE);
 
       /* Initialize the public port representation */
 

--- a/arch/arm/src/imxrt/imxrt_lpspi.c
+++ b/arch/arm/src/imxrt/imxrt_lpspi.c
@@ -2053,9 +2053,6 @@ struct spi_dev_s *imxrt_lpspibus_initialize(int bus)
           nxsem_init(&priv->rxsem, 0, 0);
           nxsem_init(&priv->txsem, 0, 0);
 
-          nxsem_set_protocol(&priv->rxsem, SEM_PRIO_NONE);
-          nxsem_set_protocol(&priv->txsem, SEM_PRIO_NONE);
-
           priv->txdma = imxrt_dmach_alloc(priv->txch | DMAMUX_CHCFG_ENBL,
                                             0);
           priv->rxdma = imxrt_dmach_alloc(priv->rxch | DMAMUX_CHCFG_ENBL,

--- a/arch/arm/src/imxrt/imxrt_serial.c
+++ b/arch/arm/src/imxrt/imxrt_serial.c
@@ -1459,7 +1459,6 @@ static int imxrt_dma_setup(struct uart_dev_s *dev)
             }
 
           nxsem_init(&priv->txdmasem, 0, 1);
-          nxsem_set_protocol(&priv->txdmasem, SEM_PRIO_NONE);
         }
 
       /* Enable Tx DMA for the UART */

--- a/arch/arm/src/imxrt/imxrt_usdhc.c
+++ b/arch/arm/src/imxrt/imxrt_usdhc.c
@@ -3220,13 +3220,6 @@ struct sdio_dev_s *imxrt_usdhc_initialize(int slotno)
    */
 
   nxsem_init(&priv->waitsem, 0, 0);
-
-  /* The waitsem semaphore is used for signaling and, hence, should not
-   * have priority inheritance enabled.
-   */
-
-  nxsem_set_protocol(&priv->waitsem, SEM_PRIO_NONE);
-
   switch (priv->addr)
     {
     case IMXRT_USDHC1_BASE:

--- a/arch/arm/src/kinetis/kinetis_edma.c
+++ b/arch/arm/src/kinetis/kinetis_edma.c
@@ -733,12 +733,6 @@ void weak_function arm_dma_initialize(void)
 #if CONFIG_KINETIS_EDMA_NTCD > 0
   nxsem_init(&g_edma.dsem, 0, CONFIG_KINETIS_EDMA_NTCD);
 
-  /* The 'dsem' is used for signaling rather than mutual exclusion and,
-   * hence, should not have priority inheritance enabled.
-   */
-
-  nxsem_set_protocol(&g_edma.dsem, SEM_PRIO_NONE);
-
   /* Initialize the list of free TCDs from the pool of pre-allocated TCDs. */
 
   kinetis_tcd_initialize();

--- a/arch/arm/src/kinetis/kinetis_sdhc.c
+++ b/arch/arm/src/kinetis/kinetis_sdhc.c
@@ -2855,12 +2855,6 @@ struct sdio_dev_s *sdhc_initialize(int slotno)
 
   nxsem_init(&priv->waitsem, 0, 0);
 
-  /* The waitsem semaphore is used for signaling and, hence, should not have
-   * priority inheritance enabled.
-   */
-
-  nxsem_set_protocol(&priv->waitsem, SEM_PRIO_NONE);
-
   /* In addition to the system clock, the SDHC module needs a clock for the
    * base for the external card clock.  There are four possible sources for
    * this clock, selected by the SIM's SOPT2 register:

--- a/arch/arm/src/kinetis/kinetis_spi.c
+++ b/arch/arm/src/kinetis/kinetis_spi.c
@@ -1682,9 +1682,6 @@ struct spi_dev_s *kinetis_spibus_initialize(int port)
           nxsem_init(&priv->rxsem, 0, 0);
           nxsem_init(&priv->txsem, 0, 0);
 
-          nxsem_set_protocol(&priv->rxsem, SEM_PRIO_NONE);
-          nxsem_set_protocol(&priv->txsem, SEM_PRIO_NONE);
-
           priv->txdma = kinetis_dmach_alloc(priv->txch | DMAMUX_CHCFG_ENBL,
                                             0);
           priv->rxdma = kinetis_dmach_alloc(priv->rxch | DMAMUX_CHCFG_ENBL,

--- a/arch/arm/src/kinetis/kinetis_usbhshost.c
+++ b/arch/arm/src/kinetis/kinetis_usbhshost.c
@@ -4042,7 +4042,6 @@ static int kinetis_epalloc(struct usbhost_driver_s *drvr,
    */
 
   nxsem_init(&epinfo->iocsem, 0, 0);
-  nxsem_set_protocol(&epinfo->iocsem, SEM_PRIO_NONE);
 
   /* Success.. return an opaque reference to the endpoint information
    * structure instance
@@ -5073,12 +5072,6 @@ struct usbhost_connection_s *kinetis_ehci_initialize(int controller)
   nxmutex_init(&g_ehci.lock);
   nxsem_init(&g_ehci.pscsem, 0, 0);
 
-  /* The pscsem semaphore is used for signaling and, hence, should not have
-   * priority inheritance enabled.
-   */
-
-  nxsem_set_protocol(&g_ehci.pscsem, SEM_PRIO_NONE);
-
   /* Initialize EP0 */
 
   nxsem_init(&g_ehci.ep0.iocsem, 0, 1);
@@ -5115,13 +5108,7 @@ struct usbhost_connection_s *kinetis_ehci_initialize(int controller)
       rhport->ep0.xfrtype = USB_EP_ATTR_XFER_CONTROL;
       rhport->ep0.speed = USB_SPEED_FULL;
       rhport->ep0.maxpacket = 8;
-
-      /* The EP0 iocsem semaphore is used for signaling and, hence, should
-       * not have priority inheritance enabled.
-       */
-
       nxsem_init(&rhport->ep0.iocsem, 0, 0);
-      nxsem_set_protocol(&rhport->ep0.iocsem, SEM_PRIO_NONE);
 
       /* Initialize the public port representation */
 

--- a/arch/arm/src/lpc17xx_40xx/lpc17_40_i2c.c
+++ b/arch/arm/src/lpc17xx_40xx/lpc17_40_i2c.c
@@ -622,12 +622,6 @@ struct i2c_master_s *lpc17_40_i2cbus_initialize(int port)
   nxmutex_init(&priv->lock);
   nxsem_init(&priv->wait, 0, 0);
 
-  /* The wait semaphore is used for signaling and, hence, should not have
-   * priority inheritance enabled.
-   */
-
-  nxsem_set_protocol(&priv->wait, SEM_PRIO_NONE);
-
   /* Attach Interrupt Handler */
 
   irq_attach(priv->irqid, lpc17_40_i2c_interrupt, priv);

--- a/arch/arm/src/lpc17xx_40xx/lpc17_40_sdcard.c
+++ b/arch/arm/src/lpc17xx_40xx/lpc17_40_sdcard.c
@@ -2747,12 +2747,6 @@ struct sdio_dev_s *sdio_initialize(int slotno)
 
   nxsem_init(&priv->waitsem, 0, 0);
 
-  /* The waitsem semaphore is used for signaling and, hence, should not have
-   * priority inheritance enabled.
-   */
-
-  nxsem_set_protocol(&priv->waitsem, SEM_PRIO_NONE);
-
 #ifdef CONFIG_LPC17_40_SDCARD_DMA
   /* Configure the SDCARD DMA request */
 

--- a/arch/arm/src/lpc17xx_40xx/lpc17_40_usbhost.c
+++ b/arch/arm/src/lpc17xx_40xx/lpc17_40_usbhost.c
@@ -2297,14 +2297,7 @@ static int lpc17_40_epalloc(struct usbhost_driver_s *drvr,
 #endif
 
       uinfo("EP%d CTRL:%08" PRIx32 "\n", epdesc->addr, ed->hw.ctrl);
-
-      /* Initialize the semaphore that is used to wait for the endpoint
-       * WDH event. The wdhsem semaphore is used for signaling and, hence,
-       * should not have priority inheritance enabled.
-       */
-
       nxsem_init(&ed->wdhsem, 0, 0);
-      nxsem_set_protocol(&ed->wdhsem, SEM_PRIO_NONE);
 
       /* Link the common tail TD to the ED's TD list */
 
@@ -3748,12 +3741,6 @@ struct usbhost_connection_s *lpc17_40_usbhost_initialize(int controller)
   nxsem_init(&priv->pscsem,  0, 0);
   nxmutex_init(&priv->lock);
 
-  /* The pscsem semaphore is used for signaling and, hence, should not
-   * have priority inheritance enabled.
-   */
-
-  nxsem_set_protocol(&priv->pscsem, SEM_PRIO_NONE);
-
 #ifndef CONFIG_USBHOST_INT_DISABLE
   priv->ininterval  = MAX_PERINTERVAL;
   priv->outinterval = MAX_PERINTERVAL;
@@ -3845,12 +3832,7 @@ struct usbhost_connection_s *lpc17_40_usbhost_initialize(int controller)
   memset((void *)TDTAIL, 0, sizeof(struct ohci_gtd_s));
   memset((void *)EDCTRL, 0, sizeof(struct lpc17_40_ed_s));
 
-  /* The EDCTRL wdhsem semaphore is used for signaling and, hence, should
-   * not have priority inheritance enabled.
-   */
-
   nxsem_init(&EDCTRL->wdhsem, 0, 0);
-  nxsem_set_protocol(&EDCTRL->wdhsem, SEM_PRIO_NONE);
 
   /* Initialize user-configurable EDs */
 

--- a/arch/arm/src/lpc2378/lpc23xx_i2c.c
+++ b/arch/arm/src/lpc2378/lpc23xx_i2c.c
@@ -585,12 +585,6 @@ struct i2c_master_s *lpc2378_i2cbus_initialize(int port)
   nxmutex_init(&priv->lock);
   nxsem_init(&priv->wait, 0, 0);
 
-  /* The wait semaphore is used for signaling and, hence, should not have
-   * priority inheritance enabled.
-   */
-
-  nxsem_set_protocol(&priv->wait, SEM_PRIO_NONE);
-
   /* Attach Interrupt Handler */
 
   irq_attach(priv->irqid, lpc2378_i2c_interrupt, priv);

--- a/arch/arm/src/lpc31xx/lpc31_ehci.c
+++ b/arch/arm/src/lpc31xx/lpc31_ehci.c
@@ -3987,12 +3987,7 @@ static int lpc31_epalloc(struct usbhost_driver_s *drvr,
   epinfo->xfrtype   = epdesc->xfrtype;
   epinfo->speed     = hport->speed;
 
-  /* The iocsem semaphore is used for signaling and, hence, should not have
-   * priority inheritance enabled.
-   */
-
   nxsem_init(&epinfo->iocsem, 0, 0);
-  nxsem_set_protocol(&epinfo->iocsem, SEM_PRIO_NONE);
 
   /* Success.. return an opaque reference to the endpoint information
    * structure instance
@@ -5026,12 +5021,6 @@ struct usbhost_connection_s *lpc31_ehci_initialize(int controller)
   nxmutex_init(&g_ehci.lock);
   nxsem_init(&g_ehci.pscsem,  0, 0);
 
-  /* The pscsem semaphore is used for signaling and, hence, should not have
-   * priority inheritance enabled.
-   */
-
-  nxsem_set_protocol(&g_ehci.pscsem, SEM_PRIO_NONE);
-
   /* Initialize EP0 */
 
   nxsem_init(&g_ehci.ep0.iocsem, 0, 1);
@@ -5069,12 +5058,7 @@ struct usbhost_connection_s *lpc31_ehci_initialize(int controller)
       rhport->ep0.speed           = USB_SPEED_FULL;
       rhport->ep0.maxpacket       = 8;
 
-      /* The port iocsem semaphore is used for signaling and, hence,
-       * should not have priority inheritance enabled.
-       */
-
       nxsem_init(&rhport->ep0.iocsem, 0, 0);
-      nxsem_set_protocol(&rhport->iocsem, SEM_PRIO_NONE);
 
       /* Initialize the public port representation */
 

--- a/arch/arm/src/lpc31xx/lpc31_i2c.c
+++ b/arch/arm/src/lpc31xx/lpc31_i2c.c
@@ -561,12 +561,6 @@ struct i2c_master_s *lpc31_i2cbus_initialize(int port)
   nxmutex_init(&priv->lock);
   nxsem_init(&priv->wait, 0, 0);
 
-  /* The wait semaphore is used for signaling and, hence, should not have
-   * priority inheritance enabled.
-   */
-
-  nxsem_set_protocol(&priv->wait, SEM_PRIO_NONE);
-
   /* Enable I2C system clocks */
 
   lpc31_enableclock(priv->clkid);

--- a/arch/arm/src/lpc43xx/lpc43_ehci.c
+++ b/arch/arm/src/lpc43xx/lpc43_ehci.c
@@ -3824,13 +3824,7 @@ static int lpc43_epalloc(struct usbhost_driver_s *drvr,
   epinfo->maxpacket = epdesc->mxpacketsize;
   epinfo->xfrtype   = epdesc->xfrtype;
   epinfo->speed     = hport->speed;
-
-  /* The endpoint iocsem semaphore is used for signaling and, hence,
-   * should not have priority inheritance enabled.
-   */
-
   nxsem_init(&epinfo->iocsem, 0, 0);
-  nxsem_set_protocol(&epinfo->iocsem, SEM_PRIO_NONE);
 
   /* Success.. return an opaque reference to the endpoint information
    * structure instance
@@ -4851,12 +4845,6 @@ struct usbhost_connection_s *lpc43_ehci_initialize(int controller)
   nxmutex_init(&g_ehci.lock);
   nxsem_init(&g_ehci.pscsem,  0, 0);
 
-  /* The pscsem semaphore is used for signaling and, hence, should not have
-   * priority inheritance enabled.
-   */
-
-  nxsem_set_protocol(&g_ehci.pscsem, SEM_PRIO_NONE);
-
   /* Initialize EP0 */
 
   nxsem_init(&g_ehci.ep0.iocsem, 0, 1);
@@ -4893,13 +4881,7 @@ struct usbhost_connection_s *lpc43_ehci_initialize(int controller)
       rhport->ep0.xfrtype         = USB_EP_ATTR_XFER_CONTROL;
       rhport->ep0.speed           = USB_SPEED_FULL;
       rhport->ep0.maxpacket       = 8;
-
-      /* The EP0 iocsem semaphore is used for signaling and, hence, should
-       * not have priority inheritance enabled.
-       */
-
       nxsem_init(&rhport->ep0.iocsem, 0, 0);
-      nxsem_set_protocol(&rhport->ep0.iocsem, SEM_PRIO_NONE);
 
       /* Initialize the public port representation */
 

--- a/arch/arm/src/lpc43xx/lpc43_i2c.c
+++ b/arch/arm/src/lpc43xx/lpc43_i2c.c
@@ -533,12 +533,6 @@ struct i2c_master_s *lpc43_i2cbus_initialize(int port)
   nxmutex_init(&priv->lock);
   nxsem_init(&priv->wait, 0, 0);
 
-  /* The wait semaphore is used for signaling and, hence, should not have
-   * priority inheritance enabled.
-   */
-
-  nxsem_set_protocol(&priv->wait, SEM_PRIO_NONE);
-
   /* Attach Interrupt Handler */
 
   irq_attach(priv->irqid, lpc43_i2c_interrupt, priv);

--- a/arch/arm/src/lpc43xx/lpc43_sdmmc.c
+++ b/arch/arm/src/lpc43xx/lpc43_sdmmc.c
@@ -2828,12 +2828,6 @@ struct sdio_dev_s *lpc43_sdmmc_initialize(int slotno)
 
   nxsem_init(&priv->waitsem, 0, 0);
 
-  /* The waitsem semaphore is used for signaling and, hence, should not have
-   * priority inheritance enabled.
-   */
-
-  nxsem_set_protocol(&priv->waitsem, SEM_PRIO_NONE);
-
   /* Configure GPIOs for 4-bit, wide-bus operation */
 
   lpc43_pin_config(GPIO_SD_D0);

--- a/arch/arm/src/lpc54xx/lpc54_i2c_master.c
+++ b/arch/arm/src/lpc54xx/lpc54_i2c_master.c
@@ -1212,12 +1212,6 @@ struct i2c_master_s *lpc54_i2cbus_initialize(int port)
   nxmutex_init(&priv->lock);
 #ifndef CONFIG_I2C_POLLED
   nxsem_init(&priv->waitsem, 0, 0);
-
-  /* The waitsem semaphore is used for signaling and, hence, should not have
-   * priority inheritance enabled.
-   */
-
-  nxsem_set_protocol(&priv->waitsem, SEM_PRIO_NONE);
 #endif
 
 #ifndef CONFIG_I2C_POLLED

--- a/arch/arm/src/lpc54xx/lpc54_sdmmc.c
+++ b/arch/arm/src/lpc54xx/lpc54_sdmmc.c
@@ -2831,12 +2831,6 @@ struct sdio_dev_s *lpc54_sdmmc_initialize(int slotno)
 
   nxsem_init(&priv->waitsem, 0, 0);
 
-  /* The waitsem semaphore is used for signaling and, hence, should not have
-   * priority inheritance enabled.
-   */
-
-  nxsem_set_protocol(&priv->waitsem, SEM_PRIO_NONE);
-
   /* Configure GPIOs for 4-bit, wide-bus operation */
 
   lpc54_gpio_config(GPIO_SD_D0);

--- a/arch/arm/src/lpc54xx/lpc54_usb0_ohci.c
+++ b/arch/arm/src/lpc54xx/lpc54_usb0_ohci.c
@@ -2390,14 +2390,7 @@ static int lpc54_epalloc(struct usbhost_driver_s *drvr,
 #endif
 
       uinfo("EP%d CTRL:%08x\n", epdesc->addr, ed->hw.ctrl);
-
-      /* Initialize the semaphore that is used to wait for the endpoint
-       * WDH event. The wdhsem semaphore is used for signaling and, hence,
-       * should not have priority inheritance enabled.
-       */
-
       nxsem_init(&ed->wdhsem, 0, 0);
-      nxsem_set_protocol(&ed->wdhsem, SEM_PRIO_NONE);
 
       /* Link the common tail TD to the ED's TD list */
 
@@ -3834,12 +3827,6 @@ struct usbhost_connection_s *lpc54_usbhost_initialize(int controller)
   nxsem_init(&priv->pscsem,  0, 0);
   nxmutex_init(&priv->lock);
 
-  /* The pscsem semaphore is used for signaling and, hence, should not have
-   * priority inheritance enabled.
-   */
-
-  nxsem_set_protocol(&priv->pscsem, SEM_PRIO_NONE);
-
 #ifndef CONFIG_OHCI_INT_DISABLE
   priv->ininterval  = MAX_PERINTERVAL;
   priv->outinterval = MAX_PERINTERVAL;
@@ -3923,12 +3910,7 @@ struct usbhost_connection_s *lpc54_usbhost_initialize(int controller)
   memset((void *)TDTAIL, 0, sizeof(struct ohci_gtd_s));
   memset((void *)EDCTRL, 0, sizeof(struct lpc54_ed_s));
 
-  /* The EDCTRL wdhsem semaphore is used for signaling and, hence, should
-   * not have priority inheritance enabled.
-   */
-
   nxsem_init(&EDCTRL->wdhsem, 0, 0);
-  nxsem_set_protocol(&EDCTRL->wdhsem, SEM_PRIO_NONE);
 
   /* Initialize user-configurable EDs */
 

--- a/arch/arm/src/nrf52/nrf52_radio.c
+++ b/arch/arm/src/nrf52/nrf52_radio.c
@@ -1163,13 +1163,7 @@ nrf52_radio_initialize(int intf, struct nrf52_radio_board_s *board)
   /* Initialize mutex */
 
   nxmutex_init(&dev->lock);
-
-  /* This semaphore is used for signaling and, hence, should not have
-   * priority inheritance enabled.
-   */
-
   nxsem_init(&dev->sem_isr, 0, 0);
-  nxsem_set_protocol(&dev->sem_isr, SEM_PRIO_NONE);
 
   /* Connect board-specific data */
 

--- a/arch/arm/src/nrf52/nrf52_rng.c
+++ b/arch/arm/src/nrf52/nrf52_rng.c
@@ -129,8 +129,6 @@ static int nrf52_rng_initialize(void)
   memset(&g_rngdev, 0, sizeof(struct rng_dev_s));
 
   nxsem_init(&g_rngdev.rd_sem, 0, 0);
-  nxsem_set_protocol(&g_rngdev.rd_sem, SEM_PRIO_NONE);
-
   nxmutex_init(&g_rngdev.lock);
 
   _info("Ready to stop\n");

--- a/arch/arm/src/nrf52/nrf52_spi.c
+++ b/arch/arm/src/nrf52/nrf52_spi.c
@@ -1475,12 +1475,7 @@ struct spi_dev_s *nrf52_spibus_initialize(int port)
   nxmutex_init(&priv->lock);
 
 #ifdef CONFIG_NRF52_SPI_MASTER_INTERRUPTS
-  /* This semaphore is used for signaling and, hence, should not have
-   * priority inheritance enabled.
-   */
-
   nxsem_init(&priv->sem_isr, 0, 0);
-  nxsem_set_protocol(&priv->sem_isr, SEM_PRIO_NONE);
 
   /* Attach SPI interrupt */
 

--- a/arch/arm/src/rp2040/rp2040_spi.c
+++ b/arch/arm/src/rp2040/rp2040_spi.c
@@ -818,7 +818,6 @@ struct spi_dev_s *rp2040_spibus_initialize(int port)
 
 #ifdef CONFIG_RP2040_SPI_DMA
   nxsem_init(&priv->dmasem, 0, 0);
-  nxsem_set_protocol(&priv->dmasem, SEM_PRIO_NONE);
 
   priv->txdmach = rp2040_dmachannel();
   txconf.size = RP2040_DMA_SIZE_BYTE;

--- a/arch/arm/src/s32k1xx/s32k1xx_edma.c
+++ b/arch/arm/src/s32k1xx/s32k1xx_edma.c
@@ -718,12 +718,6 @@ void weak_function arm_dma_initialize(void)
 #if CONFIG_S32K1XX_EDMA_NTCD > 0
   nxsem_init(&g_edma.dsem, 0, CONFIG_S32K1XX_EDMA_NTCD);
 
-  /* The 'dsem' is used for signaling rather than mutual exclusion and,
-   * hence, should not have priority inheritance enabled.
-   */
-
-  nxsem_set_protocol(&g_edma.dsem, SEM_PRIO_NONE);
-
   /* Initialize the list of free TCDs from the pool of pre-allocated TCDs. */
 
   s32k1xx_tcd_initialize();

--- a/arch/arm/src/s32k3xx/s32k3xx_edma.c
+++ b/arch/arm/src/s32k3xx/s32k3xx_edma.c
@@ -928,12 +928,6 @@ void weak_function arm_dma_initialize(void)
 #if CONFIG_S32K3XX_EDMA_NTCD > 0
   nxsem_init(&g_edma.dsem, 0, CONFIG_S32K3XX_EDMA_NTCD);
 
-  /* The 'dsem' is used for signaling rather than mutual exclusion and,
-   * hence, should not have priority inheritance enabled.
-   */
-
-  nxsem_set_protocol(&g_edma.dsem, SEM_PRIO_NONE);
-
   /* Initialize the list of free TCDs from the pool of pre-allocated TCDs. */
 
   s32k3xx_tcd_initialize();

--- a/arch/arm/src/s32k3xx/s32k3xx_lpspi.c
+++ b/arch/arm/src/s32k3xx/s32k3xx_lpspi.c
@@ -2399,10 +2399,6 @@ struct spi_dev_s *s32k3xx_lpspibus_initialize(int bus)
         {
           nxsem_init(&priv->rxsem, 0, 0);
           nxsem_init(&priv->txsem, 0, 0);
-
-          nxsem_set_protocol(&priv->rxsem, SEM_PRIO_NONE);
-          nxsem_set_protocol(&priv->txsem, SEM_PRIO_NONE);
-
           priv->txdma = s32k3xx_dmach_alloc(priv->txch | DMAMUX_CHCFG_ENBL,
                                             0);
           priv->rxdma = s32k3xx_dmach_alloc(priv->rxch | DMAMUX_CHCFG_ENBL,

--- a/arch/arm/src/s32k3xx/s32k3xx_qspi.c
+++ b/arch/arm/src/s32k3xx/s32k3xx_qspi.c
@@ -1802,13 +1802,7 @@ struct qspi_dev_s *s32k3xx_qspi_initialize(int intf)
           spierr("ERROR: Failed to attach irq %d\n", priv->irq);
         }
 
-      /* Initialize the semaphore that blocks until the operation completes.
-       * This semaphore is used for signaling and, hence, should not have
-       * priority inheritance enabled.
-       */
-
       nxsem_init(&priv->op_sem, 0, 0);
-      nxsem_set_protocol(&priv->op_sem, SEM_PRIO_NONE);
 #endif
 
       /* Perform hardware initialization.  Puts the QSPI into an active
@@ -1841,10 +1835,6 @@ struct qspi_dev_s *s32k3xx_qspi_initialize(int intf)
             {
               nxsem_init(&priv->rxsem, 0, 0);
               nxsem_init(&priv->txsem, 0, 0);
-
-              nxsem_set_protocol(&priv->rxsem, SEM_PRIO_NONE);
-              nxsem_set_protocol(&priv->txsem, SEM_PRIO_NONE);
-
               priv->txdma = s32k3xx_dmach_alloc(priv->txch
                                                 | DMAMUX_CHCFG_ENBL, 0);
               priv->rxdma = s32k3xx_dmach_alloc(priv->rxch

--- a/arch/arm/src/sam34/sam_hsmci.c
+++ b/arch/arm/src/sam34/sam_hsmci.c
@@ -2702,13 +2702,6 @@ struct sdio_dev_s *sdio_initialize(int slotno)
   /* Initialize semaphores */
 
   nxsem_init(&priv->waitsem, 0, 0);
-
-  /* The waitsem semaphore is used for signaling and, hence, should not have
-   * priority inheritance enabled.
-   */
-
-  nxsem_set_protocol(&priv->waitsem, SEM_PRIO_NONE);
-
 #ifdef CONFIG_SAM34_DMAC0
   /* Allocate a DMA channel.  A FIFO size of 8 is sufficient. */
 

--- a/arch/arm/src/sam34/sam_spi.c
+++ b/arch/arm/src/sam34/sam_spi.c
@@ -1865,13 +1865,7 @@ struct spi_dev_s *sam_spibus_initialize(int port)
       spi->initialized = true;
 
 #ifdef CONFIG_SAM34_SPI_DMA
-      /* Initialize the SPI semaphore that is used to wake up the waiting
-       * thread when the DMA transfer completes.  This semaphore is used for
-       * signaling and, hence, should not have priority inheritance enabled.
-       */
-
       nxsem_init(&spics->dmawait, 0, 0);
-      nxsem_set_protocol(&spics->dmawait, SEM_PRIO_NONE);
 #endif
 
       spi_dumpregs(spi, "After initialization");

--- a/arch/arm/src/sam34/sam_twi.c
+++ b/arch/arm/src/sam34/sam_twi.c
@@ -955,12 +955,6 @@ struct i2c_master_s *sam_i2cbus_initialize(int bus)
   nxmutex_init(&priv->lock);
   nxsem_init(&priv->waitsem, 0, 0);
 
-  /* The waitsem semaphore is used for signaling and, hence, should not have
-   * priority inheritance enabled.
-   */
-
-  nxsem_set_protocol(&priv->waitsem, SEM_PRIO_NONE);
-
   /* Configure and enable the TWI hardware */
 
   priv->pid = pid;

--- a/arch/arm/src/sama5/sam_ehci.c
+++ b/arch/arm/src/sama5/sam_ehci.c
@@ -3747,13 +3747,7 @@ static int sam_epalloc(struct usbhost_driver_s *drvr,
   epinfo->maxpacket = epdesc->mxpacketsize;
   epinfo->xfrtype   = epdesc->xfrtype;
   epinfo->speed     = hport->speed;
-
-  /* The endpoint iocsem semaphore is used for signaling and, hence,
-   * should not have priority inheritance enabled.
-   */
-
   nxsem_init(&epinfo->iocsem, 0, 0);
-  nxsem_set_protocol(&epinfo->iocsem, SEM_PRIO_NONE);
 
   /* Success.. return an opaque reference to the endpoint information
    * structure instance
@@ -4831,12 +4825,6 @@ struct usbhost_connection_s *sam_ehci_initialize(int controller)
   nxmutex_init(&g_ehci.lock);
   nxsem_init(&g_ehci.pscsem,  0, 0);
 
-  /* The pscsem semaphore is used for signaling and, hence, should not have
-   * priority inheritance enabled.
-   */
-
-  nxsem_set_protocol(&g_ehci.pscsem, SEM_PRIO_NONE);
-
   /* Initialize EP0 */
 
   nxsem_init(&g_ehci.ep0.iocsem, 0, 1);
@@ -4873,13 +4861,7 @@ struct usbhost_connection_s *sam_ehci_initialize(int controller)
       rhport->ep0.xfrtype         = USB_EP_ATTR_XFER_CONTROL;
       rhport->ep0.speed           = USB_SPEED_FULL;
       rhport->ep0.maxpacket       = 8;
-
-      /* The endpoint 0 iocsem semaphore is used for signaling and, hence,
-       * should not have priority inheritance enabled.
-       */
-
       nxsem_init(&rhport->ep0.iocsem, 0, 0);
-      nxsem_set_protocol(&rhport->ep0.iocsem, SEM_PRIO_NONE);
 
       /* Initialize the public port representation */
 

--- a/arch/arm/src/sama5/sam_hsmci.c
+++ b/arch/arm/src/sama5/sam_hsmci.c
@@ -3318,12 +3318,6 @@ struct sdio_dev_s *sdio_initialize(int slotno)
 
   nxsem_init(&priv->waitsem, 0, 0);
 
-  /* The waitsem semaphore is used for signaling and, hence, should not have
-   * priority inheritance enabled.
-   */
-
-  nxsem_set_protocol(&priv->waitsem, SEM_PRIO_NONE);
-
   /* Initialize the callbacks */
 
   memcpy(&priv->dev, &g_callbacks, sizeof(struct sdio_dev_s));

--- a/arch/arm/src/sama5/sam_nand.c
+++ b/arch/arm/src/sama5/sam_nand.c
@@ -2981,12 +2981,7 @@ struct mtd_dev_s *sam_nand_initialize(int cs)
   priv->cs             = cs;
 
 #ifdef CONFIG_SAMA5_NAND_DMA
-  /* The waitsem semaphore is used for signaling and, hence, should not have
-   * priority inheritance enabled.
-   */
-
   nxsem_init(&priv->waitsem, 0, 0);
-  nxsem_set_protocol(&priv->waitsem, SEM_PRIO_NONE);
 #endif
 
   /* Perform one-time, global NFC/PMECC initialization */
@@ -3000,12 +2995,7 @@ struct mtd_dev_s *sam_nand_initialize(int cs)
 #endif
 
 #ifdef CONFIG_SAMA5_NAND_HSMCINTERRUPTS
-      /* The waitsem semaphore is used for signaling and, hence, should not
-       * have priority inheritance enabled.
-       */
-
       nxsem_init(&g_nand.waitsem, 0, 0);
-      nxsem_set_protocol(&g_nand.waitsem, SEM_PRIO_NONE);
 #endif
 
       /* Enable the NAND FLASH Controller (The NFC is always used) */

--- a/arch/arm/src/sama5/sam_ohci.c
+++ b/arch/arm/src/sama5/sam_ohci.c
@@ -2665,12 +2665,6 @@ static int sam_epalloc(struct usbhost_driver_s *drvr,
 
   nxsem_init(&eplist->wdhsem, 0, 0);
 
-  /* The wdhsem semaphore is used for signaling and, hence, should not have
-   * priority inheritance enabled.
-   */
-
-  nxsem_set_protocol(&eplist->wdhsem, SEM_PRIO_NONE);
-
   /* We must have exclusive access to the ED pool, the bulk list, the
    * periodic list, and the interrupt table.
    */
@@ -3964,12 +3958,6 @@ struct usbhost_connection_s *sam_ohci_initialize(int controller)
 
   nxsem_init(&g_ohci.pscsem,  0, 0);
   nxmutex_init(&g_ohci.lock);
-
-  /* The pscsem semaphore is used for signaling and, hence, should not have
-   * priority inheritance enabled.
-   */
-
-  nxsem_set_protocol(&g_ohci.pscsem, SEM_PRIO_NONE);
 
 #ifndef CONFIG_USBHOST_INT_DISABLE
   g_ohci.ininterval  = MAX_PERINTERVAL;

--- a/arch/arm/src/sama5/sam_sdmmc.c
+++ b/arch/arm/src/sama5/sam_sdmmc.c
@@ -3594,12 +3594,6 @@ struct sdio_dev_s *sam_sdmmc_sdio_initialize(int slotno)
 
   nxsem_init(&priv->waitsem, 0, 0);
 
-  /* The waitsem semaphore is used for signaling and, hence, should not
-   * have priority inheritance enabled.
-   */
-
-  nxsem_set_protocol(&priv->waitsem, SEM_PRIO_NONE);
-
   switch (priv->addr)
     {
     case SAM_SDMMC0_VBASE:

--- a/arch/arm/src/sama5/sam_spi.c
+++ b/arch/arm/src/sama5/sam_spi.c
@@ -1791,13 +1791,7 @@ struct spi_dev_s *sam_spibus_initialize(int port)
       spi->initialized = true;
 
 #ifdef CONFIG_SAMA5_SPI_DMA
-      /* Initialize the SPI semaphore that is used to wake up the waiting
-       * thread when the DMA transfer completes.  This semaphore is used for
-       * signaling and, hence, should not have priority inheritance enabled.
-       */
-
       nxsem_init(&spics->dmawait, 0, 0);
-      nxsem_set_protocol(&spics->dmawait, SEM_PRIO_NONE);
 #endif
 
       spi_dumpregs(spi, "After initialization");

--- a/arch/arm/src/sama5/sam_trng.c
+++ b/arch/arm/src/sama5/sam_trng.c
@@ -342,12 +342,6 @@ static int sam_rng_initialize(void)
   nxmutex_init(&g_trngdev.lock);
   nxsem_init(&g_trngdev.waitsem, 0, 0);
 
-  /* The waitsem semaphore is used for signaling and, hence, should not have
-   * priority inheritance enabled.
-   */
-
-  nxsem_set_protocol(&g_trngdev.waitsem, SEM_PRIO_NONE);
-
   /* Enable clocking to the TRNG */
 
   sam_trng_enableclk();

--- a/arch/arm/src/sama5/sam_tsd.c
+++ b/arch/arm/src/sama5/sam_tsd.c
@@ -1654,13 +1654,7 @@ int sam_tsd_register(struct sam_adc_s *adc, int minor)
   priv->adc     = adc;               /* Save the ADC device handle */
   priv->threshx = INVALID_THRESHOLD; /* Initialize thresholding logic */
   priv->threshy = INVALID_THRESHOLD; /* Initialize thresholding logic */
-
-  /* Initialize pen event wait semaphore.  This semaphore is used for
-   * signaling and, hence, should not have priority inheritance enabled.
-   */
-
   nxsem_init(&priv->waitsem, 0, 0);
-  nxsem_set_protocol(&priv->waitsem, SEM_PRIO_NONE);
 
   /* Register the device as an input device */
 

--- a/arch/arm/src/sama5/sam_twi.c
+++ b/arch/arm/src/sama5/sam_twi.c
@@ -1257,12 +1257,6 @@ struct i2c_master_s *sam_i2cbus_initialize(int bus)
   nxmutex_init(&priv->lock);
   nxsem_init(&priv->waitsem, 0, 0);
 
-  /* The waitsem semaphore is used for signaling and, hence, should not have
-   * priority inheritance enabled.
-   */
-
-  nxsem_set_protocol(&priv->waitsem, SEM_PRIO_NONE);
-
   /* Perform repeatable TWI hardware initialization */
 
   twi_hw_initialize(priv, frequency);

--- a/arch/arm/src/sama5/sam_xdmac.c
+++ b/arch/arm/src/sama5/sam_xdmac.c
@@ -1984,12 +1984,6 @@ void sam_dmainitialize(struct sam_xdmac_s *xdmac)
 
   nxmutex_init(&xdmac->chlock);
   nxsem_init(&xdmac->dsem, 0, SAM_NDMACHAN);
-
-  /* The 'dsem' is used for signaling rather than mutual exclusion and,
-   * hence, should not have priority inheritance enabled.
-   */
-
-  nxsem_set_protocol(&xdmac->dsem, SEM_PRIO_NONE);
 }
 
 /****************************************************************************

--- a/arch/arm/src/samd2l2/sam_spi.c
+++ b/arch/arm/src/samd2l2/sam_spi.c
@@ -1434,7 +1434,6 @@ static void spi_dma_setup(struct sam_spidev_s *priv)
   /* Initialize the semaphore used to notify when DMA is complete */
 
   nxsem_init(&priv->dmasem, 0, 0);
-  nxsem_set_protocol(&priv->dmasem, SEM_PRIO_NONE);
 }
 #endif
 

--- a/arch/arm/src/samd5e5/sam_spi.c
+++ b/arch/arm/src/samd5e5/sam_spi.c
@@ -1523,7 +1523,6 @@ static void spi_dma_setup(struct sam_spidev_s *priv)
   /* Initialize the semaphore used to notify when DMA is complete */
 
   nxsem_init(&priv->dmasem, 0, 0);
-  nxsem_set_protocol(&priv->dmasem, SEM_PRIO_NONE);
 }
 #endif
 

--- a/arch/arm/src/samv7/sam_hsmci.c
+++ b/arch/arm/src/samv7/sam_hsmci.c
@@ -3315,12 +3315,6 @@ struct sdio_dev_s *sdio_initialize(int slotno)
 
   nxsem_init(&priv->waitsem, 0, 0);
 
-  /* The waitsem semaphore is used for signaling and, hence, should not have
-   * priority inheritance enabled.
-   */
-
-  nxsem_set_protocol(&priv->waitsem, SEM_PRIO_NONE);
-
   /* Initialize the callbacks */
 
   memcpy(&priv->dev, &g_callbacks, sizeof(struct sdio_dev_s));

--- a/arch/arm/src/samv7/sam_qspi.c
+++ b/arch/arm/src/samv7/sam_qspi.c
@@ -1775,13 +1775,7 @@ struct qspi_dev_s *sam_qspi_initialize(int intf)
             }
         }
 
-      /* Initialize the QSPI semaphore that is used to wake up the waiting
-       * thread when the DMA transfer completes.  This semaphore is used for
-       * signaling and, hence, should not have priority inheritance enabled.
-       */
-
       nxsem_init(&priv->dmawait, 0, 0);
-      nxsem_set_protocol(&priv->dmawait, SEM_PRIO_NONE);
 #endif
 
 #ifdef QSPI_USE_INTERRUPTS

--- a/arch/arm/src/samv7/sam_spi.c
+++ b/arch/arm/src/samv7/sam_spi.c
@@ -2165,13 +2165,7 @@ struct spi_dev_s *sam_spibus_initialize(int port)
       spi->initialized = true;
 
 #ifdef CONFIG_SAMV7_SPI_DMA
-      /* Initialize the SPI semaphore that is used to wake up the waiting
-       * thread when the DMA transfer completes.  This semaphore is used for
-       * signaling and, hence, should not have priority inheritance enabled.
-       */
-
       nxsem_init(&spics->dmawait, 0, 0);
-      nxsem_set_protocol(&spics->dmawait, SEM_PRIO_NONE);
 #endif
 
       spi_dumpregs(spi, "After initialization");

--- a/arch/arm/src/samv7/sam_trng.c
+++ b/arch/arm/src/samv7/sam_trng.c
@@ -344,12 +344,6 @@ static int sam_rng_initialize(void)
   nxmutex_init(&g_trngdev.lock);
   nxsem_init(&g_trngdev.waitsem, 0, 0);
 
-  /* The waitsem semaphore is used for signaling and, hence, should not have
-   * priority inheritance enabled.
-   */
-
-  nxsem_set_protocol(&g_trngdev.waitsem, SEM_PRIO_NONE);
-
   /* Enable clocking to the TRNG */
 
   sam_trng_enableclk();

--- a/arch/arm/src/samv7/sam_xdmac.c
+++ b/arch/arm/src/samv7/sam_xdmac.c
@@ -1566,12 +1566,6 @@ void sam_dmainitialize(struct sam_xdmac_s *xdmac)
 
   nxmutex_init(&xdmac->chlock);
   nxsem_init(&xdmac->dsem, 0, SAMV7_NDMACHAN);
-
-  /* The 'dsem' is used for signaling rather than mutual exclusion and,
-   * hence, should not have priority inheritance enabled.
-   */
-
-  nxsem_set_protocol(&xdmac->dsem, SEM_PRIO_NONE);
 }
 
 /****************************************************************************

--- a/arch/arm/src/stm32/stm32_dma2d.c
+++ b/arch/arm/src/stm32/stm32_dma2d.c
@@ -1100,14 +1100,7 @@ int stm32_dma2dinitialize(void)
        */
 
       nxmutex_init(&g_lock);
-
-      /* Initialize the semaphore for interrupt handling.  This waitsem
-       * semaphore is used for signaling and, hence, should not have
-       * priority inheritance enabled.
-       */
-
       nxsem_init(g_interrupt.sem, 0, 0);
-      nxsem_set_protocol(g_interrupt.sem, SEM_PRIO_NONE);
 
 #ifdef CONFIG_STM32_FB_CMAP
       /* Enable dma2d transfer and clut loading interrupts only */

--- a/arch/arm/src/stm32/stm32_foc.c
+++ b/arch/arm/src/stm32/stm32_foc.c
@@ -2364,7 +2364,6 @@ stm32_foc_initialize(int inst, struct stm32_foc_board_s *board)
   /* Initialize calibration semaphore */
 
   nxsem_init(&foc_priv->cal_done_sem, 0, 0);
-  nxsem_set_protocol(&foc_priv->cal_done_sem, SEM_PRIO_NONE);
 
   /* Get FOC device */
 

--- a/arch/arm/src/stm32/stm32_hciuart.c
+++ b/arch/arm/src/stm32/stm32_hciuart.c
@@ -2589,10 +2589,7 @@ void hciuart_initialize(void)
           /* Initialize signalling semaphores */
 
           nxsem_init(&state->rxwait, 0, 0);
-          nxsem_set_protocol(&state->rxwait, SEM_PRIO_NONE);
-
           nxsem_init(&state->txwait, 0, 0);
-          nxsem_set_protocol(&state->txwait, SEM_PRIO_NONE);
 
           /* Attach and enable the HCI UART IRQ */
 

--- a/arch/arm/src/stm32/stm32_ltdc.c
+++ b/arch/arm/src/stm32/stm32_ltdc.c
@@ -1611,14 +1611,7 @@ static void stm32_ltdc_irqconfig(void)
   /* Initialize the LTDC mutex that enforces mutually exclusive access */
 
   nxmutex_init(&g_lock);
-
-  /* Initialize the semaphore for interrupt handling.  This waitsem
-   * semaphore is used for signaling and, hence, should not have priority
-   * inheritance enabled.
-   */
-
   nxsem_init(g_interrupt.sem, 0, 0);
-  nxsem_set_protocol(g_interrupt.sem, SEM_PRIO_NONE);
 
   /* Attach LTDC interrupt vector */
 

--- a/arch/arm/src/stm32/stm32_otgfshost.c
+++ b/arch/arm/src/stm32/stm32_otgfshost.c
@@ -5255,12 +5255,6 @@ static inline void stm32_sw_initialize(struct stm32_usbhost_s *priv)
   nxsem_init(&priv->pscsem,  0, 0);
   nxmutex_init(&priv->lock);
 
-  /* The pscsem semaphore is used for signaling and, hence, should not have
-   * priority inheritance enabled.
-   */
-
-  nxsem_set_protocol(&priv->pscsem, SEM_PRIO_NONE);
-
   /* Initialize the driver state data */
 
   priv->smstate   = SMSTATE_DETACHED;
@@ -5278,13 +5272,7 @@ static inline void stm32_sw_initialize(struct stm32_usbhost_s *priv)
       struct stm32_chan_s *chan = &priv->chan[i];
 
       chan->chidx = i;
-
-      /* The waitsem semaphore is used for signaling and, hence, should not
-       * have priority inheritance enabled.
-       */
-
       nxsem_init(&chan->waitsem,  0, 0);
-      nxsem_set_protocol(&chan->waitsem, SEM_PRIO_NONE);
     }
 }
 

--- a/arch/arm/src/stm32/stm32_otghshost.c
+++ b/arch/arm/src/stm32/stm32_otghshost.c
@@ -5254,12 +5254,6 @@ static inline void stm32_sw_initialize(struct stm32_usbhost_s *priv)
   nxsem_init(&priv->pscsem,  0, 0);
   nxmutex_init(&priv->lock);
 
-  /* The pscsem semaphore is used for signaling and, hence, should not have
-   * priority inheritance enabled.
-   */
-
-  nxsem_set_protocol(&priv->pscsem, SEM_PRIO_NONE);
-
   /* Initialize the driver state data */
 
   priv->smstate   = SMSTATE_DETACHED;
@@ -5277,13 +5271,7 @@ static inline void stm32_sw_initialize(struct stm32_usbhost_s *priv)
       struct stm32_chan_s *chan = &priv->chan[i];
 
       chan->chidx = i;
-
-      /* The waitsem semaphore is used for signaling and, hence, should not
-       * have priority inheritance enabled.
-       */
-
       nxsem_init(&chan->waitsem,  0, 0);
-      nxsem_set_protocol(&chan->waitsem, SEM_PRIO_NONE);
     }
 }
 

--- a/arch/arm/src/stm32/stm32_rng.c
+++ b/arch/arm/src/stm32/stm32_rng.c
@@ -241,14 +241,7 @@ static ssize_t stm32_rng_read(struct file *filep, char *buffer,
 
   /* We've got the mutex. */
 
-  /* Initialize the operation semaphore with 0 for blocking until the
-   * buffer is filled from interrupts.  The readsem semaphore is used
-   * for signaling and, hence, should not have priority inheritance
-   * enabled.
-   */
-
   nxsem_init(&g_rngdev.rd_readsem, 0, 0);
-  nxsem_set_protocol(&g_rngdev.rd_readsem, SEM_PRIO_NONE);
 
   g_rngdev.rd_buflen = buflen;
   g_rngdev.rd_buf = buffer;

--- a/arch/arm/src/stm32/stm32_sdio.c
+++ b/arch/arm/src/stm32/stm32_sdio.c
@@ -3047,12 +3047,6 @@ struct sdio_dev_s *sdio_initialize(int slotno)
 
   nxsem_init(&priv->waitsem, 0, 0);
 
-  /* The waitsem semaphore is used for signaling and, hence, should not have
-   * priority inheritance enabled.
-   */
-
-  nxsem_set_protocol(&priv->waitsem, SEM_PRIO_NONE);
-
   /* Allocate a DMA channel */
 
 #ifdef CONFIG_STM32_SDIO_DMA

--- a/arch/arm/src/stm32/stm32_spi.c
+++ b/arch/arm/src/stm32/stm32_spi.c
@@ -2093,18 +2093,10 @@ static void spi_bus_initialize(struct stm32_spidev_s *priv)
   nxmutex_init(&priv->lock);
 
 #ifdef CONFIG_STM32_SPI_DMA
-  /* Initialize the SPI semaphores that is used to wait for DMA completion.
-   * This semaphore is used for signaling and, hence, should not have
-   * priority inheritance enabled.
-   */
-
   if (priv->rxch && priv->txch)
     {
       nxsem_init(&priv->rxsem, 0, 0);
       nxsem_init(&priv->txsem, 0, 0);
-
-      nxsem_set_protocol(&priv->rxsem, SEM_PRIO_NONE);
-      nxsem_set_protocol(&priv->txsem, SEM_PRIO_NONE);
 
       /* Get DMA channels.  NOTE: stm32_dmachannel() will always assign the
        * DMA channel.  If the channel is not available, then

--- a/arch/arm/src/stm32f0l0g0/stm32_rng.c
+++ b/arch/arm/src/stm32f0l0g0/stm32_rng.c
@@ -240,14 +240,7 @@ static ssize_t stm32_rng_read(struct file *filep,
 
   /* We've got the semaphore. */
 
-  /* Initialize the operation semaphore with 0 for blocking until the
-   * buffer is filled from interrupts.  The readsem semaphore is used
-   * for signaling and, hence, should not have priority inheritance
-   * enabled.
-   */
-
   nxsem_init(&g_rngdev.rd_readsem, 0, 0);
-  nxsem_set_protocol(&g_rngdev.rd_readsem, SEM_PRIO_NONE);
 
   g_rngdev.rd_buflen = buflen;
   g_rngdev.rd_buf = buffer;

--- a/arch/arm/src/stm32f0l0g0/stm32_spi.c
+++ b/arch/arm/src/stm32f0l0g0/stm32_spi.c
@@ -1960,13 +1960,6 @@ static void spi_bus_initialize(struct stm32_spidev_s *priv)
       nxsem_init(&priv->rxsem, 0, 0);
       nxsem_init(&priv->txsem, 0, 0);
 
-      /* These semaphores are used for signaling and, hence, should not have
-       * priority inheritance enabled.
-       */
-
-      nxsem_set_protocol(&priv->rxsem, SEM_PRIO_NONE);
-      nxsem_set_protocol(&priv->txsem, SEM_PRIO_NONE);
-
       /* Get DMA channels.  NOTE: stm32_dmachannel() will always assign the
        * DMA channel. If the channel is not available, then
        * stm32_dmachannel() will block and wait until the channel becomes

--- a/arch/arm/src/stm32f7/stm32_dma2d.c
+++ b/arch/arm/src/stm32f7/stm32_dma2d.c
@@ -1097,14 +1097,7 @@ int stm32_dma2dinitialize(void)
        */
 
       nxmutex_init(&g_lock);
-
-      /* Initialize the semaphore for interrupt handling.  This waitsem
-       * semaphore is used for signaling and, hence, should not have
-       * priority inheritance enabled.
-       */
-
       nxsem_init(g_interrupt.sem, 0, 0);
-      nxsem_set_protocol(g_interrupt.sem, SEM_PRIO_NONE);
 
 #ifdef CONFIG_STM32F7_FB_CMAP
       /* Enable dma2d transfer and clut loading interrupts only */

--- a/arch/arm/src/stm32f7/stm32_foc.c
+++ b/arch/arm/src/stm32f7/stm32_foc.c
@@ -2093,7 +2093,6 @@ stm32_foc_initialize(int inst, struct stm32_foc_board_s *board)
   /* Initialize calibration semaphore */
 
   nxsem_init(&foc_priv->cal_done_sem, 0, 0);
-  nxsem_set_protocol(&foc_priv->cal_done_sem, SEM_PRIO_NONE);
 
   /* Get FOC device */
 

--- a/arch/arm/src/stm32f7/stm32_ltdc.c
+++ b/arch/arm/src/stm32f7/stm32_ltdc.c
@@ -1614,14 +1614,7 @@ static void stm32_ltdc_irqconfig(void)
   /* Initialize the LTDC mutex that enforces mutually exclusive access */
 
   nxmutex_init(&g_lock);
-
-  /* Initialize the semaphore for interrupt handling.  This waitsem
-   * semaphore is used for signaling and, hence, should not have priority
-   * inheritance enabled.
-   */
-
   nxsem_init(g_interrupt.sem, 0, 0);
-  nxsem_set_protocol(g_interrupt.sem, SEM_PRIO_NONE);
 
   /* Attach LTDC interrupt vector */
 

--- a/arch/arm/src/stm32f7/stm32_otghost.c
+++ b/arch/arm/src/stm32f7/stm32_otghost.c
@@ -5227,12 +5227,6 @@ static inline void stm32_sw_initialize(struct stm32_usbhost_s *priv)
   nxsem_init(&priv->pscsem,  0, 0);
   nxmutex_init(&priv->lock);
 
-  /* The pscsem semaphore is used for signaling and, hence, should not have
-   * priority inheritance enabled.
-   */
-
-  nxsem_set_protocol(&priv->pscsem, SEM_PRIO_NONE);
-
   /* Initialize the driver state data */
 
   priv->smstate   = SMSTATE_DETACHED;
@@ -5250,13 +5244,7 @@ static inline void stm32_sw_initialize(struct stm32_usbhost_s *priv)
       struct stm32_chan_s *chan = &priv->chan[i];
 
       chan->chidx = i;
-
-      /* The waitsem semaphore is used for signaling and, hence, should not
-       * have priority inheritance enabled.
-       */
-
       nxsem_init(&chan->waitsem,  0, 0);
-      nxsem_set_protocol(&chan->waitsem, SEM_PRIO_NONE);
     }
 }
 

--- a/arch/arm/src/stm32f7/stm32_qspi.c
+++ b/arch/arm/src/stm32f7/stm32_qspi.c
@@ -2577,13 +2577,7 @@ struct qspi_dev_s *stm32f7_qspi_initialize(int intf)
             }
         }
 
-      /* Initialize the QSPI semaphore that is used to wake up the waiting
-       * thread when the DMA transfer completes.  This semaphore is used for
-       * signaling and, hence, should not have priority inheritance enabled.
-       */
-
       nxsem_init(&priv->dmawait, 0, 0);
-      nxsem_set_protocol(&priv->dmawait, SEM_PRIO_NONE);
 #endif
 
 #ifdef CONFIG_STM32F7_QSPI_INTERRUPTS
@@ -2596,13 +2590,7 @@ struct qspi_dev_s *stm32f7_qspi_initialize(int intf)
           goto errout_with_dmawait;
         }
 
-      /* Initialize the semaphore that blocks until the operation completes.
-       * This semaphore is used for signaling and, hence, should not have
-       * priority inheritance enabled.
-       */
-
       nxsem_init(&priv->op_sem, 0, 0);
-      nxsem_set_protocol(&priv->op_sem, SEM_PRIO_NONE);
 #endif
 
       /* Perform hardware initialization.  Puts the QSPI into an active

--- a/arch/arm/src/stm32f7/stm32_rng.c
+++ b/arch/arm/src/stm32f7/stm32_rng.c
@@ -259,14 +259,7 @@ static ssize_t stm32_rngread(struct file *filep, char *buffer, size_t buflen)
 
   /* We've got the device semaphore, proceed with reading */
 
-  /* Initialize the operation semaphore with 0 for blocking until the
-   * buffer is filled from interrupts.  The readsem semaphore is used
-   * for signaling and, hence, should not have priority inheritance
-   * enabled.
-   */
-
   nxsem_init(&g_rngdev.rd_readsem, 0, 0);
-  nxsem_set_protocol(&g_rngdev.rd_readsem, SEM_PRIO_NONE);
 
   g_rngdev.rd_buflen = buflen;
   g_rngdev.rd_buf = buffer;

--- a/arch/arm/src/stm32f7/stm32_sdmmc.c
+++ b/arch/arm/src/stm32f7/stm32_sdmmc.c
@@ -3415,12 +3415,6 @@ struct sdio_dev_s *sdio_initialize(int slotno)
 
   nxsem_init(&priv->waitsem, 0, 0);
 
-  /* The waitsem semaphore is used for signaling and, hence, should not have
-   * priority inheritance enabled.
-   */
-
-  nxsem_set_protocol(&priv->waitsem, SEM_PRIO_NONE);
-
 #ifdef CONFIG_STM32F7_SDMMC_DMA
   /* Allocate a DMA channel */
 

--- a/arch/arm/src/stm32f7/stm32_spi.c
+++ b/arch/arm/src/stm32f7/stm32_spi.c
@@ -2158,18 +2158,10 @@ static void spi_bus_initialize(struct stm32_spidev_s *priv)
   nxmutex_init(&priv->lock);
 
 #ifdef CONFIG_STM32F7_SPI_DMA
-  /* Initialize the SPI semaphores that is used to wait for DMA completion.
-   * This semaphore is used for signaling and, hence, should not have
-   * priority inheritance enabled.
-   */
-
   if (priv->rxch && priv->txch)
     {
       nxsem_init(&priv->rxsem, 0, 0);
       nxsem_init(&priv->txsem, 0, 0);
-
-      nxsem_set_protocol(&priv->rxsem, SEM_PRIO_NONE);
-      nxsem_set_protocol(&priv->txsem, SEM_PRIO_NONE);
 
       /* Get DMA channels.  NOTE: stm32_dmachannel() will always assign the
        * DMA channel.  If the channel is not available, then

--- a/arch/arm/src/stm32h7/stm32_otghost.c
+++ b/arch/arm/src/stm32h7/stm32_otghost.c
@@ -5231,12 +5231,6 @@ static inline void stm32_sw_initialize(struct stm32_usbhost_s *priv)
   nxsem_init(&priv->pscsem,  0, 0);
   nxmutex_init(&priv->lock);
 
-  /* The pscsem semaphore is used for signaling and, hence, should not have
-   * priority inheritance enabled.
-   */
-
-  nxsem_set_protocol(&priv->pscsem, SEM_PRIO_NONE);
-
   /* Initialize the driver state data */
 
   priv->smstate   = SMSTATE_DETACHED;
@@ -5254,13 +5248,7 @@ static inline void stm32_sw_initialize(struct stm32_usbhost_s *priv)
       struct stm32_chan_s *chan = &priv->chan[i];
 
       chan->chidx = i;
-
-      /* The waitsem semaphore is used for signaling and, hence, should not
-       * have priority inheritance enabled.
-       */
-
       nxsem_init(&chan->waitsem,  0, 0);
-      nxsem_set_protocol(&chan->waitsem, SEM_PRIO_NONE);
     }
 }
 

--- a/arch/arm/src/stm32h7/stm32_qspi.c
+++ b/arch/arm/src/stm32h7/stm32_qspi.c
@@ -2635,13 +2635,7 @@ struct qspi_dev_s *stm32h7_qspi_initialize(int intf)
             }
         }
 
-      /* Initialize the QSPI semaphore that is used to wake up the waiting
-       * thread when the DMA transfer completes.  This semaphore is used for
-       * signaling and, hence, should not have priority inheritance enabled.
-       */
-
       nxsem_init(&priv->dmawait, 0, 0);
-      nxsem_set_protocol(&priv->dmawait, SEM_PRIO_NONE);
 #endif
 
 #ifdef CONFIG_STM32H7_QSPI_INTERRUPTS
@@ -2654,13 +2648,7 @@ struct qspi_dev_s *stm32h7_qspi_initialize(int intf)
           goto errout_with_dmawait;
         }
 
-      /* Initialize the semaphore that blocks until the operation completes.
-       * This semaphore is used for signaling and, hence, should not have
-       * priority inheritance enabled.
-       */
-
       nxsem_init(&priv->op_sem, 0, 0);
-      nxsem_set_protocol(&priv->op_sem, SEM_PRIO_NONE);
 #endif
 
       /* Perform hardware initialization.  Puts the QSPI into an active

--- a/arch/arm/src/stm32h7/stm32_sdmmc.c
+++ b/arch/arm/src/stm32h7/stm32_sdmmc.c
@@ -3513,12 +3513,6 @@ struct sdio_dev_s *sdio_initialize(int slotno)
 
   nxsem_init(&priv->waitsem, 0, 0);
 
-  /* The waitsem semaphore is used for signaling and, hence, should not have
-   * priority inheritance enabled.
-   */
-
-  nxsem_set_protocol(&priv->waitsem, SEM_PRIO_NONE);
-
   /* Reset the card and assure that it is in the initial, unconfigured
    * state.
    */

--- a/arch/arm/src/stm32h7/stm32_serial.c
+++ b/arch/arm/src/stm32h7/stm32_serial.c
@@ -2225,7 +2225,6 @@ static int up_dma_setup(struct uart_dev_s *dev)
       priv->txdma = stm32_dmachannel(priv->txdma_channel);
 
       nxsem_init(&priv->txdmasem, 0, 1);
-      nxsem_set_protocol(&priv->txdmasem, SEM_PRIO_NONE);
 
       /* Enable receive Tx DMA for the UART */
 

--- a/arch/arm/src/stm32h7/stm32_spi.c
+++ b/arch/arm/src/stm32h7/stm32_spi.c
@@ -2502,16 +2502,8 @@ static void spi_bus_initialize(struct stm32_spidev_s *priv)
   nxmutex_init(&priv->lock);
 
 #ifdef CONFIG_STM32H7_SPI_DMA
-  /* Initialize the SPI semaphores that is used to wait for DMA completion.
-   * This semaphore is used for signaling and, hence, should not have
-   * priority inheritance enabled.
-   */
-
   nxsem_init(&priv->rxsem, 0, 0);
   nxsem_init(&priv->txsem, 0, 0);
-
-  nxsem_set_protocol(&priv->rxsem, SEM_PRIO_NONE);
-  nxsem_set_protocol(&priv->txsem, SEM_PRIO_NONE);
 
   /* Get DMA channels.  NOTE: stm32_dmachannel() will always assign the DMA
    * channel.  If the channel is not available, then stm32_dmachannel() will

--- a/arch/arm/src/stm32l4/stm32l4_otgfshost.c
+++ b/arch/arm/src/stm32l4/stm32l4_otgfshost.c
@@ -5268,12 +5268,6 @@ static inline void stm32l4_sw_initialize(struct stm32l4_usbhost_s *priv)
   nxsem_init(&priv->pscsem,  0, 0);
   nxmutex_init(&priv->lock);
 
-  /* The pscsem semaphore is used for signaling and, hence, should not have
-   * priority inheritance enabled.
-   */
-
-  nxsem_set_protocol(&priv->pscsem, SEM_PRIO_NONE);
-
   /* Initialize the driver state data */
 
   priv->smstate   = SMSTATE_DETACHED;
@@ -5292,13 +5286,7 @@ static inline void stm32l4_sw_initialize(struct stm32l4_usbhost_s *priv)
       struct stm32l4_chan_s *chan = &priv->chan[i];
 
       chan->chidx = i;
-
-      /* The waitsem semaphore is used for signaling and, hence, should not
-       * have priority inheritance enabled.
-       */
-
       nxsem_init(&chan->waitsem,  0, 0);
-      nxsem_set_protocol(&chan->waitsem, SEM_PRIO_NONE);
     }
 }
 

--- a/arch/arm/src/stm32l4/stm32l4_qspi.c
+++ b/arch/arm/src/stm32l4/stm32l4_qspi.c
@@ -2518,13 +2518,7 @@ struct qspi_dev_s *stm32l4_qspi_initialize(int intf)
             }
         }
 
-      /* Initialize the QSPI semaphore that is used to wake up the waiting
-       * thread when the DMA transfer completes.  This semaphore is used for
-       * signaling and, hence, should not have priority inheritance enabled.
-       */
-
       nxsem_init(&priv->dmawait, 0, 0);
-      nxsem_set_protocol(&priv->dmawait, SEM_PRIO_NONE);
 #endif
 
 #ifdef STM32L4_QSPI_INTERRUPTS
@@ -2537,13 +2531,7 @@ struct qspi_dev_s *stm32l4_qspi_initialize(int intf)
           goto errout_with_dmawait;
         }
 
-      /* Initialize the semaphore that blocks until the operation completes.
-       * This semaphore is used for signaling and, hence, should not have
-       * priority inheritance enabled.
-       */
-
       nxsem_init(&priv->op_sem, 0, 0);
-      nxsem_set_protocol(&priv->op_sem, SEM_PRIO_NONE);
 #endif
 
       /* Perform hardware initialization.  Puts the QSPI into an active

--- a/arch/arm/src/stm32l4/stm32l4_rng.c
+++ b/arch/arm/src/stm32l4/stm32l4_rng.c
@@ -245,14 +245,7 @@ static ssize_t stm32l4_rngread(struct file *filep,
 
   /* We've got the device semaphore, proceed with reading */
 
-  /* Initialize the operation semaphore with 0 for blocking until the
-   * buffer is filled from interrupts.  The readsem semaphore is used
-   * for signaling and, hence, should not have priority inheritance
-   * enabled.
-   */
-
   nxsem_init(&g_rngdev.rd_readsem, 0, 0);
-  nxsem_set_protocol(&g_rngdev.rd_readsem, SEM_PRIO_NONE);
 
   g_rngdev.rd_buflen = buflen;
   g_rngdev.rd_buf = buffer;

--- a/arch/arm/src/stm32l4/stm32l4_sdmmc.c
+++ b/arch/arm/src/stm32l4/stm32l4_sdmmc.c
@@ -3123,12 +3123,6 @@ struct sdio_dev_s *sdio_initialize(int slotno)
 
   nxsem_init(&priv->waitsem, 0, 0);
 
-  /* The waitsem semaphore is used for signaling and, hence, should not have
-   * priority inheritance enabled.
-   */
-
-  nxsem_set_protocol(&priv->waitsem, SEM_PRIO_NONE);
-
 #ifdef CONFIG_STM32L4_SDMMC_DMA
   /* Allocate a DMA channel */
 

--- a/arch/arm/src/stm32l4/stm32l4_spi.c
+++ b/arch/arm/src/stm32l4/stm32l4_spi.c
@@ -1755,13 +1755,6 @@ static void spi_bus_initialize(struct stm32l4_spidev_s *priv)
   nxsem_init(&priv->rxsem, 0, 0);
   nxsem_init(&priv->txsem, 0, 0);
 
-  /* These semaphores are used for signaling and, hence, should not have
-   * priority inheritance enabled.
-   */
-
-  nxsem_set_protocol(&priv->rxsem, SEM_PRIO_NONE);
-  nxsem_set_protocol(&priv->txsem, SEM_PRIO_NONE);
-
   /* Get DMA channels.  NOTE: stm32l4_dmachannel() will always assign the DMA
    * channel.  If the channel is not available, then stm32l4_dmachannel()
    * will block and wait until the channel becomes available.  WARNING: If

--- a/arch/arm/src/stm32u5/stm32_spi.c
+++ b/arch/arm/src/stm32u5/stm32_spi.c
@@ -2244,16 +2244,8 @@ static void spi_bus_initialize(struct stm32_spidev_s *priv)
   nxmutex_init(&priv->lock);
 
 #ifdef CONFIG_STM32U5_SPI_DMA
-  /* Initialize the SPI semaphores that is used to wait for DMA completion.
-   * This semaphore is used for signaling and, hence, should not have
-   * priority inheritance enabled.
-   */
-
   nxsem_init(&priv->rxsem, 0, 0);
   nxsem_init(&priv->txsem, 0, 0);
-
-  nxsem_set_protocol(&priv->rxsem, SEM_PRIO_NONE);
-  nxsem_set_protocol(&priv->txsem, SEM_PRIO_NONE);
 
   /* Get DMA channels.  NOTE: stm32_dmachannel() will always assign the DMA
    * channel.  If the channel is not available, then stm32_dmachannel() will

--- a/arch/arm/src/stm32wb/stm32wb_spi.c
+++ b/arch/arm/src/stm32wb/stm32wb_spi.c
@@ -1690,13 +1690,6 @@ static void spi_bus_initialize(struct stm32wb_spidev_s *priv)
   nxsem_init(&priv->rxsem, 0, 0);
   nxsem_init(&priv->txsem, 0, 0);
 
-  /* These semaphores are used for signaling and, hence, should not have
-   * priority inheritance enabled.
-   */
-
-  nxsem_set_protocol(&priv->rxsem, SEM_PRIO_NONE);
-  nxsem_set_protocol(&priv->txsem, SEM_PRIO_NONE);
-
   /* Get DMA channels.  NOTE: stm32wb_dmachannel() will always assign the DMA
    * channel.  If the channel is not available, then stm32wb_dmachannel()
    * will block and wait until the channel becomes available.  WARNING: If

--- a/arch/arm/src/stm32wl5/stm32wl5_spi.c
+++ b/arch/arm/src/stm32wl5/stm32wl5_spi.c
@@ -1733,18 +1733,10 @@ static void spi_bus_initialize(struct stm32wl5_spidev_s *priv)
   nxmutex_init(&priv->lock);
 
 #ifdef CONFIG_STM32WL5_SPI_DMA
-  /* Initialize the SPI semaphores that is used to wait for DMA completion.
-   * This semaphore is used for signaling and, hence, should not have
-   * priority inheritance enabled.
-   */
-
   if (priv->rxch && priv->txch)
     {
       nxsem_init(&priv->rxsem, 0, 0);
       nxsem_init(&priv->txsem, 0, 0);
-
-      nxsem_set_protocol(&priv->rxsem, SEM_PRIO_NONE);
-      nxsem_set_protocol(&priv->txsem, SEM_PRIO_NONE);
 
       /* Get DMA channels.  NOTE: stm32wl5_dmachannel() will always assign
        * the DMA channel.  If the channel is not available, then

--- a/arch/arm/src/tiva/common/tiva_hciuart.c
+++ b/arch/arm/src/tiva/common/tiva_hciuart.c
@@ -1846,10 +1846,7 @@ void hciuart_initialize(void)
           /* Initialize signalling semaphores */
 
           nxsem_init(&state->rxwait, 0, 0);
-          nxsem_set_protocol(&state->rxwait, SEM_PRIO_NONE);
-
           nxsem_init(&state->txwait, 0, 0);
-          nxsem_set_protocol(&state->txwait, SEM_PRIO_NONE);
 
           /* Attach and enable the HCI UART IRQ */
 

--- a/arch/arm/src/tiva/common/tiva_ssi.c
+++ b/arch/arm/src/tiva/common/tiva_ssi.c
@@ -1599,12 +1599,7 @@ struct spi_dev_s *tiva_ssibus_initialize(int port)
   /* Initialize the state structure */
 
 #ifndef CONFIG_SSI_POLLWAIT
-  /* The xfrsem semaphore is used for signaling and, hence, should not have
-   * priority inheritance enabled.
-   */
-
   nxsem_init(&priv->xfrsem, 0, 0);
-  nxsem_set_protocol(&priv->xfrsem, SEM_PRIO_NONE);
 #endif
   nxmutex_init(&priv->lock);
 

--- a/arch/arm/src/xmc4/xmc4_spi.c
+++ b/arch/arm/src/xmc4/xmc4_spi.c
@@ -2065,14 +2065,7 @@ struct spi_dev_s *xmc4_spibus_initialize(int channel)
       spi->initialized = true;
 
 #ifdef CONFIG_XMC4_SPI_DMA
-
-      /* Initialize the SPI semaphore that is used to wake up the waiting
-       * thread when the DMA transfer completes.  This semaphore is used for
-       * signaling and, hence, should not have priority inheritance enabled.
-       */
-
       nxsem_init(&spics->dmawait, 0, 0);
-      nxsem_set_protocol(&spics->dmawait, SEM_PRIO_NONE);
 #endif
 
       spi_dumpregs(spi, "After initialization");

--- a/arch/mips/src/pic32mz/pic32mz_spi.c
+++ b/arch/mips/src/pic32mz/pic32mz_spi.c
@@ -2016,12 +2016,7 @@ struct spi_dev_s *pic32mz_spibus_initialize(int port)
       spierr("ERROR: Failed to allocate the TX DMA channel\n");
     }
 
-  /* Initialize the SPI semaphore. This semaphore is used for signaling and,
-   * hence, should not have priority inheritance enabled.
-   */
-
   nxsem_init(&priv->dmawait, 0, 0);
-  nxsem_set_protocol(&priv->dmawait, SEM_PRIO_NONE);
 #endif
 
 #ifdef CONFIG_PIC32MZ_SPI_INTERRUPTS

--- a/arch/renesas/src/rx65n/rx65n_rspi.c
+++ b/arch/renesas/src/rx65n/rx65n_rspi.c
@@ -2213,26 +2213,13 @@ static void rspi_bus_initialize(FAR struct rx65n_rspidev_s *priv)
 
 #ifdef CONFIG_RX65N_RSPI_SW_DT_MODE
 #ifndef CONFIG_SPI_POLLWAIT
-  /* Initialize the semaphore that is used to wake up the waiting
-   * thread when the transfer completes.  This semaphore is used for
-   * signaling and, hence, should not have priority inheritance enabled.
-   */
-
   nxsem_init(&priv->waitsem, 0, 0);
-  nxsem_set_protocol(&priv->waitsem, SEM_PRIO_NONE);
 #endif
 #elif defined(CONFIG_RX65N_RSPI_DTC_DT_MODE)
   /* Initialize the SPI semaphores that is used to wait for DTC completion */
 
   nxsem_init(&priv->rxsem, 0, 0);
   nxsem_init(&priv->txsem, 0, 0);
-
-  /* These semaphores are used for signaling and, hence, should not have
-   * priority inheritance enabled.
-   */
-
-  nxsem_set_protocol(&priv->rxsem, SEM_PRIO_NONE);
-  nxsem_set_protocol(&priv->txsem, SEM_PRIO_NONE);
 
   /* Prepare Transmit and receive parameter */
 

--- a/arch/renesas/src/rx65n/rx65n_rspi_sw.c
+++ b/arch/renesas/src/rx65n/rx65n_rspi_sw.c
@@ -1844,13 +1844,7 @@ static void rspi_bus_initialize(FAR struct rx65n_rspidev_s *priv)
   uint16_t regval16;
 
 #ifndef CONFIG_SPI_POLLWAIT
-  /* Initialize the semaphore that is used to wake up the waiting
-   * thread when the transfer completes.  This semaphore is used for
-   * signaling and, hence, should not have priority inheritance enabled.
-   */
-
   nxsem_init(&priv->waitsem, 0, 0);
-  nxsem_set_protocol(&priv->waitsem, SEM_PRIO_NONE);
 #endif
   nxmutex_init(&priv->lock);
 

--- a/arch/renesas/src/rx65n/rx65n_usbhost.c
+++ b/arch/renesas/src/rx65n/rx65n_usbhost.c
@@ -6730,14 +6730,7 @@ static int rx65n_usbhost_epalloc(struct usbhost_driver_s *drvr,
       /* Special Case isochronous transfer types */
 
       uinfo("EP%d CTRL:%08x\n", epdesc->addr, ed->hw.ctrl);
-
-      /* Initialize the semaphore that is used to wait for the endpoint
-       * WDH event. The wdhsem semaphore is used for signaling and, hence,
-       * should not have priority inheritance enabled.
-       */
-
       nxsem_init(&ed->wdhsem, 0, 0);
-      nxsem_set_protocol(&ed->wdhsem, SEM_PRIO_NONE);
 
       /* Link the common tail TD to the ED's TD list */
 
@@ -8372,12 +8365,6 @@ struct usbhost_connection_s *rx65n_usbhost_initialize(int controller)
   nxsem_init(&priv->pscsem,  0, 0);
   nxmutex_lock(&priv->lock);
 
-  /* The pscsem semaphore is used for signaling and, hence, should not have
-   * priority inheritance enabled.
-   */
-
-  nxsem_set_protocol(&priv->pscsem, SEM_PRIO_NONE);
-
 #ifndef CONFIG_USBHOST_INT_DISABLE
   priv->ininterval  = MAX_PERINTERVAL;
   priv->outinterval = MAX_PERINTERVAL;
@@ -8413,13 +8400,7 @@ struct usbhost_connection_s *rx65n_usbhost_initialize(int controller)
   up_mdelay(100);
 
   leave_critical_section(flags);
-
-  /* The EDCTRL wdhsem semaphore is used for signaling and, hence, should
-   * not have priority inheritance enabled.
-   */
-
   nxsem_init(&EDCTRL->wdhsem, 0, 0);
-  nxsem_set_protocol(&EDCTRL->wdhsem, SEM_PRIO_NONE);
 
   /* Initialize user-configurable EDs */
 

--- a/arch/risc-v/src/esp32c3/esp32c3_wifi_utils.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_wifi_utils.c
@@ -590,11 +590,5 @@ int esp_wifi_scan_init(void)
       return ret;
     }
 
-  if ((ret = nxsem_set_protocol(&scan_priv->scan_signal,
-                                SEM_PRIO_NONE)) != OK)
-    {
-      wlerr("ERROR: Set semaphore protocol attribute failed: %d\n", ret);
-    }
-
   return ret;
 }

--- a/arch/risc-v/src/litex/litex_sdio.c
+++ b/arch/risc-v/src/litex/litex_sdio.c
@@ -1443,7 +1443,6 @@ struct sdio_dev_s *sdio_initialize(int slotno)
   mcinfo("slotno: %d\n", slotno);
 
   nxsem_init(&priv->waitsem, 0, 0);
-  nxsem_set_protocol(&priv->waitsem, SEM_PRIO_NONE);
 
   litex_reset(&priv->dev);
   return &g_sdiodev.dev;

--- a/arch/risc-v/src/mpfs/mpfs_emmcsd.c
+++ b/arch/risc-v/src/mpfs/mpfs_emmcsd.c
@@ -2956,12 +2956,6 @@ struct sdio_dev_s *sdio_initialize(int slotno)
 
   nxsem_init(&priv->waitsem, 0, 0);
 
-  /* The waitsem semaphore is used for signaling and, hence, should not have
-   * priority inheritance enabled.
-   */
-
-  nxsem_set_protocol(&priv->waitsem, SEM_PRIO_NONE);
-
   /* Reset the card and assure that it is in the initial, unconfigured
    * state.
    */

--- a/arch/xtensa/src/esp32/esp32_wifi_utils.c
+++ b/arch/xtensa/src/esp32/esp32_wifi_utils.c
@@ -572,11 +572,5 @@ int esp_wifi_scan_init(void)
       return ret;
     }
 
-  if ((ret = nxsem_set_protocol(&scan_priv->scan_signal,
-                                SEM_PRIO_NONE)) != OK)
-    {
-      wlerr("ERROR: Set semaphore protocol attribute failed: %d\n", ret);
-    }
-
   return ret;
 }

--- a/boards/arm/cxd56xx/common/src/cxd56_imageproc.c
+++ b/boards/arm/cxd56xx/common/src/cxd56_imageproc.c
@@ -520,7 +520,6 @@ void imageproc_initialize(void)
   nxsem_init(&g_rotwait, 0, 0);
   nxmutex_init(&g_gelock);
   nxmutex_init(&g_ablock);
-  nxsem_set_protocol(&g_rotwait, SEM_PRIO_NONE);
 
   cxd56_ge2dinitialize(GEDEVNAME);
 

--- a/drivers/analog/adc.c
+++ b/drivers/analog/adc.c
@@ -678,12 +678,6 @@ int adc_register(FAR const char *path, FAR struct adc_dev_s *dev)
   nxsem_init(&dev->ad_recv.af_sem, 0, 0);
   nxmutex_init(&dev->ad_closelock);
 
-  /* The receive semaphore is used for signaling and, hence, should not have
-   * priority inheritance enabled.
-   */
-
-  nxsem_set_protocol(&dev->ad_recv.af_sem, SEM_PRIO_NONE);
-
   /* Reset the ADC hardware */
 
   DEBUGASSERT(dev->ad_ops->ao_reset != NULL);

--- a/drivers/analog/comp.c
+++ b/drivers/analog/comp.c
@@ -352,7 +352,6 @@ int comp_register(FAR const char *path, FAR struct comp_dev_s *dev)
   nxmutex_init(&dev->ad_lock);
 
   nxsem_init(&dev->ad_readsem, 0, 0);
-  nxsem_set_protocol(&dev->ad_readsem, SEM_PRIO_NONE);
 
   /* Bind the upper-half callbacks to the lower half COMP driver */
 

--- a/drivers/analog/dac.c
+++ b/drivers/analog/dac.c
@@ -503,12 +503,6 @@ int dac_register(FAR const char *path, FAR struct dac_dev_s *dev)
   nxsem_init(&dev->ad_xmit.af_sem, 0, 0);
   nxmutex_init(&dev->ad_closelock);
 
-  /* The transmit semaphore is used for signaling and, hence, should not have
-   * priority inheritance enabled.
-   */
-
-  nxsem_set_protocol(&dev->ad_xmit.af_sem, SEM_PRIO_NONE);
-
   dev->ad_ops->ao_reset(dev);
 
   return register_driver(path, &dac_fops, 0222, dev);

--- a/drivers/can/can.c
+++ b/drivers/can/can.c
@@ -325,7 +325,6 @@ static FAR struct can_reader_s *init_can_reader(FAR struct file *filep)
   reader->fifo.rx_tail  = 0;
 
   nxsem_init(&reader->fifo.rx_sem, 0, 0);
-  nxsem_set_protocol(&reader->fifo.rx_sem, SEM_PRIO_NONE);
   filep->f_priv = reader;
 
   return reader;
@@ -1193,7 +1192,6 @@ int can_register(FAR const char *path, FAR struct can_dev_s *dev)
   /* Initialize semaphores */
 
   nxsem_init(&dev->cd_xmit.tx_sem, 0, 1);
-  nxsem_set_protocol(&dev->cd_xmit.tx_sem, SEM_PRIO_NONE);
   nxmutex_init(&dev->cd_closelock);
   nxmutex_init(&dev->cd_polllock);
 
@@ -1204,7 +1202,6 @@ int can_register(FAR const char *path, FAR struct can_dev_s *dev)
        */
 
       nxsem_init(&dev->cd_rtr[i].cr_sem, 0, 0);
-      nxsem_set_protocol(&dev->cd_rtr[i].cr_sem, SEM_PRIO_NONE);
     }
 
   /* Initialize/reset the CAN hardware */

--- a/drivers/clk/clk_rpmsg.c
+++ b/drivers/clk/clk_rpmsg.c
@@ -482,7 +482,6 @@ static int64_t clk_rpmsg_sendrecv(FAR struct rpmsg_endpoint *ept,
   msg->cookie   = (uintptr_t)&cookie;
 
   nxsem_init(&cookie.sem, 0, 0);
-  nxsem_set_protocol(&cookie.sem, SEM_PRIO_NONE);
   cookie.result  = -EIO;
 
   ret = rpmsg_send_nocopy(ept, msg, len);

--- a/drivers/input/ads7843e.c
+++ b/drivers/input/ads7843e.c
@@ -1144,12 +1144,6 @@ int ads7843e_register(FAR struct spi_dev_s *spi,
   nxmutex_init(&priv->devlock);      /* Initialize device structure mutex */
   nxsem_init(&priv->waitsem, 0, 0);  /* Initialize pen event wait semaphore */
 
-  /* The pen event semaphore is used for signaling and, hence, should not
-   * have priority inheritance enabled.
-   */
-
-  nxsem_set_protocol(&priv->waitsem, SEM_PRIO_NONE);
-
   /* Make sure that interrupts are disabled */
 
   config->clear(config);

--- a/drivers/input/ft5x06.c
+++ b/drivers/input/ft5x06.c
@@ -1126,12 +1126,6 @@ int ft5x06_register(FAR struct i2c_master_s *i2c,
   nxmutex_init(&priv->devlock);        /* Initialize device structure mutex */
   nxsem_init(&priv->waitsem, 0, 0);    /* Initialize pen event wait semaphore */
 
-  /* The event wait semaphore is used for signaling and, hence, should not
-   * have priority inheritance enabled.
-   */
-
-  nxsem_set_protocol(&priv->waitsem, SEM_PRIO_NONE);
-
 #ifdef CONFIG_FT5X06_POLLMODE
   /* Allocate a timer for polling the FT5x06 */
 

--- a/drivers/input/keyboard_upper.c
+++ b/drivers/input/keyboard_upper.c
@@ -147,7 +147,6 @@ static int keyboard_open(FAR struct file *filep)
 
   nxsem_init(&opriv->waitsem, 0, 0);
   nxmutex_init(&opriv->lock);
-  nxsem_set_protocol(&opriv->waitsem, SEM_PRIO_NONE);
   list_add_tail(&upper->head, &opriv->node);
   filep->f_priv = opriv;
 

--- a/drivers/input/max11802.c
+++ b/drivers/input/max11802.c
@@ -1137,12 +1137,6 @@ int max11802_register(FAR struct spi_dev_s *spi,
   nxmutex_init(&priv->devlock);     /* Initialize device structure mutex */
   nxsem_init(&priv->waitsem, 0, 0); /* Initialize pen event wait semaphore */
 
-  /* The pen event semaphore is used for signaling and, hence, should not
-   * have priority inheritance enabled.
-   */
-
-  nxsem_set_protocol(&priv->waitsem, SEM_PRIO_NONE);
-
   /* Make sure that interrupts are disabled */
 
   config->clear(config);

--- a/drivers/input/mxt.c
+++ b/drivers/input/mxt.c
@@ -1864,12 +1864,6 @@ int mxt_register(FAR struct i2c_master_s *i2c,
   nxmutex_init(&priv->devlock);     /* Initialize device mutex */
   nxsem_init(&priv->waitsem, 0, 0); /* Initialize event wait semaphore */
 
-  /* The event wait semaphore is used for signaling and, hence, should not
-   * have priority inheritance enabled.
-   */
-
-  nxsem_set_protocol(&priv->waitsem, SEM_PRIO_NONE);
-
   /* Make sure that interrupts are disabled */
 
   MXT_CLEAR(lower);

--- a/drivers/input/spq10kbd.c
+++ b/drivers/input/spq10kbd.c
@@ -1005,12 +1005,6 @@ int spq10kbd_register(FAR struct i2c_master_s *i2c,
   nxmutex_init(&priv->lock);   /* Initialize device mutex */
   nxsem_init(&priv->waitsem, 0, 0);
 
-  /* The waitsem semaphore is used for signaling and, hence, should
-   * not have priority inheritance enabled.
-   */
-
-  nxsem_set_protocol(&priv->waitsem, SEM_PRIO_NONE);
-
   config->clear(config);
   config->enable(config, false);
 

--- a/drivers/input/touchscreen_upper.c
+++ b/drivers/input/touchscreen_upper.c
@@ -136,7 +136,6 @@ static int touch_open(FAR struct file *filep)
 
   nxsem_init(&openpriv->waitsem, 0, 0);
   nxmutex_init(&openpriv->lock);
-  nxsem_set_protocol(&openpriv->waitsem, SEM_PRIO_NONE);
   list_add_tail(&upper->head, &openpriv->node);
 
   /* Save the buffer node pointer so that it can be used directly

--- a/drivers/input/tsc2007.c
+++ b/drivers/input/tsc2007.c
@@ -1224,12 +1224,6 @@ int tsc2007_register(FAR struct i2c_master_s *dev,
   nxmutex_init(&priv->devlock);     /* Initialize device structure mutex */
   nxsem_init(&priv->waitsem, 0, 0); /* Initialize pen event wait semaphore */
 
-  /* The event wait semaphore is used for signaling and, hence, should not
-   * have priority inheritance enabled.
-   */
-
-  nxsem_set_protocol(&priv->waitsem, SEM_PRIO_NONE);
-
   /* Make sure that interrupts are disabled */
 
   config->clear(config);

--- a/drivers/ioexpander/ioe_rpmsg.c
+++ b/drivers/ioexpander/ioe_rpmsg.c
@@ -269,7 +269,6 @@ static int ioe_rpmsg_sendrecv(FAR struct rpmsg_endpoint *ept,
     }
 
   nxsem_init(&cookie.sem, 0, 0);
-  nxsem_set_protocol(&cookie.sem, SEM_PRIO_NONE);
 
   msg->command = command;
   msg->result = -ENXIO;

--- a/drivers/misc/rpmsgdev.c
+++ b/drivers/misc/rpmsgdev.c
@@ -381,7 +381,6 @@ static ssize_t rpmsgdev_write(FAR struct file *filep, const char *buffer,
 
   memset(&cookie, 0, sizeof(cookie));
   nxsem_init(&cookie.sem, 0, 0);
-  nxsem_set_protocol(&cookie.sem, SEM_PRIO_NONE);
 
   while (written < buflen)
     {
@@ -679,7 +678,6 @@ static int rpmsgdev_send_recv(FAR struct rpmsgdev_s *priv,
 
   memset(&cookie, 0, sizeof(cookie));
   nxsem_init(&cookie.sem, 0, 0);
-  nxsem_set_protocol(&cookie.sem, SEM_PRIO_NONE);
 
   if (data != NULL)
     {
@@ -1034,7 +1032,6 @@ int rpmsgdev_register(FAR const char *remotecpu, FAR const char *remotepath,
   dev->remotepath = remotepath;
 
   nxsem_init(&dev->wait, 0, 0);
-  nxsem_set_protocol(&dev->wait, SEM_PRIO_NONE);
 
   /* Register the rpmsg callback */
 

--- a/drivers/motor/foc/foc_dev.c
+++ b/drivers/motor/foc/foc_dev.c
@@ -841,7 +841,6 @@ int foc_register(FAR const char *path, FAR struct foc_dev_s *dev)
 
   nxmutex_init(&dev->closelock);
   nxsem_init(&dev->statesem, 0, 0);
-  nxsem_set_protocol(&dev->statesem, SEM_PRIO_NONE);
 
   /* Register the FOC character driver */
 

--- a/drivers/mtd/rpmsgmtd.c
+++ b/drivers/mtd/rpmsgmtd.c
@@ -325,7 +325,6 @@ static ssize_t rpmsgmtd_bwrite(FAR struct mtd_dev_s *dev, off_t startblock,
 
   memset(&cookie, 0, sizeof(cookie));
   nxsem_init(&cookie.sem, 0, 0);
-  nxsem_set_protocol(&cookie.sem, SEM_PRIO_NONE);
 
   blocksize = priv->geo.blocksize;
   while (written < nblocks)
@@ -478,7 +477,6 @@ static ssize_t rpmsgmtd_write(FAR struct mtd_dev_s *dev, off_t offset,
 
   memset(&cookie, 0, sizeof(cookie));
   nxsem_init(&cookie.sem, 0, 0);
-  nxsem_set_protocol(&cookie.sem, SEM_PRIO_NONE);
 
   while (written < nbytes)
     {
@@ -683,7 +681,6 @@ static int rpmsgmtd_send_recv(FAR struct rpmsgmtd_s *priv,
 
   memset(&cookie, 0, sizeof(cookie));
   nxsem_init(&cookie.sem, 0, 0);
-  nxsem_set_protocol(&cookie.sem, SEM_PRIO_NONE);
 
   if (data != NULL)
     {
@@ -1072,7 +1069,6 @@ int rpmsgmtd_register(FAR const char *remotecpu, FAR const char *remotepath,
   dev->remotepath = remotepath;
 
   nxsem_init(&dev->wait, 0, 0);
-  nxsem_set_protocol(&dev->wait, SEM_PRIO_NONE);
   nxmutex_init(&dev->geolock);
 
   /* Register the rpmsg callback */

--- a/drivers/net/rpmsgdrv.c
+++ b/drivers/net/rpmsgdrv.c
@@ -665,7 +665,6 @@ static int net_rpmsg_drv_send_recv(FAR struct net_driver_s *dev,
   int ret;
 
   nxsem_init(&cookie.sem, 0, 0);
-  nxsem_set_protocol(&cookie.sem, SEM_PRIO_NONE);
 
   cookie.header   = header;
   header->command = command;

--- a/drivers/net/slip.c
+++ b/drivers/net/slip.c
@@ -945,7 +945,6 @@ int slip_initialize(int intf, FAR const char *devname)
   /* Initialize the wait semaphore */
 
   nxsem_init(&priv->waitsem, 0, 0);
-  nxsem_set_protocol(&priv->waitsem, SEM_PRIO_NONE);
 
   /* Start the SLIP receiver kernel thread */
 

--- a/drivers/net/tun.c
+++ b/drivers/net/tun.c
@@ -954,13 +954,6 @@ static int tun_dev_init(FAR struct tun_device_s *priv,
   nxsem_init(&priv->read_wait_sem, 0, 0);
   nxsem_init(&priv->write_wait_sem, 0, 0);
 
-  /* The wait semaphore is used for signaling and, hence, should not have
-   * priority inheritance enabled.
-   */
-
-  nxsem_set_protocol(&priv->read_wait_sem, SEM_PRIO_NONE);
-  nxsem_set_protocol(&priv->write_wait_sem, SEM_PRIO_NONE);
-
   /* Assign d_ifname if specified. */
 
   if (devfmt)

--- a/drivers/pipes/pipe_common.c
+++ b/drivers/pipes/pipe_common.c
@@ -85,14 +85,6 @@ FAR struct pipe_dev_s *pipecommon_allocdev(size_t bufsize)
       nxmutex_init(&dev->d_bflock);
       nxsem_init(&dev->d_rdsem, 0, 0);
       nxsem_init(&dev->d_wrsem, 0, 0);
-
-      /* The read/write wait semaphores are used for signaling and, hence,
-       * should not have priority inheritance enabled.
-       */
-
-      nxsem_set_protocol(&dev->d_rdsem, SEM_PRIO_NONE);
-      nxsem_set_protocol(&dev->d_wrsem, SEM_PRIO_NONE);
-
       dev->d_bufsize = bufsize + 1; /* +1 to compensate the full indicator */
     }
 

--- a/drivers/power/battery/battery_charger.c
+++ b/drivers/power/battery/battery_charger.c
@@ -164,7 +164,6 @@ static int bat_charger_open(FAR struct file *filep)
 
   nxmutex_init(&priv->lock);
   nxsem_init(&priv->wait, 0, 0);
-  nxsem_set_protocol(&priv->wait, SEM_PRIO_NONE);
   priv->mask = dev->mask;
   list_add_tail(&dev->flist, &priv->node);
   nxmutex_unlock(&dev->batlock);

--- a/drivers/power/battery/battery_gauge.c
+++ b/drivers/power/battery/battery_gauge.c
@@ -166,7 +166,6 @@ static int bat_gauge_open(FAR struct file *filep)
 
   nxmutex_init(&priv->lock);
   nxsem_init(&priv->wait, 0, 0);
-  nxsem_set_protocol(&priv->wait, SEM_PRIO_NONE);
   priv->mask = dev->mask;
   list_add_tail(&dev->flist, &priv->node);
   nxmutex_unlock(&dev->batlock);

--- a/drivers/power/battery/battery_monitor.c
+++ b/drivers/power/battery/battery_monitor.c
@@ -165,7 +165,6 @@ static int bat_monitor_open(FAR struct file *filep)
 
   nxmutex_init(&priv->lock);
   nxsem_init(&priv->wait, 0, 0);
-  nxsem_set_protocol(&priv->wait, SEM_PRIO_NONE);
   priv->mask = dev->mask;
   list_add_tail(&dev->flist, &priv->node);
   nxmutex_unlock(&dev->batlock);

--- a/drivers/power/supply/regulator_rpmsg.c
+++ b/drivers/power/supply/regulator_rpmsg.c
@@ -488,7 +488,6 @@ static int regulator_rpmsg_sendrecv(FAR struct rpmsg_endpoint *ept,
   int ret;
 
   nxsem_init(&cookie.sem, 0, 0);
-  nxsem_set_protocol(&cookie.sem, SEM_PRIO_NONE);
 
   msg->command = command;
   msg->response = 0;

--- a/drivers/rc/lirc_dev.c
+++ b/drivers/rc/lirc_dev.c
@@ -154,7 +154,6 @@ static int lirc_open(FAR struct file *filep)
     }
 
   nxsem_init(&fh->waitsem, 0, 0);
-  nxsem_set_protocol(&fh->waitsem, SEM_PRIO_NONE);
 
   fh->lower = lower;
   fh->send_timeout_reports = true;

--- a/drivers/rptun/rptun.c
+++ b/drivers/rptun/rptun.c
@@ -1220,8 +1220,6 @@ int rptun_initialize(FAR struct rptun_dev_s *dev)
       nxsem_init(&priv->semrx, 0, 0);
     }
 
-  nxsem_set_protocol(&priv->semrx, SEM_PRIO_NONE);
-
   snprintf(arg1, sizeof(arg1), "0x%" PRIxPTR, (uintptr_t)priv);
   argv[0] = (void *)RPTUN_GET_CPUNAME(dev);
   argv[1] = arg1;
@@ -1238,7 +1236,6 @@ int rptun_initialize(FAR struct rptun_dev_s *dev)
 #endif
 
   nxsem_init(&priv->semtx, 0, 0);
-  nxsem_set_protocol(&priv->semtx, SEM_PRIO_NONE);
 
   return OK;
 

--- a/drivers/rptun/rptun_ping.c
+++ b/drivers/rptun/rptun_ping.c
@@ -109,7 +109,6 @@ static int rptun_ping_once(FAR struct rpmsg_endpoint *ept,
       msg->cookie = (uintptr_t)&sem;
 
       nxsem_init(&sem, 0, 0);
-      nxsem_set_protocol(&sem, SEM_PRIO_NONE);
 
       ret = rpmsg_send_nocopy(ept, msg, len);
       if (ret >= 0)

--- a/drivers/sensors/ds18b20.c
+++ b/drivers/sensors/ds18b20.c
@@ -949,7 +949,6 @@ int ds18b20_register(int devno, FAR struct onewire_master_s *onewire,
   priv->interval         = CONFIG_SENSORS_DS18B20_POLL_INTERVAL;
 
   nxsem_init(&priv->run, 0, 0);
-  nxsem_set_protocol(&priv->run, SEM_PRIO_NONE);
 #endif
 
   /* Temperature register */

--- a/drivers/sensors/fakesensor.c
+++ b/drivers/sensors/fakesensor.c
@@ -403,7 +403,6 @@ int fakesensor_init(int type, FAR const char *file_name,
   sensor->file_path = file_name;
 
   nxsem_init(&sensor->wakeup, 0, 0);
-  nxsem_set_protocol(&sensor->wakeup, SEM_PRIO_NONE);
 
   /* Create thread for sensor */
 

--- a/drivers/sensors/hyt271.c
+++ b/drivers/sensors/hyt271.c
@@ -914,7 +914,6 @@ int hyt271_register(int devno, FAR struct i2c_master_s *i2c, uint8_t addr,
   nxmutex_init(&priv->lock_measure_cycle);
 #ifdef CONFIG_SENSORS_HYT271_POLL
   nxsem_init(&priv->run, 0, 0);
-  nxsem_set_protocol(&priv->run, SEM_PRIO_NONE);
 #endif
 
   /* Humidity register */

--- a/drivers/sensors/lis3dh.c
+++ b/drivers/sensors/lis3dh.c
@@ -971,7 +971,6 @@ int lis3dh_register(FAR const char *devpath, FAR struct spi_dev_s *spi,
   /* Initialize read notification semaphore */
 
   nxsem_init(&priv->readsem, 0, 0);
-  nxsem_set_protocol(&priv->readsem, SEM_PRIO_NONE);
 
   /* Setup SPI frequency and mode */
 

--- a/drivers/sensors/sensor.c
+++ b/drivers/sensors/sensor.c
@@ -569,7 +569,6 @@ static int sensor_open(FAR struct file *filep)
   user->state.interval = ULONG_MAX;
   user->state.esize = upper->state.esize;
   nxsem_init(&user->buffersem, 0, 0);
-  nxsem_set_protocol(&user->buffersem, SEM_PRIO_NONE);
   list_add_tail(&upper->userlist, &user->node);
 
   /* The new user generation, notify to other users */

--- a/drivers/sensors/sensor_rpmsg.c
+++ b/drivers/sensors/sensor_rpmsg.c
@@ -357,7 +357,6 @@ static int sensor_rpmsg_ioctl(FAR struct sensor_rpmsg_dev_s *dev,
       cookie.data   = (FAR void *)(uintptr_t)arg;
       cookie.result = -ENXIO;
       nxsem_init(&cookie.sem, 0, 0);
-      nxsem_set_protocol(&cookie.sem, SEM_PRIO_NONE);
     }
 
   /* All control is always send to own proxy(remote advertisers),

--- a/drivers/serial/pty.c
+++ b/drivers/serial/pty.c
@@ -953,12 +953,6 @@ int pty_register2(int minor, bool susv1)
   nxsem_init(&devpair->pp_slavesem, 0, 0);
   nxmutex_init(&devpair->pp_lock);
 
-  /* The pp_slavesem semaphore is used for signaling and, hence, should not
-   * have priority inheritance enabled.
-   */
-
-  nxsem_set_protocol(&devpair->pp_slavesem, SEM_PRIO_NONE);
-
   devpair->pp_susv1             = susv1;
   devpair->pp_minor             = minor;
   devpair->pp_locked            = true;

--- a/drivers/serial/serial.c
+++ b/drivers/serial/serial.c
@@ -1668,13 +1668,6 @@ int uart_register(FAR const char *path, FAR uart_dev_t *dev)
   nxsem_init(&dev->recvsem,  0, 0);
   nxmutex_init(&dev->polllock);
 
-  /* The recvsem and xmitsem are used for signaling and, hence, should
-   * not have priority inheritance enabled.
-   */
-
-  nxsem_set_protocol(&dev->xmitsem, SEM_PRIO_NONE);
-  nxsem_set_protocol(&dev->recvsem, SEM_PRIO_NONE);
-
   /* Register the serial driver */
 
   sinfo("Registering %s\n", path);

--- a/drivers/serial/uart_bth4.c
+++ b/drivers/serial/uart_bth4.c
@@ -439,8 +439,6 @@ int uart_bth4_register(FAR const char *path, FAR struct bt_driver_s *drv)
   nxmutex_init(&dev->sendlock);
   nxsem_init(&dev->recvsem,  0, 0);
 
-  nxsem_set_protocol(&dev->recvsem, SEM_PRIO_NONE);
-
   ret = register_driver(path, &g_uart_bth4_ops, 0666, dev);
   if (ret < 0)
     {

--- a/drivers/syslog/ramlog.c
+++ b/drivers/syslog/ramlog.c
@@ -790,12 +790,6 @@ int ramlog_register(FAR const char *devpath, FAR char *buffer, size_t buflen)
       nxmutex_init(&priv->rl_lock);
 #ifndef CONFIG_RAMLOG_NONBLOCKING
       nxsem_init(&priv->rl_waitsem, 0, 0);
-
-      /* The rl_waitsem semaphore is used for signaling and, hence, should
-       * not have priority inheritance enabled.
-       */
-
-      nxsem_set_protocol(&priv->rl_waitsem, SEM_PRIO_NONE);
 #endif
 
       priv->rl_bufsize = buflen;

--- a/drivers/syslog/syslog_rpmsg_server.c
+++ b/drivers/syslog/syslog_rpmsg_server.c
@@ -117,8 +117,6 @@ static int syslog_rpmsg_file_ioctl(FAR struct file *filep, int cmd,
     }
 
   nxsem_init(&sem, 0, 0);
-  nxsem_set_protocol(&sem, SEM_PRIO_NONE);
-
   nxmutex_lock(&g_lock);
   list_for_every_entry(&g_list, priv, struct syslog_rpmsg_server_s, node)
     {

--- a/drivers/timers/pwm.c
+++ b/drivers/timers/pwm.c
@@ -606,12 +606,6 @@ int pwm_register(FAR const char *path, FAR struct pwm_lowerhalf_s *dev)
   nxmutex_init(&upper->lock);
 #ifdef CONFIG_PWM_PULSECOUNT
   nxsem_init(&upper->waitsem, 0, 0);
-
-  /* The wait semaphore is used for signaling and, hence, should not have
-   * priority inheritance enabled.
-   */
-
-  nxsem_set_protocol(&upper->waitsem, SEM_PRIO_NONE);
 #endif
 
   upper->dev = dev;

--- a/drivers/timers/rpmsg_rtc.c
+++ b/drivers/timers/rpmsg_rtc.c
@@ -328,7 +328,6 @@ static int rpmsg_rtc_send_recv(FAR struct rpmsg_rtc_lowerhalf_s *lower,
   int ret;
 
   nxsem_init(&cookie.sem, 0, 0);
-  nxsem_set_protocol(&cookie.sem, SEM_PRIO_NONE);
   cookie.msg = msg;
 
   msg->command = command;

--- a/drivers/usbdev/adb.c
+++ b/drivers/usbdev/adb.c
@@ -1723,7 +1723,6 @@ static ssize_t adb_char_read(FAR struct file *filep, FAR char *buffer,
 
       adb_char_waiter_sem_t sem;
       nxsem_init(&sem.sem, 0, 0);
-      nxsem_set_protocol(&sem.sem, SEM_PRIO_NONE);
 
       do
         {
@@ -1849,7 +1848,6 @@ static ssize_t adb_char_write(FAR struct file *filep,
 
       adb_char_waiter_sem_t sem;
       nxsem_init(&sem.sem, 0, 0);
-      nxsem_set_protocol(&sem.sem, SEM_PRIO_NONE);
 
       do
         {

--- a/drivers/usbdev/usbmsc.c
+++ b/drivers/usbdev/usbmsc.c
@@ -1332,13 +1332,6 @@ int usbmsc_configure(unsigned int nluns, void **handle)
   nxmutex_init(&priv->thlock);
   nxsem_init(&priv->thwaitsem, 0, 0);
 
-  /* The thsynch and thwaitsem semaphores are used for signaling and, hence,
-   * should not have priority inheritance enabled.
-   */
-
-  nxsem_set_protocol(&priv->thsynch, SEM_PRIO_NONE);
-  nxsem_set_protocol(&priv->thwaitsem, SEM_PRIO_NONE);
-
   sq_init(&priv->wrreqlist);
   priv->nluns = nluns;
 

--- a/drivers/usbhost/usbhost_hidkbd.c
+++ b/drivers/usbhost/usbhost_hidkbd.c
@@ -1920,12 +1920,6 @@ static FAR struct usbhost_class_s *
           nxmutex_init(&priv->lock);
           nxsem_init(&priv->waitsem, 0, 0);
 
-          /* The waitsem semaphore is used for signaling and, hence, should
-           * not have priority inheritance enabled.
-           */
-
-          nxsem_set_protocol(&priv->waitsem, SEM_PRIO_NONE);
-
           /* Return the instance of the USB keyboard class driver */
 
           return &priv->usbclass;
@@ -2505,12 +2499,6 @@ int usbhost_kbdinit(void)
 
   nxmutex_init(&g_lock);
   nxsem_init(&g_syncsem, 0, 0);
-
-  /* The g_syncsem semaphore is used for signaling and, hence, should not
-   * have priority inheritance enabled.
-   */
-
-  nxsem_set_protocol(&g_syncsem, SEM_PRIO_NONE);
 
   /* Advertise our availability to support (certain) devices */
 

--- a/drivers/usbhost/usbhost_hidmouse.c
+++ b/drivers/usbhost/usbhost_hidmouse.c
@@ -1873,12 +1873,6 @@ static FAR struct usbhost_class_s *
           nxmutex_init(&priv->lock);
           nxsem_init(&priv->waitsem, 0, 0);
 
-          /* The waitsem semaphore is used for signaling and, hence, should
-           * not have priority inheritance enabled.
-           */
-
-          nxsem_set_protocol(&priv->waitsem, SEM_PRIO_NONE);
-
           /* Return the instance of the USB mouse class driver */
 
           return &priv->usbclass;
@@ -2520,12 +2514,6 @@ int usbhost_mouse_init(void)
 
   nxmutex_init(&g_lock);
   nxsem_init(&g_syncsem, 0, 0);
-
-  /* The g_syncsem semaphore is used for signaling and, hence, should not
-   * have priority inheritance enabled.
-   */
-
-  nxsem_set_protocol(&g_syncsem, SEM_PRIO_NONE);
 
   /* Advertise our availability to support (certain) mouse devices */
 

--- a/drivers/usbhost/usbhost_max3421e.c
+++ b/drivers/usbhost/usbhost_max3421e.c
@@ -4703,14 +4703,6 @@ static inline int max3421e_sw_initialize(FAR struct max3421e_usbhost_s *priv,
 
   nxrmutex_init(&priv->lock);
 
-  /* The pscsem and waitsem semaphores are used for signaling and, hence,
-   * should not have
-   * priority inheritance enabled.
-   */
-
-  nxsem_set_protocol(&priv->pscsem, SEM_PRIO_NONE);
-  nxsem_set_protocol(&priv->waitsem, SEM_PRIO_NONE);
-
   /* Initialize the driver state data */
 
   priv->lower     = lower;

--- a/drivers/usbhost/usbhost_xboxcontroller.c
+++ b/drivers/usbhost/usbhost_xboxcontroller.c
@@ -1599,12 +1599,6 @@ static FAR struct usbhost_class_s *
           nxmutex_init(&priv->lock);
           nxsem_init(&priv->waitsem, 0, 0);
 
-          /* The waitsem semaphore is used for signaling and, hence, should
-           * not have priority inheritance enabled.
-           */
-
-          nxsem_set_protocol(&priv->waitsem, SEM_PRIO_NONE);
-
           /* Return the instance of the USB class driver */
 
           return &priv->usbclass;
@@ -2259,12 +2253,6 @@ int usbhost_xboxcontroller_init(void)
 
   nxmutex_init(&g_lock);
   nxsem_init(&g_syncsem, 0, 0);
-
-  /* The g_syncsem semaphore is used for signaling and, hence, should not
-   * have priority inheritance enabled.
-   */
-
-  nxsem_set_protocol(&g_syncsem, SEM_PRIO_NONE);
 
   /* Advertise our availability to support (certain) devices */
 

--- a/drivers/video/vnc/vnc_server.c
+++ b/drivers/video/vnc/vnc_server.c
@@ -281,7 +281,6 @@ int vnc_server(int argc, FAR char *argv[])
 
 #ifdef CONFIG_FB_SYNC
   nxsem_init(&session->vsyncsem, 0, 0);
-  nxsem_set_protocol(&session->vsyncsem, SEM_PRIO_NONE);
 #endif
 
   /* Inform any waiter that we have started */

--- a/drivers/wireless/bluetooth/bt_uart_bcm4343x.c
+++ b/drivers/wireless/bluetooth/bt_uart_bcm4343x.c
@@ -278,7 +278,6 @@ static int load_bcm4343x_firmware(FAR const struct btuart_lowerhalf_s *lower)
   lower->rxenable(lower, true);
 
   nxsem_init(&rxsem, 0, 0);
-  nxsem_set_protocol(&rxsem, SEM_PRIO_NONE);
 
   /* It is possible this could fail if modem is already at high speed, so we
    * can safely ignore error return value.

--- a/drivers/wireless/ieee80211/bcm43xxx/bcmf_driver.c
+++ b/drivers/wireless/ieee80211/bcm43xxx/bcmf_driver.c
@@ -972,20 +972,9 @@ FAR struct bcmf_dev_s *bcmf_allocate_device(void)
       goto exit_free_priv;
     }
 
-  if ((ret = nxsem_set_protocol(&priv->control_timeout, SEM_PRIO_NONE)) !=
-      OK)
-    {
-      goto exit_free_priv;
-    }
-
   /* Init authentication signal semaphore */
 
   if ((ret = nxsem_init(&priv->auth_signal, 0, 0)) != OK)
-    {
-      goto exit_free_priv;
-    }
-
-  if ((ret = nxsem_set_protocol(&priv->auth_signal, SEM_PRIO_NONE)) != OK)
     {
       goto exit_free_priv;
     }

--- a/drivers/wireless/ieee80211/bcm43xxx/bcmf_gspi.c
+++ b/drivers/wireless/ieee80211/bcm43xxx/bcmf_gspi.c
@@ -875,11 +875,6 @@ static int bcmf_bus_gspi_initialize(FAR struct bcmf_dev_s  *priv,
       goto exit_free_bus;
     }
 
-  if ((ret = nxsem_set_protocol(&gbus->thread_signal, SEM_PRIO_NONE)) != OK)
-    {
-      goto exit_free_bus;
-    }
-
   /* Register sdio bus */
 
   priv->bus  = &gbus->bus;

--- a/drivers/wireless/ieee80211/bcm43xxx/bcmf_sdio.c
+++ b/drivers/wireless/ieee80211/bcm43xxx/bcmf_sdio.c
@@ -693,11 +693,6 @@ static int bcmf_bus_sdio_initialize(FAR struct bcmf_dev_s *priv,
       goto exit_free_bus;
     }
 
-  if ((ret = nxsem_set_protocol(&sbus->thread_signal, SEM_PRIO_NONE)) != OK)
-    {
-      goto exit_free_bus;
-    }
-
   /* Configure hardware */
 
   bcmf_board_initialize(sbus->minor);

--- a/drivers/wireless/ieee802154/xbee/xbee.c
+++ b/drivers/wireless/ieee802154/xbee/xbee.c
@@ -1250,7 +1250,6 @@ XBEEHANDLE xbee_init(FAR struct spi_dev_s *spi,
   nxmutex_init(&priv->atquery_lock);
   nxmutex_init(&priv->tx_lock);
   nxsem_init(&priv->txdone_sem, 0, 0);
-  nxsem_set_protocol(&priv->txdone_sem, SEM_PRIO_NONE);
 
   ieee802154_primitivepool_initialize();
 
@@ -1540,8 +1539,6 @@ int xbee_atquery(FAR struct xbee_priv_s *priv, FAR const char *atcommand)
    */
 
   nxsem_init(&priv->atresp_sem, 0, 0);
-  nxsem_set_protocol(&priv->atresp_sem, SEM_PRIO_NONE);
-
   do
     {
       /* There is a note in the XBee datasheet: Once you issue a WR command,

--- a/drivers/wireless/ieee802154/xbee/xbee_netdev.c
+++ b/drivers/wireless/ieee802154/xbee/xbee_netdev.c
@@ -1284,7 +1284,6 @@ int xbee_netdev_register(XBEEHANDLE xbee)
 
   priv->xd_eventpending = false;
   nxsem_init(&priv->xd_eventsem, 0, 0);
-  nxsem_set_protocol(&priv->xd_eventsem, SEM_PRIO_NONE);
 
   sq_init(&priv->primitive_queue);
 

--- a/drivers/wireless/nrf24l01.c
+++ b/drivers/wireless/nrf24l01.c
@@ -1483,7 +1483,6 @@ int nrf24l01_register(FAR struct spi_dev_s *spi,
 
   nxmutex_init(&dev->devlock);
   nxsem_init(&dev->sem_tx, 0, 0);
-  nxsem_set_protocol(&dev->sem_tx, SEM_PRIO_NONE);
 
 #ifdef CONFIG_WL_NRF24L01_RXSUPPORT
   if ((rx_fifo = kmm_malloc(CONFIG_WL_NRF24L01_RXFIFO_LEN)) == NULL)
@@ -1498,7 +1497,6 @@ int nrf24l01_register(FAR struct spi_dev_s *spi,
 
   nxmutex_init(&dev->lock_fifo);
   nxsem_init(&dev->sem_rx, 0, 0);
-  nxsem_set_protocol(&dev->sem_rx, SEM_PRIO_NONE);
 #endif
 
   /* Configure IRQ pin  (falling edge) */

--- a/fs/rpmsgfs/rpmsgfs_client.c
+++ b/fs/rpmsgfs/rpmsgfs_client.c
@@ -341,7 +341,6 @@ static int rpmsgfs_send_recv(FAR struct rpmsgfs_s *priv,
 
   memset(&cookie, 0, sizeof(cookie));
   nxsem_init(&cookie.sem, 0, 0);
-  nxsem_set_protocol(&cookie.sem, SEM_PRIO_NONE);
 
   if (data)
     {
@@ -458,7 +457,6 @@ ssize_t rpmsgfs_client_read(FAR void *handle, int fd,
   memset(&cookie, 0, sizeof(cookie));
 
   nxsem_init(&cookie.sem, 0, 0);
-  nxsem_set_protocol(&cookie.sem, SEM_PRIO_NONE);
   cookie.data = &read;
 
   msg.header.command = RPMSGFS_READ;
@@ -501,7 +499,6 @@ ssize_t rpmsgfs_client_write(FAR void *handle, int fd,
 
   memset(&cookie, 0, sizeof(cookie));
   nxsem_init(&cookie.sem, 0, 0);
-  nxsem_set_protocol(&cookie.sem, SEM_PRIO_NONE);
 
   while (written < count)
     {
@@ -725,7 +722,6 @@ int rpmsgfs_client_bind(FAR void **handle, FAR const char *cpuname)
     }
 
   nxsem_init(&priv->wait, 0, 0);
-  nxsem_set_protocol(&priv->wait, SEM_PRIO_NONE);
   *handle = priv;
 
   return 0;

--- a/fs/vfs/fs_epoll.c
+++ b/fs/vfs/fs_epoll.c
@@ -184,7 +184,6 @@ static int epoll_do_create(int size, int flags)
     }
 
   nxsem_init(&eph->sem, 0, 0);
-  nxsem_set_protocol(&eph->sem, SEM_PRIO_NONE);
   eph->size = size;
   eph->data = (FAR epoll_data_t *)(eph + 1);
   eph->poll = (FAR struct pollfd *)(eph->data + reserve);

--- a/fs/vfs/fs_eventfd.c
+++ b/fs/vfs/fs_eventfd.c
@@ -313,8 +313,6 @@ static ssize_t eventfd_do_read(FAR struct file *filep, FAR char *buffer,
 
       eventfd_waiter_sem_t sem;
       nxsem_init(&sem.sem, 0, 0);
-      nxsem_set_protocol(&sem.sem, SEM_PRIO_NONE);
-
       do
         {
           ret = eventfd_blocking_io(dev, &sem, &dev->rdsems);
@@ -398,8 +396,6 @@ static ssize_t eventfd_do_write(FAR struct file *filep,
 
       eventfd_waiter_sem_t sem;
       nxsem_init(&sem.sem, 0, 0);
-      nxsem_set_protocol(&sem.sem, SEM_PRIO_NONE);
-
       do
         {
           ret = eventfd_blocking_io(dev, &sem, &dev->wrsems);

--- a/fs/vfs/fs_poll.c
+++ b/fs/vfs/fs_poll.c
@@ -433,13 +433,7 @@ int nx_poll(FAR struct pollfd *fds, unsigned int nfds, int timeout)
 
   DEBUGASSERT(nfds == 0 || fds != NULL);
 
-  /* This semaphore is used for signaling and, hence, should not have
-   * priority inheritance enabled.
-   */
-
   nxsem_init(&sem, 0, 0);
-  nxsem_set_protocol(&sem, SEM_PRIO_NONE);
-
   ret = poll_setup(fds, nfds, &sem);
   if (ret >= 0)
     {

--- a/fs/vfs/fs_timerfd.c
+++ b/fs/vfs/fs_timerfd.c
@@ -345,8 +345,6 @@ static ssize_t timerfd_read(FAR struct file *filep, FAR char *buffer,
 
       timerfd_waiter_sem_t sem;
       nxsem_init(&sem.sem, 0, 0);
-      nxsem_set_protocol(&sem.sem, SEM_PRIO_NONE);
-
       do
         {
           ret = timerfd_blocking_io(dev, &sem, &dev->rdsems);

--- a/graphics/nxterm/nxterm_register.c
+++ b/graphics/nxterm/nxterm_register.c
@@ -80,12 +80,7 @@ FAR struct nxterm_state_s *
 #endif
 
 #ifdef CONFIG_NXTERM_NXKBDIN
-  /* The waitsem semaphore is used for signaling and, hence, should not have
-   * priority inheritance enabled.
-   */
-
   nxsem_init(&priv->waitsem, 0, 0);
-  nxsem_set_protocol(&priv->waitsem, SEM_PRIO_NONE);
 #endif
 
   /* Connect to the font cache for the configured font characteristics */

--- a/mm/mempool/mempool.c
+++ b/mm/mempool/mempool.c
@@ -102,7 +102,6 @@ int mempool_init(FAR struct mempool_s *pool, FAR const char *name,
     }
 
   nxsem_init(&pool->wait, 0, 0);
-  nxsem_set_protocol(&pool->wait, SEM_PRIO_NONE);
 
 #ifndef CONFIG_FS_PROCFS_EXCLUDE_MEMPOOL
   mempool_procfs_register(&pool->procfs, name);

--- a/net/arp/arp_notify.c
+++ b/net/arp/arp_notify.c
@@ -72,12 +72,7 @@ void arp_wait_setup(in_addr_t ipaddr, FAR struct arp_notify_s *notify)
   notify->nt_ipaddr = ipaddr;
   notify->nt_result = -ETIMEDOUT;
 
-  /* This semaphore is used for signaling and, hence, should not have
-   * priority inheritance enabled.
-   */
-
   nxsem_init(&notify->nt_sem, 0, 0);
-  nxsem_set_protocol(&notify->nt_sem, SEM_PRIO_NONE);
 
   /* Add the wait structure to the list with interrupts disabled */
 

--- a/net/arp/arp_send.c
+++ b/net/arp/arp_send.c
@@ -276,12 +276,7 @@ int arp_send(in_addr_t ipaddr)
       goto errout_with_lock;
     }
 
-  /* This semaphore is used for signaling and, hence, should not have
-   * priority inheritance enabled.
-   */
-
   nxsem_init(&state.snd_sem, 0, 0); /* Doesn't really fail */
-  nxsem_set_protocol(&state.snd_sem, SEM_PRIO_NONE);
 
   state.snd_retries   = 0;              /* No retries yet */
   state.snd_ipaddr    = ipaddr;         /* IP address to query */

--- a/net/bluetooth/bluetooth_recvmsg.c
+++ b/net/bluetooth/bluetooth_recvmsg.c
@@ -365,12 +365,7 @@ ssize_t bluetooth_recvmsg(FAR struct socket *psock, FAR struct msghdr *msg,
       return ret;
     }
 
-  /* We will have to wait.  This semaphore is used for signaling and,
-   * hence, should not have priority inheritance enabled.
-   */
-
   nxsem_init(&state.ir_sem, 0, 0); /* Doesn't really fail */
-  nxsem_set_protocol(&state.ir_sem, SEM_PRIO_NONE);
 
   /* Set up the callback in the connection */
 

--- a/net/bluetooth/bluetooth_sendmsg.c
+++ b/net/bluetooth/bluetooth_sendmsg.c
@@ -302,13 +302,7 @@ static ssize_t bluetooth_sendto(FAR struct socket *psock,
 
   net_lock();
   memset(&state, 0, sizeof(struct bluetooth_sendto_s));
-
-  /* This semaphore is used for signaling and, hence, should not have
-   * priority inheritance enabled.
-   */
-
   nxsem_init(&state.is_sem, 0, 0); /* Doesn't really fail */
-  nxsem_set_protocol(&state.is_sem, SEM_PRIO_NONE);
 
   state.is_sock   = psock;          /* Socket descriptor to use */
   state.is_buflen = len;            /* Number of bytes to send */

--- a/net/can/can_recvmsg.c
+++ b/net/can/can_recvmsg.c
@@ -581,13 +581,7 @@ ssize_t can_recvmsg(FAR struct socket *psock, FAR struct msghdr *msg,
   /* Initialize the state structure. */
 
   memset(&state, 0, sizeof(struct can_recvfrom_s));
-
-  /* This semaphore is used for signaling and, hence, should not have
-   * priority inheritance enabled.
-   */
-
   nxsem_init(&state.pr_sem, 0, 0); /* Doesn't really fail */
-  nxsem_set_protocol(&state.pr_sem, SEM_PRIO_NONE);
 
   state.pr_buflen = msg->msg_iov->iov_len;
   state.pr_buffer = msg->msg_iov->iov_base;

--- a/net/can/can_sendmsg.c
+++ b/net/can/can_sendmsg.c
@@ -216,13 +216,7 @@ ssize_t can_sendmsg(FAR struct socket *psock, FAR struct msghdr *msg,
 
   net_lock();
   memset(&state, 0, sizeof(struct send_s));
-
-  /* This semaphore is used for signaling and, hence, should not have
-   * priority inheritance enabled.
-   */
-
   nxsem_init(&state.snd_sem, 0, 0); /* Doesn't really fail */
-  nxsem_set_protocol(&state.snd_sem, SEM_PRIO_NONE);
 
   state.snd_sock      = psock;                  /* Socket descriptor */
   state.snd_buflen    = msg->msg_iov->iov_len;  /* bytes to send */

--- a/net/icmp/icmp_recvmsg.c
+++ b/net/icmp/icmp_recvmsg.c
@@ -420,13 +420,7 @@ ssize_t icmp_recvmsg(FAR struct socket *psock, FAR struct msghdr *msg,
       /* Initialize the state structure */
 
       memset(&state, 0, sizeof(struct icmp_recvfrom_s));
-
-      /* This semaphore is used for signaling and, hence, should not have
-       * priority inheritance enabled.
-       */
-
       nxsem_init(&state.recv_sem, 0, 0);
-      nxsem_set_protocol(&state.recv_sem, SEM_PRIO_NONE);
 
       state.recv_sock   = psock;    /* The IPPROTO_ICMP socket instance */
       state.recv_result = -ENOMEM;  /* Assume allocation failure */

--- a/net/icmp/icmp_sendmsg.c
+++ b/net/icmp/icmp_sendmsg.c
@@ -373,12 +373,7 @@ ssize_t icmp_sendmsg(FAR struct socket *psock, FAR struct msghdr *msg,
 
   /* Initialize the state structure */
 
-  /* This semaphore is used for signaling and, hence, should not have
-   * priority inheritance enabled.
-   */
-
   nxsem_init(&state.snd_sem, 0, 0);
-  nxsem_set_protocol(&state.snd_sem, SEM_PRIO_NONE);
 
   state.snd_result = -ENOMEM;                 /* Assume allocation failure */
   state.snd_toaddr = inaddr->sin_addr.s_addr; /* Address of the peer to send

--- a/net/icmpv6/icmpv6_autoconfig.c
+++ b/net/icmpv6/icmpv6_autoconfig.c
@@ -177,15 +177,9 @@ static int icmpv6_send_message(FAR struct net_driver_s *dev, bool advertise)
   struct icmpv6_router_s state;
   int ret;
 
-  /* Initialize the state structure with the network locked.
-   *
-   *
-   * This semaphore is used for signaling and, hence, should not have
-   * priority inheritance enabled.
-   */
+  /* Initialize the state structure with the network locked. */
 
   nxsem_init(&state.snd_sem, 0, 0); /* Doesn't really fail */
-  nxsem_set_protocol(&state.snd_sem, SEM_PRIO_NONE);
 
   /* Remember the routing device name */
 

--- a/net/icmpv6/icmpv6_neighbor.c
+++ b/net/icmpv6/icmpv6_neighbor.c
@@ -249,14 +249,7 @@ int icmpv6_neighbor(const net_ipv6addr_t ipaddr)
       goto errout_with_lock;
     }
 
-  /* Initialize the state structure with the network locked.
-   *
-   * This semaphore is used for signaling and, hence, should not have
-   * priority inheritance enabled.
-   */
-
   nxsem_init(&state.snd_sem, 0, 0);        /* Doesn't really fail */
-  nxsem_set_protocol(&state.snd_sem, SEM_PRIO_NONE);
 
   state.snd_retries = 0;                       /* No retries yet */
   net_ipv6addr_copy(state.snd_ipaddr, lookup); /* IP address to query */

--- a/net/icmpv6/icmpv6_notify.c
+++ b/net/icmpv6/icmpv6_notify.c
@@ -86,12 +86,7 @@ void icmpv6_wait_setup(const net_ipv6addr_t ipaddr,
   net_ipv6addr_copy(notify->nt_ipaddr, ipaddr);
   notify->nt_result = -ETIMEDOUT;
 
-  /* This semaphore is used for signaling and, hence, should not have
-   * priority inheritance enabled.
-   */
-
   nxsem_init(&notify->nt_sem, 0, 0);
-  nxsem_set_protocol(&notify->nt_sem, SEM_PRIO_NONE);
 
   /* Add the wait structure to the list with interrupts disabled */
 

--- a/net/icmpv6/icmpv6_recvmsg.c
+++ b/net/icmpv6/icmpv6_recvmsg.c
@@ -427,13 +427,7 @@ ssize_t icmpv6_recvmsg(FAR struct socket *psock, FAR struct msghdr *msg,
       /* Initialize the state structure */
 
       memset(&state, 0, sizeof(struct icmpv6_recvfrom_s));
-
-      /* This semaphore is used for signaling and, hence, should not have
-       * priority inheritance enabled.
-       */
-
       nxsem_init(&state.recv_sem, 0, 0);
-      nxsem_set_protocol(&state.recv_sem, SEM_PRIO_NONE);
 
       state.recv_sock   = psock;    /* The IPPROTO_ICMP6 socket instance */
       state.recv_result = -ENOMEM;  /* Assume allocation failure */

--- a/net/icmpv6/icmpv6_rnotify.c
+++ b/net/icmpv6/icmpv6_rnotify.c
@@ -164,12 +164,7 @@ void icmpv6_rwait_setup(FAR struct net_driver_s *dev,
   memcpy(notify->rn_ifname, dev->d_ifname, IFNAMSIZ);
   notify->rn_result = -ETIMEDOUT;
 
-  /* This semaphore is used for signaling and, hence, should not have
-   * priority inheritance enabled.
-   */
-
   nxsem_init(&notify->rn_sem, 0, 0);
-  nxsem_set_protocol(&notify->rn_sem, SEM_PRIO_NONE);
 
   /* Add the wait structure to the list with interrupts disabled */
 

--- a/net/icmpv6/icmpv6_sendmsg.c
+++ b/net/icmpv6/icmpv6_sendmsg.c
@@ -364,12 +364,7 @@ ssize_t icmpv6_sendmsg(FAR struct socket *psock, FAR struct msghdr *msg,
 
   /* Initialize the state structure */
 
-  /* This semaphore is used for signaling and, hence, should not have
-   * priority inheritance enabled.
-   */
-
   nxsem_init(&state.snd_sem, 0, 0);
-  nxsem_set_protocol(&state.snd_sem, SEM_PRIO_NONE);
 
   state.snd_result = -ENOMEM;           /* Assume allocation failure */
   state.snd_buf    = buf;               /* ICMPv6 header + data payload */

--- a/net/ieee802154/ieee802154_recvmsg.c
+++ b/net/ieee802154/ieee802154_recvmsg.c
@@ -365,12 +365,7 @@ ssize_t ieee802154_recvmsg(FAR struct socket *psock, FAR struct msghdr *msg,
       return ret;
     }
 
-  /* We will have to wait.  This semaphore is used for signaling and,
-   * hence, should not have priority inheritance enabled.
-   */
-
   nxsem_init(&state.ir_sem, 0, 0); /* Doesn't really fail */
-  nxsem_set_protocol(&state.ir_sem, SEM_PRIO_NONE);
 
   /* Set up the callback in the connection */
 

--- a/net/ieee802154/ieee802154_sendmsg.c
+++ b/net/ieee802154/ieee802154_sendmsg.c
@@ -471,13 +471,7 @@ static ssize_t ieee802154_sendto(FAR struct socket *psock,
 
   net_lock();
   memset(&state, 0, sizeof(struct ieee802154_sendto_s));
-
-  /* This semaphore is used for signaling and, hence, should not have
-   * priority inheritance enabled.
-   */
-
   nxsem_init(&state.is_sem, 0, 0); /* Doesn't really fail */
-  nxsem_set_protocol(&state.is_sem, SEM_PRIO_NONE);
 
   state.is_sock   = psock;          /* Socket descriptor to use */
   state.is_buflen = len;            /* Number of bytes to send */

--- a/net/igmp/igmp_group.c
+++ b/net/igmp/igmp_group.c
@@ -121,13 +121,7 @@ FAR struct igmp_group_s *igmp_grpalloc(FAR struct net_driver_s *dev,
       /* Initialize the non-zero elements of the group structure */
 
       net_ipv4addr_copy(group->grpaddr, *addr);
-
-      /* This semaphore is used for signaling and, hence, should not have
-       * priority inheritance enabled.
-       */
-
       nxsem_init(&group->sem, 0, 0);
-      nxsem_set_protocol(&group->sem, SEM_PRIO_NONE);
 
       /* Save the interface index */
 

--- a/net/local/local_conn.c
+++ b/net/local/local_conn.c
@@ -118,15 +118,8 @@ FAR struct local_conn_s *local_alloc(void)
        */
 
 #ifdef CONFIG_NET_LOCAL_STREAM
-      /* This semaphore is used for signaling and, hence, should not have
-       * priority inheritance enabled.
-       */
-
       nxsem_init(&conn->lc_waitsem, 0, 0);
-      nxsem_set_protocol(&conn->lc_waitsem, SEM_PRIO_NONE);
-
       nxsem_init(&conn->lc_donesem, 0, 0);
-      nxsem_set_protocol(&conn->lc_donesem, SEM_PRIO_NONE);
 
 #endif
 

--- a/net/mld/mld_group.c
+++ b/net/mld/mld_group.c
@@ -112,13 +112,7 @@ FAR struct mld_group_s *mld_grpalloc(FAR struct net_driver_s *dev,
       /* Initialize the non-zero elements of the group structure */
 
       net_ipv6addr_copy(group->grpaddr, addr);
-
-      /* This semaphore is used for signaling and, hence, should not have
-       * priority inheritance enabled.
-       */
-
       nxsem_init(&group->sem, 0, 0);
-      nxsem_set_protocol(&group->sem, SEM_PRIO_NONE);
 
       /* Save the interface index */
 

--- a/net/netlink/netlink_conn.c
+++ b/net/netlink/netlink_conn.c
@@ -412,7 +412,6 @@ netlink_get_response(FAR struct netlink_conn_s *conn)
       /* Set up a semaphore to notify us when a response is queued. */
 
       nxsem_init(&waitsem, 0, 0);
-      nxsem_set_protocol(&waitsem, SEM_PRIO_NONE);
 
       /* Set up a notifier to post the semaphore when a response is
        * received.

--- a/net/pkt/pkt_recvmsg.c
+++ b/net/pkt/pkt_recvmsg.c
@@ -242,13 +242,7 @@ static void pkt_recvfrom_initialize(FAR struct socket *psock, FAR void *buf,
   /* Initialize the state structure. */
 
   memset(pstate, 0, sizeof(struct pkt_recvfrom_s));
-
-  /* This semaphore is used for signaling and, hence, should not have
-   * priority inheritance enabled.
-   */
-
   nxsem_init(&pstate->pr_sem, 0, 0); /* Doesn't really fail */
-  nxsem_set_protocol(&pstate->pr_sem, SEM_PRIO_NONE);
 
   pstate->pr_buflen = len;
   pstate->pr_buffer = buf;

--- a/net/pkt/pkt_sendmsg.c
+++ b/net/pkt/pkt_sendmsg.c
@@ -210,13 +210,7 @@ ssize_t pkt_sendmsg(FAR struct socket *psock, FAR struct msghdr *msg,
 
   net_lock();
   memset(&state, 0, sizeof(struct send_s));
-
-  /* This semaphore is used for signaling and, hence, should not have
-   * priority inheritance enabled.
-   */
-
   nxsem_init(&state.snd_sem, 0, 0); /* Doesn't really fail */
-  nxsem_set_protocol(&state.snd_sem, SEM_PRIO_NONE);
 
   state.snd_sock      = psock;          /* Socket descriptor to use */
   state.snd_buflen    = len;            /* Number of bytes to send */

--- a/net/rpmsg/rpmsg_sockif.c
+++ b/net/rpmsg/rpmsg_sockif.c
@@ -212,8 +212,6 @@ static FAR struct rpmsg_socket_conn_s *rpmsg_socket_alloc(void)
   nxmutex_init(&conn->recvlock);
   nxsem_init(&conn->sendsem, 0, 0);
   nxsem_init(&conn->recvsem, 0, 0);
-  nxsem_set_protocol(&conn->sendsem, SEM_PRIO_NONE);
-  nxsem_set_protocol(&conn->recvsem, SEM_PRIO_NONE);
 
   conn->crefs = 1;
   return conn;

--- a/net/sixlowpan/sixlowpan_send.c
+++ b/net/sixlowpan/sixlowpan_send.c
@@ -214,7 +214,6 @@ int sixlowpan_send(FAR struct net_driver_s *dev,
   /* Initialize the send state structure */
 
   nxsem_init(&sinfo.s_waitsem, 0, 0);
-  nxsem_set_protocol(&sinfo.s_waitsem, SEM_PRIO_NONE);
 
   sinfo.s_result  = -EBUSY;
   sinfo.s_ipv6hdr = ipv6hdr;

--- a/net/sixlowpan/sixlowpan_tcpsend.c
+++ b/net/sixlowpan/sixlowpan_tcpsend.c
@@ -613,7 +613,6 @@ static int sixlowpan_send_packet(FAR struct socket *psock,
           /* Initialize the send state structure */
 
           nxsem_init(&sinfo.s_waitsem, 0, 0);
-          nxsem_set_protocol(&sinfo.s_waitsem, SEM_PRIO_NONE);
 
           sinfo.s_conn      = conn;
           sinfo.s_result    = -EBUSY;

--- a/net/tcp/tcp_accept.c
+++ b/net/tcp/tcp_accept.c
@@ -260,12 +260,7 @@ int psock_tcp_accept(FAR struct socket *psock, FAR struct sockaddr *addr,
       state.acpt_newconn    = NULL;
       state.acpt_result     = OK;
 
-      /* This semaphore is used for signaling and, hence, should not have
-       * priority inheritance enabled.
-       */
-
       nxsem_init(&state.acpt_sem, 0, 0);
-      nxsem_set_protocol(&state.acpt_sem, SEM_PRIO_NONE);
 
       /* Set up the callback in the connection */
 

--- a/net/tcp/tcp_conn.c
+++ b/net/tcp/tcp_conn.c
@@ -736,7 +736,6 @@ FAR struct tcp_conn_s *tcp_alloc(uint8_t domain)
       conn->snd_bufs      = CONFIG_NET_SEND_BUFSIZE;
 
       nxsem_init(&conn->snd_sem, 0, 0);
-      nxsem_set_protocol(&conn->snd_sem, SEM_PRIO_NONE);
 #endif
     }
 

--- a/net/tcp/tcp_connect.c
+++ b/net/tcp/tcp_connect.c
@@ -86,12 +86,7 @@ static inline int psock_setup_callbacks(FAR struct socket *psock,
 
   /* Initialize the TCP state structure */
 
-  /* This semaphore is used for signaling and, hence, should not have
-   * priority inheritance enabled.
-   */
-
   nxsem_init(&pstate->tc_sem, 0, 0); /* Doesn't really fail */
-  nxsem_set_protocol(&pstate->tc_sem, SEM_PRIO_NONE);
 
   pstate->tc_conn   = conn;
   pstate->tc_result = -EAGAIN;

--- a/net/tcp/tcp_recvfrom.c
+++ b/net/tcp/tcp_recvfrom.c
@@ -514,13 +514,7 @@ static void tcp_recvfrom_initialize(FAR struct tcp_conn_s *conn,
   /* Initialize the state structure. */
 
   memset(pstate, 0, sizeof(struct tcp_recvfrom_s));
-
-  /* This semaphore is used for signaling and, hence, should not have
-   * priority inheritance enabled.
-   */
-
   nxsem_init(&pstate->ir_sem, 0, 0); /* Doesn't really fail */
-  nxsem_set_protocol(&pstate->ir_sem, SEM_PRIO_NONE);
 
   pstate->ir_buflen    = len;
   pstate->ir_buffer    = buf;

--- a/net/tcp/tcp_send_unbuffered.c
+++ b/net/tcp/tcp_send_unbuffered.c
@@ -605,13 +605,7 @@ ssize_t psock_tcp_send(FAR struct socket *psock,
     }
 
   memset(&state, 0, sizeof(struct send_s));
-
-  /* This semaphore is used for signaling and, hence, should not have
-   * priority inheritance enabled.
-   */
-
   nxsem_init(&state.snd_sem, 0, 0);    /* Doesn't really fail */
-  nxsem_set_protocol(&state.snd_sem, SEM_PRIO_NONE);
 
   state.snd_sock      = psock;             /* Socket descriptor to use */
   state.snd_buflen    = len;               /* Number of bytes to send */

--- a/net/tcp/tcp_sendfile.c
+++ b/net/tcp/tcp_sendfile.c
@@ -508,13 +508,7 @@ ssize_t tcp_sendfile(FAR struct socket *psock, FAR struct file *infile,
   conn->sendfile = true;
 #endif
   memset(&state, 0, sizeof(struct sendfile_s));
-
-  /* This semaphore is used for signaling and, hence, should not have
-   * priority inheritance enabled.
-   */
-
   nxsem_init(&state.snd_sem, 0, 0);                /* Doesn't really fail */
-  nxsem_set_protocol(&state.snd_sem, SEM_PRIO_NONE);
 
   state.snd_sock    = psock;                       /* Socket descriptor to use */
   state.snd_foffset = offset ? *offset : startpos; /* Input file offset */

--- a/net/tcp/tcp_txdrain.c
+++ b/net/tcp/tcp_txdrain.c
@@ -100,7 +100,6 @@ int tcp_txdrain(FAR struct socket *psock, unsigned int timeout)
   /* Initialize the wait semaphore */
 
   nxsem_init(&waitsem, 0, 0);
-  nxsem_set_protocol(&waitsem, SEM_PRIO_NONE);
 
   /* The following needs to be done with the network stable */
 

--- a/net/tcp/tcp_wrbuffer.c
+++ b/net/tcp/tcp_wrbuffer.c
@@ -100,7 +100,6 @@ void tcp_wrbuffer_initialize(void)
     }
 
   nxsem_init(&g_wrbuffer.sem, 0, CONFIG_NET_TCP_NWRBCHAINS);
-  nxsem_set_protocol(&g_wrbuffer.sem, SEM_PRIO_NONE);
 }
 
 /****************************************************************************

--- a/net/udp/udp_conn.c
+++ b/net/udp/udp_conn.c
@@ -614,7 +614,6 @@ FAR struct udp_conn_s *udp_alloc(uint8_t domain)
       conn->sndbufs = CONFIG_NET_SEND_BUFSIZE;
 
       nxsem_init(&conn->sndsem, 0, 0);
-      nxsem_set_protocol(&conn->sndsem, SEM_PRIO_NONE);
 #endif
 
 #ifdef CONFIG_NET_UDP_WRITE_BUFFERS

--- a/net/udp/udp_recvfrom.c
+++ b/net/udp/udp_recvfrom.c
@@ -541,13 +541,7 @@ static void udp_recvfrom_initialize(FAR struct udp_conn_s *conn,
   /* Initialize the state structure. */
 
   memset(pstate, 0, sizeof(struct udp_recvfrom_s));
-
-  /* This semaphore is used for signaling and, hence, should not have
-   * priority inheritance enabled.
-   */
-
   nxsem_init(&pstate->ir_sem, 0, 0); /* Doesn't really fail */
-  nxsem_set_protocol(&pstate->ir_sem, SEM_PRIO_NONE);
 
   pstate->ir_msg  = msg;
 

--- a/net/udp/udp_sendto_unbuffered.c
+++ b/net/udp/udp_sendto_unbuffered.c
@@ -396,13 +396,7 @@ ssize_t psock_udp_sendto(FAR struct socket *psock, FAR const void *buf,
 
   net_lock();
   memset(&state, 0, sizeof(struct sendto_s));
-
-  /* This semaphore is used for signaling and, hence, should not have
-   * priority inheritance enabled.
-   */
-
   nxsem_init(&state.st_sem, 0, 0);
-  nxsem_set_protocol(&state.st_sem, SEM_PRIO_NONE);
 
   state.st_buflen = len;
   state.st_buffer = buf;

--- a/net/udp/udp_txdrain.c
+++ b/net/udp/udp_txdrain.c
@@ -100,7 +100,6 @@ int udp_txdrain(FAR struct socket *psock, unsigned int timeout)
   /* Initialize the wait semaphore */
 
   nxsem_init(&waitsem, 0, 0);
-  nxsem_set_protocol(&waitsem, SEM_PRIO_NONE);
 
   /* The following needs to be done with the network stable */
 

--- a/net/udp/udp_wrbuffer.c
+++ b/net/udp/udp_wrbuffer.c
@@ -101,7 +101,6 @@ void udp_wrbuffer_initialize(void)
     }
 
   nxsem_init(&g_wrbuffer.sem, 0, CONFIG_NET_UDP_NWRBCHAINS);
-  nxsem_set_protocol(&g_wrbuffer.sem, SEM_PRIO_NONE);
 }
 
 /****************************************************************************

--- a/net/usrsock/usrsock_conn.c
+++ b/net/usrsock/usrsock_conn.c
@@ -208,7 +208,6 @@ int usrsock_setup_request_callback(FAR struct usrsock_conn_s *conn,
   int ret = -EBUSY;
 
   nxsem_init(&pstate->recvsem, 0, 0);
-  nxsem_set_protocol(&pstate->recvsem, SEM_PRIO_NONE);
 
   pstate->conn      = conn;
   pstate->result    = -EAGAIN;

--- a/sched/group/group_create.c
+++ b/sched/group/group_create.c
@@ -216,14 +216,9 @@ int group_allocate(FAR struct task_tcb_s *tcb, uint8_t ttype)
 #endif
 
 #if defined(CONFIG_SCHED_WAITPID) && !defined(CONFIG_SCHED_HAVE_PARENT)
-  /* Initialize the exit/wait semaphores
-   *
-   * This semaphore is used for signaling and, hence, should not have
-   * priority inheritance enabled.
-   */
+  /* Initialize the exit/wait semaphores */
 
   nxsem_init(&group->tg_exitsem, 0, 0);
-  nxsem_set_protocol(&group->tg_exitsem, SEM_PRIO_NONE);
 #endif
 
   return OK;

--- a/sched/pthread/pthread_create.c
+++ b/sched/pthread/pthread_create.c
@@ -515,20 +515,6 @@ int nx_pthread_create(pthread_trampoline_t trampoline, FAR pthread_t *thread,
       ret = -ret;
     }
 
-  /* Thse semaphore are used for signaling and, hence, should not have
-   * priority inheritance enabled.
-   */
-
-    if (ret == OK)
-      {
-        ret = nxsem_set_protocol(&pjoin->exit_sem, SEM_PRIO_NONE);
-      }
-
-    if (ret < 0)
-      {
-        ret = -ret;
-      }
-
   /* If the priority of the new pthread is lower than the priority of the
    * parent thread, then starting the pthread could result in both the
    * parent and the pthread to be blocked.  This is a recipe for priority

--- a/wireless/bluetooth/bt_hcicore.c
+++ b/wireless/bluetooth/bt_hcicore.c
@@ -1448,7 +1448,6 @@ static void cmd_queue_init(void)
   DEBUGASSERT(ret >= 0);
 
   nxsem_init(&g_btdev.ncmd_sem, 0, 1);
-  nxsem_set_protocol(&g_btdev.ncmd_sem, SEM_PRIO_NONE);
 
   g_btdev.ncmd = 1;
   ret = kthread_create("BT HCI Tx", CONFIG_BLUETOOTH_TXCMD_PRIORITY,
@@ -1790,7 +1789,6 @@ int bt_hci_cmd_send_sync(uint16_t opcode, FAR struct bt_buf_s *buf,
   /* Set up for the wait */
 
   nxsem_init(&sync_sem, 0, 0);
-  nxsem_set_protocol(&sync_sem, SEM_PRIO_NONE);
   buf->u.hci.sync = &sync_sem;
 
   /* Send the frame */

--- a/wireless/ieee802154/mac802154_device.c
+++ b/wireless/ieee802154/mac802154_device.c
@@ -834,14 +834,12 @@ int mac802154dev_register(MACHANDLE mac, int minor)
                                     * before blocking */
 
   nxsem_init(&dev->readsem, 0, 0);
-  nxsem_set_protocol(&dev->readsem, SEM_PRIO_NONE);
   dev->readpending = false;
 
   sq_init(&dev->dataind_queue);
 
   dev->geteventpending = false;
   nxsem_init(&dev->geteventsem, 0, 0);
-  nxsem_set_protocol(&dev->geteventsem, SEM_PRIO_NONE);
 
   sq_init(&dev->primitive_queue);
 

--- a/wireless/ieee802154/mac802154_netdev.c
+++ b/wireless/ieee802154/mac802154_netdev.c
@@ -1285,7 +1285,6 @@ int mac802154netdev_register(MACHANDLE mac)
 
   priv->md_eventpending = false;
   nxsem_init(&priv->md_eventsem, 0, 0);
-  nxsem_set_protocol(&priv->md_eventsem, SEM_PRIO_NONE);
 
   sq_init(&priv->primitive_queue);
 


### PR DESCRIPTION
## Summary
[step 1](https://github.com/apache/incubator-nuttx/pull/5070)
[step 2](https://github.com/apache/incubator-nuttx/pull/6965)
 this is step 3, remove all defult `nxsem_set_protocol` with `SEM_PRIO_NONE`,and then add it in `nxsem_init` & `nxmutex_init`

## Impact
nothing
## Testing
ostest
