### PR TITLE
esp32s2: Fix SPI

### DIFF
--- a/arch/xtensa/src/esp32s2/Kconfig
+++ b/arch/xtensa/src/esp32s2/Kconfig
@@ -397,7 +397,33 @@ config ESP32S2_SPI_UDCS
 	---help---
 		Use user-defined CS.
 
+config ESP32S2_SPI2_DMA
+	bool "SPI2 use DMA"
+	default y
+	depends on ESP32S2_SPI2
+
+config ESP32S2_SPI3_DMA
+	bool "SPI3 use DMA"
+	default y
+	depends on ESP32S2_SPI3
+
+config SPI_DMADESC_NUM
+	int "SPI DMA maximum number of descriptors"
+	default 2
+	---help---
+		Configure the maximum number of out-link/in-link descriptors to
+		be chained for a SPI DMA transfer.
+
+config ESP32S2_SPI_DMATHRESHOLD
+	int "SPI DMA threshold"
+	default 64
+	depends on ESP32S2_SPI2_DMA || ESP32S2_SPI3_DMA
+	---help---
+		When SPI DMA is enabled, DMA transfers whose size are below the
+		defined threshold will be performed by polling logic.
+
 if ESP32S2_SPI2
+
 config ESP32S2_SPI2_CSPIN
 	int "SPI2 CS Pin"
 	default 10

--- a/arch/xtensa/src/esp32s2/hardware/esp32s2_spi.h
+++ b/arch/xtensa/src/esp32s2/hardware/esp32s2_spi.h
@@ -720,10 +720,6 @@
 #define SPI_USR_MISO_DBITLEN_V  0x007FFFFF
 #define SPI_USR_MISO_DBITLEN_S  0
 
-/* SPI_SLV_WR_STATUS_REG register */
-
-#define SPI_SLV_WR_STATUS_REG(i) (REG_SPI_BASE(i) + 0x2c)
-
 /* SPI_OPI_MODE : R/W; bitpos: [1]; default: 0;
  * Just for master mode. 1: spi controller is in OPI mode (all in 8-b-m). 0:
  * others.
@@ -746,7 +742,7 @@
 
 /* SPI_MISC_REG register */
 
-#define SPI_MISC_REG(i)          (REG_SPI_BASE(i) + 0x30)
+#define SPI_MISC_REG(i)          (REG_SPI_BASE(i) + 0x2c)
 
 /* SPI_QUAD_DIN_PIN_SWAP : R/W; bitpos: [31]; default: 0;
  * 1:  spi quad input swap enable  0:  spi quad input swap disable
@@ -917,7 +913,7 @@
 
 /* SPI_SLAVE_REG register */
 
-#define SPI_SLAVE_REG(i)  (REG_SPI_BASE(i) + 0x34)
+#define SPI_SLAVE_REG(i)  (REG_SPI_BASE(i) + 0x30)
 
 /* SPI_SOFT_RESET : R/W; bitpos: [31]; default: 0;
  * Software reset enable, reset the spi clock line cs line and data lines.
@@ -1031,7 +1027,7 @@
 
 /* SPI_SLAVE1_REG register */
 
-#define SPI_SLAVE1_REG(i)    (REG_SPI_BASE(i) + 0x38)
+#define SPI_SLAVE1_REG(i)    (REG_SPI_BASE(i) + 0x34)
 
 /* SPI_SLV_LAST_ADDR : R/W; bitpos: [31:24]; default: 0;
  * In the slave mode it is the value of address.
@@ -1081,10 +1077,6 @@
 #define SPI_SLV_ADDR_ERR_V  0x00000001
 #define SPI_SLV_ADDR_ERR_S  13
 
-/* SPI_SLAVE2_REG register */
-
-#define SPI_SLAVE2_REG(i)      (REG_SPI_BASE(i) + 0x3c)
-
 /* SPI_SLV_RD_DMA_DONE : R/W; bitpos: [8]; default: 0;
  * The interrupt raw bit for the completion of Rd-DMA operation in the slave
  * mode.  Can not be changed by CONF_buf.
@@ -1097,7 +1089,7 @@
 
 /* SPI_SLV_WRBUF_DLEN_REG register */
 
-#define SPI_SLV_WRBUF_DLEN_REG(i)  (REG_SPI_BASE(i) + 0x40)
+#define SPI_SLV_WRBUF_DLEN_REG(i)  (REG_SPI_BASE(i) + 0x38)
 
 /* SPI_CONF_BASE_BITLEN : R/W; bitpos: [31:25]; default: 108;
  * The basic spi_clk cycles of CONF state. The real cycle length of CONF
@@ -1122,7 +1114,7 @@
 
 /* SPI_SLV_RDBUF_DLEN_REG register */
 
-#define SPI_SLV_RDBUF_DLEN_REG(i)  (REG_SPI_BASE(i) + 0x44)
+#define SPI_SLV_RDBUF_DLEN_REG(i)  (REG_SPI_BASE(i) + 0x3c)
 
 /* SPI_SEG_MAGIC_ERR : R/W; bitpos: [25]; default: 0;
  * 1: The recent magic value in CONF buffer is not right in master DMA
@@ -1156,7 +1148,7 @@
 
 /* SPI_SLV_RD_BYTE_REG register */
 
-#define SPI_SLV_RD_BYTE_REG(i)    (REG_SPI_BASE(i) + 0x48)
+#define SPI_SLV_RD_BYTE_REG(i)    (REG_SPI_BASE(i) + 0x40)
 
 /* SPI_USR_CONF : R/W; bitpos: [31]; default: 0;
  * 1: Enable the DMA CONF phase of current seg-trans operation, which means
@@ -1230,7 +1222,7 @@
 
 /* SPI_FSM_REG register */
 
-#define SPI_FSM_REG(i)          (REG_SPI_BASE(i) + 0x50)
+#define SPI_FSM_REG(i)          (REG_SPI_BASE(i) + 0x44)
 
 /* SPI_MST_DMA_RD_BYTELEN : R/W; bitpos: [31:12]; default: 0;
  * Define the master DMA read byte length in non seg-trans or seg-trans
@@ -1255,7 +1247,7 @@
 
 /* SPI_HOLD_REG register */
 
-#define SPI_HOLD_REG(i)           (REG_SPI_BASE(i) + 0x54)
+#define SPI_HOLD_REG(i)           (REG_SPI_BASE(i) + 0x48)
 
 /* SPI_DMA_SEG_TRANS_DONE : R/W; bitpos: [7]; default: 0;
  * 1:  spi master DMA full-duplex/half-duplex seg-trans ends or slave
@@ -1311,7 +1303,7 @@
 
 /* SPI_DMA_CONF_REG register */
 
-#define SPI_DMA_CONF_REG(i)    (REG_SPI_BASE(i) + 0x58)
+#define SPI_DMA_CONF_REG(i)    (REG_SPI_BASE(i) + 0x4c)
 
 /* SPI_EXT_MEM_BK_SIZE : R/W; bitpos: [27:26]; default: 0;
  * Select the external memory block size.
@@ -1552,7 +1544,7 @@
 
 /* SPI_DMA_OUT_LINK_REG register */
 
-#define SPI_DMA_OUT_LINK_REG(i)  (REG_SPI_BASE(i) + 0x5c)
+#define SPI_DMA_OUT_LINK_REG(i)  (REG_SPI_BASE(i) + 0x50)
 
 /* SPI_DMA_TX_ENA : R/W; bitpos: [31]; default: 0;
  * spi dma write data status bit.
@@ -1601,7 +1593,7 @@
 
 /* SPI_DMA_IN_LINK_REG register */
 
-#define SPI_DMA_IN_LINK_REG(i)   (REG_SPI_BASE(i) + 0x60)
+#define SPI_DMA_IN_LINK_REG(i)   (REG_SPI_BASE(i) + 0x54)
 
 /* SPI_DMA_RX_ENA : R/W; bitpos: [31]; default: 0;
  * spi dma read data status bit.
@@ -1660,7 +1652,7 @@
 
 /* SPI_DMA_INT_ENA_REG register */
 
-#define SPI_DMA_INT_ENA_REG(i)       (REG_SPI_BASE(i) + 0x64)
+#define SPI_DMA_INT_ENA_REG(i)       (REG_SPI_BASE(i) + 0x58)
 
 /* SPI_OUT_TOTAL_EOF_INT_ENA : R/W; bitpos: [8]; default: 0;
  * The enable bit for sending all the packets to host done.
@@ -1745,7 +1737,7 @@
 
 /* SPI_DMA_INT_RAW_REG register */
 
-#define SPI_DMA_INT_RAW_REG(i)       (REG_SPI_BASE(i) + 0x68)
+#define SPI_DMA_INT_RAW_REG(i)       (REG_SPI_BASE(i) + 0x5c)
 
 /* SPI_OUT_TOTAL_EOF_INT_RAW : RO; bitpos: [8]; default: 0;
  * The raw bit for sending all the packets to host done.
@@ -1830,7 +1822,7 @@
 
 /* SPI_DMA_INT_ST_REG register */
 
-#define SPI_DMA_INT_ST_REG(i)       (REG_SPI_BASE(i) + 0x6c)
+#define SPI_DMA_INT_ST_REG(i)       (REG_SPI_BASE(i) + 0x60)
 
 /* SPI_OUT_TOTAL_EOF_INT_ST : RO; bitpos: [8]; default: 0;
  * The status bit for sending all the packets to host done.
@@ -1915,7 +1907,7 @@
 
 /* SPI_DMA_INT_CLR_REG register */
 
-#define SPI_DMA_INT_CLR_REG(i)       (REG_SPI_BASE(i) + 0x70)
+#define SPI_DMA_INT_CLR_REG(i)       (REG_SPI_BASE(i) + 0x64)
 
 /* SPI_OUT_TOTAL_EOF_INT_CLR : R/W; bitpos: [8]; default: 0;
  * The clear bit for sending all the packets to host done.
@@ -2000,7 +1992,7 @@
 
 /* SPI_IN_ERR_EOF_DES_ADDR_REG register */
 
-#define SPI_IN_ERR_EOF_DES_ADDR_REG(i)   (REG_SPI_BASE(i) + 0x74)
+#define SPI_IN_ERR_EOF_DES_ADDR_REG(i)   (REG_SPI_BASE(i) + 0x68)
 
 /* SPI_DMA_IN_ERR_EOF_DES_ADDR : RO; bitpos: [31:0]; default: 0;
  * The inlink descriptor address when spi dma produce receiving error.
@@ -2013,7 +2005,7 @@
 
 /* SPI_IN_SUC_EOF_DES_ADDR_REG register */
 
-#define SPI_IN_SUC_EOF_DES_ADDR_REG(i) (REG_SPI_BASE(i) + 0x78)
+#define SPI_IN_SUC_EOF_DES_ADDR_REG(i) (REG_SPI_BASE(i) + 0x6c)
 
 /* SPI_DMA_IN_SUC_EOF_DES_ADDR : RO; bitpos: [31:0]; default: 0;
  * The last inlink descriptor address when spi dma produce from_suc_eof.
@@ -2026,7 +2018,7 @@
 
 /* SPI_INLINK_DSCR_REG register */
 
-#define SPI_INLINK_DSCR_REG(i)         (REG_SPI_BASE(i) + 0x7c)
+#define SPI_INLINK_DSCR_REG(i)         (REG_SPI_BASE(i) + 0x70)
 
 /* SPI_DMA_INLINK_DSCR : RO; bitpos: [31:0]; default: 0;
  * The content of current in descriptor pointer.
@@ -2039,7 +2031,7 @@
 
 /* SPI_INLINK_DSCR_BF0_REG register */
 
-#define SPI_INLINK_DSCR_BF0_REG(i)       (REG_SPI_BASE(i) + 0x80)
+#define SPI_INLINK_DSCR_BF0_REG(i)       (REG_SPI_BASE(i) + 0x74)
 
 /* SPI_DMA_INLINK_DSCR_BF0 : RO; bitpos: [31:0]; default: 0;
  * The content of next in descriptor pointer.
@@ -2065,7 +2057,7 @@
 
 /* SPI_OUT_EOF_BFR_DES_ADDR_REG register */
 
-#define SPI_OUT_EOF_BFR_DES_ADDR_REG(i)    (REG_SPI_BASE(i) + 0x88)
+#define SPI_OUT_EOF_BFR_DES_ADDR_REG(i)    (REG_SPI_BASE(i) + 0x7c)
 
 /* SPI_DMA_OUT_EOF_BFR_DES_ADDR : RO; bitpos: [31:0]; default: 0;
  * The address of buffer relative to the outlink descriptor that produce eof.
@@ -2078,7 +2070,7 @@
 
 /* SPI_OUT_EOF_DES_ADDR_REG register */
 
-#define SPI_OUT_EOF_DES_ADDR_REG(i)     (REG_SPI_BASE(i) + 0x8c)
+#define SPI_OUT_EOF_DES_ADDR_REG(i)     (REG_SPI_BASE(i) + 0x80)
 
 /* SPI_DMA_OUT_EOF_DES_ADDR : RO; bitpos: [31:0]; default: 0;
  * The last outlink descriptor address when spi dma produce to_eof.
@@ -2091,7 +2083,7 @@
 
 /* SPI_OUTLINK_DSCR_REG register */
 
-#define SPI_OUTLINK_DSCR_REG(i)     (REG_SPI_BASE(i) + 0x90)
+#define SPI_OUTLINK_DSCR_REG(i)     (REG_SPI_BASE(i) + 0x84)
 
 /* SPI_DMA_OUTLINK_DSCR : RO; bitpos: [31:0]; default: 0;
  * The content of current out descriptor pointer.
@@ -2104,7 +2096,7 @@
 
 /* SPI_OUTLINK_DSCR_BF0_REG register */
 
-#define SPI_OUTLINK_DSCR_BF0_REG(i)       (REG_SPI_BASE(i) + 0x94)
+#define SPI_OUTLINK_DSCR_BF0_REG(i)       (REG_SPI_BASE(i) + 0x88)
 
 /* SPI_DMA_OUTLINK_DSCR_BF0 : RO; bitpos: [31:0]; default: 0;
  * The content of next out descriptor pointer.
@@ -2117,7 +2109,7 @@
 
 /* SPI_OUTLINK_DSCR_BF1_REG register */
 
-#define SPI_OUTLINK_DSCR_BF1_REG(i)       (REG_SPI_BASE(i) + 0x98)
+#define SPI_OUTLINK_DSCR_BF1_REG(i)       (REG_SPI_BASE(i) + 0x8c)
 
 /* SPI_DMA_OUTLINK_DSCR_BF1 : RO; bitpos: [31:0]; default: 0;
  * The content of current out descriptor data buffer pointer.
@@ -2130,7 +2122,7 @@
 
 /* SPI_DMA_OUTSTATUS_REG register */
 
-#define SPI_DMA_OUTSTATUS_REG(i)       (REG_SPI_BASE(i) + 0x9c)
+#define SPI_DMA_OUTSTATUS_REG(i)       (REG_SPI_BASE(i) + 0x90)
 
 /* SPI_DMA_OUTFIFO_EMPTY : RO; bitpos: [31]; default: 1;
  * SPI dma outfifo is empty.
@@ -2188,7 +2180,7 @@
 
 /* SPI_DMA_INSTATUS_REG register */
 
-#define SPI_DMA_INSTATUS_REG(i)       (REG_SPI_BASE(i) + 0xa0)
+#define SPI_DMA_INSTATUS_REG(i)       (REG_SPI_BASE(i) + 0x94)
 
 /* SPI_DMA_INFIFO_EMPTY : RO; bitpos: [31]; default: 1;
  * SPI dma infifo is empty.
@@ -2246,7 +2238,7 @@
 
 /* SPI_W0_REG register */
 
-#define SPI_W0_REG(i)      (REG_SPI_BASE(i) + 0xa4)
+#define SPI_W0_REG(i)      (REG_SPI_BASE(i) + 0x98)
 
 /* SPI_BUF0 : R/W; bitpos: [31:0]; default: 0;
  * data buffer
@@ -2259,7 +2251,7 @@
 
 /* SPI_W1_REG register */
 
-#define SPI_W1_REG(i)      (REG_SPI_BASE(i) + 0xa8)
+#define SPI_W1_REG(i)      (REG_SPI_BASE(i) + 0x9c)
 
 /* SPI_BUF1 : R/W; bitpos: [31:0]; default: 0;
  * data buffer
@@ -2272,7 +2264,7 @@
 
 /* SPI_W2_REG register */
 
-#define SPI_W2_REG(i)      (REG_SPI_BASE(i) + 0xac)
+#define SPI_W2_REG(i)      (REG_SPI_BASE(i) + 0xa0)
 
 /* SPI_BUF2 : R/W; bitpos: [31:0]; default: 0;
  * data buffer
@@ -2285,7 +2277,7 @@
 
 /* SPI_W3_REG register */
 
-#define SPI_W3_REG(i)      (REG_SPI_BASE(i) + 0xb0)
+#define SPI_W3_REG(i)      (REG_SPI_BASE(i) + 0xa4)
 
 /* SPI_BUF3 : R/W; bitpos: [31:0]; default: 0;
  * data buffer
@@ -2298,7 +2290,7 @@
 
 /* SPI_W4_REG register */
 
-#define SPI_W4_REG(i)      (REG_SPI_BASE(i) + 0xb4)
+#define SPI_W4_REG(i)      (REG_SPI_BASE(i) + 0xa8)
 
 /* SPI_BUF4 : R/W; bitpos: [31:0]; default: 0;
  * data buffer
@@ -2311,7 +2303,7 @@
 
 /* SPI_W5_REG register */
 
-#define SPI_W5_REG(i)      (REG_SPI_BASE(i) + 0xb8)
+#define SPI_W5_REG(i)      (REG_SPI_BASE(i) + 0xac)
 
 /* SPI_BUF5 : R/W; bitpos: [31:0]; default: 0;
  * data buffer
@@ -2324,7 +2316,7 @@
 
 /* SPI_W6_REG register */
 
-#define SPI_W6_REG(i)      (REG_SPI_BASE(i) + 0xbc)
+#define SPI_W6_REG(i)      (REG_SPI_BASE(i) + 0xb0)
 
 /* SPI_BUF6 : R/W; bitpos: [31:0]; default: 0;
  * data buffer
@@ -2337,7 +2329,7 @@
 
 /* SPI_W7_REG register */
 
-#define SPI_W7_REG(i)      (REG_SPI_BASE(i) + 0xc0)
+#define SPI_W7_REG(i)      (REG_SPI_BASE(i) + 0xb4)
 
 /* SPI_BUF7 : R/W; bitpos: [31:0]; default: 0;
  * data buffer
@@ -2350,7 +2342,7 @@
 
 /* SPI_W8_REG register */
 
-#define SPI_W8_REG(i)      (REG_SPI_BASE(i) + 0xc4)
+#define SPI_W8_REG(i)      (REG_SPI_BASE(i) + 0xb8)
 
 /* SPI_BUF8 : R/W; bitpos: [31:0]; default: 0;
  * data buffer
@@ -2363,7 +2355,7 @@
 
 /* SPI_W9_REG register */
 
-#define SPI_W9_REG(i)      (REG_SPI_BASE(i) + 0xc8)
+#define SPI_W9_REG(i)      (REG_SPI_BASE(i) + 0xbc)
 
 /* SPI_BUF9 : R/W; bitpos: [31:0]; default: 0;
  * data buffer
@@ -2376,7 +2368,7 @@
 
 /* SPI_W10_REG register */
 
-#define SPI_W10_REG(i)      (REG_SPI_BASE(i) + 0xcc)
+#define SPI_W10_REG(i)      (REG_SPI_BASE(i) + 0xc0)
 
 /* SPI_BUF10 : R/W; bitpos: [31:0]; default: 0;
  * data buffer
@@ -2389,7 +2381,7 @@
 
 /* SPI_W11_REG register */
 
-#define SPI_W11_REG(i)      (REG_SPI_BASE(i) + 0xd0)
+#define SPI_W11_REG(i)      (REG_SPI_BASE(i) + 0xc4)
 
 /* SPI_BUF11 : R/W; bitpos: [31:0]; default: 0;
  * data buffer
@@ -2402,7 +2394,7 @@
 
 /* SPI_W12_REG register */
 
-#define SPI_W12_REG(i)      (REG_SPI_BASE(i) + 0xd4)
+#define SPI_W12_REG(i)      (REG_SPI_BASE(i) + 0xc8)
 
 /* SPI_BUF12 : R/W; bitpos: [31:0]; default: 0;
  * data buffer
@@ -2415,7 +2407,7 @@
 
 /* SPI_W13_REG register */
 
-#define SPI_W13_REG(i)      (REG_SPI_BASE(i) + 0xd8)
+#define SPI_W13_REG(i)      (REG_SPI_BASE(i) + 0xcc)
 
 /* SPI_BUF13 : R/W; bitpos: [31:0]; default: 0;
  * data buffer
@@ -2428,7 +2420,7 @@
 
 /* SPI_W14_REG register */
 
-#define SPI_W14_REG(i)      (REG_SPI_BASE(i) + 0xdc)
+#define SPI_W14_REG(i)      (REG_SPI_BASE(i) + 0xd0)
 
 /* SPI_BUF14 : R/W; bitpos: [31:0]; default: 0;
  * data buffer
@@ -2441,7 +2433,7 @@
 
 /* SPI_W15_REG register */
 
-#define SPI_W15_REG(i)      (REG_SPI_BASE(i) + 0xe0)
+#define SPI_W15_REG(i)      (REG_SPI_BASE(i) + 0xd4)
 
 /* SPI_BUF15 : R/W; bitpos: [31:0]; default: 0;
  * data buffer
@@ -2454,7 +2446,7 @@
 
 /* SPI_W16_REG register */
 
-#define SPI_W16_REG(i)      (REG_SPI_BASE(i) + 0xe4)
+#define SPI_W16_REG(i)      (REG_SPI_BASE(i) + 0xd8)
 
 /* SPI_BUF16 : R/W; bitpos: [31:0]; default: 0;
  * data buffer
@@ -2467,7 +2459,7 @@
 
 /* SPI_W17_REG register */
 
-#define SPI_W17_REG(i)      (REG_SPI_BASE(i) + 0xe8)
+#define SPI_W17_REG(i)      (REG_SPI_BASE(i) + 0xdc)
 
 /* SPI_BUF17 : R/W; bitpos: [31:0]; default: 0;
  * data buffer
@@ -2480,7 +2472,7 @@
 
 /* SPI_DIN_MODE_REG register */
 
-#define SPI_DIN_MODE_REG(i)          (REG_SPI_BASE(i) + 0xec)
+#define SPI_DIN_MODE_REG(i)          (REG_SPI_BASE(i) + 0xe0)
 
 /* SPI_TIMING_CLK_ENA : R/W; bitpos: [24]; default: 0;
  * 1:enable hclk in spi_timing.v.  0: disable it.
@@ -2597,7 +2589,7 @@
 
 /* SPI_DIN_NUM_REG register */
 
-#define SPI_DIN_NUM_REG(i)     (REG_SPI_BASE(i) + 0xf0)
+#define SPI_DIN_NUM_REG(i)     (REG_SPI_BASE(i) + 0xe4)
 
 /* SPI_DIN7_NUM : R/W; bitpos: [15:14]; default: 0;
  * the input signals are delayed by system clock cycles, 0: delayed by 1
@@ -2681,7 +2673,7 @@
 
 /* SPI_DOUT_MODE_REG register */
 
-#define SPI_DOUT_MODE_REG(i)     (REG_SPI_BASE(i) + 0xf4)
+#define SPI_DOUT_MODE_REG(i)     (REG_SPI_BASE(i) + 0xe8)
 
 /* SPI_DOUT7_MODE : R/W; bitpos: [23:21]; default: 0;
  * Configure the output signal delay mode. 0: without delayed, 1: with the
@@ -2789,7 +2781,7 @@
 
 /* SPI_DOUT_NUM_REG register */
 
-#define SPI_DOUT_NUM_REG(i)     (REG_SPI_BASE(i) + 0xf8)
+#define SPI_DOUT_NUM_REG(i)     (REG_SPI_BASE(i) + 0xec)
 
 /* SPI_DOUT7_NUM : R/W; bitpos: [15:14]; default: 0;
  * the output signals are delayed by system clock cycles, 0: delayed by 1
@@ -2873,7 +2865,7 @@
 
 /* SPI_LCD_CTRL_REG register */
 
-#define SPI_LCD_CTRL_REG(i)     (REG_SPI_BASE(i) + 0xfc)
+#define SPI_LCD_CTRL_REG(i)     (REG_SPI_BASE(i) + 0xf0)
 
 /* SPI_LCD_SRGB_MODE_EN : R/W; bitpos: [31]; default: 0;
  * 1: Enable LCD mode output vsync, hsync, de. 0: Disable.
@@ -2913,7 +2905,7 @@
 
 /* SPI_LCD_CTRL1_REG register */
 
-#define SPI_LCD_CTRL1_REG(i)       (REG_SPI_BASE(i) + 0x100)
+#define SPI_LCD_CTRL1_REG(i)       (REG_SPI_BASE(i) + 0xf4)
 
 /* SPI_LCD_HT_WIDTH : R/W; bitpos: [31:20]; default: 0;
  * It is the horizontal total width of a frame.
@@ -2944,7 +2936,7 @@
 
 /* SPI_LCD_CTRL2_REG register */
 
-#define SPI_LCD_CTRL2_REG(i)      (REG_SPI_BASE(i) + 0x104)
+#define SPI_LCD_CTRL2_REG(i)      (REG_SPI_BASE(i) + 0xf8)
 
 /* SPI_LCD_HSYNC_POSITION : R/W; bitpos: [31:24]; default: 0;
  * It is the position of spi_hsync_out active pulse in a line.
@@ -3002,7 +2994,7 @@
 
 /* SPI_LCD_D_MODE_REG register */
 
-#define SPI_LCD_D_MODE_REG(i)      (REG_SPI_BASE(i) + 0x108)
+#define SPI_LCD_D_MODE_REG(i)      (REG_SPI_BASE(i) + 0xfc)
 
 /* SPI_D_VSYNC_MODE : R/W; bitpos: [14:12]; default: 0;
  * Configure the output  spi_vsync delay mode. 0: without delayed, 1: with
@@ -3071,7 +3063,7 @@
 
 /* SPI_LCD_D_NUM_REG register */
 
-#define SPI_LCD_D_NUM_REG(i)      (REG_SPI_BASE(i) + 0x10c)
+#define SPI_LCD_D_NUM_REG(i)      (REG_SPI_BASE(i) + 0x100)
 
 /* SPI_D_VSYNC_NUM : R/W; bitpos: [9:8]; default: 0;
  * the output spi_vsync is delayed by system clock cycles, 0: delayed by 1

--- a/boards/xtensa/esp32s2/common/include/esp32s2_max6675.h
+++ b/boards/xtensa/esp32s2/common/include/esp32s2_max6675.h
@@ -1,0 +1,36 @@
+/****************************************************************************
+ * boards/xtensa/esp32s2/common/include/esp32s2_max6675.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: board_max6675_initialize
+ *
+ * Description:
+ *   Initialize and register the MAX6675 Temperature Sensor driver.
+ *
+ * Input Parameters:
+ *   devno - The device number, used to build the device path as /dev/tempN
+ *   busno - The SPI bus number
+ *
+ * Returned Value:
+ *   Zero (OK) on success; a negated errno value on failure.
+ *
+ ****************************************************************************/
+
+int board_max6675_initialize(int devno, int busno);

--- a/boards/xtensa/esp32s2/common/src/Make.defs
+++ b/boards/xtensa/esp32s2/common/src/Make.defs
@@ -24,6 +24,10 @@ ifeq ($(CONFIG_WATCHDOG),y)
   CSRCS += esp32s2_board_wdt.c
 endif
 
+ifeq ($(CONFIG_SENSORS_MAX6675),y)
+  CSRCS += esp32s2_max6675.c
+endif
+
 DEPPATH += --dep-path src
 VPATH += :src
 CFLAGS += $(shell $(INCDIR) "$(CC)" $(TOPDIR)$(DELIM)arch$(DELIM)$(CONFIG_ARCH)$(DELIM)src$(DELIM)board$(DELIM)src)

--- a/boards/xtensa/esp32s2/common/src/esp32s2_max6675.c
+++ b/boards/xtensa/esp32s2/common/src/esp32s2_max6675.c
@@ -1,0 +1,103 @@
+/****************************************************************************
+ * boards/xtensa/esp32s2/common/src/esp32s2_max6675.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+#include <nuttx/arch.h>
+#include <nuttx/sensors/max6675.h>
+#include <nuttx/spi/spi.h>
+#include <stdio.h>
+#include <debug.h>
+#include "esp32s2_spi.h"
+
+#ifdef CONFIG_SENSORS_MAX6675
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Types
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Function Prototypes
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: board_max6675_initialize
+ *
+ * Description:
+ *   Initialize and register the MAX6675 Temperature Sensor driver.
+ *
+ * Input Parameters:
+ *   devno - The device number, used to build the device path as /dev/tempN
+ *   busno - The SPI bus number
+ *
+ * Returned Value:
+ *   Zero (OK) on success; a negated errno value on failure.
+ *
+ ****************************************************************************/
+
+int board_max6675_initialize(int devno, int busno)
+{
+  struct spi_dev_s *spi;
+  char devpath[12];
+  int ret;
+
+  spi = esp32s2_spibus_initialize(busno);
+
+  if (!spi)
+    {
+      return -ENODEV;
+    }
+
+  /* Then register the barometer sensor */
+
+  snprintf(devpath, sizeof(devpath), "/dev/temp%d", devno);
+  ret = max6675_register(devpath, spi);
+  if (ret < 0)
+    {
+      snerr("ERROR: Error registering MAX6675\n");
+    }
+
+  return ret;
+}
+
+#endif

--- a/boards/xtensa/esp32s2/esp32s2-saola-1/src/Make.defs
+++ b/boards/xtensa/esp32s2/esp32s2-saola-1/src/Make.defs
@@ -49,6 +49,10 @@ ifeq ($(CONFIG_SENSORS_BMP180),y)
 CSRCS += esp32s2_bmp180.c
 endif
 
+ifeq ($(CONFIG_ESP32S2_SPI),y)
+CSRCS += esp32s2_board_spi.c
+endif
+
 SCRIPTIN = $(SCRIPTDIR)$(DELIM)esp32s2.template.ld
 SCRIPTOUT = $(SCRIPTDIR)$(DELIM)esp32s2_out.ld
 

--- a/boards/xtensa/esp32s2/esp32s2-saola-1/src/esp32s2_board_spi.c
+++ b/boards/xtensa/esp32s2/esp32s2-saola-1/src/esp32s2_board_spi.c
@@ -1,0 +1,126 @@
+/****************************************************************************
+ * boards/xtensa/esp32s2/esp32s2-saola-1/src/esp32s2_board_spi.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <debug.h>
+
+#include <nuttx/spi/spi.h>
+
+#include "esp32s2_gpio.h"
+#include "esp32s2-saola-1.h"
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: esp32s2_spi2_status
+ ****************************************************************************/
+
+#ifdef CONFIG_ESP32S2_SPI2
+
+uint8_t esp32s2_spi2_status(struct spi_dev_s *dev, uint32_t devid)
+{
+  uint8_t status = 0;
+
+  return status;
+}
+
+#endif
+
+/****************************************************************************
+ * Name: esp32s2_spi2_cmddata
+ ****************************************************************************/
+
+#if defined(CONFIG_ESP32S2_SPI2) && defined(CONFIG_SPI_CMDDATA)
+
+int esp32s2_spi2_cmddata(struct spi_dev_s *dev, uint32_t devid, bool cmd)
+{
+  if (devid == SPIDEV_DISPLAY(0))
+    {
+      /*  This is the Data/Command control pad which determines whether the
+       *  data bits are data or a command.
+       */
+
+      esp32s2_gpiowrite(GPIO_LCD_DC, !cmd);
+
+      return OK;
+    }
+
+  spiinfo("devid: %" PRIu32 " CMD: %s\n", devid, cmd ? "command" :
+          "data");
+
+  return -ENODEV;
+}
+
+#endif
+
+/****************************************************************************
+ * Name: esp32s2_spi3_status
+ ****************************************************************************/
+
+#ifdef CONFIG_ESP32S2_SPI3
+
+uint8_t esp32s2_spi3_status(struct spi_dev_s *dev, uint32_t devid)
+{
+  uint8_t status = 0;
+
+  return status;
+}
+
+#endif
+
+/****************************************************************************
+ * Name: esp32s2_spi3_cmddata
+ ****************************************************************************/
+
+#if defined(CONFIG_ESP32S2_SPI3) && defined(CONFIG_SPI_CMDDATA)
+
+int esp32s2_spi3_cmddata(struct spi_dev_s *dev, uint32_t devid, bool cmd)
+{
+  if (devid == SPIDEV_DISPLAY(0))
+    {
+      /*  This is the Data/Command control pad which determines whether the
+       *  data bits are data or a command.
+       */
+
+      esp32s2_gpiowrite(CONFIG_ESP32S2_SPI3_MISOPIN, !cmd);
+
+      return OK;
+    }
+
+  spiinfo("devid: %" PRIu32 " CMD: %s\n", devid, cmd ? "command" :
+          "data");
+
+  return -ENODEV;
+}
+
+#endif

--- a/boards/xtensa/esp32s2/esp32s2-saola-1/src/esp32s2_bringup.c
+++ b/boards/xtensa/esp32s2/esp32s2-saola-1/src/esp32s2_bringup.c
@@ -62,6 +62,10 @@
 #  include "esp32s2_board_wdt.h"
 #endif
 
+#ifdef CONFIG_SENSORS_MAX6675
+#  include "esp32s2_max6675.h"
+#endif
+
 #include "esp32s2-saola-1.h"
 
 /****************************************************************************
@@ -214,6 +218,14 @@ int esp32s2_bringup(void)
     {
       syslog(LOG_ERR,
              "Failed to initialize BMP180 driver for I2C0: %d\n", ret);
+    }
+#endif
+
+#ifdef CONFIG_SENSORS_MAX6675
+  ret = board_max6675_initialize(0, 2);
+  if (ret < 0)
+    {
+      syslog(LOG_ERR, "ERROR: MAX6675 initialization failed: %d\n", ret);
     }
 #endif
 


### PR DESCRIPTION
## Summary
Fix issues found on ESP32S2 SPI driver
## Impact
User will be able to use SPI on ESP32S2
## Testing
esp32s2-saola-1
