### PR TITLE
xtensa: Save SCOMPARE1 on context switches

### DIFF
--- a/arch/xtensa/src/common/xtensa_context.S
+++ b/arch/xtensa/src/common/xtensa_context.S
@@ -138,6 +138,11 @@ _xtensa_context_save:
 	rsr		a3, SAR
 	s32i	a3, sp, (4 * REG_SAR)
 
+#if XCHAL_HAVE_S32C1I != 0
+	rsr		a3, SCOMPARE1
+	s32i	a3, sp, (4 * REG_SCOMPARE1)
+#endif
+
 #if XCHAL_HAVE_LOOPS != 0
 	rsr		a3, LBEG
 	s32i	a3, sp, (4 * REG_LBEG)


### PR DESCRIPTION
## Summary

This PR intends to fix the usage of atomic operations on Xtensa chips that provide support for the `S32CI1` instruction.
The lock-free atomic operation could result in failure due to the `SCOMPARE1` register not being correctly saved during a context switch.

This fix is a complement to #4664.

## Impact

Xtensa-based chips that implement the `S32CI1` instruction (e.g. **ESP32** and **ESP32-S3**).

## Testing

```c
#include <nuttx/config.h>

#include <stdatomic.h>
#include <stdio.h>

int main(int argc, FAR char *argv[])
{
  printf("Atomic test start.\n");

  atomic_uint count;
  atomic_init(&count, 0);

  for (int set = 0; set < 100; set++)
    {
      for (int i = 0; i < 1000000; i++)
        {
          atomic_fetch_add_explicit(&count, 1, memory_order_acquire);
          if (count != 1)
            {
              printf("Failed to acquire:set=%d, loop=%d, counter=%d\n", set, i, count);
              goto end;
            }

          atomic_fetch_sub_explicit(&count, 1, memory_order_release);
          if (count != 0)
            {
              printf("Failed to release:set=%d, loop=%d, counter=%d\n", set, i, count);
              goto end;
            }
        }
      printf("set=%d\n", set);
    }

end:
  printf("Atomic test end.\n");

  return 0;
}
```

**Expected**
Test ends successfully after 100 iterations.

**Actual**
Test terminates with the following error: `Failed to release:set=13, loop=100440, counter=1`.

