### PR TITLE
esp32c3:fix i2c bug of timout

### DIFF
--- a/arch/risc-v/src/esp32c3/esp32c3_i2c.c
+++ b/arch/risc-v/src/esp32c3/esp32c3_i2c.c
@@ -844,7 +844,7 @@ static int esp32c3_i2c_polling_waitdone(struct esp32c3_i2c_priv_s *priv)
    * and an error didn't occur within the timeout
    */
 
-  while ((current < timeout) && (priv->error == 0))
+  while ((sclock_t)(current - timeout) < 0 && (priv->error == 0))
     {
       /* Check if any interrupt triggered, clear them
        * process the operation.


### PR DESCRIPTION
Signed-off-by: flyingfish89 <2914061332@qq.com>

## Summary
An integer overflow is fixed in this patch. 

## Impact
Esp32C3 I2c only.

## Testing
Tested on Esp32C3
