### PR TITLE
mm/shm: Implement shmem drivers for risc-v target

### DIFF
--- a/arch/risc-v/src/common/Make.defs
+++ b/arch/risc-v/src/common/Make.defs
@@ -103,4 +103,5 @@ endif
 
 ifeq ($(CONFIG_ARCH_ADDRENV),y)
 CMN_CSRCS += riscv_addrenv.c riscv_pgalloc.c riscv_addrenv_perms.c
+CMN_CSRCS += riscv_addrenv_utils.c
 endif

--- a/arch/risc-v/src/common/Make.defs
+++ b/arch/risc-v/src/common/Make.defs
@@ -103,5 +103,5 @@ endif
 
 ifeq ($(CONFIG_ARCH_ADDRENV),y)
 CMN_CSRCS += riscv_addrenv.c riscv_pgalloc.c riscv_addrenv_perms.c
-CMN_CSRCS += riscv_addrenv_utils.c
+CMN_CSRCS += riscv_addrenv_utils.c riscv_addrenv_shm.c
 endif

--- a/arch/risc-v/src/common/riscv_addrenv_shm.c
+++ b/arch/risc-v/src/common/riscv_addrenv_shm.c
@@ -1,0 +1,176 @@
+/****************************************************************************
+ * arch/risc-v/src/common/riscv_addrenv_shm.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <errno.h>
+#include <assert.h>
+#include <debug.h>
+
+#include <nuttx/addrenv.h>
+#include <nuttx/arch.h>
+#include <nuttx/irq.h>
+#include <nuttx/pgalloc.h>
+
+#include <arch/barriers.h>
+
+#include "addrenv.h"
+#include "pgalloc.h"
+#include "riscv_mmu.h"
+
+#if defined(CONFIG_BUILD_KERNEL) && defined(CONFIG_MM_SHM)
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: up_shmat
+ *
+ * Description:
+ *   Attach, i.e, map, on shared memory region to a user virtual address
+ *
+ * Input Parameters:
+ *   pages - A pointer to the first element in a array of physical address,
+ *     each corresponding to one page of memory.
+ *   npages - The number of pages in the list of physical pages to be mapped.
+ *   vaddr - The virtual address corresponding to the beginning of the
+ *     (contiguous) virtual address region.
+ *
+ * Returned Value:
+ *   Zero (OK) is returned on success; a negated errno value is returned
+ *   on failure.
+ *
+ ****************************************************************************/
+
+int up_shmat(uintptr_t *pages, unsigned int npages, uintptr_t vaddr)
+{
+  struct tcb_s        *tcb = nxsched_self();
+  struct task_group_s *group;
+  uintptr_t            ptlast;
+  uintptr_t            ptlevel;
+  uintptr_t            paddr;
+
+  /* Sanity checks */
+
+  DEBUGASSERT(tcb && tcb->group);
+  DEBUGASSERT(pages != NULL && npages > 0);
+  DEBUGASSERT(vaddr >= CONFIG_ARCH_SHM_VBASE && vaddr < ARCH_SHM_VEND);
+  DEBUGASSERT(MM_ISALIGNED(vaddr));
+
+  group   = tcb->group;
+  ptlevel = RV_MMU_PT_LEVELS;
+
+  /* Add the references to pages[] into the caller's address environment */
+
+  for (; npages > 0; npages--)
+    {
+      /* Get the address of the last level page table */
+
+      ptlast = riscv_pgvaddr(riscv_get_pgtable(&group->tg_addrenv, vaddr));
+      if (!ptlast)
+        {
+          return -ENOMEM;
+        }
+
+      /* Then add the reference */
+
+      paddr = *pages++;
+      mmu_ln_setentry(ptlevel, ptlast, paddr, vaddr, MMU_UDATA_FLAGS);
+      vaddr += MM_PGSIZE;
+    }
+
+  /* Flush the data cache, so the changes are committed to memory */
+
+  __DMB();
+
+  return OK;
+}
+
+/****************************************************************************
+ * Name: up_shmdt
+ *
+ * Description:
+ *   Detach, i.e, unmap, on shared memory region from a user virtual address
+ *
+ * Input Parameters:
+ *   vaddr - The virtual address corresponding to the beginning of the
+ *     (contiguous) virtual address region.
+ *   npages - The number of pages to be unmapped
+ *
+ * Returned Value:
+ *   Zero (OK) is returned on success; a negated errno value is returned
+ *   on failure.
+ *
+ ****************************************************************************/
+
+int up_shmdt(uintptr_t vaddr, unsigned int npages)
+{
+  struct tcb_s        *tcb = nxsched_self();
+  struct task_group_s *group;
+  uintptr_t            ptlast;
+  uintptr_t            ptprev;
+  uintptr_t            ptlevel;
+  uintptr_t            paddr;
+
+  /* Sanity checks */
+
+  DEBUGASSERT(tcb && tcb->group);
+  DEBUGASSERT(npages > 0);
+  DEBUGASSERT(vaddr >= CONFIG_ARCH_SHM_VBASE && vaddr < ARCH_SHM_VEND);
+  DEBUGASSERT(MM_ISALIGNED(vaddr));
+
+  group   = tcb->group;
+  ptlevel = ARCH_SPGTS;
+  ptprev  = riscv_pgvaddr(group->tg_addrenv.spgtables[ARCH_SPGTS - 1]);
+  if (!ptprev)
+    {
+      /* Something is very wrong */
+
+      return -EFAULT;
+    }
+
+  /* Remove the references from the caller's address environment */
+
+  for (; npages > 0; npages--)
+    {
+      /* Get the current final level entry corresponding to this vaddr */
+
+      paddr = mmu_pte_to_paddr(mmu_ln_getentry(ptlevel, ptprev, vaddr));
+      ptlast = riscv_pgvaddr(paddr);
+
+      /* Then wipe the reference */
+
+      mmu_ln_clear(ptlevel + 1, ptlast, vaddr);
+      vaddr += MM_PGSIZE;
+    }
+
+  /* Flush the data cache, so the changes are committed to memory */
+
+  __DMB();
+
+  return OK;
+}
+
+#endif /* CONFIG_BUILD_KERNEL */

--- a/arch/risc-v/src/common/riscv_mmu.h
+++ b/arch/risc-v/src/common/riscv_mmu.h
@@ -364,6 +364,25 @@ void mmu_ln_restore(uint32_t ptlevel, uintptr_t lnvaddr, uintptr_t vaddr,
                     uintptr_t entry);
 
 /****************************************************************************
+ * Name: mmu_ln_clear
+ *
+ * Description:
+ *   Unmap a level n translation table entry.
+ *
+ * Input Parameters:
+ *   ptlevel - The translation table level, amount of levels is
+ *     MMU implementation specific
+ *   lnvaddr - The virtual address of the beginning of the page table at
+ *     level n
+ *   vaddr - The virtual address to get pte for. Must be aligned to a PPN
+ *     address boundary which is dependent on the level of the entry
+ *
+ ****************************************************************************/
+
+#define mmu_ln_clear(ptlevel, lnvaddr, vaddr) \
+  mmu_ln_restore(ptlevel, lnvaddr, vaddr, 0)
+
+/****************************************************************************
  * Name: mmu_ln_map_region
  *
  * Description:

--- a/arch/risc-v/src/common/riscv_pgalloc.c
+++ b/arch/risc-v/src/common/riscv_pgalloc.c
@@ -37,6 +37,7 @@
 
 #include <arch/barriers.h>
 
+#include "addrenv.h"
 #include "pgalloc.h"
 #include "riscv_mmu.h"
 
@@ -53,48 +54,6 @@
 /****************************************************************************
  * Private Functions
  ****************************************************************************/
-
-/****************************************************************************
- * Name: get_pgtable
- *
- * Description:
- *   Get the physical address of the last page table level corresponding to
- *   'vaddr'
- *
- ****************************************************************************/
-
-static uintptr_t get_pgtable(group_addrenv_t *addrenv, uintptr_t vaddr)
-{
-  uintptr_t paddr;
-  uintptr_t ptprev;
-  uint32_t  ptlevel;
-
-  /* Get the current level MAX_LEVELS-1 entry corresponding to this vaddr */
-
-  ptlevel = ARCH_SPGTS;
-  ptprev  = riscv_pgvaddr(addrenv->spgtables[ARCH_SPGTS - 1]);
-  paddr   = mmu_pte_to_paddr(mmu_ln_getentry(ptlevel, ptprev, vaddr));
-
-  if (!paddr)
-    {
-      /* No page table has been allocated... allocate one now */
-
-      paddr = mm_pgalloc(1);
-      if (paddr)
-        {
-          /* Wipe the page and assign it */
-
-          riscv_pgwipe(paddr);
-          mmu_ln_setentry(ptlevel, ptprev, paddr, vaddr, MMU_UPGT_FLAGS);
-        }
-    }
-
-  /* Flush the data cache, so the changes are committed to memory */
-
-  __DMB();
-
-  return paddr;
-}
 
 /****************************************************************************
  * Public Functions
@@ -172,7 +131,7 @@ uintptr_t pgalloc(uintptr_t brkaddr, unsigned int npages)
     {
       /* Get the address of the last level page table */
 
-      ptlast = riscv_pgvaddr(get_pgtable(&group->tg_addrenv, vaddr));
+      ptlast = riscv_pgvaddr(riscv_get_pgtable(&group->tg_addrenv, vaddr));
       if (!ptlast)
         {
           return 0;

--- a/mm/shm/shm_initialize.c
+++ b/mm/shm/shm_initialize.c
@@ -25,6 +25,7 @@
 #include <nuttx/config.h>
 
 #include <assert.h>
+#include <debug.h>
 #include <errno.h>
 
 #include <nuttx/addrenv.h>

--- a/mm/shm/shmat.c
+++ b/mm/shm/shmat.c
@@ -26,6 +26,7 @@
 
 #include <sys/shm.h>
 #include <assert.h>
+#include <debug.h>
 #include <errno.h>
 
 #include <nuttx/sched.h>

--- a/mm/shm/shmctl.c
+++ b/mm/shm/shmctl.c
@@ -31,6 +31,7 @@
 #include <time.h>
 #include <errno.h>
 #include <assert.h>
+#include <debug.h>
 
 #include <nuttx/mm/shm.h>
 #include <nuttx/pgalloc.h>

--- a/mm/shm/shmdt.c
+++ b/mm/shm/shmdt.c
@@ -26,11 +26,13 @@
 
 #include <sys/shm.h>
 #include <assert.h>
+#include <debug.h>
 #include <errno.h>
 
 #include <nuttx/arch.h>
 #include <nuttx/sched.h>
 #include <nuttx/mm/shm.h>
+#include <nuttx/pgalloc.h>
 
 #include "shm/shm.h"
 

--- a/mm/shm/shmget.c
+++ b/mm/shm/shmget.c
@@ -28,6 +28,7 @@
 #include <sys/ipc.h>
 #include <unistd.h>
 #include <string.h>
+#include <debug.h>
 #include <errno.h>
 
 #include <nuttx/pgalloc.h>


### PR DESCRIPTION
## Summary
Implements up_shmat and up_shmdt for risc-v target
## Impact
None, if CONFIG_MM_SHM is not enabled
## Testing
icicle:knsh (example config file update will follow later)
