### PR TITLE
net/icmp: ICMP_NO_STACK should not depends on NET_IPv4

### DIFF
--- a/net/icmp/Kconfig
+++ b/net/icmp/Kconfig
@@ -3,7 +3,6 @@
 # see the file kconfig-language.txt in the NuttX tools repository.
 #
 
-if NET_IPv4
 menu "ICMP Networking Support"
 
 config NET_ICMP
@@ -44,4 +43,3 @@ config NET_ICMP_NPOLLWAITERS
 endif # NET_ICMP_SOCKET
 endif # NET_ICMP && !NET_ICMP_NO_STACK
 endmenu # ICMP Networking Support
-endif # NET_IPv4

--- a/net/icmpv6/Kconfig
+++ b/net/icmpv6/Kconfig
@@ -3,7 +3,6 @@
 # see the file kconfig-language.txt in the NuttX tools repository.
 #
 
-if NET_IPv6
 menu "ICMPv6 Networking Support"
 
 config NET_ICMPv6
@@ -213,4 +212,3 @@ endif # NET_ICMPv6_SOCKET
 
 endif # NET_ICMPv6 && !NET_ICMPv6_NO_STACK
 endmenu # ICMPv6 Networking Support
-endif # NET_IPv6

--- a/net/utils/Make.defs
+++ b/net/utils/Make.defs
@@ -44,9 +44,13 @@ endif
 # ICMP utilities
 
 ifeq ($(CONFIG_NET_ICMP),y)
-NET_CSRCS += net_icmpchksum.c
+  ifneq ($(CONFIG_NET_ICMP_NO_STACK),y)
+    NET_CSRCS += net_icmpchksum.c
+  endif
 else ifeq ($(CONFIG_NET_ICMPv6),y)
-NET_CSRCS += net_icmpchksum.c
+  ifneq ($(CONFIG_NET_ICMPv6_NO_STACK),y)
+    NET_CSRCS += net_icmpchksum.c
+  endif
 endif
 
 # Bound device find


### PR DESCRIPTION
## Summary

net/icmp: ICMP_NO_STACK should not depends on NET_IPv4
sim/vncserver: SIM_NETUSRSOCK does not require l3 protocol support

## Impact

N/A

## Testing

vncserver test