### PR TITLE
esp32/i2s: Reduce MCLK multiple to support existing boards

### DIFF
--- a/arch/xtensa/src/esp32/esp32_i2s.c
+++ b/arch/xtensa/src/esp32/esp32_i2s.c
@@ -336,7 +336,7 @@ static const struct esp32_i2s_config_s esp32_i2s0_config =
   .data_width       = CONFIG_ESP32_I2S0_DATA_BIT_WIDTH,
   .rate             = CONFIG_ESP32_I2S0_SAMPLE_RATE,
   .total_slot       = 2,
-  .mclk_multiple    = I2S_MCLK_MULTIPLE_384,
+  .mclk_multiple    = I2S_MCLK_MULTIPLE_256,
   .tx_en            = I2S0_TX_ENABLED,
   .rx_en            = I2S0_RX_ENABLED,
 #ifdef CONFIG_ESP32_I2S0_MCLK


### PR DESCRIPTION
## Summary

Using the current 384 multiplier to generate the MCLK of I2S might cause some high frequency noise on the audio playback of some existing boards. Reducing the multiplier to 256 fixes this issue.

## Impact

The generated MCLK will be slower. Using 44100 Hz sampling rate, for example, the MCLK will be reduced from 16.9344 MHz to 11.2896 MHz.

## Testing

Tested using an ESP32-LyraT board by running nxplayer and playing some audio files.