### PR TITLE
Minor improvement for tools/ci/cibuild.sh

### DIFF
--- a/tools/ci/cibuild.sh
+++ b/tools/ci/cibuild.sh
@@ -37,7 +37,7 @@ EXTRA_PATH=
 
 case ${os} in
   Darwin)
-    install="arm-gcc-toolchain arm64-gcc-toolchain avr-gcc-toolchain binutils c-cache elf-toolchain gen-romfs kconfig-frontends python-tools riscv-gcc-toolchain rust xtensa-esp32-gcc-toolchain u-boot-tools"
+    install="arm-gcc-toolchain arm64-gcc-toolchain avr-gcc-toolchain binutils bloaty c-cache elf-toolchain gen-romfs kconfig-frontends python-tools riscv-gcc-toolchain rust xtensa-esp32-gcc-toolchain u-boot-tools"
     mkdir -p "${prebuilt}"/homebrew
     export HOMEBREW_CACHE=${prebuilt}/homebrew
     # https://github.com/actions/virtual-environments/issues/2322#issuecomment-749211076
@@ -46,7 +46,7 @@ case ${os} in
     brew update --quiet
     ;;
   Linux)
-    install="arm-clang-toolchain arm-gcc-toolchain arm64-gcc-toolchain c-cache clang_clang-tidy gen-romfs gperf kconfig-frontends mips-gcc-toolchain python-tools riscv-gcc-toolchain rust rx-gcc-toolchain sparc-gcc-toolchain xtensa-esp32-gcc-toolchain"
+    install="arm-clang-toolchain arm-gcc-toolchain arm64-gcc-toolchain bloaty c-cache clang_clang-tidy gen-romfs gperf kconfig-frontends mips-gcc-toolchain python-tools riscv-gcc-toolchain rust rx-gcc-toolchain sparc-gcc-toolchain xtensa-esp32-gcc-toolchain"
     ;;
 esac
 

--- a/tools/ci/cibuild.sh
+++ b/tools/ci/cibuild.sh
@@ -46,7 +46,7 @@ case ${os} in
     brew update --quiet
     ;;
   Linux)
-    install="python-tools codechecker clang_clang-tidy gen-romfs gperf kconfig-frontends rust arm-clang-toolchain arm-gcc-toolchain arm64-gcc-toolchain mips-gcc-toolchain riscv-gcc-toolchain xtensa-esp32-gcc-toolchain rx-gcc-toolchain sparc-gcc-toolchain c-cache"
+    install="python-tools clang_clang-tidy gen-romfs gperf kconfig-frontends rust arm-clang-toolchain arm-gcc-toolchain arm64-gcc-toolchain mips-gcc-toolchain riscv-gcc-toolchain xtensa-esp32-gcc-toolchain rx-gcc-toolchain sparc-gcc-toolchain c-cache"
     ;;
 esac
 
@@ -62,23 +62,21 @@ function python-tools {
   PYTHONUSERBASE=${prebuilt}/pylocal
   export PYTHONUSERBASE
   add_path "${PYTHONUSERBASE}"/bin
+  pip3 install CodeChecker
+  pip3 install cxxfilt
+  pip3 install esptool==3.3.1
   pip3 install pexpect==4.8.0
+  pip3 install pyelftools
+  pip3 install pyserial==3.5
   pip3 install pytest==6.2.5
-  pip3 install pytest-repeat==0.9.1
   pip3 install pytest-json==0.4.0
   pip3 install pytest-ordering==0.6
-  pip3 install pyserial==3.5
-  pip3 install pyelftools
-  pip3 install cxxfilt
+  pip3 install pytest-repeat==0.9.1
 
   # MCUboot's tool for image signing and key management
   if ! command -v imgtool &> /dev/null; then
     pip3 install imgtool
   fi
-}
-
-function codechecker {
-  pip3 install CodeChecker
 }
 
 function clang_clang-tidy {
@@ -282,7 +280,6 @@ function xtensa-esp32-gcc-toolchain {
     esac
   fi
   xtensa-esp32-elf-gcc --version
-  pip3 install esptool==3.3.1
 }
 
 function avr-gcc-toolchain {


### PR DESCRIPTION
## Summary

- tools/ci/cibuild.sh: Change wget to curl 
- tools/ci/cibuild.sh: Move all pip3 installation into python-tools
- tools/ci/cibuild.sh: Keep the installation in alphabetical order 
- tools/ci/cibuild.sh: Add bloaty to install variable

## Impact
None code refactor only

## Testing
Pass CI
