### PR TITLE
esp32/i2c: Add macros to conform with other peripherals and fix typos

### DIFF
--- a/arch/xtensa/src/esp32/esp32_i2c.h
+++ b/arch/xtensa/src/esp32/esp32_i2c.h
@@ -43,6 +43,14 @@ extern "C"
 #define EXTERN extern
 #endif
 
+#ifdef CONFIG_ESP32_I2C0
+#  define ESP32_I2C0 0
+#endif /* CONFIG_ESP32_I2C0 */
+
+#ifdef CONFIG_ESP32_I2C1
+#  define ESP32_I2C1 1
+#endif /* CONFIG_ESP32_I2C1 */
+
 /****************************************************************************
  * Public Function Prototypes
  ****************************************************************************/

--- a/boards/xtensa/esp32/common/include/esp32_board_i2c.h
+++ b/boards/xtensa/esp32/common/include/esp32_board_i2c.h
@@ -48,7 +48,7 @@ extern "C"
  * Name: esp32_i2c_register
  *
  * Description:
- *   registar an ESP32 I2C interface.
+ *   Register an ESP32 I2C interface.
  *
  * Returned Value:
  *   Zero (OK) is returned on success; A negated errno value is returned


### PR DESCRIPTION
## Summary

Added missing macros to the I2C files for the ESP32. Also fixed some typos.

## Impact

None

## Testing

Tested the macros by initializing devices that use I2C.