### PR TITLE
Fix bcmf_netdev.c:705:7: error: 'strnlen' specified bound 2 exceeds source size 1 [-Werror=stringop-overread]

### DIFF
--- a/drivers/sensors/hyt271.c
+++ b/drivers/sensors/hyt271.c
@@ -782,11 +782,11 @@ static int hyt271_thread(int argc, char** argv)
 {
   FAR struct hyt271_dev_s *priv = (FAR struct hyt271_dev_s *)
     ((uintptr_t)strtoul(argv[1], NULL, 0));
+  uint32_t orawdata = 0;
 
   while (true)
     {
       int ret;
-      uint32_t orawdata;
       struct hyt271_sensor_data_s data;
       struct hyt271_sensor_s *hsensor = &priv->sensor[HYT271_SENSOR_HUMI];
       struct hyt271_sensor_s *tsensor = &priv->sensor[HYT271_SENSOR_TEMP];
@@ -806,12 +806,7 @@ static int hyt271_thread(int argc, char** argv)
             }
         }
 
-      /* Store the last sensor data for later comparison */
-
-      orawdata = data.data;
-
       ret = hyt271_measure_read(priv, &data);
-
       if (!ret)
         {
           /* Notify upper */
@@ -838,6 +833,10 @@ static int hyt271_thread(int argc, char** argv)
             {
               priv->initial_read = true;
             }
+
+          /* Store the last sensor data for later comparison */
+
+          orawdata = data.data;
         }
 
       /* Sleeping thread before fetching the next sensor data */

--- a/drivers/wireless/ieee80211/bcm43xxx/bcmf_netdev.c
+++ b/drivers/wireless/ieee80211/bcm43xxx/bcmf_netdev.c
@@ -702,7 +702,7 @@ static int bcmf_ifup(FAR struct net_driver_s *dev)
       goto errout_in_wl_active;
     }
 
-  if (strnlen(CONFIG_IEEE80211_BROADCOM_DEFAULT_COUNTRY, 2) == 2)
+  if (CONFIG_IEEE80211_BROADCOM_DEFAULT_COUNTRY[0])
     {
       bcmf_wl_set_country_code(priv, CHIP_STA_INTERFACE,
                                CONFIG_IEEE80211_BROADCOM_DEFAULT_COUNTRY);


### PR DESCRIPTION
## Summary
Report here: https://github.com/apache/incubator-nuttx-apps/actions/runs/3303013192/jobs/5450504682

## Impact
Minor

## Testing
Pass CI
