### PR TITLE
tools/ci/docker/linux/Dockerfile: Intall libtinfo5 in final image

### DIFF
--- a/tools/ci/docker/linux/Dockerfile
+++ b/tools/ci/docker/linux/Dockerfile
@@ -248,6 +248,7 @@ RUN apt-get update -qq && DEBIAN_FRONTEND="noninteractive" apt-get install -y -q
   libpulse-dev libpulse-dev:i386 \
   libpython2.7 \
   libncurses5-dev \
+  libtinfo5 \
   libx11-dev libx11-dev:i386 \
   libxext-dev libxext-dev:i386 \
   linux-libc-dev:i386 \

--- a/tools/ci/docker/linux/Dockerfile
+++ b/tools/ci/docker/linux/Dockerfile
@@ -27,15 +27,15 @@ RUN apt-get update -qq && apt-get install -y -qq \
 FROM builder-base AS nuttx-tools
 
 RUN apt-get update -qq && DEBIAN_FRONTEND="noninteractive" apt-get install -y -qq \
-  flex \
   bison \
-  gperf \
-  libncurses5-dev \
-  make \
   cmake \
+  flex \
   g++ \
   gawk \
-  git
+  git \
+  gperf \
+  libncurses5-dev \
+  make
 
 RUN mkdir /tools
 WORKDIR /tools
@@ -44,8 +44,10 @@ RUN mkdir -p /tools/nuttx-tools
 RUN curl -s -L https://bitbucket.org/nuttx/tools/get/9ad3e1ee75c7.tar.gz \
   | tar -C nuttx-tools --strip-components=1 -xz
 
-RUN cd nuttx-tools/kconfig-frontends \
-  && ./configure --enable-mconf --disable-gconf --disable-qconf --enable-static --prefix=/tools/kconfig-frontends \
+RUN mkdir bloaty -p \
+  && git clone --depth 1 --branch v1.1 https://github.com/google/bloaty bloaty \
+  && cd bloaty \
+  && cmake -DCMAKE_SYSTEM_PREFIX_PATH=/tools/bloaty \
   && make install
 
 RUN cd nuttx-tools \
@@ -54,10 +56,8 @@ RUN cd nuttx-tools \
   && cd genromfs \
   && make install PREFIX=/tools/genromfs
 
-RUN mkdir bloaty -p \
-  && git clone --depth 1 --branch v1.1 https://github.com/google/bloaty bloaty \
-  && cd bloaty \
-  && cmake -DCMAKE_SYSTEM_PREFIX_PATH=/tools/bloaty \
+RUN cd nuttx-tools/kconfig-frontends \
+  && ./configure --enable-mconf --disable-gconf --disable-qconf --enable-static --prefix=/tools/kconfig-frontends \
   && make install
 
 # Install Rust and targets supported from NuttX
@@ -83,17 +83,17 @@ WORKDIR /tools
 # Build image for tool required by ARM builds
 ###############################################################################
 FROM nuttx-toolchain-base AS nuttx-toolchain-arm
+# Download the latest ARM clang toolchain prebuilt by ARM
+RUN mkdir clang-arm-none-eabi && \
+  curl -s -L  "https://github.com/ARM-software/LLVM-embedded-toolchain-for-Arm/releases/download/release-14.0.0/LLVMEmbeddedToolchainForArm-14.0.0-linux.tar.gz" \
+  | tar -C clang-arm-none-eabi --strip-components 1 -xz
+
 # Download the latest ARM GCC toolchain prebuilt by ARM
 RUN mkdir gcc-arm-none-eabi && \
   curl -s -L  "https://developer.arm.com/-/media/Files/downloads/gnu/11.3.rel1/binrel/arm-gnu-toolchain-11.3.rel1-x86_64-arm-none-eabi.tar.xz" \
   | tar -C gcc-arm-none-eabi --strip-components 1 -xJ  \
   && curl -s -L -O "https://raw.githubusercontent.com/apache/incubator-nuttx/master/tools/ci/patch/arm-none-eabi-workaround-for-newlib-version-break.patch" \
   && patch -p0 < arm-none-eabi-workaround-for-newlib-version-break.patch
-
-# Download the latest ARM clang toolchain prebuilt by ARM
-RUN mkdir clang-arm-none-eabi && \
-  curl -s -L  "https://github.com/ARM-software/LLVM-embedded-toolchain-for-Arm/releases/download/release-14.0.0/LLVMEmbeddedToolchainForArm-14.0.0-linux.tar.gz" \
-  | tar -C clang-arm-none-eabi --strip-components 1 -xz
 
 ###############################################################################
 # Build image for tool required by ARM64 builds
@@ -113,6 +113,63 @@ FROM nuttx-toolchain-base AS nuttx-toolchain-pinguino
 RUN mkdir pinguino-compilers && \
   curl -s -L "https://github.com/PinguinoIDE/pinguino-compilers/archive/62db5158d7f6d41c6fadb05de81cc31dd81a1958.tar.gz" \
   | tar -C pinguino-compilers --strip-components=2 --wildcards -xz */linux64
+
+###############################################################################
+# Build image for tool required by Renesas builds
+###############################################################################
+FROM nuttx-toolchain-base AS nuttx-toolchain-renesas
+# Build Renesas RX GCC toolchain
+RUN apt-get update -qq && DEBIAN_FRONTEND="noninteractive" apt-get install -y -qq \
+  bison \
+  flex \
+  g++ \
+  gcc \
+  libncurses5-dev \
+  m4 \
+  make \
+  texinfo \
+  wget
+
+# Download toolchain source code
+RUN mkdir -p /tools/renesas-tools/source/binutils && \
+  curl -s -L "https://gcc-renesas.com/downloads/d.php?f=rx/binutils/4.8.4.201803-gnurx/rx_binutils2.24_2018Q3.tar.gz" \
+  | tar -C renesas-tools/source/binutils --strip-components=1 -xz
+RUN mkdir -p /tools/renesas-tools/source/gcc && \
+  curl -s -L "https://gcc-renesas.com/downloads/d.php?f=rx/gcc/4.8.4.201803-gnurx/rx_gcc_4.8.4_2018Q3.tar.gz" \
+  | tar -C renesas-tools/source/gcc --strip-components=1 -xz
+RUN mkdir -p /tools/renesas-tools/source/newlib && \
+  curl -s -L "https://gcc-renesas.com/downloads/d.php?f=rx/newlib/4.8.4.201803-gnurx/rx_newlib2.2.0_2018Q3.tar.gz" \
+  | tar -C renesas-tools/source/newlib --strip-components=1 -xz
+
+# Install binutils
+RUN cd renesas-tools/source/binutils && \
+  chmod +x ./configure ./mkinstalldirs && \
+  mkdir -p /tools/renesas-tools/build/binutils && cd /tools/renesas-tools/build/binutils && \
+  /tools/renesas-tools/source/binutils/configure --target=rx-elf --prefix=/tools/renesas-toolchain/rx-elf-gcc --disable-werror &&\
+  make && make install 
+ENV PATH="/tools/renesas-toolchain/rx-elf-gcc/bin:$PATH"
+
+# Install gcc
+RUN cd renesas-tools/source/gcc && \
+  chmod +x ./contrib/download_prerequisites ./configure ./move-if-change ./libgcc/mkheader.sh && \
+  ./contrib/download_prerequisites && \
+  sed -i '1s/^/@documentencoding ISO-8859-1\n/' ./gcc/doc/gcc.texi && \
+  sed -i 's/@tex/\n&/g' ./gcc/doc/gcc.texi && sed -i 's/@end tex/\n&/g' ./gcc/doc/gcc.texi && \
+  mkdir -p /tools/renesas-tools/build/gcc && cd /tools/renesas-tools/build/gcc && \
+  /tools/renesas-tools/source/gcc/configure --target=rx-elf --prefix=/tools/renesas-toolchain/rx-elf-gcc \
+  --disable-shared --disable-multilib --disable-libssp --disable-libstdcxx-pch --disable-werror --enable-lto \
+  --enable-gold --with-pkgversion=GCC_Build_1.02 --with-newlib --enable-languages=c && \
+  make && make install 
+ENV PATH="/tools/renesas-toolchain/rx-elf-gcc/bin:$PATH"
+
+# Install newlib
+RUN cd renesas-tools/source/newlib && \
+  chmod +x ./configure && \
+  mkdir -p /tools/renesas-tools/build/newlib && cd /tools/renesas-tools/build/newlib && \
+  /tools/renesas-tools/source/newlib/configure --target=rx-elf --prefix=/tools/renesas-toolchain/rx-elf-gcc && \  
+  make && make install
+RUN cd /tools/renesas-tools/build/gcc && \
+  make && make install
 
 ###############################################################################
 # Build image for tool required by RISCV builds
@@ -161,63 +218,6 @@ RUN mkdir -p /tools/blobs && cd /tools/blobs \
   && curl -s -L "https://github.com/espressif/esp-nuttx-bootloader/releases/download/latest/partition-table-esp32s3.bin" -o partition-table-esp32s3.bin
 
 ###############################################################################
-# Build image for tool required by Renesas builds
-###############################################################################
-FROM nuttx-toolchain-base AS nuttx-toolchain-renesas
-# Build Renesas RX GCC toolchain
-RUN apt-get update -qq && DEBIAN_FRONTEND="noninteractive" apt-get install -y -qq \
-  flex \
-  bison \
-  texinfo \
-  libncurses5-dev \
-  m4 \
-  make \
-  gcc \
-  g++ \
-  wget
-
-# Download toolchain source code
-RUN mkdir -p /tools/renesas-tools/source/binutils && \
-  curl -s -L "https://gcc-renesas.com/downloads/d.php?f=rx/binutils/4.8.4.201803-gnurx/rx_binutils2.24_2018Q3.tar.gz" \
-  | tar -C renesas-tools/source/binutils --strip-components=1 -xz
-RUN mkdir -p /tools/renesas-tools/source/gcc && \
-  curl -s -L "https://gcc-renesas.com/downloads/d.php?f=rx/gcc/4.8.4.201803-gnurx/rx_gcc_4.8.4_2018Q3.tar.gz" \
-  | tar -C renesas-tools/source/gcc --strip-components=1 -xz
-RUN mkdir -p /tools/renesas-tools/source/newlib && \
-  curl -s -L "https://gcc-renesas.com/downloads/d.php?f=rx/newlib/4.8.4.201803-gnurx/rx_newlib2.2.0_2018Q3.tar.gz" \
-  | tar -C renesas-tools/source/newlib --strip-components=1 -xz
-
-# Install binutils
-RUN cd renesas-tools/source/binutils && \
-  chmod +x ./configure ./mkinstalldirs && \
-  mkdir -p /tools/renesas-tools/build/binutils && cd /tools/renesas-tools/build/binutils && \
-  /tools/renesas-tools/source/binutils/configure --target=rx-elf --prefix=/tools/renesas-toolchain/rx-elf-gcc --disable-werror &&\
-  make && make install 
-ENV PATH="/tools/renesas-toolchain/rx-elf-gcc/bin:$PATH"
-
-# Install gcc
-RUN cd renesas-tools/source/gcc && \
-  chmod +x ./contrib/download_prerequisites ./configure ./move-if-change ./libgcc/mkheader.sh && \
-  ./contrib/download_prerequisites && \
-  sed -i '1s/^/@documentencoding ISO-8859-1\n/' ./gcc/doc/gcc.texi && \
-  sed -i 's/@tex/\n&/g' ./gcc/doc/gcc.texi && sed -i 's/@end tex/\n&/g' ./gcc/doc/gcc.texi && \
-  mkdir -p /tools/renesas-tools/build/gcc && cd /tools/renesas-tools/build/gcc && \
-  /tools/renesas-tools/source/gcc/configure --target=rx-elf --prefix=/tools/renesas-toolchain/rx-elf-gcc \
-  --disable-shared --disable-multilib --disable-libssp --disable-libstdcxx-pch --disable-werror --enable-lto \
-  --enable-gold --with-pkgversion=GCC_Build_1.02 --with-newlib --enable-languages=c && \
-  make && make install 
-ENV PATH="/tools/renesas-toolchain/rx-elf-gcc/bin:$PATH"
-
-# Install newlib
-RUN cd renesas-tools/source/newlib && \
-  chmod +x ./configure && \
-  mkdir -p /tools/renesas-tools/build/newlib && cd /tools/renesas-tools/build/newlib && \
-  /tools/renesas-tools/source/newlib/configure --target=rx-elf --prefix=/tools/renesas-toolchain/rx-elf-gcc && \  
-  make && make install
-RUN cd /tools/renesas-tools/build/gcc && \
-  make && make install
-
-###############################################################################
 # Final Docker image used for running CI system.  This includes all toolchains
 # supported by the CI system.
 ###############################################################################
@@ -232,28 +232,30 @@ RUN apt-get update -qq && DEBIAN_FRONTEND="noninteractive" apt-get install -y -q
   avr-libc \
   build-essential \
   ccache \
+  clang \
+  clang-tidy \
   cmake \
   curl \
   gcc \
   gcc-avr \
   gcc-multilib \
-  clang \
-  clang-tidy \
   gettext \
   git \
   lib32z1-dev \
-  libc6-dev-i386 \
   libasound2-dev libasound2-dev:i386 \
+  libc6-dev-i386 \
   libcurl4-openssl-dev \
+  libncurses5-dev \
   libpulse-dev libpulse-dev:i386 \
   libpython2.7 \
-  libncurses5-dev \
   libtinfo5 \
   libx11-dev libx11-dev:i386 \
   libxext-dev libxext-dev:i386 \
-  linux-libc-dev:i386 \
   linux-headers-generic \
+  linux-libc-dev:i386 \
   ninja-build \
+  qemu-system-arm \
+  qemu-system-misc \
   python3 \
   python3-pip \
   python-is-python3 \
@@ -261,8 +263,6 @@ RUN apt-get update -qq && DEBIAN_FRONTEND="noninteractive" apt-get install -y -q
   unzip \
   wget \
   xxd \
-  qemu-system-arm \
-  qemu-system-misc \
   && rm -rf /var/lib/apt/lists/*
 
 # Configure out base setup for adding python packages
@@ -277,25 +277,28 @@ RUN pip3 install setuptools wheel
 # Install CodeChecker and use it to statically analyze the code.
 RUN pip3 install CodeChecker
 # Install pytest
+RUN pip3 install cxxfilt
+RUN pip3 install esptool
+RUN pip3 install imgtool
 RUN pip3 install pexpect==4.8.0
+RUN pip3 install pyelftools
+RUN pip3 install pyserial==3.5
 RUN pip3 install pytest==6.2.5
-RUN pip3 install pytest-repeat==0.9.1
 RUN pip3 install pytest-json==0.4.0
 RUN pip3 install pytest-ordering==0.6
-RUN pip3 install pyserial==3.5
+RUN pip3 install pytest-repeat==0.9.1
 # Used to generate symbol table files
-RUN pip3 install pyelftools cxxfilt
 
 RUN mkdir /tools
 WORKDIR /tools
 
 # Pull in the tools we just built for nuttx
+COPY --from=nuttx-tools /tools/bloaty/ bloaty/
+ENV PATH="/tools/bloaty/bin:$PATH"
 COPY --from=nuttx-tools /tools/genromfs/ /tools/genromfs/
 ENV PATH="/tools/genromfs/usr/bin:$PATH"
 COPY --from=nuttx-tools /tools/kconfig-frontends/ kconfig-frontends/
 ENV PATH="/tools/kconfig-frontends/bin:$PATH"
-COPY --from=nuttx-tools /tools/bloaty/ bloaty/
-ENV PATH="/tools/bloaty/bin:$PATH"
 
 # Pull in the Rust toolchain including supported targets
 COPY --from=nuttx-tools /tools/rust/ /tools/rust/
@@ -304,11 +307,11 @@ ENV RUSTUP_HOME=/tools/rust/rustup
 ENV PATH="/tools/rust/cargo/bin:$PATH"
 
 # ARM toolchain
-COPY --from=nuttx-toolchain-arm /tools/gcc-arm-none-eabi/ gcc-arm-none-eabi/
-ENV PATH="/tools/gcc-arm-none-eabi/bin:$PATH"
-
 COPY --from=nuttx-toolchain-arm /tools/clang-arm-none-eabi/ clang-arm-none-eabi/
 ENV PATH="/tools/clang-arm-none-eabi/bin:$PATH"
+
+COPY --from=nuttx-toolchain-arm /tools/gcc-arm-none-eabi/ gcc-arm-none-eabi/
+ENV PATH="/tools/gcc-arm-none-eabi/bin:$PATH"
 
 # ARM64 toolchain
 COPY --from=nuttx-toolchain-arm64 /tools/gcc-aarch64-none-elf/ gcc-aarch64-none-elf/
@@ -317,6 +320,10 @@ ENV PATH="/tools/gcc-aarch64-none-elf/bin:$PATH"
 # MIPS toolchain
 COPY --from=nuttx-toolchain-pinguino /tools/pinguino-compilers/p32/ pinguino-compilers/p32/
 ENV PATH="/tools/pinguino-compilers/p32/bin:$PATH"
+
+# Renesas toolchain
+COPY --from=nuttx-toolchain-renesas /tools/renesas-toolchain/rx-elf-gcc/ renesas-toolchain/rx-elf-gcc/
+ENV PATH="/tools/renesas-toolchain/rx-elf-gcc/bin:$PATH"
 
 # RISCV toolchain
 COPY --from=nuttx-toolchain-riscv /tools/riscv64-unknown-elf-gcc/ riscv64-unknown-elf-gcc/
@@ -340,28 +347,23 @@ ENV PATH="/tools/xtensa-esp32s3-elf-gcc/bin:$PATH"
 
 RUN mkdir -p /tools/blobs/esp-bins
 COPY --from=nuttx-toolchain-esp32 /tools/blobs/* /tools/blobs/esp-bins/
-RUN pip3 install esptool
-
-# Renesas toolchain
-COPY --from=nuttx-toolchain-renesas /tools/renesas-toolchain/rx-elf-gcc/ renesas-toolchain/rx-elf-gcc/
-ENV PATH="/tools/renesas-toolchain/rx-elf-gcc/bin:$PATH"
-
-# MCUboot's tool for image signing and key management
-RUN pip3 install imgtool
 
 # Configure ccache
 RUN mkdir -p /tools/ccache/bin && \
+  ln -sf `which ccache` /tools/ccache/bin/aarch64-none-elf-gcc && \
+  ln -sf `which ccache` /tools/ccache/bin/aarch64-none-elf-g++ && \
+  ln -sf `which ccache` /tools/ccache/bin/arm-none-eabi-gcc && \
+  ln -sf `which ccache` /tools/ccache/bin/arm-none-eabi-g++ && \
+  ln -sf `which ccache` /tools/ccache/bin/avr-gcc && \
+  ln -sf `which ccache` /tools/ccache/bin/avr-g++ && \
   ln -sf `which ccache` /tools/ccache/bin/cc && \
   ln -sf `which ccache` /tools/ccache/bin/c++ && \
   ln -sf `which ccache` /tools/ccache/bin/clang && \
   ln -sf `which ccache` /tools/ccache/bin/clang++ && \
   ln -sf `which ccache` /tools/ccache/bin/gcc && \
   ln -sf `which ccache` /tools/ccache/bin/g++ && \
-  ln -sf `which ccache` /tools/ccache/bin/arm-none-eabi-gcc && \
-  ln -sf `which ccache` /tools/ccache/bin/arm-none-eabi-g++ && \
-  ln -sf `which ccache` /tools/ccache/bin/aarch64-none-elf-gcc && \
-  ln -sf `which ccache` /tools/ccache/bin/aarch64-none-elf-g++ && \
   ln -sf `which ccache` /tools/ccache/bin/p32-gcc && \
+  ln -sf `which ccache` /tools/ccache/bin/rx-elf-gcc && \
   ln -sf `which ccache` /tools/ccache/bin/riscv64-unknown-elf-gcc && \
   ln -sf `which ccache` /tools/ccache/bin/riscv64-unknown-elf-g++ && \
   ln -sf `which ccache` /tools/ccache/bin/sparc-gaisler-elf-gcc && \
@@ -371,10 +373,7 @@ RUN mkdir -p /tools/ccache/bin && \
   ln -sf `which ccache` /tools/ccache/bin/xtensa-esp32s2-elf-gcc && \
   ln -sf `which ccache` /tools/ccache/bin/xtensa-esp32s2-elf-g++ && \
   ln -sf `which ccache` /tools/ccache/bin/xtensa-esp32s3-elf-gcc && \
-  ln -sf `which ccache` /tools/ccache/bin/xtensa-esp32s3-elf-g++ && \
-  ln -sf `which ccache` /tools/ccache/bin/avr-gcc && \
-  ln -sf `which ccache` /tools/ccache/bin/avr-g++ && \
-  ln -sf `which ccache` /tools/ccache/bin/rx-elf-gcc
+  ln -sf `which ccache` /tools/ccache/bin/xtensa-esp32s3-elf-g++
 ENV PATH="/tools/ccache/bin:$PATH"
 
 CMD [ "/bin/bash" ]


### PR DESCRIPTION
## Summary
and keep the installation in alphabetical order

## Impact
Required by arm clang toolchain, reported here:
https://github.com/apache/incubator-nuttx/actions/runs/3303662256/jobs/5453251147

## Testing
Pass CI
