### PR TITLE
arch: cxd56xx: Fix deadlock by using GNSS CEP file on SPI-Flash

### DIFF
--- a/arch/arm/src/cxd56xx/Kconfig
+++ b/arch/arm/src/cxd56xx/Kconfig
@@ -1312,6 +1312,12 @@ config CXD56_GNSS_CEP_FILENAME
 	---help---
 		Specify the path and file name of cep data.
 
+config CXD56_GNSS_CEP_ON_SPIFLASH
+	bool "GNSS CEP file on SPI-Flash"
+	default n
+	---help---
+		Use a cep file on SPI-Flash.
+
 config CXD56_GNSS_FW_RTK
 	bool "Support carrier-phase data output for Real-Time Kinematic"
 	default n


### PR DESCRIPTION
## Summary
If you specify a file path on SPI-Flash in CONFIG_CXD56_GNSS_CEP_FILENAME, it causes a deadlock issue in the inter-CPU communication. To resolve it, introduce a new CONFIG_CXD56_GNSS_CEP_ON_SPIFLASH and then use pre-read buffers during checking CEP file. So this needs the large of free memory.

## Impact
only spresense gnss

## Testing

