### PR TITLE
include/nuttx/can.h: make error definitions compatible with Linux

### DIFF
--- a/arch/arm/src/stm32/stm32_can_sock.c
+++ b/arch/arm/src/stm32/stm32_can_sock.c
@@ -1632,7 +1632,7 @@ static void stm32can_sceinterrupt_work(void *arg)
               /* Receive CRC Error */
 
               errbits |= CAN_ERR_PROT;
-              data[3] |= CAN_ERR_PROT_LOC_CRCSEQ;
+              data[3] |= CAN_ERR_PROT_LOC_CRC_SEQ;
             }
         }
 

--- a/arch/arm/src/stm32/stm32_fdcan_sock.c
+++ b/arch/arm/src/stm32/stm32_fdcan_sock.c
@@ -2233,7 +2233,8 @@ static void fdcan_error(struct stm32_fdcan_s *priv, uint32_t status)
               /* Receive CRC Error */
 
               errbits |= CAN_ERR_PROT;
-              data[3] |= (CAN_ERR_PROT_LOC_CRCSEQ | CAN_ERR_PROT_LOC_CRCDEL);
+              data[3] |= (CAN_ERR_PROT_LOC_CRC_SEQ |
+                          CAN_ERR_PROT_LOC_CRC_DEL);
             }
 
           if ((psr & FDCAN_PSR_LEC(FDCAN_PSR_EC_NO_CHANGE)) != 0)
@@ -2298,7 +2299,8 @@ static void fdcan_error(struct stm32_fdcan_s *priv, uint32_t status)
               /* Receive CRC Error */
 
               errbits |= CAN_ERR_PROT;
-              data[3] |= (CAN_ERR_PROT_LOC_CRCSEQ | CAN_ERR_PROT_LOC_CRCDEL);
+              data[3] |= (CAN_ERR_PROT_LOC_CRC_SEQ |
+                          CAN_ERR_PROT_LOC_CRC_DEL);
             }
 
           if ((psr & FDCAN_PSR_DLEC(FDCAN_PSR_EC_NO_CHANGE)) != 0)
@@ -2347,7 +2349,7 @@ static void fdcan_error(struct stm32_fdcan_s *priv, uint32_t status)
     {
       /* Timeout Occurred */
 
-      errbits |= CAN_ERR_TXTIMEOUT;
+      errbits |= CAN_ERR_TX_TIMEOUT;
     }
 
   if ((status & (FDCAN_INT_MRAF | FDCAN_INT_ELO)) != 0)

--- a/arch/arm/src/stm32f7/stm32_can_sock.c
+++ b/arch/arm/src/stm32f7/stm32_can_sock.c
@@ -1656,7 +1656,7 @@ static void stm32can_sceinterrupt_work(void *arg)
               /* Receive CRC Error */
 
               errbits |= CAN_ERR_PROT;
-              data[3] |= CAN_ERR_PROT_LOC_CRCSEQ;
+              data[3] |= CAN_ERR_PROT_LOC_CRC_SEQ;
             }
         }
 

--- a/include/nuttx/can.h
+++ b/include/nuttx/can.h
@@ -212,7 +212,7 @@
 
 /* Error class in can_id */
 
-#define CAN_ERR_TXTIMEOUT        (1 << 0) /* Bit 0: TX timeout */
+#define CAN_ERR_TX_TIMEOUT       (1 << 0) /* Bit 0: TX timeout */
 #define CAN_ERR_LOSTARB          (1 << 1) /* Bit 1: Lost arbitration (See CAN_ERR_LOSTARB_* definitions) */
 #define CAN_ERR_CRTL             (1 << 2) /* Bit 2: Controller error (See CAN_ERR_CRTL_* definitions) */
 #define CAN_ERR_PROT             (1 << 3) /* Bit 3: Protocol error (see CAN_ERR_PROT_* definitions) */
@@ -271,10 +271,10 @@
 #define CAN_ERR_PROT_LOC_RES1    0x0b /* Reserved bit 1 */
 #define CAN_ERR_PROT_LOC_DLC     0x0c /* Data length code */
 #define CAN_ERR_PROT_LOC_DATA    0x0d /* Data section */
-#define CAN_ERR_PROT_LOC_CRCSEQ  0x0e /* CRC sequence */
-#define CAN_ERR_PROT_LOC_CRCDEL  0x0f /* CRC delimiter */
+#define CAN_ERR_PROT_LOC_CRC_SEQ 0x0e /* CRC sequence */
+#define CAN_ERR_PROT_LOC_CRC_DEL 0x0f /* CRC delimiter */
 #define CAN_ERR_PROT_LOC_ACK     0x10 /* ACK slot */
-#define CAN_ERR_PROT_LOC_ACKDEL  0x11 /* ACK delimiter */
+#define CAN_ERR_PROT_LOC_ACK_DEL 0x11 /* ACK delimiter */
 #define CAN_ERR_PROT_LOC_EOF     0x12 /* End of frame */
 #define CAN_ERR_PROT_LOC_INTERM  0x13 /* Intermission */
 


### PR DESCRIPTION
## Summary
include/nuttx/can.h: make error definitions compatible with Linux

## Impact

## Testing
CI
