### PR TITLE
arm/phy62xx: fix compile warning on gcc-11.3 ('while' clause does not guard)

### DIFF
--- a/arch/arm/src/phy62xx/flash.c
+++ b/arch/arm/src/phy62xx/flash.c
@@ -43,7 +43,7 @@
 #define SPIF_STATUS_WAIT_IDLE(n)                    \
     do                                              \
     {                                               \
-        while ((AP_SPIF->fcmd &0x02)==0x02);         \
+        while ((AP_SPIF->fcmd &0x02)==0x02)         \
         {                                           \
             volatile int delay_cycle = n;           \
             while (delay_cycle--){;}                \


### PR DESCRIPTION
## Summary

arm/phy62xx: fix compile warning on gcc-11.3 ('while' clause does not guard)

```
chip/flash.c: In function '_spif_read_status_reg_x': chip/flash.c:46:9: warning: this 'while' clause does not guard... [-Wmisleading-indentation]
   46 |         while ((AP_SPIF->fcmd &0x02)==0x02);         \
      |         ^~~~~
chip/flash.c:128:3: note: in expansion of macro 'SPIF_STATUS_WAIT_IDLE'
  128 |   SPIF_STATUS_WAIT_IDLE(SPIF_WAIT_IDLE_CYC);
      |   ^~~~~~~~~~~~~~~~~~~~~
```

Signed-off-by: chao an <anchao@xiaomi.com>


## Impact

N/A

## Testing

ci-check