### PR TITLE
arch/armv6-m: fix compile error on LLVM clang

### DIFF
--- a/arch/arm/src/armv6-m/arm_exception.S
+++ b/arch/arm/src/armv6-m/arm_exception.S
@@ -104,6 +104,7 @@
 	.align	2
 	.code	16
 	.thumb_func
+	.syntax	unified
 	.type	exception_common, function
 exception_common:
 
@@ -136,8 +137,8 @@ exception_common:
 2:
 	/* Save SP, PRIMASK, and R4-R7 in the context array */
 
-	sub		r1, #SW_XCPT_SIZE			/* R1=Beginning of context array on the stack */
-	mov		r2, #XCPTCONTEXT_SIZE			/* R2=Size of the context array */
+	subs		r1, #SW_XCPT_SIZE			/* R1=Beginning of context array on the stack */
+	movs		r2, #XCPTCONTEXT_SIZE			/* R2=Size of the context array */
 	add		r2, r1					/* R2=MSP/PSP before the interrupt was taken */
 								/* (ignoring the xPSR[9] alignment bit) */
 	mrs		r3, primask				/* R3=Current PRIMASK setting */
@@ -181,7 +182,7 @@ exception_common:
 	 */
 
 	mov		r2, r1					/* Reserve signal context */
-	sub		r2, r2, #XCPTCONTEXT_SIZE
+	subs		r2, r2, #XCPTCONTEXT_SIZE
 	msr		msp, r2					/* We are using the main stack pointer */
 #endif
 
@@ -193,8 +194,8 @@ exception_common:
 
 	/* Recover R8-R11 and EXEC_RETURN (5 registers) */
 
-	mov		r2, #(4*REG_R8)				/* R2=Offset to R8 storage */
-	add		r1, r0, r2				/* R1=Address of R8 storage */
+	movs		r2, #(4*REG_R8)				/* R2=Offset to R8 storage */
+	adds		r1, r0, r2				/* R1=Address of R8 storage */
 #ifdef CONFIG_BUILD_PROTECTED
 	ldmia		r1!, {r2-r6}				/* Recover R8-R11 and R14 (5 registers)*/
 	mov		r8, r2					/* Move to position in high registers */
@@ -215,8 +216,8 @@ exception_common:
 	 */
 
 	ldmia		r0!, {r2-r7}				/* Recover R4-R7 + 2 temp values */
-	mov		r1, #HW_XCPT_SIZE			/* R1=Size of hardware-saved portion of the context array */
-	sub		r1, r2, r1				/* R1=Value of MSP/PSP on exception entry */
+	movs		r1, #HW_XCPT_SIZE			/* R1=Size of hardware-saved portion of the context array */
+	subs		r1, r2, r1				/* R1=Value of MSP/PSP on exception entry */
 
 	/* Restore the stack pointer.  The EXC_RETURN value tells us whether the
 	 * context is on the MSP or PSP.

--- a/boards/arm/phy62xx/phy6222/src/bringup.c
+++ b/boards/arm/phy62xx/phy6222/src/bringup.c
@@ -70,7 +70,7 @@ extern int phyplus_timer_initialize(const char *devpath, int timer);
 
 int phy62xx_bringup(void)
 {
-  int ret;
+  int ret = OK;
 
 #ifdef CONFIG_FS_PROCFS
   /* Mount the procfs file system */
@@ -167,6 +167,5 @@ int phy62xx_bringup(void)
     }
 #endif
 
-  UNUSED(ret);
-  return OK;
+  return ret;
 }


### PR DESCRIPTION
## Summary

arch/armv6-m: fix compile error on LLVM clang

```
armv6-m/arm_exception.S:139:2: error: invalid instruction, any one of the following would fix this:
 sub r1, #(4 * (10))
 ^
armv6-m/arm_exception.S:139:2: note: instruction requires: thumb2
 sub r1, #(4 * (10))
 ^
armv6-m/arm_exception.S:139:10: note: invalid operand for instruction
 sub r1, #(4 * (10))
         ^
armv6-m/arm_exception.S:139:2: note: no flag-preserving variant of this instruction available
 sub r1, #(4 * (10))
 ^
armv6-m/arm_exception.S:139:10: note: operand must be a register in range [r0, r7]
 sub r1, #(4 * (10))
         ^
```


```
bringup.c:125:18: warning: variable 'ret' is uninitialized when used here [-Wuninitialized]
          return ret;
                 ^~~
bringup.c:73:10: note: initialize the variable 'ret' to silence this warning
  int ret;
         ^
          = 0
```


## Impact

N/A

## Testing

CI check