### PR TITLE
gmtimer: Fixed range of tm_yday.

### DIFF
--- a/arch/arm/src/stm32/stm32_rtcc.c
+++ b/arch/arm/src/stm32/stm32_rtcc.c
@@ -815,7 +815,7 @@ int up_rtc_getdatetime(struct tm *tp)
 
   tmp = (dr & RTC_DR_WDU_MASK) >> RTC_DR_WDU_SHIFT;
   tp->tm_wday = tmp % 7;
-  tp->tm_yday = tp->tm_mday +
+  tp->tm_yday = tp->tm_mday - 1 +
                 clock_daysbeforemonth(tp->tm_mon,
                                       clock_isleapyear(tp->tm_year + 1900));
   tp->tm_isdst = 0;

--- a/arch/arm/src/stm32/stm32f40xxx_rtcc.c
+++ b/arch/arm/src/stm32/stm32f40xxx_rtcc.c
@@ -1205,7 +1205,7 @@ int up_rtc_getdatetime(struct tm *tp)
 
   tmp = (dr & RTC_DR_WDU_MASK) >> RTC_DR_WDU_SHIFT;
   tp->tm_wday = tmp % 7;
-  tp->tm_yday = tp->tm_mday +
+  tp->tm_yday = tp->tm_mday - 1 +
                 clock_daysbeforemonth(tp->tm_mon,
                                       clock_isleapyear(tp->tm_year + 1900));
   tp->tm_isdst = 0;

--- a/arch/arm/src/stm32/stm32l15xxx_rtcc.c
+++ b/arch/arm/src/stm32/stm32l15xxx_rtcc.c
@@ -1127,7 +1127,7 @@ int stm32_rtc_getdatetime_with_subseconds(struct tm *tp, long *nsec)
 
   tmp = (dr & RTC_DR_WDU_MASK) >> RTC_DR_WDU_SHIFT;
   tp->tm_wday = tmp % 7;
-  tp->tm_yday = tp->tm_mday +
+  tp->tm_yday = tp->tm_mday - 1 +
                 clock_daysbeforemonth(tp->tm_mon,
                                       clock_isleapyear(tp->tm_year + 1900));
   tp->tm_isdst = 0;

--- a/arch/arm/src/stm32f7/stm32_rtc.c
+++ b/arch/arm/src/stm32f7/stm32_rtc.c
@@ -1180,7 +1180,7 @@ int up_rtc_getdatetime(struct tm *tp)
 
   tmp = (dr & RTC_DR_WDU_MASK) >> RTC_DR_WDU_SHIFT;
   tp->tm_wday = tmp % 7;
-  tp->tm_yday = tp->tm_mday +
+  tp->tm_yday = tp->tm_mday - 1 +
     clock_daysbeforemonth(tp->tm_mon, clock_isleapyear(tp->tm_year + 1900));
   tp->tm_isdst = 0;
 

--- a/arch/arm/src/stm32h7/stm32_rtc.c
+++ b/arch/arm/src/stm32h7/stm32_rtc.c
@@ -1180,7 +1180,7 @@ int up_rtc_getdatetime(struct tm *tp)
 
   tmp = (dr & RTC_DR_WDU_MASK) >> RTC_DR_WDU_SHIFT;
   tp->tm_wday = tmp % 7;
-  tp->tm_yday = tp->tm_mday +
+  tp->tm_yday = tp->tm_mday - 1 +
     clock_daysbeforemonth(tp->tm_mon, clock_isleapyear(tp->tm_year + 1900));
   tp->tm_isdst = 0;
 

--- a/arch/arm/src/stm32l4/stm32l4_rtc.c
+++ b/arch/arm/src/stm32l4/stm32l4_rtc.c
@@ -1091,7 +1091,7 @@ int stm32l4_rtc_getdatetime_with_subseconds(struct tm *tp,
 
   tmp = (dr & RTC_DR_WDU_MASK) >> RTC_DR_WDU_SHIFT;
   tp->tm_wday = tmp % 7;
-  tp->tm_yday = tp->tm_mday +
+  tp->tm_yday = tp->tm_mday - 1 +
                 clock_daysbeforemonth(tp->tm_mon,
                                       clock_isleapyear(tp->tm_year + 1900));
   tp->tm_isdst = 0;

--- a/arch/arm/src/stm32wb/stm32wb_rtc.c
+++ b/arch/arm/src/stm32wb/stm32wb_rtc.c
@@ -1078,7 +1078,7 @@ int stm32wb_rtc_getdatetime_with_subseconds(struct tm *tp,
 
   tmp = (dr & RTC_DR_WDU_MASK) >> RTC_DR_WDU_SHIFT;
   tp->tm_wday = tmp % 7;
-  tp->tm_yday = tp->tm_mday +
+  tp->tm_yday = tp->tm_mday - 1 +
                 clock_daysbeforemonth(tp->tm_mon,
                                       clock_isleapyear(tp->tm_year + 1900));
   tp->tm_isdst = 0;

--- a/libs/libc/time/lib_gmtimer.c
+++ b/libs/libc/time/lib_gmtimer.c
@@ -334,7 +334,7 @@ FAR struct tm *gmtime_r(FAR const time_t *timep, FAR struct tm *result)
   result->tm_sec    = (int)sec;
 
   result->tm_wday   = clock_dayoftheweek(day, month, year);
-  result->tm_yday   = day +
+  result->tm_yday   = day - 1 +
                       clock_daysbeforemonth(result->tm_mon,
                                             clock_isleapyear(year));
   result->tm_isdst  = 0;


### PR DESCRIPTION
## Summary

`tm_yday` is zero-based, and has a range of 0-365.

Previously the returned value had the range of 1-366 which is wrong. This PR fixes it.

## Impact

Bug fix.

## Testing

Tested on simulator, it now returns the correct value for the current day (as of writing this, 290).
