### PR TITLE
stm32/socketcan: fix the EFF flag for received frames

### DIFF
--- a/arch/arm/src/stm32/stm32_can_sock.c
+++ b/arch/arm/src/stm32/stm32_can_sock.c
@@ -1207,12 +1207,11 @@ static int stm32can_rxinterrupt_work(struct stm32_can_s *priv, int rxmb)
   if ((regval & CAN_RIR_IDE) != 0)
     {
       frame->can_id  = (regval & CAN_RIR_EXID_MASK) >> CAN_RIR_EXID_SHIFT;
-      frame->can_id &= ~CAN_EFF_FLAG;
+      frame->can_id |= CAN_EFF_FLAG;
     }
   else
     {
       frame->can_id  = (regval & CAN_RIR_STID_MASK) >> CAN_RIR_STID_SHIFT;
-      frame->can_id |= CAN_EFF_FLAG;
     }
 #else
   if ((regval & CAN_RIR_IDE) != 0)

--- a/arch/arm/src/stm32f7/stm32_can_sock.c
+++ b/arch/arm/src/stm32f7/stm32_can_sock.c
@@ -1231,12 +1231,11 @@ static int stm32can_rxinterrupt_work(struct stm32_can_s *priv, int rxmb)
   if ((regval & CAN_RIR_IDE) != 0)
     {
       frame->can_id  = (regval & CAN_RIR_EXID_MASK) >> CAN_RIR_EXID_SHIFT;
-      frame->can_id &= ~CAN_EFF_FLAG;
+      frame->can_id |= CAN_EFF_FLAG;
     }
   else
     {
       frame->can_id  = (regval & CAN_RIR_STID_MASK) >> CAN_RIR_STID_SHIFT;
-      frame->can_id |= CAN_EFF_FLAG;
     }
 #else
   if ((regval & CAN_RIR_IDE) != 0)


### PR DESCRIPTION
## Summary
stm32/socketcan: fix the EFF flag for received frames
## Impact
The EFF flag for the received frames was set the opposite
## Testing
Lely-core coctl tool
