### PR TITLE
mm: Restore the return type of mm_lock from bool to int

### DIFF
--- a/mm/mm_heap/mm.h
+++ b/mm/mm_heap/mm.h
@@ -240,7 +240,7 @@ typedef CODE void (*mmchunk_handler_t)(FAR struct mm_allocnode_s *node,
 
 /* Functions contained in mm_lock.c *****************************************/
 
-bool mm_lock(FAR struct mm_heap_s *heap);
+int mm_lock(FAR struct mm_heap_s *heap);
 void mm_unlock(FAR struct mm_heap_s *heap);
 
 /* Functions contained in mm_shrinkchunk.c **********************************/

--- a/mm/mm_heap/mm_extend.c
+++ b/mm/mm_heap/mm_extend.c
@@ -56,7 +56,6 @@ void mm_extend(FAR struct mm_heap_s *heap, FAR void *mem, size_t size,
   FAR struct mm_allocnode_s *newnode;
   uintptr_t blockstart;
   uintptr_t blockend;
-  bool ret;
 
   /* Make sure that we were passed valid parameters */
 
@@ -78,8 +77,7 @@ void mm_extend(FAR struct mm_heap_s *heap, FAR void *mem, size_t size,
 
   /* Take the memory manager mutex */
 
-  ret = mm_lock(heap);
-  DEBUGASSERT(ret);
+  DEBUGVERIFY(mm_lock(heap));
 
   /* Get the terminal node in the old heap.  The block to extend must
    * immediately follow this node.

--- a/mm/mm_heap/mm_foreach.c
+++ b/mm/mm_heap/mm_foreach.c
@@ -68,7 +68,7 @@ void mm_foreach(FAR struct mm_heap_s *heap, mmchunk_handler_t handler,
        * Retake the mutex for each region to reduce latencies
        */
 
-      if (!mm_lock(heap))
+      if (mm_lock(heap) < 0)
         {
           return;
         }

--- a/mm/mm_heap/mm_free.c
+++ b/mm/mm_heap/mm_free.c
@@ -84,7 +84,7 @@ void mm_free(FAR struct mm_heap_s *heap, FAR void *mem)
       return;
     }
 
-  if (mm_lock(heap) == false)
+  if (mm_lock(heap) < 0)
     {
       /* Meet -ESRCH return, which means we are in situations
        * during context switching(See mm_lock() & getpid()).

--- a/mm/mm_heap/mm_free.c
+++ b/mm/mm_heap/mm_free.c
@@ -37,7 +37,7 @@
  * Private Functions
  ****************************************************************************/
 
-static void mm_add_delaylist(FAR struct mm_heap_s *heap, FAR void *mem)
+static void add_delaylist(FAR struct mm_heap_s *heap, FAR void *mem)
 {
 #if defined(CONFIG_BUILD_FLAT) || defined(__KERNEL__)
   FAR struct mm_delaynode_s *tmp = mem;
@@ -91,7 +91,7 @@ void mm_free(FAR struct mm_heap_s *heap, FAR void *mem)
        * Then add to the delay list.
        */
 
-      mm_add_delaylist(heap, mem);
+      add_delaylist(heap, mem);
       return;
     }
 

--- a/mm/mm_heap/mm_initialize.c
+++ b/mm/mm_heap/mm_initialize.c
@@ -61,7 +61,6 @@ void mm_addregion(FAR struct mm_heap_s *heap, FAR void *heapstart,
   FAR struct mm_freenode_s *node;
   uintptr_t heapbase;
   uintptr_t heapend;
-  bool ret;
 #if CONFIG_MM_REGIONS > 1
   int IDX;
 
@@ -92,8 +91,7 @@ void mm_addregion(FAR struct mm_heap_s *heap, FAR void *heapstart,
 
   kasan_register(heapstart, &heapsize);
 
-  ret = mm_lock(heap);
-  DEBUGASSERT(ret);
+  DEBUGVERIFY(mm_lock(heap));
 
   /* Adjust the provided heap start and size.
    *

--- a/mm/mm_heap/mm_lock.c
+++ b/mm/mm_heap/mm_lock.c
@@ -51,11 +51,11 @@
  *   heap  - heap instance want to take mutex
  *
  * Returned Value:
- *   true if the lock can be taken, otherwise false.
+ *   0 if the lock can be taken, otherwise negative errno.
  *
  ****************************************************************************/
 
-bool mm_lock(FAR struct mm_heap_s *heap)
+int mm_lock(FAR struct mm_heap_s *heap)
 {
 #if defined(CONFIG_BUILD_FLAT) || defined(__KERNEL__)
   /* Check current environment */
@@ -67,11 +67,11 @@ bool mm_lock(FAR struct mm_heap_s *heap)
        * Or, touch the heap internal data directly.
        */
 
-      return !nxmutex_is_locked(&heap->mm_lock);
+      return nxmutex_is_locked(&heap->mm_lock) ? -EAGAIN : 0;
 #else
       /* Can't take mutex in SMP interrupt handler */
 
-      return false;
+      return -EAGAIN;
 #endif
     }
   else
@@ -89,11 +89,11 @@ bool mm_lock(FAR struct mm_heap_s *heap)
 
   if (getpid() < 0)
     {
-      return false;
+      return -ESRCH;
     }
   else
     {
-      return nxmutex_lock(&heap->mm_lock) >= 0;
+      return nxmutex_lock(&heap->mm_lock);
     }
 }
 

--- a/mm/mm_heap/mm_malloc.c
+++ b/mm/mm_heap/mm_malloc.c
@@ -40,7 +40,7 @@
  * Private Functions
  ****************************************************************************/
 
-static void mm_free_delaylist(FAR struct mm_heap_s *heap)
+static void free_delaylist(FAR struct mm_heap_s *heap)
 {
 #if defined(CONFIG_BUILD_FLAT) || defined(__KERNEL__)
   FAR struct mm_delaynode_s *tmp;
@@ -111,7 +111,7 @@ FAR void *mm_malloc(FAR struct mm_heap_s *heap, size_t size)
 
   /* Free the delay list first */
 
-  mm_free_delaylist(heap);
+  free_delaylist(heap);
 
   /* Ignore zero-length allocations */
 

--- a/mm/mm_heap/mm_malloc.c
+++ b/mm/mm_heap/mm_malloc.c
@@ -108,7 +108,6 @@ FAR void *mm_malloc(FAR struct mm_heap_s *heap, size_t size)
   size_t alignsize;
   FAR void *ret = NULL;
   int ndx;
-  bool val;
 
   /* Free the delay list first */
 
@@ -138,8 +137,7 @@ FAR void *mm_malloc(FAR struct mm_heap_s *heap, size_t size)
 
   /* We need to hold the MM mutex while we muck with the nodelist. */
 
-  val = mm_lock(heap);
-  DEBUGASSERT(val);
+  DEBUGVERIFY(mm_lock(heap));
 
   /* Get the location in the node list to start the search. Special case
    * really big allocations

--- a/mm/mm_heap/mm_memalign.c
+++ b/mm/mm_heap/mm_memalign.c
@@ -57,7 +57,6 @@ FAR void *mm_memalign(FAR struct mm_heap_s *heap, size_t alignment,
   size_t mask = (size_t)(alignment - 1);
   size_t allocsize;
   size_t newsize;
-  bool ret;
 
   /* Make sure that alignment is less than half max size_t */
 
@@ -121,8 +120,7 @@ FAR void *mm_memalign(FAR struct mm_heap_s *heap, size_t alignment,
    * nodelist.
    */
 
-  ret = mm_lock(heap);
-  DEBUGASSERT(ret);
+  DEBUGVERIFY(mm_lock(heap));
 
   /* Get the node associated with the allocation and the next node after
    * the allocation.

--- a/mm/mm_heap/mm_realloc.c
+++ b/mm/mm_heap/mm_realloc.c
@@ -72,7 +72,6 @@ FAR void *mm_realloc(FAR struct mm_heap_s *heap, FAR void *oldmem,
   size_t prevsize = 0;
   size_t nextsize = 0;
   FAR void *newmem;
-  bool ret;
 
   /* If oldmem is NULL, then realloc is equivalent to malloc */
 
@@ -109,8 +108,7 @@ FAR void *mm_realloc(FAR struct mm_heap_s *heap, FAR void *oldmem,
 
   /* We need to hold the MM mutex while we muck with the nodelist. */
 
-  ret = mm_lock(heap);
-  DEBUGASSERT(ret);
+  DEBUGVERIFY(mm_lock(heap));
   DEBUGASSERT(oldnode->preceding & MM_ALLOC_BIT);
   DEBUGASSERT(mm_heapmember(heap, oldmem));
 


### PR DESCRIPTION
## Summary
Fix the issue reported here better: https://github.com/apache/incubator-nuttx/pull/6995

## Impact
Code refactor only

## Testing
Pass CI
