### PR TITLE
Add %T and %R conversion specifiers to strftime(3)

### DIFF
--- a/libs/libc/time/lib_strftime.c
+++ b/libs/libc/time/lib_strftime.c
@@ -368,6 +368,15 @@ size_t strftime(FAR char *s, size_t max, FAR const char *format,
              }
              break;
 
+            /* %R: Shortcut for %H:%M. */
+
+           case 'R':
+             {
+               len = snprintf(dest, chleft, "%02d:%02d",
+                              tm->tm_hour, tm->tm_min);
+             }
+             break;
+
            /* %s: The number of seconds since the Epoch, that is,
             * since 1970-01-01 00:00:00 UTC.
             * Hmmm... mktime argume is not 'const'.

--- a/libs/libc/time/lib_strftime.c
+++ b/libs/libc/time/lib_strftime.c
@@ -408,6 +408,15 @@ size_t strftime(FAR char *s, size_t max, FAR const char *format,
              }
              break;
 
+           /* %T: Shortcut for %H:%M:%S. */
+
+           case 'T':
+             {
+               len = snprintf(dest, chleft, "%02d:%02d:%02d",
+                              tm->tm_hour, tm->tm_min, tm->tm_sec);
+             }
+             break;
+
            /* %w: The weekday as a decimal number (range 0 to 6). */
 
            case 'w':


### PR DESCRIPTION
## Summary
This PR adds two missing conversion specifiers supplied by [`strftime(3)`](https://pubs.opengroup.org/onlinepubs/9699919799/functions/strftime.html) that are defined by POSIX.1-2017, namely `%R` and `%T`.

## Impact

## Testing

