### PR TITLE
fs/unionfs: fix memory leak about directory operation

### DIFF
--- a/fs/unionfs/fs_unionfs.c
+++ b/fs/unionfs/fs_unionfs.c
@@ -1601,10 +1601,7 @@ static int unionfs_closedir(FAR struct inode *mountpt,
       kmm_free(udir->fu_relpath);
     }
 
-  udir->fu_ndx      = 0;
-  udir->fu_relpath  = NULL;
-  udir->fu_lower[0] = NULL;
-  udir->fu_lower[1] = NULL;
+  kmm_free(udir);
 
   /* Decrement the count of open reference.  If that count would go to zero
    * and if the file system has been unmounted, then destroy the file system


### PR DESCRIPTION

## Summary
fs/unionfs: fix memory leak about directory operation

Signed-off-by: dongjiuzhu1 <dongjiuzhu1@xiaomi.com>
## Impact
fix memory leak 
## Testing
local test
