### PR TITLE
drivers/segger: make RTT_MODE configurable

### DIFF
--- a/drivers/segger/Kconfig
+++ b/drivers/segger/Kconfig
@@ -62,6 +62,21 @@ config SEGGER_RTT_BUFFER_SIZE_DOWN
 	---help---
 		Size of the buffer for terminal input to target from host (Usually keyboard input)
 
+choice
+	prompt "SEGGER_RTT_MODE"
+	default SEGGER_RTT_MODE_NO_BLOCK_SKIP
+
+config SEGGER_RTT_MODE_NO_BLOCK_SKIP
+	bool "Skip. Do not block, output nothing. (Default)"
+
+config SEGGER_RTT_MODE_NO_BLOCK_TRIM
+	bool "Trim: Do not block, output as much as fits."
+
+config SEGGER_RTT_MODE_BLOCK_IF_FIFO_FULL
+	bool "Block: Wait until there is space in the buffer."
+
+endchoice # SEGGER_RTT_MODE
+
 if SEGGER_SYSVIEW
 
 config SEGGER_SYSVIEW_RTT_BUFFER_SIZE

--- a/drivers/segger/config/SEGGER_RTT_Conf.h
+++ b/drivers/segger/config/SEGGER_RTT_Conf.h
@@ -63,7 +63,13 @@
 
 /* Mode for pre-initialized terminal channel */
 
-#define SEGGER_RTT_MODE_DEFAULT         SEGGER_RTT_MODE_BLOCK_IF_FIFO_FULL
+#if defined(CONFIG_SEGGER_RTT_MODE_NO_BLOCK_TRIM)
+#  define SEGGER_RTT_MODE_DEFAULT       SEGGER_RTT_MODE_NO_BLOCK_TRIM
+#elif defined(SEGGER_RTT_MODE_BLOCK_IF_FIFO_FULL)
+#  define SEGGER_RTT_MODE_DEFAULT       SEGGER_RTT_MODE_BLOCK_IF_FIFO_FULL
+#else
+#  define SEGGER_RTT_MODE_DEFAULT       SEGGER_RTT_MODE_NO_BLOCK_SKIP
+#endif
 
 /* 0: Use memcpy/SEGGER_RTT_MEMCPY, 1: Use a simple byte-loop */
 


### PR DESCRIPTION
Configure segger RTT_MODE through Kconfig

## Summary

Change default RTT_MODE to NO_BLOCK_SKIP, so code can run without debugger connected.

## Impact

Default mode is changed.

## Testing

Tested with stm32f1, syslog works as usual.

