### PR TITLE
arch/arm/src/samv7: fix missing sam_pendsv

### DIFF
--- a/arch/arm/src/samv7/sam_irq.c
+++ b/arch/arm/src/samv7/sam_irq.c
@@ -161,11 +161,10 @@ static int sam_nmi(int irq, void *context, void *arg)
   return 0;
 }
 
-static int sam_busfault(int irq, void *context, void *arg)
+static int sam_pendsv(int irq, void *context, void *arg)
 {
   up_irq_save();
-  _err("PANIC!!! Bus fault received: %08" PRIx32 "\n",
-       getreg32(NVIC_CFAULTS));
+  _err("PANIC!!! PendSV received\n");
   PANIC();
   return 0;
 }


### PR DESCRIPTION

## Summary
The commit d1a3f5e47f752142251c30b188c8d1b47ef59941 invalidly removed `sam_pendsv` instead of `sam_busfault`.

## Impact
Fix of build.

## Testing
Build for `same70` based custom board.
