### PR TITLE
ci/docker: copy `clang-extdef-mapping` to clang-arm

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -163,7 +163,7 @@ jobs:
             if [ "X${{matrix.boards}}" = "Xcodechecker" ]; then
                 ./cibuild.sh -A -R -c --codechecker testlist/${{matrix.boards}}.dat
             else
-              ./cibuild.sh -A -R -c testlist/${{matrix.boards}}.dat
+                ./cibuild.sh -A -R -c testlist/${{matrix.boards}}.dat
             fi
             ccache -s
 

--- a/tools/ci/cibuild.sh
+++ b/tools/ci/cibuild.sh
@@ -177,6 +177,7 @@ function arm-clang-toolchain {
     curl -O -L -s https://github.com/ARM-software/LLVM-embedded-toolchain-for-Arm/releases/download/release-14.0.0/LLVMEmbeddedToolchainForArm-14.0.0-linux.tar.gz
     tar zxf LLVMEmbeddedToolchainForArm-14.0.0-linux.tar.gz
     mv LLVMEmbeddedToolchainForArm-14.0.0 clang-arm-none-eabi
+    cp /usr/bin/clang-extdef-mapping-10 clang-arm-none-eabi/bin/clang-extdef-mapping
     rm LLVMEmbeddedToolchainForArm-14.0.0-linux.tar.gz
   fi
   clang --version

--- a/tools/ci/docker/linux/Dockerfile
+++ b/tools/ci/docker/linux/Dockerfile
@@ -308,6 +308,7 @@ ENV PATH="/tools/rust/cargo/bin:$PATH"
 
 # ARM toolchain
 COPY --from=nuttx-toolchain-arm /tools/clang-arm-none-eabi/ clang-arm-none-eabi/
+CMD cp /usr/bin/clang-extdef-mapping-10 clang-arm-none-eabi/bin/clang-extdef-mapping
 ENV PATH="/tools/clang-arm-none-eabi/bin:$PATH"
 
 COPY --from=nuttx-toolchain-arm /tools/gcc-arm-none-eabi/ gcc-arm-none-eabi/


### PR DESCRIPTION
## Summary

Clang relies on clang-extdef-mapping for ctu checking. But clang-arm doesn't provide this file 
A tweaking way to support this feature is copy a `clang-extdef-mapping` from other clang version.

## Impact

## Testing

