### PR TITLE
arm/cache: fix build warning on LLVM clang

### DIFF
--- a/arch/arm/src/armv7-m/arm_cache.c
+++ b/arch/arm/src/armv7-m/arm_cache.c
@@ -90,6 +90,7 @@
  *
  ****************************************************************************/
 
+#ifdef CONFIG_ARMV7M_DCACHE
 static inline uint32_t arm_clz(unsigned int value)
 {
   uint32_t ret;
@@ -97,6 +98,7 @@ static inline uint32_t arm_clz(unsigned int value)
   __asm__ __volatile__ ("clz %0, %1" : "=r"(ret) : "r"(value));
   return ret;
 }
+#endif
 
 /****************************************************************************
  * Public Functions


### PR DESCRIPTION

## Summary

arm/cache: fix build warning on LLVM clang

```
armv7-m/arm_cache.c:93:24: warning: unused function 'arm_clz' [-Wunused-function]
static inline uint32_t arm_clz(unsigned int value)
                       ^
```


Signed-off-by: chao an <anchao@xiaomi.com>


## Impact

## Testing

