### PR TITLE
lpwan/sx127x: correct device unlock interface to nxmutex_unlock()

### DIFF
--- a/drivers/wireless/lpwan/sx127x/sx127x.c
+++ b/drivers/wireless/lpwan/sx127x/sx127x.c
@@ -942,7 +942,7 @@ errout:
    */
 
   sx127x_opmode_set(dev, dev->idle);
-  nxsem_post(&dev->dev_lock);
+  nxmutex_unlock(&dev->dev_lock);
 
   return ret;
 #endif


### PR DESCRIPTION
## Summary

lpwan/sx127x: correct device unlock interface to nxmutex_unlock()

## Impact

N/A

## Testing

ci check