### PR TITLE
fs/userfs: destroy nxmutex properly

### DIFF
--- a/drivers/clk/clk_rpmsg.c
+++ b/drivers/clk/clk_rpmsg.c
@@ -485,18 +485,17 @@ static int64_t clk_rpmsg_sendrecv(FAR struct rpmsg_endpoint *ept,
   cookie.result  = -EIO;
 
   ret = rpmsg_send_nocopy(ept, msg, len);
-  if (ret < 0)
+  if (ret >= 0)
     {
-      return ret;
+      ret = nxsem_wait_uninterruptible(&cookie.sem);
+      if (ret >= 0)
+        {
+          ret = cookie.result;
+        }
     }
 
-  ret = nxsem_wait_uninterruptible(&cookie.sem);
-  if (ret < 0)
-    {
-      return ret;
-    }
-
-  return cookie.result;
+  nxsem_destroy(&cookie.sem);
+  return ret;
 }
 
 static bool clk_rpmsg_server_match(FAR struct rpmsg_device *rdev,

--- a/drivers/ioexpander/ioe_rpmsg.c
+++ b/drivers/ioexpander/ioe_rpmsg.c
@@ -275,18 +275,17 @@ static int ioe_rpmsg_sendrecv(FAR struct rpmsg_endpoint *ept,
   msg->cookie = (uintptr_t)&cookie;
 
   ret = rpmsg_send(ept, msg, len);
-  if (ret < 0)
+  if (ret >= 0)
     {
-      return ret;
+      ret = rpmsg_wait(ept, &cookie.sem);
+      if (ret >= 0)
+        {
+          ret = cookie.result;
+        }
     }
 
-  ret = rpmsg_wait(ept, &cookie.sem);
-  if (ret < 0)
-    {
-      return ret;
-    }
-
-  return cookie.result;
+  nxsem_destroy(&cookie.sem);
+  return ret;
 }
 
 static int ioe_rpmsg_direction(FAR struct ioexpander_dev_s *dev, uint8_t pin,

--- a/drivers/loop/losetup.c
+++ b/drivers/loop/losetup.c
@@ -408,6 +408,7 @@ errout_with_file:
   file_close(&dev->devfile);
 
 errout_with_dev:
+  nxmutex_destroy(&dev->lock);
   kmm_free(dev);
   return ret;
 }
@@ -471,6 +472,7 @@ int loteardown(FAR const char *devname)
       file_close(&dev->devfile);
     }
 
+  nxmutex_destroy(&dev->lock);
   kmm_free(dev);
   return ret;
 }

--- a/drivers/misc/rpmsgdev_server.c
+++ b/drivers/misc/rpmsgdev_server.c
@@ -403,6 +403,7 @@ static void rpmsgdev_ns_bind(FAR struct rpmsg_device *rdev,
                          rpmsgdev_ept_cb, rpmsgdev_ns_unbind);
   if (ret < 0)
     {
+      nxmutex_destroy(&server->lock);
       kmm_free(server);
     }
 }

--- a/drivers/misc/rwbuffer.c
+++ b/drivers/misc/rwbuffer.c
@@ -814,6 +814,7 @@ int rwb_initialize(FAR struct rwbuffer_s *rwb)
       if (!rwb->wrbuffer)
         {
           ferr("Write buffer kmm_malloc(%" PRIu32 ") failed\n", allocsize);
+          nxmutex_destroy(&rwb->wrlock);
           return -ENOMEM;
         }
 
@@ -842,6 +843,19 @@ int rwb_initialize(FAR struct rwbuffer_s *rwb)
         {
           ferr("Read-ahead buffer kmm_malloc(%" PRIu32 ") failed\n",
           allocsize);
+          nxmutex_destroy(&rwb->rhlock);
+#ifdef CONFIG_DRVR_WRITEBUFFER
+          if (rwb->wrmaxblocks > 0)
+            {
+              nxmutex_destroy(&rwb->wrlock);
+            }
+
+          if (rwb->wrbuffer != NULL)
+            {
+              kmm_free(rwb->wrbuffer);
+            }
+#endif
+
           return -ENOMEM;
         }
 

--- a/drivers/mtd/rpmsgmtd.c
+++ b/drivers/mtd/rpmsgmtd.c
@@ -1109,6 +1109,7 @@ fail_with_rpmsg:
 
 fail:
   nxsem_destroy(&dev->wait);
+  nxmutex_destroy(&dev->geolock);
   kmm_free(dev);
   return ret;
 }

--- a/drivers/power/supply/regulator_rpmsg.c
+++ b/drivers/power/supply/regulator_rpmsg.c
@@ -495,18 +495,17 @@ static int regulator_rpmsg_sendrecv(FAR struct rpmsg_endpoint *ept,
   msg->cookie = (uintptr_t)&cookie;
 
   ret = rpmsg_send_nocopy(ept, msg, len);
-  if (ret < 0)
+  if (ret >= 0)
     {
-      return ret;
+      ret = nxsem_wait_uninterruptible(&cookie.sem);
+      if (ret >= 0)
+        {
+          ret = cookie.result;
+        }
     }
 
-  ret = nxsem_wait_uninterruptible(&cookie.sem);
-  if (ret < 0)
-    {
-      return ret;
-    }
-
-  return cookie.result;
+  nxsem_destroy(&cookie.sem);
+  return ret;
 }
 
 static int regulator_rpmsg_enable(FAR struct regulator_dev_s *rdev)

--- a/fs/userfs/fs_userfs.c
+++ b/fs/userfs/fs_userfs.c
@@ -1487,6 +1487,7 @@ errout_with_psock:
   psock_close(&priv->psock);
 
 errout_with_alloc:
+  nxmutex_destroy(&priv->lock);
   kmm_free(priv);
   return ret;
 }
@@ -1570,6 +1571,7 @@ static int userfs_unbind(FAR void *handle, FAR struct inode **blkdriver,
   /* Free resources and return success */
 
   psock_close(&priv->psock);
+  nxmutex_destroy(&priv->lock);
   kmm_free(priv);
   return OK;
 }

--- a/graphics/nxterm/nxterm_register.c
+++ b/graphics/nxterm/nxterm_register.c
@@ -143,6 +143,10 @@ FAR struct nxterm_state_s *
   return (NXTERM)priv;
 
 errout:
+  nxmutex_destroy(&priv->lock);
+#ifdef CONFIG_NXTERM_NXKBDIN
+  nxsem_destroy(&priv->waitsem);
+#endif
   kmm_free(priv);
   return NULL;
 }

--- a/net/icmp/icmp_recvmsg.c
+++ b/net/icmp/icmp_recvmsg.c
@@ -449,6 +449,8 @@ ssize_t icmp_recvmsg(FAR struct socket *psock, FAR struct msghdr *msg,
           icmp_callback_free(dev, conn, state.recv_cb);
         }
 
+      nxsem_destroy(&state.recv_sem);
+
       /* Return the negated error number in the event of a failure, or the
        * number of bytes received on success.
        */

--- a/net/icmp/icmp_sendmsg.c
+++ b/net/icmp/icmp_sendmsg.c
@@ -445,6 +445,8 @@ ssize_t icmp_sendmsg(FAR struct socket *psock, FAR struct msghdr *msg,
       icmp_callback_free(dev, conn, state.snd_cb);
     }
 
+  nxsem_destroy(&state.snd_sem);
+
   net_unlock();
 
   /* Return the negated error number in the event of a failure, or the

--- a/net/icmpv6/icmpv6_recvmsg.c
+++ b/net/icmpv6/icmpv6_recvmsg.c
@@ -456,6 +456,8 @@ ssize_t icmpv6_recvmsg(FAR struct socket *psock, FAR struct msghdr *msg,
           icmpv6_callback_free(dev, conn, state.recv_cb);
         }
 
+      nxsem_destroy(&state.recv_sem);
+
       /* Return the negated error number in the event of a failure, or the
        * number of bytes received on success.
        */

--- a/net/icmpv6/icmpv6_sendmsg.c
+++ b/net/icmpv6/icmpv6_sendmsg.c
@@ -426,6 +426,8 @@ ssize_t icmpv6_sendmsg(FAR struct socket *psock, FAR struct msghdr *msg,
       icmpv6_callback_free(dev, conn, state.snd_cb);
     }
 
+  nxsem_destroy(&state.snd_sem);
+
   net_unlock();
 
   /* Return the negated error number in the event of a failure, or the

--- a/wireless/bluetooth/bt_hcicore.c
+++ b/wireless/bluetooth/bt_hcicore.c
@@ -1846,6 +1846,8 @@ int bt_hci_cmd_send_sync(uint16_t opcode, FAR struct bt_buf_s *buf,
       bt_buf_release(buf->u.hci.sync);
     }
 
+  nxsem_destroy(&sync_sem);
+
   return ret;
 }
 


### PR DESCRIPTION
## Summary

fs/userfs: destroy nxmutex properly

Signed-off-by: chao an <anchao@xiaomi.com>


## Impact

N/A

## Testing

ci-check