### PR TITLE
sched/mqueue: make mqueue and mqueue sysv can disable separately

### DIFF
--- a/fs/procfs/fs_procfsproc.c
+++ b/fs/procfs/fs_procfsproc.c
@@ -411,7 +411,7 @@ static FAR const char * const g_statenames[] =
   "Inactive",
   "Waiting,Semaphore",
   "Waiting,Signal"
-#if !defined(CONFIG_DISABLE_MQUEUE) && !defined(CONFIG_DISABLE_MQUEUE_SYSV)
+#if !defined(CONFIG_DISABLE_MQUEUE) || !defined(CONFIG_DISABLE_MQUEUE_SYSV)
   , "Waiting,MQ empty"
   , "Waiting,MQ full"
 #endif

--- a/fs/vfs/fs_stat.c
+++ b/fs/vfs/fs_stat.c
@@ -269,7 +269,7 @@ int inode_stat(FAR struct inode *inode, FAR struct stat *buf, int resolve)
     }
   else
 #endif
-#if !defined(CONFIG_DISABLE_MQUEUE) && !defined(CONFIG_DISABLE_MQUEUE_SYSV)
+#if !defined(CONFIG_DISABLE_MQUEUE) || !defined(CONFIG_DISABLE_MQUEUE_SYSV)
   /* Check for a message queue */
 
   if (INODE_IS_MQUEUE(inode))

--- a/include/nuttx/sched.h
+++ b/include/nuttx/sched.h
@@ -206,7 +206,7 @@ enum tstate_e
   TSTATE_TASK_INACTIVE,       /* BLOCKED      - Initialized but not yet activated */
   TSTATE_WAIT_SEM,            /* BLOCKED      - Waiting for a semaphore */
   TSTATE_WAIT_SIG,            /* BLOCKED      - Waiting for a signal */
-#if !defined(CONFIG_DISABLE_MQUEUE) && !defined(CONFIG_DISABLE_MQUEUE_SYSV)
+#if !defined(CONFIG_DISABLE_MQUEUE) || !defined(CONFIG_DISABLE_MQUEUE_SYSV)
   TSTATE_WAIT_MQNOTEMPTY,     /* BLOCKED      - Waiting for a MQ to become not empty. */
   TSTATE_WAIT_MQNOTFULL,      /* BLOCKED      - Waiting for a MQ to become not full. */
 #endif

--- a/sched/Kconfig
+++ b/sched/Kconfig
@@ -1586,7 +1586,7 @@ endmenu # Signal Numbers
 endmenu # Signal Configuration
 
 menu "Message Queue Options"
-	depends on !DISABLE_MQUEUE && !DISABLE_MQUEUE_SYSV
+	depends on !DISABLE_MQUEUE || !DISABLE_MQUEUE_SYSV
 
 config PREALLOC_MQ_MSGS
 	int "Number of pre-allocated messages"

--- a/sched/init/nx_start.c
+++ b/sched/init/nx_start.c
@@ -576,7 +576,7 @@ void nx_start(void)
 
   nxsig_initialize();
 
-#if !defined(CONFIG_DISABLE_MQUEUE) && !defined(CONFIG_DISABLE_MQUEUE_SYSV)
+#if !defined(CONFIG_DISABLE_MQUEUE) || !defined(CONFIG_DISABLE_MQUEUE_SYSV)
   /* Initialize the named message queue facility (if in link) */
 
   nxmq_initialize();

--- a/sched/signal/sig_dispatch.c
+++ b/sched/signal/sig_dispatch.c
@@ -441,7 +441,7 @@ int nxsig_tcbdispatch(FAR struct tcb_s *stcb, siginfo_t *info)
           nxsem_wait_irq(stcb, EINTR);
         }
 
-#if !defined(CONFIG_DISABLE_MQUEUE) && !defined(CONFIG_DISABLE_MQUEUE_SYSV)
+#if !defined(CONFIG_DISABLE_MQUEUE) || !defined(CONFIG_DISABLE_MQUEUE_SYSV)
       /* If the task is blocked waiting on a message queue, then that task
        * must be unblocked when a signal is received.
        */

--- a/sched/task/task_cancelpt.c
+++ b/sched/task/task_cancelpt.c
@@ -392,7 +392,7 @@ bool nxnotify_cancellation(FAR struct tcb_s *tcb)
               nxsig_wait_irq(tcb, ECANCELED);
             }
 
-#if !defined(CONFIG_DISABLE_MQUEUE) && !defined(CONFIG_DISABLE_MQUEUE_SYSV)
+#if !defined(CONFIG_DISABLE_MQUEUE) || !defined(CONFIG_DISABLE_MQUEUE_SYSV)
           /* If the thread is blocked waiting on a message queue, then
            * the thread must be unblocked to handle the cancellation.
            */

--- a/sched/task/task_recover.c
+++ b/sched/task/task_recover.c
@@ -78,7 +78,7 @@ void nxtask_recover(FAR struct tcb_s *tcb)
 
   nxsem_recover(tcb);
 
-#if !defined(CONFIG_DISABLE_MQUEUE) && !defined(CONFIG_DISABLE_MQUEUE_SYSV)
+#if !defined(CONFIG_DISABLE_MQUEUE) || !defined(CONFIG_DISABLE_MQUEUE_SYSV)
   /* Handle cases where the thread was waiting for a message queue event */
 
   nxmq_recover(tcb);


### PR DESCRIPTION
## Summary

Modify mqueue macro, to make sure mqueue and sysv can disable separately.

## Impact

NA

## Testing

sim:ostest
