### PR TITLE
random_pool:add a new api arc4random

### DIFF
--- a/crypto/random_pool.c
+++ b/crypto/random_pool.c
@@ -550,3 +550,27 @@ void arc4random_buf(FAR void *bytes, size_t nbytes)
   rng_buf_internal(bytes, nbytes);
   nxmutex_unlock(&g_rng.rd_lock);
 }
+
+/****************************************************************************
+ * Name: arc4random
+ *
+ * Description:
+ *   Returns a single 32-bit value. This is the preferred interface for
+ *   getting random numbers. The traditional /dev/random approach is
+ *   susceptible for things like the attacker exhausting file
+ *   descriptors on purpose.
+ *
+ *   Note that this function cannot fail, other than by asserting.
+ *
+ * Returned Value:
+ *   a random 32-bit value.
+ *
+ ****************************************************************************/
+
+uint32_t arc4random(void)
+{
+  uint32_t ret;
+
+  arc4random_buf(&ret, sizeof(ret));
+  return ret;
+}

--- a/include/stdlib.h
+++ b/include/stdlib.h
@@ -138,6 +138,7 @@ long      random(void);
 
 #ifdef CONFIG_CRYPTO_RANDOM_POOL
 void      arc4random_buf(FAR void *bytes, size_t nbytes);
+uint32_t  arc4random(void);
 #endif
 
 /* Environment variable support */


### PR DESCRIPTION
Signed-off-by: anjiahao <anjiahao@xiaomi.com>
## Summary
The [arc4random](https://man.openbsd.org/arc4random.3#arc4random)() function returns a single 32-bit value.

[arc4random_buf](https://man.openbsd.org/arc4random.3#arc4random_buf)() fills the region buf of length nbytes with random data.
## Impact
random_poll
## Testing
ci
