### PR TITLE
nuttx/sched: use pid to check idle task

### DIFF
--- a/arch/sim/src/sim/up_assert.c
+++ b/arch/sim/src/sim/up_assert.c
@@ -119,7 +119,7 @@ void up_assert(const char *filename, int lineno)
 
   syslog_flush();
 
-  if (CURRENT_REGS || rtcb->flink == NULL)
+  if (CURRENT_REGS || is_idle_task(rtcb))
     {
       /* Exit the simulation */
 

--- a/drivers/segger/note_sysview.c
+++ b/drivers/segger/note_sysview.c
@@ -319,7 +319,7 @@ void sched_note_resume(FAR struct tcb_s *tcb)
 
   if (!up_interrupt_context())
     {
-      if (tcb->flink == NULL)
+      if (is_idle_task(tcb))
         {
           SEGGER_SYSVIEW_OnIdle();
         }
@@ -354,7 +354,7 @@ void sched_note_irqhandler(int irq, FAR void *handler, bool enter)
         {
           FAR struct tcb_s *tcb = this_task();
 
-          if (tcb && tcb->flink != NULL)
+          if (tcb && !is_idle_task(tcb))
             {
               SEGGER_SYSVIEW_OnTaskStartExec(tcb->pid);
             }

--- a/sched/mqueue/mq_rcvinternal.c
+++ b/sched/mqueue/mq_rcvinternal.c
@@ -180,7 +180,7 @@ int nxmq_wait_receive(FAR struct mqueue_inode_s *msgq,
            * isn't going to end well.
            */
 
-          DEBUGASSERT(NULL != rtcb->flink);
+          DEBUGASSERT(!is_idle_task(rtcb));
           up_block_task(rtcb, TSTATE_WAIT_MQNOTEMPTY);
 
           /* When we resume at this point, either (1) the message queue

--- a/sched/mqueue/mq_sndinternal.c
+++ b/sched/mqueue/mq_sndinternal.c
@@ -266,7 +266,7 @@ int nxmq_wait_send(FAR struct mqueue_inode_s *msgq, int oflags)
        * isn't going to end well.
        */
 
-      DEBUGASSERT(NULL != rtcb->flink);
+      DEBUGASSERT(!is_idle_task(rtcb));
       up_block_task(rtcb, TSTATE_WAIT_MQNOTFULL);
 
       /* When we resume at this point, either (1) the message queue

--- a/sched/paging/pg_miss.c
+++ b/sched/paging/pg_miss.c
@@ -133,7 +133,7 @@ void pg_miss(void)
    * that isn't going to end well.
    */
 
-  DEBUGASSERT(NULL != ftcb->flink);
+  DEBUGASSERT(!is_idle_task(ftcb));
   up_block_task(ftcb, TSTATE_WAIT_PAGEFILL);
 
   /* Boost the page fill worker thread priority.

--- a/sched/sched/sched.h
+++ b/sched/sched/sched.h
@@ -56,6 +56,8 @@
 #  define this_task()            (current_task(this_cpu()))
 #endif
 
+#define is_idle_task(t)          ((t)->pid < CONFIG_SMP_NCPUS)
+
 /* This macro returns the running task which may different from this_task()
  * during interrupt level context switches.
  */

--- a/sched/sched/sched_addreadytorun.c
+++ b/sched/sched/sched_addreadytorun.c
@@ -95,7 +95,7 @@ bool nxsched_add_readytorun(FAR struct tcb_s *btcb)
        * is now the new active task!
        */
 
-      DEBUGASSERT(rtcb->lockcount == 0 && btcb->flink != NULL);
+      DEBUGASSERT(rtcb->lockcount == 0 && !is_idle_task(btcb));
 
       btcb->task_state = TSTATE_TASK_RUNNING;
       btcb->flink->task_state = TSTATE_TASK_READYTORUN;

--- a/sched/sched/sched_cpuselect.c
+++ b/sched/sched/sched_cpuselect.c
@@ -83,7 +83,7 @@ int nxsched_select_cpu(cpu_set_t affinity)
            * IDLE task is always the last task in the assigned task list.
            */
 
-          if (rtcb->flink == NULL)
+          if (is_idle_task(rtcb))
             {
               /* The IDLE task should always be assigned to this CPU and have
                * a priority of zero.

--- a/sched/sched/sched_idletask.c
+++ b/sched/sched/sched_idletask.c
@@ -76,7 +76,7 @@ bool sched_idletask(void)
        * different PIDs in the SMP configuration.
        */
 
-      return (rtcb->flink == NULL);
+      return is_idle_task(rtcb);
     }
 
   /* We must be on the IDLE thread if we are early in initialization */

--- a/sched/sched/sched_suspend.c
+++ b/sched/sched/sched_suspend.c
@@ -84,7 +84,7 @@ void nxsched_suspend(FAR struct tcb_s *tcb)
        * descheduling that isn't going to end well.
        */
 
-      DEBUGASSERT(NULL != tcb->flink);
+      DEBUGASSERT(!is_idle_task(tcb));
       up_block_task(tcb, TSTATE_TASK_STOPPED);
     }
 

--- a/sched/semaphore/sem_holder.c
+++ b/sched/semaphore/sem_holder.c
@@ -707,7 +707,7 @@ void nxsem_add_holder_tcb(FAR struct tcb_s *htcb, FAR sem_t *sem)
    * inheritance is effectively disabled.
    */
 
-  if (htcb->flink != NULL && (sem->flags & PRIOINHERIT_FLAGS_ENABLE) != 0)
+  if (!is_idle_task(htcb) && (sem->flags & PRIOINHERIT_FLAGS_ENABLE) != 0)
     {
       /* Find or allocate a container for this new holder */
 

--- a/sched/semaphore/sem_wait.c
+++ b/sched/semaphore/sem_wait.c
@@ -151,7 +151,7 @@ int nxsem_wait(FAR sem_t *sem)
            * isn't going to end well.
            */
 
-          DEBUGASSERT(NULL != rtcb->flink);
+          DEBUGASSERT(!is_idle_task(rtcb));
           up_block_task(rtcb, TSTATE_WAIT_SEM);
 
           /* When we resume at this point, either (1) the semaphore has been

--- a/sched/signal/sig_suspend.c
+++ b/sched/signal/sig_suspend.c
@@ -122,7 +122,7 @@ int sigsuspend(FAR const sigset_t *set)
        * isn't going to end well.
        */
 
-      DEBUGASSERT(NULL != rtcb->flink);
+      DEBUGASSERT(!is_idle_task(rtcb));
       up_block_task(rtcb, TSTATE_WAIT_SIG);
 
       /* We are running again, restore the original sigprocmask */

--- a/sched/signal/sig_timedwait.c
+++ b/sched/signal/sig_timedwait.c
@@ -319,7 +319,7 @@ int nxsig_timedwait(FAR const sigset_t *set, FAR struct siginfo *info,
            * descheduling that isn't going to end well.
            */
 
-          DEBUGASSERT(NULL != rtcb->flink);
+          DEBUGASSERT(!is_idle_task(rtcb));
           up_block_task(rtcb, TSTATE_WAIT_SIG);
 
           /* We no longer need the watchdog */
@@ -336,7 +336,7 @@ int nxsig_timedwait(FAR const sigset_t *set, FAR struct siginfo *info,
            * descheduling that isn't going to end well.
            */
 
-          DEBUGASSERT(NULL != rtcb->flink);
+          DEBUGASSERT(!is_idle_task(rtcb));
           up_block_task(rtcb, TSTATE_WAIT_SIG);
         }
 


### PR DESCRIPTION
## Summary

Use pid to determine idle task, this is more robust when we want to use other data structure to optimize the task list.

## Impact

NA

## Testing

IMX6Q
