### PR TITLE
arm/armv6-m: fix build break if enable syntax unified 

### DIFF
--- a/arch/arm/src/armv6-m/arm_exception.S
+++ b/arch/arm/src/armv6-m/arm_exception.S
@@ -116,7 +116,7 @@ exception_common:
 
 #ifdef CONFIG_BUILD_PROTECTED
 	mov		r0, r14					/* Copy high register to low register */
-	lsl		r0, #(31 - EXC_RETURN_PROCESS_BITNO)	/* Move to bit 31 */
+	lsls		r0, #(31 - EXC_RETURN_PROCESS_BITNO)	/* Move to bit 31 */
 	bmi		1f					/* Test bit 31 */
 	mrs		r1, msp					/* R1=The main stack pointer */
 	b		2f
@@ -225,7 +225,7 @@ exception_common:
 
 #ifdef CONFIG_BUILD_PROTECTED
 	mov		r0, r14					/* Copy high register to low register */
-	lsl		r0, #(31 - EXC_RETURN_PROCESS_BITNO)	/* Move to bit 31 */
+	lsls		r0, #(31 - EXC_RETURN_PROCESS_BITNO)	/* Move to bit 31 */
 	bmi		3f					/* Test bit 31 */
 	msr		msp, r1					/* R1=The main stack pointer */
 	b		4f

--- a/arch/arm/src/rp2040/chip.h
+++ b/arch/arm/src/rp2040/chip.h
@@ -70,7 +70,7 @@
   .macro  setintstack, tmp1, tmp2
   ldr  \tmp1, =RP2040_SIO_CPUID
   ldr  \tmp1, [\tmp1, #0]
-  lsl  \tmp1, \tmp1, #2
+  lsls  \tmp1, \tmp1, #2
   ldr  \tmp2, =g_cpu_intstack_top
   add  \tmp2, \tmp2, \tmp1
   ldr  \tmp2, [\tmp2, #0]


### PR DESCRIPTION
## Summary

arm/armv6-m: fix build break if enable syntax unified

```
armv6-m/arm_exception.S: Assembler messages:
armv6-m/arm_exception.S:171: Error: cannot honor width suffix -- `lsl r7,r7,#2'
```

Signed-off-by: chao an <anchao@xiaomi.com>


## Impact

N/A

## Testing

CI-check