### PR TITLE
tools: Fix an issue that libboard.a is not exported

### DIFF
--- a/tools/FlatLibs.mk
+++ b/tools/FlatLibs.mk
@@ -132,6 +132,12 @@ ifeq ($(CONFIG_OPENAMP),y)
 NUTTXLIBS += staging$(DELIM)libopenamp$(LIBEXT)
 endif
 
+# Add libraries for board common support
+
+ifeq ($(CONFIG_ARCH_BOARD_COMMON),y)
+NUTTXLIBS += staging$(DELIM)libboard$(LIBEXT)
+endif
+
 # Export all libraries
 
 EXPORTLIBS = $(NUTTXLIBS)

--- a/tools/KernelLibs.mk
+++ b/tools/KernelLibs.mk
@@ -118,6 +118,12 @@ ifeq ($(CONFIG_OPENAMP),y)
 NUTTXLIBS += staging$(DELIM)libopenamp$(LIBEXT)
 endif
 
+# Add libraries for board common support
+
+ifeq ($(CONFIG_ARCH_BOARD_COMMON),y)
+NUTTXLIBS += staging$(DELIM)libboard$(LIBEXT)
+endif
+
 # Export only the user libraries
 
 EXPORTLIBS = $(USERLIBS)

--- a/tools/LibTargets.mk
+++ b/tools/LibTargets.mk
@@ -73,6 +73,12 @@ boards$(DELIM)libboards$(LIBEXT): pass2dep
 staging$(DELIM)libboards$(LIBEXT): boards$(DELIM)libboards$(LIBEXT)
 	$(Q) $(call INSTALL_LIB,$<,$@)
 
+$(ARCH_SRC)$(DELIM)board$(DELIM)libboard$(LIBEXT): pass2dep
+	$(Q) $(MAKE) -C $(ARCH_SRC)/board libboard$(LIBEXT) EXTRAFLAGS="$(KDEFINE) $(EXTRAFLAGS)"
+
+staging$(DELIM)libboard$(LIBEXT): $(ARCH_SRC)$(DELIM)board$(DELIM)libboard$(LIBEXT)
+	$(Q) $(call INSTALL_LIB,$<,$@)
+
 crypto$(DELIM)libcrypto$(LIBEXT): pass2dep
 	$(Q) $(MAKE) -C crypto libcrypto$(LIBEXT) EXTRAFLAGS="$(KDEFINE) $(EXTRAFLAGS)"
 

--- a/tools/ProtectedLibs.mk
+++ b/tools/ProtectedLibs.mk
@@ -132,6 +132,12 @@ ifeq ($(CONFIG_OPENAMP),y)
 NUTTXLIBS += staging$(DELIM)libopenamp$(LIBEXT)
 endif
 
+# Add libraries for board common support
+
+ifeq ($(CONFIG_ARCH_BOARD_COMMON),y)
+NUTTXLIBS += staging$(DELIM)libboard$(LIBEXT)
+endif
+
 # Export only the user libraries
 
 EXPORTLIBS = $(USERLIBS)


### PR DESCRIPTION
## Summary
Fix an issue libboard.a is not built with make export when CONFIG_ARCH_BOARD_COMMON is enabled.
Fix Issue https://github.com/apache/incubator-nuttx/issues/7232

## Impact
CONFIG_ARCH_BOARD_COMMON=y

## Testing
Normal operation by make, and libboard.a is exported by make export.
