### PR TITLE
Add Network Address Translation (NAT) for NuttX

### DIFF
--- a/Documentation/reference/os/nat.rst
+++ b/Documentation/reference/os/nat.rst
@@ -1,0 +1,169 @@
+=================================
+Network Address Translation (NAT)
+=================================
+
+NuttX supports full cone NAT logic, which currently supports
+
+- TCP
+- UDP
+- ICMP ECHO (REQUEST & REPLY)
+
+Workflow
+========
+
+::
+
+  Local Network (LAN)                          External Network (WAN)
+                    |----------------|
+       <local IP,   |                | <external IP,             <peer IP,
+         -----------|                |-----------------------------
+        local port> |                |  external port>            peer port>
+                    |----------------|
+
+- Outbound
+
+  - **LAN** -> **Forward** -> **NAT** (only if targeting at WAN) -> **WAN**
+
+  - All packets from **LAN** and targeting at **WAN** will be masqueraded
+    with ``local ip:port`` changed to ``external ip:port``.
+
+- Inbound
+
+  - **WAN** -> **NAT** (only from WAN, change destination) -> **Forward** -> **LAN**
+
+  - Packets from **WAN** will try to be changed back from
+    ``external ip:port`` to ``local ip:port`` and send to **LAN**.
+
+Configuration Options
+=====================
+
+``CONFIG_NET_NAT``
+  Enable or disable Network Address Translation (NAT) function.
+  Depends on ``CONFIG_NET_IPFORWARD``.
+``CONFIG_NET_NAT_TCP_EXPIRE_SEC``
+  The expiration time for idle TCP entry in NAT.
+  The default value 86400 is suggested by RFC2663, Section 2.6,
+  Page 5. But we may set it to shorter time like 240s for better
+  performance.
+``CONFIG_NET_NAT_UDP_EXPIRE_SEC``
+  The expiration time for idle UDP entry in NAT.
+``CONFIG_NET_NAT_ICMP_EXPIRE_SEC``
+  The expiration time for idle ICMP entry in NAT.
+
+Usage
+=====
+
+  - :c:func:`ipv4_nat_enable()`
+  - :c:func:`ipv4_nat_disable()`
+
+.. c:function:: int ipv4_nat_enable(FAR struct net_driver_s *dev);
+
+  Enable NAT function on a network device, on which the outbound packets
+  will be masqueraded.
+
+  Note that NAT is currently designed to be enabled on single device, it
+  may work when enabled on multiple devices, but external ports will not
+  be isolated between devices, so an external port used on one NAT device
+  will also be used by same local ip:port on another NAT device.
+
+  :return: Zero is returned if NAT function is successfully enabled on
+    the device; A negated errno value is returned if failed.
+
+.. c:function:: int ipv4_nat_disable(FAR struct net_driver_s *dev);
+
+  Disable NAT function on a network device.
+
+  :return: Zero is returned if NAT function is successfully disabled on
+    the device; A negated errno value is returned if failed.
+
+Validation
+==========
+
+Validated on Ubuntu 22.04 x86_64 with NuttX SIM by following steps:
+
+1. Configure NuttX with >=2 TAP devices (host route mode) and NAT enabled:
+
+  ..  code-block:: Kconfig
+
+      CONFIG_NET_IPFORWARD=y
+      CONFIG_NET_NAT=y
+      # CONFIG_SIM_NET_BRIDGE is not set
+      CONFIG_SIM_NETDEV_NUMBER=2
+
+2. Call ``ipv4_nat_enable`` on one dev on startup
+
+  ..  code-block:: c
+
+      /* arch/sim/src/sim/up_netdriver.c */
+      int netdriver_init(void)
+      {
+        ...
+        ipv4_nat_enable(&g_sim_dev[0]);
+        ...
+      }
+
+3. Set IP Address for NuttX on startup
+
+  ..  code-block:: shell
+
+    ifconfig eth0 10.0.1.2
+    ifup eth0
+    ifconfig eth1 10.0.10.2
+    ifup eth1
+
+4. Configure IP & namespace & route on host side (maybe need to be root, then try ``sudo -i``)
+
+  ..  code-block:: bash
+
+    IF_HOST="enp1s0"
+    IF_0="tap0"
+    IP_HOST_0="10.0.1.1"
+    IF_1="tap1"
+    IP_HOST_1="10.0.10.1"
+    IP_NUTTX_1="10.0.10.2"
+
+    # add net namespace LAN for $IF_1
+    ip netns add LAN
+    ip netns exec LAN sysctl -w net.ipv4.ip_forward=1
+    ip link set $IF_1 netns LAN
+    ip netns exec LAN ip link set $IF_1 up
+    ip netns exec LAN ip link set lo up
+
+    # add address and set default route
+    ip addr add $IP_HOST_0/24 dev $IF_0
+    ip netns exec LAN ip addr add $IP_HOST_1/24 dev $IF_1
+    ip netns exec LAN ip route add default dev $IF_1 via $IP_NUTTX_1
+
+    # nat to allow NuttX to access the internet
+    iptables -t nat -A POSTROUTING -o $IF_HOST -j MASQUERADE
+    iptables -A FORWARD -i $IF_HOST -o $IF_0 -j ACCEPT
+    iptables -A FORWARD -i $IF_0 -o $IF_HOST -j ACCEPT
+    sysctl -w net.ipv4.ip_forward=1
+
+5. Do anything in the LAN namespace will go through NAT
+
+  ..  code-block:: shell
+
+    # Host side
+    iperf -B 10.0.1.1 -s -i 1
+    # LAN side
+    sudo ip netns exec LAN iperf -B 10.0.10.1 -c 10.0.1.1 -i 1
+
+  ..  code-block:: shell
+
+    # Host side
+    python3 -m http.server
+    # LAN side
+    for i in {1..20000}; do sudo ip netns exec LAN curl 'http://10.0.1.1:8000/' > /dev/null 2>1; done
+
+  ..  code-block:: shell
+
+    # LAN side
+    sudo ip netns exec LAN ping 8.8.8.8
+
+  ..  code-block:: shell
+
+    # Host side
+    tcpdump -nn -i tap0
+    # LAN side
+    sudo ip netns exec LAN tcpdump -nn -i tap1

--- a/include/net/if.h
+++ b/include/net/if.h
@@ -53,6 +53,7 @@
 #define IFF_LOOPBACK       (1 << 5)  /* Is a loopback net */
 #define IFF_POINTOPOINT    (1 << 6)  /* Is point-to-point link */
 #define IFF_NOARP          (1 << 7)  /* ARP is not required for this packet */
+#define IFF_NAT            (1 << 8)  /* NAT is enabled for this interface */
 #define IFF_MULTICAST      (1 << 12) /* Supports multicast. */
 #define IFF_BROADCAST      (1 << 13) /* Broadcast address valid. */
 
@@ -61,6 +62,7 @@
 #define IFF_SET_UP(f)          do { (f) |= IFF_UP; } while (0)
 #define IFF_SET_RUNNING(f)     do { (f) |= IFF_RUNNING; } while (0)
 #define IFF_SET_NOARP(f)       do { (f) |= IFF_NOARP; } while (0)
+#define IFF_SET_NAT(f)         do { (f) |= IFF_NAT; } while (0)
 #define IFF_SET_LOOPBACK(f)    do { (f) |= IFF_LOOPBACK; } while (0)
 #define IFF_SET_POINTOPOINT(f) do { (f) |= IFF_POINTOPOINT; } while (0)
 #define IFF_SET_MULTICAST(f)   do { (f) |= IFF_MULTICAST; } while (0)
@@ -69,6 +71,7 @@
 #define IFF_CLR_UP(f)          do { (f) &= ~IFF_UP; } while (0)
 #define IFF_CLR_RUNNING(f)     do { (f) &= ~IFF_RUNNING; } while (0)
 #define IFF_CLR_NOARP(f)       do { (f) &= ~IFF_NOARP; } while (0)
+#define IFF_CLR_NAT(f)         do { (f) &= ~IFF_NAT; } while (0)
 #define IFF_CLR_LOOPBACK(f)    do { (f) &= ~IFF_LOOPBACK; } while (0)
 #define IFF_CLR_POINTOPOINT(f) do { (f) &= ~IFF_POINTOPOINT; } while (0)
 #define IFF_CLR_MULTICAST(f)   do { (f) &= ~IFF_MULTICAST; } while (0)
@@ -77,6 +80,7 @@
 #define IFF_IS_UP(f)          (((f) & IFF_UP) != 0)
 #define IFF_IS_RUNNING(f)     (((f) & IFF_RUNNING) != 0)
 #define IFF_IS_NOARP(f)       (((f) & IFF_NOARP) != 0)
+#define IFF_IS_NAT(f)         (((f) & IFF_NAT) != 0)
 #define IFF_IS_LOOPBACK(f)    (((f) & IFF_LOOPBACK) != 0)
 #define IFF_IS_POINTOPOINT(f) (((f) & IFF_POINTOPOINT) != 0)
 #define IFF_IS_MULTICAST(f)   (((f) & IFF_MULTICAST) != 0)

--- a/include/nuttx/queue.h
+++ b/include/nuttx/queue.h
@@ -158,6 +158,10 @@
 #define sq_for_every(q, p) \
   for ((p) = (q)->head; (p) != NULL; (p) = (p)->flink)
 
+#define sq_for_every_safe(q, p, tmp) \
+  for((p) = (q)->head, (tmp) = (p) ? (p)->flink : NULL; \
+      (p) != NULL; (p) = (tmp), (tmp) = (p) ? (p)->flink : NULL)
+
 #define sq_rem(p, q) \
   do \
     { \

--- a/net/Kconfig
+++ b/net/Kconfig
@@ -320,6 +320,7 @@ menuconfig NET_6LOWPAN
 
 source "net/sixlowpan/Kconfig"
 source "net/ipforward/Kconfig"
+source "net/nat/Kconfig"
 
 endmenu # Internet Protocol Selection
 

--- a/net/Makefile
+++ b/net/Makefile
@@ -47,6 +47,7 @@ include bluetooth/Make.defs
 include ieee802154/Make.defs
 include devif/Make.defs
 include ipforward/Make.defs
+include nat/Make.defs
 include route/Make.defs
 include procfs/Make.defs
 include usrsock/Make.defs

--- a/net/devif/ipv4_input.c
+++ b/net/devif/ipv4_input.c
@@ -103,6 +103,7 @@
 
 #include "ipforward/ipforward.h"
 #include "devif/devif.h"
+#include "nat/nat.h"
 
 /****************************************************************************
  * Private Data
@@ -205,6 +206,16 @@ int ipv4_input(FAR struct net_driver_s *dev)
       nwarn("WARNING: IP fragment dropped\n");
       goto drop;
     }
+
+#ifdef CONFIG_NET_NAT
+  /* Try NAT inbound, rule matching will be performed in NAT module. */
+
+  if (ipv4_nat_inbound(dev, ipv4) < 0)
+    {
+      nwarn("WARNING: Performing NAT inbound failed!\n");
+      goto drop;
+    }
+#endif
 
   /* Get the destination IP address in a friendlier form */
 

--- a/net/ipforward/ipv4_forward.c
+++ b/net/ipforward/ipv4_forward.c
@@ -38,6 +38,7 @@
 #include "utils/utils.h"
 #include "sixlowpan/sixlowpan.h"
 #include "ipforward/ipforward.h"
+#include "nat/nat.h"
 #include "devif/devif.h"
 
 #if defined(CONFIG_NET_IPFORWARD) && defined(CONFIG_NET_IPv4)
@@ -311,6 +312,18 @@ static int ipv4_dev_forward(FAR struct net_driver_s *dev,
       ret = -EMULTIHOP;
       goto errout_with_iobchain;
     }
+
+#ifdef CONFIG_NET_NAT
+  /* Try NAT outbound, rule matching will be performed in NAT module. */
+
+  ret = ipv4_nat_outbound(fwd->f_dev,
+                          (FAR struct ipv4_hdr_s *)fwd->f_iob->io_data);
+  if (ret < 0)
+    {
+      nwarn("WARNING: Performing NAT outbound failed, dropping!\n");
+      goto errout_with_iobchain;
+    }
+#endif
 
   /* Then set up to forward the packet according to the protocol. */
 

--- a/net/nat/Kconfig
+++ b/net/nat/Kconfig
@@ -19,3 +19,13 @@ config NET_NAT_TCP_EXPIRE_SEC
 
 		Note: The default value 86400 is suggested by RFC2663, Section 2.6,
 		Page 5.
+
+config NET_NAT_ICMP_EXPIRE_SEC
+	int "ICMP NAT entry expiration seconds"
+	default 60
+	depends on NET_NAT
+	---help---
+		The expiration time for idle ICMP entry in NAT.
+
+		Note: The default value 60 is suggested by RFC5508, Section 3.2,
+		Page 8.

--- a/net/nat/Kconfig
+++ b/net/nat/Kconfig
@@ -1,0 +1,11 @@
+#
+# For a description of the syntax of this configuration file,
+# see the file kconfig-language.txt in the NuttX tools repository.
+#
+
+config NET_NAT
+	bool "Network Address Translation (NAT)"
+	default n
+	depends on NET_IPFORWARD
+	---help---
+		Enable or disable Network Address Translation (NAT) function.

--- a/net/nat/Kconfig
+++ b/net/nat/Kconfig
@@ -9,3 +9,13 @@ config NET_NAT
 	depends on NET_IPFORWARD
 	---help---
 		Enable or disable Network Address Translation (NAT) function.
+
+config NET_NAT_TCP_EXPIRE_SEC
+	int "TCP NAT entry expiration seconds"
+	default 86400
+	depends on NET_NAT
+	---help---
+		The expiration time for idle TCP entry in NAT.
+
+		Note: The default value 86400 is suggested by RFC2663, Section 2.6,
+		Page 5.

--- a/net/nat/Kconfig
+++ b/net/nat/Kconfig
@@ -20,6 +20,17 @@ config NET_NAT_TCP_EXPIRE_SEC
 		Note: The default value 86400 is suggested by RFC2663, Section 2.6,
 		Page 5.
 
+config NET_NAT_UDP_EXPIRE_SEC
+	int "UDP NAT entry expiration seconds"
+	default 240
+	depends on NET_NAT
+	---help---
+		The expiration time for idle UDP entry in NAT.
+
+		Note: RFC2663 (Section 2.6, Page 5) suggests that non-TCP sessions
+		that have not been used for a couple of minutes can be assumed to be
+		terminated.
+
 config NET_NAT_ICMP_EXPIRE_SEC
 	int "ICMP NAT entry expiration seconds"
 	default 60

--- a/net/nat/Make.defs
+++ b/net/nat/Make.defs
@@ -1,0 +1,34 @@
+############################################################################
+# net/nat/Make.defs
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+# NAT source files
+
+ifeq ($(CONFIG_NET_NAT),y)
+
+ifeq ($(CONFIG_NET_IPv4),y)
+NET_CSRCS += ipv4_nat.c ipv4_nat_entry.c
+endif
+
+# Include NAT build support
+
+DEPPATH += --dep-path nat
+VPATH += :nat
+
+endif

--- a/net/nat/ipv4_nat.c
+++ b/net/nat/ipv4_nat.c
@@ -321,4 +321,34 @@ int ipv4_nat_outbound(FAR struct net_driver_s *dev,
   return OK;
 }
 
+/****************************************************************************
+ * Name: ipv4_nat_port_inuse
+ *
+ * Description:
+ *   Check whether a port is currently used by NAT.
+ *
+ * Input Parameters:
+ *   protocol      - The L4 protocol of the packet.
+ *   ip            - The IP bind with the port (in network byte order).
+ *   port          - The port number to check (in network byte order).
+ *
+ * Returned Value:
+ *   True if the port is already used by NAT, otherwise false.
+ *
+ ****************************************************************************/
+
+bool ipv4_nat_port_inuse(uint8_t protocol, in_addr_t ip, uint16_t port)
+{
+  FAR struct ipv4_nat_entry *entry =
+      ipv4_nat_inbound_entry_find(protocol, port);
+
+  /* Not checking ip is enough for single NAT device, may save external_ip in
+   * entry for multiple device support in future.
+   */
+
+  UNUSED(ip);
+
+  return entry != NULL;
+}
+
 #endif /* CONFIG_NET_NAT && CONFIG_NET_IPv4 */

--- a/net/nat/ipv4_nat.c
+++ b/net/nat/ipv4_nat.c
@@ -131,7 +131,7 @@ static int ipv4_nat_outbound_tcp(FAR struct net_driver_s *dev,
   FAR struct tcp_hdr_s *tcp =
       (FAR struct tcp_hdr_s *)((FAR uint8_t *)ipv4 + iphdrlen);
   FAR struct ipv4_nat_entry *entry = ipv4_nat_outbound_entry_find(
-      IP_PROTO_TCP, net_ip4addr_conv32(ipv4->srcipaddr), tcp->srcport);
+      dev, IP_PROTO_TCP, net_ip4addr_conv32(ipv4->srcipaddr), tcp->srcport);
   if (!entry)
     {
       /* Outbound entry creation failed, should have corresponding entry. */

--- a/net/nat/ipv4_nat.c
+++ b/net/nat/ipv4_nat.c
@@ -1,0 +1,324 @@
+/****************************************************************************
+ * net/nat/ipv4_nat.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <debug.h>
+#include <errno.h>
+#include <stdint.h>
+#include <sys/types.h>
+
+#include <nuttx/net/tcp.h>
+
+#include "nat/nat.h"
+#include "utils/utils.h"
+
+#if defined(CONFIG_NET_NAT) && defined(CONFIG_NET_IPv4)
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/* Adjust checksums in headers. */
+
+#define chksum_adjust(chksum,old_data,new_data) \
+  net_chksum_adjust((FAR uint16_t *)&(chksum), \
+                    (FAR uint16_t *)&(old_data), sizeof(old_data), \
+                    (FAR uint16_t *)&(new_data), sizeof(new_data))
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: ipv4_nat_inbound_tcp
+ *
+ * Description:
+ *   Check if a received TCP packet belongs to a NAT entry. If so, translate
+ *   it.
+ *
+ * Input Parameters:
+ *   ipv4  - Points to the IPv4 header with dev->d_buf.
+ *
+ * Returned Value:
+ *   Zero is returned if NAT is successfully applied, or is not enabled for
+ *   this packet;
+ *   A negated errno value is returned if error occured.
+ *
+ * Assumptions:
+ *   Packet is received on NAT device and is targeting at the address
+ *   assigned to the device.
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_NET_TCP
+static int ipv4_nat_inbound_tcp(FAR struct ipv4_hdr_s *ipv4)
+{
+  uint16_t iphdrlen = (ipv4->vhl & IPv4_HLMASK) << 2;
+  FAR struct tcp_hdr_s *tcp =
+      (FAR struct tcp_hdr_s *)((FAR uint8_t *)ipv4 + iphdrlen);
+  FAR struct ipv4_nat_entry *entry =
+      ipv4_nat_inbound_entry_find(IP_PROTO_TCP, tcp->destport);
+  if (!entry)
+    {
+      /* Inbound without entry is OK (e.g. towards NuttX itself), skip NAT. */
+
+      return OK;
+    }
+
+  /* Modify port and checksum. */
+
+  chksum_adjust(tcp->tcpchksum, tcp->destport, entry->local_port);
+  tcp->destport = entry->local_port;
+
+  /* Modify address and checksum. */
+
+  chksum_adjust(tcp->tcpchksum, ipv4->destipaddr, entry->local_ip);
+  chksum_adjust(ipv4->ipchksum, ipv4->destipaddr, entry->local_ip);
+  net_ipv4addr_hdrcopy(ipv4->destipaddr, &entry->local_ip);
+
+  return OK;
+}
+#endif
+
+/****************************************************************************
+ * Name: ipv4_nat_outbound_tcp
+ *
+ * Description:
+ *   Check if we want to perform NAT with this outbound TCP packet before
+ *   sending it. If so, translate it.
+ *
+ * Input Parameters:
+ *   dev   - The device to sent the packet.
+ *   ipv4  - Points to the IPv4 header to be filled into dev->d_buf later.
+ *
+ * Returned Value:
+ *   Zero is returned if NAT is successfully applied, or is not enabled for
+ *   this packet;
+ *   A negated errno value is returned if error occured.
+ *
+ * Assumptions:
+ *   Packet will be sent on NAT device.
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_NET_TCP
+static int ipv4_nat_outbound_tcp(FAR struct net_driver_s *dev,
+                                 FAR struct ipv4_hdr_s *ipv4)
+{
+  uint16_t iphdrlen = (ipv4->vhl & IPv4_HLMASK) << 2;
+  FAR struct tcp_hdr_s *tcp =
+      (FAR struct tcp_hdr_s *)((FAR uint8_t *)ipv4 + iphdrlen);
+  FAR struct ipv4_nat_entry *entry = ipv4_nat_outbound_entry_find(
+      IP_PROTO_TCP, net_ip4addr_conv32(ipv4->srcipaddr), tcp->srcport);
+  if (!entry)
+    {
+      /* Outbound entry creation failed, should have corresponding entry. */
+
+      return -ENOMEM;
+    }
+
+  /* Modify port and checksum. */
+
+  chksum_adjust(tcp->tcpchksum, tcp->srcport, entry->external_port);
+  tcp->srcport = entry->external_port;
+
+  /* Modify address and checksum. */
+
+  chksum_adjust(tcp->tcpchksum, ipv4->srcipaddr, dev->d_ipaddr);
+  chksum_adjust(ipv4->ipchksum, ipv4->srcipaddr, dev->d_ipaddr);
+  net_ipv4addr_hdrcopy(ipv4->srcipaddr, &dev->d_ipaddr);
+
+  return OK;
+}
+#endif
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: ipv4_nat_enable
+ *
+ * Description:
+ *   Enable NAT function on a network device.
+ *
+ * Input Parameters:
+ *   dev   - The device on which the outbound packets will be masqueraded.
+ *
+ * Returned Value:
+ *   Zero is returned if NAT function is successfully enabled on the device;
+ *   A negated errno value is returned if failed.
+ *
+ * Assumptions:
+ *   NAT will only be enabled on at most one device.
+ *
+ * Limitations:
+ *   External ports are not isolated between devices yet, so if NAT is
+ *   enabled on more than one device, an external port used on one device
+ *   will also be used by same local ip:port on another device.
+ *
+ * TODO:
+ *   Support multiple NAT devices with isolated external port mapping.
+ ****************************************************************************/
+
+int ipv4_nat_enable(FAR struct net_driver_s *dev)
+{
+  if (IFF_IS_NAT(dev->d_flags))
+    {
+      nwarn("WARNING: NAT was already enabled for %s!\n", dev->d_ifname);
+      return -EEXIST;
+    }
+
+  IFF_SET_NAT(dev->d_flags);
+  return OK;
+}
+
+/****************************************************************************
+ * Name: ipv4_nat_disable
+ *
+ * Description:
+ *   Disable NAT function on a network device.
+ *
+ * Input Parameters:
+ *   dev   - The device on which the NAT function will be disabled.
+ *
+ * Returned Value:
+ *   Zero is returned if NAT function is successfully disabled on the device;
+ *   A negated errno value is returned if failed.
+ *
+ ****************************************************************************/
+
+int ipv4_nat_disable(FAR struct net_driver_s *dev)
+{
+  if (!IFF_IS_NAT(dev->d_flags))
+    {
+      nwarn("WARNING: NAT was not enabled for %s!\n", dev->d_ifname);
+      return -ENODEV;
+    }
+
+  /* TODO: Clear entries related to dev. */
+
+  IFF_CLR_NAT(dev->d_flags);
+  return OK;
+}
+
+/****************************************************************************
+ * Name: ipv4_nat_inbound
+ *
+ * Description:
+ *   Check if a received packet belongs to a NAT entry. If so, translate it.
+ *
+ * Input Parameters:
+ *   dev   - The device on which the packet is received.
+ *   ipv4  - Points to the IPv4 header with dev->d_buf.
+ *
+ * Returned Value:
+ *   Zero is returned if NAT is successfully applied, or is not enabled for
+ *   this packet;
+ *   A negated errno value is returned if error occured.
+ *
+ ****************************************************************************/
+
+int ipv4_nat_inbound(FAR struct net_driver_s *dev,
+                     FAR struct ipv4_hdr_s *ipv4)
+{
+  /* We only process packets from NAT device and targeting at the address
+   * assigned to the device.
+   */
+
+  if (IFF_IS_NAT(dev->d_flags) &&
+      net_ipv4addr_hdrcmp(ipv4->destipaddr, &dev->d_ipaddr))
+    {
+      switch (ipv4->proto)
+        {
+#ifdef CONFIG_NET_TCP
+          case IP_PROTO_TCP:
+            return ipv4_nat_inbound_tcp(ipv4);
+#endif
+
+#ifdef CONFIG_NET_UDP
+#         warning Missing logic
+#endif
+
+#ifdef CONFIG_NET_ICMP
+#         warning Missing logic
+#endif
+        }
+    }
+
+  return OK;
+}
+
+/****************************************************************************
+ * Name: ipv4_nat_outbound
+ *
+ * Description:
+ *   Check if we want to perform NAT with this outbound packet before sending
+ *   it. If so, translate it.
+ *
+ * Input Parameters:
+ *   dev   - The device on which the packet will be sent.
+ *   ipv4  - Points to the IPv4 header to be filled into dev->d_buf later.
+ *
+ * Returned Value:
+ *   Zero is returned if NAT is successfully applied, or is not enabled for
+ *   this packet;
+ *   A negated errno value is returned if error occured.
+ *
+ ****************************************************************************/
+
+int ipv4_nat_outbound(FAR struct net_driver_s *dev,
+                      FAR struct ipv4_hdr_s *ipv4)
+{
+  /* We only process packets targeting at NAT device but not targeting at the
+   * address assigned to the device.
+   */
+
+  if (IFF_IS_NAT(dev->d_flags) &&
+      !net_ipv4addr_hdrcmp(ipv4->destipaddr, &dev->d_ipaddr))
+    {
+      /* TODO: Skip broadcast? */
+
+      switch (ipv4->proto)
+        {
+#ifdef CONFIG_NET_TCP
+          case IP_PROTO_TCP:
+            return ipv4_nat_outbound_tcp(dev, ipv4);
+#endif
+
+#ifdef CONFIG_NET_UDP
+#         warning Missing logic
+#endif
+
+#ifdef CONFIG_NET_ICMP
+#         warning Missing logic
+#endif
+        }
+    }
+
+  return OK;
+}
+
+#endif /* CONFIG_NET_NAT && CONFIG_NET_IPv4 */

--- a/net/nat/ipv4_nat.c
+++ b/net/nat/ipv4_nat.c
@@ -79,7 +79,7 @@ static int ipv4_nat_inbound_tcp(FAR struct ipv4_hdr_s *ipv4)
   FAR struct tcp_hdr_s *tcp =
       (FAR struct tcp_hdr_s *)((FAR uint8_t *)ipv4 + iphdrlen);
   FAR struct ipv4_nat_entry *entry =
-      ipv4_nat_inbound_entry_find(IP_PROTO_TCP, tcp->destport);
+      ipv4_nat_inbound_entry_find(IP_PROTO_TCP, tcp->destport, true);
   if (!entry)
     {
       /* Inbound without entry is OK (e.g. towards NuttX itself), skip NAT. */
@@ -340,7 +340,7 @@ int ipv4_nat_outbound(FAR struct net_driver_s *dev,
 bool ipv4_nat_port_inuse(uint8_t protocol, in_addr_t ip, uint16_t port)
 {
   FAR struct ipv4_nat_entry *entry =
-      ipv4_nat_inbound_entry_find(protocol, port);
+      ipv4_nat_inbound_entry_find(protocol, port, false);
 
   /* Not checking ip is enough for single NAT device, may save external_ip in
    * entry for multiple device support in future.

--- a/net/nat/ipv4_nat_entry.c
+++ b/net/nat/ipv4_nat_entry.c
@@ -26,6 +26,7 @@
 
 #include <debug.h>
 
+#include <nuttx/clock.h>
 #include <nuttx/kmalloc.h>
 #include <nuttx/queue.h>
 
@@ -37,7 +38,7 @@
  * Private Data
  ****************************************************************************/
 
-static sq_queue_t g_entries;
+static dq_queue_t g_entries;
 
 /****************************************************************************
  * Private Functions
@@ -67,6 +68,45 @@ static uint16_t ipv4_nat_select_port(uint8_t protocol, uint16_t local_port)
 # warning Missing logic
 
   return local_port;
+}
+
+/****************************************************************************
+ * Name: ipv4_nat_entry_refresh
+ *
+ * Description:
+ *   Refresh a NAT entry, update its expiration time.
+ *
+ * Input Parameters:
+ *   entry      - The entry to refresh.
+ *
+ ****************************************************************************/
+
+static void ipv4_nat_entry_refresh(FAR struct ipv4_nat_entry *entry)
+{
+  switch (entry->protocol)
+    {
+#ifdef CONFIG_NET_TCP
+      case IP_PROTO_TCP:
+        /* NOTE: According to RFC2663, Section 2.6, Page 5, we can reduce the
+         * time to 4min if we have received FINs from both side of one
+         * connection, and keep 24h for other TCP connections. However, full
+         * cone NAT may have multiple connections on one entry, so this
+         * optimization may not work and we only use one expiration time.
+         */
+
+        entry->expire_time = TICK2SEC(clock_systime_ticks()) +
+                             CONFIG_NET_NAT_TCP_EXPIRE_SEC;
+        break;
+#endif
+
+#ifdef CONFIG_NET_UDP
+#     warning Missing logic
+#endif
+
+#ifdef CONFIG_NET_ICMP
+#     warning Missing logic
+#endif
+  }
 }
 
 /****************************************************************************
@@ -103,8 +143,31 @@ ipv4_nat_entry_create(uint8_t protocol, uint16_t external_port,
   entry->local_ip      = local_ip;
   entry->local_port    = local_port;
 
-  sq_addfirst((FAR sq_entry_t *)entry, &g_entries);
+  ipv4_nat_entry_refresh(entry);
+
+  dq_addfirst((FAR dq_entry_t *)entry, &g_entries);
   return entry;
+}
+
+/****************************************************************************
+ * Name: ipv4_nat_entry_delete
+ *
+ * Description:
+ *   Delete a NAT entry and remove from entry list.
+ *
+ * Input Parameters:
+ *   entry      - The entry to remove.
+ *
+ ****************************************************************************/
+
+void ipv4_nat_entry_delete(FAR struct ipv4_nat_entry *entry)
+{
+  ninfo("INFO: Removing NAT entry proto=%d, local=%x:%d, external=:%d\n",
+        entry->protocol, entry->local_ip, entry->local_port,
+        entry->external_port);
+
+  dq_rem((FAR dq_entry_t *)entry, &g_entries);
+  kmm_free(entry);
 }
 
 /****************************************************************************
@@ -120,6 +183,7 @@ ipv4_nat_entry_create(uint8_t protocol, uint16_t external_port,
  * Input Parameters:
  *   protocol      - The L4 protocol of the packet.
  *   external_port - The external port of the packet.
+ *   refresh       - Whether to refresh the selected entry.
  *
  * Returned Value:
  *   Pointer to entry on success; null on failure
@@ -127,16 +191,34 @@ ipv4_nat_entry_create(uint8_t protocol, uint16_t external_port,
  ****************************************************************************/
 
 FAR struct ipv4_nat_entry *
-ipv4_nat_inbound_entry_find(uint8_t protocol, uint16_t external_port)
+ipv4_nat_inbound_entry_find(uint8_t protocol, uint16_t external_port,
+                            bool refresh)
 {
   FAR sq_entry_t *p;
-  sq_for_every(&g_entries, p)
+  FAR sq_entry_t *tmp;
+  uint32_t current_time = TICK2SEC(clock_systime_ticks());
+
+  sq_for_every_safe((FAR sq_queue_t *)&g_entries, p, tmp)
     {
       FAR struct ipv4_nat_entry *entry = (FAR struct ipv4_nat_entry *)p;
+
+      /* Remove expired entries. */
+
+      if (entry->expire_time < current_time)
+        {
+          ipv4_nat_entry_delete(entry);
+          continue;
+        }
+
       if (entry->protocol == protocol &&
           entry->external_port == external_port)
         {
           /* TODO: Use hash table, or move recent node to head. */
+
+          if (refresh)
+            {
+              ipv4_nat_entry_refresh(entry);
+            }
 
           return entry;
         }
@@ -169,15 +251,28 @@ ipv4_nat_outbound_entry_find(uint8_t protocol, in_addr_t local_ip,
                              uint16_t local_port)
 {
   FAR sq_entry_t *p;
-  sq_for_every(&g_entries, p)
+  FAR sq_entry_t *tmp;
+  uint32_t current_time = TICK2SEC(clock_systime_ticks());
+
+  sq_for_every_safe((FAR sq_queue_t *)&g_entries, p, tmp)
     {
       FAR struct ipv4_nat_entry *entry = (FAR struct ipv4_nat_entry *)p;
+
+      /* Remove expired entries. */
+
+      if (entry->expire_time < current_time)
+        {
+          ipv4_nat_entry_delete(entry);
+          continue;
+        }
+
       if (entry->protocol == protocol &&
           net_ipv4addr_cmp(entry->local_ip, local_ip) &&
           entry->local_port == local_port)
         {
           /* TODO: Use hash table, or move recent node to head. */
 
+          ipv4_nat_entry_refresh(entry);
           return entry;
         }
     }

--- a/net/nat/ipv4_nat_entry.c
+++ b/net/nat/ipv4_nat_entry.c
@@ -1,0 +1,203 @@
+/****************************************************************************
+ * net/nat/ipv4_nat_entry.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <debug.h>
+
+#include <nuttx/kmalloc.h>
+#include <nuttx/queue.h>
+
+#include "nat/nat.h"
+
+#if defined(CONFIG_NET_NAT) && defined(CONFIG_NET_IPv4)
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+static sq_queue_t g_entries;
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: ipv4_nat_select_port
+ *
+ * Description:
+ *   Select an available port number for TCP/UDP protocol, or id for ICMP.
+ *
+ * Input Parameters:
+ *   protocol   - The L4 protocol of the packet.
+ *   local_port - The local port of the packet, as reference.
+ *
+ * Returned Value:
+ *   port number on success; 0 on failure
+ *
+ ****************************************************************************/
+
+static uint16_t ipv4_nat_select_port(uint8_t protocol, uint16_t local_port)
+{
+  /* TODO: Implement this, need to consider local ports and nat ports.
+   * TODO: Shall we let the chosen port same as local_port if possible?
+   * TODO: Also need to modify local port number assignment.
+   */
+
+# warning Missing logic
+
+  return local_port;
+}
+
+/****************************************************************************
+ * Name: ipv4_nat_entry_create
+ *
+ * Description:
+ *   Create a NAT entry and insert into entry list.
+ *
+ * Input Parameters:
+ *   protocol      - The L4 protocol of the packet.
+ *   external_port - The external port of the packet.
+ *   local_ip      - The local ip of the packet.
+ *   local_port    - The local port of the packet.
+ *
+ * Returned Value:
+ *   Pointer to entry on success; null on failure
+ *
+ ****************************************************************************/
+
+static FAR struct ipv4_nat_entry *
+ipv4_nat_entry_create(uint8_t protocol, uint16_t external_port,
+                      in_addr_t local_ip, uint16_t local_port)
+{
+  FAR struct ipv4_nat_entry *entry =
+      (FAR struct ipv4_nat_entry *)kmm_malloc(sizeof(struct ipv4_nat_entry));
+  if (entry == NULL)
+    {
+      nwarn("WARNING: Failed to allocate IPv4 NAT entry\n");
+      return NULL;
+    }
+
+  entry->protocol      = protocol;
+  entry->external_port = external_port;
+  entry->local_ip      = local_ip;
+  entry->local_port    = local_port;
+
+  sq_addfirst((FAR sq_entry_t *)entry, &g_entries);
+  return entry;
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: ipv4_nat_inbound_entry_find
+ *
+ * Description:
+ *   Find the inbound entry in NAT entry list.
+ *
+ * Input Parameters:
+ *   protocol      - The L4 protocol of the packet.
+ *   external_port - The external port of the packet.
+ *
+ * Returned Value:
+ *   Pointer to entry on success; null on failure
+ *
+ ****************************************************************************/
+
+FAR struct ipv4_nat_entry *
+ipv4_nat_inbound_entry_find(uint8_t protocol, uint16_t external_port)
+{
+  FAR sq_entry_t *p;
+  sq_for_every(&g_entries, p)
+    {
+      FAR struct ipv4_nat_entry *entry = (FAR struct ipv4_nat_entry *)p;
+      if (entry->protocol == protocol &&
+          entry->external_port == external_port)
+        {
+          /* TODO: Use hash table, or move recent node to head. */
+
+          return entry;
+        }
+    }
+
+  nwarn("WARNING: Failed to find IPv4 inbound NAT entry for "
+        "proto=%d, external_port=%d\n", protocol, external_port);
+  return NULL;
+}
+
+/****************************************************************************
+ * Name: ipv4_nat_outbound_entry_find
+ *
+ * Description:
+ *   Find the outbound entry in NAT entry list. Create one if corresponding
+ *   entry does not exist.
+ *
+ * Input Parameters:
+ *   protocol   - The L4 protocol of the packet.
+ *   local_ip   - The local ip of the packet.
+ *   local_port - The local port of the packet.
+ *
+ * Returned Value:
+ *   Pointer to entry on success; null on failure
+ *
+ ****************************************************************************/
+
+FAR struct ipv4_nat_entry *
+ipv4_nat_outbound_entry_find(uint8_t protocol, in_addr_t local_ip,
+                             uint16_t local_port)
+{
+  FAR sq_entry_t *p;
+  sq_for_every(&g_entries, p)
+    {
+      FAR struct ipv4_nat_entry *entry = (FAR struct ipv4_nat_entry *)p;
+      if (entry->protocol == protocol &&
+          net_ipv4addr_cmp(entry->local_ip, local_ip) &&
+          entry->local_port == local_port)
+        {
+          /* TODO: Use hash table, or move recent node to head. */
+
+          return entry;
+        }
+    }
+
+  /* Failed to find the entry, create one. */
+
+  ninfo("INFO: Failed to find IPv4 outbound NAT entry for "
+        "proto=%d, local=%x:%d, try creating one.\n",
+        protocol, local_ip, local_port);
+
+  uint16_t external_port = ipv4_nat_select_port(protocol, local_port);
+  if (!external_port)
+    {
+      nwarn("WARNING: Failed to find an available port!\n");
+      return NULL;
+    }
+
+  return ipv4_nat_entry_create(protocol, external_port, local_ip,
+                               local_port);
+}
+
+#endif /* CONFIG_NET_NAT && CONFIG_NET_IPv4 */

--- a/net/nat/ipv4_nat_entry.c
+++ b/net/nat/ipv4_nat_entry.c
@@ -62,7 +62,6 @@ static uint16_t ipv4_nat_select_port(uint8_t protocol, uint16_t local_port)
 {
   /* TODO: Implement this, need to consider local ports and nat ports.
    * TODO: Shall we let the chosen port same as local_port if possible?
-   * TODO: Also need to modify local port number assignment.
    */
 
 # warning Missing logic

--- a/net/nat/nat.h
+++ b/net/nat/nat.h
@@ -204,6 +204,7 @@ ipv4_nat_inbound_entry_find(uint8_t protocol, uint16_t external_port,
  *   entry does not exist.
  *
  * Input Parameters:
+ *   dev        - The device on which the packet will be sent.
  *   protocol   - The L4 protocol of the packet.
  *   local_ip   - The local ip of the packet.
  *   local_port - The local port of the packet.
@@ -214,8 +215,8 @@ ipv4_nat_inbound_entry_find(uint8_t protocol, uint16_t external_port,
  ****************************************************************************/
 
 FAR struct ipv4_nat_entry *
-ipv4_nat_outbound_entry_find(uint8_t protocol, in_addr_t local_ip,
-                             uint16_t local_port);
+ipv4_nat_outbound_entry_find(FAR struct net_driver_s *dev, uint8_t protocol,
+                             in_addr_t local_ip, uint16_t local_port);
 
 #endif /* CONFIG_NET_NAT && CONFIG_NET_IPv4 */
 #endif /* __NET_NAT_NAT_H */

--- a/net/nat/nat.h
+++ b/net/nat/nat.h
@@ -27,6 +27,7 @@
 
 #include <nuttx/config.h>
 
+#include <stdbool.h>
 #include <stdint.h>
 
 #include <netinet/in.h>
@@ -155,6 +156,24 @@ int ipv4_nat_inbound(FAR struct net_driver_s *dev,
 
 int ipv4_nat_outbound(FAR struct net_driver_s *dev,
                       FAR struct ipv4_hdr_s *ipv4);
+
+/****************************************************************************
+ * Name: ipv4_nat_port_inuse
+ *
+ * Description:
+ *   Check whether a port is currently used by NAT.
+ *
+ * Input Parameters:
+ *   protocol      - The L4 protocol of the packet.
+ *   ip            - The IP bind with the port (in network byte order).
+ *   port          - The port number to check (in network byte order).
+ *
+ * Returned Value:
+ *   True if the port is already used by NAT, otherwise false.
+ *
+ ****************************************************************************/
+
+bool ipv4_nat_port_inuse(uint8_t protocol, in_addr_t ip, uint16_t port);
 
 /****************************************************************************
  * Name: ipv4_nat_inbound_entry_find

--- a/net/nat/nat.h
+++ b/net/nat/nat.h
@@ -43,13 +43,14 @@
 
 struct ipv4_nat_entry
 {
-  /* Support for single-linked lists.
+  /* Support for doubly-linked lists.
    *
    * TODO: Implement a general hash table, and use it to optimize performance
    * here.
    */
 
   FAR struct ipv4_nat_entry *flink;
+  FAR struct ipv4_nat_entry *blink;
 
   /*  Local Network                             External Network
    *                |----------------|
@@ -67,7 +68,7 @@ struct ipv4_nat_entry
   uint16_t   external_port;  /* The external port of local (private) host. */
   uint8_t    protocol;       /* L4 protocol (TCP, UDP etc). */
 
-  /* TODO: Timeout check and remove outdated entry. */
+  uint32_t   expire_time;    /* The expiration time of this entry. */
 };
 
 /****************************************************************************
@@ -184,6 +185,7 @@ bool ipv4_nat_port_inuse(uint8_t protocol, in_addr_t ip, uint16_t port);
  * Input Parameters:
  *   protocol      - The L4 protocol of the packet.
  *   external_port - The external port of the packet.
+ *   refresh       - Whether to refresh the selected entry.
  *
  * Returned Value:
  *   Pointer to entry on success; null on failure
@@ -191,7 +193,8 @@ bool ipv4_nat_port_inuse(uint8_t protocol, in_addr_t ip, uint16_t port);
  ****************************************************************************/
 
 FAR struct ipv4_nat_entry *
-ipv4_nat_inbound_entry_find(uint8_t protocol, uint16_t external_port);
+ipv4_nat_inbound_entry_find(uint8_t protocol, uint16_t external_port,
+                            bool refresh);
 
 /****************************************************************************
  * Name: ipv4_nat_outbound_entry_find

--- a/net/nat/nat.h
+++ b/net/nat/nat.h
@@ -1,0 +1,199 @@
+/****************************************************************************
+ * net/nat/nat.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __NET_NAT_NAT_H
+#define __NET_NAT_NAT_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <stdint.h>
+
+#include <netinet/in.h>
+
+#include <nuttx/net/ip.h>
+#include <nuttx/net/netdev.h>
+
+#if defined(CONFIG_NET_NAT) && defined(CONFIG_NET_IPv4)
+
+/****************************************************************************
+ * Public Types
+ ****************************************************************************/
+
+struct ipv4_nat_entry
+{
+  /* Support for single-linked lists.
+   *
+   * TODO: Implement a general hash table, and use it to optimize performance
+   * here.
+   */
+
+  FAR struct ipv4_nat_entry *flink;
+
+  /*  Local Network                             External Network
+   *                |----------------|
+   *   <local IP,   |                | <external IP,             <peer IP,
+   *     -----------|                |-----------------------------
+   *    local port> |                |  external port>            peer port>
+   *                |----------------|
+   *
+   * Full cone NAT on single WAN only need to save local ip:port and external
+   * port. For ICMP, save id in port field.
+   */
+
+  in_addr_t  local_ip;       /* IP address of the local (private) host. */
+  uint16_t   local_port;     /* Port of the local (private) host. */
+  uint16_t   external_port;  /* The external port of local (private) host. */
+  uint8_t    protocol;       /* L4 protocol (TCP, UDP etc). */
+
+  /* TODO: Timeout check and remove outdated entry. */
+};
+
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: ipv4_nat_enable
+ *
+ * Description:
+ *   Enable NAT function on a network device.
+ *
+ * Input Parameters:
+ *   dev   - The device on which the outbound packets will be masqueraded.
+ *
+ * Returned Value:
+ *   Zero is returned if NAT function is successfully enabled on the device;
+ *   A negated errno value is returned if failed.
+ *
+ * Assumptions:
+ *   NAT will only be enabled on at most one device.
+ *
+ * Limitations:
+ *   External ports are not isolated between devices yet, so if NAT is
+ *   enabled on more than one device, an external port used on one device
+ *   will also be used by same local ip:port on another device.
+ *
+ ****************************************************************************/
+
+int ipv4_nat_enable(FAR struct net_driver_s *dev);
+
+/****************************************************************************
+ * Name: ipv4_nat_disable
+ *
+ * Description:
+ *   Disable NAT function on a network device.
+ *
+ * Input Parameters:
+ *   dev   - The device on which the NAT function will be disabled.
+ *
+ * Returned Value:
+ *   Zero is returned if NAT function is successfully disabled on the device;
+ *   A negated errno value is returned if failed.
+ *
+ ****************************************************************************/
+
+int ipv4_nat_disable(FAR struct net_driver_s *dev);
+
+/****************************************************************************
+ * Name: ipv4_nat_inbound
+ *
+ * Description:
+ *   Check if a received packet belongs to a NAT entry. If so, translate it.
+ *
+ * Input Parameters:
+ *   dev   - The device on which the packet is received.
+ *   ipv4  - Points to the IPv4 header with dev->d_buf.
+ *
+ * Returned Value:
+ *   Zero is returned if NAT is successfully applied, or is not enabled for
+ *   this packet;
+ *   A negated errno value is returned if error occured.
+ *
+ ****************************************************************************/
+
+int ipv4_nat_inbound(FAR struct net_driver_s *dev,
+                     FAR struct ipv4_hdr_s *ipv4);
+
+/****************************************************************************
+ * Name: ipv4_nat_outbound
+ *
+ * Description:
+ *   Check if we want to perform NAT with this outbound packet before sending
+ *   it. If so, translate it.
+ *
+ * Input Parameters:
+ *   dev   - The device on which the packet will be sent.
+ *   ipv4  - Points to the IPv4 header to be filled into dev->d_buf later.
+ *
+ * Returned Value:
+ *   Zero is returned if NAT is successfully applied, or is not enabled for
+ *   this packet;
+ *   A negated errno value is returned if error occured.
+ *
+ ****************************************************************************/
+
+int ipv4_nat_outbound(FAR struct net_driver_s *dev,
+                      FAR struct ipv4_hdr_s *ipv4);
+
+/****************************************************************************
+ * Name: ipv4_nat_inbound_entry_find
+ *
+ * Description:
+ *   Find the inbound entry in NAT entry list.
+ *
+ * Input Parameters:
+ *   protocol      - The L4 protocol of the packet.
+ *   external_port - The external port of the packet.
+ *
+ * Returned Value:
+ *   Pointer to entry on success; null on failure
+ *
+ ****************************************************************************/
+
+FAR struct ipv4_nat_entry *
+ipv4_nat_inbound_entry_find(uint8_t protocol, uint16_t external_port);
+
+/****************************************************************************
+ * Name: ipv4_nat_outbound_entry_find
+ *
+ * Description:
+ *   Find the outbound entry in NAT entry list. Create one if corresponding
+ *   entry does not exist.
+ *
+ * Input Parameters:
+ *   protocol   - The L4 protocol of the packet.
+ *   local_ip   - The local ip of the packet.
+ *   local_port - The local port of the packet.
+ *
+ * Returned Value:
+ *   Pointer to entry on success; null on failure
+ *
+ ****************************************************************************/
+
+FAR struct ipv4_nat_entry *
+ipv4_nat_outbound_entry_find(uint8_t protocol, in_addr_t local_ip,
+                             uint16_t local_port);
+
+#endif /* CONFIG_NET_NAT && CONFIG_NET_IPv4 */
+#endif /* __NET_NAT_NAT_H */

--- a/net/tcp/tcp.h
+++ b/net/tcp/tcp.h
@@ -553,6 +553,27 @@ FAR struct tcp_conn_s *tcp_alloc_accept(FAR struct net_driver_s *dev,
                                         FAR struct tcp_hdr_s *tcp);
 
 /****************************************************************************
+ * Name: tcp_selectport
+ *
+ * Description:
+ *   If the port number is zero; select an unused port for the connection.
+ *   If the port number is non-zero, verify that no other connection has
+ *   been created with this port number.
+ *
+ * Returned Value:
+ *   Selected or verified port number in network order on success, a negated
+ *   errno on failure.
+ *
+ * Assumptions:
+ *   Interrupts are disabled
+ *
+ ****************************************************************************/
+
+int tcp_selectport(uint8_t domain,
+                   FAR const union ip_addr_u *ipaddr,
+                   uint16_t portno);
+
+/****************************************************************************
  * Name: tcp_bind
  *
  * Description:

--- a/net/udp/udp_conn.c
+++ b/net/udp/udp_conn.c
@@ -64,6 +64,7 @@
 #include <nuttx/net/udp.h>
 
 #include "devif/devif.h"
+#include "nat/nat.h"
 #include "netdev/netdev.h"
 #include "inet/inet.h"
 #include "udp/udp.h"
@@ -533,7 +534,13 @@ uint16_t udp_select_port(uint8_t domain, FAR union ip_binding_u *u)
           g_last_udp_port = 4096;
         }
     }
-  while (udp_find_conn(domain, u, HTONS(g_last_udp_port)) != NULL);
+  while (udp_find_conn(domain, u, HTONS(g_last_udp_port)) != NULL
+#if defined(CONFIG_NET_NAT) && defined(CONFIG_NET_IPv4)
+         || (domain == PF_INET &&
+             ipv4_nat_port_inuse(IP_PROTO_UDP, u->ipv4.laddr,
+                                 HTONS(g_last_udp_port)))
+#endif
+  );
 
   /* Initialize and return the connection structure, bind it to the
    * port number
@@ -816,7 +823,13 @@ int udp_bind(FAR struct udp_conn_s *conn, FAR const struct sockaddr *addr)
        * and port ?
        */
 
-      if (udp_find_conn(conn->domain, &conn->u, portno) == NULL)
+      if (udp_find_conn(conn->domain, &conn->u, portno) == NULL
+#if defined(CONFIG_NET_NAT) && defined(CONFIG_NET_IPv4)
+          && !(conn->domain == PF_INET &&
+               ipv4_nat_port_inuse(IP_PROTO_UDP, conn->u.ipv4.laddr,
+                                   portno))
+#endif
+      )
         {
           /* No.. then bind the socket to the port */
 


### PR DESCRIPTION
## Summary
Add full cone NAT for NuttX, supports TCP / UDP / ICMP ECHO (PING)

Outbound: LAN ->  Forward  ->  NAT(only if targeting at WAN)  -> WAN
Inbound:  WAN ->  NAT(only from WAN, change dest) -> Forward  -> LAN

patches included:
- net: add basic NAT workflow
- net: verify NAT port usage in tcp_selectport
- net: select NAT external port by tcp_selectport for TCP
- net/nat: Add TCP entry expiration logic
- net/nat: Add ICMP ECHO (REQUEST & REPLY) support
- net/nat: Add UDP support
- Documentation: add NAT description

## Impact
If `CONFIG_NET_NAT` is enabled, and `ipv4_nat_enable` is called on any netdev (which sets `IFF_NAT`), the device will be regarded as WAN and outbound packets will be masqueraded on the device.

## Testing
Tested on Ubuntu 22.04 x86_64 by following steps:
1. Configure NuttX with >=2 TAP devices (host route mode) and NAT enabled:
```Kconfig
CONFIG_NET_IPFORWARD=y
CONFIG_NET_NAT=y
# CONFIG_SIM_NET_BRIDGE is not set
CONFIG_SIM_NETDEV_NUMBER=2
```
2. Call `ipv4_nat_enable` on one dev on startup
```C
/* arch/sim/src/sim/up_netdriver.c */
int netdriver_init(void)
{
  ...
  ipv4_nat_enable(&g_sim_dev[0]);
  ...
}
```
3. Set IP Address for NuttX on startup
```shell
ifconfig eth0 10.0.1.2
ifup eth0
ifconfig eth1 10.0.10.2
ifup eth1
```
4. Configure IP & namespace & route on host side (maybe need to be root, then try `sudo -i`)
```bash
IF_HOST="enp1s0"
IF_0="tap0"
IP_HOST_0="10.0.1.1"
IF_1="tap1"
IP_HOST_1="10.0.10.1"
IP_NUTTX_1="10.0.10.2"

# add net namespace LAN for $IF_1
ip netns add LAN
ip netns exec LAN sysctl -w net.ipv4.ip_forward=1
ip link set $IF_1 netns LAN
ip netns exec LAN ip link set $IF_1 up
ip netns exec LAN ip link set lo up

# add address and set default route
ip addr add $IP_HOST_0/24 dev $IF_0
ip netns exec LAN ip addr add $IP_HOST_1/24 dev $IF_1
ip netns exec LAN ip route add default dev $IF_1 via $IP_NUTTX_1

# nat to allow NuttX to access the internet
iptables -t nat -A POSTROUTING -o $IF_HOST -j MASQUERADE
iptables -A FORWARD -i $IF_HOST -o $IF_0 -j ACCEPT
iptables -A FORWARD -i $IF_0 -o $IF_HOST -j ACCEPT
sysctl -w net.ipv4.ip_forward=1
```
5. Do anything in the LAN namespace will go through NAT
```shell
# Host side
iperf -B 10.0.1.1 -s -i 1
# LAN side
sudo ip netns exec LAN iperf -B 10.0.10.1 -c 10.0.1.1 -i 1
```
```shell
# Host side
python3 -m http.server
# LAN side
for i in {1..20000}; do sudo ip netns exec LAN curl 'http://10.0.1.1:8000/' > /dev/null 2>1; done
```
```shell
# LAN side
sudo ip netns exec LAN ping 8.8.8.8
```
```shell
# Host side
tcpdump -nn -i tap0
# LAN side
sudo ip netns exec LAN tcpdump -nn -i tap1
```