### PR TITLE
Fix random_pool.c:214:13: error: conflicting types for 'getentropy'

### DIFF
--- a/crypto/random_pool.c
+++ b/crypto/random_pool.c
@@ -189,7 +189,7 @@ static void addentropy(FAR const uint32_t *buf, size_t n, bool inc_new)
 }
 
 /****************************************************************************
- * Name: getentropy
+ * Name: initentropy
  *
  * Description:
  *   Hash entropy pool to BLAKE2s context. This is an internal interface for
@@ -211,7 +211,7 @@ static void addentropy(FAR const uint32_t *buf, size_t n, bool inc_new)
  *
  ****************************************************************************/
 
-static void getentropy(FAR blake2s_state *S)
+static void initentropy(FAR blake2s_state *S)
 {
 #ifdef CONFIG_SCHED_CPULOAD
   struct cpuload_s load;
@@ -281,7 +281,7 @@ static void rng_reseed(void)
 
   /* Initialize with randomness from entropy pool */
 
-  getentropy(&g_rng.blake2xs.ctx);
+  initentropy(&g_rng.blake2xs.ctx);
 
   /* Absorb also the previous root */
 


### PR DESCRIPTION
## Summary
```
   214 | static void getentropy(FAR blake2s_state *S)
       |             ^~~~~~~~~~
 In file included from /home/work/ssd1/workspace/MiRTOS-CI@2/out/miwear/ap/.unionfs/nuttx/include/nuttx/mutex.h:31,
                  from random_pool.c:37:
 /home/work/ssd1/workspace/MiRTOS-CI@2/out/miwear/ap/.unionfs/nuttx/include/unistd.h:428:9: note: previous declaration of 'getentropy' was here
   428 | int     getentropy(FAR void *buffer, size_t length);
       |         ^~~~~~~~~~
```

## Impact
Minor

## Testing
Pass CI
