### PR TITLE
sched/getprioritymax: handle invaild policy as posix style

### DIFF
--- a/libs/libc/sched/sched_getprioritymax.c
+++ b/libs/libc/sched/sched_getprioritymax.c
@@ -52,6 +52,11 @@
 
 int sched_get_priority_max(int policy)
 {
-  DEBUGASSERT(policy >= SCHED_FIFO && policy <= SCHED_OTHER);
+  if (policy < SCHED_FIFO || policy > SCHED_OTHER)
+    {
+      set_errno(EINVAL);
+      return ERROR;
+    }
+
   return SCHED_PRIORITY_MAX;
 }


### PR DESCRIPTION
## Summary

sched/getprioritymax: handle invaild policy as posix style

modify the return value according to posix standard



```
SCHED_GET_PRIORITY_MAX(2)

NAME
       sched_get_priority_max, sched_get_priority_min  - get static priority range

RETURN VALUE
       On success, sched_get_priority_max() and sched_get_priority_min() return the
                   maximum/minimum priority value for the named scheduling policy.
       On error, -1 is returned, and errno is set appropriately.

ERRORS
       EINVAL The argument policy does not identify a defined scheduling policy.
```

Signed-off-by: chao an <anchao@xiaomi.com>


https://github.com/linux-test-project/ltp/blob/master/testcases/open_posix_testsuite/conformance/interfaces/sched_get_priority_max/2-1.c#L25

## Impact

N/A

## Testing

ci check