### PR TITLE
binfmt: elf_addrenv_free select addrenv before up_addrenv_destroy

### DIFF
--- a/binfmt/libelf/libelf_addrenv.c
+++ b/binfmt/libelf/libelf_addrenv.c
@@ -259,7 +259,9 @@ void elf_addrenv_free(FAR struct elf_loadinfo_s *loadinfo)
 
   /* Free the address environment */
 
+  elf_addrenv_select(loadinfo);
   ret = up_addrenv_destroy(&loadinfo->addrenv);
+  elf_addrenv_restore(loadinfo);
   if (ret < 0)
     {
       berr("ERROR: up_addrenv_destroy failed: %d\n", ret);


### PR DESCRIPTION
## Summary
to avoid up_addrenv_destroy delete the current task page table this patch fix the below panic due to elf contain the unresolved symbol:
```
qemu-system-arm -s -S -semihosting -M sabrelite -m 1024 -smp 4 -kernel nuttx -nographic -net nic -net user,hostfwd=tcp:127.0.0.1:10023-10.0.2.15:23,hostfwd=tcp:127.0.0.1:10021-10.0.2.15:21,hostfwd=tcp:127.0.0.1:15001-10.0.2.15:5001,hostfwd=tcp:127.0.0.1:15555-10.0.2.15:5555 ABDGHIJKNOPQ
[    0.470000] elf_relocate: Section 2 reloc 163: Failed to get value of symbol[1505]: -2
[    0.530000] arm_dataabort: Data abort. PC: 108323de DFAR: 80202778 DFSR: 00000005
[    0.530000] up_assert: Assertion failed at file:armv7-a/arm_dataabort.c line: 161 task: /system/bin/init
[    0.530000] arm_registerdump: R0: 10845820 R1: 80202778 R2: 00000001  R3: 80202778
[    0.530000] arm_registerdump: R4: 80202624 R5: 80202634 R6: 80200330  FP: 80202628
[    0.530000] arm_registerdump: R8: 802026b4 SB: 00000000 SL: 8000dbfe R11: 00000000
[    0.530000] arm_registerdump: IP: 108453e0 SP: 108456b0 LR: 1082b091  PC: 108323de
[    0.530000] arm_registerdump: CPSR: a000007f
[    0.530000] arm_dump_stack: IRQ Stack:
[    0.530000] arm_dump_stack: sp:     10845510
[    0.530000] arm_dump_stack:   base: 108397c0
[    0.530000] arm_dump_stack:   size: 00000800
[    0.530000] arm_dump_stack: ERROR: IRQ Stack pointer is not within the stack
[    0.530000] arm_stackdump: 10839f00: deadbeef 00adbeef 00000001 10844990 00000000 00000000 80300000 1082f2ef
[    0.530000] arm_stackdump: 10839f20: deadbeef 00000000 deadbeef 10844990 80200000 1082f2ff 1083d980 1082f311
[    0.530000] arm_stackdump: 10839f40: 00000002 10814659 00000004 00000002 deadbeef 1081469b 00000001 00000000
[    0.530000] arm_stackdump: 10839f60: 10845460 00000057 10844a90 00000002 deadbeef 10808d1b 10845460 00000057
[    0.530000] arm_stackdump: 10839f80: 00dfbeef 00000057 00000000 00000002 deadbeef 10801d1f 10845460 00000057
[    0.530000] arm_stackdump: 10839fa0: 00000000 10800fc5 deadbeef 10845460 00000057 00000057 deadbeef 108000a0
[    0.530000] arm_dump_stack: User Stack:
[    0.530000] arm_dump_stack: sp:     108456b0
[    0.530000] arm_dump_stack:   base: 80202038
[    0.530000] arm_dump_stack:   size: 000007c8
[    0.530000] arm_dump_stack: ERROR: User Stack pointer is not within the stack
[    0.530000] arm_dump_stack: Kernel Stack:
[    0.530000] arm_dump_stack: sp:     108456b0
[    0.530000] arm_dump_stack:   base: 10844c10
[    0.530000] arm_dump_stack:   size: 00000c00
[    0.530000] arm_stackdump: 108456a0: 00000000 108453e0 108323de a000007f 80202778 10845820 00000000 10812aa9
[    0.530000] arm_stackdump: 108456c0: 00000000 1083ff90 10845838 00000000 001f001e 10812b2f 10840008 1083ff90
[    0.530000] arm_stackdump: 108456e0: 10845840 10812fab 10845840 1083ff90 005f0000 10844990 10845818 10845ff8
[    0.530000] arm_stackdump: 10845700: 10845ff8 10845838 10845840 10812017 fffffffe 10845820 80202624 1082b091
[    0.530000] arm_stackdump: 10845720: 00000000 00000000 80202778 10841d40 00000000 10845840 10845820 fffffffe
[    0.530000] arm_stackdump: 10845740: 00000000 1082998b 00000000 80200330 802026b4 80202778 10845788 0084578c
[    0.530000] arm_stackdump: 10845760: 10841d40 10844990 00000000 108306fb 00000000 80202634 802026b4 80202634
[    0.530000] arm_stackdump: 10845780: 80202778 80202628 00000000 00000000 00000000 00000000 00000000 1083085f
[    0.530000] arm_stackdump: 108457a0: 80200330 00000000 00000000 00000000 80202634 80202624 80202778 80202628
[    0.530000] arm_stackdump: 108457c0: 00000000 00000000 00000000 80202614 80202624 1080f26b 802026b4 80200330
[    0.530000] arm_stackdump: 108457e0: 80202624 80202778 80202628 0000001f 00000000 80202634 802026b4 108012c3
[    0.530000] arm_showtasks:    PID    PRI     STACK      USED   FILLED    COMMAND
[    0.530000] arm_showtasks:   ----   ----      2048       188     9.1%    irq
[    0.530000] arm_dump_task:      0      0      2024      1240    61.2%    Idle Task
[    0.530000] arm_dump_task:      1    224      1992       504    25.3%    hpwork 0x1083e0f8
[    0.530000] arm_dump_task:      2    100      1992       504    25.3%    lpwork 0x1083e110
```
after apply this patch, nsh report error instead of crash:
```
qemu-system-arm -s -S -semihosting -M sabrelite -m 1024 -smp 4 -kernel nuttx -nographic -net nic -net user,hostfwd=tcp:127.0.0.1:10023-10.0.2.15:23,hostfwd=tcp:127.0.0.1:10021-10.0.2.15:21,hostfwd=tcp:127.0.0.1:15001-10.0.2.15:5001,hostfwd=tcp:127.0.0.1:15555-10.0.2.15:5555
ABDGHIJKNOPQ
[    0.440000] elf_relocate: Section 2 reloc 163: Failed to get value of symbol[1505]: -2
telnetd [4:100]

NuttShell (NSH) NuttX-11.0.0
nsh> nsh: telnetd: command not found
```

## Impact
binfmt error path

## Testing
sabre-6quad/netknsh
