### PR TITLE
boards: cxd56xx: Update imageproc driver

### DIFF
--- a/boards/arm/cxd56xx/spresense/include/cxd56_imageproc.h
+++ b/boards/arm/cxd56xx/spresense/include/cxd56_imageproc.h
@@ -107,20 +107,24 @@ extern "C"
  *  [in,out] ibuf: image
  *  [in] hsize: Horizontal size
  *  [in] vsize: Vertical size
+ *
+ * return 0 on success, otherwise error code.
  */
 
-  void imageproc_convert_yuv2rgb(uint8_t * ibuf, uint32_t hsize,
-                                 uint32_t vsize);
+  int imageproc_convert_yuv2rgb(uint8_t * ibuf, uint32_t hsize,
+                                uint32_t vsize);
 
 /* Convert color format (RGB to YUV)
  *
  *  [in,out] ibuf: image
  *  [in] hsize: Horizontal size
  *  [in] vsize: Vertical size
+ *
+ * return 0 on success, otherwise error code.
  */
 
-  void imageproc_convert_rgb2yuv(uint8_t * ibuf, uint32_t hsize,
-                                 uint32_t vsize);
+  int imageproc_convert_rgb2yuv(uint8_t * ibuf, uint32_t hsize,
+                                uint32_t vsize);
 
 /* Convert color format (YUV to grayscale)
  *


### PR DESCRIPTION
## Summary
Fix raster operation bug in non-scaling case, and change the type of return value to int with error code for some functions.

## Impact
Only spresense board

## Testing

