### PR TITLE
socket: Remove the unused nx_xxx functions

### DIFF
--- a/include/nuttx/net/net.h
+++ b/include/nuttx/net/net.h
@@ -68,11 +68,9 @@
  */
 
 #if !defined(CONFIG_BUILD_FLAT) && defined(__KERNEL__)
-#  define _NX_SEND(s,b,l,f)         nx_send(s,b,l,f)
 #  define _NX_RECV(s,b,l,f)         nx_recv(s,b,l,f)
 #  define _NX_RECVFROM(s,b,l,f,a,n) nx_recvfrom(s,b,l,f,a,n)
 #else
-#  define _NX_SEND(s,b,l,f)         send(s,b,l,f)
 #  define _NX_RECV(s,b,l,f)         recv(s,b,l,f)
 #  define _NX_RECVFROM(s,b,l,f,a,n) recvfrom(s,b,l,f,a,n)
 #endif
@@ -928,36 +926,6 @@ ssize_t psock_send(FAR struct socket *psock, const void *buf, size_t len,
                    int flags);
 
 /****************************************************************************
- * Name: nx_send
- *
- * Description:
- *   The nx_send() call may be used only when the socket is in a
- *   connected state (so that the intended recipient is known).  This is an
- *   internal OS interface.  It is functionally equivalent to send() except
- *   that:
- *
- *   - It is not a cancellation point, and
- *   - It does not modify the errno variable.
- *
- *   See comments with send() for more a more complete description of the
- *   functionality.
- *
- * Input Parameters:
- *   sockfd   Socket descriptor of the socket
- *   buf      Data to send
- *   len      Length of data to send
- *   flags    Send flags
- *
- * Returned Value:
- *   On success, returns the number of characters sent.  On any failure, a
- *   negated errno value is returned (See comments with send() for a list
- *   of the appropriate errno value).
- *
- ****************************************************************************/
-
-ssize_t nx_send(int sockfd, FAR const void *buf, size_t len, int flags);
-
-/****************************************************************************
  * Name: psock_sendto
  *
  * Description:
@@ -1326,7 +1294,6 @@ int psock_ioctl(FAR struct socket *psock, int cmd, ...);
  ****************************************************************************/
 
 struct pollfd; /* Forward reference -- see poll.h */
-
 int psock_poll(FAR struct socket *psock, struct pollfd *fds, bool setup);
 
 /****************************************************************************

--- a/net/socket/recvfrom.c
+++ b/net/socket/recvfrom.c
@@ -97,49 +97,6 @@ ssize_t psock_recvfrom(FAR struct socket *psock, FAR void *buf, size_t len,
 }
 
 /****************************************************************************
- * Name: nx_recvfrom
- *
- * Description:
- *   nx_recvfrom() receives messages from a socket, and may be used to
- *   receive data on a socket whether or not it is connection-oriented.
- *   This is an internal OS interface.  It is functionally equivalent to
- *   recvfrom() except that:
- *
- *   - It is not a cancellation point, and
- *   - It does not modify the errno variable.
- *
- * Input Parameters:
- *   sockfd    Socket descriptor of socket
- *   buf       Buffer to receive data
- *   len       Length of buffer
- *   flags     Receive flags
- *   from      Address of source (may be NULL)
- *   fromlen   The length of the address structure
- *
- * Returned Value:
- *   On success, returns the number of characters received.  If no data is
- *   available to be received and the peer has performed an orderly shutdown,
- *   nx_recvfrom() will return 0.  Otherwise, on any failure, a negated errno
- *   value is returned (see comments with recvfrom() for a list of
- *   appropriate errno values).
- *
- ****************************************************************************/
-
-ssize_t nx_recvfrom(int sockfd, FAR void *buf, size_t len, int flags,
-                    FAR struct sockaddr *from, FAR socklen_t *fromlen)
-{
-  FAR struct socket *psock;
-
-  /* Get the underlying socket structure */
-
-  psock = sockfd_socket(sockfd);
-
-  /* Then let psock_recvfrom() do all of the work */
-
-  return psock_recvfrom(psock, buf, len, flags, from, fromlen);
-}
-
-/****************************************************************************
  * Name: recvfrom
  *
  * Description:
@@ -193,18 +150,23 @@ ssize_t nx_recvfrom(int sockfd, FAR void *buf, size_t len, int flags,
 ssize_t recvfrom(int sockfd, FAR void *buf, size_t len, int flags,
                  FAR struct sockaddr *from, FAR socklen_t *fromlen)
 {
+  FAR struct socket *psock;
   ssize_t ret;
 
   /* recvfrom() is a cancellation point */
 
   enter_cancellation_point();
 
-  /* Let psock_recvfrom() do all of the work */
+  /* Get the underlying socket structure */
 
-  ret = nx_recvfrom(sockfd, buf, len, flags, from, fromlen);
+  psock = sockfd_socket(sockfd);
+
+  /* Then let psock_recvfrom() do all of the work */
+
+  ret = psock_recvfrom(psock, buf, len, flags, from, fromlen);
   if (ret < 0)
     {
-      _SO_SETERRNO(sockfd_socket(sockfd), -ret);
+      _SO_SETERRNO(psock, -ret);
       ret = ERROR;
     }
 


### PR DESCRIPTION
## Summary

- net: Remove the unused nx_send to prefer psock_send for kernel
- net: Remove the unused nx_recv[from] to prefer psock_recv[from] for kernel

## Impact
Code refactor only

## Testing
Internal test
