### PR TITLE
libs/libc/time: fix regression in clock_calendar2utc

### DIFF
--- a/libs/libc/time/lib_calendar2utc.c
+++ b/libs/libc/time/lib_calendar2utc.c
@@ -162,7 +162,7 @@ time_t clock_calendar2utc(int year, int month, int day)
 
   /* Add in the extra days for the leap years prior to the current year. */
 
-  days += (year - EPOCH_YEAR - 1) >> 2;
+  days += (year - (EPOCH_YEAR - 1)) >> 2;
 
   /* Add in the days up to the beginning of this month. */
 


### PR DESCRIPTION
## Summary
Fix regression after https://github.com/apache/incubator-nuttx/pull/7440/commits/fbe471b99cbcbdf9c96b5fa255a801bfd6a80996

## Impact
Bugfix

## Testing
Synthetic test with `mktime` + `localtime_r` 