### PR TITLE
sched/task/task_getpid: getpid should return process id not thread id

### DIFF
--- a/arch/arm/src/cxd56xx/cxd56_farapi.c
+++ b/arch/arm/src/cxd56xx/cxd56_farapi.c
@@ -192,14 +192,14 @@ void farapi_main(int id, void *arg, struct modulelist_s *mlist)
     {
       /* Save the current cpuset */
 
-      sched_getaffinity(getpid(), sizeof(cpu_set_t), &cpuset0);
+      sched_getaffinity(gettid(), sizeof(cpu_set_t), &cpuset0);
 
       /* Assign the current task to cpu0 */
 
       cpu_set_t cpuset1;
       CPU_ZERO(&cpuset1);
       CPU_SET(0, &cpuset1);
-      sched_setaffinity(getpid(), sizeof(cpu_set_t), &cpuset1);
+      sched_setaffinity(gettid(), sizeof(cpu_set_t), &cpuset1);
 
       /* NOTE: a workaround to finish rescheduling */
 
@@ -267,7 +267,7 @@ err:
     {
       /* Restore the cpu affinity */
 
-      sched_setaffinity(getpid(), sizeof(cpu_set_t), &cpuset0);
+      sched_setaffinity(gettid(), sizeof(cpu_set_t), &cpuset0);
 
       /* NOTE: a workaround to finish rescheduling */
 

--- a/arch/arm/src/lc823450/lc823450_i2s.c
+++ b/arch/arm/src/lc823450/lc823450_i2s.c
@@ -1045,11 +1045,11 @@ struct i2s_dev_s *lc823450_i2sdev_initialize(void)
 
   /* Backup the current affinity */
 
-  nxsched_get_affinity(getpid(), sizeof(cpuset0), &cpuset0);
+  nxsched_get_affinity(gettid(), sizeof(cpuset0), &cpuset0);
 
   /* Set the new affinity which assigns to CPU0 */
 
-  nxsched_set_affinity(getpid(), sizeof(cpuset1), &cpuset1);
+  nxsched_set_affinity(gettid(), sizeof(cpuset1), &cpuset1);
   nxsig_usleep(10 * 1000);
 #endif
 
@@ -1062,7 +1062,7 @@ struct i2s_dev_s *lc823450_i2sdev_initialize(void)
 #ifdef CONFIG_SMP
   /* Restore the original affinity */
 
-  nxsched_set_affinity(getpid(), sizeof(cpuset0), &cpuset0);
+  nxsched_set_affinity(gettid(), sizeof(cpuset0), &cpuset0);
   nxsig_usleep(10 * 1000);
 #endif
 

--- a/arch/sim/src/sim/up_heap.c
+++ b/arch/sim/src/sim/up_heap.c
@@ -217,10 +217,10 @@ void mm_free(struct mm_heap_s *heap, void *mem)
   else
 #endif
 
-  if (getpid() < 0)
+  if (gettid() < 0)
     {
-      /* getpid() return -ESRCH, means we are in situations
-       * during context switching(See getpid's comment).
+      /* gettid() return -ESRCH, means we are in situations
+       * during context switching(See gettid's comment).
        * Then add to the delay list.
        */
 

--- a/drivers/syslog/vsyslog.c
+++ b/drivers/syslog/vsyslog.c
@@ -155,9 +155,9 @@ int nx_vsyslog(int priority, FAR const IPTR char *fmt, FAR va_list *ap)
 #endif
 
 #if defined(CONFIG_SYSLOG_PROCESSID)
-  /* Prepend the Process ID */
+  /* Prepend the Thread ID */
 
-  ret += lib_sprintf(&stream.public, "[%2d] ", (int)getpid());
+  ret += lib_sprintf(&stream.public, "[%2d] ", gettid());
 #endif
 
 #if defined(CONFIG_SYSLOG_COLOR_OUTPUT)
@@ -211,9 +211,9 @@ int nx_vsyslog(int priority, FAR const IPTR char *fmt, FAR va_list *ap)
 #endif
 
 #if CONFIG_TASK_NAME_SIZE > 0 && defined(CONFIG_SYSLOG_PROCESS_NAME)
-  /* Prepend the process name */
+  /* Prepend the thread name */
 
-  tcb = nxsched_get_tcb(getpid());
+  tcb = nxsched_get_tcb(gettid());
   ret += lib_sprintf(&stream.public, "%s: ",
                      (tcb != NULL) ? tcb->name : "(null)");
 #endif

--- a/fs/procfs/fs_procfsproc.c
+++ b/fs/procfs/fs_procfsproc.c
@@ -1484,7 +1484,7 @@ static int proc_open(FAR struct file *filep, FAR const char *relpath,
 
   if (strncmp(relpath, "self", 4) == 0)
     {
-      tmp = (unsigned long)getpid();    /* Get the PID of the calling task */
+      tmp = gettid();                   /* Get the TID of the calling task */
       ptr = (FAR char *)relpath + 4;    /* Discard const */
     }
   else
@@ -1792,7 +1792,7 @@ static int proc_opendir(FAR const char *relpath,
 
   if (strncmp(relpath, "self", 4) == 0)
     {
-      tmp = (unsigned long)getpid();    /* Get the PID of the calling task */
+      tmp = gettid();                   /* Get the TID of the calling task */
       ptr = (FAR char *)relpath + 4;    /* Discard const */
     }
   else
@@ -2032,7 +2032,7 @@ static int proc_stat(const char *relpath, struct stat *buf)
 
   if (strncmp(relpath, "self", 4) == 0)
     {
-      tmp = (unsigned long)getpid();    /* Get the PID of the calling task */
+      tmp = gettid();                   /* Get the TID of the calling task */
       ptr = (FAR char *)relpath + 4;    /* Discard const */
     }
   else

--- a/include/pthread.h
+++ b/include/pthread.h
@@ -525,7 +525,7 @@ void pthread_yield(void);
 
 /* A thread may obtain a copy of its own thread handle. */
 
-#define pthread_self() ((pthread_t)getpid())
+#define pthread_self() ((pthread_t)gettid())
 
 /* Compare two thread IDs. */
 

--- a/include/threads.h
+++ b/include/threads.h
@@ -120,7 +120,7 @@ typedef CODE void (*tss_dtor_t)(FAR void *);
  * thrd_t thrd_current(void);
  */
 
-#define thrd_current() ((thrd_t)getpid())
+#define thrd_current() ((thrd_t)gettid())
 
 /* thrd_sleep: suspends execution of the calling thread for the given
  * period of time

--- a/libs/libc/misc/lib_err.c
+++ b/libs/libc/misc/lib_err.c
@@ -66,9 +66,9 @@ void vwarn(FAR const char *fmt, va_list ap)
 #endif
 
 #ifdef CONFIG_FILE_STREAM
-  fprintf(stderr, "%d: %pV: %s\n", getpid(), &vaf, strerror(error));
+  fprintf(stderr, "%d: %pV: %s\n", gettid(), &vaf, strerror(error));
 #else
-  dprintf(STDERR_FILENO, "%d: %pV: %s\n", getpid(), &vaf, strerror(error));
+  dprintf(STDERR_FILENO, "%d: %pV: %s\n", gettid(), &vaf, strerror(error));
 #endif
 
 #ifdef va_copy
@@ -97,9 +97,9 @@ void vwarnx(FAR const char *fmt, va_list ap)
 #endif
 
 #ifdef CONFIG_FILE_STREAM
-  fprintf(stderr, "%d: %pV\n", getpid(), &vaf);
+  fprintf(stderr, "%d: %pV\n", gettid(), &vaf);
 #else
-  dprintf(STDERR_FILENO, "%d: %pV\n", getpid(), &vaf);
+  dprintf(STDERR_FILENO, "%d: %pV\n", gettid(), &vaf);
 #endif
 
 #ifdef va_copy

--- a/libs/libc/unistd/lib_getpriority.c
+++ b/libs/libc/unistd/lib_getpriority.c
@@ -73,7 +73,7 @@ int getpriority(int which, id_t who)
 
   if (who == 0)
     {
-      who = getpid();
+      who = gettid();
     }
 
   ret = sched_getparam(who, &param);

--- a/libs/libc/unistd/lib_setpriority.c
+++ b/libs/libc/unistd/lib_setpriority.c
@@ -62,7 +62,7 @@ int setpriority(int which, id_t who, int value)
 
   if (who == 0)
     {
-      who = getpid();
+      who = gettid();
     }
 
   ret = sched_getparam(who, &param);

--- a/mm/mm_heap/mm.h
+++ b/mm/mm_heap/mm.h
@@ -73,7 +73,7 @@
      do \
        { \
          FAR struct mm_allocnode_s *tmp = (FAR struct mm_allocnode_s *)(ptr); \
-         tmp->pid = getpid(); \
+         tmp->pid = gettid(); \
        } \
      while (0)
 #elif CONFIG_MM_BACKTRACE > 0
@@ -82,7 +82,7 @@
        { \
          FAR struct mm_allocnode_s *tmp = (FAR struct mm_allocnode_s *)(ptr); \
          kasan_unpoison(tmp, SIZEOF_MM_ALLOCNODE); \
-         tmp->pid = getpid(); \
+         tmp->pid = gettid(); \
          if ((heap)->mm_procfs.backtrace) \
            { \
              memset(tmp->backtrace, 0, sizeof(tmp->backtrace)); \

--- a/mm/mm_heap/mm_free.c
+++ b/mm/mm_heap/mm_free.c
@@ -87,7 +87,7 @@ void mm_free(FAR struct mm_heap_s *heap, FAR void *mem)
   if (mm_lock(heap) < 0)
     {
       /* Meet -ESRCH return, which means we are in situations
-       * during context switching(See mm_lock() & getpid()).
+       * during context switching(See mm_lock() & gettid()).
        * Then add to the delay list.
        */
 

--- a/mm/mm_heap/mm_lock.c
+++ b/mm/mm_heap/mm_lock.c
@@ -77,17 +77,17 @@ int mm_lock(FAR struct mm_heap_s *heap)
   else
 #endif
 
-  /* getpid() returns the task ID of the task at the head of the ready-to-
+  /* gettid() returns the task ID of the task at the head of the ready-to-
    * run task list.  mm_lock() may be called during context
    * switches.  There are certain situations during context switching when
    * the OS data structures are in flux and then can't be freed immediately
    * (e.g. the running thread stack).
    *
-   * This is handled by getpid() to return the special value -ESRCH to
+   * This is handled by gettid() to return the special value -ESRCH to
    * indicate this special situation.
    */
 
-  if (getpid() < 0)
+  if (gettid() < 0)
     {
       return -ESRCH;
     }

--- a/net/netlink/netlink_sockif.c
+++ b/net/netlink/netlink_sockif.c
@@ -262,7 +262,7 @@ static int netlink_bind(FAR struct socket *psock,
   nladdr = (FAR struct sockaddr_nl *)addr;
   conn   = (FAR struct netlink_conn_s *)psock->s_conn;
 
-  conn->pid    = nladdr->nl_pid ? nladdr->nl_pid : getpid();
+  conn->pid    = nladdr->nl_pid ? nladdr->nl_pid : gettid();
   conn->groups = nladdr->nl_groups;
 
   return OK;

--- a/sched/mqueue/mq_timedreceive.c
+++ b/sched/mqueue/mq_timedreceive.c
@@ -202,7 +202,7 @@ ssize_t file_mq_timedreceive(FAR struct file *mq, FAR char *msg,
 
       /* Start the watchdog */
 
-      wd_start(&rtcb->waitdog, ticks, nxmq_rcvtimeout, getpid());
+      wd_start(&rtcb->waitdog, ticks, nxmq_rcvtimeout, gettid());
     }
 
   /* Get the message from the message queue */

--- a/sched/mqueue/mq_timedsend.c
+++ b/sched/mqueue/mq_timedsend.c
@@ -245,7 +245,7 @@ int file_mq_timedsend(FAR struct file *mq, FAR const char *msg,
 
   /* Start the watchdog and begin the wait for MQ not full */
 
-  wd_start(&rtcb->waitdog, ticks, nxmq_sndtimeout, getpid());
+  wd_start(&rtcb->waitdog, ticks, nxmq_sndtimeout, gettid());
 
   /* And wait for the message queue to be non-empty */
 

--- a/sched/pthread/pthread_condclockwait.c
+++ b/sched/pthread/pthread_condclockwait.c
@@ -74,7 +74,7 @@ int pthread_cond_clockwait(FAR pthread_cond_t *cond,
                            FAR const struct timespec *abstime)
 {
   irqstate_t flags;
-  int mypid = getpid();
+  int mypid = gettid();
   int ret = OK;
   int status;
 

--- a/sched/pthread/pthread_condwait.c
+++ b/sched/pthread/pthread_condwait.c
@@ -74,7 +74,7 @@ int pthread_cond_wait(FAR pthread_cond_t *cond, FAR pthread_mutex_t *mutex)
 
   /* Make sure that the caller holds the mutex */
 
-  else if (mutex->pid != (int)getpid())
+  else if (mutex->pid != gettid())
     {
       ret = EPERM;
     }
@@ -140,7 +140,7 @@ int pthread_cond_wait(FAR pthread_cond_t *cond, FAR pthread_mutex_t *mutex)
         {
           /* Yes.. Then initialize it properly */
 
-          mutex->pid    = getpid();
+          mutex->pid    = gettid();
 #ifndef CONFIG_PTHREAD_MUTEX_UNSAFE
           mutex->flags  = mflags;
 #endif

--- a/sched/pthread/pthread_exit.c
+++ b/sched/pthread/pthread_exit.c
@@ -79,7 +79,7 @@ void nx_pthread_exit(FAR void *exit_value)
 
   /* Complete pending join operations */
 
-  status = pthread_completejoin(getpid(), exit_value);
+  status = pthread_completejoin(gettid(), exit_value);
   if (status != OK)
     {
       /* Assume that the join completion failured because this

--- a/sched/pthread/pthread_join.c
+++ b/sched/pthread/pthread_join.c
@@ -88,7 +88,7 @@ int pthread_join(pthread_t thread, FAR pthread_addr_t *pexit_value)
    * ourself.
    */
 
-  if ((pid_t)thread == getpid())
+  if ((pid_t)thread == gettid())
     {
       leave_cancellation_point();
       return EDEADLK;

--- a/sched/pthread/pthread_mutextimedlock.c
+++ b/sched/pthread/pthread_mutextimedlock.c
@@ -78,7 +78,7 @@
 int pthread_mutex_timedlock(FAR pthread_mutex_t *mutex,
                             FAR const struct timespec *abs_timeout)
 {
-  pid_t mypid = getpid();
+  pid_t mypid = gettid();
   int ret = EINVAL;
 
   sinfo("mutex=%p\n", mutex);

--- a/sched/pthread/pthread_mutextrylock.c
+++ b/sched/pthread/pthread_mutextrylock.c
@@ -76,7 +76,7 @@ int pthread_mutex_trylock(FAR pthread_mutex_t *mutex)
 
   if (mutex != NULL)
     {
-      pid_t mypid = getpid();
+      pid_t mypid = gettid();
 
       /* Make sure the semaphore is stable while we make the following
        * checks.  This all needs to be one atomic action.

--- a/sched/pthread/pthread_mutexunlock.c
+++ b/sched/pthread/pthread_mutexunlock.c
@@ -142,7 +142,7 @@ int pthread_mutex_unlock(FAR pthread_mutex_t *mutex)
        * thread owns the semaphore.
        */
 
-      if (mutex->pid != (int)getpid())
+      if (mutex->pid != gettid())
 
 #elif defined(CONFIG_PTHREAD_MUTEX_UNSAFE) && defined(CONFIG_PTHREAD_MUTEX_TYPES)
       /* If mutex types are not supported, then all mutexes are NORMAL (or
@@ -150,7 +150,7 @@ int pthread_mutex_unlock(FAR pthread_mutex_t *mutex)
        * non-robust NORMAL mutex type.
        */
 
-      if (mutex->type != PTHREAD_MUTEX_NORMAL && mutex->pid != (int)getpid())
+      if (mutex->type != PTHREAD_MUTEX_NORMAL && mutex->pid != gettid())
 
 #else /* CONFIG_PTHREAD_MUTEX_BOTH */
       /* Skip the error check if this is a non-robust NORMAL mutex */
@@ -164,7 +164,7 @@ int pthread_mutex_unlock(FAR pthread_mutex_t *mutex)
        * the EPERM error?
        */
 
-      if (errcheck && mutex->pid != (int)getpid())
+      if (errcheck && mutex->pid != gettid())
 #endif
         {
           /* No... return an EPERM error.

--- a/sched/sched/sched_setscheduler.c
+++ b/sched/sched/sched_setscheduler.c
@@ -100,7 +100,7 @@ int nxsched_set_scheduler(pid_t pid, int policy,
 
   if (pid == 0)
     {
-      pid = getpid();
+      pid = gettid();
     }
 
   /* Verify that the pid corresponds to a real task */

--- a/sched/semaphore/sem_clockwait.c
+++ b/sched/semaphore/sem_clockwait.c
@@ -159,7 +159,7 @@ int nxsem_clockwait(FAR sem_t *sem, clockid_t clockid,
 
   /* Start the watchdog */
 
-  wd_start(&rtcb->waitdog, ticks, nxsem_timeout, getpid());
+  wd_start(&rtcb->waitdog, ticks, nxsem_timeout, gettid());
 
   /* Now perform the blocking wait.  If nxsem_wait() fails, the
    * negated errno value will be returned below.

--- a/sched/semaphore/sem_tickwait.c
+++ b/sched/semaphore/sem_tickwait.c
@@ -105,7 +105,7 @@ int nxsem_tickwait(FAR sem_t *sem, uint32_t delay)
 
   /* Start the watchdog with interrupts still disabled */
 
-  wd_start(&rtcb->waitdog, delay, nxsem_timeout, getpid());
+  wd_start(&rtcb->waitdog, delay, nxsem_timeout, gettid());
 
   /* Now perform the blocking wait */
 

--- a/sched/task/task_exithook.c
+++ b/sched/task/task_exithook.c
@@ -66,7 +66,7 @@ static inline void nxtask_exitstatus(FAR struct task_group_s *group,
     {
       /* No.. Find the exit status entry for this task in the parent TCB */
 
-      child = group_find_child(group, getpid());
+      child = group_find_child(group, gettid());
       if (child)
         {
           /* Save the exit status..  For the case of HAVE_GROUP_MEMBERS,
@@ -105,7 +105,7 @@ static inline void nxtask_groupexit(FAR struct task_group_s *group)
     {
       /* No.. Find the exit status entry for this task in the parent TCB */
 
-      child = group_find_child(group, getpid());
+      child = group_find_child(group, gettid());
       if (child)
         {
           /* Mark that all members of the child task group has exited */

--- a/sched/task/task_getpid.c
+++ b/sched/task/task_getpid.c
@@ -38,22 +38,16 @@
  * Name: getpid
  *
  * Description:
- *   Get the task ID of the currently executing task.
+ *   Get the Process ID of the currently executing task.
  *
  * Input parameters:
  *   None
  *
  * Returned Value:
  *   Normally when called from user applications, getpid() will return the
- *   task ID of the currently executing task, that is, the task at the head
- *   of the ready-to-run list.  There is no specification for any errors
+ *   Process ID of the currently executing task. that is, the main task
+ *   for the task groups. There is no specification for any errors
  *   returned from getpid().
- *
- *   getpid(), however, may be called from within the OS in some cases.
- *   There are certain situations during context switching when the OS data
- *   structures are in flux and where the current task at the head of the
- *   ready-to-run task list is not actually running.  In that case,
- *   getpid() will return the error: -ESRCH
  *
  ****************************************************************************/
 
@@ -65,31 +59,17 @@ pid_t getpid(void)
    * will usually be the currently executing task.  There is are two
    * exceptions to this:
    *
-   * 1. Early in the start-up sequence, the ready-to-run list may be
-   *    empty!  In this case, of course, the CPU0 start-up/IDLE thread with
-   *    pid == 0 must be running, and
-   * 2. As described above, during certain context-switching conditions the
-   *    task at the head of the ready-to-run list may not actually be
-   *    running.
+   * Early in the start-up sequence, the ready-to-run list may be
+   * empty!  In this case, of course, the CPU0 start-up/IDLE thread with
+   * pid == 0 must be running, and
    */
 
   rtcb = this_task();
   if (rtcb != NULL)
     {
-      /* Check if the task is actually running */
+      /* Yes.. Return the Process ID */
 
-      if (rtcb->task_state == TSTATE_TASK_RUNNING)
-        {
-          /* Yes.. Return the task ID from the TCB at the head of the
-           * ready-to-run task list
-           */
-
-          return rtcb->pid;
-        }
-
-      /* No.. return -ESRCH to indicate this condition */
-
-      return (pid_t)-ESRCH;
+      return rtcb->group->tg_pid;
     }
 
   /* We must have been called earlier in the start up sequence from the


### PR DESCRIPTION
## Summary
   implement the right semantics:
1. getpid should return the main thread id
2. gettid should return the current thread id

Refer to:
 https://github.com/apache/incubator-nuttx/issues/2499
 https://github.com/apache/incubator-nuttx/pull/2518

## Impact
any code that use getpid/gettid need to check

## Testing
ostest PASSED at qemu with configure 
1. ./tools/configure.sh -l sabre-6quad:nsh
2. ./tools/configure.sh -l qemu-armv8a:nsh

Signed-off-by: qinwei1 <qinwei1@xiaomi.com>