### PR TITLE
Refine SCTLR register configuration to confirm the spec

### DIFF
--- a/arch/arm/src/armv7-a/arm_pghead.S
+++ b/arch/arm/src/armv7-a/arm_pghead.S
@@ -453,6 +453,15 @@ __start:
 	orr		r0, r0, #(SCTLR_A)
 #endif
 
+#ifdef CONFIG_ENDIAN_BIG
+	/* Big endian mode
+	 *
+	 *   SCTLR_EE   Bit 25: 1=Big endian.
+	 */
+
+	orr		r0, r0, #(SCTLR_EE)
+#endif
+
 #ifdef CPU_AFE_ENABLE
 	/* AP[0:2] Permissions model
 	 *

--- a/arch/arm/src/armv7-r/arm_head.S
+++ b/arch/arm/src/armv7-r/arm_head.S
@@ -191,7 +191,6 @@ __start:
 	 *   SCTLR_EE       Bit 25: 0=Little endian.
 	 *   SCTLR_NMFI     Bit 27: Non-maskable FIQ (NMFI) support
 	 *   SCTLR_TE       Bit 30: All exceptions handled in ARM state.
-	 *   SCTLR_IE       Bit 31: Instruction endian-ness.
 	 */
 
 	/* Clear all configurable bits */
@@ -199,7 +198,7 @@ __start:
 	bic		r0, r0, #(SCTLR_M | SCTLR_A  | SCTLR_C | SCTLR_CCP15BEN | SCTLR_B)
 	bic		r0, r0, #(SCTLR_SW | SCTLR_I | SCTLR_V   | SCTLR_RR)
 	bic		r0, r0, #(SCTLR_BR | SCTLR_DZ | SCTLR_FI | SCTLR_U)
-	bic		r0, r0, #(SCTLR_VE | SCTLR_EE | SCTLR_NMFI | SCTLR_TE | SCTLR_IE)
+	bic		r0, r0, #(SCTLR_VE | SCTLR_EE | SCTLR_NMFI | SCTLR_TE)
 
 	/* Set configured bits */
 

--- a/arch/arm/src/armv7-r/arm_head.S
+++ b/arch/arm/src/armv7-r/arm_head.S
@@ -195,9 +195,9 @@ __start:
 
 	/* Clear all configurable bits */
 
-	bic		r0, r0, #(SCTLR_M | SCTLR_A  | SCTLR_C | SCTLR_CCP15BEN | SCTLR_B)
-	bic		r0, r0, #(SCTLR_SW | SCTLR_I | SCTLR_V   | SCTLR_RR)
-	bic		r0, r0, #(SCTLR_BR | SCTLR_DZ | SCTLR_FI | SCTLR_U)
+	bic		r0, r0, #(SCTLR_M  | SCTLR_A  | SCTLR_C    | SCTLR_CCP15BEN | SCTLR_B)
+	bic		r0, r0, #(SCTLR_SW | SCTLR_I  | SCTLR_V    | SCTLR_RR)
+	bic		r0, r0, #(SCTLR_BR | SCTLR_DZ | SCTLR_FI)
 	bic		r0, r0, #(SCTLR_VE | SCTLR_EE | SCTLR_NMFI | SCTLR_TE)
 
 	/* Set configured bits */

--- a/arch/arm/src/armv7-r/sctlr.h
+++ b/arch/arm/src/armv7-r/sctlr.h
@@ -159,7 +159,6 @@
 #define SCTLR_NMFI         (1 << 27) /* Bit 27: Non-maskable FIQ (NMFI) support */
                                      /* Bits 28-29: Reserved */
 #define SCTLR_TE           (1 << 30) /* Bit 30: Thumb exception enable */
-#define SCTLR_IE           (1 << 31) /* Bit 31: Instruction endian-ness */
 
 /* Auxiliary Control Register (ACTLR): CRn=c1, opc1=0, CRm=c0, opc2=1
  * Implementation defined


### PR DESCRIPTION
## Summary

- arch/armv7-r: Remove the nonexistent SCTLR_IE 
- arch/armv7-a: Support the big endian in arm_pghead.S like arm_head.S 
- arch/armv7-r: Don't clear SCTLR_U bit since spec require it's always one 

## Impact
armv7-a/r

## Testing

