### PR TITLE
tools/ci: patch for docker gcc-arm-none-eabi to 11.3.Rel1 August 08, 2022

### DIFF
--- a/tools/ci/patch/arm-none-eabi-workaround-for-newlib-version-break.patch
+++ b/tools/ci/patch/arm-none-eabi-workaround-for-newlib-version-break.patch
@@ -1,0 +1,38 @@
+From 819ab4ac433b809fdaca33246e2bffa1426acc0f Mon Sep 17 00:00:00 2001
+From: chao an <anchao@xiaomi.com>
+Date: Tue, 11 Oct 2022 15:27:37 +0800
+Subject: [PATCH] arm-none-eabi: workaround for newlib version break
+
+Signed-off-by: chao an <anchao@xiaomi.com>
+---
+ arm-none-eabi/include/_newlib_version.h | 15 ++++-----------
+ 1 file changed, 4 insertions(+), 11 deletions(-)
+
+diff --git a/arm-none-eabi/include/_newlib_version.h gcc-arm-none-eabi/arm-none-eabi/include/_newlib_version.h
+index 0dbf962e..c5d2be6d 100644
+--- a/arm-none-eabi/include/_newlib_version.h
++++ gcc-arm-none-eabi/arm-none-eabi/include/_newlib_version.h
+@@ -3,16 +3,9 @@
+ #ifndef _NEWLIB_VERSION_H__
+ #define _NEWLIB_VERSION_H__ 1
+
+-/* The newlib version in string format. */
+-#define _NEWLIB_VERSION "@NEWLIB_VERSION@"
+-
+-/* The newlib major version number. */
+-#define __NEWLIB__ @NEWLIB_MAJOR_VERSION@
+-
+-/* The newlib minor version number. */
+-#define __NEWLIB_MINOR__ @NEWLIB_MINOR_VERSION@
+-
+-/* The newlib patch level. */
+-#define __NEWLIB_PATCHLEVEL__ @NEWLIB_PATCHLEVEL_VERSION@
++#define _NEWLIB_VERSION "4.2.0"
++#define __NEWLIB__ 4
++#define __NEWLIB_MINOR__ 2
++#define __NEWLIB_PATCHLEVEL__ 0
+
+ #endif /* !_NEWLIB_VERSION_H__ */
+--
+2.25.1
+


### PR DESCRIPTION
## Summary

tools/ci: patch for docker gcc-arm-none-eabi to 11.3.Rel1 August 08, 2022

Fix Wrong Newlib version strings, error when stdlib.h is included

Reference:
https://community.arm.com/support-forums/f/compilers-and-libraries-forum/53470/arm-gnu-toolchain-11-3-rel1-x86_64-arm-none-eabi-wrong-newlib-version-strings-error-when-stdlib-h-is-included

Signed-off-by: chao an <anchao@xiaomi.com>

## Impact

Depends by:
https://github.com/apache/incubator-nuttx/pull/7325
## Testing

ci 