### PR TITLE
boards/esp32: Fix invalid IRAM option in linker script

### DIFF
--- a/boards/xtensa/esp32/common/scripts/flat.template.ld
+++ b/boards/xtensa/esp32/common/scripts/flat.template.ld
@@ -147,13 +147,13 @@ MEMORY
   extmem_seg (RWX) :     org = 0x3f800000, len = 0x400000
 }
 
-#if CONFIG_ESP32_DEVKIT_RUN_IRAM
+#if CONFIG_ESP32_RUN_IRAM
   REGION_ALIAS("default_rodata_seg", dram0_0_seg);
   REGION_ALIAS("default_code_seg", iram0_0_seg);
 #else
   REGION_ALIAS("default_rodata_seg", drom0_0_seg);
   REGION_ALIAS("default_code_seg", irom0_0_seg);
-#endif /* CONFIG_ESP32_DEVKIT_RUN_IRAM */
+#endif /* CONFIG_ESP32_RUN_IRAM */
 
 /* Heap ends at top of dram0_0_seg */
 


### PR DESCRIPTION
## Summary

A non-existent option (`CONFIG_ESP32_DEVKIT_RUN_IRAM`) is checked during the ESP32 linking. This PR fixes this problem by using the correct option (`CONFIG_ESP32_RUN_IRAM`).

## Impact

Correct linking when using the `CONFIG_ESP32_RUN_IRAM` option.

## Testing

Compiled using `CONFIG_ESP32_RUN_IRAM`.