### PR TITLE
arch/sim: fix MTU mismatch on TAP device in host route mode

### DIFF
--- a/arch/sim/src/sim/posix/up_tapdev.c
+++ b/arch/sim/src/sim/posix/up_tapdev.c
@@ -189,10 +189,7 @@ void tapdev_init(int devidx, void *priv,
   struct ifreq ifr;
   int tapdevfd;
   int ret;
-
-#ifdef CONFIG_SIM_NET_BRIDGE
   int sockfd;
-#endif
 
   /* Open the tap device */
 
@@ -219,7 +216,6 @@ void tapdev_init(int devidx, void *priv,
 
   strncpy(gdevname[devidx], ifr.ifr_name, IFNAMSIZ);
 
-#ifdef CONFIG_SIM_NET_BRIDGE
   /* Get a socket with which to manipulate the tap device; the remaining
    * ioctl calls unfortunately won't work on the tap device fd.
    */
@@ -232,6 +228,7 @@ void tapdev_init(int devidx, void *priv,
       return;
     }
 
+#ifdef CONFIG_SIM_NET_BRIDGE
   /* Assign the tap device to a bridge */
 
   memset(&ifr, 0, sizeof(ifr));
@@ -248,6 +245,10 @@ void tapdev_init(int devidx, void *priv,
       close(tapdevfd);
       return;
     }
+#else
+  memset(&ifr, 0, sizeof(ifr));
+  strncpy(ifr.ifr_name, gdevname[devidx], IFNAMSIZ);
+#endif
 
   ret = ioctl(sockfd, SIOCGIFMTU, &ifr);
   close(sockfd);
@@ -262,7 +263,6 @@ void tapdev_init(int devidx, void *priv,
     {
       netdriver_setmtu(devidx, ifr.ifr_mtu);
     }
-#endif
 
   gtapdevfd[devidx] = tapdevfd;
   g_priv[devidx] = priv;

--- a/arch/sim/src/sim/up_netdriver.c
+++ b/arch/sim/src/sim/up_netdriver.c
@@ -441,7 +441,7 @@ void netdriver_setmacaddr(int devidx, unsigned char *macaddr)
 
 void netdriver_setmtu(int devidx, int mtu)
 {
-  g_sim_dev[devidx].d_pktsize = mtu;
+  g_sim_dev[devidx].d_pktsize = mtu + ETH_HDRLEN;
 }
 
 void netdriver_loop(void)


### PR DESCRIPTION
## Summary
In host route mode (bridge mode disabled), the `d_pktsize` of TAP device is not initialized and will be set to `CONFIG_NET_ETH_PKTSIZE` in `netdev_register`, while the MTU on host side keeps at 1500. Input packets larger than `CONFIG_NET_ETH_PKTSIZE` will be dropped because 'IP packet shorter than length in IP header'.
This patch fix this issue by reading MTU from host side and set as `d_pktsize`, just the same as what is done in bridge mode.

## Impact
Netdriver in sim.

## Testing
Tested on Ubuntu 22.04 x86_64, with actual HTTP stream.
