### PR TITLE
boards: spresense: enable lte modem

### DIFF
--- a/boards/arm/cxd56xx/common/src/Make.defs
+++ b/boards/arm/cxd56xx/common/src/Make.defs
@@ -30,8 +30,8 @@ ifeq ($(CONFIG_CXD56_AUDIO),y)
 CSRCS += cxd56_audio.c
 endif
 
-ifeq ($(CONFIG_MODEM_ALTMDM),y)
-CSRCS += cxd56_altmdm.c
+ifeq ($(CONFIG_MODEM_ALT1250),y)
+CSRCS += cxd56_alt1250.c
 endif
 
 ifeq ($(CONFIG_BOARDCTL_UNIQUEID),y)

--- a/boards/arm/cxd56xx/spresense/include/board.h
+++ b/boards/arm/cxd56xx/spresense/include/board.h
@@ -45,7 +45,7 @@
 #include "cxd56_gpioif.h"
 
 #include "cxd56_audio.h"
-#include "cxd56_altmdm.h"
+#include "cxd56_alt1250.h"
 #include "cxd56_ak09912.h"
 #include "cxd56_apds9930.h"
 #include "cxd56_apds9960.h"
@@ -272,11 +272,11 @@ enum board_power_device
 
 /* Altair modem device pin definitions **************************************/
 
-#define ALTMDM_SLAVE_REQ          PIN_SPI2_SCK
-#define ALTMDM_MASTER_REQ         PIN_RTC_IRQ_OUT
-#define ALTMDM_WAKEUP             PIN_SPI2_MOSI
-#define ALTMDM_SHUTDOWN           PIN_SPI2_MISO
-#define ALTMDM_LTE_POWER_BUTTON   PIN_AP_CLK
+#define ALT1250_SLAVE_REQ          PIN_SPI2_SCK
+#define ALT1250_MASTER_REQ         PIN_RTC_IRQ_OUT
+#define ALT1250_WAKEUP             PIN_SPI2_MOSI
+#define ALT1250_SHUTDOWN           PIN_SPI2_MISO
+#define ALT1250_LTE_POWER_BUTTON   PIN_AP_CLK
 
 /****************************************************************************
  * Public Types

--- a/boards/arm/cxd56xx/spresense/include/cxd56_alt1250.h
+++ b/boards/arm/cxd56xx/spresense/include/cxd56_alt1250.h
@@ -1,5 +1,5 @@
 /****************************************************************************
- * boards/arm/cxd56xx/spresense/src/cxd56_altmdm_power.c
+ * boards/arm/cxd56xx/spresense/include/cxd56_alt1250.h
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -18,69 +18,92 @@
  *
  ****************************************************************************/
 
+#ifndef __BOARDS_ARM_CXD56XX_SPRESENSE_INCLUDE_CXD56_ALT1250_H
+#define __BOARDS_ARM_CXD56XX_SPRESENSE_INCLUDE_CXD56_ALT1250_H
+
 /****************************************************************************
  * Included Files
  ****************************************************************************/
 
 #include <nuttx/config.h>
 
-#if defined(CONFIG_MODEM_ALTMDM)
-
-#include <stdio.h>
-#include <debug.h>
-#include <errno.h>
-
-#include <nuttx/board.h>
-#include <nuttx/spi/spi.h>
-#include <nuttx/modem/altmdm.h>
-#include <arch/board/board.h>
-#include "cxd56_gpio.h"
-#include "cxd56_pinconfig.h"
+#ifndef __ASSEMBLY__
 
 /****************************************************************************
- * Public Functions
+ * Public Data
  ****************************************************************************/
 
+#undef EXTERN
+#if defined(__cplusplus)
+#define EXTERN extern "C"
+extern "C"
+{
+#else
+#define EXTERN extern
+#endif
+
 /****************************************************************************
- * Name: board_altmdm_poweron
+ * Public Function Prototypes
+ ****************************************************************************/
+
+#if defined(CONFIG_MODEM_ALT1250)
+
+/****************************************************************************
+ * Name: board_alt1250_initialize
+ *
+ * Description:
+ *   Initialize Altair modem
+ *
+ ****************************************************************************/
+
+int board_alt1250_initialize(const char *devpath);
+
+/****************************************************************************
+ * Name: board_alt1250_uninitialize
+ *
+ * Description:
+ *   Uninitialize Altair modem
+ *
+ ****************************************************************************/
+
+int board_alt1250_uninitialize(void);
+
+/****************************************************************************
+ * Name: board_alt1250_poweron
  *
  * Description:
  *   Power on the Altair modem device on the board.
  *
  ****************************************************************************/
 
-void board_altmdm_poweron(void)
-{
-  /* Power on altair modem device */
-
-  cxd56_gpio_config(ALTMDM_SHUTDOWN, false);
-  cxd56_gpio_write(ALTMDM_SHUTDOWN, true);
-
-  cxd56_gpio_config(ALTMDM_LTE_POWER_BUTTON, false);
-  cxd56_gpio_write(ALTMDM_LTE_POWER_BUTTON, true);
-
-  board_power_control(POWER_LTE, true);
-}
+void board_alt1250_poweron(void);
 
 /****************************************************************************
- * Name: board_altmdm_poweroff
+ * Name: board_alt1250_poweroff
  *
  * Description:
  *   Power off the Altair modem device on the board.
  *
  ****************************************************************************/
 
-void board_altmdm_poweroff(void)
-{
-  /* Power off Altair modem device */
+void board_alt1250_poweroff(void);
 
-  cxd56_gpio_write(ALTMDM_SHUTDOWN, true);
+/****************************************************************************
+ * Name: board_alt1250_reset
+ *
+ * Description:
+ *   Reset the Altair modem device on the board.
+ *
+ ****************************************************************************/
 
-  board_power_control(POWER_LTE, false);
-
-  cxd56_gpio_write(ALTMDM_SHUTDOWN, false);
-  cxd56_gpio_write(ALTMDM_LTE_POWER_BUTTON, false);
-}
+void board_alt1250_reset(void);
 
 #endif
 
+#undef EXTERN
+#if defined(__cplusplus)
+}
+#endif
+
+#endif /* __ASSEMBLY__ */
+#endif /* __BOARDS_ARM_CXD56XX_SPRESENSE_INCLUDE_CXD56_ALT1250_H */

--- a/boards/arm/cxd56xx/spresense/src/Make.defs
+++ b/boards/arm/cxd56xx/spresense/src/Make.defs
@@ -71,8 +71,8 @@ ifeq ($(CONFIG_USBDEV_COMPOSITE),y)
 CSRCS += cxd56_composite.c
 endif
 
-ifeq ($(CONFIG_MODEM_ALTMDM),y)
-CSRCS += cxd56_altmdm_power.c
+ifeq ($(CONFIG_MODEM_ALT1250),y)
+CSRCS += cxd56_alt1250_power.c
 endif
 
 DEPPATH += --dep-path board


### PR DESCRIPTION
## Summary
Enable and configure ALT1250 LTE modem

## Impact
SPRESENSE LTE board

## Testing
spresense
