### PR TITLE
stm32_eth: Fix in assertion parameters.

### DIFF
--- a/arch/arm/src/stm32/stm32_eth.c
+++ b/arch/arm/src/stm32/stm32_eth.c
@@ -1134,7 +1134,7 @@ static int stm32_transmit(struct stm32_ethmac_s *priv)
 
       /* Set frame size */
 
-      DEBUGASSERT(priv->dev.d_len <= CONFIG_NET_ETH_PKTSIZE);
+      DEBUGASSERT(priv->dev.d_len <= CONFIG_STM32_ETH_BUFSIZE);
       txdesc->tdes1 = priv->dev.d_len;
 
       /* Set the Buffer1 address pointer */


### PR DESCRIPTION
## Summary

Fixes an assertion in STM32 Ethernet driver.

Since this code is about to use the STM32 buffers, I think it is more correct to check against this size, instead of the size of the Ethernet buffer size.

Typically `CONFIG_NET_ETH_PKTSIZE` and `CONFIG_STM32_ETH_BUFSIZE` are equal (so the functionality of the code does not change), but I think this way it is "more correct". Especially in any special case that these two macros have different value.

## Impact

N/A

## Testing

Basic network test on an STM32F427.  
I didn't notice this assertion to fail.
