### PR TITLE
driver/mtd: add support for mx25l16 serial flash

### DIFF
--- a/drivers/mtd/mx25lx.c
+++ b/drivers/mtd/mx25lx.c
@@ -64,6 +64,12 @@
 
 /* Chip Geometries **********************************************************/
 
+/* MX25L1606E capacity is 16Mbit  (2048Kbit x 8) =   2Mb (256kb x 8) */
+
+#define MX25L_MX25L1606E_SECTOR_SHIFT  12    /* Sector size 1 << 12 = 4Kb */
+#define MX25L_MX25L1606E_NSECTORS      512
+#define MX25L_MX25L1606E_PAGE_SHIFT    8     /* Page size 1 << 8 = 256 */
+
 /* MX25L3233F capacity is 32Mbit  (4096Kbit x 8) =   4Mb (512kb x 8) */
 
 #define MX25L_MX25L3233F_SECTOR_SHIFT  12    /* Sector size 1 << 12 = 4Kb */
@@ -177,6 +183,8 @@
 
 #define MX25L_JEDEC_MANUFACTURER         0xc2  /* Macronix manufacturer ID */
 #define MX25L_JEDEC_MEMORY_TYPE          0x20  /* MX25Lx  memory type */
+
+#define MX25L_JEDEC_MX25L1606E_CAPACITY  0x15  /* MX25L1606E memory capacity */
 #define MX25L_JEDEC_MX25L3233F_CAPACITY  0x16  /* MX25L3233F memory capacity */
 #define MX25L_JEDEC_MX25L6433F_CAPACITY  0x17  /* MX25L6433F memory capacity */
 #define MX25L_JEDEC_MX25L25635F_CAPACITY 0x19  /* MX25L25635F memory capacity */
@@ -368,7 +376,17 @@ static inline int mx25l_readid(FAR struct mx25l_dev_s *priv)
     {
       /* Okay.. is it a FLASH capacity that we understand? */
 
-      if (capacity == MX25L_JEDEC_MX25L3233F_CAPACITY)
+      if (capacity == MX25L_JEDEC_MX25L1606E_CAPACITY)
+        {
+          /* Save the FLASH geometry */
+
+          priv->sectorshift  = MX25L_MX25L1606E_SECTOR_SHIFT;
+          priv->nsectors     = MX25L_MX25L1606E_NSECTORS;
+          priv->pageshift    = MX25L_MX25L1606E_PAGE_SHIFT;
+          priv->addressbytes = MX25L_ADDRESSBYTES_3;
+          return OK;
+        }
+      else if (capacity == MX25L_JEDEC_MX25L3233F_CAPACITY)
         {
           /* Save the FLASH geometry */
 


### PR DESCRIPTION
## Summary
add support for mx25l16 serial flash

## Impact
None

## Testing
local test pass
```
[01/01/70 00:00:00.120000] mx25l_readid: manufacturer: c2 memory: 20 capacity: 15
[01/01/70 00:00:00.130000] mx25l_initialize_spi: Return 0x20002f10
[01/01/70 00:00:00.150000] mx25l_ioctl: cmd: 1537
[01/01/70 00:00:00.150000] mx25l_ioctl: blocksize: 256 erasesize: 4096 neraseblocks: 512
[01/01/70 00:00:00.160000] mx25l_ioctl: return 0
```