### PR TITLE
mpfs/mpfs_mm_init: Fix the section align mask checks

### DIFF
--- a/arch/risc-v/src/common/riscv_mmu.h
+++ b/arch/risc-v/src/common/riscv_mmu.h
@@ -110,7 +110,8 @@
 
 /* Minimum alignment requirement for any section of memory is 2MB */
 
-#define RV_MMU_SECTION_ALIGN    (RV_MMU_L2_PAGE_SIZE)
+#define RV_MMU_SECTION_ALIGN        (RV_MMU_L2_PAGE_SIZE)
+#define RV_MMU_SECTION_ALIGN_MASK   (RV_MMU_SECTION_ALIGN - 1)
 #else
 #error "Unsupported RISC-V MMU implementation selected"
 #endif /* CONFIG_ARCH_MMU_TYPE_SV39 */

--- a/arch/risc-v/src/mpfs/mpfs_mm_init.c
+++ b/arch/risc-v/src/mpfs/mpfs_mm_init.c
@@ -215,9 +215,9 @@ void mpfs_kernel_mappings(void)
    * handle unaligned L3 sections.
    */
 
-  ASSERT((KFLASH_START & RV_MMU_SECTION_ALIGN) == 0);
-  ASSERT((KSRAM_START & RV_MMU_SECTION_ALIGN) == 0);
-  ASSERT((PGPOOL_START & RV_MMU_SECTION_ALIGN) == 0);
+  ASSERT((KFLASH_START & RV_MMU_SECTION_ALIGN_MASK) == 0);
+  ASSERT((KSRAM_START & RV_MMU_SECTION_ALIGN_MASK) == 0);
+  ASSERT((PGPOOL_START & RV_MMU_SECTION_ALIGN_MASK) == 0);
 
   /* Check that the L3 table is of sufficient size */
 


### PR DESCRIPTION
The boundary-1 mask needs to be tested, not the alignment boundary

## Summary
Fix the alignment boundary sanity tests in mpfs_mm_init
## Impact
MPFS kernel mode only
## Testing
icicle:knsh
