### PR TITLE
Fix warning found by https://github.com/apache/incubator-nuttx-apps/pull/1408

### DIFF
--- a/arch/arm/src/lpc43xx/lpc43_tickless_rit.c
+++ b/arch/arm/src/lpc43xx/lpc43_tickless_rit.c
@@ -124,11 +124,6 @@ static inline void lpc43_tl_set_mask(uint32_t value)
     }
 }
 
-static inline uint32_t lpc43_tl_get_mask(void)
-{
-  return mask_cache;
-}
-
 static inline bool lpc43_tl_get_ctrl_bit(uint32_t bit)
 {
   return ((ctrl_cache & bit)?true:false);
@@ -164,11 +159,6 @@ static inline bool lpc43_tl_get_reset_on_match(void)
 static inline void lpc43_tl_set_enable(bool value)
 {
   lpc43_tl_set_ctrl_bit(RIT_CTRL_EN, value);
-}
-
-static inline bool lpc43_tl_get_enable(void)
-{
-  return lpc43_tl_get_ctrl_bit(RIT_CTRL_EN);
 }
 
 static inline void lpc43_tl_clear_interrupt(void)

--- a/arch/arm/src/lpc54xx/lpc54_serial.c
+++ b/arch/arm/src/lpc54xx/lpc54_serial.c
@@ -894,28 +894,6 @@ static inline void lpc54_serialout(struct lpc54_dev_s *priv,
 }
 
 /****************************************************************************
- * Name: lpc54_modifyreg
- ****************************************************************************/
-
-static inline void lpc54_modifyreg(struct lpc54_dev_s *priv,
-                                   unsigned int offset, uint32_t setbits,
-                                   uint32_t clrbits)
-{
-  irqstate_t flags;
-  uintptr_t regaddr = priv->uartbase + offset;
-  uint32_t regval;
-
-  flags   = enter_critical_section();
-
-  regval  = getreg32(regaddr);
-  regval &= ~clrbits;
-  regval |= setbits;
-  putreg32(regval, regaddr);
-
-  leave_critical_section(flags);
-}
-
-/****************************************************************************
  * Name: lpc54_fifoint_enable
  ****************************************************************************/
 


### PR DESCRIPTION
## Summary

- Fix Error: chip/lpc43_tickless_rit.c:127:24: error: unused function 'lpc43_tl_get_mask' [-Werror,-Wunused-function]
- Error: chip/lpc54_serial.c:900:20: error: unused function 'lpc54_modifyreg' [-Werror,-Wunused-function]

## Impact
Fix warning

## Testing

