### PR TITLE
sched/mutex: NXMUTEX_INITIALIZER should enable priority inheritance

### DIFF
--- a/include/nuttx/mutex.h
+++ b/include/nuttx/mutex.h
@@ -36,10 +36,10 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-#define NXRMUTEX_NO_HOLDER     (pid_t)-1
-#define NXMUTEX_INITIALIZER    NXSEM_INITIALIZER(1, 0)
-#define NXRMUTEX_INITIALIZER   {NXSEM_INITIALIZER(1, 0), \
-                                NXRMUTEX_NO_HOLDER, 0}
+#define NXRMUTEX_NO_HOLDER   (pid_t)-1
+#define NXMUTEX_INITIALIZER  NXSEM_INITIALIZER(1, PRIOINHERIT_FLAGS_ENABLE)
+#define NXRMUTEX_INITIALIZER {NXSEM_INITIALIZER(1, PRIOINHERIT_FLAGS_ENABLE), \
+                              NXRMUTEX_NO_HOLDER, 0}
 
 /****************************************************************************
  * Public Type Definitions

--- a/include/semaphore.h
+++ b/include/semaphore.h
@@ -49,10 +49,8 @@
 /* Bit definitions for the struct sem_s flags field */
 
 #define PRIOINHERIT_FLAGS_ENABLE (1 << 0)  /* Bit 0: Priority inheritance
-                                            * is enabled for this semaphore. */
-
-#define PRIOINHERIT_FLAGS_DISABLE (0 << 0)  /* Bit 0: Priority inheritance
-                                             * is disabled for this semaphore. */
+                                            * is enabled for this semaphore.
+                                            */
 
 /****************************************************************************
  * Public Type Declarations


### PR DESCRIPTION
## Summary
and remove the unused macro PRIOINHERIT_FLAGS_DISABLE

## Impact
when CONFIG_PRIORITY_INHERITANCE is enabled

## Testing
Pass CI
