### PR TITLE
Remove DISCLAIMER. Apache NuttX has graduated the Incubator.

### DIFF
--- a/DISCLAIMER
+++ b/DISCLAIMER
@@ -1,6 +1,0 @@
-Apache NuttX is an effort undergoing incubation at The Apache Software Foundation (ASF),
-sponsored by the Apache Incubator. Incubation is required of all newly accepted projects
-until a further review indicates that the infrastructure, communications, and decision
-making process have stabilized in a manner consistent with other successful ASF projects.
-While incubation status is not necessarily a reflection of the completeness or stability
-of the code, it does indicate that the project has yet to be fully endorsed by the ASF.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
-# APACHE NUTTX (INCUBATING)
+# APACHE NUTTX
 
 * Introduction
-  - Incubation Status
 * Community
   - Getting Help
   - Mailing Lists
@@ -47,25 +46,18 @@
 
 # INTRODUCTION
 
-Apache NuttX (Incubating) is a real-time operating system (RTOS) with an
-emphasis on standards compliance and small footprint.  Scalable from 8-bit
-to 32-bit microcontroller environments, the primary governing standards in
-NuttX are POSIX and ANSI standards. Additional standard APIs from Unix and
-other common RTOSs (such as VxWorks) are adopted for functionality not
-available under these standards, or for functionality that is not
-appropriate for deeply-embedded environments (such as fork()).
+Apache NuttX is a real-time operating system (RTOS) with an emphasis on
+standards compliance and small footprint. Scalable from 8-bit to 64-bit
+microcontroller environments, the primary governing standards in NuttX are
+POSIX and ANSI standards. Additional standard APIs from Unix and other
+common RTOSs (such as VxWorks) are adopted for functionality not available
+under these standards, or for functionality that is not appropriate for
+deeply-embedded environments (such as fork()).
 
 Extensive documentation can be found on the project wiki:
   <https://cwiki.apache.org/NUTTX/NuttX>
 
-## Incubation Status
-
-Apache NuttX (Incubating) is an effort undergoing Incubation at The Apache
-Software Foundation (ASF), sponsored by the Incubator.  For more on our
-incubation effort, please see the file DISCLAIMER-WIP, in the same
-directory as this README.
-
-For brevity, the rest of this file will refer to it as Apache NuttX or
+For brevity, many parts of the documentation will refer to Apache NuttX as
 simply NuttX.
 
 # COMMUNITY


### PR DESCRIPTION
## Summary

NuttX has graduated the Incubator!

- Removing the DISCLAIMER file.
- Removing additional disclaimer from README.md.

## Impact

None.

## Testing

N/A.