### PR TITLE
audio/i2s: add i2s_mclkfrequency method to the I2S lower half 

### DIFF
--- a/arch/xtensa/src/esp32/esp32_i2s.c
+++ b/arch/xtensa/src/esp32/esp32_i2s.c
@@ -242,6 +242,7 @@ struct esp32_i2s_s
   sem_t             exclsem;    /* Assures mutually exclusive access */
   uint32_t          rate;       /* I2S actual configured sample-rate */
   uint32_t          data_width; /* I2S actual configured data_width */
+  uint32_t          mclk_freq;  /* I2S actual master clock */
   int               cpuint;     /* I2S interrupt ID */
   uint8_t           cpu;        /* CPU ID */
   spinlock_t        lock;       /* Device specific lock. */
@@ -305,13 +306,15 @@ static void     i2s_tx_schedule(struct esp32_i2s_s *priv,
 
 /* I2S methods (and close friends) */
 
+static uint32_t esp32_i2s_mclkfrequency(struct i2s_dev_s *dev,
+                                        uint32_t frequency);
 static uint32_t esp32_i2s_txsamplerate(struct i2s_dev_s *dev,
-                                        uint32_t rate);
+                                       uint32_t rate);
 static uint32_t esp32_i2s_txdatawidth(struct i2s_dev_s *dev, int bits);
 static int      esp32_i2s_send(struct i2s_dev_s *dev,
-                                struct ap_buffer_s *apb,
-                                i2s_callback_t callback, void *arg,
-                                uint32_t timeout);
+                               struct ap_buffer_s *apb,
+                               i2s_callback_t callback, void *arg,
+                               uint32_t timeout);
 
 /****************************************************************************
  * Private Data
@@ -319,9 +322,10 @@ static int      esp32_i2s_send(struct i2s_dev_s *dev,
 
 static const struct i2s_ops_s g_i2sops =
 {
-  .i2s_txsamplerate = esp32_i2s_txsamplerate,
-  .i2s_txdatawidth  = esp32_i2s_txdatawidth,
-  .i2s_send         = esp32_i2s_send,
+  .i2s_txsamplerate   = esp32_i2s_txsamplerate,
+  .i2s_txdatawidth    = esp32_i2s_txdatawidth,
+  .i2s_send           = esp32_i2s_send,
+  .i2s_mclkfrequency  = esp32_i2s_mclkfrequency,
 };
 
 #ifdef CONFIG_ESP32_I2S0
@@ -395,7 +399,7 @@ static const struct esp32_i2s_config_s esp32_i2s1_config =
   .data_width       = CONFIG_ESP32_I2S1_DATA_BIT_WIDTH,
   .rate             = CONFIG_ESP32_I2S1_SAMPLE_RATE,
   .total_slot       = 2,
-  .mclk_multiple    = I2S_MCLK_MULTIPLE_384,
+  .mclk_multiple    = I2S_MCLK_MULTIPLE_256,
   .tx_en            = I2S1_TX_ENABLED,
   .rx_en            = I2S1_RX_ENABLED,
 #ifdef CONFIG_ESP32_I2S1_MCLK
@@ -1132,6 +1136,10 @@ static void i2s_configure(struct esp32_i2s_s *priv)
       modifyreg32(I2S_FIFO_CONF_REG(priv->config->port), 0,
                   I2S_TX_FIFO_MOD_FORCE_EN);
 
+      esp32_i2s_mclkfrequency((struct i2s_dev_s *)priv,
+                              (priv->config->rate *
+                               priv->config->mclk_multiple));
+
       esp32_i2s_txsamplerate((struct i2s_dev_s *)priv, priv->config->rate);
     }
 
@@ -1226,6 +1234,42 @@ static int esp32_i2s_interrupt(int irq, void *context, void *arg)
 }
 
 /****************************************************************************
+ * Name: esp32_i2s_mclkfrequency
+ *
+ * Description:
+ *   Set the master clock frequency. Usually, the MCLK is a multiple of the
+ *   sample rate. Most of the audio codecs require setting specific MCLK
+ *   frequency according to the sample rate.
+ *
+ * Input Parameters:
+ *   dev        - Device-specific state data
+ *   frequency  - The I2S master clock's frequency
+ *
+ * Returned Value:
+ *   Returns the resulting master clock or a negated errno value on failure.
+ *
+ ****************************************************************************/
+
+static uint32_t esp32_i2s_mclkfrequency(struct i2s_dev_s *dev,
+                                        uint32_t frequency)
+{
+  struct esp32_i2s_s *priv = (struct esp32_i2s_s *)dev;
+
+  /* Check if the master clock frequency is beyond the highest possible
+   * value and return an error.
+   */
+
+  if (frequency >= (I2S_LL_BASE_CLK / 2))
+    {
+      return -EINVAL;
+    }
+
+  priv->mclk_freq = frequency;
+
+  return frequency;
+}
+
+/****************************************************************************
  * Name: esp32_i2s_txsamplerate
  *
  * Description:
@@ -1276,7 +1320,7 @@ static uint32_t esp32_i2s_txsamplerate(struct i2s_dev_s *dev, uint32_t rate)
   if (priv->config->role == I2S_ROLE_MASTER)
     {
       bclk = rate * priv->config->total_slot * priv->data_width;
-      mclk = rate * priv->config->mclk_multiple;
+      mclk = priv->mclk_freq;
       bclk_div = mclk / bclk;
     }
   else

--- a/drivers/audio/cs4344.c
+++ b/drivers/audio/cs4344.c
@@ -54,6 +54,7 @@
  * Private Function Prototypes
  ****************************************************************************/
 
+static int  cs4344_setmclkfrequency(FAR struct cs4344_dev_s *priv);
 static void cs4344_setdatawidth(FAR struct cs4344_dev_s *priv);
 static void cs4344_setbitrate(FAR struct cs4344_dev_s *priv);
 
@@ -154,9 +155,137 @@ static const struct audio_ops_s g_audioops =
   cs4344_release        /* release */
 };
 
+struct mclk_rate_s
+{
+  uint32_t mclk_freq;   /* Master clock frequency (in Hz) */
+  uint32_t sample_rate; /* Sample rate (in Hz) */
+  uint16_t multiple;    /* Multiple of the mclk_freq to the sample_rate */
+};
+
+static const struct mclk_rate_s mclk_rate[] =
+{
+  {
+    8192000,  /* mclk_freq */
+    16000,    /* sample_rate */
+    512,      /* multiple */
+  },
+  {
+    12288000, /* mclk_freq */
+    16000,    /* sample_rate */
+    768,      /* multiple */
+  },
+  {
+    11289600, /* mclk_freq */
+    22050,    /* sample_rate */
+    512,      /* multiple */
+  },
+  {
+    8192000,  /* mclk_freq */
+    32000,    /* sample_rate */
+    256,      /* multiple */
+  },
+  {
+    12288000, /* mclk_freq */
+    32000,    /* sample_rate */
+    384,      /* multiple */
+  },
+  {
+    11289600, /* mclk_freq */
+    44100,    /* sample_rate */
+    256,      /* multiple */
+  },
+  {
+    16934400, /* mclk_freq */
+    44100,    /* sample_rate */
+    384,      /* multiple */
+  },
+  {
+    22579200, /* mclk_freq */
+    44100,    /* sample_rate */
+    512,      /* multiple */
+  },
+  {
+    12288000, /* mclk_freq */
+    48000,    /* sample_rate */
+    256,      /* multiple */
+  },
+  {
+    18432000, /* mclk_freq */
+    48000,    /* sample_rate */
+    384,      /* multiple */
+  },
+  {
+    24576000, /* mclk_freq */
+    48000,    /* sample_rate */
+    512,      /* multiple */
+  },
+};
+
 /****************************************************************************
  * Private Functions
  ****************************************************************************/
+
+/****************************************************************************
+ * Name: cs4344_setmclkfrequency
+ *
+ * Description:
+ *   Set the frequency of the Master Clock (MCLK)
+ *
+ * Input Parameters:
+ *   priv - A reference to the driver state structure
+ *
+ * Returned Value:
+ *   Returns OK or a negated errno value on failure.
+ *
+ ****************************************************************************/
+
+static int cs4344_setmclkfrequency(FAR struct cs4344_dev_s *priv)
+{
+  int ret = OK;
+  int i;
+
+  priv->mclk_freq = 0;
+
+  for (i = 0; i < ARRAY_SIZE(mclk_rate); i++)
+    {
+      if (mclk_rate[i].sample_rate == priv->samprate)
+        {
+          /* Normally master clock should be multiple of the sample rate
+           * and bclk at the same time. The field mclk_rate_s::multiple
+           * means the multiple of mclk to the sample rate. This value
+           * should be divisible by the size (in bytes) of the sample,
+           * otherwise the ws signal will be inaccurate. For instance,
+           * if data width is 24 bits, in order to keep mclk a multiple
+           * to the bclk, the mclk_rate_s::multiple should be divisible
+           * by the size of the sample, i.e, 24 / 8 = 3.
+           */
+
+          priv->mclk_freq = mclk_rate[i].mclk_freq;
+
+          /* Check if the current master clock frequency is divisible by
+           * the size (in bytes) of the sample. If so, we have a perfect
+           * match. Otherwise, try to find a more suitable value for the
+           * master clock.
+           */
+
+          if (mclk_rate[i].multiple % (priv->bpsamp / 8) == 0)
+            {
+              break;
+            }
+        }
+    }
+
+  if (priv->mclk_freq != 0)
+    {
+      ret = I2S_MCLKFREQUENCY(priv->i2s, priv->mclk_freq);
+    }
+  else
+    {
+      ret = -EINVAL;
+    }
+
+  return ret > 0 ? OK : ret;
+}
 
 /****************************************************************************
  * Name: cs4344_setdatawidth
@@ -407,6 +536,8 @@ cs4344_configure(FAR struct audio_lowerhalf_s *dev,
 
     case AUDIO_TYPE_OUTPUT:
       {
+        ret = OK;
+
         audinfo("  AUDIO_TYPE_OUTPUT:\n");
         audinfo("    Number of channels: %u\n", caps->ac_channels);
         audinfo("    Sample rate:        %u\n", caps->ac_controls.hw[0]);
@@ -414,11 +545,11 @@ cs4344_configure(FAR struct audio_lowerhalf_s *dev,
 
         /* Verify that all of the requested values are supported */
 
-        ret = -ERANGE;
         if (caps->ac_channels != 1 && caps->ac_channels != 2)
           {
             auderr("ERROR: Unsupported number of channels: %d\n",
                    caps->ac_channels);
+            ret = -ERANGE;
             break;
           }
 
@@ -426,6 +557,7 @@ cs4344_configure(FAR struct audio_lowerhalf_s *dev,
           {
             auderr("ERROR: Unsupported bits per sample: %d\n",
                    caps->ac_controls.b[2]);
+            ret = -ERANGE;
             break;
           }
 
@@ -435,13 +567,30 @@ cs4344_configure(FAR struct audio_lowerhalf_s *dev,
         priv->nchannels = caps->ac_channels;
         priv->bpsamp    = caps->ac_controls.b[2];
 
-        /* Reconfigure the FLL to support the resulting number or channels,
-         * bits per sample, and bitrate.
+        /* Reconfigure the master clock to support the resulting number of
+         * channels, data width, and sample rate. However, if I2S lower half
+         * doesn't provide support for setting the master clock, execution
+         * goes on and try just to set the data width and sample rate.
          */
+
+        ret = cs4344_setmclkfrequency(priv);
+        if (ret != OK)
+          {
+            if (ret != -ENOTTY)
+              {
+                auderr("ERROR: Unsupported combination of sample rate and"
+                       "data width\n");
+                break;
+              }
+            else
+              {
+                audwarn("WARNING: MCLK could not be set on lower half\n");
+                priv->mclk_freq = 0;
+              }
+          }
 
         cs4344_setdatawidth(priv);
         cs4344_setbitrate(priv);
-        ret = OK;
       }
       break;
 
@@ -1255,6 +1404,7 @@ static void cs4344_reset(FAR struct cs4344_dev_s *priv)
   priv->samprate   = CS4344_DEFAULT_SAMPRATE;
   priv->nchannels  = CS4344_DEFAULT_NCHANNELS;
   priv->bpsamp     = CS4344_DEFAULT_BPSAMP;
+  priv->mclk_freq  = 0;
 
   /* Configure the FLL and the LRCLK */
 

--- a/drivers/audio/cs4344.c
+++ b/drivers/audio/cs4344.c
@@ -272,7 +272,6 @@ static int cs4344_getcaps(FAR struct audio_lowerhalf_s *dev, int type,
               /* Report the Sample rates we support */
 
               caps->ac_controls.b[0] =
-                AUDIO_SAMP_RATE_8K | AUDIO_SAMP_RATE_11K |
                 AUDIO_SAMP_RATE_16K | AUDIO_SAMP_RATE_22K |
                 AUDIO_SAMP_RATE_32K | AUDIO_SAMP_RATE_44K |
                 AUDIO_SAMP_RATE_48K;

--- a/drivers/audio/cs4344.h
+++ b/drivers/audio/cs4344.h
@@ -41,6 +41,10 @@
  * Pre-Processor Definitions
  ****************************************************************************/
 
+#ifndef ARRAY_SIZE
+#  define ARRAY_SIZE(x)   (sizeof(x) / sizeof((x)[0]))
+#endif
+
 #define CS4344_DEFAULT_SAMPRATE      11025     /* Initial sample rate */
 #define CS4344_DEFAULT_NCHANNELS     1         /* Initial number of channels */
 #define CS4344_DEFAULT_BPSAMP        16        /* Initial bits per sample */
@@ -76,6 +80,7 @@ struct cs4344_dev_s
   uint16_t                samprate;         /* Configured samprate (samples/sec) */
   uint8_t                 nchannels;        /* Number of channels (1 or 2) */
   uint8_t                 bpsamp;           /* Bits per sample (8 or 16) */
+  uint32_t                mclk_freq;        /* Master clock frequency */
   volatile uint8_t        inflight;         /* Number of audio buffers in-flight */
   bool                    running;          /* True: Worker thread is running */
   bool                    paused;           /* True: Playing is paused */

--- a/include/nuttx/audio/i2s.h
+++ b/include/nuttx/audio/i2s.h
@@ -226,6 +226,29 @@
   ((d)->ops->i2s_send ? (d)->ops->i2s_send(d,b,c,a,t) : -ENOTTY)
 
 /****************************************************************************
+ * Name: I2S_MCLKFREQUENCY
+ *
+ * Description:
+ *   Set the master clock frequency. Usually, the MCLK is a multiple of the
+ *   sample rate. Most of the audio codecs require setting specific MCLK
+ *   frequency according to the sample rate. NOTE: this parameter may not
+ *   be implemented on I2S driver. If not implemented, the I2S may set
+ *   internally any value to the master clock (or even does not support it).
+ *
+ * Input Parameters:
+ *   dev        - Device-specific state data
+ *   frequency  - The I2S master clock's frequency
+ *
+ * Returned Value:
+ *   Returns the resulting master clock or a negated errno value on failure.
+ *
+ ****************************************************************************/
+
+#define I2S_MCLKFREQUENCY(d,f) \
+  ((d)->ops->i2s_mclkfrequency ? \
+   (d)->ops->i2s_mclkfrequency(d,f) : -ENOTTY)
+
+/****************************************************************************
  * Name: I2S_IOCTL
  *
  * Description:
@@ -285,6 +308,11 @@ struct i2s_ops_s
                             i2s_callback_t callback,
                             FAR void *arg,
                             uint32_t timeout);
+
+  /* Master Clock methods */
+
+  CODE uint32_t (*i2s_mclkfrequency)(FAR struct i2s_dev_s *dev,
+                                     uint32_t frequency);
 
   /* Ioctl */
 


### PR DESCRIPTION
## Summary
This method allows the codec driver to set a specific mclk frequency for the I2S lower half, allowing to change it on run time according to the supported master clock frequency of the audio codec, the sample rate and the data width of the audio file being played.
Also, add support for setting I2S's mclk on CS4344 audio codec and on ESP32's I2S driver.

## Impact
Implementation does not impact existing audio codec drivers and I2S drivers as the method would be NULL.

## Testing
Internal CI and hardware testing using ESP32-DevKitC board + Audio Codec CS4344.