### PR TITLE
CI: Update worker base OS versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -177,7 +177,7 @@ jobs:
   macOS:
     permissions:
       contents: none
-    runs-on: macos-10.15
+    runs-on: macos-12
     needs: Fetch-Source
     strategy:
       matrix:
@@ -204,6 +204,11 @@ jobs:
       - name: Export NuttX Repo SHA
         run: echo "nuttx_sha=`git -C sources/nuttx rev-parse HEAD`" >> $GITHUB_ENV
 
+      # Released version of Cython has issues with Python 11. Set runner to use Python 3.10
+      # https://github.com/cython/cython/issues/4500
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10' 
       - name: Run Builds
         run: |
           echo "::add-matcher::sources/nuttx/.github/gcc.json"

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -26,7 +26,7 @@ permissions:
 
 jobs:
   check:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout nuttx repo

--- a/tools/ci/cibuild.sh
+++ b/tools/ci/cibuild.sh
@@ -147,10 +147,13 @@ function binutils {
 function bloaty {
   add_path "${prebuilt}"/bloaty/bin
   if [ ! -f "${prebuilt}/bloaty/bin/bloaty" ]; then
-    git clone --depth 1 --branch v1.1 https://github.com/google/bloaty bloaty-src
+    git clone --branch main https://github.com/google/bloaty bloaty-src
     cd bloaty-src
+    # Due to issues with latest MacOS versions use pinned commit.
+    # https://github.com/google/bloaty/pull/326
+    git checkout 52948c107c8f81045e7f9223ec02706b19cfa882
     mkdir -p "${prebuilt}"/bloaty
-    cmake -DCMAKE_SYSTEM_PREFIX_PATH="${prebuilt}"/bloaty
+    cmake -D BLOATY_PREFER_SYSTEM_CAPSTONE=NO -DCMAKE_SYSTEM_PREFIX_PATH="${prebuilt}"/bloaty
     make install -j 6
     cd "${prebuilt}"
     rm -rf bloaty-src
@@ -260,16 +263,17 @@ function python-tools {
   PYTHONUSERBASE=${prebuilt}/pylocal
   export PYTHONUSERBASE
   add_path "${PYTHONUSERBASE}"/bin
-  pip3 install CodeChecker
-  pip3 install cxxfilt
-  pip3 install esptool==3.3.1
-  pip3 install pexpect==4.8.0
-  pip3 install pyelftools
-  pip3 install pyserial==3.5
-  pip3 install pytest==6.2.5
-  pip3 install pytest-json==0.4.0
-  pip3 install pytest-ordering==0.6
-  pip3 install pytest-repeat==0.9.1
+  pip3 install \
+    CodeChecker \
+    cxxfilt \
+    esptool==3.3.1 \
+    pexpect==4.8.0 \
+    pyelftools \
+    pyserial==3.5 \
+    pytest==6.2.5 \
+    pytest-json==0.4.0 \
+    pytest-ordering==0.6 \
+    pytest-repeat==0.9.1 
 
   # MCUboot's tool for image signing and key management
   if ! command -v imgtool &> /dev/null; then


### PR DESCRIPTION
## Summary
Update base OS versions:
Linux
 * Only the check job is updated from  Ubuntu 18.04 [deprecated]  to "latest" (20.04). Others were already on "latest" which is  Ubuntu 20.04 
MacOS
 * Update from  macOS Catalina 10.15 [deprecated] to  macOS Monterey 12
 * Also pin Bloaty to this commit to address issue with googletest version in 1.1 release https://github.com/google/bloaty/commit/52948c107c8f81045e7f9223ec02706b19cfa882
## Impact
Builds are moved off deprecated runner images.  The Linux build itself should not change as it was already running in a container with a pinned version.

## Testing
Passing CI provides coverage for this change.
