### PR TITLE
arch_timer: adjust timer/arch_timer to support tick

### DIFF
--- a/arch/arm/src/cxd56xx/cxd56_timer.c
+++ b/arch/arm/src/cxd56xx/cxd56_timer.c
@@ -72,7 +72,7 @@
  * wrap around. Timer's base clock is dynamically changed with cpu clock.
  */
 
-#define TIMER_MAXTIMEOUT    (ULONG_MAX / 160 / TIMER_DIVIDER)
+#define CXD56_MAXTIMEOUT    (ULONG_MAX / 160 / TIMER_DIVIDER)
 
 /****************************************************************************
  * Private Types
@@ -377,10 +377,10 @@ static int cxd56_settimeout(struct timer_lowerhalf_s *lower,
 
   /* Can this timeout be represented? */
 
-  if (timeout < 1 || timeout > TIMER_MAXTIMEOUT)
+  if (timeout < 1 || timeout > CXD56_MAXTIMEOUT)
     {
       tmrerr("ERROR: Cannot represent timeout=%" PRIu32 " > %lu\n",
-             timeout, TIMER_MAXTIMEOUT);
+             timeout, CXD56_MAXTIMEOUT);
       return -ERANGE;
     }
 

--- a/drivers/timers/Kconfig
+++ b/drivers/timers/Kconfig
@@ -75,6 +75,7 @@ config TIMER_ARCH
 	select ARCH_HAVE_TICKLESS
 	select ARCH_HAVE_TIMEKEEPING
 	select SCHED_TICKLESS_LIMIT_MAX_SLEEP if SCHED_TICKLESS
+	select SCHED_TICKLESS_TICK_ARGUMENT if SCHED_TICKLESS
 	---help---
 		Implement timer arch API on top of timer driver interface.
 

--- a/drivers/timers/timer.c
+++ b/drivers/timers/timer.c
@@ -285,14 +285,7 @@ static int timer_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
       {
         /* Start the timer, resetting the time to the current timeout */
 
-        if (lower->ops->start)
-          {
-            ret = lower->ops->start(lower);
-          }
-        else
-          {
-            ret = -ENOSYS;
-          }
+        ret = TIMER_START(lower);
       }
       break;
 
@@ -305,8 +298,7 @@ static int timer_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
       {
         /* Stop the timer */
 
-        DEBUGASSERT(lower->ops->stop != NULL); /* Required */
-        ret = lower->ops->stop(lower);
+        ret = TIMER_STOP(lower);
         nxsig_cancel_notification(&upper->work);
       }
       break;
@@ -322,21 +314,14 @@ static int timer_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
 
         /* Get the current timer status */
 
-        if (lower->ops->getstatus) /* Optional */
+        status = (FAR struct timer_status_s *)((uintptr_t)arg);
+        if (status)
           {
-            status = (FAR struct timer_status_s *)((uintptr_t)arg);
-            if (status)
-              {
-                ret = lower->ops->getstatus(lower, status);
-              }
-            else
-              {
-                ret = -EINVAL;
-              }
+            ret = TIMER_GETSTATUS(lower, status);
           }
         else
           {
-            ret = -ENOSYS;
+            ret = -EINVAL;
           }
       }
       break;
@@ -353,14 +338,7 @@ static int timer_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
       {
         /* Set a new timeout value (and reset the timer) */
 
-        if (lower->ops->settimeout) /* Optional */
-          {
-            ret = lower->ops->settimeout(lower, (uint32_t)arg);
-          }
-        else
-          {
-            ret = -ENOSYS;
-          }
+        ret = TIMER_SETTIMEOUT(lower, (uint32_t)arg);
       }
       break;
 
@@ -396,14 +374,7 @@ static int timer_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
       {
         /*  Get the maximum supported timeout value */
 
-        if (lower->ops->maxtimeout) /* Optional */
-          {
-            ret = lower->ops->maxtimeout(lower, (FAR uint32_t *)arg);
-          }
-        else
-          {
-            ret = -ENOSYS;
-          }
+        ret = TIMER_MAXTIMEOUT(lower, (FAR uint32_t *)arg);
       }
       break;
 
@@ -420,14 +391,7 @@ static int timer_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
          * method.
          */
 
-        if (lower->ops->ioctl) /* Optional */
-          {
-            ret = lower->ops->ioctl(lower, cmd, arg);
-          }
-        else
-          {
-            ret = -ENOTTY;
-          }
+        ret = TIMER_IOCTL(lower, cmd, arg);
       }
       break;
     }
@@ -553,8 +517,7 @@ void timer_unregister(FAR void *handle)
 
   /* Disable the timer */
 
-  DEBUGASSERT(lower->ops->stop); /* Required */
-  lower->ops->stop(lower);
+  TIMER_STOP(lower);
   nxsig_cancel_notification(&upper->work);
 
   /* Unregister the timer device */


### PR DESCRIPTION
## Summary

Enable CONFIG_SCHED_TICKLESS_TICK_ARGUMENT in tickless mode to improve the performance.

## Impact

NA

## Testing

bl602
