### PR TITLE
Fix vfs/fs_timerfd.c:73:17: error: duplicate member 'lock'

### DIFF
--- a/fs/vfs/fs_timerfd.c
+++ b/fs/vfs/fs_timerfd.c
@@ -70,7 +70,7 @@ struct timerfd_priv_s
   struct wdog_s wdog;           /* The watchdog that provides the timing */
   struct work_s work;           /* For deferred timeout operations */
   timerfd_t     counter;        /* timerfd counter */
-  spinlock_t    lock;           /* timerfd counter specific lock */
+  spinlock_t    splock;         /* timerfd counter specific lock */
   unsigned int  minor;          /* timerfd minor number */
   uint8_t       crefs;          /* References counts on timerfd (max: 255) */
 
@@ -166,9 +166,9 @@ static timerfd_t timerfd_get_counter(FAR struct timerfd_priv_s *dev)
   timerfd_t counter;
   irqstate_t intflags;
 
-  intflags = spin_lock_irqsave(&dev->lock);
+  intflags = spin_lock_irqsave(&dev->splock);
   counter = dev->counter;
-  spin_unlock_irqrestore(&dev->lock, intflags);
+  spin_unlock_irqrestore(&dev->splock, intflags);
 
   return counter;
 }
@@ -364,12 +364,12 @@ static ssize_t timerfd_read(FAR struct file *filep, FAR char *buffer,
    * counter to zero
    */
 
-  intflags = spin_lock_irqsave(&dev->lock);
+  intflags = spin_lock_irqsave(&dev->splock);
 
   *(FAR timerfd_t *)buffer = dev->counter;
   dev->counter = 0;
 
-  spin_unlock_irqrestore(&dev->lock, intflags);
+  spin_unlock_irqrestore(&dev->splock, intflags);
 
   nxmutex_unlock(&dev->lock);
   return sizeof(timerfd_t);
@@ -485,7 +485,7 @@ static void timerfd_timeout(wdparm_t idev)
    * atomically
    */
 
-  intflags = spin_lock_irqsave(&dev->lock);
+  intflags = spin_lock_irqsave(&dev->splock);
 
   /* Increment timer expiration counter */
 
@@ -500,7 +500,7 @@ static void timerfd_timeout(wdparm_t idev)
       wd_start(&dev->wdog, dev->delay, timerfd_timeout, idev);
     }
 
-  spin_unlock_irqrestore(&dev->lock, intflags);
+  spin_unlock_irqrestore(&dev->splock, intflags);
 }
 
 /****************************************************************************
@@ -648,7 +648,7 @@ int timerfd_settime(int fd, int flags,
    * atomicaly and timeout work is canceled with the same sequence
    */
 
-  intflags = spin_lock_irqsave(&dev->lock);
+  intflags = spin_lock_irqsave(&dev->splock);
 
   /* Disarm the timer (in case the timer was already armed when
    * timerfd_settime() is called).
@@ -670,7 +670,7 @@ int timerfd_settime(int fd, int flags,
 
   if (new_value->it_value.tv_sec <= 0 && new_value->it_value.tv_nsec <= 0)
     {
-      spin_unlock_irqrestore(NULL, intflags);
+      spin_unlock_irqrestore(&dev->splock, intflags);
       return OK;
     }
 
@@ -728,12 +728,12 @@ int timerfd_settime(int fd, int flags,
       ret = wd_start(&dev->wdog, delay, timerfd_timeout, (wdparm_t)dev);
       if (ret < 0)
         {
-          spin_unlock_irqrestore(&dev->lock, intflags);
+          spin_unlock_irqrestore(&dev->splock, intflags);
           goto errout;
         }
     }
 
-  spin_unlock_irqrestore(&dev->lock, intflags);
+  spin_unlock_irqrestore(&dev->splock, intflags);
   return OK;
 
 errout:

--- a/syscall/syscall.csv
+++ b/syscall/syscall.csv
@@ -159,7 +159,7 @@
 "sigtimedwait","signal.h","","int","FAR const sigset_t *","FAR struct siginfo *","FAR const struct timespec *"
 "sigwaitinfo","signal.h","","int","FAR const sigset_t *","FAR struct siginfo *"
 "socket","sys/socket.h","defined(CONFIG_NET)","int","int","int","int"
-"socketpair","sys/socket.h","defined(CONFIG_NET)","int","int","int","int","int *"
+"socketpair","sys/socket.h","defined(CONFIG_NET)","int","int","int","int","int [2]|FAR int *"
 "stat","sys/stat.h","","int","FAR const char *","FAR struct stat *"
 "statfs","sys/statfs.h","","int","FAR const char *","FAR struct statfs *"
 "symlink","unistd.h","defined(CONFIG_PSEUDOFS_SOFTLINKS)","int","FAR const char *","FAR const char *"


### PR DESCRIPTION
## Summary
regression by: https://github.com/apache/incubator-nuttx/pull/6965

## Impact
Fix compiler error

## Testing
Pass CI
