### PR TITLE
stm32fh7:Allow the use of the Network Monitor via polling

### DIFF
--- a/arch/arm/src/imxrt/Kconfig
+++ b/arch/arm/src/imxrt/Kconfig
@@ -1816,7 +1816,7 @@ config IMXRT_ENET_PHYINIT
 		function one time before it first uses the PHY.
 
 config IMXRT_PHY_POLLING
-	bool "Support network monitoring by poling the PHY"
+	bool "Support network monitoring by polling the PHY"
 	default n
 	depends on IMXRT_ENET
 	select ARCH_PHY_POLLED

--- a/arch/arm/src/stm32f7/Kconfig
+++ b/arch/arm/src/stm32f7/Kconfig
@@ -6355,7 +6355,7 @@ config STM32F7_PHYINIT
 		one time before it first uses the PHY.
 
 config STM32F7_PHY_POLLING
-	bool "Support network monitoring by poling the PHY"
+	bool "Support network monitoring by polling the PHY"
 	default n
 	depends on STM32F7_HAVE_PHY_POLLED
 	select ARCH_PHY_POLLED

--- a/arch/arm/src/stm32h7/Kconfig
+++ b/arch/arm/src/stm32h7/Kconfig
@@ -449,6 +449,10 @@ config STM32H7_HAVE_ETHERNET
 	bool
 	default n
 
+config STM32H7_HAVE_PHY_POLLED
+	bool
+	default n
+
 config STM32H7_HAVE_FMC
 	bool
 	default n
@@ -614,6 +618,7 @@ config STM32H7_ETHMAC
 	depends on STM32H7_HAVE_ETHERNET
 	select NETDEVICES
 	select ARCH_HAVE_PHY
+	select STM32H7_HAVE_PHY_POLLED
 
 config STM32H7_FMC
 	bool "FMC"
@@ -5086,6 +5091,16 @@ config STM32H7_PHYINIT
 		STM32H7_PHYINIT is defined in the configuration then the board specific logic must
 		provide stm32_phyinitialize();  The STM32 Ethernet driver will call this function
 		one time before it first uses the PHY.
+
+config STM32H7_PHY_POLLING
+	bool "Support network monitoring by polling the PHY"
+	default n
+	depends on STM32H7_HAVE_PHY_POLLED
+	select ARCH_PHY_POLLED
+	---help---
+		Some boards may not have an interrupt connected to the PHY.
+		This option allows the network monitor to be used by polling the
+		the PHY for status.
 
 config STM32H7_MII
 	bool "Use MII interface"


### PR DESCRIPTION
## Summary

   Not all boards have an interrupt line from the phy to
   the Soc. This commit allows the phy to be polled for
   link status.

   This may not work on all MAC/PHY combination that
   have mutually exclusive link management and operating
   modes. The STM32H7 and LAN8742AI do not have such a
   limitation.

## Impact

None - New Switch defaults to off

## Testing
px4_fmu-v6x