### PR TITLE
armv8-m MPU fixes

### DIFF
--- a/arch/arm/src/armv8-m/arm_mpu.c
+++ b/arch/arm/src/armv8-m/arm_mpu.c
@@ -163,7 +163,7 @@ void mpu_configure_region(uintptr_t base, size_t size,
    * aligns with the size of the selected region."
    */
 
-  limit = (base + size) & MPU_RLAR_LIMIT_MASK;
+  limit = (base + size - 1) & MPU_RLAR_LIMIT_MASK;
   base &= MPU_RBAR_BASE_MASK;
 
   /* Select the region */

--- a/arch/arm/src/armv8-m/mpu.h
+++ b/arch/arm/src/armv8-m/mpu.h
@@ -59,9 +59,9 @@
 #define MPU_RBAR_A3_OFFSET      0x0024
 #define MPU_RLAR_A3_OFFSET      0x0028
 
-#define MPU_MAIR_OFFSET(n)      (0x0040 + 4 * ((n) >> 2))
-#define MPU_MAIR0_OFFSET        0x0040 /* MPU Memory Attribute Indirection Register 0 */
-#define MPU_MAIR1_OFFSET        0x0044 /* MPU Memory Attribute Indirection Register 1 */
+#define MPU_MAIR_OFFSET(n)      (0x0030 + 4 * ((n) >> 2))
+#define MPU_MAIR0_OFFSET        0x0030 /* MPU Memory Attribute Indirection Register 0 */
+#define MPU_MAIR1_OFFSET        0x0034 /* MPU Memory Attribute Indirection Register 1 */
 
 /* MPU Register Addresses */
 


### PR DESCRIPTION
## Summary

- On armv8-m the MPU region limits are inclusive.  Thus, we must substract one byte of size from (base + limit).
- Both MPU_MAIR0 and MPU_MAIR1 were off by 0x10.

## Impact

Should have none, but fixing problems.

## Testing

Tested on a custom board with an STM32U585
