### PR TITLE
arch/armv7-ar: add isb after CACHE and TLB operations.

### DIFF
--- a/arch/arm/src/armv7-a/arm_cpuhead.S
+++ b/arch/arm/src/armv7-a/arm_cpuhead.S
@@ -211,6 +211,7 @@ __cpu3_start:
 	mcr		CP15_BPIALL(r0)		/* Invalidate entire branch prediction array */
 	mcr		CP15_ICIALLU(r0)	/* Invalidate I-cache */
 #endif
+	isb
 
 	/* Load the page table address.
 	 *
@@ -369,6 +370,7 @@ __cpu3_start:
 	/* Then write the configured control register */
 
 	mcr		CP15_SCTLR(r0)			/* Write control reg */
+	isb
 	.rept		12				/* Cortex A8 wants lots of NOPs here */
 	nop
 	.endr

--- a/arch/arm/src/armv7-a/arm_head.S
+++ b/arch/arm/src/armv7-a/arm_head.S
@@ -208,6 +208,7 @@ __cpu0_start:
 	bic		r0, r0, #(SCTLR_M | SCTLR_C)
 	bic		r0, r0, #(SCTLR_I)
 	mcr		CP15_SCTLR(r0)
+	isb
 
 	/* Clear the 16K level 1 page table */
 
@@ -363,6 +364,8 @@ __cpu0_start:
 	mcr		CP15_BPIALL(r0)		/* Invalidate entire branch prediction array */
 	mcr		CP15_ICIALLU(r0)	/* Invalidate I-cache */
 #endif
+
+	isb
 
 	/* Load the page table address.
 	 *
@@ -523,6 +526,7 @@ __cpu0_start:
 	/* Then write the configured control register */
 
 	mcr		CP15_SCTLR(r0)			/* Write control reg */
+	isb
 	.rept		12				/* Cortex A8 wants lots of NOPs here */
 	nop
 	.endr

--- a/arch/arm/src/armv7-a/arm_pghead.S
+++ b/arch/arm/src/armv7-a/arm_pghead.S
@@ -320,6 +320,7 @@ __start:
 	mcr		CP15_TLBIALL(r0,c5)
 	mcr		CP15_BPIALL(r0)		/* Invalidate entire branch prediction array */
 	mcr		CP15_ICIALLU(r0)	/* Invalidate I-cache */
+	isb
 
 	/* Load the page table address.
 	 *
@@ -467,6 +468,7 @@ __start:
 	/* Then write the configured control register */
 
 	mcr		CP15_SCTLR(r0)			/* Write control reg */
+	isb
 	.rept		12				/* Cortex A8 wants lots of NOPs here */
 	nop
 	.endr

--- a/arch/arm/src/armv7-r/arm_head.S
+++ b/arch/arm/src/armv7-r/arm_head.S
@@ -161,6 +161,7 @@ __start:
 	mcr		CP15_BPIALL(r0)		/* Invalidate entire branch prediction array */
 	mcr		CP15_ICIALLU(r0)	/* Invalidate I-cache */
 	mcr		CP15_DCIALLU(r0)	/* Invalidate D-cache */
+	isb
 
 	/* Configure the system control register (see sctrl.h) */
 
@@ -313,6 +314,7 @@ __start:
 	/* Then write the configured control register */
 
 	mcr		CP15_SCTLR(r0)			/* Write control reg */
+	isb
 	.rept		12				/* Some CPUs want want lots of NOPs here */
 	nop
 	.endr


### PR DESCRIPTION
## Summary

Add ISB instruction after CACHE and TLB operations to ensure the effects of the operation are visible to instructions fetched after the ISB instruction.

## Impact

NA

## Testing

sabre-6quad:nsh
