### PR TITLE
Fix arch/arm/src/samv7/sam_pwm.c:489:1: error: Missing blank line after comment

### DIFF
--- a/arch/arm/src/samv7/sam_pwm.c
+++ b/arch/arm/src/samv7/sam_pwm.c
@@ -486,7 +486,8 @@ static int pwm_start(struct pwm_lowerhalf_s *dev,
             }
           else
             {
-              /* release overwrite of channel */
+              /* Release overwrite of channel */
+
               regval = (1 << priv->channels[i].channel);
               pwm_putreg(priv, SAMV7_PWM_OSC, regval);
             }


### PR DESCRIPTION
## Summary

## Impact

## Testing

