### PR TITLE
Add SAMV7's capability to overwirte pwm pins

### DIFF
--- a/arch/arm/src/samv7/sam_pwm.c
+++ b/arch/arm/src/samv7/sam_pwm.c
@@ -449,6 +449,7 @@ static int pwm_start(struct pwm_lowerhalf_s *dev,
                      const struct pwm_info_s *info)
 {
   struct sam_pwm_s *priv = (struct sam_pwm_s *)dev;
+  uint32_t regval;
 
 #ifdef CONFIG_PWM_MULTICHAN
       for (int i = 0; i < PWM_NCHANNELS; i++)
@@ -472,6 +473,23 @@ static int pwm_start(struct pwm_lowerhalf_s *dev,
                            info->frequency);
               pwm_set_output(dev, priv->channels[index - 1].channel,
                              info->channels[i].duty);
+
+          if (info->channels[i].ch_outp_ovrwr)
+            {
+              regval = pwm_getreg(priv, SAMV7_PWM_OOV);
+              regval &= ~(info->channels[i].ch_outp_ovrwr_val
+                  << priv->channels[i].channel);
+              pwm_putreg(priv, SAMV7_PWM_OOV, regval);
+
+              regval = (1 << priv->channels[i].channel);
+              pwm_putreg(priv, SAMV7_PWM_OSS, regval);
+            }
+          else
+            {
+              /* release overwrite of channel */
+              regval = (1 << priv->channels[i].channel);
+              pwm_putreg(priv, SAMV7_PWM_OSC, regval);
+            }
             }
         }
 #else

--- a/include/nuttx/timers/pwm.h
+++ b/include/nuttx/timers/pwm.h
@@ -120,6 +120,10 @@
 struct pwm_chan_s
 {
   ub16_t duty;
+#ifdef CONFIG_SAMV7_PWM
+  bool ch_outp_ovrwr;
+  bool ch_outp_ovrwr_val;
+#endif
   int8_t channel;
 };
 #endif


### PR DESCRIPTION
… 1 immediately. Changing the dutycycle to 0 or 100 will take effect only on end of cycle, which could be to late for some applications.

This solution adds a overwrite flag and value when updating the duty cycle.

## Summary

## Impact

## Testing

