### PR TITLE
socket: Separation error code EBADF and ENOTSOCK

### DIFF
--- a/drivers/net/telnet.c
+++ b/drivers/net/telnet.c
@@ -941,12 +941,11 @@ static int telnet_session(FAR struct telnet_session_s *session)
    * instance resided in the daemon's task group`).
    */
 
-  psock = sockfd_socket(session->ts_sd);
-  if (!psock)
+  ret = sockfd_socket(session->ts_sd, &psock);
+  if (ret != OK)
     {
       nerr("ERROR: Failed to convert sd=%d to a socket structure\n",
            session->ts_sd);
-      ret = -EINVAL;
       goto errout_with_dev;
     }
 

--- a/fs/socket/socket.c
+++ b/fs/socket/socket.c
@@ -175,9 +175,13 @@ int sockfd_allocate(FAR struct socket *psock, int oflags)
  * Input Parameters:
  *   sockfd - The socket descriptor index to use.
  *
- * Returned Value:
- *   On success, a reference to the socket structure associated with the
- *   the socket descriptor is returned.  NULL is returned on any failure.
+ * Returns zero (OK) on success.  On failure, it returns a negated errno
+ * value to indicate the nature of the error.
+ *
+ *    EBADF
+ *      The file descriptor is not a valid index in the descriptor table.
+ *    ENOTSOCK
+ *      psock is a descriptor for a file, not a socket.
  *
  ****************************************************************************/
 
@@ -192,16 +196,19 @@ FAR struct socket *file_socket(FAR struct file *filep)
   return NULL;
 }
 
-FAR struct socket *sockfd_socket(int sockfd)
+int sockfd_socket(int sockfd, FAR struct socket **socketp)
 {
   FAR struct file *filep;
 
   if (fs_getfilep(sockfd, &filep) < 0)
     {
-      return NULL;
+      *socketp = NULL;
+      return -EBADF;
     }
 
-  return file_socket(filep);
+  *socketp = file_socket(filep);
+
+  return *socketp != NULL ? OK : -ENOTSOCK;
 }
 
 /****************************************************************************

--- a/include/nuttx/net/net.h
+++ b/include/nuttx/net/net.h
@@ -527,14 +527,18 @@ int sockfd_allocate(FAR struct socket *psock, int oflags);
  * Input Parameters:
  *   sockfd - The socket descriptor index to use.
  *
- * Returned Value:
- *   On success, a reference to the socket structure associated with the
- *   the socket descriptor is returned.  NULL is returned on any failure.
+ * Returns zero (OK) on success.  On failure, it returns a negated errno
+ * value to indicate the nature of the error.
+ *
+ *    EBADF
+ *      The file descriptor is not a valid index in the descriptor table.
+ *    ENOTSOCK
+ *      psock is a descriptor for a file, not a socket.
  *
  ****************************************************************************/
 
 FAR struct socket *file_socket(FAR struct file *filep);
-FAR struct socket *sockfd_socket(int sockfd);
+int sockfd_socket(int sockfd, FAR struct socket **socketp);
 
 /****************************************************************************
  * Name: psock_socket

--- a/net/socket/accept.c
+++ b/net/socket/accept.c
@@ -229,9 +229,8 @@ int psock_accept(FAR struct socket *psock, FAR struct sockaddr *addr,
 
 int accept(int sockfd, FAR struct sockaddr *addr, FAR socklen_t *addrlen)
 {
-  FAR struct socket *psock = sockfd_socket(sockfd);
+  FAR struct socket *psock;
   FAR struct socket *newsock;
-  FAR struct file *filep;
   int errcode;
   int newfd;
   int ret;
@@ -240,24 +239,15 @@ int accept(int sockfd, FAR struct sockaddr *addr, FAR socklen_t *addrlen)
 
   enter_cancellation_point();
 
+  /* Get the underlying socket structure */
+
+  ret = sockfd_socket(sockfd, &psock);
+
   /* Verify that the sockfd corresponds to valid, allocated socket */
 
-  if (psock == NULL || psock->s_conn == NULL)
+  if (ret < 0)
     {
-      /* It is not a valid socket description.  Distinguish between the cases
-       * where sockfd is a just valid and when it is a valid file descriptor
-       * used in the wrong context.
-       */
-
-      if (fs_getfilep(sockfd, &filep) == 0)
-        {
-          errcode = ENOTSOCK;
-        }
-      else
-        {
-          errcode = EBADF;
-        }
-
+      errcode = -ret;
       goto errout;
     }
 

--- a/net/socket/bind.c
+++ b/net/socket/bind.c
@@ -139,13 +139,17 @@ int bind(int sockfd, const struct sockaddr *addr, socklen_t addrlen)
   FAR struct socket *psock;
   int ret;
 
-  /* Use the socket descriptor to get the underlying socket structure */
+  /* Get the underlying socket structure */
 
-  psock = sockfd_socket(sockfd);
+  ret = sockfd_socket(sockfd, &psock);
 
   /* Then let psock_bind do all of the work */
 
-  ret = psock_bind(psock, addr, addrlen);
+  if (ret == OK)
+    {
+      ret = psock_bind(psock, addr, addrlen);
+    }
+
   if (ret < 0)
     {
       _SO_SETERRNO(psock, -ret);

--- a/net/socket/connect.c
+++ b/net/socket/connect.c
@@ -226,11 +226,15 @@ int connect(int sockfd, FAR const struct sockaddr *addr, socklen_t addrlen)
 
   /* Get the underlying socket structure */
 
-  psock = sockfd_socket(sockfd);
+  ret = sockfd_socket(sockfd, &psock);
 
   /* Then let psock_connect() do all of the work */
 
-  ret = psock_connect(psock, addr, addrlen);
+  if (ret == OK)
+    {
+      ret = psock_connect(psock, addr, addrlen);
+    }
+
   if (ret < 0)
     {
       _SO_SETERRNO(psock, -ret);

--- a/net/socket/getpeername.c
+++ b/net/socket/getpeername.c
@@ -145,12 +145,20 @@ int psock_getpeername(FAR struct socket *psock, FAR struct sockaddr *addr,
 int getpeername(int sockfd, FAR struct sockaddr *addr,
                 FAR socklen_t *addrlen)
 {
-  FAR struct socket *psock = sockfd_socket(sockfd);
+  FAR struct socket *psock;
   int ret;
+
+  /* Get the underlying socket structure */
+
+  ret = sockfd_socket(sockfd, &psock);
 
   /* Let psock_getpeername() do all of the work */
 
-  ret = psock_getpeername(psock, addr, addrlen);
+  if (ret == OK)
+    {
+      ret = psock_getpeername(psock, addr, addrlen);
+    }
+
   if (ret < 0)
     {
       _SO_SETERRNO(psock, -ret);

--- a/net/socket/getsockname.c
+++ b/net/socket/getsockname.c
@@ -139,12 +139,20 @@ int psock_getsockname(FAR struct socket *psock, FAR struct sockaddr *addr,
 int getsockname(int sockfd, FAR struct sockaddr *addr,
                 FAR socklen_t *addrlen)
 {
-  FAR struct socket *psock = sockfd_socket(sockfd);
+  FAR struct socket *psock;
   int ret;
+
+  /* Get the underlying socket structure */
+
+  ret = sockfd_socket(sockfd, &psock);
 
   /* Let psock_getsockname() do all of the work */
 
-  ret = psock_getsockname(psock, addr, addrlen);
+  if (ret == OK)
+    {
+      ret = psock_getsockname(psock, addr, addrlen);
+    }
+
   if (ret < 0)
     {
       _SO_SETERRNO(psock, -ret);

--- a/net/socket/getsockopt.c
+++ b/net/socket/getsockopt.c
@@ -507,11 +507,15 @@ int getsockopt(int sockfd, int level, int option,
 
   /* Get the underlying socket structure */
 
-  psock = sockfd_socket(sockfd);
+  ret = sockfd_socket(sockfd, &psock);
 
   /* Then let psock_getsockopt() do all of the work */
 
-  ret = psock_getsockopt(psock, level, option, value, value_len);
+  if (ret == OK)
+    {
+      ret = psock_getsockopt(psock, level, option, value, value_len);
+    }
+
   if (ret < 0)
     {
       set_errno(-ret);

--- a/net/socket/listen.c
+++ b/net/socket/listen.c
@@ -132,38 +132,22 @@ int psock_listen(FAR struct socket *psock, int backlog)
 
 int listen(int sockfd, int backlog)
 {
-  FAR struct socket *psock = sockfd_socket(sockfd);
-  FAR struct file *filep;
-  int errcode;
+  FAR struct socket *psock;
   int ret;
 
-  /* Verify that the sockfd corresponds to valid, allocated socket */
+  /* Get the underlying socket structure */
 
-  if (psock == NULL || psock->s_conn == NULL)
-    {
-      /* It is not a valid socket description.  Distinguish between the
-       * cases where sockfd is a just invalid and when it is a valid file
-       * descriptor used in the wrong context.
-       */
-
-      if (fs_getfilep(sockfd, &filep) == 0)
-        {
-          errcode = ENOTSOCK;
-        }
-      else
-        {
-          errcode = EBADF;
-        }
-
-      _SO_SETERRNO(psock, errcode);
-      return ERROR;
-    }
+  ret = sockfd_socket(sockfd, &psock);
 
   /* The let psock_listen to the work. If psock_listen() fails, it will have
    * set the errno variable.
    */
 
-  ret = psock_listen(psock, backlog);
+  if (ret == OK)
+    {
+      ret = psock_listen(psock, backlog);
+    }
+
   if (ret < 0)
     {
       _SO_SETERRNO(psock, -ret);

--- a/net/socket/recvfrom.c
+++ b/net/socket/recvfrom.c
@@ -159,11 +159,15 @@ ssize_t recvfrom(int sockfd, FAR void *buf, size_t len, int flags,
 
   /* Get the underlying socket structure */
 
-  psock = sockfd_socket(sockfd);
+  ret = sockfd_socket(sockfd, &psock);
 
   /* Then let psock_recvfrom() do all of the work */
 
-  ret = psock_recvfrom(psock, buf, len, flags, from, fromlen);
+  if (ret == OK)
+    {
+      ret = psock_recvfrom(psock, buf, len, flags, from, fromlen);
+    }
+
   if (ret < 0)
     {
       _SO_SETERRNO(psock, -ret);

--- a/net/socket/recvmsg.c
+++ b/net/socket/recvmsg.c
@@ -157,11 +157,15 @@ ssize_t recvmsg(int sockfd, FAR struct msghdr *msg, int flags)
 
   /* Get the underlying socket structure */
 
-  psock = sockfd_socket(sockfd);
+  ret = sockfd_socket(sockfd, &psock);
 
-  /* Then let psock_recvmsg() do all of the work */
+  /* Let psock_recvmsg() do all of the work */
 
-  ret = psock_recvmsg(psock, msg, flags);
+  if (ret == OK)
+    {
+      ret = psock_recvmsg(psock, msg, flags);
+    }
+
   if (ret < 0)
     {
       _SO_SETERRNO(psock, -ret);

--- a/net/socket/send.c
+++ b/net/socket/send.c
@@ -165,11 +165,15 @@ ssize_t send(int sockfd, FAR const void *buf, size_t len, int flags)
 
   /* Get the underlying socket structure */
 
-  psock = sockfd_socket(sockfd);
+  ret = sockfd_socket(sockfd, &psock);
 
   /* And let psock_send do all of the work */
 
-  ret = psock_send(psock, buf, len, flags);
+  if (ret == OK)
+    {
+      ret = psock_send(psock, buf, len, flags);
+    }
+
   if (ret < 0)
     {
       _SO_SETERRNO(psock, -ret);

--- a/net/socket/sendmsg.c
+++ b/net/socket/sendmsg.c
@@ -147,11 +147,15 @@ ssize_t sendmsg(int sockfd, FAR struct msghdr *msg, int flags)
 
   /* Get the underlying socket structure */
 
-  psock = sockfd_socket(sockfd);
+  ret = sockfd_socket(sockfd, &psock);
 
-  /* Then let psock_sendmsg() do all of the work */
+  /* Let psock_sendmsg() do all of the work */
 
-  ret = psock_sendmsg(psock, msg, flags);
+  if (ret == OK)
+    {
+      ret = psock_sendmsg(psock, msg, flags);
+    }
+
   if (ret < 0)
     {
       _SO_SETERRNO(psock, -ret);

--- a/net/socket/sendto.c
+++ b/net/socket/sendto.c
@@ -205,11 +205,15 @@ ssize_t sendto(int sockfd, FAR const void *buf, size_t len, int flags,
 
   /* Get the underlying socket structure */
 
-  psock = sockfd_socket(sockfd);
+  ret = sockfd_socket(sockfd, &psock);
 
   /* And let psock_sendto do all of the work */
 
-  ret = psock_sendto(psock, buf, len, flags, to, tolen);
+  if (ret == OK)
+    {
+      ret = psock_sendto(psock, buf, len, flags, to, tolen);
+    }
+
   if (ret < 0)
     {
       _SO_SETERRNO(psock, -ret);

--- a/net/socket/setsockopt.c
+++ b/net/socket/setsockopt.c
@@ -642,11 +642,15 @@ int setsockopt(int sockfd, int level, int option, const void *value,
 
   /* Get the underlying socket structure */
 
-  psock = sockfd_socket(sockfd);
+  ret = sockfd_socket(sockfd, &psock);
 
   /* Then let psock_setockopt() do all of the work */
 
-  ret = psock_setsockopt(psock, level, option, value, value_len);
+  if (ret == OK)
+    {
+      ret = psock_setsockopt(psock, level, option, value, value_len);
+    }
+
   if (ret < 0)
     {
       set_errno(-ret);


### PR DESCRIPTION
Signed-off-by: zhanghongyu <zhanghongyu@xiaomi.com>

## Summary
user space can close fd when errno is ENOTSOCK.
## Impact

## Testing

