### PR TITLE
romfs: expand file cache by CONFIG_FS_ROMFS_FCACHE_NSECTORS

### DIFF
--- a/fs/romfs/Kconfig
+++ b/fs/romfs/Kconfig
@@ -20,4 +20,11 @@ config FS_ROMFS_CACHE_NODE
 		is mounted so that we can quick access entry of ROMFS
 		filesystem on emmc/sdcard.
 
+config FS_ROMFS_CACHE_FILE_NSECTORS
+	int "The number of file cache sector"
+	range 1 256
+	default 1
+	---help---
+		The number of file cache sector
+
 endif

--- a/fs/romfs/fs_romfs.c
+++ b/fs/romfs/fs_romfs.c
@@ -424,7 +424,7 @@ static ssize_t romfs_read(FAR struct file *filep, FAR char *buffer,
        */
 
       nsectors = SEC_NSECTORS(rm, buflen);
-      if (nsectors > 0 && sectorndx == 0)
+      if (nsectors >= rf->rf_ncachesector && sectorndx == 0)
         {
           /* Read maximum contiguous sectors directly to the user's
            * buffer without using our tiny read buffer.
@@ -460,7 +460,9 @@ static ssize_t romfs_read(FAR struct file *filep, FAR char *buffer,
 
           /* Copy the partial sector into the user buffer */
 
-          bytesread = rm->rm_hwsectorsize - sectorndx;
+          bytesread = (rf->rf_cachesector + rf->rf_ncachesector - sector) *
+                      rm->rm_hwsectorsize - sectorndx;
+          sectorndx = rf->rf_ncachesector * rm->rm_hwsectorsize - bytesread;
           if (bytesread > buflen)
             {
               /* We will not read to the end of the buffer */

--- a/fs/romfs/fs_romfs.h
+++ b/fs/romfs/fs_romfs.h
@@ -149,8 +149,10 @@ struct romfs_mountpt_s
 struct romfs_file_s
 {
   uint32_t rf_startoffset;        /* Offset to the start of the file data */
+  uint32_t rf_endsector;          /* Last sector of the file data */
   uint32_t rf_size;               /* Size of the file in bytes */
-  uint32_t rf_cachesector;        /* Current sector in the rf_buffer */
+  uint32_t rf_cachesector;        /* First sector in the rf_buffer */
+  uint32_t rf_ncachesector;       /* Number of sectors in the rf_buffer */
   FAR uint8_t *rf_buffer;         /* File sector buffer, allocated if rm_xipbase==0 */
   uint8_t rf_type;                /* File type (for fstat()) */
   char rf_path[1];                /* Path of open file */


### PR DESCRIPTION

## Summary

The default size of file cache is size of a sector, it may not be good size for optimizing read speed in physical device. So we can set the config according to speed test profile to optimize access IO speed.

Signed-off-by: dongjiuzhu1 <dongjiuzhu1@xiaomi.com>

## Impact
improve read speed for romfs
## Testing
Vela CI
