### PR TITLE
esp32[-s2/-s3/-c3]: Re-sort SPI Flash configs

### DIFF
--- a/arch/risc-v/src/esp32c3/Kconfig
+++ b/arch/risc-v/src/esp32c3/Kconfig
@@ -86,47 +86,6 @@ config ESP32C3_FLASH_DETECT
 	---help---
 		Auto detect flash size when flashing.
 
-choice ESP32C3_FLASH_MODE
-	prompt "SPI FLASH mode"
-	default ESP32C3_FLASH_MODE_DIO
-	---help---
-		These options control how many I/O pins are used for communication with the attached SPI flash chip.
-		The option selected here is then used by esptool when flashing.
-
-config ESP32C3_FLASH_MODE_DIO
-	bool "Dual IO (DIO)"
-
-config ESP32C3_FLASH_MODE_DOUT
-	bool "Dual Output (DOUT)"
-
-config ESP32C3_FLASH_MODE_QIO
-	bool "Quad IO (QIO)"
-
-config ESP32C3_FLASH_MODE_QOUT
-	bool "Quad Output (QOUT)"
-
-endchoice # ESP32C3_FLASH_MODE
-
-choice ESP32C3_FLASH_FREQ
-	prompt "SPI FLASH frequency"
-	default ESP32C3_FLASH_FREQ_40M
-	---help---
-		SPI FLASH frequency
-
-config ESP32C3_FLASH_FREQ_80M
-	bool "80 MHz"
-
-config ESP32C3_FLASH_FREQ_40M
-	bool "40 MHz"
-
-config ESP32C3_FLASH_FREQ_26M
-	bool "26 MHz"
-
-config ESP32C3_FLASH_FREQ_20M
-	bool "20 MHz"
-
-endchoice # ESP32C3_FLASH_FREQ
-
 choice ESP32C3_CPU_FREQ
 	prompt "CPU frequency"
 	default ESP32C3_CPU_FREQ_160
@@ -948,7 +907,47 @@ config ESP32C3_BLE_TASK_PRIORITY
 endmenu # BLE Configuration
 
 menu "SPI Flash configuration"
-	depends on ESP32C3_SPIFLASH
+
+choice ESP32C3_FLASH_MODE
+	prompt "SPI Flash mode"
+	default ESP32C3_FLASH_MODE_DIO
+	---help---
+		These options control how many I/O pins are used for communication with the attached SPI Flash chip.
+		The option selected here is then used by esptool when flashing.
+
+config ESP32C3_FLASH_MODE_DIO
+	bool "Dual IO (DIO)"
+
+config ESP32C3_FLASH_MODE_DOUT
+	bool "Dual Output (DOUT)"
+
+config ESP32C3_FLASH_MODE_QIO
+	bool "Quad IO (QIO)"
+
+config ESP32C3_FLASH_MODE_QOUT
+	bool "Quad Output (QOUT)"
+
+endchoice # ESP32C3_FLASH_MODE
+
+choice ESP32C3_FLASH_FREQ
+	prompt "SPI Flash frequency"
+	default ESP32C3_FLASH_FREQ_40M
+	---help---
+		SPI Flash frequency.
+
+config ESP32C3_FLASH_FREQ_80M
+	bool "80 MHz"
+
+config ESP32C3_FLASH_FREQ_40M
+	bool "40 MHz"
+
+config ESP32C3_FLASH_FREQ_26M
+	bool "26 MHz"
+
+config ESP32C3_FLASH_FREQ_20M
+	bool "20 MHz"
+
+endchoice # ESP32C3_FLASH_FREQ
 
 if ESP32C3_HAVE_OTA_PARTITION
 
@@ -993,6 +992,8 @@ config ESP32C3_OTA_SCRATCH_DEVPATH
 
 endif
 
+if ESP32C3_SPIFLASH
+
 comment "General storage MTD configuration"
 
 config ESP32C3_MTD
@@ -1033,7 +1034,9 @@ config ESP32C3_PARTITION_MOUNTPT
 	default "/dev/esp/partition/"
 	depends on ESP32C3_PARTITION_TABLE
 
-endif
+endif # ESP32C3_APP_FORMAT_LEGACY
+
+endif # ESP32C3_SPIFLASH
 
 endmenu # SPI Flash configuration
 

--- a/arch/xtensa/src/esp32/Kconfig
+++ b/arch/xtensa/src/esp32/Kconfig
@@ -135,47 +135,6 @@ config ESP32_ESP32DXWDXX
 	select ESP32_DUAL_CPU
 	select ARCH_HAVE_I2CRESET
 
-choice ESP32_FLASH_MODE
-	prompt "SPI FLASH mode"
-	default ESP32_FLASH_MODE_DIO
-	---help---
-		These options control how many I/O pins are used for communication with the attached SPI flash chip.
-		The option selected here is then used by esptool when flashing.
-
-config ESP32_FLASH_MODE_DIO
-	bool "Dual IO (DIO)"
-
-config ESP32_FLASH_MODE_DOUT
-	bool "Dual Output (DOUT)"
-
-config ESP32_FLASH_MODE_QIO
-	bool "Quad IO (QIO)"
-
-config ESP32_FLASH_MODE_QOUT
-	bool "Quad Output (QOUT)"
-
-endchoice # ESP32_FLASH_MODE
-
-choice ESP32_FLASH_FREQ
-	prompt "SPI FLASH frequency"
-	default ESP32_FLASH_FREQ_40M
-	---help---
-		SPI FLASH frequency
-
-config ESP32_FLASH_FREQ_80M
-	bool "80 MHz"
-
-config ESP32_FLASH_FREQ_40M
-	bool "40 MHz"
-
-config ESP32_FLASH_FREQ_26M
-	bool "26 MHz"
-
-config ESP32_FLASH_FREQ_20M
-	bool "20 MHz"
-
-endchoice # ESP32_FLASH_FREQ
-
 choice ESP32_DEFAULT_CPU_FREQ
 	prompt "CPU frequency"
 	default ESP32_DEFAULT_CPU_FREQ_240
@@ -1637,7 +1596,47 @@ endif # ESP32_PCNT_U7
 endmenu # ESP32_PCNT
 
 menu "SPI Flash configuration"
-	depends on ESP32_SPIFLASH
+
+choice ESP32_FLASH_MODE
+	prompt "SPI Flash mode"
+	default ESP32_FLASH_MODE_DIO
+	---help---
+		These options control how many I/O pins are used for communication with the attached SPI Flash chip.
+		The option selected here is then used by esptool when flashing.
+
+config ESP32_FLASH_MODE_DIO
+	bool "Dual IO (DIO)"
+
+config ESP32_FLASH_MODE_DOUT
+	bool "Dual Output (DOUT)"
+
+config ESP32_FLASH_MODE_QIO
+	bool "Quad IO (QIO)"
+
+config ESP32_FLASH_MODE_QOUT
+	bool "Quad Output (QOUT)"
+
+endchoice # ESP32_FLASH_MODE
+
+choice ESP32_FLASH_FREQ
+	prompt "SPI Flash frequency"
+	default ESP32_FLASH_FREQ_40M
+	---help---
+		SPI Flash frequency.
+
+config ESP32_FLASH_FREQ_80M
+	bool "80 MHz"
+
+config ESP32_FLASH_FREQ_40M
+	bool "40 MHz"
+
+config ESP32_FLASH_FREQ_26M
+	bool "26 MHz"
+
+config ESP32_FLASH_FREQ_20M
+	bool "20 MHz"
+
+endchoice # ESP32_FLASH_FREQ
 
 if ESP32_HAVE_OTA_PARTITION
 
@@ -1682,6 +1681,8 @@ config ESP32_OTA_SCRATCH_DEVPATH
 
 endif
 
+if ESP32_SPIFLASH
+
 comment "General storage MTD configuration"
 
 config ESP32_STORAGE_MTD_ENCRYPT
@@ -1725,9 +1726,11 @@ config ESP32_PARTITION_MOUNTPT
 	default "/dev/esp/partition/"
 	depends on ESP32_PARTITION_TABLE
 
-endif
+endif # ESP32_PARTITION_TABLE
 
-endmenu # ESP32_SPIFLASH
+endif # ESP32_SPIFLASH
+
+endmenu # SPI Flash configuration
 
 menu "SPI RAM Config"
 	depends on ESP32_SPIRAM

--- a/arch/xtensa/src/esp32s2/Kconfig
+++ b/arch/xtensa/src/esp32s2/Kconfig
@@ -178,48 +178,6 @@ config ESP32S2_FLASH_DETECT
 	---help---
 		Auto detect flash size when flashing.
 
-choice ESP32S2_FLASH_MODE
-	prompt "SPI FLASH mode"
-	default ESP32S2_FLASH_MODE_DIO
-	---help---
-		These options control how many I/O pins are used for communication
-		with the attached SPI flash chip.
-		The option selected here is then used by esptool when flashing.
-
-	config ESP32S2_FLASH_MODE_DIO
-	bool "Dual IO (DIO)"
-
-	config ESP32S2_FLASH_MODE_DOUT
-	bool "Dual Output (DOUT)"
-
-	config ESP32S2_FLASH_MODE_QIO
-	bool "Quad IO (QIO)"
-
-	config ESP32S2_FLASH_MODE_QOUT
-	bool "Quad Output (QOUT)"
-
-endchoice # SPI FLASH mode
-
-choice ESP32S2_FLASH_FREQ
-	prompt "SPI FLASH frequency"
-	default ESP32S2_FLASH_FREQ_40M
-	---help---
-		SPI FLASH frequency
-
-	config ESP32S2_FLASH_FREQ_80M
-	bool "80 MHz"
-
-	config ESP32S2_FLASH_FREQ_40M
-	bool "40 MHz"
-
-	config ESP32S2_FLASH_FREQ_26M
-	bool "26 MHz"
-
-	config ESP32S2_FLASH_FREQ_20M
-	bool "20 MHz"
-
-endchoice # SPI FLASH frequency
-
 config ESP32S2_RUN_IRAM
 	bool "Run from IRAM"
 	default n
@@ -689,7 +647,48 @@ config ESP32S2_I2CTIMEOMS
 endmenu # I2C Configuration
 
 menu "SPI Flash Configuration"
-	depends on ESP32S2_SPIFLASH
+
+choice ESP32S2_FLASH_MODE
+	prompt "SPI Flash mode"
+	default ESP32S2_FLASH_MODE_DIO
+	---help---
+		These options control how many I/O pins are used for communication
+		with the attached SPI Flash chip.
+		The option selected here is then used by esptool when flashing.
+
+	config ESP32S2_FLASH_MODE_DIO
+	bool "Dual IO (DIO)"
+
+	config ESP32S2_FLASH_MODE_DOUT
+	bool "Dual Output (DOUT)"
+
+	config ESP32S2_FLASH_MODE_QIO
+	bool "Quad IO (QIO)"
+
+	config ESP32S2_FLASH_MODE_QOUT
+	bool "Quad Output (QOUT)"
+
+endchoice # ESP32S2_FLASH_MODE
+
+choice ESP32S2_FLASH_FREQ
+	prompt "SPI Flash frequency"
+	default ESP32S2_FLASH_FREQ_40M
+	---help---
+		SPI Flash frequency.
+
+	config ESP32S2_FLASH_FREQ_80M
+	bool "80 MHz"
+
+	config ESP32S2_FLASH_FREQ_40M
+	bool "40 MHz"
+
+	config ESP32S2_FLASH_FREQ_26M
+	bool "26 MHz"
+
+	config ESP32S2_FLASH_FREQ_20M
+	bool "20 MHz"
+
+endchoice # ESP32S2_FLASH_FREQ
 
 if ESP32S2_HAVE_OTA_PARTITION
 

--- a/arch/xtensa/src/esp32s3/Kconfig
+++ b/arch/xtensa/src/esp32s3/Kconfig
@@ -250,48 +250,6 @@ config ESP32S3_PSRAM_8M
 	bool
 	default n
 
-choice ESP32S3_FLASH_MODE
-	prompt "SPI FLASH mode"
-	default ESP32S3_FLASH_MODE_DIO
-	---help---
-		These options control how many I/O pins are used for communication
-		with the attached SPI flash chip.
-		The option selected here is then used by esptool when flashing.
-
-	config ESP32S3_FLASH_MODE_DIO
-		bool "Dual IO (DIO)"
-
-	config ESP32S3_FLASH_MODE_DOUT
-		bool "Dual Output (DOUT)"
-
-	config ESP32S3_FLASH_MODE_QIO
-		bool "Quad IO (QIO)"
-
-	config ESP32S3_FLASH_MODE_QOUT
-		bool "Quad Output (QOUT)"
-
-endchoice # ESP32S3_FLASH_MODE
-
-choice ESP32S3_FLASH_FREQ
-	prompt "SPI FLASH frequency"
-	default ESP32S3_FLASH_FREQ_40M
-	---help---
-		SPI FLASH frequency
-
-	config ESP32S3_FLASH_FREQ_120M
-		bool "120 MHz"
-
-	config ESP32S3_FLASH_FREQ_80M
-		bool "80 MHz"
-
-	config ESP32S3_FLASH_FREQ_40M
-		bool "40 MHz"
-
-	config ESP32S3_FLASH_FREQ_20M
-		bool "20 MHz"
-
-endchoice # ESP32S3_FLASH_FREQ
-
 config ESP32S3_RUN_IRAM
 	bool "Run from IRAM"
 	default n
@@ -826,7 +784,50 @@ config ESP32S3_SPIFLASH
 	default n
 
 menu "SPI Flash configuration"
-	depends on ESP32S3_SPIFLASH
+
+choice ESP32S3_FLASH_MODE
+	prompt "SPI Flash mode"
+	default ESP32S3_FLASH_MODE_DIO
+	---help---
+		These options control how many I/O pins are used for communication
+		with the attached SPI Flash chip.
+		The option selected here is then used by esptool when flashing.
+
+	config ESP32S3_FLASH_MODE_DIO
+		bool "Dual IO (DIO)"
+
+	config ESP32S3_FLASH_MODE_DOUT
+		bool "Dual Output (DOUT)"
+
+	config ESP32S3_FLASH_MODE_QIO
+		bool "Quad IO (QIO)"
+
+	config ESP32S3_FLASH_MODE_QOUT
+		bool "Quad Output (QOUT)"
+
+endchoice # ESP32S3_FLASH_MODE
+
+choice ESP32S3_FLASH_FREQ
+	prompt "SPI Flash frequency"
+	default ESP32S3_FLASH_FREQ_40M
+	---help---
+		SPI Flash frequency
+
+	config ESP32S3_FLASH_FREQ_120M
+		bool "120 MHz"
+
+	config ESP32S3_FLASH_FREQ_80M
+		bool "80 MHz"
+
+	config ESP32S3_FLASH_FREQ_40M
+		bool "40 MHz"
+
+	config ESP32S3_FLASH_FREQ_20M
+		bool "20 MHz"
+
+endchoice # ESP32S3_FLASH_FREQ
+
+if ESP32S3_SPIFLASH
 
 comment "General storage MTD configuration"
 
@@ -852,6 +853,8 @@ config ESP32S3_STORAGE_MTD_DEBUG
 	---help---
 		If this option is enabled, Storage MTD driver read and write functions
 		will output input parameters and return values (if applicable).
+
+endif # ESP32S3_SPIFLASH
 
 endmenu # SPI Flash configuration
 


### PR DESCRIPTION
## Summary
This PR intends to reorder some configs related to SPI Flash. These are the expected outcomes:

- Reduce "SPI Flash configuration" menu dependency on SPI Flash driver just to MTD-related configs.
- Move SPI Flash Mode and Frequency configs to SPI Flash configuration menu.

## Impact
MCUboot-related options for Application Image slots won't depend on the SPI Flash peripheral driver anymore.\
No expected side-effects.

## Testing
CI build pass.
