### PR TITLE
docs: Include released 10.x and 11.x versions under security policy.

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -4,6 +4,10 @@
 
 | Version | Supported          |
 | ------- | ------------------ |
+| 11.0.x  | :heavy_check_mark: |
+| 10.3.x  | :heavy_check_mark: |
+| 10.2.x  | :heavy_check_mark: |
+| 10.1.x  | :heavy_check_mark: |
 | 10.0.x  | :heavy_check_mark: |
 | 9.1.x   | :heavy_check_mark: |
 | < 9.1   | :x:                |


### PR DESCRIPTION
Fixes #7514

Linked page for security questions now lists the 10.x and 11.x releases as supported for fixes and backports.