### PR TITLE
arch/stm32/1wire: Don't free the context if the reference doesn't equal zero

### DIFF
--- a/arch/arm/src/stm32/stm32_1wire.c
+++ b/arch/arm/src/stm32/stm32_1wire.c
@@ -1273,7 +1273,6 @@ int stm32_1wireuninitialize(struct onewire_dev_s *dev)
   if (--priv->refs)
     {
       nxmutex_unlock(&priv->lock);
-      kmm_free(priv);
       return OK;
     }
 


### PR DESCRIPTION
## Summary

## Impact
avoid the dangle pointer

## Testing
Pass CI
