### PR TITLE
arch: cxd56xx: Fix stall bulk xfer when sending 512 byte data

### DIFF
--- a/arch/arm/src/cxd56xx/cxd56_usbdev.c
+++ b/arch/arm/src/cxd56xx/cxd56_usbdev.c
@@ -757,14 +757,6 @@ static int cxd56_epwrite(struct cxd56_ep_s *privep, uint8_t *buf,
   /* Set Poll bit to ready to send */
 
   ctrl = getreg32(CXD56_USB_IN_EP_CONTROL(epphy));
-
-  /* Send NULL packet request */
-
-  if (privep->txnullpkt)
-    {
-      ctrl |= USB_SENDNULL;
-    }
-
   putreg32(ctrl | USB_P | USB_CNAK, CXD56_USB_IN_EP_CONTROL(epphy));
 
   return nbytes;


### PR DESCRIPTION
## Summary
Remove hardware zero length packet enhancement because of driver logic already processed the ZLP correctly. It is unnecessary and cause of IN interrupt lost.

## Impact
only spresense

## Testing

