### PR TITLE
net/tcp: TCP_WAITALL should use state flag

### DIFF
--- a/net/tcp/tcp_recvfrom.c
+++ b/net/tcp/tcp_recvfrom.c
@@ -402,7 +402,8 @@ static uint16_t tcp_recvhandler(FAR struct net_driver_s *dev,
            * next receive is performed.
            */
 
-          if ((pstate->ir_recvlen > 0 && (flags & TCP_WAITALL) == 0) ||
+          if ((pstate->ir_recvlen > 0 &&
+               (pstate->ir_cb->flags & TCP_WAITALL) == 0) ||
               pstate->ir_buflen == 0)
             {
               ninfo("TCP resume\n");


### PR DESCRIPTION
## Summary

 net/tcp: TCP_WAITALL should use state flag
 
 The feature of MSG_WAITALL is broken since the wrong flag is used
 
 Signed-off-by: chao an <anchao@xiaomi.com>


## Impact

N/A

## Testing

recv with flag MSG_WAITALL