### PR TITLE
mm/mm_heap: optimize MM_XX_SHIFT define

### DIFF
--- a/include/nuttx/lib/math32.h
+++ b/include/nuttx/lib/math32.h
@@ -27,7 +27,37 @@
 
 #include <nuttx/config.h>
 
+#include <inttypes.h>
 #include <stdint.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/* Returns one plus the index of the most significant 1-bit of n,
+ * or if n is zero, returns zero.
+ */
+
+#if UINTPTR_MAX > UINT32_MAX
+#  define FLS(n) ((n) & UINT64_C(0xffffffff00000000) ? 32 + \
+                  FLS32((size_t)(n) >> 32) : FLS32(n))
+#else
+#  define FLS(n) FLS32(n)
+#endif
+
+#define FLS32(n) ((n) & 0xffff0000 ? 16 + FLS16((n) >> 16) : FLS16(n))
+#define FLS16(n) ((n) & 0xff00     ?  8 + FLS8 ((n) >>  8) : FLS8 (n))
+#define FLS8(n)  ((n) & 0xf0       ?  4 + FLS4 ((n) >>  4) : FLS4 (n))
+#define FLS4(n)  ((n) & 0xc        ?  2 + FLS2 ((n) >>  2) : FLS2 (n))
+#define FLS2(n)  ((n) & 0x2        ?  1 + FLS1 ((n) >>  1) : FLS1 (n))
+#define FLS1(n)  ((n) & 0x1        ?  1 : 0)
+
+/* Returns round up and round down value of log2(n). Note: it can be used at
+ * compile time.
+ */
+
+#define LOG2_CEIL(n)  ((n) & (n - 1) ? FLS(n) : FLS(n) - 1)
+#define LOG2_FLOOR(n) (FLS(n) - 1)
 
 /****************************************************************************
  * Public Types

--- a/mm/mm_heap/mm.h
+++ b/mm/mm_heap/mm.h
@@ -29,6 +29,7 @@
 
 #include <nuttx/mutex.h>
 #include <nuttx/fs/procfs.h>
+#include <nuttx/lib/math32.h>
 
 #include <assert.h>
 #include <execinfo.h>
@@ -60,38 +61,14 @@
  *   minor performance losses.
  */
 
+#define MM_MIN_SHIFT      LOG2_CEIL(sizeof(struct mm_freenode_s))
 #if defined(CONFIG_MM_SMALL) && UINTPTR_MAX <= UINT32_MAX
-/* Two byte offsets; Pointers may be 2 or 4 bytes;
- * sizeof(struct mm_freenode_s) is 8 or 12 bytes.
- * REVISIT: We could do better on machines with 16-bit addressing.
- */
-
-#  define MM_MIN_SHIFT_   ( 4)  /* 16 bytes */
 #  define MM_MAX_SHIFT    (15)  /* 32 Kb */
-
-#elif defined(CONFIG_HAVE_LONG_LONG)
-/* Four byte offsets; Pointers may be 4 or 8 bytes
- * sizeof(struct mm_freenode_s) is 16 or 24 bytes.
- */
-
-#  if UINTPTR_MAX <= UINT32_MAX
-#    define MM_MIN_SHIFT_ ( 4)  /* 16 bytes */
-#  elif UINTPTR_MAX <= UINT64_MAX
-#    define MM_MIN_SHIFT_ ( 5)  /* 32 bytes */
-#  endif
-#  define MM_MAX_SHIFT    (22)  /*  4 Mb */
-
 #else
-/* Four byte offsets; Pointers must be 4 bytes.
- * sizeof(struct mm_freenode_s) is 16 bytes.
- */
-
-#  define MM_MIN_SHIFT_   ( 4)  /* 16 bytes */
 #  define MM_MAX_SHIFT    (22)  /*  4 Mb */
 #endif
 
 #if CONFIG_MM_BACKTRACE == 0
-#  define MM_MIN_SHIFT    (MM_MIN_SHIFT_ + 1)
 #  define MM_ADD_BACKTRACE(heap, ptr) \
      do \
        { \
@@ -100,7 +77,6 @@
        } \
      while (0)
 #elif CONFIG_MM_BACKTRACE > 0
-#  define MM_MIN_SHIFT    (MM_MIN_SHIFT_ + 2)
 #  define MM_ADD_BACKTRACE(heap, ptr) \
      do \
        { \
@@ -121,7 +97,6 @@
      while (0)
 #else
 #  define MM_ADD_BACKTRACE(heap, ptr)
-#  define MM_MIN_SHIFT MM_MIN_SHIFT_
 #endif
 
 /* All other definitions derive from these two */
@@ -185,9 +160,6 @@ struct mm_allocnode_s
   mmsize_t preceding;                       /* Size of the preceding chunk */
 };
 
-static_assert(SIZEOF_MM_ALLOCNODE <= MM_MIN_CHUNK,
-              "Error size for struct mm_allocnode_s\n");
-
 /* This describes a free chunk */
 
 struct mm_freenode_s
@@ -203,6 +175,9 @@ struct mm_freenode_s
   FAR struct mm_freenode_s *flink;          /* Supports a doubly linked list */
   FAR struct mm_freenode_s *blink;
 };
+
+static_assert(SIZEOF_MM_ALLOCNODE <= MM_MIN_CHUNK,
+              "Error size for struct mm_allocnode_s\n");
 
 static_assert(SIZEOF_MM_FREENODE <= MM_MIN_CHUNK,
               "Error size for struct mm_freenode_s\n");

--- a/mm/mm_heap/mm.h
+++ b/mm/mm_heap/mm.h
@@ -114,6 +114,7 @@
  */
 
 #define MM_ALLOC_BIT     0x1
+#define MM_MASK_BIT      MM_ALLOC_BIT
 #ifdef CONFIG_MM_SMALL
 # define MMSIZE_MAX      UINT16_MAX
 #else

--- a/mm/mm_heap/mm_foreach.c
+++ b/mm/mm_heap/mm_foreach.c
@@ -86,7 +86,7 @@ void mm_foreach(FAR struct mm_heap_s *heap, mmchunk_handler_t handler,
           handler(node, arg);
 
           DEBUGASSERT(prev == NULL ||
-                      prev->size == (node->preceding & ~MM_ALLOC_BIT));
+                      prev->size == (node->preceding & ~MM_MASK_BIT));
           prev = node;
         }
 

--- a/mm/mm_heap/mm_free.c
+++ b/mm/mm_heap/mm_free.c
@@ -107,12 +107,12 @@ void mm_free(FAR struct mm_heap_s *heap, FAR void *mem)
 
   DEBUGASSERT(node->preceding & MM_ALLOC_BIT);
 
-  node->preceding &= ~MM_ALLOC_BIT;
+  node->preceding &= ~MM_MASK_BIT;
 
   /* Check if the following node is free and, if so, merge it */
 
   next = (FAR struct mm_freenode_s *)((FAR char *)node + node->size);
-  DEBUGASSERT((next->preceding & ~MM_ALLOC_BIT) == node->size);
+  DEBUGASSERT((next->preceding & ~MM_MASK_BIT) == node->size);
   if ((next->preceding & MM_ALLOC_BIT) == 0)
     {
       FAR struct mm_allocnode_s *andbeyond;
@@ -140,7 +140,7 @@ void mm_free(FAR struct mm_heap_s *heap, FAR void *mem)
 
       node->size          += next->size;
       andbeyond->preceding = node->size |
-                             (andbeyond->preceding & MM_ALLOC_BIT);
+                             (andbeyond->preceding & MM_MASK_BIT);
       next                 = (FAR struct mm_freenode_s *)andbeyond;
     }
 
@@ -149,7 +149,7 @@ void mm_free(FAR struct mm_heap_s *heap, FAR void *mem)
    */
 
   prev = (FAR struct mm_freenode_s *)((FAR char *)node - node->preceding);
-  DEBUGASSERT((node->preceding & ~MM_ALLOC_BIT) == prev->size);
+  DEBUGASSERT((node->preceding & ~MM_MASK_BIT) == prev->size);
   if ((prev->preceding & MM_ALLOC_BIT) == 0)
     {
       /* Remove the node.  There must be a predecessor, but there may
@@ -166,7 +166,7 @@ void mm_free(FAR struct mm_heap_s *heap, FAR void *mem)
       /* Then merge the two chunks */
 
       prev->size     += node->size;
-      next->preceding = prev->size | (next->preceding & MM_ALLOC_BIT);
+      next->preceding = prev->size | (next->preceding & MM_MASK_BIT);
       node            = prev;
     }
 

--- a/mm/mm_heap/mm_malloc.c
+++ b/mm/mm_heap/mm_malloc.c
@@ -221,7 +221,7 @@ FAR void *mm_malloc(FAR struct mm_heap_s *heap, size_t size)
            * the allocated flag.
            */
 
-          next->preceding = remaining | (next->preceding & MM_ALLOC_BIT);
+          next->preceding = remaining | (next->preceding & MM_MASK_BIT);
 
           /* Add the remainder back into the nodelist */
 

--- a/mm/mm_heap/mm_memalign.c
+++ b/mm/mm_heap/mm_memalign.c
@@ -184,7 +184,7 @@ FAR void *mm_memalign(FAR struct mm_heap_s *heap, size_t alignment,
       /* Reduce the size of the original chunk and mark it not allocated, */
 
       node->size = precedingsize;
-      node->preceding &= ~MM_ALLOC_BIT;
+      node->preceding &= ~MM_MASK_BIT;
 
       /* Fix the preceding size of the next node */
 

--- a/mm/mm_heap/mm_realloc.c
+++ b/mm/mm_heap/mm_realloc.c
@@ -151,7 +151,7 @@ FAR void *mm_realloc(FAR struct mm_heap_s *heap, FAR void *oldmem,
     }
 
   prev = (FAR struct mm_freenode_s *)
-    ((FAR char *)oldnode - (oldnode->preceding & ~MM_ALLOC_BIT));
+    ((FAR char *)oldnode - (oldnode->preceding & ~MM_MASK_BIT));
   if ((prev->preceding & MM_ALLOC_BIT) == 0)
     {
       prevsize = prev->size;
@@ -253,7 +253,7 @@ FAR void *mm_realloc(FAR struct mm_heap_s *heap, FAR void *oldmem,
               newnode->size      = oldsize + takeprev;
               newnode->preceding = prev->size | MM_ALLOC_BIT;
               next->preceding    = newnode->size |
-                                   (next->preceding & MM_ALLOC_BIT);
+                                   (next->preceding & MM_MASK_BIT);
 
               /* Return the previous free node to the nodelist
                * (with the new size)
@@ -268,7 +268,7 @@ FAR void *mm_realloc(FAR struct mm_heap_s *heap, FAR void *oldmem,
               newnode->size      += oldsize;
               newnode->preceding |= MM_ALLOC_BIT;
               next->preceding     = newnode->size |
-                                    (next->preceding & MM_ALLOC_BIT);
+                                    (next->preceding & MM_MASK_BIT);
             }
 
           newmem = (FAR void *)((FAR char *)newnode + SIZEOF_MM_ALLOCNODE);
@@ -321,7 +321,7 @@ FAR void *mm_realloc(FAR struct mm_heap_s *heap, FAR void *oldmem,
               DEBUGASSERT(newnode->size >= SIZEOF_MM_FREENODE);
               newnode->preceding   = oldnode->size;
               andbeyond->preceding = newnode->size |
-                                     (andbeyond->preceding & MM_ALLOC_BIT);
+                                     (andbeyond->preceding & MM_MASK_BIT);
 
               /* Add the new free node to the nodelist (with the new size) */
 
@@ -332,7 +332,7 @@ FAR void *mm_realloc(FAR struct mm_heap_s *heap, FAR void *oldmem,
               /* Yes, just update some pointers. */
 
               andbeyond->preceding = oldnode->size |
-                                     (andbeyond->preceding & MM_ALLOC_BIT);
+                                     (andbeyond->preceding & MM_MASK_BIT);
             }
         }
 

--- a/mm/mm_heap/mm_shrinkchunk.c
+++ b/mm/mm_heap/mm_shrinkchunk.c
@@ -95,7 +95,7 @@ void  mm_shrinkchunk(FAR struct mm_heap_s *heap,
       newnode->preceding   = size;
       node->size           = size;
       andbeyond->preceding = newnode->size |
-                             (andbeyond->preceding & MM_ALLOC_BIT);
+                             (andbeyond->preceding & MM_MASK_BIT);
 
       /* Add the new node to the freenodelist */
 
@@ -121,7 +121,8 @@ void  mm_shrinkchunk(FAR struct mm_heap_s *heap,
       newnode->size        = node->size - size;
       newnode->preceding   = size;
       node->size           = size;
-      next->preceding      = newnode->size | MM_ALLOC_BIT;
+      next->preceding      = newnode->size |
+                             (next->preceding & MM_MASK_BIT);
 
       /* Add the new node to the freenodelist */
 


### PR DESCRIPTION
## Summary
1. using LOG2_CEIL to calc MM_MIN_SHIFT/MM_MAX_SHIFT at compile time.
2. define MM_MASK_BIT to optimze code when using more significant bit of member preceding in furure.
## Impact
optimize header file
## Testing
local test
