### PR TITLE
Fix error: mmcsd/mmcsd_sdio.c:2669:35: error: 'buffer' may be used uninitialized [-Werror=maybe-uninitialized]

### DIFF
--- a/arch/arm/src/sam34/sam4s_nand.c
+++ b/arch/arm/src/sam34/sam4s_nand.c
@@ -149,7 +149,10 @@ static int nand_wait_ready(struct sam_nandcs_s *priv)
 
   /* The ready/busy (R/nB) signal of the NAND Flash  */
 
-  while (!sam_gpioread(priv->rb));
+  while (!sam_gpioread(priv->rb))
+    {
+    }
+
   WRITE_COMMAND8(&priv->raw, COMMAND_STATUS);
 
   /* Issue command */

--- a/drivers/mmcsd/mmcsd_sdio.c
+++ b/drivers/mmcsd/mmcsd_sdio.c
@@ -2659,6 +2659,8 @@ static int mmcsd_read_csd(FAR struct mmcsd_state_s *priv)
       return -EPERM;
     }
 
+  memset(buffer, 0, sizeof(buffer));
+
 #if defined(CONFIG_SDIO_DMA) && defined(CONFIG_ARCH_HAVE_SDIO_PREFLIGHT)
   /* If we think we are going to perform a DMA transfer, make sure that we
    * will be able to before we commit the card to the operation.

--- a/drivers/usbhost/usbhost_hub.c
+++ b/drivers/usbhost/usbhost_hub.c
@@ -1336,7 +1336,7 @@ errout_with_ctrlreq:
   kmm_free(priv->ctrlreq);
 
 errout_with_hub:
-  kmm_free(priv);
+  kmm_free(alloc);
   return NULL;
 }
 


### PR DESCRIPTION
## Summary
since new version gcc toolchain make more check.

## Impact
Minor

## Testing
Pass CI
