### PR TITLE
net/tcp: Remove the unused TCP_STOPPED flags

### DIFF
--- a/include/nuttx/net/tcp.h
+++ b/include/nuttx/net/tcp.h
@@ -95,8 +95,7 @@
 #  define TCP_CLOSING     0x07
 #  define TCP_TIME_WAIT   0x08
 #  define TCP_LAST_ACK    0x09
-#  define TCP_STOPPED     0x10 /* Bit 4: stopped */
-                               /* Bit 5-7: Unused, but not available */
+                               /* Bit 4-7: Unused, but not available */
 
 /* TCP header sizes
  *

--- a/net/tcp/tcp_input.c
+++ b/net/tcp/tcp_input.c
@@ -1016,8 +1016,7 @@ found:
          * the sequence numbers will be screwed up.
          */
 
-        if ((tcp->flags & TCP_FIN) != 0 &&
-            (conn->tcpstateflags & TCP_STOPPED) == 0)
+        if ((tcp->flags & TCP_FIN) != 0)
           {
             /* Needs to be investigated further.
              * Windows often sends FIN packets together with the last ACK for
@@ -1150,12 +1149,10 @@ found:
 #endif
 
         /* If d_len > 0 we have TCP data in the packet, and we flag this
-         * by setting the TCP_NEWDATA flag. If the application has stopped
-         * the data flow using TCP_STOPPED, we must not accept any data
-         * packets from the remote host.
+         * by setting the TCP_NEWDATA flag.
          */
 
-        if (dev->d_len > 0 && (conn->tcpstateflags & TCP_STOPPED) == 0)
+        if (dev->d_len > 0)
           {
             flags |= TCP_NEWDATA;
           }


### PR DESCRIPTION
## Summary
report here:
https://github.com/apache/incubator-nuttx/issues/4005

## Impact
Remove the dead code

## Testing
Pass CI
