### PR TITLE
Call nxsem_destroy or nxmutex_destry in the error path

### DIFF
--- a/arch/arm/src/tiva/common/tiva_can.c
+++ b/arch/arm/src/tiva/common/tiva_can.c
@@ -699,7 +699,7 @@ int tivacan_rxhandler(int argc, char** argv)
   struct can_msg_s msg;
 
 #ifdef CONFIG_CAN_ERRORS
-  int      ret;
+  int ret;
 #endif
 
   /* argv[0] contains the thread name */

--- a/binfmt/libnxflat/libnxflat_bind.c
+++ b/binfmt/libnxflat/libnxflat_bind.c
@@ -379,7 +379,7 @@ static inline int nxflat_bindimports(FAR struct nxflat_loadinfo_s *loadinfo,
   FAR struct nxflat_hdr_s    *hdr;
   FAR const struct symtab_s  *symbol;
 
-  char    *symname;
+  FAR char *symname;
   uint32_t offset;
   uint16_t nimports;
 #ifdef CONFIG_ARCH_ADDRENV

--- a/boards/arm/kinetis/freedom-k28f/src/k28_usbhshost.c
+++ b/boards/arm/kinetis/freedom-k28f/src/k28_usbhshost.c
@@ -398,9 +398,9 @@ static void usb_msc_disconnect(void *arg)
 
 int k28_usbhost_initialize(void)
 {
-  int      ret;
+  int ret;
 #  ifdef HAVE_USB_AUTOMOUNTER
-  int      index;
+  int index;
 #  endif
 
   /* First, register all of the class drivers needed to support the drivers

--- a/drivers/analog/comp.c
+++ b/drivers/analog/comp.c
@@ -249,7 +249,7 @@ static int comp_open(FAR struct file *filep)
 
 static int comp_close(FAR struct file *filep)
 {
-  FAR struct inode     *inode = filep->f_inode;
+  FAR struct inode      *inode = filep->f_inode;
   FAR struct comp_dev_s *dev   = inode->i_private;
   irqstate_t            flags;
   int                   ret;
@@ -363,16 +363,19 @@ int comp_register(FAR const char *path, FAR struct comp_dev_s *dev)
       if (ret < 0)
         {
           aerr("ERROR: Failed to bind callbacks: %d\n", ret);
+          nxmutex_destroy(&dev->ad_lock);
+          nxsem_destroy(&dev->ad_readsem);
           return ret;
         }
     }
 
   /* Register the COMP character driver */
 
-  ret =  register_driver(path, &comp_fops, 0444, dev);
+  ret = register_driver(path, &comp_fops, 0444, dev);
   if (ret < 0)
     {
       nxmutex_destroy(&dev->ad_lock);
+      nxsem_destroy(&dev->ad_readsem);
     }
 
   return ret;

--- a/drivers/analog/ltc1867l.c
+++ b/drivers/analog/ltc1867l.c
@@ -331,12 +331,7 @@ int ltc1867l_register(FAR const char *devpath, FAR struct spi_dev_s *spi,
   adcpriv->channel_config = channel_config;
   adcpriv->channel_config_count = channel_config_count;
 
-  ret = nxmutex_init(&adcpriv->lock);
-  if (ret < 0)
-    {
-      kmm_free(adcpriv);
-      return ret;
-    }
+  nxmutex_init(&adcpriv->lock);
 
   adcdev = (FAR struct adc_dev_s *)kmm_malloc(sizeof(struct adc_dev_s));
   if (adcdev == NULL)

--- a/drivers/audio/cs4344.c
+++ b/drivers/audio/cs4344.c
@@ -1440,7 +1440,7 @@ FAR struct audio_lowerhalf_s *cs4344_initialize(FAR struct i2s_dev_s *i2s)
 
   /* Allocate a CS4344 device structure */
 
-  priv = (FAR struct cs4344_dev_s *) kmm_zalloc(sizeof(struct cs4344_dev_s));
+  priv = (FAR struct cs4344_dev_s *)kmm_zalloc(sizeof(struct cs4344_dev_s));
   if (priv)
     {
       /* Initialize the CS4344 device structure.  Since we used kmm_zalloc,
@@ -1460,7 +1460,5 @@ FAR struct audio_lowerhalf_s *cs4344_initialize(FAR struct i2s_dev_s *i2s)
       return &priv->dev;
     }
 
-  nxmutex_destroy(&priv->pendlock);
-  kmm_free(priv);
   return NULL;
 }

--- a/drivers/can/mcp2515.c
+++ b/drivers/can/mcp2515.c
@@ -196,26 +196,27 @@ enum can_state_s
 
 struct mcp2515_can_s
 {
-  struct mcp2515_config_s *config; /* The constant configuration */
-  uint8_t state;                   /* See enum can_state_s */
-  uint8_t nalloc;                  /* Number of allocated filters */
-  mutex_t lock;                    /* Enforces mutually exclusive access */
-  sem_t txfsem;                    /* Used to wait for TX FIFO availability */
-  uint32_t btp;                    /* Current bit timing */
-  uint8_t rxints;                  /* Configured RX interrupts */
-  uint8_t txints;                  /* Configured TX interrupts */
+  FAR struct mcp2515_config_s *config; /* The constant configuration */
+
+  uint8_t state;               /* See enum can_state_s */
+  uint8_t nalloc;              /* Number of allocated filters */
+  mutex_t lock;                /* Enforces mutually exclusive access */
+  sem_t txfsem;                /* Used to wait for TX FIFO availability */
+  uint32_t btp;                /* Current bit timing */
+  uint8_t rxints;              /* Configured RX interrupts */
+  uint8_t txints;              /* Configured TX interrupts */
 #ifdef CONFIG_CAN_ERRORS
-  uint32_t olderrors;              /* Used to detect the changes in error states */
+  uint32_t olderrors;          /* Used to detect the changes in error states */
 #endif
-  uint8_t filters;                 /* Standard/Extende filter bit allocator. */
-  uint8_t txbuffers;               /* TX Buffers bit allocator. */
+  uint8_t filters;             /* Standard/Extende filter bit allocator. */
+  uint8_t txbuffers;           /* TX Buffers bit allocator. */
 
   FAR uint8_t *spi_txbuf;
   FAR uint8_t *spi_rxbuf;
 #ifdef CONFIG_MCP2515_REGDEBUG
-  uintptr_t regaddr;               /* Last register address read */
-  uint32_t regval;                 /* Last value read from the register */
-  unsigned int count;              /* Number of times that the value was read */
+  uintptr_t regaddr;           /* Last register address read */
+  uint32_t regval;             /* Last value read from the register */
+  unsigned int count;          /* Number of times that the value was read */
 #endif
 };
 
@@ -1182,14 +1183,9 @@ static void mcp2515_reset_lowlevel(FAR struct mcp2515_can_s *priv)
 
   nxsig_usleep(1000);
 
-  /* Make sure that all buffers are released.
-   *
-   * REVISIT: What if a thread is waiting for a buffer?  The following
-   * will not wake up any waiting threads.
-   */
+  /* Make sure that all buffers are released. */
 
-  nxsem_destroy(&priv->txfsem);
-  nxsem_init(&priv->txfsem, 0, MCP2515_NUM_TX_BUFFERS);
+  nxsem_reset(&priv->txfsem, MCP2515_NUM_TX_BUFFERS);
   priv->txbuffers = 0b111;
 
   /* Define the current state and unlock */
@@ -2136,7 +2132,7 @@ static void mcp2515_receive(FAR struct can_dev_s *dev, uint8_t offset)
 
   /* Save the message data */
 
-  ret = can_receive(dev, &hdr, (FAR uint8_t *) & RXREGVAL(MCP2515_RXB0D0));
+  ret = can_receive(dev, &hdr, (FAR uint8_t *)&RXREGVAL(MCP2515_RXB0D0));
 
   if (ret < 0)
     {

--- a/drivers/input/ads7843e.c
+++ b/drivers/input/ads7843e.c
@@ -716,7 +716,7 @@ static int ads7843e_interrupt(int irq, FAR void *context, FAR void *arg)
 static int ads7843e_open(FAR struct file *filep)
 {
 #ifdef CONFIG_ADS7843E_REFCNT
-  FAR struct inode         *inode;
+  FAR struct inode          *inode;
   FAR struct ads7843e_dev_s *priv;
   uint8_t                   tmp;
   int                       ret;
@@ -772,7 +772,7 @@ errout_with_lock:
 static int ads7843e_close(FAR struct file *filep)
 {
 #ifdef CONFIG_ADS7843E_REFCNT
-  FAR struct inode         *inode;
+  FAR struct inode          *inode;
   FAR struct ads7843e_dev_s *priv;
   int                       ret;
 
@@ -943,7 +943,7 @@ errout:
 
 static int ads7843e_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
 {
-  FAR struct inode         *inode;
+  FAR struct inode          *inode;
   FAR struct ads7843e_dev_s *priv;
   int                       ret;
 
@@ -1214,6 +1214,7 @@ int ads7843e_register(FAR struct spi_dev_s *spi,
 
 errout_with_priv:
   nxmutex_destroy(&priv->devlock);
+  nxsem_destroy(&priv->waitsem);
 #ifdef CONFIG_ADS7843E_MULTIPLE
   kmm_free(priv);
 #endif

--- a/drivers/input/ft5x06.c
+++ b/drivers/input/ft5x06.c
@@ -850,7 +850,7 @@ static ssize_t ft5x06_read(FAR struct file *filep, FAR char *buffer,
                            size_t len)
 {
   FAR struct inode *inode;
-  FAR struct ft5x06_dev_s  *priv;
+  FAR struct ft5x06_dev_s *priv;
   int ret;
 
   DEBUGASSERT(filep);
@@ -921,9 +921,9 @@ errout:
 
 static int ft5x06_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
 {
-  FAR struct inode         *inode;
+  FAR struct inode        *inode;
   FAR struct ft5x06_dev_s *priv;
-  int                       ret;
+  int                      ret;
 
   iinfo("cmd: %d arg: %ld\n", cmd, arg);
   DEBUGASSERT(filep);
@@ -975,12 +975,12 @@ static int ft5x06_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
  ****************************************************************************/
 
 static int ft5x06_poll(FAR struct file *filep, FAR struct pollfd *fds,
-                        bool setup)
+                       bool setup)
 {
-  FAR struct inode         *inode;
+  FAR struct inode        *inode;
   FAR struct ft5x06_dev_s *priv;
-  int                       ret;
-  int                       i;
+  int                      ret;
+  int                      i;
 
   iinfo("setup: %d\n", (int)setup);
   DEBUGASSERT(filep && fds);
@@ -1176,6 +1176,7 @@ int ft5x06_register(FAR struct i2c_master_s *i2c,
 
 errout_with_priv:
   nxmutex_destroy(&priv->devlock);
+  nxsem_destroy(&priv->waitsem);
   kmm_free(priv);
   return ret;
 }

--- a/drivers/input/max11802.c
+++ b/drivers/input/max11802.c
@@ -709,7 +709,7 @@ static int max11802_interrupt(int irq, FAR void *context, FAR void *arg)
 static int max11802_open(FAR struct file *filep)
 {
 #ifdef CONFIG_MAX11802_REFCNT
-  FAR struct inode         *inode;
+  FAR struct inode          *inode;
   FAR struct max11802_dev_s *priv;
   uint8_t                   tmp;
   int                       ret;
@@ -765,7 +765,7 @@ errout_with_lock:
 static int max11802_close(FAR struct file *filep)
 {
 #ifdef CONFIG_MAX11802_REFCNT
-  FAR struct inode         *inode;
+  FAR struct inode          *inode;
   FAR struct max11802_dev_s *priv;
   int                       ret;
 
@@ -936,7 +936,7 @@ errout:
 
 static int max11802_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
 {
-  FAR struct inode         *inode;
+  FAR struct inode          *inode;
   FAR struct max11802_dev_s *priv;
   int                       ret;
 
@@ -1248,6 +1248,7 @@ int max11802_register(FAR struct spi_dev_s *spi,
 
 errout_with_priv:
   nxmutex_destroy(&priv->devlock);
+  nxsem_destroy(&priv->waitsem);
 #ifdef CONFIG_MAX11802_MULTIPLE
   kmm_free(priv);
 #endif

--- a/drivers/input/nunchuck.c
+++ b/drivers/input/nunchuck.c
@@ -188,7 +188,7 @@ static int nunchuck_sample(FAR struct nunchuck_dev_s *priv,
 {
   uint8_t cmd[2];
   uint8_t data[6];
-  static bool initialized = false;
+  static bool initialized;
 
   if (!initialized)
     {

--- a/drivers/input/spq10kbd.c
+++ b/drivers/input/spq10kbd.c
@@ -293,7 +293,7 @@ static djoy_buttonset_t djoy_supported(
 static djoy_buttonset_t djoy_sample(
   FAR const struct djoy_lowerhalf_s *lower)
 {
-  FAR struct spq10kbd_dev_s  *priv =
+  FAR struct spq10kbd_dev_s *priv =
     (FAR struct spq10kbd_dev_s *)(lower->config);
   return priv->djoystate;
 }
@@ -311,7 +311,7 @@ static void djoy_enable(FAR const struct djoy_lowerhalf_s *lower,
                         djoy_buttonset_t press, djoy_buttonset_t release,
                         djoy_interrupt_t handler, FAR void *arg)
 {
-  FAR struct spq10kbd_dev_s  *priv =
+  FAR struct spq10kbd_dev_s *priv =
     (FAR struct spq10kbd_dev_s *)(lower->config);
   priv->djoypressmask    = press;
   priv->djoyreleasemask  = release;
@@ -326,11 +326,11 @@ static void djoy_enable(FAR const struct djoy_lowerhalf_s *lower,
 
 static void spq10kbd_worker(FAR void *arg)
 {
-  FAR struct spq10kbd_dev_s  *priv = (FAR struct spq10kbd_dev_s *)arg;
-  uint16_t                    regval;
-  uint8_t                     key;
-  uint8_t                     state;
-  int                         ret;
+  FAR struct spq10kbd_dev_s *priv = (FAR struct spq10kbd_dev_s *)arg;
+  uint16_t                   regval;
+  uint8_t                    key;
+  uint8_t                    state;
+  int                        ret;
 
   ret = nxmutex_lock(&priv->lock);
   if (ret < 0)
@@ -420,8 +420,8 @@ static void spq10kbd_worker(FAR void *arg)
 
 static int spq10kbd_interrupt(int irq, FAR void *context, FAR void *arg)
 {
-  FAR struct spq10kbd_dev_s  *priv = (FAR struct spq10kbd_dev_s *)arg;
-  int                         ret;
+  FAR struct spq10kbd_dev_s *priv = (FAR struct spq10kbd_dev_s *)arg;
+  int                        ret;
 
   /* Let the event worker know that it has an interrupt event to handle
    * It is possbile that we will already have work scheduled from a
@@ -451,8 +451,8 @@ static int spq10kbd_interrupt(int irq, FAR void *context, FAR void *arg)
 
 static int spq10kbd_open(FAR struct file *filep)
 {
-  FAR struct inode           *inode;
-  FAR struct spq10kbd_dev_s  *priv;
+  FAR struct inode          *inode;
+  FAR struct spq10kbd_dev_s *priv;
 
   DEBUGASSERT(filep && filep->f_inode);
   inode = filep->f_inode;
@@ -475,8 +475,8 @@ static int spq10kbd_open(FAR struct file *filep)
 
 static int spq10kbd_close(FAR struct file *filep)
 {
-  FAR struct inode           *inode;
-  FAR struct spq10kbd_dev_s  *priv;
+  FAR struct inode          *inode;
+  FAR struct spq10kbd_dev_s *priv;
 
   DEBUGASSERT(filep && filep->f_inode);
   inode = filep->f_inode;
@@ -502,11 +502,11 @@ static int spq10kbd_close(FAR struct file *filep)
 static ssize_t spq10kbd_read(FAR struct file *filep, FAR char *buffer,
                              size_t len)
 {
-  FAR struct inode           *inode;
-  FAR struct spq10kbd_dev_s  *priv;
-  size_t                      nbytes;
-  uint16_t                    tail;
-  int                         ret;
+  FAR struct inode          *inode;
+  FAR struct spq10kbd_dev_s *priv;
+  size_t                     nbytes;
+  uint16_t                   tail;
+  int                        ret;
 
   DEBUGASSERT(filep && filep->f_inode && buffer);
   inode = filep->f_inode;
@@ -603,10 +603,10 @@ static ssize_t spq10kbd_write(FAR struct file *filep, FAR const char *buffer,
 static int spq10kbd_poll(FAR struct file *filep, FAR struct pollfd *fds,
                          bool setup)
 {
-  FAR struct inode           *inode;
-  FAR struct spq10kbd_dev_s  *priv;
-  int                         ret;
-  int                         i;
+  FAR struct inode          *inode;
+  FAR struct spq10kbd_dev_s *priv;
+  int                        ret;
+  int                        i;
 
   DEBUGASSERT(filep && filep->f_inode && fds);
   inode = filep->f_inode;
@@ -994,7 +994,7 @@ int spq10kbd_register(FAR struct i2c_master_s *i2c,
   priv->waiting   = false;
 
 #ifdef CONFIG_SPQ10KBD_DJOY
-  priv->djoylower.config       = (FAR void *)priv;
+  priv->djoylower.config       = priv;
   priv->djoylower.dl_supported = djoy_supported;
   priv->djoylower.dl_sample    = djoy_sample;
   priv->djoylower.dl_enable    = djoy_enable;
@@ -1045,6 +1045,7 @@ int spq10kbd_register(FAR struct i2c_master_s *i2c,
 
 errout_with_priv:
   nxmutex_destroy(&priv->lock);
+  nxsem_destroy(&priv->waitsem);
   kmm_free(priv);
   return ret;
 }

--- a/drivers/input/tsc2007.c
+++ b/drivers/input/tsc2007.c
@@ -1290,6 +1290,7 @@ int tsc2007_register(FAR struct i2c_master_s *dev,
 
 errout_with_priv:
   nxmutex_destroy(&priv->devlock);
+  nxsem_destroy(&priv->waitsem);
 #ifdef CONFIG_TSC2007_MULTIPLE
   kmm_free(priv);
 #endif

--- a/drivers/ipcc/ipcc_priv.h
+++ b/drivers/ipcc/ipcc_priv.h
@@ -35,13 +35,13 @@
 
 struct ipcc_driver_s
 {
-  FAR struct pollfd        *fds[CONFIG_IPCC_NPOLLWAITERS];
-  FAR struct ipcc_lower_s  *ipcc;     /* Lower half driver state */
-  int                       crefs;    /* Count number of open references */
-  int                       unlinked; /* 1 - driver has been unlinked */
-  mutex_t                   lock;     /* Mutual exclusion for driver */
-  sem_t                     rxsem;    /* Data ready to read semaphore */
-  sem_t                     txsem;    /* Data ready to send semaphore */
+  FAR struct pollfd       *fds[CONFIG_IPCC_NPOLLWAITERS];
+  FAR struct ipcc_lower_s *ipcc;     /* Lower half driver state */
+  int                      crefs;    /* Count number of open references */
+  int                      unlinked; /* 1 - driver has been unlinked */
+  mutex_t                  lock;     /* Mutual exclusion for driver */
+  sem_t                    rxsem;    /* Data ready to read semaphore */
+  sem_t                    txsem;    /* Data ready to send semaphore */
 };
 
 /****************************************************************************

--- a/drivers/lcd/ht16k33_14seg.c
+++ b/drivers/lcd/ht16k33_14seg.c
@@ -193,7 +193,7 @@ static inline void ht16k33_write_cmd(FAR struct ht16k33_dev_s *priv,
   msg.frequency = CONFIG_HT16K33_I2C_FREQ;   /* I2C frequency */
   msg.addr      = HT16K33_I2C_ADDR + dev_id; /* 7-bit address */
   msg.flags     = 0;                         /* Write transaction */
-  msg.buffer    = (FAR uint8_t *) data;      /* Transfer from this address */
+  msg.buffer    = data;                      /* Transfer from this address */
   msg.length    = 1;                         /* Send one byte */
 
   /* Perform the transfer */
@@ -233,11 +233,11 @@ static inline void ht16k33_write_data(FAR struct ht16k33_dev_s *priv,
 
   /* Setup the message to write data to HT16K33 */
 
-  msg.frequency = CONFIG_HT16K33_I2C_FREQ;    /* I2C frequency */
-  msg.addr      = HT16K33_I2C_ADDR + dev_id;  /* 7-bit address */
-  msg.flags     = 0;                          /* Write transaction */
-  msg.buffer    = (FAR uint8_t *) data;       /* Transfer from here */
-  msg.length    = nbytes + 1;                 /* Send cmd + nbytes */
+  msg.frequency = CONFIG_HT16K33_I2C_FREQ;   /* I2C frequency */
+  msg.addr      = HT16K33_I2C_ADDR + dev_id; /* 7-bit address */
+  msg.flags     = 0;                         /* Write transaction */
+  msg.buffer    = data;                      /* Transfer from here */
+  msg.length    = nbytes + 1;                /* Send cmd + nbytes */
 
   /* Perform the transfer */
 

--- a/drivers/leds/userled_upper.c
+++ b/drivers/leds/userled_upper.c
@@ -158,7 +158,7 @@ static int userled_open(FAR struct file *filep)
 
   /* Attach the open structure to the file structure */
 
-  filep->f_priv = (FAR void *)opriv;
+  filep->f_priv = opriv;
   ret = OK;
 
 errout_with_lock:

--- a/drivers/leds/ws2812.c
+++ b/drivers/leds/ws2812.c
@@ -123,7 +123,7 @@ struct ws2812_dev_s
 {
   FAR struct spi_dev_s *spi;  /* SPI interface */
   uint16_t nleds;             /* Number of addressable LEDs */
-  uint8_t *tx_buf;            /* Buffer for write transaction and state */
+  FAR uint8_t *tx_buf;        /* Buffer for write transaction and state */
   mutex_t lock;               /* Assures exclusive access to the driver */
 };
 
@@ -144,9 +144,9 @@ static void ws2812_pack(FAR uint8_t *buf, uint32_t rgb);
 
 #ifdef CONFIG_WS2812_NON_SPI_DRIVER
 
-static ssize_t  ws2812_open(FAR struct file  *filep);
+static ssize_t ws2812_open(FAR struct file *filep);
 
-static ssize_t  ws2812_close(FAR struct file  *filep);
+static ssize_t ws2812_close(FAR struct file *filep);
 
 #endif /* CONFIG_WS2812_NON_SPI_DRIVER */
 
@@ -255,7 +255,7 @@ static const uint8_t ws2812_gamma[256] =
  *
  ****************************************************************************/
 
-ssize_t  ws2812_open(FAR struct file  *filep)
+ssize_t ws2812_open(FAR struct file *filep)
 {
   FAR struct inode        *inode = filep->f_inode;
   FAR struct ws2812_dev_s *priv  = inode->i_private;
@@ -283,9 +283,9 @@ ssize_t  ws2812_open(FAR struct file  *filep)
 
 static int ws2812_close(FAR struct file *filep)
 {
-  FAR struct inode         *inode    = filep->f_inode;
-  FAR struct ws2812_dev_s  *priv     = inode->i_private;
-  int                       res      = OK;
+  FAR struct inode        *inode = filep->f_inode;
+  FAR struct ws2812_dev_s *priv  = inode->i_private;
+  int                      res   = OK;
 
   if (priv != NULL  &&  priv->close != NULL)
     {
@@ -316,9 +316,9 @@ ssize_t ws2812_write(FAR struct file *filep,
                      FAR const char  *data,
                      size_t           len)
 {
-  FAR struct inode         *inode    = filep->f_inode;
-  FAR struct ws2812_dev_s  *priv     = inode->i_private;
-  ssize_t                   res;
+  FAR struct inode        *inode = filep->f_inode;
+  FAR struct ws2812_dev_s *priv  = inode->i_private;
+  ssize_t                  res;
 
   if ((len % WS2812_RW_PIXEL_SIZE) != 0)
     {
@@ -350,9 +350,9 @@ ssize_t ws2812_read(FAR struct file *filep,
                     FAR char        *data,
                     size_t           len)
 {
-  FAR struct inode         *inode    = filep->f_inode;
-  FAR struct ws2812_dev_s  *priv     = inode->i_private;
-  ssize_t                   res;
+  FAR struct inode        *inode = filep->f_inode;
+  FAR struct ws2812_dev_s *priv  = inode->i_private;
+  ssize_t                  res;
 
   if (priv == NULL  ||  priv->read == NULL)
     {
@@ -846,8 +846,8 @@ uint32_t ws2812_hsv_to_rgb(uint8_t hue,
 uint32_t ws2812_gamma_correct(uint32_t pixel)
 {
   uint32_t     res;
-  FAR uint8_t *in  = (FAR uint8_t *) &pixel;
-  FAR uint8_t *out = (FAR uint8_t *) &res;
+  FAR uint8_t *in  = (FAR uint8_t *)&pixel;
+  FAR uint8_t *out = (FAR uint8_t *)&res;
 
   *out++ = ws2812_gamma[*in++];
   *out++ = ws2812_gamma[*in++];

--- a/drivers/misc/rwbuffer.c
+++ b/drivers/misc/rwbuffer.c
@@ -72,12 +72,9 @@ static ssize_t rwb_read_(FAR struct rwbuffer_s *rwb, off_t startblock,
  ****************************************************************************/
 
 #if defined(CONFIG_DRVR_WRITEBUFFER)
-static int rwb_lock(FAR mutex_t *lock)
-{
-  return nxmutex_lock(lock);
-}
+#  define rwb_lock(l) nxmutex_lock(l)
 #else
-# define rwb_lock(s) OK
+#  define rwb_lock(l) OK
 #endif
 
 /****************************************************************************
@@ -85,9 +82,9 @@ static int rwb_lock(FAR mutex_t *lock)
  ****************************************************************************/
 
 #if defined(CONFIG_DRVR_WRITEBUFFER)
-# define rwb_unlock(l) nxmutex_unlock(l)
+#  define rwb_unlock(l) nxmutex_unlock(l)
 #else
-# define rwb_unlock(l)
+#  define rwb_unlock(l)
 #endif
 
 /****************************************************************************
@@ -211,7 +208,7 @@ static void rwb_wrstarttimeout(FAR struct rwbuffer_s *rwb)
    */
 
   int ticks = MSEC2TICK(CONFIG_DRVR_WRDELAY);
-  work_queue(LPWORK, &rwb->work, rwb_wrtimeout, (FAR void *)rwb, ticks);
+  work_queue(LPWORK, &rwb->work, rwb_wrtimeout, rwb, ticks);
 #endif
 }
 #endif

--- a/drivers/mmcsd/mmcsd_spi.c
+++ b/drivers/mmcsd/mmcsd_spi.c
@@ -2049,14 +2049,6 @@ int mmcsd_spislotinitialize(int minor, int slotno, FAR struct spi_dev_s *spi)
   memset(slot, 0, sizeof(struct mmcsd_slot_s));
   nxmutex_init(&slot->lock);
 
-#ifdef CONFIG_DEBUG_FEATURES
-  if (slot->spi)
-    {
-      ferr("ERROR: Already registered\n");
-      return -EBUSY;
-    }
-#endif
-
   /* Bind the SPI port to the slot */
 
   slot->spi      = spi;
@@ -2094,6 +2086,7 @@ int mmcsd_spislotinitialize(int minor, int slotno, FAR struct spi_dev_s *spi)
   if (ret < 0)
     {
       ferr("ERROR: register_blockdriver failed: %d\n", -ret);
+      nxmutex_destroy(&slot->lock);
       slot->spi = NULL;
       return ret;
     }
@@ -2102,7 +2095,7 @@ int mmcsd_spislotinitialize(int minor, int slotno, FAR struct spi_dev_s *spi)
    * removal of cards.
    */
 
-  SPI_REGISTERCALLBACK(spi, mmcsd_mediachanged, (FAR void *)slot);
+  SPI_REGISTERCALLBACK(spi, mmcsd_mediachanged, slot);
   return OK;
 }
 

--- a/drivers/sensors/hc_sr04.c
+++ b/drivers/sensors/hc_sr04.c
@@ -423,6 +423,7 @@ int hcsr04_register(FAR const char *devpath,
   if (ret < 0)
     {
       nxmutex_destroy(&priv->devlock);
+      nxsem_destroy(&priv->conv_donesem);
       kmm_free(priv);
       hcsr04_dbg("Error occurred during the driver registering = %d\n", ret);
       return ret;

--- a/drivers/sensors/hyt271.c
+++ b/drivers/sensors/hyt271.c
@@ -972,6 +972,9 @@ temp_err:
   sensor_unregister(&priv->sensor[HYT271_SENSOR_TEMP].lower, devno);
 
   nxmutex_destroy(&priv->lock_measure_cycle);
+#ifdef CONFIG_SENSORS_HYT271_POLL
+  nxsem_destroy(&priv->run);
+#endif
   kmm_free(priv);
   return ret;
 }

--- a/drivers/sensors/lps25h.c
+++ b/drivers/sensors/lps25h.c
@@ -709,7 +709,7 @@ static int lps25h_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
       break;
 
     case SNIOC_PRESSURE_OUT:
-      ret = lps25h_read_pressure(dev, (lps25h_pressure_data_t *) arg);
+      ret = lps25h_read_pressure(dev, (FAR lps25h_pressure_data_t *)arg);
       break;
 
     case SNIOC_TEMPERATURE_OUT:
@@ -717,7 +717,7 @@ static int lps25h_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
        * or results are bogus.
        */
 
-      ret = lps25h_read_temper(dev, (lps25h_temper_data_t *) arg);
+      ret = lps25h_read_temper(dev, (FAR lps25h_temper_data_t *)arg);
       break;
 
     case SNIOC_SENSOR_OFF:
@@ -725,7 +725,7 @@ static int lps25h_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
       break;
 
     case SNIOC_GET_DEV_ID:
-      ret = lps25h_who_am_i(dev, (lps25h_who_am_i_data *) arg);
+      ret = lps25h_who_am_i(dev, (FAR lps25h_who_am_i_data *)arg);
       break;
 
     default:

--- a/drivers/sensors/lsm330_spi.c
+++ b/drivers/sensors/lsm330_spi.c
@@ -896,8 +896,8 @@ static ssize_t lsm330acl_dvr_read(FAR void *instance_handle,
 
   DEBUGASSERT(priv != NULL);
 
-  lsm330_read_acl_registerblk(priv, priv->seek_address, (uint8_t *)buffer,
-                              buflen);
+  lsm330_read_acl_registerblk(priv, priv->seek_address,
+                              (FAR uint8_t *)buffer, buflen);
   return buflen;
 }
 
@@ -912,8 +912,8 @@ static ssize_t lsm330gyro_dvr_read(FAR void *instance_handle,
 
   DEBUGASSERT(priv != NULL);
 
-  lsm330_read_gyro_registerblk(priv, priv->seek_address, (uint8_t *)buffer,
-                               buflen);
+  lsm330_read_gyro_registerblk(priv, priv->seek_address,
+                               (FAR uint8_t *)buffer, buflen);
   return buflen;
 }
 
@@ -933,8 +933,8 @@ static ssize_t lsm330acl_dvr_write(FAR void *instance_handle,
       return -EROFS;
     }
 
-  lsm330_write_acl_registerblk(priv, priv->seek_address, (uint8_t *)buffer,
-                               buflen);
+  lsm330_write_acl_registerblk(priv, priv->seek_address,
+                               (FAR uint8_t *)buffer, buflen);
   return buflen;
 }
 
@@ -1139,7 +1139,7 @@ static int lsm330acl_open(FAR struct file *filep)
   FAR struct lsm330_dev_s *priv = inode->i_private;
   int ret;
 
-  ret = lsm330acl_dvr_open((FAR void *)priv, 0);
+  ret = lsm330acl_dvr_open(priv, 0);
   return ret;
 }
 
@@ -1153,7 +1153,7 @@ static int lsm330gyro_open(FAR struct file *filep)
   FAR struct lsm330_dev_s *priv = inode->i_private;
   int ret;
 
-  ret = lsm330gyro_dvr_open((FAR void *)priv, 0);
+  ret = lsm330gyro_dvr_open(priv, 0);
   return ret;
 }
 
@@ -1167,7 +1167,7 @@ static int lsm330acl_close(FAR struct file *filep)
   FAR struct lsm330_dev_s *priv = inode->i_private;
   int ret;
 
-  ret = lsm330acl_dvr_close((FAR void *)priv, 0);
+  ret = lsm330acl_dvr_close(priv, 0);
   return ret;
 }
 
@@ -1181,7 +1181,7 @@ static int lsm330gyro_close(FAR struct file *filep)
   FAR struct lsm330_dev_s *priv = inode->i_private;
   int ret;
 
-  ret = lsm330gyro_dvr_close((FAR void *)priv, 0);
+  ret = lsm330gyro_dvr_close(priv, 0);
   return ret;
 }
 
@@ -1367,7 +1367,7 @@ int lsm330_register(FAR const char *devpath_acl,
   priv->flink = g_lsm330a_list;
   g_lsm330a_list = priv;
   priva = priv;
-  config_acl->leaf_handle = (void *)priv;
+  config_acl->leaf_handle = priv;
 
   /* Initialize the LSM330 gyroscope device structure. */
 
@@ -1405,7 +1405,7 @@ int lsm330_register(FAR const char *devpath_acl,
 
   priv->flink = g_lsm330g_list;
   g_lsm330g_list = priv;
-  config_gyro->leaf_handle = (void *)priv;
+  config_gyro->leaf_handle = priv;
 
   config_acl->sc_ops  = &g_lsm330acl_dops;
   config_gyro->sc_ops = &g_lsm330gyro_dops;

--- a/drivers/sensors/mlx90393.c
+++ b/drivers/sensors/mlx90393.c
@@ -473,7 +473,7 @@ static ssize_t mlx90393_read(FAR struct file *filep, FAR char *buffer,
 
   /* Check if enough memory was provided for the read call */
 
-  if (buflen < sizeof(FAR struct mlx90393_sensor_data_s))
+  if (buflen < sizeof(struct mlx90393_sensor_data_s))
     {
       snerr("ERROR: "
             "Not enough memory for reading out a sensor data sample\n");
@@ -492,7 +492,7 @@ static ssize_t mlx90393_read(FAR struct file *filep, FAR char *buffer,
     }
 
   data = (FAR struct mlx90393_sensor_data_s *)buffer;
-  memset(data, 0, sizeof(FAR struct mlx90393_sensor_data_s));
+  memset(data, 0, sizeof(struct mlx90393_sensor_data_s));
 
   data->x_mag = priv->data.x_mag;
   data->y_mag = priv->data.y_mag;
@@ -503,7 +503,7 @@ static ssize_t mlx90393_read(FAR struct file *filep, FAR char *buffer,
 
   nxmutex_unlock(&priv->datalock);
 
-  return sizeof(FAR struct mlx90393_sensor_data_s);
+  return sizeof(struct mlx90393_sensor_data_s);
 }
 
 /****************************************************************************

--- a/drivers/sensors/ms5611.c
+++ b/drivers/sensors/ms5611.c
@@ -85,20 +85,20 @@ struct ms5611_dev_s
   FAR struct sensor_lowerhalf_s sensor_lower;
 
 #ifdef CONFIG_MS5611_I2C
-  FAR struct i2c_master_s  *i2c;       /* I2C interface */
-  uint8_t                   addr;      /* I2C address */
+  FAR struct i2c_master_s *i2c;       /* I2C interface */
+  uint8_t                  addr;      /* I2C address */
 #endif
 
 #ifdef CONFIG_MS5611_SPI
-  FAR struct spi_dev_s     *spi;       /* SPI interface */
+  FAR struct spi_dev_s    *spi;       /* SPI interface */
 #endif
 
-  uint32_t                  freq;      /* Bus Frequency I2C/SPI */
-  struct ms5611_calib_s     calib;     /* Calib. params from ROM */
-  unsigned long             interval;  /* Polling interval */
-  bool                      enabled;   /* Enable/Disable MS5611 */
-  sem_t                     run;       /* Locks measure cycle */
-  mutex_t                   lock;      /* Manages exclusive to device */
+  uint32_t                 freq;      /* Bus Frequency I2C/SPI */
+  struct ms5611_calib_s    calib;     /* Calib. params from ROM */
+  unsigned long            interval;  /* Polling interval */
+  bool                     enabled;   /* Enable/Disable MS5611 */
+  sem_t                    run;       /* Locks measure cycle */
+  mutex_t                  lock;      /* Manages exclusive to device */
 };
 
 /****************************************************************************
@@ -668,6 +668,7 @@ int ms5611_register(FAR struct i2c_master_s *i2c, int devno, uint8_t addr)
     {
       snerr("Failed to initialize physical device ms5611:%d\n", ret);
       nxmutex_destroy(&priv->lock);
+      nxsem_destroy(&priv->run);
       kmm_free(priv);
       return ret;
     }
@@ -679,6 +680,7 @@ int ms5611_register(FAR struct i2c_master_s *i2c, int devno, uint8_t addr)
     {
       snerr("Failed to register driver: %d\n", ret);
       nxmutex_destroy(&priv->lock);
+      nxsem_destroy(&priv->run);
       kmm_free(priv);
       return ret;
     }
@@ -696,6 +698,7 @@ int ms5611_register(FAR struct i2c_master_s *i2c, int devno, uint8_t addr)
       snerr("Failed to create the notification kthread!\n");
       sensor_unregister(&priv->sensor_lower, devno);
       nxmutex_destroy(&priv->lock);
+      nxsem_destroy(&priv->run);
       kmm_free(priv);
       return ret;
     }

--- a/drivers/serial/uart_bth4.c
+++ b/drivers/serial/uart_bth4.c
@@ -50,7 +50,7 @@ union bt_hdr_u
 
 struct uart_bth4_s
 {
-  FAR struct bt_driver_s  *drv;
+  FAR struct bt_driver_s *drv;
 
   FAR struct circbuf_s    circbuf;
 
@@ -60,7 +60,7 @@ struct uart_bth4_s
   size_t                  sendlen;
   mutex_t                 sendlock;
 
-  FAR struct pollfd       *fds[CONFIG_UART_BTH4_NPOLLWAITERS];
+  FAR struct pollfd      *fds[CONFIG_UART_BTH4_NPOLLWAITERS];
 };
 
 /****************************************************************************
@@ -437,7 +437,7 @@ int uart_bth4_register(FAR const char *path, FAR struct bt_driver_s *drv)
   drv->priv    = dev;
 
   nxmutex_init(&dev->sendlock);
-  nxsem_init(&dev->recvsem,  0, 0);
+  nxsem_init(&dev->recvsem, 0, 0);
 
   ret = register_driver(path, &g_uart_bth4_ops, 0666, dev);
   if (ret < 0)

--- a/drivers/syslog/syslog_device.c
+++ b/drivers/syslog/syslog_device.c
@@ -145,6 +145,15 @@ static inline int syslog_dev_lock(FAR struct syslog_dev_s *syslog_dev)
 }
 
 /****************************************************************************
+ * Name: syslog_dev_unlock
+ ****************************************************************************/
+
+static inline void syslog_dev_unlock(FAR struct syslog_dev_s *syslog_dev)
+{
+  nxrmutex_unlock(&syslog_dev->sl_lock);
+}
+
+/****************************************************************************
  * Name: syslog_dev_open
  *
  * Description:
@@ -499,12 +508,12 @@ static ssize_t syslog_dev_write(FAR struct syslog_channel_s *channel,
         }
     }
 
-  nxrmutex_unlock(&syslog_dev->sl_lock);
+  syslog_dev_unlock(syslog_dev);
   return buflen;
 
 errout_with_lock:
   syslog_dev->sl_state = SYSLOG_FAILURE;
-  nxrmutex_unlock(&syslog_dev->sl_lock);
+  syslog_dev_unlock(syslog_dev);
   return ret;
 }
 
@@ -588,7 +597,7 @@ static int syslog_dev_putc(FAR struct syslog_channel_s *channel, int ch)
       nbytes = file_write(&syslog_dev->sl_file, &uch, 1);
     }
 
-  nxrmutex_unlock(&syslog_dev->sl_lock);
+  syslog_dev_unlock(syslog_dev);
 
   /* Check if the write was successful.  If not, nbytes will be
    * a negated errno value.
@@ -689,7 +698,7 @@ static int syslog_dev_flush(FAR struct syslog_channel_s *channel)
 FAR struct syslog_channel_s *syslog_dev_initialize(FAR const char *devpath,
                                                    int oflags, int mode)
 {
-  FAR struct syslog_dev_s * syslog_dev;
+  FAR struct syslog_dev_s *syslog_dev;
 
   syslog_dev = kmm_zalloc(sizeof(struct syslog_dev_s));
 

--- a/drivers/video/max7456.c
+++ b/drivers/video/max7456.c
@@ -1262,7 +1262,7 @@ static ssize_t mx7_read_cm(FAR struct file *filep, FAR char *buf, size_t len)
   ssize_t ret;
 
   nxmutex_lock(&dev->lock);
-  ret = __read_cm(dev, filep->f_pos, (FAR uint8_t *) buf, len);
+  ret = __read_cm(dev, filep->f_pos, (FAR uint8_t *)buf, len);
   nxmutex_unlock(&dev->lock);
 
   return ret;
@@ -1346,7 +1346,7 @@ static ssize_t mx7_write_fb(FAR struct file *filep, FAR const char *buf,
   ssize_t ret;
 
   nxmutex_lock(&dev->lock);
-  ret = __write_fb(dev, (FAR uint8_t *) buf, len, dev->ca, filep->f_pos);
+  ret = __write_fb(dev, (FAR uint8_t *)buf, len, dev->ca, filep->f_pos);
   nxmutex_unlock(&dev->lock);
 
   return ret;

--- a/drivers/video/video.c
+++ b/drivers/video/video.c
@@ -114,7 +114,7 @@ typedef struct video_format_s video_format_t;
 
 struct video_type_inf_s
 {
-  mutex_t                lock_state;
+  mutex_t              lock_state;
   enum video_state_e   state;
   int32_t              remaining_capnum;
   video_wait_capture_t wait_capture;
@@ -658,7 +658,7 @@ static int start_capture(enum v4l2_buf_type type,
      sf,
      &si);
   g_video_data_ops->start_capture(nr_fmt, df, &di, video_complete_capture);
-  g_video_data_ops->set_buf((uint8_t *)bufaddr, bufsize);
+  g_video_data_ops->set_buf((FAR uint8_t *)bufaddr, bufsize);
 
   return OK;
 }
@@ -847,7 +847,7 @@ static int32_t initialize_scene_gamma(uint8_t **gamma)
     }
 
   *gamma = malloc(sz);
-  val.p_u8 = (uint8_t *)*gamma;
+  val.p_u8 = (FAR uint8_t *)*gamma;
   g_video_sensor_ops->get_value(IMGSENSOR_ID_GAMMA_CURVE, sz, &val);
   return sz;
 }
@@ -1787,7 +1787,6 @@ static int video_takepict_start(FAR struct video_mng_s *vmng,
   irqstate_t           flags;
   enum video_state_e   next_video_state;
   FAR vbuf_container_t *container;
-
   int                  ret = OK;
 
   if (vmng == NULL)
@@ -2221,7 +2220,7 @@ static int set_pvalue(uint32_t id, int size, void *pval)
       return -ENOTTY;
     }
 
-  value.p_u8 = (uint8_t *)pval;
+  value.p_u8 = (FAR uint8_t *)pval;
   return g_video_sensor_ops->set_value(id, size, value);
 }
 
@@ -3069,7 +3068,7 @@ static int video_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
 
 static FAR void *video_register(FAR const char *devpath)
 {
-  FAR    video_mng_t *priv;
+  FAR video_mng_t *priv;
   int    ret;
   size_t allocsize;
 
@@ -3128,7 +3127,7 @@ static FAR void *video_register(FAR const char *devpath)
       return NULL;
     }
 
-  return (FAR void *)priv;
+  return priv;
 }
 
 static int video_unregister(FAR video_mng_t *v_mgr)
@@ -3142,7 +3141,7 @@ static int video_unregister(FAR video_mng_t *v_mgr)
   else
     {
       nxmutex_destroy(&v_mgr->lock_open_num);
-      unregister_driver((const char *)v_mgr->devpath);
+      unregister_driver(v_mgr->devpath);
 
       kmm_free(v_mgr->devpath);
       kmm_free(v_mgr);
@@ -3227,8 +3226,8 @@ static int video_complete_capture(uint8_t  err_code, uint32_t datasize)
         }
       else
         {
-          g_video_data_ops->set_buf((uint8_t *)container->buf.m.userptr,
-                                  container->buf.length);
+          g_video_data_ops->set_buf((FAR uint8_t *)container->buf.m.userptr,
+                                    container->buf.length);
         }
     }
 

--- a/drivers/wireless/cc1101.c
+++ b/drivers/wireless/cc1101.c
@@ -435,7 +435,7 @@ static ssize_t cc1101_file_write(FAR struct file *filep,
       return ret;
     }
 
-  ret = cc1101_write(dev, (const uint8_t *)buffer, buflen);
+  ret = cc1101_write(dev, (FAR const uint8_t *)buffer, buflen);
   cc1101_send(dev);
   nxmutex_unlock(&dev->devlock);
   return ret;
@@ -560,7 +560,7 @@ static ssize_t cc1101_file_read(FAR struct file *filep, FAR char *buffer,
       return ret;
     }
 
-  buflen = fifo_get(dev, (uint8_t *)buffer, buflen);
+  buflen = fifo_get(dev, (FAR uint8_t *)buffer, buflen);
   nxmutex_unlock(&dev->devlock);
   return buflen;
 }

--- a/drivers/wireless/gs2200m.c
+++ b/drivers/wireless/gs2200m.c
@@ -816,7 +816,7 @@ static void _write_data(FAR struct gs2200m_dev_s *dev,
  ****************************************************************************/
 
 static void _read_data(FAR struct gs2200m_dev_s *dev,
-                       FAR uint8_t  *buff,
+                       FAR uint8_t *buff,
                        FAR uint16_t len)
 {
   memset(buff, 0, len);
@@ -832,8 +832,8 @@ static void _read_data(FAR struct gs2200m_dev_s *dev,
 
 static uint16_t _read_data_len(FAR struct gs2200m_dev_s *dev)
 {
-  uint8_t  hdr[8];
-  uint8_t  res[8];
+  uint8_t hdr[8];
+  uint8_t res[8];
   uint16_t len = 0;
   int n = 0;
 
@@ -889,10 +889,10 @@ retry:
  ****************************************************************************/
 
 enum spi_status_e gs2200m_hal_write(FAR struct gs2200m_dev_s *dev,
-                                    const void *data,
+                                    FAR const void *data,
                                     uint16_t txlen)
 {
-  uint8_t *tx = (uint8_t *)data;
+  FAR uint8_t *tx = (FAR uint8_t *)data;
   uint8_t  hdr[8];
   uint8_t  res[8];
   int n = 0;
@@ -1091,6 +1091,7 @@ static void _parse_pkt_in_s0(FAR struct pkt_ctx_s *pkt_ctx,
 static void _parse_pkt_in_s1(FAR struct pkt_ctx_s *pkt_ctx,
                              FAR struct pkt_dat_s *pkt_dat)
 {
+  FAR char *msg;
   int msize;
   int n;
 
@@ -1102,7 +1103,7 @@ static void _parse_pkt_in_s1(FAR struct pkt_ctx_s *pkt_ctx,
   ASSERT(pkt_ctx->ptr > pkt_ctx->head);
   msize = pkt_ctx->ptr - pkt_ctx->head;
 
-  char *msg = (char *)kmm_calloc(msize + 1, 1);
+  msg = (FAR char *)kmm_calloc(msize + 1, 1);
   ASSERT(msg);
 
   memcpy(msg, pkt_ctx->head, msize);
@@ -1219,7 +1220,7 @@ static void _parse_pkt_in_s3(FAR struct pkt_ctx_s *pkt_ctx,
 
       /* Read data length */
 
-      pkt_ctx->dlen = _to_uint16((char *)pkt_ctx->ptr);
+      pkt_ctx->dlen = _to_uint16((FAR char *)pkt_ctx->ptr);
       pkt_ctx->ptr += 3;
 
       wlinfo("dlen=%d\n", pkt_ctx->dlen);
@@ -1271,7 +1272,7 @@ static void _parse_pkt_in_s4(FAR struct pkt_ctx_s *pkt_ctx,
 
       memset(addr, 0, sizeof(addr));
       memset(port, 0, sizeof(port));
-      n = sscanf((char *)pkt_ctx->ptr, "%s %s\t", addr, port);
+      n = sscanf((FAR const char *)pkt_ctx->ptr, "%s %s\t", addr, port);
       ASSERT(2 == n);
 
       wlinfo("from (%s:%s)\n", addr, port);
@@ -1286,7 +1287,7 @@ static void _parse_pkt_in_s4(FAR struct pkt_ctx_s *pkt_ctx,
 
       /* Read data length */
 
-      pkt_ctx->dlen = _to_uint16((char *)pkt_ctx->ptr);
+      pkt_ctx->dlen = _to_uint16((FAR char *)pkt_ctx->ptr);
       pkt_ctx->ptr += 3;
 
       wlinfo("dlen=%d\n", pkt_ctx->dlen);
@@ -1367,7 +1368,7 @@ static enum pkt_type_e _parse_pkt(FAR uint8_t *p, uint16_t len,
 static void _dup_pkt_dat_and_notify(FAR struct gs2200m_dev_s *dev,
                                     FAR struct pkt_dat_s *pkt_dat0)
 {
-  struct pkt_dat_s *pkt_dat;
+  FAR struct pkt_dat_s *pkt_dat;
   uint8_t c;
 
   /* Only bulk data */
@@ -1419,9 +1420,9 @@ static enum pkt_type_e gs2200m_recv_pkt(FAR struct gs2200m_dev_s *dev,
   enum pkt_type_e   t = TYPE_ERROR;
   enum spi_status_e s;
   uint16_t len;
-  uint8_t *p;
+  FAR uint8_t *p;
 
-  p = (uint8_t *)kmm_calloc(MAX_PKT_LEN, 1);
+  p = (FAR uint8_t *)kmm_calloc(MAX_PKT_LEN, 1);
   ASSERT(p);
 
   s = gs2200m_hal_read(dev, p, &len);
@@ -1633,7 +1634,7 @@ errout:
 
 static enum pkt_type_e gs2200m_disassociate(FAR struct gs2200m_dev_s *dev)
 {
-  return gs2200m_send_cmd2(dev, (char *)"AT+WD\r\n");
+  return gs2200m_send_cmd2(dev, "AT+WD\r\n");
 }
 
 /****************************************************************************
@@ -1826,7 +1827,7 @@ enum pkt_type_e gs2200m_get_wstatus(FAR struct gs2200m_dev_s *dev)
   /* Initialize pkt_dat and send command */
 
   memset(&pkt_dat, 0, sizeof(pkt_dat));
-  r = gs2200m_send_cmd(dev, (char *)"AT+WSTATUS\r\n", &pkt_dat);
+  r = gs2200m_send_cmd(dev, "AT+WSTATUS\r\n", &pkt_dat);
 
   if (r != TYPE_OK)
     {
@@ -2017,7 +2018,8 @@ static enum pkt_type_e gs2200m_send_bulk(FAR struct gs2200m_dev_s *dev,
 
   /* Send the bulk data */
 
-  s = gs2200m_hal_write(dev, (char *)dev->tx_buff, msg->len + bulk_hdr_size);
+  s = gs2200m_hal_write(dev, (FAR char *)dev->tx_buff,
+                        msg->len + bulk_hdr_size);
 
   if (s == SPI_TIMEOUT)
     {
@@ -3502,6 +3504,7 @@ FAR void *gs2200m_register(FAR const char *devpath,
   dev->spi   = spi;
   dev->path  = strdup(devpath);
   dev->lower = lower;
+  dev->pfd   = NULL;
 
   nxmutex_init(&dev->dev_lock);
 

--- a/drivers/wireless/ieee80211/bcm43xxx/bcmf_driver.c
+++ b/drivers/wireless/ieee80211/bcm43xxx/bcmf_driver.c
@@ -1980,17 +1980,7 @@ int bcmf_wl_set_ssid(FAR struct bcmf_dev_s *priv, struct iwreq *iwr)
 
   /* Init authentication signal semaphore */
 
-  ret = nxsem_init(&auth_signal, 0, 0);
-  if (ret == OK)
-    {
-      ret = nxsem_set_protocol(&auth_signal, SEM_PRIO_NONE);
-    }
-
-  if (ret < OK)
-    {
-      goto errout_with_auth;
-    }
-
+  nxsem_init(&auth_signal, 0, 0);
   priv->auth_signal = &auth_signal;
 
   ssid.ssid_len = iwr->u.essid.length;

--- a/drivers/wireless/ieee80211/bcm43xxx/bcmf_gspi.c
+++ b/drivers/wireless/ieee80211/bcm43xxx/bcmf_gspi.c
@@ -71,9 +71,9 @@ extern const struct bcmf_chip_data g_cyw43439_config_data;
 
 /* Chip-common registers */
 
-#define CHIPCOMMON_GPIO_CONTROL ((uint32_t)(0x18000000 + 0x06c) )
-#define CHIPCOMMON_SR_CONTROL0  ((uint32_t)(0x18000000 + 0x504) )
-#define CHIPCOMMON_SR_CONTROL1  ((uint32_t)(0x18000000 + 0x508) )
+#define CHIPCOMMON_GPIO_CONTROL ((uint32_t)(0x18000000 + 0x06c))
+#define CHIPCOMMON_SR_CONTROL0  ((uint32_t)(0x18000000 + 0x504))
+#define CHIPCOMMON_SR_CONTROL1  ((uint32_t)(0x18000000 + 0x508))
 
 /****************************************************************************
  * Private Data
@@ -337,9 +337,9 @@ static int bcmf_gspi_bus_lowpower(FAR bcmf_gspi_dev_t *gbus, bool enable)
  * Name: bcmf_gspi_thread_isr
  ****************************************************************************/
 
-static int bcmf_gspi_thread_isr(int isr, void *context, void *arg)
+static int bcmf_gspi_thread_isr(int isr, FAR void *context, FAR void *arg)
 {
-  FAR bcmf_gspi_dev_t *gbus = (FAR bcmf_gspi_dev_t  *) arg;
+  FAR bcmf_gspi_dev_t *gbus = (FAR bcmf_gspi_dev_t *)arg;
   FAR gspi_dev_t      *gspi = gbus->gspi;
   int                 semcount;
 
@@ -613,9 +613,9 @@ static int bcmf_gspi_init_device(FAR bcmf_gspi_dev_t *gbus)
 
 static int bcmf_gspi_probe_chip(FAR bcmf_gspi_dev_t *gbus)
 {
-  uint32_t        value;
-  int             chipid;
-  int             ret;
+  uint32_t value;
+  int      chipid;
+  int      ret;
 
   wlinfo("entered\n");
 
@@ -817,11 +817,10 @@ static int bcmf_gspi_hw_uninitialize(FAR bcmf_gspi_dev_t *gbus)
  *
  ****************************************************************************/
 
-static int bcmf_bus_gspi_initialize(FAR struct bcmf_dev_s  *priv,
-                                    FAR struct gspi_dev_s  *gspi)
+static int bcmf_bus_gspi_initialize(FAR struct bcmf_dev_s *priv,
+                                    FAR struct gspi_dev_s *gspi)
 {
   FAR bcmf_gspi_dev_t *gbus;
-  int                  ret;
 
   wlinfo("entered.\n");
 
@@ -856,11 +855,7 @@ static int bcmf_bus_gspi_initialize(FAR struct bcmf_dev_s  *priv,
 
   /* Init transmit frames queue */
 
-  if ((ret = nxmutex_init(&gbus->queue_lock)) != OK)
-    {
-      goto exit_free_bus;
-    }
-
+  nxmutex_init(&gbus->queue_lock);
   list_initialize(&gbus->tx_queue);
   list_initialize(&gbus->rx_queue);
 
@@ -870,10 +865,7 @@ static int bcmf_bus_gspi_initialize(FAR struct bcmf_dev_s  *priv,
 
   /* Init thread semaphore */
 
-  if ((ret = nxsem_init(&gbus->thread_signal, 0, 0)) != OK)
-    {
-      goto exit_free_bus;
-    }
+  nxsem_init(&gbus->thread_signal, 0, 0);
 
   /* Register sdio bus */
 
@@ -886,13 +878,6 @@ static int bcmf_bus_gspi_initialize(FAR struct bcmf_dev_s  *priv,
   wlinfo("complete.\n");
 
   return OK;
-
-exit_free_bus:
-  wlinfo("failed.\n");
-
-  kmm_free(gbus);
-  priv->bus = NULL;
-  return ret;
 }
 
 /****************************************************************************
@@ -947,11 +932,11 @@ exit_free_device:
 int bcmf_bus_gspi_active(FAR struct bcmf_dev_s *priv,
                          bool                   active)
 {
-  FAR bcmf_gspi_dev_t  *gbus = (FAR bcmf_gspi_dev_t *)priv->bus;
-  FAR gspi_dev_t       *gspi = gbus->gspi;
-  int                   ret  = OK;
-  FAR char             *argv[2];
-  char                  arg1[32];
+  FAR bcmf_gspi_dev_t *gbus = (FAR bcmf_gspi_dev_t *)priv->bus;
+  FAR gspi_dev_t      *gspi = gbus->gspi;
+  int                  ret  = OK;
+  FAR char            *argv[2];
+  char                 arg1[32];
 
   wlinfo("entered.  active = %d\n", active);
 
@@ -1082,7 +1067,7 @@ int bcmf_transfer_bytes(FAR bcmf_gspi_dev_t *gbus,
                         function,
                         address,
                         len,
-                        (FAR uint32_t *) buf);
+                        (FAR uint32_t *)buf);
 
       return ret;
     }
@@ -1094,7 +1079,7 @@ int bcmf_transfer_bytes(FAR bcmf_gspi_dev_t *gbus,
                    function,
                    address,
                    len,
-                   (FAR uint32_t *) buf);
+                   (FAR uint32_t *)buf);
 
   return ret;
 }

--- a/drivers/wireless/ieee80211/bcm43xxx/bcmf_sdio.c
+++ b/drivers/wireless/ieee80211/bcm43xxx/bcmf_sdio.c
@@ -66,9 +66,9 @@
 
 /* Chip-common registers */
 
-#define CHIPCOMMON_GPIO_CONTROL ((uint32_t)(0x18000000 + 0x6c) )
-#define CHIPCOMMON_SR_CONTROL0  ((uint32_t)(0x18000000 + 0x504) )
-#define CHIPCOMMON_SR_CONTROL1  ((uint32_t)(0x18000000 + 0x508) )
+#define CHIPCOMMON_GPIO_CONTROL ((uint32_t)(0x18000000 + 0x6c))
+#define CHIPCOMMON_SR_CONTROL0  ((uint32_t)(0x18000000 + 0x504))
+#define CHIPCOMMON_SR_CONTROL1  ((uint32_t)(0x18000000 + 0x508))
 
 /****************************************************************************
  * Public Data
@@ -652,7 +652,6 @@ static int bcmf_bus_sdio_initialize(FAR struct bcmf_dev_s *priv,
   /* Allocate sdio bus structure */
 
   sbus = (FAR struct bcmf_sdio_dev_s *)kmm_malloc(sizeof(*sbus));
-
   if (!sbus)
     {
       return -ENOMEM;
@@ -674,11 +673,7 @@ static int bcmf_bus_sdio_initialize(FAR struct bcmf_dev_s *priv,
 
   /* Init transmit frames queue */
 
-  if ((ret = nxmutex_init(&sbus->queue_lock)) != OK)
-    {
-      goto exit_free_bus;
-    }
-
+  nxmutex_init(&sbus->queue_lock);
   list_initialize(&sbus->tx_queue);
   list_initialize(&sbus->rx_queue);
 
@@ -688,10 +683,7 @@ static int bcmf_bus_sdio_initialize(FAR struct bcmf_dev_s *priv,
 
   /* Init thread semaphore */
 
-  if ((ret = nxsem_init(&sbus->thread_signal, 0, 0)) != OK)
-    {
-      goto exit_free_bus;
-    }
+  nxsem_init(&sbus->thread_signal, 0, 0);
 
   /* Configure hardware */
 

--- a/drivers/wireless/ieee80211/bcm43xxx/bcmf_utils.c
+++ b/drivers/wireless/ieee80211/bcm43xxx/bcmf_utils.c
@@ -44,7 +44,7 @@
  * Name: bcmf_hexdump
  ****************************************************************************/
 
-void bcmf_hexdump(uint8_t *data, unsigned int len, unsigned long offset)
+void bcmf_hexdump(FAR uint8_t *data, unsigned int len, unsigned long offset)
 {
   unsigned int i;
   unsigned int char_count = 0;

--- a/drivers/wireless/ieee80211/bcm43xxx/bcmf_utils.h
+++ b/drivers/wireless/ieee80211/bcm43xxx/bcmf_utils.h
@@ -39,17 +39,17 @@
  * Public Function Prototypes
  ****************************************************************************/
 
-void bcmf_hexdump(uint8_t *data, unsigned int len, unsigned long offset);
+void bcmf_hexdump(FAR uint8_t *dat, unsigned int len, unsigned long offset);
 
-static inline uint16_t bcmf_getle16(void *val)
+static inline uint16_t bcmf_getle16(FAR void *val)
 {
-  uint8_t *valb = (uint8_t *)val;
+  FAR uint8_t *valb = (FAR uint8_t *)val;
   return (uint16_t)valb[0] << 8 | (uint16_t)valb[1];
 }
 
-static inline uint32_t bcmf_getle32(void *val)
+static inline uint32_t bcmf_getle32(FAR void *val)
 {
-  uint16_t *valw = (uint16_t *)val;
+  FAR uint16_t *valw = (FAR uint16_t *)val;
   return (uint32_t)bcmf_getle16(valw) << 16 | bcmf_getle16(valw + 1);
 }
 

--- a/drivers/wireless/lpwan/sx127x/sx127x.c
+++ b/drivers/wireless/lpwan/sx127x/sx127x.c
@@ -415,10 +415,10 @@ static int sx127x_txfifo_write(FAR struct sx127x_dev_s *dev,
                                FAR const uint8_t *data, size_t datalen);
 #endif
 #ifdef CONFIG_LPWAN_SX127X_RXSUPPORT
-static ssize_t sx127x_rxfifo_get(struct sx127x_dev_s *dev,
+static ssize_t sx127x_rxfifo_get(FAR struct sx127x_dev_s *dev,
                                  FAR uint8_t *buffer, size_t buflen);
-static void sx127x_rxfifo_put(struct sx127x_dev_s *dev, FAR uint8_t *buffer,
-                              size_t buflen);
+static void sx127x_rxfifo_put(FAR struct sx127x_dev_s *dev,
+                              FAR uint8_t *buffer, size_t buflen);
 #endif
 
 /* POSIX API */
@@ -494,7 +494,7 @@ static void sx127x_unlock(FAR struct spi_dev_s *spi)
  * Name: sx127x_select
  ****************************************************************************/
 
-static inline void sx127x_select(struct sx127x_dev_s * dev)
+static inline void sx127x_select(FAR struct sx127x_dev_s *dev)
 {
   SPI_SELECT(dev->spi, SPIDEV_LPWAN(0), true);
 }
@@ -503,7 +503,7 @@ static inline void sx127x_select(struct sx127x_dev_s * dev)
  * Name: sx127x_deselect
  ****************************************************************************/
 
-static inline void sx127x_deselect(struct sx127x_dev_s * dev)
+static inline void sx127x_deselect(FAR struct sx127x_dev_s *dev)
 {
   SPI_SELECT(dev->spi, SPIDEV_LPWAN(0), false);
 }
@@ -866,7 +866,7 @@ static ssize_t sx127x_read(FAR struct file *filep, FAR char *buffer,
 
   /* Get RX data from fifo */
 
-  ret = sx127x_rxfifo_get(dev, (uint8_t *)buffer, buflen);
+  ret = sx127x_rxfifo_get(dev, (FAR uint8_t *)buffer, buflen);
 
   nxmutex_unlock(&dev->dev_lock);
   return ret;
@@ -926,7 +926,7 @@ static ssize_t sx127x_write(FAR struct file *filep, FAR const char *buffer,
 
   /* Call modulation specific send */
 
-  ret = dev->ops.send(dev, (uint8_t *)buffer, buflen);
+  ret = dev->ops.send(dev, (FAR uint8_t *)buffer, buflen);
 
   /* Change mode to TX to start data transfer */
 
@@ -1497,7 +1497,7 @@ static void sx127x_isr0_process(FAR void *arg)
 {
   DEBUGASSERT(arg);
 
-  FAR struct sx127x_dev_s *dev = (struct sx127x_dev_s *)arg;
+  FAR struct sx127x_dev_s *dev = (FAR struct sx127x_dev_s *)arg;
   int ret = OK;
 
   /* Return immediately if isr0_process is not initialized */
@@ -1606,7 +1606,7 @@ static size_t sx127x_fskook_rxhandle(FAR struct sx127x_dev_s *dev)
 
   /* Put data on local fifo */
 
-  sx127x_rxfifo_put(dev, (uint8_t *)&rxdata, len);
+  sx127x_rxfifo_put(dev, (FAR uint8_t *)&rxdata, len);
 
   /* Return total length */
 
@@ -1684,7 +1684,7 @@ static size_t sx127x_lora_rxhandle(FAR struct sx127x_dev_s *dev)
 
   /* Put data on local fifo */
 
-  sx127x_rxfifo_put(dev, (uint8_t *)&rxdata, len);
+  sx127x_rxfifo_put(dev, (FAR uint8_t *)&rxdata, len);
 
   /* Return total length */
 
@@ -1863,7 +1863,7 @@ static int sx127x_fskook_send(FAR struct sx127x_dev_s *dev,
     {
       /* First byte is length */
 
-      ret = sx127x_txfifo_write(dev, (uint8_t *)&datalen, 1);
+      ret = sx127x_txfifo_write(dev, (FAR uint8_t *)&datalen, 1);
     }
 
   /* Write payload */

--- a/drivers/wireless/nrf24l01.c
+++ b/drivers/wireless/nrf24l01.c
@@ -330,7 +330,7 @@ static inline void nrf24l01_configspi(FAR struct spi_dev_s *spi)
  * Name: nrf24l01_select
  ****************************************************************************/
 
-static inline void nrf24l01_select(struct nrf24l01_dev_s * dev)
+static inline void nrf24l01_select(FAR struct nrf24l01_dev_s *dev)
 {
   SPI_SELECT(dev->spi, SPIDEV_WIRELESS(0), true);
 }
@@ -339,7 +339,7 @@ static inline void nrf24l01_select(struct nrf24l01_dev_s * dev)
  * Name: nrf24l01_deselect
  ****************************************************************************/
 
-static inline void nrf24l01_deselect(struct nrf24l01_dev_s * dev)
+static inline void nrf24l01_deselect(FAR struct nrf24l01_dev_s *dev)
 {
   SPI_SELECT(dev->spi, SPIDEV_WIRELESS(0), false);
 }
@@ -638,7 +638,7 @@ static inline bool nrf24l01_chipenable(FAR struct nrf24l01_dev_s *dev,
 #ifdef CONFIG_WL_NRF24L01_RXSUPPORT
 static void nrf24l01_worker(FAR void *arg)
 {
-  FAR struct nrf24l01_dev_s *dev = (FAR struct nrf24l01_dev_s *) arg;
+  FAR struct nrf24l01_dev_s *dev = (FAR struct nrf24l01_dev_s *)arg;
   uint8_t status;
   uint8_t fifo_status;
 
@@ -1053,7 +1053,8 @@ static ssize_t nrf24l01_read(FAR struct file *filep, FAR char *buffer,
         }
     }
 
-  ret = nrf24l01_recv(dev, (uint8_t *)buffer, buflen, &dev->last_recvpipeno);
+  ret = nrf24l01_recv(dev, (FAR uint8_t *)buffer, buflen,
+                      &dev->last_recvpipeno);
 
 errout:
   nxmutex_unlock(&dev->devlock);
@@ -1084,7 +1085,7 @@ static ssize_t nrf24l01_write(FAR struct file *filep, FAR const char *buffer,
       return ret;
     }
 
-  ret = nrf24l01_send(dev, (const uint8_t *)buffer, buflen);
+  ret = nrf24l01_send(dev, (FAR const uint8_t *)buffer, buflen);
 
   nxmutex_unlock(&dev->devlock);
   return ret;

--- a/fs/fat/fs_fat32.h
+++ b/fs/fat/fs_fat32.h
@@ -861,8 +861,8 @@
 struct fat_file_s;
 struct fat_mountpt_s
 {
-  struct inode      *fs_blkdriver; /* The block driver inode that hosts the FAT32 fs */
-  struct fat_file_s *fs_head;      /* A list to all files opened on this mountpoint */
+  FAR struct inode      *fs_blkdriver; /* The block driver inode that hosts the FAT32 fs */
+  FAR struct fat_file_s *fs_head;      /* A list to all files opened on this mountpoint */
 
   mutex_t  fs_lock;                /* Used to assume thread-safe access */
   off_t    fs_hwsectorsize;        /* HW: Sector size reported by block driver */
@@ -896,7 +896,7 @@ struct fat_mountpt_s
 
 struct fat_file_s
 {
-  struct fat_file_s *ff_next;      /* Retained in a singly linked list */
+  FAR struct fat_file_s *ff_next;  /* Retained in a singly linked list */
   uint8_t  ff_bflags;              /* The file buffer/mount flags */
   uint8_t  ff_oflags;              /* Flags provided when file was opened */
   uint8_t  ff_sectorsincluster;    /* Sectors remaining in cluster */
@@ -1013,10 +1013,10 @@ extern "C"
 
 /* Utitilies to handle unaligned or byte swapped accesses */
 
-EXTERN uint16_t fat_getuint16(uint8_t *ptr);
-EXTERN uint32_t fat_getuint32(uint8_t *ptr);
-EXTERN void   fat_putuint16(uint8_t *ptr, uint16_t value16);
-EXTERN void   fat_putuint32(uint8_t *ptr, uint32_t value32);
+EXTERN uint16_t fat_getuint16(FAR uint8_t *ptr);
+EXTERN uint32_t fat_getuint32(FAR uint8_t *ptr);
+EXTERN void   fat_putuint16(FAR uint8_t *ptr, uint16_t value16);
+EXTERN void   fat_putuint32(FAR uint8_t *ptr, uint32_t value32);
 
 /* Get the current time for FAT creation and write times */
 
@@ -1025,79 +1025,84 @@ EXTERN time_t fat_fattime2systime(uint16_t fattime, uint16_t fatdate);
 
 /* Handle hardware interactions for mounting */
 
-EXTERN int    fat_mount(struct fat_mountpt_s *fs, bool writeable);
-EXTERN int    fat_checkmount(struct fat_mountpt_s *fs);
+EXTERN int    fat_mount(FAR struct fat_mountpt_s *fs, bool writeable);
+EXTERN int    fat_checkmount(FAR struct fat_mountpt_s *fs);
 
 /* low-level hardware access */
 
-EXTERN int    fat_hwread(struct fat_mountpt_s *fs, uint8_t *buffer,
+EXTERN int    fat_hwread(FAR struct fat_mountpt_s *fs, FAR uint8_t *buffer,
                          off_t sector, unsigned int nsectors);
-EXTERN int    fat_hwwrite(struct fat_mountpt_s *fs, uint8_t *buffer,
+EXTERN int    fat_hwwrite(FAR struct fat_mountpt_s *fs, FAR uint8_t *buffer,
                           off_t sector, unsigned int nsectors);
 
 /* Cluster / cluster chain access helpers */
 
-EXTERN off_t  fat_cluster2sector(struct fat_mountpt_s *fs, uint32_t cluster);
-EXTERN off_t  fat_getcluster(struct fat_mountpt_s *fs, uint32_t clusterno);
-EXTERN int    fat_putcluster(struct fat_mountpt_s *fs, uint32_t clusterno,
-                             off_t startsector);
-EXTERN int    fat_removechain(struct fat_mountpt_s *fs, uint32_t cluster);
-EXTERN int32_t fat_extendchain(struct fat_mountpt_s *fs, uint32_t cluster);
+EXTERN off_t  fat_cluster2sector(FAR struct fat_mountpt_s *fs,
+                                 uint32_t cluster);
+EXTERN off_t  fat_getcluster(FAR struct fat_mountpt_s *fs,
+                             uint32_t clusterno);
+EXTERN int    fat_putcluster(FAR struct fat_mountpt_s *fs,
+                             uint32_t clusterno, off_t startsector);
+EXTERN int    fat_removechain(FAR struct fat_mountpt_s *fs,
+                              uint32_t cluster);
+EXTERN int32_t fat_extendchain(FAR struct fat_mountpt_s *fs,
+                               uint32_t cluster);
 
 #define fat_createchain(fs) fat_extendchain(fs, 0)
 
 /* Help for traversing directory trees and accessing directory entries */
 
-EXTERN int    fat_nextdirentry(struct fat_mountpt_s *fs,
-                               struct fs_fatdir_s *dir);
-EXTERN int    fat_finddirentry(struct fat_mountpt_s *fs,
-                               struct fat_dirinfo_s *dirinfo,
-                               const char *path);
-EXTERN int    fat_dirnamewrite(struct fat_mountpt_s *fs,
-                               struct fat_dirinfo_s *dirinfo);
-EXTERN int    fat_dirwrite(struct fat_mountpt_s *fs,
-                           struct fat_dirinfo_s *dirinfo,
+EXTERN int    fat_nextdirentry(FAR struct fat_mountpt_s *fs,
+                               FAR struct fs_fatdir_s *dir);
+EXTERN int    fat_finddirentry(FAR struct fat_mountpt_s *fs,
+                               FAR struct fat_dirinfo_s *dirinfo,
+                               FAR const char *path);
+EXTERN int    fat_dirnamewrite(FAR struct fat_mountpt_s *fs,
+                               FAR struct fat_dirinfo_s *dirinfo);
+EXTERN int    fat_dirwrite(FAR struct fat_mountpt_s *fs,
+                           FAR struct fat_dirinfo_s *dirinfo,
                            uint8_t attributes, uint32_t fattime);
-EXTERN int    fat_allocatedirentry(struct fat_mountpt_s *fs,
-                                   struct fat_dirinfo_s *dirinfo);
-EXTERN int    fat_freedirentry(struct fat_mountpt_s *fs,
-                               struct fat_dirseq_s *seq);
+EXTERN int    fat_allocatedirentry(FAR struct fat_mountpt_s *fs,
+                                   FAR struct fat_dirinfo_s *dirinfo);
+EXTERN int    fat_freedirentry(FAR struct fat_mountpt_s *fs,
+                               FAR struct fat_dirseq_s *seq);
 EXTERN int    fat_dirname2path(FAR struct fat_mountpt_s *fs,
                                FAR struct fs_dirent_s *dir,
                                FAR struct dirent *entry);
 
 /* File creation and removal helpers */
 
-EXTERN int    fat_dirtruncate(struct fat_mountpt_s *fs,
+EXTERN int    fat_dirtruncate(FAR struct fat_mountpt_s *fs,
                               FAR uint8_t *direntry);
-EXTERN int    fat_dirshrink(struct fat_mountpt_s *fs, FAR uint8_t *direntry,
-                            off_t length);
-EXTERN int    fat_dirextend(FAR struct fat_mountpt_s *fs,
-                            FAR struct fat_file_s *ff, off_t length);
-EXTERN int    fat_dircreate(struct fat_mountpt_s *fs,
-                            struct fat_dirinfo_s *dirinfo);
-EXTERN int    fat_remove(struct fat_mountpt_s *fs, const char *relpath,
+EXTERN int    fat_dirshrink(FAR struct fat_mountpt_s *fs,
+                            FAR uint8_t *direntry, off_t length);
+EXTERN int    fat_dirextend(FAR FAR struct fat_mountpt_s *fs,
+                            FAR FAR struct fat_file_s *ff, off_t length);
+EXTERN int    fat_dircreate(FAR struct fat_mountpt_s *fs,
+                            FAR struct fat_dirinfo_s *dirinfo);
+EXTERN int    fat_remove(FAR struct fat_mountpt_s *fs,
+                         FAR const char *relpath,
                          bool directory);
 
 /* Mountpoint and file buffer cache (for partial sector accesses) */
 
-EXTERN int    fat_fscacheflush(struct fat_mountpt_s *fs);
-EXTERN int    fat_fscacheread(struct fat_mountpt_s *fs, off_t sector);
-EXTERN int    fat_ffcacheflush(struct fat_mountpt_s *fs,
-                               struct fat_file_s *ff);
-EXTERN int    fat_ffcacheread(struct fat_mountpt_s *fs,
-                              struct fat_file_s *ff, off_t sector);
-EXTERN int    fat_ffcacheinvalidate(struct fat_mountpt_s *fs,
-                                    struct fat_file_s *ff);
+EXTERN int    fat_fscacheflush(FAR struct fat_mountpt_s *fs);
+EXTERN int    fat_fscacheread(FAR struct fat_mountpt_s *fs, off_t sector);
+EXTERN int    fat_ffcacheflush(FAR struct fat_mountpt_s *fs,
+                               FAR struct fat_file_s *ff);
+EXTERN int    fat_ffcacheread(FAR struct fat_mountpt_s *fs,
+                              FAR struct fat_file_s *ff, off_t sector);
+EXTERN int    fat_ffcacheinvalidate(FAR struct fat_mountpt_s *fs,
+                                    FAR struct fat_file_s *ff);
 
 /* FSINFO sector support */
 
-EXTERN int    fat_updatefsinfo(struct fat_mountpt_s *fs);
-EXTERN int    fat_computefreeclusters(struct fat_mountpt_s *fs);
-EXTERN int    fat_nfreeclusters(struct fat_mountpt_s *fs,
-                                fsblkcnt_t *pfreeclusters);
-EXTERN int    fat_currentsector(struct fat_mountpt_s *fs,
-                                struct fat_file_s *ff, off_t position);
+EXTERN int    fat_updatefsinfo(FAR struct fat_mountpt_s *fs);
+EXTERN int    fat_computefreeclusters(FAR struct fat_mountpt_s *fs);
+EXTERN int    fat_nfreeclusters(FAR struct fat_mountpt_s *fs,
+                                FAR fsblkcnt_t *pfreeclusters);
+EXTERN int    fat_currentsector(FAR struct fat_mountpt_s *fs,
+                                FAR struct fat_file_s *ff, off_t position);
 
 #undef EXTERN
 #if defined(__cplusplus)

--- a/fs/fat/fs_fat32dirent.c
+++ b/fs/fat/fs_fat32dirent.c
@@ -1147,9 +1147,9 @@ static int fat_findsfnentry(FAR struct fat_mountpt_s *fs,
   uint16_t diroffset;
   FAR uint8_t *direntry;
 #ifdef CONFIG_FAT_LFN
-  off_t    startsector;
+  off_t startsector;
 #endif
-  int      ret;
+  int ret;
 
   /* Save the starting sector of the directory.  This is not really needed
    * for short name entries, but this keeps things consistent with long
@@ -2702,11 +2702,11 @@ int fat_finddirentry(FAR struct fat_mountpt_s *fs,
 int fat_allocatedirentry(FAR struct fat_mountpt_s *fs,
                          FAR struct fat_dirinfo_s *dirinfo)
 {
-  int32_t  cluster;
-  int32_t  prevcluster;
-  off_t    sector;
-  int      ret;
-  int      i;
+  int32_t cluster;
+  int32_t prevcluster;
+  off_t   sector;
+  int     ret;
+  int     i;
 
   /* Re-initialize directory object */
 
@@ -2909,7 +2909,7 @@ int fat_freedirentry(FAR struct fat_mountpt_s *fs, struct fat_dirseq_s *seq)
 
 #else
   FAR uint8_t *direntry;
-  int      ret;
+  int ret;
 
   /* Free the single short file name entry.
    *

--- a/fs/hostfs/hostfs.h
+++ b/fs/hostfs/hostfs.h
@@ -60,8 +60,8 @@ struct hostfs_ofile_s
 
 struct hostfs_mountpt_s
 {
-  FAR struct hostfs_ofile_s  *fs_head;      /* A singly-linked list of open files */
-  char                        fs_root[HOSTFS_MAX_PATH];
+  FAR struct hostfs_ofile_s *fs_head;      /* A singly-linked list of open files */
+  char                       fs_root[HOSTFS_MAX_PATH];
 };
 
 /****************************************************************************

--- a/fs/nfs/nfs_mount.h
+++ b/fs/nfs/nfs_mount.h
@@ -69,7 +69,7 @@ struct nfsmount
 {
   FAR struct nfsnode       *nm_head;          /* A list of all files opened on this mountpoint */
   mutex_t                   nm_lock;          /* Used to assure thread-safe access */
-  nfsfh_t                  *nm_fh;            /* File handle of root dir */
+  FAR nfsfh_t              *nm_fh;            /* File handle of root dir */
   char                      nm_path[90];      /* server's path of the directory being mounted */
   struct nfs_fattr          nm_fattr;         /* nfs file attribute cache */
   FAR struct rpcclnt       *nm_rpcclnt;       /* RPC state */

--- a/fs/nfs/nfs_vfsops.c
+++ b/fs/nfs/nfs_vfsops.c
@@ -241,14 +241,14 @@ const struct mountpt_operations nfs_operations =
 static int nfs_filecreate(FAR struct nfsmount *nmp, FAR struct nfsnode *np,
                           FAR const char *relpath, mode_t mode)
 {
-  struct file_handle      fhandle;
-  struct nfs_fattr        fattr;
-  char                    filename[NAME_MAX + 1];
-  FAR uint32_t           *ptr;
-  uint32_t                tmp;
-  int                     namelen;
-  int                     reqlen;
-  int                     ret;
+  struct file_handle  fhandle;
+  struct nfs_fattr    fattr;
+  char                filename[NAME_MAX + 1];
+  FAR uint32_t       *ptr;
+  uint32_t            tmp;
+  int                 namelen;
+  int                 reqlen;
+  int                 ret;
 
   /* Find the NFS node of the directory containing the file to be created */
 
@@ -332,8 +332,8 @@ static int nfs_filecreate(FAR struct nfsmount *nmp, FAR struct nfsnode *np,
 
   nfs_statistics(NFSPROC_CREATE);
   ret = nfs_request(nmp, NFSPROC_CREATE,
-                    (FAR void *)&nmp->nm_msgbuffer.create, reqlen,
-                    (FAR void *)nmp->nm_iobuffer, nmp->nm_buflen);
+                    &nmp->nm_msgbuffer.create, reqlen,
+                    nmp->nm_iobuffer, nmp->nm_buflen);
 
   /* Check for success */
 
@@ -499,8 +499,8 @@ static int nfs_filechstat(FAR struct nfsmount *nmp, FAR struct nfsnode *np,
 
   nfs_statistics(NFSPROC_SETATTR);
   ret = nfs_request(nmp, NFSPROC_SETATTR,
-                    (FAR void *)&nmp->nm_msgbuffer.setattr, reqlen,
-                    (FAR void *)nmp->nm_iobuffer, nmp->nm_buflen);
+                    &nmp->nm_msgbuffer.setattr, reqlen,
+                    nmp->nm_iobuffer, nmp->nm_buflen);
   if (ret != OK)
     {
       ferr("ERROR: nfs_request failed: %d\n", ret);
@@ -778,8 +778,8 @@ static int nfs_close(FAR struct file *filep)
 
   /* Recover our private data from the struct file instance */
 
-  nmp = (FAR struct nfsmount *) filep->f_inode->i_private;
-  np  = (FAR struct nfsnode *) filep->f_priv;
+  nmp = (FAR struct nfsmount *)filep->f_inode->i_private;
+  np  = (FAR struct nfsnode *)filep->f_priv;
 
   DEBUGASSERT(nmp != NULL);
 
@@ -957,8 +957,8 @@ static ssize_t nfs_read(FAR struct file *filep, FAR char *buffer,
       finfo("Reading %zu bytes\n", readsize);
       nfs_statistics(NFSPROC_READ);
       ret = nfs_request(nmp, NFSPROC_READ,
-                        (FAR void *)&nmp->nm_msgbuffer.read, reqlen,
-                        (FAR void *)nmp->nm_iobuffer, nmp->nm_buflen);
+                        &nmp->nm_msgbuffer.read, reqlen,
+                        nmp->nm_iobuffer, nmp->nm_buflen);
       if (ret)
         {
           ferr("ERROR: nfs_request failed: %d\n", ret);
@@ -1035,17 +1035,17 @@ errout_with_lock:
 static ssize_t nfs_write(FAR struct file *filep, FAR const char *buffer,
                          size_t buflen)
 {
-  FAR struct nfsmount   *nmp;
-  FAR struct nfsnode    *np;
-  ssize_t                writesize;
-  ssize_t                bufsize;
-  ssize_t                byteswritten = 0;
-  size_t                 reqlen;
-  FAR uint32_t          *ptr;
-  uint32_t               tmp;
-  int                    commit = 0;
-  int                    committed = NFSV3WRITE_FILESYNC;
-  int                    ret;
+  FAR struct nfsmount *nmp;
+  FAR struct nfsnode  *np;
+  ssize_t              writesize;
+  ssize_t              bufsize;
+  ssize_t              byteswritten = 0;
+  size_t               reqlen;
+  FAR uint32_t        *ptr;
+  uint32_t             tmp;
+  int                  commit = 0;
+  int                  committed = NFSV3WRITE_FILESYNC;
+  int                  ret;
 
   finfo("Write %zu bytes to offset %jd\n",
         buflen, (intmax_t)filep->f_pos);
@@ -1140,8 +1140,8 @@ static ssize_t nfs_write(FAR struct file *filep, FAR const char *buffer,
 
       nfs_statistics(NFSPROC_WRITE);
       ret = nfs_request(nmp, NFSPROC_WRITE,
-                        (FAR void *)nmp->nm_iobuffer, reqlen,
-                        (FAR void *)&nmp->nm_msgbuffer.write,
+                        nmp->nm_iobuffer, reqlen,
+                        &nmp->nm_msgbuffer.write,
                         sizeof(struct rpc_reply_write));
       if (ret)
         {
@@ -1579,8 +1579,8 @@ read_dir:
 
   nfs_statistics(NFSPROC_READDIR);
   ret = nfs_request(nmp, NFSPROC_READDIR,
-                    (FAR void *)&nmp->nm_msgbuffer.readdir, reqlen,
-                    (FAR void *)nmp->nm_iobuffer, nmp->nm_buflen);
+                    &nmp->nm_msgbuffer.readdir, reqlen,
+                    nmp->nm_iobuffer, nmp->nm_buflen);
   if (ret != OK)
     {
       ferr("ERROR: nfs_request failed: %d\n", ret);
@@ -2081,7 +2081,7 @@ static int nfs_bind(FAR struct inode *blkdriver, FAR const void *data,
 
   /* Mounted! */
 
-  *handle = (FAR void *)nmp;
+  *handle = nmp;
 
   finfo("Successfully mounted\n");
   return OK;
@@ -2198,8 +2198,8 @@ static int nfs_fsinfo(FAR struct nfsmount *nmp)
 
   nfs_statistics(NFSPROC_FSINFO);
   ret = nfs_request(nmp, NFSPROC_FSINFO,
-                    (FAR void *)fsinfo, sizeof(struct FS3args),
-                    (FAR void *)nmp->nm_iobuffer, nmp->nm_buflen);
+                    fsinfo, sizeof(struct FS3args),
+                    nmp->nm_iobuffer, nmp->nm_buflen);
   if (ret)
     {
       return ret;
@@ -2264,8 +2264,8 @@ static int nfs_fsinfo(FAR struct nfsmount *nmp)
     {
       nfs_statistics(NFSPROC_GETATTR);
       ret = nfs_request(nmp, NFSPROC_GETATTR,
-                        (FAR void *)fsinfo, sizeof(struct FS3args),
-                        (FAR void *)nmp->nm_iobuffer, nmp->nm_buflen);
+                        fsinfo, sizeof(struct FS3args),
+                        nmp->nm_iobuffer, nmp->nm_buflen);
       if (ret)
         {
           return ret;
@@ -2321,8 +2321,8 @@ static int nfs_statfs(FAR struct inode *mountpt, FAR struct statfs *sbp)
 
   nfs_statistics(NFSPROC_FSSTAT);
   ret = nfs_request(nmp, NFSPROC_FSSTAT,
-                    (FAR void *)fsstat, sizeof(struct FS3args),
-                    (FAR void *)nmp->nm_iobuffer, nmp->nm_buflen);
+                    fsstat, sizeof(struct FS3args),
+                    nmp->nm_iobuffer, nmp->nm_buflen);
   if (ret)
     {
       goto errout_with_lock;
@@ -2360,14 +2360,14 @@ errout_with_lock:
 
 static int nfs_remove(FAR struct inode *mountpt, FAR const char *relpath)
 {
-  FAR struct nfsmount    *nmp;
-  struct file_handle      fhandle;
-  struct nfs_fattr        fattr;
-  char                    filename[NAME_MAX + 1];
-  FAR uint32_t           *ptr;
-  int                     namelen;
-  int                     reqlen;
-  int                     ret;
+  FAR struct nfsmount *nmp;
+  struct file_handle   fhandle;
+  struct nfs_fattr     fattr;
+  char                 filename[NAME_MAX + 1];
+  FAR uint32_t        *ptr;
+  int                  namelen;
+  int                  reqlen;
+  int                  ret;
 
   /* Sanity checks */
 
@@ -2420,8 +2420,8 @@ static int nfs_remove(FAR struct inode *mountpt, FAR const char *relpath)
 
   nfs_statistics(NFSPROC_REMOVE);
   ret = nfs_request(nmp, NFSPROC_REMOVE,
-                    (FAR void *)&nmp->nm_msgbuffer.removef, reqlen,
-                    (FAR void *)nmp->nm_iobuffer, nmp->nm_buflen);
+                    &nmp->nm_msgbuffer.removef, reqlen,
+                    nmp->nm_iobuffer, nmp->nm_buflen);
 
 errout_with_lock:
   nxmutex_unlock(&nmp->nm_lock);
@@ -2442,15 +2442,15 @@ errout_with_lock:
 static int nfs_mkdir(FAR struct inode *mountpt, FAR const char *relpath,
                      mode_t mode)
 {
-  FAR struct nfsmount   *nmp;
-  struct file_handle     fhandle;
-  struct nfs_fattr       fattr;
-  char                   dirname[NAME_MAX + 1];
-  FAR uint32_t          *ptr;
-  uint32_t               tmp;
-  int                    namelen;
-  int                    reqlen;
-  int                    ret;
+  FAR struct nfsmount *nmp;
+  struct file_handle   fhandle;
+  struct nfs_fattr     fattr;
+  char                 dirname[NAME_MAX + 1];
+  FAR uint32_t        *ptr;
+  uint32_t             tmp;
+  int                  namelen;
+  int                  reqlen;
+  int                  ret;
 
   /* Sanity checks */
 
@@ -2458,7 +2458,7 @@ static int nfs_mkdir(FAR struct inode *mountpt, FAR const char *relpath,
 
   /* Get the mountpoint private data from the inode structure */
 
-  nmp = (FAR struct nfsmount *) mountpt->i_private;
+  nmp = (FAR struct nfsmount *)mountpt->i_private;
 
   ret = nxmutex_lock(&nmp->nm_lock);
   if (ret < 0)
@@ -2543,8 +2543,8 @@ static int nfs_mkdir(FAR struct inode *mountpt, FAR const char *relpath,
 
   nfs_statistics(NFSPROC_MKDIR);
   ret = nfs_request(nmp, NFSPROC_MKDIR,
-                    (FAR void *)&nmp->nm_msgbuffer.mkdir, reqlen,
-                    (FAR void *)&nmp->nm_iobuffer, nmp->nm_buflen);
+                    &nmp->nm_msgbuffer.mkdir, reqlen,
+                    &nmp->nm_iobuffer, nmp->nm_buflen);
   if (ret)
     {
       ferr("ERROR: nfs_request failed: %d\n", ret);
@@ -2568,14 +2568,14 @@ errout_with_lock:
 
 static int nfs_rmdir(FAR struct inode *mountpt, FAR const char *relpath)
 {
-  FAR struct nfsmount   *nmp;
-  struct file_handle     fhandle;
-  struct nfs_fattr       fattr;
-  char                   dirname[NAME_MAX + 1];
-  FAR uint32_t          *ptr;
-  int                    namelen;
-  int                    reqlen;
-  int                    ret;
+  FAR struct nfsmount *nmp;
+  struct file_handle   fhandle;
+  struct nfs_fattr     fattr;
+  char                 dirname[NAME_MAX + 1];
+  FAR uint32_t        *ptr;
+  int                  namelen;
+  int                  reqlen;
+  int                  ret;
 
   /* Sanity checks */
 
@@ -2630,8 +2630,8 @@ static int nfs_rmdir(FAR struct inode *mountpt, FAR const char *relpath)
 
   nfs_statistics(NFSPROC_RMDIR);
   ret = nfs_request(nmp, NFSPROC_RMDIR,
-                        (FAR void *)&nmp->nm_msgbuffer.rmdir, reqlen,
-                        (FAR void *)nmp->nm_iobuffer, nmp->nm_buflen);
+                    &nmp->nm_msgbuffer.rmdir, reqlen,
+                    nmp->nm_iobuffer, nmp->nm_buflen);
 
 errout_with_lock:
   nxmutex_unlock(&nmp->nm_lock);
@@ -2652,16 +2652,16 @@ errout_with_lock:
 static int nfs_rename(FAR struct inode *mountpt, FAR const char *oldrelpath,
                       FAR const char *newrelpath)
 {
-  FAR struct nfsmount    *nmp;
-  struct file_handle      from_handle;
-  struct file_handle      to_handle;
-  char                    from_name[NAME_MAX + 1];
-  char                    to_name[NAME_MAX + 1];
-  struct nfs_fattr        fattr;
-  FAR uint32_t           *ptr;
-  int                     namelen;
-  int                     reqlen;
-  int                     ret;
+  FAR struct nfsmount *nmp;
+  struct file_handle   from_handle;
+  struct file_handle   to_handle;
+  char                 from_name[NAME_MAX + 1];
+  char                 to_name[NAME_MAX + 1];
+  struct nfs_fattr     fattr;
+  FAR uint32_t        *ptr;
+  int                  namelen;
+  int                  reqlen;
+  int                  ret;
 
   /* Sanity checks */
 
@@ -2743,8 +2743,8 @@ static int nfs_rename(FAR struct inode *mountpt, FAR const char *oldrelpath,
 
   nfs_statistics(NFSPROC_RENAME);
   ret = nfs_request(nmp, NFSPROC_RENAME,
-                    (FAR void *)&nmp->nm_msgbuffer.renamef, reqlen,
-                    (FAR void *)nmp->nm_iobuffer, nmp->nm_buflen);
+                    &nmp->nm_msgbuffer.renamef, reqlen,
+                    nmp->nm_iobuffer, nmp->nm_buflen);
 
 errout_with_lock:
   nxmutex_unlock(&nmp->nm_lock);

--- a/fs/nxffs/nxffs_initialize.c
+++ b/fs/nxffs/nxffs_initialize.c
@@ -305,6 +305,7 @@ errout_with_cache:
   kmm_free(volume->cache);
 errout_with_volume:
   nxmutex_destroy(&volume->lock);
+  nxsem_destroy(&volume->wrsem);
 #ifndef CONFIG_NXFFS_PREALLOCATED
   kmm_free(volume);
 #endif

--- a/fs/nxffs/nxffs_open.c
+++ b/fs/nxffs/nxffs_open.c
@@ -1094,7 +1094,7 @@ int nxffs_dup(FAR const struct file *oldp, FAR struct file *newp)
   /* Just increment the reference count on the ofile */
 
   ofile->crefs++;
-  newp->f_priv = (FAR void *)ofile;
+  newp->f_priv = ofile;
   return OK;
 }
 

--- a/fs/romfs/fs_romfs.c
+++ b/fs/romfs/fs_romfs.c
@@ -602,7 +602,7 @@ static int romfs_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
        * the file.
        */
 
-      *ppv = (FAR void *)(rm->rm_xipbase + rf->rf_startoffset);
+      *ppv = rm->rm_xipbase + rf->rf_startoffset;
       return OK;
     }
   else if (cmd == FIOC_FILEPATH)
@@ -1098,7 +1098,7 @@ static int romfs_bind(FAR struct inode *blkdriver, FAR const void *data,
 
   /* Mounted! */
 
-  *handle = (FAR void *)rm;
+  *handle = rm;
   return OK;
 
 errout_with_buffer:

--- a/fs/smartfs/smartfs.h
+++ b/fs/smartfs/smartfs.h
@@ -33,7 +33,6 @@
 
 #include <nuttx/mtd/mtd.h>
 #include <nuttx/fs/smart.h>
-#include <nuttx/mutex.h>
 
 /****************************************************************************
  * Pre-processor Definitions
@@ -194,7 +193,7 @@
 #define SMARTFS_TRUNCBUFFER_SIZE 512
 
 #ifndef offsetof
-#  define offsetof(type, member) ((size_t) & (((type *)0)->member))
+#  define offsetof(type, member) ((size_t)&(((FAR type *)0)->member))
 #endif
 
 #ifdef CONFIG_SMARTFS_ALIGNED_ACCESS
@@ -207,12 +206,12 @@
                                             (uint16_t)(v))
 
 #else
-#  define SMARTFS_NEXTSECTOR(h)        (*((uint16_t *)h->nextsector))
-#  define SMARTFS_SET_NEXTSECTOR(h, v) ((*((uint16_t *)h->nextsector)) = \
+#  define SMARTFS_NEXTSECTOR(h)        (*((FAR uint16_t *)h->nextsector))
+#  define SMARTFS_SET_NEXTSECTOR(h, v) ((*((FAR uint16_t *)h->nextsector)) = \
                                             (uint16_t)(v))
 
-#  define SMARTFS_USED(h)              (*((uint16_t *)h->used))
-#  define SMARTFS_SET_USED(h, v)       ((*((uint16_t *)h->used)) = \
+#  define SMARTFS_USED(h)              (*((FAR uint16_t *)h->used))
+#  define SMARTFS_SET_USED(h, v)       ((*((FAR uint16_t *)h->used)) = \
                                             (uint16_t)(v))
 #endif
 
@@ -290,24 +289,24 @@ struct smartfs_chain_header_s
 
 struct smartfs_ofile_s
 {
-  struct smartfs_ofile_s   *fnext;        /* Supports a singly linked list */
+  FAR struct smartfs_ofile_s *fnext;        /* Supports a singly linked list */
 #ifdef CONFIG_SMARTFS_USE_SECTOR_BUFFER
-  uint8_t                  *buffer;       /* Sector buffer to reduce writes */
-  uint8_t                   bflags;       /* Buffer flags */
+  FAR uint8_t                *buffer;       /* Sector buffer to reduce writes */
+  uint8_t                     bflags;       /* Buffer flags */
 #endif
-  int16_t                   crefs;        /* Reference count */
-  mode_t                    oflags;       /* Open mode */
-  struct smartfs_entry_s    entry;        /* Describes the SMARTFS inode entry */
-  size_t                    filepos;      /* Current file position */
-  uint16_t                  currsector;   /* Current sector of filepos */
-  uint16_t                  curroffset;   /* Current offset in sector */
-  uint16_t                  byteswritten; /* Count of bytes written to currsector
-                                           * that have not been recorded in the
-                                           * sector yet.  We delay updating the
-                                           * used field until the file is closed,
-                                           * a seek, or more data is written that
-                                           * causes the sector to change.
-                                           */
+  int16_t                     crefs;        /* Reference count */
+  mode_t                      oflags;       /* Open mode */
+  struct smartfs_entry_s      entry;        /* Describes the SMARTFS inode entry */
+  size_t                      filepos;      /* Current file position */
+  uint16_t                    currsector;   /* Current sector of filepos */
+  uint16_t                    curroffset;   /* Current offset in sector */
+  uint16_t                    byteswritten; /* Count of bytes written to currsector
+                                             * that have not been recorded in the
+                                             * sector yet.  We delay updating the
+                                             * used field until the file is closed,
+                                             * a seek, or more data is written that
+                                             * causes the sector to change.
+                                             */
 };
 
 /* This structure represents the overall mountpoint state.  An instance of
@@ -318,15 +317,15 @@ struct smartfs_ofile_s
 struct smartfs_mountpt_s
 {
 #if defined(CONFIG_SMARTFS_MULTI_ROOT_DIRS) || defined(CONFIG_FS_PROCFS)
-  struct smartfs_mountpt_s   *fs_next;       /* Pointer to next SMART filesystem */
+  FAR struct smartfs_mountpt_s *fs_next;       /* Pointer to next SMART filesystem */
 #endif
-  FAR struct inode           *fs_blkdriver;  /* Our underlying block device */
-  FAR struct smartfs_ofile_s *fs_head;       /* A singly-linked list of open files */
-  bool                        fs_mounted;    /* true: The file system is ready */
-  struct smart_format_s       fs_llformat;   /* Low level device format info */
-  char                       *fs_rwbuffer;   /* Read/Write working buffer */
-  char                       *fs_workbuffer; /* Working buffer */
-  uint8_t                     fs_rootsector; /* Root directory sector num */
+  FAR struct inode             *fs_blkdriver;  /* Our underlying block device */
+  FAR struct smartfs_ofile_s   *fs_head;       /* A singly-linked list of open files */
+  bool                          fs_mounted;    /* true: The file system is ready */
+  struct smart_format_s         fs_llformat;   /* Low level device format info */
+  FAR char                     *fs_rwbuffer;   /* Read/Write working buffer */
+  FAR char                     *fs_workbuffer; /* Working buffer */
+  uint8_t                       fs_rootsector; /* Root directory sector num */
 };
 
 /****************************************************************************
@@ -377,18 +376,18 @@ int smartfs_extendfile(FAR struct smartfs_mountpt_s *fs,
 
 uint16_t smartfs_rdle16(FAR const void *val);
 
-void smartfs_wrle16(void *dest, uint16_t val);
+void smartfs_wrle16(FAR void *dest, uint16_t val);
 
 uint32_t smartfs_rdle32(FAR const void *val);
 
-void smartfs_wrle32(uint8_t *dest, uint32_t val);
+void smartfs_wrle32(FAR uint8_t *dest, uint32_t val);
 
 #if defined(CONFIG_FS_PROCFS) && !defined(CONFIG_FS_PROCFS_EXCLUDE_SMARTFS)
-struct smartfs_mountpt_s *smartfs_get_first_mount(void);
+FAR struct smartfs_mountpt_s *smartfs_get_first_mount(void);
 #endif
 
 #if defined(CONFIG_FS_PROCFS) && !defined(CONFIG_FS_PROCFS_EXCLUDE_SMARTFS)
-struct smartfs_mountpt_s *smartfs_get_first_mount(void);
+FAR struct smartfs_mountpt_s *smartfs_get_first_mount(void);
 #endif
 
 struct file;        /* Forward references */

--- a/fs/smartfs/smartfs_smart.c
+++ b/fs/smartfs/smartfs_smart.c
@@ -62,12 +62,12 @@ struct smartfs_dir_s
  * Private Function Prototypes
  ****************************************************************************/
 
-static int     smartfs_open(FAR struct file *filep, const char *relpath,
+static int     smartfs_open(FAR struct file *filep, FAR const char *relpath,
                         int oflags, mode_t mode);
 static int     smartfs_close(FAR struct file *filep);
-static ssize_t smartfs_read(FAR struct file *filep, char *buffer,
+static ssize_t smartfs_read(FAR struct file *filep, FAR char *buffer,
                         size_t buflen);
-static ssize_t smartfs_write(FAR struct file *filep, const char *buffer,
+static ssize_t smartfs_write(FAR struct file *filep, FAR const char *buffer,
                         size_t buflen);
 static off_t   smartfs_seek(FAR struct file *filep, off_t offset,
                         int whence);
@@ -90,12 +90,12 @@ static int     smartfs_readdir(FAR struct inode *mountpt,
                         FAR struct fs_dirent_s *dir,
                         FAR struct dirent *dentry);
 static int     smartfs_rewinddir(FAR struct inode *mountpt,
-                       FAR struct fs_dirent_s *dir);
+                        FAR struct fs_dirent_s *dir);
 
 static int     smartfs_bind(FAR struct inode *blkdriver,
                         FAR const void *data,
                         FAR void **handle);
-static int     smartfs_unbind(void *handle, FAR struct inode **blkdriver,
+static int     smartfs_unbind(FAR void *handle, FAR struct inode **blkdriver,
                         unsigned int flags);
 static int     smartfs_statfs(FAR struct inode *mountpt,
                         FAR struct statfs *buf);
@@ -109,7 +109,7 @@ static int     smartfs_rmdir(FAR struct inode *mountpt,
                         FAR const char *relpath);
 static int     smartfs_rename(FAR struct inode *mountpt,
                         FAR const char *oldrelpath,
-                        const char *newrelpath);
+                        FAR const char *newrelpath);
 static void    smartfs_stat_common(FAR struct smartfs_mountpt_s *fs,
                         FAR struct smartfs_entry_s *entry,
                         FAR struct stat *buf);
@@ -172,17 +172,17 @@ const struct mountpt_operations smartfs_operations =
  * Name: smartfs_open
  ****************************************************************************/
 
-static int smartfs_open(FAR struct file *filep, const char *relpath,
+static int smartfs_open(FAR struct file *filep, FAR const char *relpath,
                         int oflags, mode_t mode)
 {
-  struct inode             *inode;
-  struct smartfs_mountpt_s *fs;
-  int                       ret;
-  uint16_t                  parentdirsector;
-  const char               *filename;
-  struct smartfs_ofile_s   *sf;
+  FAR struct inode             *inode;
+  FAR struct smartfs_mountpt_s *fs;
+  int                           ret;
+  uint16_t                      parentdirsector;
+  FAR const char               *filename;
+  FAR struct smartfs_ofile_s   *sf;
 #ifdef CONFIG_SMARTFS_USE_SECTOR_BUFFER
-  struct smart_read_write_s readwrite;
+  struct smart_read_write_s     readwrite;
 #endif
 
   /* Sanity checks */
@@ -208,7 +208,7 @@ static int smartfs_open(FAR struct file *filep, const char *relpath,
 
   /* Locate the directory entry for this path */
 
-  sf = (struct smartfs_ofile_s *)kmm_malloc(sizeof *sf);
+  sf = (FAR struct smartfs_ofile_s *)kmm_malloc(sizeof *sf);
   if (sf == NULL)
     {
       ret = -ENOMEM;
@@ -218,7 +218,7 @@ static int smartfs_open(FAR struct file *filep, const char *relpath,
   /* Allocate a sector buffer if CRC enabled in the MTD layer */
 
 #ifdef CONFIG_SMARTFS_USE_SECTOR_BUFFER
-  sf->buffer = (uint8_t *)kmm_malloc(fs->fs_llformat.availbytes);
+  sf->buffer = (FAR uint8_t *)kmm_malloc(fs->fs_llformat.availbytes);
   if (sf->buffer == NULL)
     {
       /* Error ... no memory */
@@ -340,9 +340,9 @@ static int smartfs_open(FAR struct file *filep, const char *relpath,
       readwrite.logsector = sf->currsector;
       readwrite.offset    = 0;
       readwrite.count     = fs->fs_llformat.availbytes;
-      readwrite.buffer    = (uint8_t *) sf->buffer;
+      readwrite.buffer    = (FAR uint8_t *)sf->buffer;
 
-      ret = FS_IOCTL(fs, BIOC_READSECT, (unsigned long) &readwrite);
+      ret = FS_IOCTL(fs, BIOC_READSECT, (unsigned long)&readwrite);
       if (ret < 0)
         {
           ferr("ERROR: Error %d reading sector %d header\n",
@@ -409,11 +409,11 @@ errout_with_lock:
 
 static int smartfs_close(FAR struct file *filep)
 {
-  struct inode             *inode;
-  struct smartfs_mountpt_s *fs;
-  struct smartfs_ofile_s   *sf;
-  struct smartfs_ofile_s   *nextfile;
-  struct smartfs_ofile_s   *prevfile;
+  FAR struct inode             *inode;
+  FAR struct smartfs_mountpt_s *fs;
+  FAR struct smartfs_ofile_s   *sf;
+  FAR struct smartfs_ofile_s   *nextfile;
+  FAR struct smartfs_ofile_s   *prevfile;
   int ret;
 
   /* Sanity checks */
@@ -511,18 +511,18 @@ okout:
  * Name: smartfs_read
  ****************************************************************************/
 
-static ssize_t smartfs_read(FAR struct file *filep, char *buffer,
+static ssize_t smartfs_read(FAR struct file *filep, FAR char *buffer,
                             size_t buflen)
 {
-  struct inode             *inode;
-  struct smartfs_mountpt_s *fs;
-  struct smartfs_ofile_s   *sf;
-  struct smart_read_write_s readwrite;
-  struct smartfs_chain_header_s *header;
-  int                       ret = OK;
-  uint32_t                  bytesread;
-  uint16_t                  bytestoread;
-  uint16_t                  bytesinsector;
+  FAR struct inode                  *inode;
+  FAR struct smartfs_mountpt_s      *fs;
+  FAR struct smartfs_ofile_s        *sf;
+  struct smart_read_write_s          readwrite;
+  FAR struct smartfs_chain_header_s *header;
+  int                                ret = OK;
+  uint32_t                           bytesread;
+  uint16_t                           bytestoread;
+  uint16_t                           bytesinsector;
 
   /* Sanity checks */
 
@@ -562,9 +562,9 @@ static ssize_t smartfs_read(FAR struct file *filep, char *buffer,
 
       readwrite.logsector = sf->currsector;
       readwrite.offset = 0;
-      readwrite.buffer = (uint8_t *) fs->fs_rwbuffer;
+      readwrite.buffer = (FAR uint8_t *)fs->fs_rwbuffer;
       readwrite.count = fs->fs_llformat.availbytes;
-      ret = FS_IOCTL(fs, BIOC_READSECT, (unsigned long) &readwrite);
+      ret = FS_IOCTL(fs, BIOC_READSECT, (unsigned long)&readwrite);
       if (ret < 0)
         {
           ferr("ERROR: Error %d reading sector %d data\n",
@@ -574,7 +574,7 @@ static ssize_t smartfs_read(FAR struct file *filep, char *buffer,
 
       /* Point header to the read data to get used byte count */
 
-      header = (struct smartfs_chain_header_s *) fs->fs_rwbuffer;
+      header = (FAR struct smartfs_chain_header_s *)fs->fs_rwbuffer;
 
       /* Get number of used bytes in this sector */
 
@@ -644,16 +644,16 @@ errout_with_lock:
  * Name: smartfs_write
  ****************************************************************************/
 
-static ssize_t smartfs_write(FAR struct file *filep, const char *buffer,
-                         size_t buflen)
+static ssize_t smartfs_write(FAR struct file *filep, FAR const char *buffer,
+                             size_t buflen)
 {
-  struct inode             *inode;
-  struct smartfs_mountpt_s *fs;
-  struct smartfs_ofile_s   *sf;
-  struct smart_read_write_s readwrite;
-  struct smartfs_chain_header_s *header;
-  size_t                    byteswritten;
-  int                       ret;
+  FAR struct inode                  *inode;
+  FAR struct smartfs_mountpt_s      *fs;
+  FAR struct smartfs_ofile_s        *sf;
+  struct smart_read_write_s          readwrite;
+  FAR struct smartfs_chain_header_s *header;
+  size_t                             byteswritten;
+  int                                ret;
 
   DEBUGASSERT(filep->f_priv != NULL && filep->f_inode != NULL);
 
@@ -701,7 +701,7 @@ static ssize_t smartfs_write(FAR struct file *filep, const char *buffer,
    * a new one.
    */
 
-  header = (struct smartfs_chain_header_s *) fs->fs_rwbuffer;
+  header = (FAR struct smartfs_chain_header_s *)fs->fs_rwbuffer;
   byteswritten = 0;
   while ((sf->filepos < sf->entry.datlen) && (buflen > 0))
     {
@@ -714,7 +714,7 @@ static ssize_t smartfs_write(FAR struct file *filep, const char *buffer,
 
       readwrite.offset = sf->curroffset;
       readwrite.logsector = sf->currsector;
-      readwrite.buffer = (uint8_t *) &buffer[byteswritten];
+      readwrite.buffer = (FAR uint8_t *)&buffer[byteswritten];
       readwrite.count = fs->fs_llformat.availbytes - sf->curroffset;
 
       /* Limit the write based on available data to write */
@@ -737,7 +737,7 @@ static ssize_t smartfs_write(FAR struct file *filep, const char *buffer,
 
       if (readwrite.count > 0)
         {
-          ret = FS_IOCTL(fs, BIOC_WRITESECT, (unsigned long) &readwrite);
+          ret = FS_IOCTL(fs, BIOC_WRITESECT, (unsigned long)&readwrite);
           if (ret < 0)
             {
               ferr("ERROR: Error %d writing sector %d data\n",
@@ -763,9 +763,9 @@ static ssize_t smartfs_write(FAR struct file *filep, const char *buffer,
            */
 
           readwrite.offset = 0;
-          readwrite.buffer = (uint8_t *) fs->fs_rwbuffer;
+          readwrite.buffer = (FAR uint8_t *)fs->fs_rwbuffer;
           readwrite.count = sizeof(struct smartfs_chain_header_s);
-          ret = FS_IOCTL(fs, BIOC_READSECT, (unsigned long) &readwrite);
+          ret = FS_IOCTL(fs, BIOC_READSECT, (unsigned long)&readwrite);
           if (ret < 0)
             {
               ferr("ERROR: Error %d reading sector %d header\n",
@@ -802,7 +802,7 @@ static ssize_t smartfs_write(FAR struct file *filep, const char *buffer,
 #else  /* CONFIG_SMARTFS_USE_SECTOR_BUFFER */
       readwrite.offset = sf->curroffset;
       readwrite.logsector = sf->currsector;
-      readwrite.buffer = (uint8_t *) &buffer[byteswritten];
+      readwrite.buffer = (FAR uint8_t *)&buffer[byteswritten];
       readwrite.count = fs->fs_llformat.availbytes - sf->curroffset;
       if (readwrite.count > buflen)
         {
@@ -815,7 +815,7 @@ static ssize_t smartfs_write(FAR struct file *filep, const char *buffer,
 
       if (readwrite.count > 0)
         {
-          ret = FS_IOCTL(fs, BIOC_WRITESECT, (unsigned long) &readwrite);
+          ret = FS_IOCTL(fs, BIOC_WRITESECT, (unsigned long)&readwrite);
           if (ret < 0)
             {
               ferr("ERROR: Error %d writing sector %d data\n",
@@ -851,7 +851,7 @@ static ssize_t smartfs_write(FAR struct file *filep, const char *buffer,
 
           /* Copy the new sector to the old one and chain it */
 
-          header = (struct smartfs_chain_header_s *) sf->buffer;
+          header = (FAR struct smartfs_chain_header_s *)sf->buffer;
           SMARTFS_SET_NEXTSECTOR(header, ret);
 
           /* Now sync the file to write this sector out */
@@ -907,13 +907,13 @@ static ssize_t smartfs_write(FAR struct file *filep, const char *buffer,
 
               /* Copy the new sector to the old one and chain it */
 
-              header = (struct smartfs_chain_header_s *) fs->fs_rwbuffer;
+              header = (FAR struct smartfs_chain_header_s *)fs->fs_rwbuffer;
               SMARTFS_SET_NEXTSECTOR(header, ret);
               readwrite.offset = offsetof(struct smartfs_chain_header_s,
                 nextsector);
-              readwrite.buffer = (uint8_t *) header->nextsector;
+              readwrite.buffer = (FAR uint8_t *)header->nextsector;
               readwrite.count = sizeof(uint16_t);
-              ret = FS_IOCTL(fs, BIOC_WRITESECT, (unsigned long) &readwrite);
+              ret = FS_IOCTL(fs, BIOC_WRITESECT, (unsigned long)&readwrite);
               if (ret < 0)
                 {
                   ferr("ERROR: Error %d writing next sector\n", ret);
@@ -952,10 +952,10 @@ errout_with_lock:
 
 static off_t smartfs_seek(FAR struct file *filep, off_t offset, int whence)
 {
-  struct inode             *inode;
-  struct smartfs_mountpt_s *fs;
-  struct smartfs_ofile_s   *sf;
-  int                       ret;
+  FAR struct inode             *inode;
+  FAR struct smartfs_mountpt_s *fs;
+  FAR struct smartfs_ofile_s   *sf;
+  int                           ret;
 
   /* Sanity checks */
 
@@ -1010,10 +1010,10 @@ static int smartfs_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
 
 static int smartfs_sync(FAR struct file *filep)
 {
-  struct inode             *inode;
-  struct smartfs_mountpt_s *fs;
-  struct smartfs_ofile_s   *sf;
-  int                       ret;
+  FAR struct inode             *inode;
+  FAR struct smartfs_mountpt_s *fs;
+  FAR struct smartfs_ofile_s   *sf;
+  int                           ret;
 
   /* Sanity checks */
 
@@ -1050,7 +1050,7 @@ static int smartfs_sync(FAR struct file *filep)
 
 static int smartfs_dup(FAR const struct file *oldp, FAR struct file *newp)
 {
-  struct smartfs_ofile_s   *sf;
+  FAR struct smartfs_ofile_s *sf;
 
   finfo("Dup %p->%p\n", oldp, newp);
 
@@ -1069,7 +1069,7 @@ static int smartfs_dup(FAR const struct file *oldp, FAR struct file *newp)
   /* Just increment the reference count on the ofile */
 
   sf->crefs++;
-  newp->f_priv = (FAR void *)sf;
+  newp->f_priv = sf;
 
   return OK;
 }
@@ -1298,11 +1298,11 @@ static int smartfs_readdir(FAR struct inode *mountpt,
 {
   FAR struct smartfs_mountpt_s *fs;
   FAR struct smartfs_dir_s *sdir;
-  int                   ret;
-  uint16_t              entrysize;
-  struct                smartfs_chain_header_s *header;
-  struct                smart_read_write_s readwrite;
-  struct                smartfs_entry_header_s *entry;
+  FAR struct smartfs_chain_header_s *header;
+  struct smart_read_write_s readwrite;
+  FAR struct smartfs_entry_header_s *entry;
+  uint16_t entrysize;
+  int ret;
 
   /* Sanity checks */
 
@@ -1332,9 +1332,9 @@ static int smartfs_readdir(FAR struct inode *mountpt,
 
       readwrite.logsector = sdir->fs_currsector;
       readwrite.count = fs->fs_llformat.availbytes;
-      readwrite.buffer = (uint8_t *)fs->fs_rwbuffer;
+      readwrite.buffer = (FAR uint8_t *)fs->fs_rwbuffer;
       readwrite.offset = 0;
-      ret = FS_IOCTL(fs, BIOC_READSECT, (unsigned long) &readwrite);
+      ret = FS_IOCTL(fs, BIOC_READSECT, (unsigned long)&readwrite);
       if (ret < 0)
         {
           goto errout_with_lock;
@@ -1350,7 +1350,7 @@ static int smartfs_readdir(FAR struct inode *mountpt,
         {
           /* Point to next entry */
 
-          entry = (struct smartfs_entry_header_s *) &fs->fs_rwbuffer[
+          entry = (FAR struct smartfs_entry_header_s *)&fs->fs_rwbuffer[
             sdir->fs_curroffset];
 
           /* Test if this entry is valid and active */
@@ -1406,7 +1406,7 @@ static int smartfs_readdir(FAR struct inode *mountpt,
 
               sdir->fs_curroffset =
                 sizeof(struct smartfs_chain_header_s);
-              header = (struct smartfs_chain_header_s *) fs->fs_rwbuffer;
+              header = (FAR struct smartfs_chain_header_s *)fs->fs_rwbuffer;
               sdir->fs_currsector = SMARTFS_NEXTSECTOR(header);
             }
 
@@ -1421,7 +1421,7 @@ static int smartfs_readdir(FAR struct inode *mountpt,
        * done and will report ENOENT.
        */
 
-      header = (struct smartfs_chain_header_s *) fs->fs_rwbuffer;
+      header = (FAR struct smartfs_chain_header_s *)fs->fs_rwbuffer;
       sdir->fs_curroffset = sizeof(struct smartfs_chain_header_s);
       sdir->fs_currsector = SMARTFS_NEXTSECTOR(header);
     }
@@ -1442,7 +1442,8 @@ errout_with_lock:
  *
  ****************************************************************************/
 
-static int smartfs_rewinddir(struct inode *mountpt, struct fs_dirent_s *dir)
+static int smartfs_rewinddir(FAR struct inode *mountpt,
+                             FAR struct fs_dirent_s *dir)
 {
   FAR struct smartfs_dir_s *sdir = (FAR struct smartfs_dir_s *)dir;
 
@@ -1469,10 +1470,10 @@ static int smartfs_rewinddir(struct inode *mountpt, struct fs_dirent_s *dir)
  *
  ****************************************************************************/
 
-static int smartfs_bind(FAR struct inode *blkdriver, const void *data,
-                        void **handle)
+static int smartfs_bind(FAR struct inode *blkdriver, FAR const void *data,
+                        FAR void **handle)
 {
-  struct smartfs_mountpt_s *fs;
+  FAR struct smartfs_mountpt_s *fs;
   int ret;
 
   /* Open the block driver */
@@ -1490,7 +1491,7 @@ static int smartfs_bind(FAR struct inode *blkdriver, const void *data,
 
   /* Create an instance of the mountpt state structure */
 
-  fs = (struct smartfs_mountpt_s *)
+  fs = (FAR struct smartfs_mountpt_s *)
     kmm_zalloc(sizeof(struct smartfs_mountpt_s));
   if (!fs)
     {
@@ -1522,7 +1523,7 @@ static int smartfs_bind(FAR struct inode *blkdriver, const void *data,
       return ret;
     }
 
-  *handle = (FAR void *)fs;
+  *handle = fs;
   nxmutex_unlock(&g_lock);
   return OK;
 }
@@ -1587,9 +1588,9 @@ static int smartfs_unbind(FAR void *handle, FAR struct inode **blkdriver,
  *
  ****************************************************************************/
 
-static int smartfs_statfs(struct inode *mountpt, struct statfs *buf)
+static int smartfs_statfs(FAR struct inode *mountpt, FAR struct statfs *buf)
 {
-  struct smartfs_mountpt_s *fs;
+  FAR struct smartfs_mountpt_s *fs;
   int ret;
 
   /* Sanity checks */
@@ -1613,7 +1614,7 @@ static int smartfs_statfs(struct inode *mountpt, struct statfs *buf)
 
   /* Re-request the low-level format info to update free blocks */
 
-  ret = FS_IOCTL(fs, BIOC_GETFORMAT, (unsigned long) &fs->fs_llformat);
+  ret = FS_IOCTL(fs, BIOC_GETFORMAT, (unsigned long)&fs->fs_llformat);
 
   buf->f_namelen = fs->fs_llformat.namesize;
   buf->f_bsize = fs->fs_llformat.sectorsize;
@@ -1639,13 +1640,13 @@ static int smartfs_statfs(struct inode *mountpt, struct statfs *buf)
  *
  ****************************************************************************/
 
-static int smartfs_unlink(struct inode *mountpt, const char *relpath)
+static int smartfs_unlink(FAR struct inode *mountpt, FAR const char *relpath)
 {
-  struct smartfs_mountpt_s *fs;
-  int                       ret;
-  struct smartfs_entry_s    entry;
-  const char               *filename;
-  uint16_t                  parentdirsector;
+  FAR struct smartfs_mountpt_s *fs;
+  int                           ret;
+  struct smartfs_entry_s        entry;
+  FAR const char               *filename;
+  uint16_t                      parentdirsector;
 
   /* Sanity checks */
 
@@ -1711,14 +1712,14 @@ errout_with_lock:
  *
  ****************************************************************************/
 
-static int smartfs_mkdir(struct inode *mountpt, const char *relpath,
+static int smartfs_mkdir(FAR struct inode *mountpt, FAR const char *relpath,
                          mode_t mode)
 {
-  struct smartfs_mountpt_s *fs;
-  int                       ret;
-  struct smartfs_entry_s    entry;
-  uint16_t                  parentdirsector;
-  const char               *filename;
+  FAR struct smartfs_mountpt_s *fs;
+  int                           ret;
+  struct smartfs_entry_s        entry;
+  uint16_t                      parentdirsector;
+  FAR const char               *filename;
 
   /* Sanity checks */
 
@@ -1799,13 +1800,13 @@ errout_with_lock:
  *
  ****************************************************************************/
 
-int smartfs_rmdir(struct inode *mountpt, const char *relpath)
+int smartfs_rmdir(FAR struct inode *mountpt, FAR const char *relpath)
 {
-  struct smartfs_mountpt_s *fs;
-  int                       ret;
-  struct smartfs_entry_s    entry;
-  const char               *filename;
-  uint16_t                  parentdirsector;
+  FAR struct smartfs_mountpt_s *fs;
+  int                           ret;
+  struct smartfs_entry_s        entry;
+  FAR const char               *filename;
+  uint16_t                      parentdirsector;
 
   /* Sanity checks */
 
@@ -1893,21 +1894,21 @@ errout_with_lock:
  *
  ****************************************************************************/
 
-int smartfs_rename(struct inode *mountpt, const char *oldrelpath,
-               const char *newrelpath)
+int smartfs_rename(FAR struct inode *mountpt, FAR const char *oldrelpath,
+                   FAR const char *newrelpath)
 {
-  struct smartfs_mountpt_s *fs;
-  int                       ret;
-  struct smartfs_entry_s    oldentry;
-  uint16_t                  oldparentdirsector;
-  const char               *oldfilename;
-  struct smartfs_entry_s    newentry;
-  uint16_t                  newparentdirsector;
-  const char               *newfilename;
-  mode_t                    mode;
-  uint16_t                  type;
-  struct smartfs_entry_header_s *direntry;
-  struct smart_read_write_s readwrite;
+  FAR struct smartfs_mountpt_s      *fs;
+  int                                ret;
+  struct smartfs_entry_s             oldentry;
+  uint16_t                           oldparentdirsector;
+  FAR const char                    *oldfilename;
+  struct smartfs_entry_s             newentry;
+  uint16_t                           newparentdirsector;
+  FAR const char                    *newfilename;
+  mode_t                             mode;
+  uint16_t                           type;
+  FAR struct smartfs_entry_header_s *direntry;
+  struct smart_read_write_s          readwrite;
 
   /* Sanity checks */
 
@@ -1970,8 +1971,8 @@ int smartfs_rename(struct inode *mountpt, const char *oldrelpath,
       readwrite.logsector = oldentry.dsector;
       readwrite.offset = 0;
       readwrite.count = fs->fs_llformat.availbytes;
-      readwrite.buffer = (uint8_t *) fs->fs_rwbuffer;
-      ret = FS_IOCTL(fs, BIOC_READSECT, (unsigned long) &readwrite);
+      readwrite.buffer = (FAR uint8_t *)fs->fs_rwbuffer;
+      ret = FS_IOCTL(fs, BIOC_READSECT, (unsigned long)&readwrite);
       if (ret < 0)
         {
           ferr("ERROR: Error %d reading sector %d data\n",
@@ -1979,7 +1980,7 @@ int smartfs_rename(struct inode *mountpt, const char *oldrelpath,
           goto errout_with_lock;
         }
 
-      direntry = (struct smartfs_entry_header_s *)
+      direntry = (FAR struct smartfs_entry_header_s *)
         &fs->fs_rwbuffer[oldentry.doffset];
 #if CONFIG_SMARTFS_ERASEDSTATE == 0xff
       direntry->flags &= ~SMARTFS_DIRENT_ACTIVE;
@@ -1991,8 +1992,8 @@ int smartfs_rename(struct inode *mountpt, const char *oldrelpath,
 
       readwrite.offset = oldentry.doffset;
       readwrite.count = sizeof(direntry->flags);
-      readwrite.buffer = (uint8_t *) &direntry->flags;
-      ret = FS_IOCTL(fs, BIOC_WRITESECT, (unsigned long) &readwrite);
+      readwrite.buffer = (FAR uint8_t *)&direntry->flags;
+      ret = FS_IOCTL(fs, BIOC_WRITESECT, (unsigned long)&readwrite);
       if (ret < 0)
         {
           ferr("ERROR: Error %d writing flag bytes for sector %d\n",
@@ -2085,7 +2086,7 @@ static int smartfs_stat(FAR struct inode *mountpt, FAR const char *relpath,
                         FAR struct stat *buf)
 {
   FAR struct smartfs_mountpt_s *fs;
-  FAR struct smartfs_entry_s entry;
+  struct smartfs_entry_s entry;
   FAR const char *filename;
   uint16_t parentdirsector;
   int ret;

--- a/graphics/nxterm/nxterm.h
+++ b/graphics/nxterm/nxterm.h
@@ -109,7 +109,7 @@ struct nxterm_state_s
 {
   FAR const struct nxterm_operations_s *ops; /* Window operations */
   FAR void *handle;                          /* The window handle */
-  FAR struct nxterm_window_s wndo;           /* Describes the window and font */
+  struct nxterm_window_s wndo;               /* Describes the window and font */
   mutex_t lock;                              /* Forces mutually exclusive access */
 #ifdef CONFIG_DEBUG_GRAPHICS
   pid_t holder;                              /* Deadlock avoidance */

--- a/include/nuttx/analog/dac.h
+++ b/include/nuttx/analog/dac.h
@@ -60,18 +60,18 @@
 
 begin_packed_struct struct dac_msg_s
 {
-  uint8_t      am_channel;               /* The 8-bit DAC Channel */
-  int32_t      am_data;                  /* DAC convert result (4 bytes) */
+  uint8_t am_channel;               /* The 8-bit DAC Channel */
+  int32_t am_data;                  /* DAC convert result (4 bytes) */
 } end_packed_struct;
 
 struct dac_fifo_s
 {
-  sem_t         af_sem;                  /* Counting semaphore */
-  uint8_t       af_head;                 /* Index to the head [IN] index
-                                          * in the circular buffer */
-  uint8_t       af_tail;                 /* Index to the tail [OUT] index
-                                          * in the circular buffer */
-                                         /* Circular buffer of DAC messages */
+  sem_t   af_sem;                  /* Counting semaphore */
+  uint8_t af_head;                 /* Index to the head [IN] index
+                                    * in the circular buffer */
+  uint8_t af_tail;                 /* Index to the tail [OUT] index
+                                    * in the circular buffer */
+                                   /* Circular buffer of DAC messages */
   struct dac_msg_s af_buffer[CONFIG_DAC_FIFOSIZE];
 };
 
@@ -128,14 +128,14 @@ struct dac_ops_s
 
 struct dac_dev_s
 {
-  const struct dac_ops_s *ad_ops;       /* Arch-specific operations */
-  void                   *ad_priv;      /* Used by the arch-specific logic */
-  uint8_t                 ad_ocount;    /* The number of times the device has
-                                         * been opened */
-  uint8_t                 ad_nchannel;  /* Number of dac channel */
-  mutex_t                 ad_closelock; /* Locks out new opens while close is
-                                         * in progress */
-  struct dac_fifo_s       ad_xmit;      /* Describes receive FIFO */
+  FAR const struct dac_ops_s *ad_ops;       /* Arch-specific operations */
+  FAR void                   *ad_priv;      /* Used by the arch-specific logic */
+  uint8_t                     ad_ocount;    /* The number of times the device has
+                                             * been opened */
+  uint8_t                     ad_nchannel;  /* Number of dac channel */
+  mutex_t                     ad_closelock; /* Locks out new opens while close is
+                                             * in progress */
+  struct dac_fifo_s           ad_xmit;      /* Describes receive FIFO */
 };
 
 /****************************************************************************

--- a/include/nuttx/drivers/rwbuffer.h
+++ b/include/nuttx/drivers/rwbuffer.h
@@ -129,7 +129,7 @@ struct rwbuffer_s
 #ifdef CONFIG_DRVR_WRITEBUFFER
   mutex_t       wrlock;          /* Enforces exclusive access to the write buffer */
   struct work_s work;            /* Delayed work to flush buffer after a delay with no activity */
-  uint8_t      *wrbuffer;        /* Allocated write buffer */
+  FAR uint8_t  *wrbuffer;        /* Allocated write buffer */
   uint16_t      wrnblocks;       /* Number of blocks in write buffer */
   off_t         wrblockstart;    /* First block in write buffer */
 #endif
@@ -138,7 +138,7 @@ struct rwbuffer_s
 
 #ifdef CONFIG_DRVR_READAHEAD
   mutex_t       rhlock;          /* Enforces exclusive access to the write buffer */
-  uint8_t      *rhbuffer;        /* Allocated read-ahead buffer */
+  FAR uint8_t  *rhbuffer;        /* Allocated read-ahead buffer */
   uint16_t      rhnblocks;       /* Number of blocks in read-ahead buffer */
   off_t         rhblockstart;    /* First block in read-ahead buffer */
 #endif


### PR DESCRIPTION
## Summary

1.  Don't check the return value of nxsem_init or nxmutex_init
2. Fix some style issue

## Impact
error handling

## Testing
Pass CI
