### PR TITLE
arch: stm32h7: Flush D-Cache on flash erase operation

### DIFF
--- a/arch/arm/src/stm32h7/stm32h743xx_flash.c
+++ b/arch/arm/src/stm32h7/stm32h743xx_flash.c
@@ -769,6 +769,12 @@ ssize_t up_progmem_eraseblock(size_t block)
       return (ssize_t)ret;
     }
 
+  /* Flush and invalidate D-Cache for this block */
+
+#ifdef CONFIG_ARMV7M_DCACHE
+  up_flush_dcache(block_address, block_address + FLASH_SECTOR_SIZE);
+#endif
+
   if (stm32h7_wait_for_last_operation(priv))
     {
       ret = -EIO;


### PR DESCRIPTION
Signed-off-by: Andrés Sánchez Pascual <tito97_sp@hotmail.com>

## Summary
Flash sector erase is unreliable on STM32H743 in conditions where the D-Cache is enabled. To solve it a flush of the D-Cache is performed just before any other erase operation

The errata is reported in by STM as **Cortex®-M7 data corruption when using Data cache configured in
write-through** [ES0392 STM32H742xI/G and STM32H743xI/G device limitations](https://www.st.com/resource/en/errata_sheet/es0392-stm32h742xig-and-stm32h743xig-device-limitations-stmicroelectronics.pdf) document.
http://infocenter.arm.com.


## Impact
STM32H743 board

