### PR TITLE
sched/signal: fix sigtimedwait error handling

### DIFF
--- a/sched/signal/sig_pending.c
+++ b/sched/signal/sig_pending.c
@@ -42,7 +42,7 @@
  * Name: sigpending
  *
  * Description:
- *   This function returns the set of signals that are blocked from deliveryi
+ *   This function returns the set of signals that are blocked from delivery
  *   and that are pending for the calling process in the space pointed to by
  *   set.
  *


### PR DESCRIPTION
## Summary
According to https://pubs.opengroup.org/onlinepubs/9699919799/functions/sigtimedwait.html the `sigtimedwait` should return immediately the `timespec` structure pointed to by `timeout` is zero-valued and if none of the signals specified by set are pending.

Also do not update non-NULL `info` if `sigtimedwait` is returned with an error.

## Impact
Improve POSIX compliance

## Testing
Pass CI.
Still need to write ostest for this.