### PR TITLE
net/sockif: add si_getsockopt and si_setsockopt to simply getsockopt and setsockopt

### DIFF
--- a/include/nuttx/net/net.h
+++ b/include/nuttx/net/net.h
@@ -166,6 +166,12 @@ struct sock_intf_s
   CODE int        (*si_ioctl)(FAR struct socket *psock,
                     int cmd, unsigned long arg);
   CODE int        (*si_socketpair)(FAR struct socket *psocks[2]);
+#ifdef CONFIG_NET_SOCKOPTS
+  CODE int        (*si_getsockopt)(FAR struct socket *psock, int level,
+                    int option, FAR void *value, FAR socklen_t *value_len);
+  CODE int        (*si_setsockopt)(FAR struct socket *psock, int level,
+                    int option, FAR const void *value, socklen_t value_len);
+#endif
 #ifdef CONFIG_NET_SENDFILE
   CODE ssize_t    (*si_sendfile)(FAR struct socket *psock,
                     FAR struct file *infile, FAR off_t *offset,
@@ -209,9 +215,6 @@ struct socket_conn_s
   socktimeo_t   s_sndtimeo;  /* Send timeout value (in deciseconds) */
 #ifdef CONFIG_NET_SOLINGER
   socktimeo_t   s_linger;    /* Linger timeout value (in deciseconds) */
-#endif
-#ifdef CONFIG_NET_TIMESTAMP
-  int32_t       s_timestamp; /* Socket timestamp enabled/disabled */
 #endif
 #ifdef CONFIG_NET_BINDTODEVICE
   uint8_t       s_boundto;   /* Index of the interface we are bound to.

--- a/include/sys/socket.h
+++ b/include/sys/socket.h
@@ -202,6 +202,9 @@
                             */
 #define SO_BINDTODEVICE 17 /* Bind this socket to a specific network device.
                             */
+#define SO_PEERCRED     18 /* Return the credentials of the peer process
+                            * connected to this socket.
+                            */
 
 /* The options are unsupported but included for compatibility
  * and portability
@@ -328,6 +331,13 @@ struct cmsghdr
   unsigned long cmsg_len;       /* Data byte count, including hdr */
   int cmsg_level;               /* Originating protocol */
   int cmsg_type;                /* Protocol-specific type */
+};
+
+struct ucred
+{
+  pid_t pid;
+  uid_t uid;
+  gid_t gid;
 };
 
 /****************************************************************************

--- a/net/can/can.h
+++ b/net/can/can.h
@@ -111,6 +111,9 @@ struct can_conn_s
   int32_t tx_deadline;
 # endif
 #endif
+#ifdef CONFIG_NET_TIMESTAMP
+  int32_t timestamp; /* Socket timestamp enabled/disabled */
+#endif
 };
 
 /****************************************************************************
@@ -353,6 +356,7 @@ void can_readahead_signal(FAR struct can_conn_s *conn);
  *
  * Input Parameters:
  *   psock     Socket structure of socket to operate on
+ *   level     Protocol level to set the option
  *   option    identifies the option to set
  *   value     Points to the argument value
  *   value_len The length of the argument value
@@ -365,7 +369,7 @@ void can_readahead_signal(FAR struct can_conn_s *conn);
  ****************************************************************************/
 
 #ifdef CONFIG_NET_CANPROTO_OPTIONS
-int can_setsockopt(FAR struct socket *psock, int option,
+int can_setsockopt(FAR struct socket *psock, int level, int option,
                    FAR const void *value, socklen_t value_len);
 #endif
 
@@ -399,7 +403,7 @@ int can_setsockopt(FAR struct socket *psock, int option,
  ****************************************************************************/
 
 #ifdef CONFIG_NET_CANPROTO_OPTIONS
-int can_getsockopt(FAR struct socket *psock, int option,
+int can_getsockopt(FAR struct socket *psock, int level, int option,
                    FAR void *value, FAR socklen_t *value_len);
 #endif
 

--- a/net/can/can_callback.c
+++ b/net/can/can_callback.c
@@ -123,7 +123,7 @@ uint16_t can_callback(FAR struct net_driver_s *dev,
 #ifdef CONFIG_NET_TIMESTAMP
       /* TIMESTAMP sockopt is activated, create timestamp and copy to iob */
 
-      if (conn->sconn.s_timestamp)
+      if (conn->timestamp)
         {
           struct timespec *ts = (struct timespec *)
                                                 &dev->d_appdata[dev->d_len];

--- a/net/can/can_getsockopt.c
+++ b/net/can/can_getsockopt.c
@@ -74,7 +74,7 @@
  *
  ****************************************************************************/
 
-int can_getsockopt(FAR struct socket *psock, int option,
+int can_getsockopt(FAR struct socket *psock, int level, int option,
                    FAR void *value, FAR socklen_t *value_len)
 {
   FAR struct can_conn_s *conn;
@@ -83,6 +83,24 @@ int can_getsockopt(FAR struct socket *psock, int option,
   DEBUGASSERT(psock != NULL && value != NULL && value_len != NULL &&
               psock->s_conn != NULL);
   conn = (FAR struct can_conn_s *)psock->s_conn;
+
+#ifdef CONFIG_NET_TIMESTAMP
+  if (level == SOL_SOCKET && option == SO_TIMESTAMP)
+    {
+      if (*value_len != sizeof(int32_t))
+        {
+          return -EINVAL;
+        }
+
+      *(FAR int32_t *)value = conn->timestamp;
+      return OK;
+    }
+#endif
+
+  if (level != SOL_CAN_RAW)
+    {
+      return -ENOPROTOOPT;
+    }
 
   if (psock->s_type != SOCK_RAW)
     {

--- a/net/can/can_recvmsg.c
+++ b/net/can/can_recvmsg.c
@@ -434,9 +434,9 @@ static uint16_t can_recvfrom_eventhandler(FAR struct net_driver_s *dev,
 #endif
             {
 #ifdef CONFIG_NET_TIMESTAMP
-              if ((conn->sconn.s_timestamp && (dev->d_len >
+              if ((conn->timestamp && (dev->d_len >
                   sizeof(struct can_frame) + sizeof(struct timeval)))
-                  || (!conn->sconn.s_timestamp && (dev->d_len >
+                  || (!conn->timestamp && (dev->d_len >
                    sizeof(struct can_frame))))
 #else
               if (dev->d_len > sizeof(struct can_frame))
@@ -454,7 +454,7 @@ static uint16_t can_recvfrom_eventhandler(FAR struct net_driver_s *dev,
           can_newdata(dev, pstate);
 
 #ifdef CONFIG_NET_TIMESTAMP
-          if (conn->sconn.s_timestamp)
+          if (conn->timestamp)
             {
               if (pstate->pr_msglen == sizeof(struct timeval))
                 {
@@ -587,7 +587,7 @@ ssize_t can_recvmsg(FAR struct socket *psock, FAR struct msghdr *msg,
   state.pr_buffer = msg->msg_iov->iov_base;
 
 #ifdef CONFIG_NET_TIMESTAMP
-  if (conn->sconn.s_timestamp && msg->msg_controllen >=
+  if (conn->timestamp && msg->msg_controllen >=
         (sizeof(struct cmsghdr) + sizeof(struct timeval)))
     {
       struct cmsghdr *cmsg = CMSG_FIRSTHDR(msg);
@@ -619,7 +619,7 @@ ssize_t can_recvmsg(FAR struct socket *psock, FAR struct msghdr *msg,
   if (ret > 0)
     {
 #ifdef CONFIG_NET_TIMESTAMP
-      if (conn->sconn.s_timestamp)
+      if (conn->timestamp)
         {
           if (state.pr_msglen == sizeof(struct timeval))
             {

--- a/net/can/can_setsockopt.c
+++ b/net/can/can_setsockopt.c
@@ -58,6 +58,7 @@
  *
  * Input Parameters:
  *   psock     Socket structure of socket to operate on
+ *   level     Protocol level to set the option
  *   option    identifies the option to set
  *   value     Points to the argument value
  *   value_len The length of the argument value
@@ -69,7 +70,7 @@
  *
  ****************************************************************************/
 
-int can_setsockopt(FAR struct socket *psock, int option,
+int can_setsockopt(FAR struct socket *psock, int level, int option,
                    FAR const void *value, socklen_t value_len)
 {
   FAR struct can_conn_s *conn;
@@ -80,6 +81,37 @@ int can_setsockopt(FAR struct socket *psock, int option,
   DEBUGASSERT(value_len == 0 || value != NULL);
 
   conn = (FAR struct can_conn_s *)psock->s_conn;
+
+#ifdef CONFIG_NET_TIMESTAMP
+
+  /* Generates a timestamp for each incoming packet */
+
+  if (level == SOL_SOCKET && option == SO_TIMESTAMP)
+    {
+      /* Verify that option is at least the size of an integer. */
+
+      if (value_len < sizeof(int32_t))
+        {
+          return -EINVAL;
+        }
+
+      /* Lock the network so that we have exclusive access to the socket
+       * options.
+       */
+
+      net_lock();
+
+      conn->timestamp = *((FAR int32_t *)value);
+
+      net_unlock();
+      return OK;
+    }
+#endif
+
+  if (level != SOL_CAN_RAW)
+    {
+      return -ENOPROTOOPT;
+    }
 
   if (psock->s_type != SOCK_RAW)
     {

--- a/net/can/can_sockif.c
+++ b/net/can/can_sockif.c
@@ -84,7 +84,13 @@ const struct sock_intf_s g_can_sockif =
   can_poll_local,   /* si_poll */
   can_sendmsg,      /* si_sendmsg */
   can_recvmsg,      /* si_recvmsg */
-  can_close         /* si_close */
+  can_close,        /* si_close */
+  NULL,             /* si_ioctl */
+  NULL              /* si_socketpair */
+#if defined(CONFIG_NET_SOCKOPTS) && defined(CONFIG_NET_CANPROTO_OPTIONS)
+  , can_getsockopt  /* si_getsockopt */
+  , can_setsockopt  /* si_setsockopt */
+#endif
 };
 
 /****************************************************************************

--- a/net/local/local.h
+++ b/net/local/local.h
@@ -129,6 +129,7 @@ struct local_conn_s
   uint16_t lc_cfpcount;          /* Control file pointer counter */
   FAR struct file *
      lc_cfps[LOCAL_NCONTROLFDS]; /* Socket message control filep */
+  struct ucred lc_cred;          /* The credentials of connection instance */
 #endif /* CONFIG_NET_LOCAL_SCM */
 
   mutex_t lc_sendlock;           /* Make sending multi-thread safe */

--- a/net/local/local_conn.c
+++ b/net/local/local_conn.c
@@ -29,6 +29,7 @@
 #include <assert.h>
 #include <errno.h>
 #include <debug.h>
+#include <unistd.h>
 
 #include <nuttx/kmalloc.h>
 #include <nuttx/queue.h>
@@ -128,6 +129,12 @@ FAR struct local_conn_s *local_alloc(void)
        */
 
       nxmutex_init(&conn->lc_sendlock);
+
+#ifdef CONFIG_NET_LOCAL_SCM
+      conn->lc_cred.pid = getpid();
+      conn->lc_cred.uid = getuid();
+      conn->lc_cred.gid = getgid();
+#endif
 
       /* Add the connection structure to the list of listeners */
 

--- a/net/local/local_sockif.c
+++ b/net/local/local_sockif.c
@@ -72,6 +72,12 @@ static int        local_close(FAR struct socket *psock);
 static int        local_ioctl(FAR struct socket *psock,
                     int cmd, unsigned long arg);
 static int        local_socketpair(FAR struct socket *psocks[2]);
+#ifdef CONFIG_NET_SOCKOPTS
+static int        local_getsockopt(FAR struct socket *psock, int level,
+                    int option, FAR void *value, FAR socklen_t *value_len);
+static int        local_setsockopt(FAR struct socket *psock, int level,
+                    int option, FAR const void *value, socklen_t value_len);
+#endif
 
 /****************************************************************************
  * Public Data
@@ -94,6 +100,10 @@ const struct sock_intf_s g_local_sockif =
   local_close,       /* si_close */
   local_ioctl,       /* si_ioctl */
   local_socketpair   /* si_socketpair */
+#ifdef CONFIG_NET_SOCKOPTS
+  , local_getsockopt /* si_getsockopt */
+  , local_setsockopt /* si_setsockopt */
+#endif
 };
 
 /****************************************************************************
@@ -433,6 +443,88 @@ static int local_getpeername(FAR struct socket *psock,
 {
   return local_getsockname(psock, addr, addrlen);
 }
+
+#ifdef CONFIG_NET_SOCKOPTS
+
+/****************************************************************************
+ * Name: local_getsockopt
+ *
+ * Description:
+ *   local_getsockopt() retrieve the value for the option specified by the
+ *   'option' argument at the protocol level specified by the 'level'
+ *   argument. If the size of the option value is greater than 'value_len',
+ *   the value stored in the object pointed to by the 'value' argument will
+ *   be silently truncated. Otherwise, the length pointed to by the
+ *   'value_len' argument will be modified to indicate the actual length
+ *   of the 'value'.
+ *
+ *   The 'level' argument specifies the protocol level of the option. To
+ *   retrieve options at the socket level, specify the level argument as
+ *   SOL_SOCKET.
+ *
+ *   See <sys/socket.h> a complete list of values for the 'option' argument.
+ *
+ * Input Parameters:
+ *   psock     Socket structure of the socket to query
+ *   level     Protocol level to set the option
+ *   option    identifies the option to get
+ *   value     Points to the argument value
+ *   value_len The length of the argument value
+ *
+ ****************************************************************************/
+
+static int local_getsockopt(FAR struct socket *psock, int level, int option,
+                            FAR void *value, FAR socklen_t *value_len)
+{
+  DEBUGASSERT(psock != NULL && psock->s_conn != NULL &&
+              psock->s_domain == PF_LOCAL);
+
+#ifdef CONFIG_NET_LOCAL_SCM
+  if (level == SOL_SOCKET && option == SO_PEERCRED)
+    {
+      FAR struct local_conn_s *conn = psock->s_conn;
+      if (*value_len != sizeof(struct ucred))
+        {
+          return -EINVAL;
+        }
+
+      memcpy(value, &conn->lc_peer->lc_cred, sizeof(struct ucred));
+      return OK;
+    }
+#endif
+
+  return -ENOPROTOOPT;
+}
+
+/****************************************************************************
+ * Name: local_setsockopt
+ *
+ * Description:
+ *   local_setsockopt() sets the option specified by the 'option' argument,
+ *   at the protocol level specified by the 'level' argument, to the value
+ *   pointed to by the 'value' argument for the usrsock connection.
+ *
+ *   The 'level' argument specifies the protocol level of the option. To set
+ *   options at the socket level, specify the level argument as SOL_SOCKET.
+ *
+ *   See <sys/socket.h> a complete list of values for the 'option' argument.
+ *
+ * Input Parameters:
+ *   psock     Socket structure of the socket to query
+ *   level     Protocol level to set the option
+ *   option    identifies the option to set
+ *   value     Points to the argument value
+ *   value_len The length of the argument value
+ *
+ ****************************************************************************/
+
+static int local_setsockopt(FAR struct socket *psock, int level, int option,
+                            FAR const void *value, socklen_t value_len)
+{
+  return -ENOPROTOOPT;
+}
+
+#endif
 
 /****************************************************************************
  * Name: local_listen

--- a/net/usrsock/usrsock.h
+++ b/net/usrsock/usrsock.h
@@ -546,7 +546,7 @@ ssize_t usrsock_recvmsg(FAR struct socket *psock, FAR struct msghdr *msg,
  *   See <sys/socket.h> a complete list of values for the 'option' argument.
  *
  * Input Parameters:
- *   conn      usrsock socket connection structure
+ *   psock     Socket structure of the socket to query
  *   level     Protocol level to set the option
  *   option    identifies the option to get
  *   value     Points to the argument value
@@ -554,9 +554,8 @@ ssize_t usrsock_recvmsg(FAR struct socket *psock, FAR struct msghdr *msg,
  *
  ****************************************************************************/
 
-int usrsock_getsockopt(FAR struct usrsock_conn_s *conn, int level,
-                       int option, FAR void *value,
-                       FAR socklen_t *value_len);
+int usrsock_getsockopt(FAR struct socket *psock, int level, int option,
+                       FAR void *value, FAR socklen_t *value_len);
 
 /****************************************************************************
  * Name: usrsock_setsockopt
@@ -572,7 +571,7 @@ int usrsock_getsockopt(FAR struct usrsock_conn_s *conn, int level,
  *   See <sys/socket.h> a complete list of values for the 'option' argument.
  *
  * Input Parameters:
- *   conn      usrsock socket connection structure
+ *   psock     Socket structure of the socket to query
  *   level     Protocol level to set the option
  *   option    identifies the option to set
  *   value     Points to the argument value
@@ -580,9 +579,8 @@ int usrsock_getsockopt(FAR struct usrsock_conn_s *conn, int level,
  *
  ****************************************************************************/
 
-int usrsock_setsockopt(FAR struct usrsock_conn_s *conn, int level,
-                       int option, FAR const void *value,
-                       FAR socklen_t value_len);
+int usrsock_setsockopt(FAR struct socket *psock, int level, int option,
+                       FAR const void *value, socklen_t value_len);
 
 /****************************************************************************
  * Name: usrsock_getsockname

--- a/net/usrsock/usrsock_sockif.c
+++ b/net/usrsock/usrsock_sockif.c
@@ -66,7 +66,12 @@ const struct sock_intf_s g_usrsock_sockif =
   usrsock_sendmsg,            /* si_sendmsg */
   usrsock_recvmsg,            /* si_recvmsg */
   usrsock_sockif_close,       /* si_close */
-  usrsock_ioctl               /* si_ioctl */
+  usrsock_ioctl,              /* si_ioctl */
+  NULL                        /* si_socketpair */
+#ifdef CONFIG_NET_SOCKOPTS
+  , usrsock_getsockopt        /* si_getsockopt */
+  , usrsock_setsockopt        /* si_setsockopt */
+#endif
 };
 
 /****************************************************************************


### PR DESCRIPTION
## Summary
1. net/sockif: add si_getsockopt and si_setsockopt to simply getsockopt and setsockopt
2. support SO_PEERCRED for local socket.
## Impact
simply code
## Testing
local test
