### PR TITLE
pthread_barrier:don't destroy when barrier used

### DIFF
--- a/libs/libc/pthread/pthread_barrierdestroy.c
+++ b/libs/libc/pthread/pthread_barrierdestroy.c
@@ -61,6 +61,7 @@
 
 int pthread_barrier_destroy(FAR pthread_barrier_t *barrier)
 {
+  int semcount;
   int ret = OK;
 
   if (!barrier)
@@ -69,6 +70,17 @@ int pthread_barrier_destroy(FAR pthread_barrier_t *barrier)
     }
   else
     {
+      ret = sem_getvalue(&barrier->sem, &semcount);
+      if (ret != OK)
+        {
+          return ret;
+        }
+
+      if (semcount < 0)
+        {
+          return EBUSY;
+        }
+
       sem_destroy(&barrier->sem);
       barrier->count = 0;
     }


### PR DESCRIPTION
this is fix a ltp test case and update
the error code of pthread_barrierdestroy

ltptcase is : apps/testing/ltp/ltp/testcases/open_posix_testsuite/conformance/interfaces/pthread_barrier_destroy/2-1.c
Signed-off-by: anjiahao <anjiahao@xiaomi.com>

## Summary
Enhance  pthread_barrier api
## Impact
pthread_barrier
## Testing
ltp
