### PR TITLE
sched/posix/timer: handle invaild timerid correctly

### DIFF
--- a/include/nuttx/queue.h
+++ b/include/nuttx/queue.h
@@ -156,7 +156,7 @@
   while (0)
 
 #define sq_for_every(q, p) \
-  for((p) = (q)->head; (p) != NULL; (p) = (p)->flink)
+  for ((p) = (q)->head; (p) != NULL; (p) = (p)->flink)
 
 #define sq_rem(p, q) \
   do \

--- a/sched/timer/timer.h
+++ b/sched/timer/timer.h
@@ -86,6 +86,7 @@ extern volatile sq_queue_t g_alloctimers;
 void timer_initialize(void);
 void timer_deleteall(pid_t pid);
 int timer_release(FAR struct posix_timer_s *timer);
+FAR struct posix_timer_s *timer_gethandle(timer_t timerid);
 
 #endif /* CONFIG_DISABLE_POSIX_TIMERS */
 #endif /* __SCHED_TIMER_TIMER_H */

--- a/sched/timer/timer_delete.c
+++ b/sched/timer/timer_delete.c
@@ -62,7 +62,7 @@
 
 int timer_delete(timer_t timerid)
 {
-  int ret = timer_release((FAR struct posix_timer_s *)timerid);
+  int ret = timer_release(timer_gethandle(timerid));
   if (ret < 0)
     {
       set_errno(-ret);

--- a/sched/timer/timer_gettime.c
+++ b/sched/timer/timer_gettime.c
@@ -70,7 +70,7 @@
 
 int timer_gettime(timer_t timerid, FAR struct itimerspec *value)
 {
-  FAR struct posix_timer_s *timer = (FAR struct posix_timer_s *)timerid;
+  FAR struct posix_timer_s *timer = timer_gethandle(timerid);
   sclock_t ticks;
 
   if (!timer || !value)

--- a/sched/timer/timer_initialize.c
+++ b/sched/timer/timer_initialize.c
@@ -143,4 +143,45 @@ void timer_deleteall(pid_t pid)
   leave_critical_section(flags);
 }
 
+/****************************************************************************
+ * Name: timer_gethandle
+ *
+ * Description:
+ *   Returns the posix timer in the activity from the corresponding timerid
+ *
+ * Input Parameters:
+ *   timerid - The pre-thread timer, previously created by the call to
+ *     timer_create(), to be be set.
+ *
+ * Returned Value:
+ *   On success, timer_gethandle() returns pointer to the posix_timer_s;
+ *   On error, NULL is returned.
+ *
+ ****************************************************************************/
+
+FAR struct posix_timer_s *timer_gethandle(timer_t timerid)
+{
+  FAR struct posix_timer_s *timer = NULL;
+  FAR sq_entry_t *entry;
+  irqstate_t intflags;
+
+  if (timerid != NULL)
+    {
+      intflags = enter_critical_section();
+
+      sq_for_every(&g_alloctimers, entry)
+        {
+          if (entry == timerid)
+            {
+              timer = (FAR struct posix_timer_s *)timerid;
+              break;
+            }
+        }
+
+      leave_critical_section(intflags);
+    }
+
+  return timer;
+}
+
 #endif /* CONFIG_DISABLE_POSIX_TIMERS */


### PR DESCRIPTION

## Summary

sched/posix/timer: handle invaild timerid correctly

```
TIMER_SETTIME(2)

NAME
       timer_settime, timer_gettime - arm/disarm and fetch state of POSIX per-process timer

SYNOPSIS
       #include <time.h>

       int timer_settime(timer_t timerid, int flags,
                         const struct itimerspec *new_value,
                         struct itimerspec *old_value);
       int timer_gettime(timer_t timerid, struct itimerspec *curr_value);
...
ERRORS
...
       EINVAL timerid is invalid.
```

Signed-off-by: chao an <anchao@xiaomi.com>

https://github.com/linux-test-project/ltp/blob/master/testcases/open_posix_testsuite/conformance/interfaces/timer_delete/1-2.c#L43-L55

## Impact

N/A

## Testing

ltp test / ci check