### PR TITLE
Fix some configure error in Windows native build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,13 +30,6 @@ ifeq ($(wildcard .config),)
 else
 include .config
 
-# Build any necessary tools needed early in the build.
-# incdir - Is needed immediately by all Make.defs file.
-
-TOPDIR := ${shell echo $(CURDIR) | sed -e 's/ /\\ /g'}
-DUMMY  := ${shell $(MAKE) -C tools -f Makefile.host incdir \
-          INCDIR="$(TOPDIR)/tools/incdir.sh"}
-
 # Include the correct Makefile for the selected architecture.
 
 ifeq ($(CONFIG_WINDOWS_NATIVE),y)

--- a/tools/Config.mk
+++ b/tools/Config.mk
@@ -62,7 +62,7 @@ endif
 # Define HOSTCC on the make command line if it differs from these defaults
 # Define HOSTCFLAGS with -g on the make command line to build debug versions
 
-ifeq ($(CONFIG_WINDOWS_MSYS),y)
+ifeq ($(CONFIG_WINDOWS_NATIVE),y)
 
 # In the Windows native environment, the MinGW GCC compiler is used
 

--- a/tools/Config.mk
+++ b/tools/Config.mk
@@ -523,12 +523,18 @@ ifeq ($(CONFIG_ARCH_COVERAGE),y)
 endif
 
 ifeq ($(CONFIG_WINDOWS_NATIVE),y)
+
+define NEWLINE
+
+
+endef
+
 define CLEAN
 	$(Q) if exist *$(OBJEXT) (del /f /q *$(OBJEXT))
 	$(Q) if exist *$(LIBEXT) (del /f /q *$(LIBEXT))
 	$(Q) if exist *~ (del /f /q *~)
 	$(Q) if exist (del /f /q  .*.swp)
-	$(Q) if exist $(OBJS) (del /f /q $(OBJS))
+	$(foreach OBJ, $(OBJS), $(NEWLINE) $(call DELFILE,$(OBJ)))
 	$(Q) if exist $(BIN) (del /f /q  $(BIN))
 	$(Q) if exist $(EXTRA) (del /f /q  $(EXTRA))
 endef

--- a/tools/Unix.mk
+++ b/tools/Unix.mk
@@ -702,12 +702,12 @@ ifeq ($(CONFIG_ARCH_HAVE_BOOTLOADER),y)
 	$(Q) $(MAKE) clean_bootloader
 endif
 	$(Q) $(MAKE) clean_context
+	$(Q) $(MAKE) -C tools -f Makefile.host clean
 	$(call DELFILE, Make.defs)
 	$(call DELFILE, defconfig)
 	$(call DELFILE, .config)
 	$(call DELFILE, .config.old)
 	$(call DELFILE, .gdbinit)
-	$(Q) $(MAKE) -C tools -f Makefile.host clean
 
 # Application housekeeping targets.  The APPDIR variable refers to the user
 # application directory.  A sample apps/ directory is included with NuttX,

--- a/tools/Unix.mk
+++ b/tools/Unix.mk
@@ -19,6 +19,13 @@
 ############################################################################
 
 export TOPDIR := ${shell echo $(CURDIR) | sed -e 's/ /\\ /g'}
+
+# Build any necessary tools needed early in the build.
+# incdir - Is needed immediately by all Make.defs file.
+
+DUMMY  := ${shell $(MAKE) -C tools -f Makefile.host incdir \
+          INCDIR="$(TOPDIR)/tools/incdir.sh"}
+
 include $(TOPDIR)/Make.defs
 
 # GIT directory present

--- a/tools/Win.mk
+++ b/tools/Win.mk
@@ -21,6 +21,13 @@
 export SHELL=cmd
 
 export TOPDIR := ${shell echo %CD%}
+
+# Build any necessary tools needed early in the build.
+# incdir - Is needed immediately by all Make.defs file.
+
+DUMMY  := ${shell $(MAKE) -C tools -f Makefile.host incdir \
+          INCDIR="$(TOPDIR)\tools\incdir.bat"}
+
 include $(TOPDIR)\Make.defs
 -include $(TOPDIR)\.version
 
@@ -53,7 +60,7 @@ APPDIR := $(realpath ${shell if exist "$(CONFIG_APPS_DIR)\Makefile" echo $(CONFI
 # so that main Kconfig can find it. Otherwise, we redirect it to a dummy Kconfig
 # This is due to kconfig inability to do conditional inclusion.
 
-EXTERNALDIR := $(shell if [ -r $(TOPDIR)\external\Kconfig ]; then echo 'external'; else echo 'dummy'; fi)
+EXTERNALDIR := ${shell if exist "$(TOPDIR)\external\Kconfig" (echo external) else (echo dummy)}
 
 # CONTEXTDIRS include directories that have special, one-time pre-build
 #   requirements.  Normally this includes things like auto-generation of

--- a/tools/Win.mk
+++ b/tools/Win.mk
@@ -661,11 +661,11 @@ ifeq ($(CONFIG_ARCH_HAVE_BOOTLOADER),y)
 	$(Q) $(MAKE) clean_bootloader
 endif
 	$(Q) $(MAKE) clean_context
+	$(Q) $(MAKE) -C tools -f Makefile.host clean
 	$(call DELFILE, Make.defs)
 	$(call DELFILE, defconfig)
 	$(call DELFILE, .config)
 	$(call DELFILE, .config.old)
-	$(Q) $(MAKE) -C tools -f Makefile.host clean
 
 # Application housekeeping targets.  The APPDIR variable refers to the user
 # application directory.  A sample apps\ directory is included with NuttX,

--- a/tools/cxd56/Makefile.host
+++ b/tools/cxd56/Makefile.host
@@ -18,6 +18,7 @@
 #
 ############################################################################
 
+include $(TOPDIR)/Make.defs
 all: mkspk
 default: mkspk
 .PHONY: clean
@@ -32,5 +33,9 @@ mkspk:
 	@gcc $(CFLAGS) -o mkspk mkspk.c clefia.c
 
 clean:
-	@rm -f *.o *.a *.dSYM *~ .*.swp
-	@rm -f mkspk mkspk.exe
+ifneq ($(CONFIG_WINDOWS_NATIVE),y)
+	$(Q) rm -rf *.dSYM
+endif
+	$(call DELFILE, mkspk)
+	$(call DELFILE, mkspk.exe)
+	$(call CLEAN)

--- a/tools/incdir.c
+++ b/tools/incdir.c
@@ -21,8 +21,10 @@
 /****************************************************************************
  * Included Files
  ****************************************************************************/
-
+#ifndef CONFIG_WINDOWS_NATIVE
 #include <sys/utsname.h>
+#endif
+
 #include <stdbool.h>
 #include <stdlib.h>
 #include <stdarg.h>
@@ -115,16 +117,17 @@ static void show_help(const char *progname, int exitcode)
 
 static enum os_e get_os(char *ccname)
 {
-  struct utsname buf;
-  int ret;
-
+#ifdef CONFIG_WINDOWS_NATIVE
   /* Check for MinGW which implies a Windows native environment */
 
   if (strstr(ccname, "mingw") != NULL)
     {
       return OS_WINDOWS;
     }
-
+#else
+  struct utsname buf;
+  int ret;
+  
   /* Get the context names */
 
   ret = uname(&buf);
@@ -165,8 +168,9 @@ static enum os_e get_os(char *ccname)
     {
       fprintf(stderr, "ERROR:  Unknown operating system: %s\n",
               buf.sysname);
-      return OS_UNKNOWN;
     }
+#endif
+  return OS_UNKNOWN;
 }
 
 static enum compiler_e get_compiler(char *ccname, enum os_e os)

--- a/tools/incdir.c
+++ b/tools/incdir.c
@@ -127,7 +127,7 @@ static enum os_e get_os(char *ccname)
 #else
   struct utsname buf;
   int ret;
-  
+
   /* Get the context names */
 
   ret = uname(&buf);
@@ -169,6 +169,7 @@ static enum os_e get_os(char *ccname)
       fprintf(stderr, "ERROR:  Unknown operating system: %s\n",
               buf.sysname);
     }
+
 #endif
   return OS_UNKNOWN;
 }

--- a/tools/pic32/Makefile.host
+++ b/tools/pic32/Makefile.host
@@ -18,6 +18,7 @@
 #
 ############################################################################
 
+include $(TOPDIR)/Make.defs
 all: mkpichex
 default: mkpichex
 .PHONY: clean
@@ -32,5 +33,9 @@ mkpichex: mkpichex.c
 	@gcc $(CFLAGS) -o mkpichex mkpichex.c
 
 clean:
-	@rm -f *.o *.a *.dSYM *~ .*.swp
-	@rm -f mkpichex mkpichex.exe
+ifneq ($(CONFIG_WINDOWS_NATIVE),y)
+	$(Q) rm -rf *.dSYM
+endif
+	$(call DELFILE, mkpichex)
+	$(call DELFILE, mkpichex.exe)
+	$(call CLEAN)


### PR DESCRIPTION
## Summary
1. there's a 'input line is too long' error when call CLEAN ;
2. there's no uname support in MinGW's  lib ;
3. Make.defs and .config deleted too early In distclean, and Makefile.host of pic32 and cxd56 did'nt considering Windows native build.
4. when pipe input to sed, there's a bug with a pipe being in the string, so in Windows native build we can't use `TOPDIR := ${shell echo $(CURDIR) | sed -e 's/ /\\ /g'}`
[https://stackoverflow.com/questions/804646/how-do-you-strip-quotes-out-of-an-echoed-string-in-a-windows-batch-file](url)
## Impact
Windows native build
## Testing
MinGW + GnuWin32 + custom_apps + Windows native build configs
