### PR TITLE
arm/toolchain: update toolchain comment to avoid confusion

### DIFF
--- a/arch/arm/Kconfig
+++ b/arch/arm/Kconfig
@@ -7,7 +7,7 @@ if ARCH_ARM
 comment "ARM Options"
 
 choice
-	prompt "Toolchain Selection"
+	prompt "ARM Toolchain Selection"
 	default ARM_TOOLCHAIN_GNU_EABI
 
 config ARM_TOOLCHAIN_IAR
@@ -39,7 +39,7 @@ config ARM_TOOLCHAIN_GNU_OABI
 		This option should work for any GNU toolchain.
 
 config ARM_TOOLCHAIN_CLANG
-	bool "Generic Clang toolchain"
+	bool "LLVM Clang toolchain"
 	select ARCH_TOOLCHAIN_CLANG
 
 config ARM_TOOLCHAIN_ARMCLANG


### PR DESCRIPTION

## Summary

arm/toolchain: update toolchain comment to avoid confusion

```
1. add 'ARM' prefix to choice menu
2. rename 'Generic Clang toolchain' to 'LLVM Clang toolchain' to avoid confuse with CONFIG_ARM_TOOLCHAIN_ARMCLANG
```

Signed-off-by: chao an <anchao@xiaomi.com>

## Impact

N/A

## Testing

menuconfig