### PR TITLE
fs/procfs: check task group before get group info

### DIFF
--- a/fs/procfs/fs_procfsproc.c
+++ b/fs/procfs/fs_procfsproc.c
@@ -493,7 +493,6 @@ static ssize_t proc_status(FAR struct proc_file_s *procfile,
                            FAR struct tcb_s *tcb, FAR char *buffer,
                            size_t buflen, off_t offset)
 {
-  FAR struct task_group_s *group;
   FAR const char *policy;
   FAR const char *name;
   size_t remaining;
@@ -543,12 +542,9 @@ static ssize_t proc_status(FAR struct proc_file_s *procfile,
       return totalsize;
     }
 
-  group = tcb->group;
-  DEBUGASSERT(group != NULL);
-
   linesize   = procfs_snprintf(procfile->line, STATUS_LINELEN,
-                               "%-12s%d\n",
-                               "Group:", group->tg_pid);
+                               "%-12s%d\n", "Group:",
+                               tcb->group ? tcb->group->tg_pid : -1);
   copysize   = procfs_memcpy(procfile->line, linesize, buffer, remaining,
                              &offset);
 


### PR DESCRIPTION
## Summary

When ps cmd is invoked during the task exit process, the group information of the task may be deleted. So need check the task flag before get the task group information.

## Impact

NA

## Testing

sabre-6quad:smp