### PR TITLE
include/nuttx/tls.h: add CXX extern define for tls

### DIFF
--- a/include/nuttx/tls.h
+++ b/include/nuttx/tls.h
@@ -63,6 +63,14 @@
  * Public Types
  ****************************************************************************/
 
+#ifdef __cplusplus
+#define EXTERN extern "C"
+extern "C"
+{
+#else
+#define EXTERN extern
+#endif
+
 /* type tls_ndxset_t & tls_dtor_t *******************************************/
 
 /* Smallest addressable type that can hold the entire configured number of
@@ -344,5 +352,10 @@ void tls_destruct(void);
  ****************************************************************************/
 
 FAR struct task_info_s *task_get_info(void);
+
+#undef EXTERN
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __INCLUDE_NUTTX_TLS_H */


### PR DESCRIPTION
## Summary
   In order to use C functions in C++ code, "extern C"
needs to be defined in the C header file.
   Add "extern C" define for tls.h

Signed-off-by: qinwei1 <qinwei1@xiaomi.com>

## Impact
None

## Testing
Compile PASSED
