### PR TITLE
mm_heap: add debug assert to check the alignment problem

### DIFF
--- a/mm/mm_heap/mm_initialize.c
+++ b/mm/mm_heap/mm_initialize.c
@@ -135,6 +135,7 @@ void mm_addregion(FAR struct mm_heap_s *heap, FAR void *heapstart,
   heap->mm_heapstart[IDX]->preceding = MM_ALLOC_BIT;
   node                               = (FAR struct mm_freenode_s *)
                                        (heapbase + SIZEOF_MM_ALLOCNODE);
+  DEBUGASSERT((((uintptr_t)node + SIZEOF_MM_ALLOCNODE) % MM_MIN_CHUNK) == 0);
   node->size                         = heapsize - 2*SIZEOF_MM_ALLOCNODE;
   node->preceding                    = SIZEOF_MM_ALLOCNODE;
   heap->mm_heapend[IDX]              = (FAR struct mm_allocnode_s *)

--- a/mm/mm_heap/mm_malloc.c
+++ b/mm/mm_heap/mm_malloc.c
@@ -271,5 +271,6 @@ FAR void *mm_malloc(FAR struct mm_heap_s *heap, size_t size)
     }
 #endif
 
+  DEBUGASSERT(ret == NULL || ((uintptr_t)ret) % MM_MIN_CHUNK == 0);
   return ret;
 }

--- a/mm/mm_heap/mm_memalign.c
+++ b/mm/mm_heap/mm_memalign.c
@@ -79,7 +79,9 @@ FAR void *mm_memalign(FAR struct mm_heap_s *heap, size_t alignment,
 
   if (alignment <= MM_MIN_CHUNK)
     {
-      return mm_malloc(heap, size);
+      FAR void *ptr = mm_malloc(heap, size);
+      DEBUGASSERT(ptr == NULL || ((uintptr_t)ptr) % alignment == 0);
+      return ptr;
     }
 
   /* Adjust the size to account for (1) the size of the allocated node, (2)
@@ -230,5 +232,6 @@ FAR void *mm_memalign(FAR struct mm_heap_s *heap, size_t alignment,
   kasan_unpoison((FAR void *)alignedchunk,
                  mm_malloc_size((FAR void *)alignedchunk));
 
+  DEBUGASSERT(alignedchunk % alignment == 0);
   return (FAR void *)alignedchunk;
 }


### PR DESCRIPTION
## Summary
Delete the realloc test in apps: https://github.com/apache/incubator-nuttx-apps/pull/1393
It's better to add DEBUGASSERT in mm code to check the unaligned problem instead add a complex test case.
And this pr follow https://github.com/apache/incubator-nuttx/pull/5991, so @yamt could you have a look?

## Impact
mm

## Testing
sim:nsh, mm test pass
