### PR TITLE
net/tcp: fix build break if enable NET_TCP_NO_STACK 

### DIFF
--- a/net/tcp/tcp.h
+++ b/net/tcp/tcp.h
@@ -37,11 +37,18 @@
 #include <nuttx/net/net.h>
 #include <nuttx/wqueue.h>
 
-#if defined(CONFIG_NET_TCP) && !defined(CONFIG_NET_TCP_NO_STACK)
+#ifdef CONFIG_NET_TCP
 
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
+
+/* This is a helper pointer for accessing the contents of the tcp header */
+
+#define TCPIPv4BUF ((FAR struct tcp_hdr_s *)IPBUF(IPv4_HDRLEN))
+#define TCPIPv6BUF ((FAR struct tcp_hdr_s *)IPBUF(IPv6_HDRLEN))
+
+#ifndef CONFIG_NET_TCP_NO_STACK
 
 #define NET_TCP_HAVE_STACK 1
 
@@ -103,11 +110,6 @@
  */
 
 #define TCP_FAST_RETRANSMISSION_THRESH 3
-
-/* This is a helper pointer for accessing the contents of the tcp header */
-
-#define TCPIPv4BUF ((FAR struct tcp_hdr_s *)IPBUF(IPv4_HDRLEN))
-#define TCPIPv6BUF ((FAR struct tcp_hdr_s *)IPBUF(IPv6_HDRLEN))
 
 /****************************************************************************
  * Public Type Definitions
@@ -2025,5 +2027,6 @@ void tcp_sendbuffer_notify(FAR struct tcp_conn_s *conn);
 }
 #endif
 
-#endif /* CONFIG_NET_TCP && !CONFIG_NET_TCP_NO_STACK */
+#endif /* !CONFIG_NET_TCP_NO_STACK */
+#endif /* CONFIG_NET_TCP */
 #endif /* __NET_TCP_TCP_H */


### PR DESCRIPTION


## Summary

net/tcp: fix build break if enable NET_TCP_NO_STACK

```
devif/ipv6_input.c: In function 'ipv6_input':
devif/ipv6_input.c:59:33: error: 'TCPIPv6BUF' undeclared (first use in this function); did you mean 'IPv6BUF'?
   59 | #define PAYLOAD ((FAR uint8_t *)TCPIPv6BUF)
      |                                 ^~~~~~~~~~
devif/ipv6_input.c:302:14: note: in expansion of macro 'PAYLOAD'
  302 |   payload  = PAYLOAD;     /* Assume payload starts right after IPv6 header */
      |
```

Signed-off-by: chao an <anchao@xiaomi.com>

## Impact

https://github.com/apache/incubator-nuttx/issues/7481

## Testing

enable config:
```
CONFIG_NET_TCP=y
CONFIG_NET_IPv6=y
CONFIG_NET_TCP_NO_STACK=y
```