### PR TITLE
Added flush of the read buffers when a file is reopened.

### DIFF
--- a/libs/libc/stdio/lib_freopen.c
+++ b/libs/libc/stdio/lib_freopen.c
@@ -100,9 +100,16 @@ FAR FILE *freopen(FAR const char *path, FAR const char *mode,
           return NULL;
         }
 
-      /* Flush the stream and duplicate the new fd to it */
+      /* Flush the stream and invalidate the read buffer. */
 
       fflush(stream);
+
+#ifndef CONFIG_STDIO_DISABLE_BUFFERING
+      lib_rdflush(stream);
+#endif
+
+      /* Duplicate the new fd to the stream. */
+
       ret = dup2(fd, fileno(stream));
       close(fd);
       if (ret < 0)


### PR DESCRIPTION
## Summary

When `CONFIG_STDIO_DISABLE_BUFFERING` is not set (i.e. buffering IS enabled), and when a file is reopened (`freopen()`), then the read buffers where not flushed.

This had as a result that the file position and the buffer became de-synchronized.  
When reading from this file, wrong data were returned, from a position different to what the file position dictated.  

The addition of the `fseek()` call ensures that the file position is correctly set to what the re-open wants, and internally calls `lib_rdflush()`.

## Impact

Bug fix.

## Testing

Tested on simulator with a test scenario that:
1. Opened an existing file, and read 1 character from it.
2. Re-opened the file.
3. Read 1 character from the file again.

Before, step 3 returned the *second* character of the file.  
Now it correctly returns the *first* character, as it should.




