### PR TITLE
risc-v/mpfs: fix compile warning

### DIFF
--- a/arch/risc-v/src/mpfs/mpfs_opensbi.c
+++ b/arch/risc-v/src/mpfs/mpfs_opensbi.c
@@ -225,7 +225,7 @@ static const struct sbi_platform platform =
 
 /* This must go into l2_scratchpad region, starting at 0x0a000000. */
 
-sbi_scratch_holder_t g_scratches[0] \
+sbi_scratch_holder_t g_scratches[MPFS_MAX_NUM_HARTS] \
                __attribute__((section(".l2_scratchpad")));
 
 /****************************************************************************


### PR DESCRIPTION
After commit b7d2b38, the system suffers from -Warray-bounds warning with -Wall:

chip/mpfs_opensbi.c: In function 'mpfs_hart_to_scratch': chip/mpfs_opensbi.c:251:26: warning: array subscript hartid is outside array bounds of 'sbi_scratch_holder_t[0]' {aka 'struct sbi_scratch_holder_s[]'} [-Warray-bounds]
  251 |   return (unsigned long)(&g_scratches[hartid].scratch);

Fix it by reverting back to what is was earlier. g_scratches shouldn't be in the bss region that would be zeroed out.

Signed-off-by: Eero Nurkkala <eero.nurkkala@offcode.fi>

## Summary

Earlier commit introduced a warning with -Wall, fix it

## Impact

MPFS / OpenSBI

## Testing

MPFS Icicle board with coldboot hart  = 3 or 4
