### PR TITLE
mtd/smart: Fix a compile error in smart_fsck

### DIFF
--- a/drivers/mtd/smart.c
+++ b/drivers/mtd/smart.c
@@ -146,6 +146,28 @@
 #define CLR_BITMAP(m, n) do { (m)[(n) / 8] &= ~(1 << ((n) % 8)); } while (0)
 #define ISSET_BITMAP(m, n) ((m)[(n) / 8] & (1 << ((n) % 8)))
 
+#ifdef CONFIG_SMARTFS_ALIGNED_ACCESS
+#  define SMARTFS_NEXTSECTOR(h) \
+  (uint16_t)((FAR const uint8_t *)(h)->nextsector)[1] << 8 | \
+  (uint16_t)((FAR const uint8_t *)(h)->nextsector)[0]
+
+#  define SMARTFS_SET_NEXTSECTOR(h, v) \
+  do \
+    { \
+      ((FAR uint8_t *)(h)->nextsector)[0] = (v) & 0xff; \
+      ((FAR uint8_t *)(h)->nextsector)[1] = (v) >> 8;   \
+    } while (0)
+
+#else
+#  define SMARTFS_NEXTSECTOR(h) (*((FAR uint16_t *)(h)->nextsector))
+#  define SMARTFS_SET_NEXTSECTOR(h, v) \
+  do \
+    { \
+      ((*((FAR uint16_t *)(h)->nextsector)) = (uint16_t)(v)); \
+    } while (0)
+
+#endif
+
 #ifdef CONFIG_MTD_SMART_WEAR_LEVEL
 
 /****************************************************************************


### PR DESCRIPTION
## Summary
Fix a compile error caused by below commit.
9ad75fd95d Added SMART flash filesystem to RP2040
Add some macro functions for smartfs driver.
Fix Issue https://github.com/apache/incubator-nuttx/issues/7233

## Impact
None

## Testing
Compile check when CONFIG_MTD_SMART_FSCK is enabled
