### PR TITLE
lib/atexit: correct return value of exitfunc lock 

### DIFF
--- a/drivers/sensors/mpu60x0.c
+++ b/drivers/sensors/mpu60x0.c
@@ -694,6 +694,7 @@ static int mpu_reset(FAR struct mpu_dev_s *dev)
   ret = __mpu_write_pwr_mgmt_1(dev, PWR_MGMT_1__DEVICE_RESET);
   if (ret != OK)
     {
+      mpu_unlock(dev);
       snerr("Could not find mpu60x0!\n");
       return ret;
     }

--- a/libs/libc/stdlib/lib_atexit.c
+++ b/libs/libc/stdlib/lib_atexit.c
@@ -59,51 +59,13 @@ static FAR struct atexit_list_s * get_exitfuncs(void)
 }
 
 /****************************************************************************
- * Name: exitfunc_lock
- *
- * Description:
- *    Obtain the exit function lock.
- *
- * Returned Value:
- *   OK on success, or negated errno on failure
- *
- ****************************************************************************/
-
-static int exitfunc_lock(void)
-{
-  FAR struct task_info_s *info = task_get_info();
-  int ret = nxmutex_lock(&info->ta_lock);
-
-  if (ret < 0)
-    {
-      ret = -ret;
-    }
-
-  return ret;
-}
-
-/****************************************************************************
- * Name: exitfunc_unlock
- *
- * Description:
- *    Release exit function lock .
- *
- ****************************************************************************/
-
-static void exitfunc_unlock(void)
-{
-  FAR struct task_info_s *info = task_get_info();
-
-  nxmutex_unlock(&info->ta_lock);
-}
-
-/****************************************************************************
  * Public Functions
  ****************************************************************************/
 
 int atexit_register(int type, CODE void (*func)(void), FAR void *arg,
                     FAR void *dso)
 {
+  FAR struct task_info_s   *info = task_get_info();
   FAR struct atexit_list_s *aehead;
   int                       idx;
   int                       ret = ERROR;
@@ -118,10 +80,10 @@ int atexit_register(int type, CODE void (*func)(void), FAR void *arg,
 
   if (func)
     {
-      ret = exitfunc_lock();
+      ret = nxmutex_lock(&info->ta_lock);
       if (ret < 0)
         {
-          return ret;
+          return -ret;
         }
 
       if ((idx = aehead->nfuncs) < ATEXIT_MAX)
@@ -137,7 +99,7 @@ int atexit_register(int type, CODE void (*func)(void), FAR void *arg,
           ret = ERROR;
         }
 
-      exitfunc_unlock();
+      nxmutex_unlock(&info->ta_lock);
     }
 
   return ret;


### PR DESCRIPTION
## Summary

lib/atexit: correct return value of exitfunc lock
sensor/mpu60x0: correct mutex usage

## Impact

N/A

## Testing

ci-check