### PR TITLE
sched/semaphore: add the wdog judge before cancel

### DIFF
--- a/sched/semaphore/sem_post.c
+++ b/sched/semaphore/sem_post.c
@@ -151,7 +151,10 @@ int nxsem_post(FAR sem_t *sem)
 
               /* Stop the watchdog timer */
 
-              wd_cancel(&stcb->waitdog);
+              if (WDOG_ISACTIVE(&stcb->waitdog))
+                {
+                  wd_cancel(&stcb->waitdog);
+                }
 
               /* Restart the waiting task. */
 


### PR DESCRIPTION
## Summary
to avoid entering critical again in wd_cancel when wdog not actived. But when the wdog is actived, may add more judge

## Impact
Improve the speed

## Testing
Pass CI
