### PR TITLE
arch: Fix linking of multiple preprocessed linker script files

### DIFF
--- a/arch/arm/src/Makefile
+++ b/arch/arm/src/Makefile
@@ -110,7 +110,7 @@ endif
 
 
 ARCHSCRIPT := $(call CONVERT_PATH,$(ARCHSCRIPT))
-LDFLAGS += $(addprefix $(SCRIPT_OPT),$(ARCHSCRIPT).tmp) $(EXTRALINKCMDS)
+LDFLAGS += $(addprefix $(SCRIPT_OPT),$(addsuffix .tmp,$(ARCHSCRIPT))) $(EXTRALINKCMDS)
 LIBPATHS += $(LIBPATH_OPT) $(call CONVERT_PATH,$(TOPDIR)$(DELIM)staging)
 
 BOARDMAKE = $(if $(wildcard board$(DELIM)Makefile),y,)

--- a/arch/risc-v/src/Makefile
+++ b/arch/risc-v/src/Makefile
@@ -80,7 +80,7 @@ KBIN = libkarch$(LIBEXT)
 BIN  = libarch$(LIBEXT)
 
 ARCHSCRIPT := $(call CONVERT_PATH,$(ARCHSCRIPT))
-LDFLAGS += $(addprefix -T,$(ARCHSCRIPT).tmp) $(EXTRALINKCMDS)
+LDFLAGS += $(addprefix -T,$(addsuffix .tmp,$(ARCHSCRIPT))) $(EXTRALINKCMDS)
 
 ifeq ($(LD),$(CC))
   LDSTARTGROUP ?= -Wl,--start-group

--- a/arch/xtensa/src/Makefile
+++ b/arch/xtensa/src/Makefile
@@ -81,7 +81,7 @@ BIN  = libarch$(LIBEXT)
 # Override in Make.defs if linker is not 'ld'
 
 ARCHSCRIPT := $(call CONVERT_PATH,$(ARCHSCRIPT))
-LDFLAGS += $(addprefix -T,$(ARCHSCRIPT).tmp) $(EXTRALINKCMDS)
+LDFLAGS += $(addprefix -T,$(addsuffix .tmp,$(ARCHSCRIPT))) $(EXTRALINKCMDS)
 
 ifeq ($(LD),$(CC))
   LDSTARTGROUP ?= -Wl,--start-group


### PR DESCRIPTION
## Summary
This PR intends to fix the preprocessing of multiple linker script files introduced in #7208.
Only the last item from the ARCHSCRIPT list was being suffixed with ".tmp", resulting in build failures:

```bash
LD: nuttx
xtensa-esp32s3-elf-ld --entry=__start -nostdlib --gc-sections --cref -Map=/home/nihei/Projects/NuttX/nuttx/nuttx.map -T/home/nihei/Projects/NuttX/nuttx/boards/xtensa/esp32s3/esp32s3-devkit/../common/scripts/esp32s3_peripherals.ld -T/home/nihei/Projects/NuttX/nuttx/boards/xtensa/esp32s3/esp32s3-devkit/../common/scripts/esp32s3_rom.ld -T/home/nihei/Projects/NuttX/nuttx/boards/xtensa/esp32s3/esp32s3-devkit/../common/scripts/esp32s3.template.ld -T/home/nihei/Projects/NuttX/nuttx/boards/xtensa/esp32s3/esp32s3-devkit/../common/scripts/esp32s3.ld.tmp  -L /home/nihei/Projects/NuttX/nuttx/staging -L /home/nihei/Projects/NuttX/nuttx/arch/xtensa/src/board  \
        -o /home/nihei/Projects/NuttX/nuttx/nuttx xtensa_vectors.o xtensa_window_vector.o xtensa_windowspill.o xtensa_int_handlers.o xtensa_user_handler.o esp32s3_start.o  \
        --start-group -lsched -ldrivers -lboards -lc -lmm -larch -lxx -lapps -lfs -lbinfmt -lboard -lboard /home/nihei/.espressif/tools/xtensa-esp32s3-elf/esp-2021r2-patch3-8.4.0/xtensa-esp32s3-elf/bin/../lib/gcc/xtensa-esp32s3-elf/8.4.0/libgcc.a /home/nihei/.espressif/tools/xtensa-esp32s3-elf/esp-2021r2-patch3-8.4.0/xtensa-esp32s3-elf/bin/../lib/gcc/xtensa-esp32s3-elf/8.4.0/../../../../xtensa-esp32s3-elf/lib/libm.a --end-group
xtensa-esp32s3-elf-ld:/home/nihei/Projects/NuttX/nuttx/boards/xtensa/esp32s3/esp32s3-devkit/../common/scripts/esp32s3.template.ld:13: ignoring invalid character `#' in expression
xtensa-esp32s3-elf-ld:/home/nihei/Projects/NuttX/nuttx/boards/xtensa/esp32s3/esp32s3-devkit/../common/scripts/esp32s3.template.ld:13: syntax error
make[1]: *** [Makefile:151: nuttx] Error 1
```

## Impact
Bugfix, no expected side effects.

## Testing
Successful build of `esp32s3-devkit` during development of #7500.

