### PR TITLE
prctl syscall is present unconditionally

### DIFF
--- a/include/sys/syscall_lookup.h
+++ b/include/sys/syscall_lookup.h
@@ -27,6 +27,7 @@
 SYSCALL_LOOKUP1(_exit,                     1)
 SYSCALL_LOOKUP(getpid,                     0)
 SYSCALL_LOOKUP(gettid,                     0)
+SYSCALL_LOOKUP(prctl,                      2)
 
 #ifdef CONFIG_SCHED_HAVE_PARENT
   SYSCALL_LOOKUP(getppid,                  0)
@@ -366,12 +367,6 @@ SYSCALL_LOOKUP(futimens,                   2)
   SYSCALL_LOOKUP(setsockopt,               5)
   SYSCALL_LOOKUP(socket,                   3)
   SYSCALL_LOOKUP(socketpair,               4)
-#endif
-
-/* The following is defined only if CONFIG_TASK_NAME_SIZE > 0 */
-
-#if CONFIG_TASK_NAME_SIZE > 0
-  SYSCALL_LOOKUP(prctl,                    2)
 #endif
 
 /* The following is defined only if entropy pool random number generator

--- a/syscall/syscall.csv
+++ b/syscall/syscall.csv
@@ -80,7 +80,7 @@
 "poll","poll.h","","int","FAR struct pollfd *","nfds_t","int"
 "posix_spawn","spawn.h","!defined(CONFIG_BINFMT_DISABLE) && defined(CONFIG_LIBC_EXECFUNCS)","int","FAR pid_t *","FAR const char *","FAR const posix_spawn_file_actions_t *","FAR const posix_spawnattr_t *","FAR char * const []|FAR char * const *","FAR char * const []|FAR char * const *"
 "ppoll","poll.h","","int","FAR struct pollfd *","nfds_t","FAR const struct timespec *","FAR const sigset_t *"
-"prctl","sys/prctl.h", "CONFIG_TASK_NAME_SIZE > 0","int","int","...","uintptr_t","uintptr_t"
+"prctl","sys/prctl.h","","int","int","...","uintptr_t","uintptr_t"
 "pread","unistd.h","","ssize_t","int","FAR void *","size_t","off_t"
 "pselect","sys/select.h","","int","int","FAR fd_set *","FAR fd_set *","FAR fd_set *","FAR const struct timespec *","FAR const sigset_t *"
 "pthread_cancel","pthread.h","!defined(CONFIG_DISABLE_PTHREAD)","int","pthread_t"


### PR DESCRIPTION
## Summary

I had a link problem regarding prctl while CONFIG_TASK_NAME_SIZE was defined 0 and building in protected mode.  Turns out in monolithic build prctl is present no matter what CONFIG_TASK_NAME_SIZE, but in protected mode build its only present if CONFIG_TASK_NAME_SIZE > 0. So, bring protected mode build in sync with the monolithic one.

## Impact

Fixes a linkage error in a specific configuration (CONFIG_TASK_NAME_SIZE = 0) for the protected mode build.

## Testing

Tested with custom board

