### PR TITLE
Fix armclang build warning: L6306W

### DIFF
--- a/arch/arm/src/armv7-a/arm_vectortab.S
+++ b/arch/arm/src/armv7-a/arm_vectortab.S
@@ -34,6 +34,10 @@
  * Public Symbols
  ****************************************************************************/
 
+#ifdef CONFIG_ARM_TOOLCHAIN_ARMCLANG
+	.eabi_attribute Tag_ABI_align_preserved, 1
+#endif
+
 	.globl		_vector_start
 	.globl		_vector_end
 

--- a/arch/arm/src/armv7-r/arm_vectortab.S
+++ b/arch/arm/src/armv7-r/arm_vectortab.S
@@ -34,6 +34,10 @@
  * Public Symbols
  ****************************************************************************/
 
+#ifdef CONFIG_ARM_TOOLCHAIN_ARMCLANG
+	.eabi_attribute Tag_ABI_align_preserved, 1
+#endif
+
 	.globl		_vector_start
 	.globl		_vector_end
 


### PR DESCRIPTION
When a function is known to preserve eight-byte alignment of the stack, armclang assigns the build attribute Tag_ABI_align_preserved to that function. However, the armclang integrated assembler does not automatically assign this attribute to assembly code.

Signed-off-by: xiangdong6 <xiangdong6@xiaomi.com>

## Summary

## Impact

## Testing

