### PR TITLE
tools/ci/docker/linux/Dockerfile: Intall libncurses5-dev in final image

### DIFF
--- a/tools/ci/docker/linux/Dockerfile
+++ b/tools/ci/docker/linux/Dockerfile
@@ -247,6 +247,7 @@ RUN apt-get update -qq && DEBIAN_FRONTEND="noninteractive" apt-get install -y -q
   libcurl4-openssl-dev \
   libpulse-dev libpulse-dev:i386 \
   libpython2.7 \
+  libncurses5-dev \
   libx11-dev libx11-dev:i386 \
   libxext-dev libxext-dev:i386 \
   linux-libc-dev:i386 \


### PR DESCRIPTION
## Summary
fix the following warning:
clang: error while loading shared libraries: libtinfo.so.5: cannot open shared object file: No such file or directory

## Impact
clang can run correctly

## Testing

