### PR TITLE
arm/backtrace_sp: fix build warning

### DIFF
--- a/arch/arm/src/common/arm_backtrace_sp.c
+++ b/arch/arm/src/common/arm_backtrace_sp.c
@@ -250,7 +250,7 @@ int up_backtrace(struct tcb_s *tcb,
 #  ifdef CONFIG_SMP
           top = arm_intstack_top();
 #  else
-          top = g_intstacktop;
+          top = (unsigned long)g_intstacktop;
 #  endif /* CONFIG_SMP */
 #else
           top = (unsigned long)rtcb->stack_base_ptr +


### PR DESCRIPTION
## Summary
Fix build warning of  -Wint-conversion in arm_backtrace_sp.c
```
common/arm_backtrace_sp.c: In function 'up_backtrace': common/arm_backtrace_sp.c:253:15: warning: assignment to 'long unsigned int' from 'uint8_t *' {aka 'unsigned char *'} makes integer from pointer without a cast [-Wint-conversion]
  253 |           top = g_intstacktop;
      |
```
## Impact

## Testing

