### PR TITLE
arm: Added breakpoint in stack overflow trap.

### DIFF
--- a/arch/arm/src/armv7-m/Kconfig
+++ b/arch/arm/src/armv7-m/Kconfig
@@ -116,6 +116,16 @@ config ARMV7M_STACKCHECK
 		CFLAGS when you compile. This addition to your CFLAGS should probably
 		be added to the definition of the CFFLAGS in your board Make.defs file.
 
+config ARMV7M_STACKCHECK_BREAKPOINT
+	bool "Breakpoint on stack overflow"
+	default n
+	depends on ARMV7M_STACKCHECK
+	---help---
+		If enabled, a hard-coded breakpoint will be inserted to the stack
+		overflow trap. This is useful to stop the execution of the program
+		and diagnose the issue before the hardfault handler is called (and
+		context information is lost).
+
 config ARMV7M_ITMSYSLOG
 	bool "ITM SYSLOG support"
 	default n

--- a/arch/arm/src/armv7-m/arm_stackcheck.c
+++ b/arch/arm/src/armv7-m/arm_stackcheck.c
@@ -69,6 +69,14 @@ void __stack_overflow_trap(void)
 
   uint32_t regval;
 
+#ifdef CONFIG_ARMV7M_STACKCHECK_BREAKPOINT
+  regval = getreg32(NVIC_DHCSR);
+  if (regval & NVIC_DHCSR_C_DEBUGEN)
+    {
+      __asm("bkpt 1");
+    }
+#endif
+
   /* force hard fault */
 
   regval  = getreg32(NVIC_INTCTRL);

--- a/arch/arm/src/armv8-m/Kconfig
+++ b/arch/arm/src/armv8-m/Kconfig
@@ -115,6 +115,16 @@ config ARMV8M_STACKCHECK_HARDWARE
 
 endchoice
 
+config ARMV8M_STACKCHECK_BREAKPOINT
+	bool "Breakpoint on stack overflow"
+	default n
+	depends on ARMV8M_STACKCHECK
+	---help---
+		If enabled, a hard-coded breakpoint will be inserted to the stack
+		overflow trap. This is useful to stop the execution of the program
+		and diagnose the issue before the hardfault handler is called (and
+		context information is lost).
+
 config ARMV8M_ITMSYSLOG
 	bool "ITM SYSLOG support"
 	default n

--- a/arch/arm/src/armv8-m/arm_stackcheck.c
+++ b/arch/arm/src/armv8-m/arm_stackcheck.c
@@ -69,6 +69,14 @@ void __stack_overflow_trap(void)
 
   uint32_t regval;
 
+#ifdef CONFIG_ARMV8M_STACKCHECK_BREAKPOINT
+  regval = getreg32(NVIC_DHCSR);
+  if (regval & NVIC_DHCSR_C_DEBUGEN)
+    {
+      __asm("bkpt 1");
+    }
+#endif
+
   /* force hard fault */
 
   regval  = getreg32(NVIC_INTCTRL);


### PR DESCRIPTION
## Summary

When `CONFIG_ARMV7M_STACKCHECK` is enabled, the function `__stack_overflow_trap()` will be called in case of a stack overflow.

The problem however is that this function will immediately cause an NMI, with no information preserved about the fact. You just see the system crash, but with no way of telling why.

Here, a hard-coded breakpoint is inserted, so at least during a debugging session the developer can see the root cause of the crash.

I was thinking of adding and/or some prints, but I am not sure if this would be appropriate.  
There is a stack overflow, so better not call any other functions?

## Impact

Improved debugging.

## Testing

Tested a stack overflow on an STM32F4, using a JLink as a debugger.  
Indeed the code stops within the trap, indicating the fact of the overflow.

