### PR TITLE
risc-v/mpfs: opensbi: fix random boot failures

### DIFF
--- a/arch/risc-v/src/mpfs/mpfs_opensbi.c
+++ b/arch/risc-v/src/mpfs/mpfs_opensbi.c
@@ -225,7 +225,7 @@ static const struct sbi_platform platform =
 
 /* This must go into l2_scratchpad region, starting at 0x0a000000. */
 
-sbi_scratch_holder_t g_scratches[MPFS_MAX_NUM_HARTS] \
+sbi_scratch_holder_t g_scratches[0] \
                __attribute__((section(".l2_scratchpad")));
 
 /****************************************************************************

--- a/arch/risc-v/src/mpfs/mpfs_opensbi_utils.S
+++ b/arch/risc-v/src/mpfs/mpfs_opensbi_utils.S
@@ -103,7 +103,6 @@ mpfs_opensbi_prepare_hart:
   mul  t0, a0, t1
   la   sp, g_scratches
   add  sp, sp, t0
-  add  sp, sp, t1
   jal  mpfs_opensbi_setup
 
 /****************************************************************************


### PR DESCRIPTION
After the commit b8b541f, the system would not start up properly with certain coldboot conditions. For example, if the OpenSBI picked hart4 as the coldboot hart in preference to hart3, the system would get stuck due to stack corruption. OpenSBI uses a lottery mechanism to pick the coldboot hart.

Also fix g_scratches area in such a manner than it will not get initialized to zero. If several harts initialize the area to zero, there's danger the stack pointer gets wiped out.

Now any coldboot hart works.

Signed-off-by: Eero Nurkkala <eero.nurkkala@offcode.fi>

## Summary

Some coldboot harts caused stack corruption, fix the issue

## Impact

MPFS with booting Linux kernel

## Testing

MPFS Icicle board, with forced coldboot configs