### PR TITLE
arch: Remove the unnecessary nosanitize_address from backtrace source code

### DIFF
--- a/arch/arm/src/common/arm_backtrace_fp.c
+++ b/arch/arm/src/common/arm_backtrace_fp.c
@@ -101,7 +101,6 @@ static int backtrace(uintptr_t *base, uintptr_t *limit,
  *
  ****************************************************************************/
 
-nosanitize_address
 int up_backtrace(struct tcb_s *tcb,
                  void **buffer, int size, int skip)
 {

--- a/arch/arm/src/common/arm_backtrace_sp.c
+++ b/arch/arm/src/common/arm_backtrace_sp.c
@@ -73,7 +73,7 @@ static void **g_backtrace_code_regions;
  *
  ****************************************************************************/
 
-nosanitize_address static bool in_code_region(unsigned long pc)
+static bool in_code_region(unsigned long pc)
 {
   int i = 0;
 
@@ -191,7 +191,7 @@ static int backtrace_branch(unsigned long top, unsigned long sp,
  *
  ****************************************************************************/
 
-nosanitize_address void up_backtrace_init_code_regions(void **regions)
+void up_backtrace_init_code_regions(void **regions)
 {
   g_backtrace_code_regions = regions;
 }

--- a/arch/arm/src/common/arm_backtrace_unwind.c
+++ b/arch/arm/src/common/arm_backtrace_unwind.c
@@ -109,7 +109,6 @@ struct unwind_ctrl_s
  *
  ****************************************************************************/
 
-nosanitize_address
 static const struct __EIT_entry *
 search_index(unsigned long addr, const struct __EIT_entry *start,
              const struct __EIT_entry *origin,
@@ -163,7 +162,6 @@ search_index(unsigned long addr, const struct __EIT_entry *start,
   return (start->fnoffset <= addr_prel31) ? start : NULL;
 }
 
-nosanitize_address
 static const struct __EIT_entry *
 unwind_find_origin(const struct __EIT_entry *start,
                    const struct __EIT_entry *stop)
@@ -191,7 +189,6 @@ unwind_find_origin(const struct __EIT_entry *start,
   return stop;
 }
 
-nosanitize_address
 static const struct __EIT_entry *unwind_find_entry(unsigned long addr)
 {
   /* Main unwind table */
@@ -201,7 +198,6 @@ static const struct __EIT_entry *unwind_find_entry(unsigned long addr)
                       __exidx_end);
 }
 
-nosanitize_address
 static unsigned long unwind_get_byte(struct unwind_ctrl_s *ctrl)
 {
   unsigned long ret;
@@ -235,7 +231,6 @@ static unsigned long unwind_get_byte(struct unwind_ctrl_s *ctrl)
  *
  ****************************************************************************/
 
-nosanitize_address
 static int unwind_pop_register(struct unwind_ctrl_s *ctrl,
                                unsigned long **vsp, unsigned int reg)
 {
@@ -266,9 +261,8 @@ static int unwind_pop_register(struct unwind_ctrl_s *ctrl,
  *
  ****************************************************************************/
 
-nosanitize_address static int
-unwind_exec_pop_subset_r4_to_r13(struct unwind_ctrl_s *ctrl,
-                                 unsigned long mask)
+static int unwind_exec_pop_subset_r4_to_r13(struct unwind_ctrl_s *ctrl,
+                                            unsigned long mask)
 {
   unsigned long *vsp = (unsigned long *)ctrl->vrs[SP];
   int load_sp;
@@ -294,7 +288,6 @@ unwind_exec_pop_subset_r4_to_r13(struct unwind_ctrl_s *ctrl,
   return 0;
 }
 
-nosanitize_address
 static int unwind_exec_pop_r4_to_rn(struct unwind_ctrl_s *ctrl,
                                     unsigned long content)
 {
@@ -321,7 +314,6 @@ static int unwind_exec_pop_r4_to_rn(struct unwind_ctrl_s *ctrl,
   return 0;
 }
 
-nosanitize_address
 static int unwind_exec_pop_subset_r0_to_r3(struct unwind_ctrl_s *ctrl,
                                            unsigned long mask)
 {
@@ -354,7 +346,6 @@ static int unwind_exec_pop_subset_r0_to_r3(struct unwind_ctrl_s *ctrl,
  *
  ****************************************************************************/
 
-nosanitize_address
 static int unwind_exec_content(struct unwind_ctrl_s *ctrl)
 {
   unsigned long content = unwind_get_byte(ctrl);
@@ -424,7 +415,6 @@ static int unwind_exec_content(struct unwind_ctrl_s *ctrl)
   return ret;
 }
 
-nosanitize_address
 int unwind_frame(struct unwind_frame_s *frame)
 {
   const struct __EIT_entry *entry;
@@ -606,7 +596,6 @@ static int backtrace_unwind(struct unwind_frame_s *frame,
  *
  ****************************************************************************/
 
-nosanitize_address
 int up_backtrace(struct tcb_s *tcb,
                  void **buffer, int size, int skip)
 {

--- a/arch/arm/src/tlsr82/tc32/tc32_backtrace.c
+++ b/arch/arm/src/tlsr82/tc32/tc32_backtrace.c
@@ -81,7 +81,7 @@ static void **g_backtrace_code_regions;
  *
  ****************************************************************************/
 
-nosanitize_address static int getlroffset(uint8_t *lr)
+static int getlroffset(uint8_t *lr)
 {
   lr = (uint8_t *)((uintptr_t)lr & 0xfffffffe);
 
@@ -113,7 +113,7 @@ nosanitize_address static int getlroffset(uint8_t *lr)
  *
  ****************************************************************************/
 
-nosanitize_address static bool in_code_region(void *pc)
+static bool in_code_region(void *pc)
 {
   int i = 0;
 
@@ -161,7 +161,6 @@ nosanitize_address static bool in_code_region(void *pc)
  *
  ****************************************************************************/
 
-nosanitize_address
 static void *backtrace_push_internal(void **psp, void **ppc)
 {
   uint8_t *sp = *psp;
@@ -413,7 +412,7 @@ static int backtrace_branch(void *limit, void *sp,
  *
  ****************************************************************************/
 
-nosanitize_address void up_backtrace_init_code_regions(void **regions)
+void up_backtrace_init_code_regions(void **regions)
 {
   g_backtrace_code_regions = regions;
 }

--- a/arch/arm64/src/common/arm64_backtrace.c
+++ b/arch/arm64/src/common/arm64_backtrace.c
@@ -105,7 +105,6 @@ static int backtrace(uintptr_t *base, uintptr_t *limit,
  *
  ****************************************************************************/
 
-nosanitize_address
 int up_backtrace(struct tcb_s *tcb,
                  void **buffer, int size, int skip)
 {

--- a/arch/risc-v/src/common/riscv_backtrace.c
+++ b/arch/risc-v/src/common/riscv_backtrace.c
@@ -60,6 +60,7 @@ static inline uintptr_t getfp(void)
  *
  ****************************************************************************/
 
+nosanitize_address
 static int backtrace(uintptr_t *base, uintptr_t *limit,
                      uintptr_t *fp, uintptr_t *ra,
                      void **buffer, int size, int *skip)

--- a/arch/xtensa/src/common/xtensa_backtrace.c
+++ b/arch/xtensa/src/common/xtensa_backtrace.c
@@ -105,6 +105,7 @@ static void get_window_regs(struct xtensa_windowregs_s *frame)
  ****************************************************************************/
 
 #ifndef __XTENSA_CALL0_ABI__
+nosanitize_address
 static int backtrace_window(uintptr_t *base, uintptr_t *limit,
                             struct xtensa_windowregs_s *frame,
                             void **buffer, int size, int *skip)
@@ -155,6 +156,7 @@ static int backtrace_window(uintptr_t *base, uintptr_t *limit,
  *
  ****************************************************************************/
 
+nosanitize_address
 static int backtrace_stack(uintptr_t *base, uintptr_t *limit,
                            uintptr_t *sp, uintptr_t *ra,
                            void **buffer, int size, int *skip)


### PR DESCRIPTION
## Summary
only code which modify buffer argument need exclude from address sanitize

## Impact
backtrace code

## Testing

