### PR TITLE
net/arp: Make NET_ARP(Address Resolution Protocol) configurable

### DIFF
--- a/net/arp/Kconfig
+++ b/net/arp/Kconfig
@@ -6,7 +6,7 @@
 menu "ARP Configuration"
 
 config NET_ARP
-	bool
+	bool "Address Resolution Protocol"
 	default y
 	depends on NET_ETHERNET && NET_IPv4
 	---help---


### PR DESCRIPTION
## Summary

net/arp: Make NET_ARP(Address Resolution Protocol) configurable

Some boards that use USRSOCK will not need this feature

Signed-off-by: chao an <anchao@xiaomi.com>

## Impact

N/A

## Testing

ci-check