### PR TITLE
Refine the implementation of files_allocate

### DIFF
--- a/fs/inode/fs_files.c
+++ b/fs/inode/fs_files.c
@@ -168,7 +168,7 @@ void files_releaselist(FAR struct filelist *list)
  ****************************************************************************/
 
 int file_allocate(FAR struct inode *inode, int oflags, off_t pos,
-                  FAR void *priv, int minfd)
+                  FAR void *priv, int minfd, bool addref)
 {
   FAR struct filelist *list;
   int ret;
@@ -217,6 +217,12 @@ int file_allocate(FAR struct inode *inode, int oflags, off_t pos,
               list->fl_files[i][j].f_inode  = inode;
               list->fl_files[i][j].f_priv   = priv;
               nxmutex_unlock(&list->fl_lock);
+
+              if (addref)
+                {
+                  inode_addref(inode);
+                }
+
               return i * CONFIG_NFILE_DESCRIPTORS_PER_BLOCK + j;
             }
         }
@@ -229,17 +235,24 @@ int file_allocate(FAR struct inode *inode, int oflags, off_t pos,
   /* The space of file array isn't enough, allocate a new filechunk */
 
   ret = files_extend(list, i + 1);
-  if (ret >= 0)
+  if (ret < 0)
     {
-      list->fl_files[i][0].f_oflags = oflags;
-      list->fl_files[i][0].f_pos    = pos;
-      list->fl_files[i][0].f_inode  = inode;
-      list->fl_files[i][0].f_priv   = priv;
-      ret = i * CONFIG_NFILE_DESCRIPTORS_PER_BLOCK;
+      nxmutex_unlock(&list->fl_lock);
+      return ret;
     }
 
+  list->fl_files[i][0].f_oflags = oflags;
+  list->fl_files[i][0].f_pos    = pos;
+  list->fl_files[i][0].f_inode  = inode;
+  list->fl_files[i][0].f_priv   = priv;
   nxmutex_unlock(&list->fl_lock);
-  return ret;
+
+  if (addref)
+    {
+      inode_addref(inode);
+    }
+
+  return i * CONFIG_NFILE_DESCRIPTORS_PER_BLOCK;
 }
 
 /****************************************************************************

--- a/fs/inode/fs_files.c
+++ b/fs/inode/fs_files.c
@@ -155,16 +155,20 @@ void files_releaselist(FAR struct filelist *list)
 }
 
 /****************************************************************************
- * Name: files_allocate
+ * Name: file_allocate
  *
  * Description:
  *   Allocate a struct files instance and associate it with an inode
  *   instance.  Returns the file descriptor == index into the files array.
  *
+ * Returned Value:
+ *   Zero (OK) is returned on success; a negated errno value is returned on
+ *   any failure.
+ *
  ****************************************************************************/
 
-int files_allocate(FAR struct inode *inode, int oflags, off_t pos,
-                   FAR void *priv, int minfd)
+int file_allocate(FAR struct inode *inode, int oflags, off_t pos,
+                  FAR void *priv, int minfd)
 {
   FAR struct filelist *list;
   int ret;

--- a/fs/inode/fs_files.c
+++ b/fs/inode/fs_files.c
@@ -159,11 +159,11 @@ void files_releaselist(FAR struct filelist *list)
  *
  * Description:
  *   Allocate a struct files instance and associate it with an inode
- *   instance.  Returns the file descriptor == index into the files array.
+ *   instance.
  *
  * Returned Value:
- *   Zero (OK) is returned on success; a negated errno value is returned on
- *   any failure.
+ *     Returns the file descriptor == index into the files array on success;
+ *     a negated errno value is returned on any failure.
  *
  ****************************************************************************/
 

--- a/fs/inode/inode.h
+++ b/fs/inode/inode.h
@@ -408,16 +408,20 @@ void inode_release(FAR struct inode *inode);
 int foreach_inode(foreach_inode_t handler, FAR void *arg);
 
 /****************************************************************************
- * Name: files_allocate
+ * Name: file_allocate
  *
  * Description:
  *   Allocate a struct files instance and associate it with an inode
  *   instance.  Returns the file descriptor == index into the files array.
  *
+ * Returned Value:
+ *   Zero (OK) is returned on success; a negated errno value is returned on
+ *   any failure.
+ *
  ****************************************************************************/
 
-int files_allocate(FAR struct inode *inode, int oflags, off_t pos,
-                   FAR void *priv, int minfd);
+int file_allocate(FAR struct inode *inode, int oflags, off_t pos,
+                  FAR void *priv, int minfd);
 
 /****************************************************************************
  * Name: dir_allocate

--- a/fs/inode/inode.h
+++ b/fs/inode/inode.h
@@ -408,22 +408,6 @@ void inode_release(FAR struct inode *inode);
 int foreach_inode(foreach_inode_t handler, FAR void *arg);
 
 /****************************************************************************
- * Name: file_allocate
- *
- * Description:
- *   Allocate a struct files instance and associate it with an inode
- *   instance.  Returns the file descriptor == index into the files array.
- *
- * Returned Value:
- *   Zero (OK) is returned on success; a negated errno value is returned on
- *   any failure.
- *
- ****************************************************************************/
-
-int file_allocate(FAR struct inode *inode, int oflags, off_t pos,
-                  FAR void *priv, int minfd);
-
-/****************************************************************************
  * Name: dir_allocate
  *
  * Description:

--- a/fs/mqueue/mq_open.c
+++ b/fs/mqueue/mq_open.c
@@ -349,11 +349,11 @@ static mqd_t nxmq_vopen(FAR const char *mq_name, int oflags, va_list ap)
       return ret;
     }
 
-  ret = file_allocate(mq.f_inode, mq.f_oflags, mq.f_pos, mq.f_priv, 0);
+  ret = file_allocate(mq.f_inode, mq.f_oflags,
+                      mq.f_pos, mq.f_priv, 0, false);
   if (ret < 0)
     {
       file_mq_close(&mq);
-
       if (created)
         {
           file_mq_unlink(mq_name);

--- a/fs/mqueue/mq_open.c
+++ b/fs/mqueue/mq_open.c
@@ -349,7 +349,7 @@ static mqd_t nxmq_vopen(FAR const char *mq_name, int oflags, va_list ap)
       return ret;
     }
 
-  ret = files_allocate(mq.f_inode, mq.f_oflags, mq.f_pos, mq.f_priv, 0);
+  ret = file_allocate(mq.f_inode, mq.f_oflags, mq.f_pos, mq.f_priv, 0);
   if (ret < 0)
     {
       file_mq_close(&mq);

--- a/fs/socket/socket.c
+++ b/fs/socket/socket.c
@@ -165,7 +165,7 @@ int sockfd_allocate(FAR struct socket *psock, int oflags)
 {
   int sockfd;
 
-  sockfd = files_allocate(&g_sock_inode, oflags, 0, psock, 0);
+  sockfd = file_allocate(&g_sock_inode, oflags, 0, psock, 0);
   if (sockfd >= 0)
     {
       inode_addref(&g_sock_inode);

--- a/fs/socket/socket.c
+++ b/fs/socket/socket.c
@@ -163,15 +163,7 @@ static int sock_file_poll(FAR struct file *filep, FAR struct pollfd *fds,
 
 int sockfd_allocate(FAR struct socket *psock, int oflags)
 {
-  int sockfd;
-
-  sockfd = file_allocate(&g_sock_inode, oflags, 0, psock, 0);
-  if (sockfd >= 0)
-    {
-      inode_addref(&g_sock_inode);
-    }
-
-  return sockfd;
+  return file_allocate(&g_sock_inode, oflags, 0, psock, 0, true);
 }
 
 /****************************************************************************

--- a/fs/vfs/fs_dup.c
+++ b/fs/vfs/fs_dup.c
@@ -66,8 +66,8 @@ int file_dup(FAR struct file *filep, int minfd)
 
   /* Then allocate a new file descriptor for the inode */
 
-  fd2 = files_allocate(filep2.f_inode, filep2.f_oflags,
-                       filep2.f_pos, filep2.f_priv, minfd);
+  fd2 = file_allocate(filep2.f_inode, filep2.f_oflags,
+                      filep2.f_pos, filep2.f_priv, minfd);
   if (fd2 < 0)
     {
       file_close(&filep2);

--- a/fs/vfs/fs_dup.c
+++ b/fs/vfs/fs_dup.c
@@ -67,7 +67,7 @@ int file_dup(FAR struct file *filep, int minfd)
   /* Then allocate a new file descriptor for the inode */
 
   fd2 = file_allocate(filep2.f_inode, filep2.f_oflags,
-                      filep2.f_pos, filep2.f_priv, minfd);
+                      filep2.f_pos, filep2.f_priv, minfd, false);
   if (fd2 < 0)
     {
       file_close(&filep2);

--- a/fs/vfs/fs_epoll.c
+++ b/fs/vfs/fs_epoll.c
@@ -198,7 +198,7 @@ static int epoll_do_create(int size, int flags)
 
   /* Alloc the file descriptor */
 
-  fd = files_allocate(&g_epoll_inode, flags, 0, eph, 0);
+  fd = file_allocate(&g_epoll_inode, flags, 0, eph, 0);
   if (fd < 0)
     {
       nxsem_destroy(&eph->sem);

--- a/fs/vfs/fs_epoll.c
+++ b/fs/vfs/fs_epoll.c
@@ -198,7 +198,7 @@ static int epoll_do_create(int size, int flags)
 
   /* Alloc the file descriptor */
 
-  fd = file_allocate(&g_epoll_inode, flags, 0, eph, 0);
+  fd = file_allocate(&g_epoll_inode, flags, 0, eph, 0, true);
   if (fd < 0)
     {
       nxsem_destroy(&eph->sem);
@@ -207,7 +207,6 @@ static int epoll_do_create(int size, int flags)
       return -1;
     }
 
-  inode_addref(&g_epoll_inode);
   nxsem_post(&eph->sem);
   return fd;
 }

--- a/fs/vfs/fs_open.c
+++ b/fs/vfs/fs_open.c
@@ -245,8 +245,8 @@ static int nx_vopen(FAR const char *path, int oflags, va_list ap)
 
   /* Allocate a new file descriptor for the inode */
 
-  fd = files_allocate(filep.f_inode, filep.f_oflags,
-                      filep.f_pos, filep.f_priv, 0);
+  fd = file_allocate(filep.f_inode, filep.f_oflags,
+                     filep.f_pos, filep.f_priv, 0);
   if (fd < 0)
     {
       file_close(&filep);

--- a/fs/vfs/fs_open.c
+++ b/fs/vfs/fs_open.c
@@ -246,7 +246,7 @@ static int nx_vopen(FAR const char *path, int oflags, va_list ap)
   /* Allocate a new file descriptor for the inode */
 
   fd = file_allocate(filep.f_inode, filep.f_oflags,
-                     filep.f_pos, filep.f_priv, 0);
+                     filep.f_pos, filep.f_priv, 0, false);
   if (fd < 0)
     {
       file_close(&filep);

--- a/include/nuttx/fs/fs.h
+++ b/include/nuttx/fs/fs.h
@@ -780,11 +780,11 @@ int files_duplist(FAR struct filelist *plist, FAR struct filelist *clist);
  *
  * Description:
  *   Allocate a struct files instance and associate it with an inode
- *   instance.  Returns the file descriptor == index into the files array.
+ *   instance.
  *
  * Returned Value:
- *   Zero (OK) is returned on success; a negated errno value is returned on
- *   any failure.
+ *     Returns the file descriptor == index into the files array on success;
+ *     a negated errno value is returned on any failure.
  *
  ****************************************************************************/
 

--- a/include/nuttx/fs/fs.h
+++ b/include/nuttx/fs/fs.h
@@ -776,6 +776,22 @@ void files_releaselist(FAR struct filelist *list);
 int files_duplist(FAR struct filelist *plist, FAR struct filelist *clist);
 
 /****************************************************************************
+ * Name: file_allocate
+ *
+ * Description:
+ *   Allocate a struct files instance and associate it with an inode
+ *   instance.  Returns the file descriptor == index into the files array.
+ *
+ * Returned Value:
+ *   Zero (OK) is returned on success; a negated errno value is returned on
+ *   any failure.
+ *
+ ****************************************************************************/
+
+int file_allocate(FAR struct inode *inode, int oflags, off_t pos,
+                  FAR void *priv, int minfd);
+
+/****************************************************************************
  * Name: file_dup
  *
  * Description:

--- a/include/nuttx/fs/fs.h
+++ b/include/nuttx/fs/fs.h
@@ -789,7 +789,7 @@ int files_duplist(FAR struct filelist *plist, FAR struct filelist *clist);
  ****************************************************************************/
 
 int file_allocate(FAR struct inode *inode, int oflags, off_t pos,
-                  FAR void *priv, int minfd);
+                  FAR void *priv, int minfd, bool addref);
 
 /****************************************************************************
  * Name: file_dup


### PR DESCRIPTION
## Summary

- fs/vfs: Rename files_allocate to file_allocate
- fs/vfs: Move file_allocate from fs/inode/inode.h to include/nuttx/fs/fs.h
- fs/vfs: Let caller control whether add the reference count of inode in file_allocate

## Impact
The caller of files_allocate 

## Testing
Pass CI
