### PR TITLE
sys: boardctl: Add more reset causes to enum

### DIFF
--- a/include/sys/boardctl.h
+++ b/include/sys/boardctl.h
@@ -425,7 +425,10 @@ enum boardioc_reset_cause_e
   BOARDIOC_RESETCAUSE_CORE_RWDT,        /* RTC watchdog core reset */
   BOARDIOC_RESETCAUSE_CPU_MWDT,         /* main watchdog cpu reset */
   BOARDIOC_RESETCAUSE_CPU_SOFT,         /* software cpu reset */
-  BOARDIOC_RESETCAUSE_CPU_RWDT          /* RTC watchdog cpu reset */
+  BOARDIOC_RESETCAUSE_CPU_RWDT,         /* RTC watchdog cpu reset */
+  BOARDIOC_RESETCAUSE_PIN,              /* Pin reset */
+  BOARDIOC_RESETCAUSE_LOWPOWER,         /* Low power reset */
+  BOARDIOC_RESETCAUSE_UNKOWN            /* Unknown reset cause */
 };
 
 enum boardioc_softreset_subreason_e


### PR DESCRIPTION
Signed-off-by: Andrés Sánchez Pascual <tito97_sp@hotmail.com>

## Summary
Add more reset causes to the list.

## Impact

## Testing

