### PR TITLE
usrsock: add REMOTE_CLOSED event handler to connect

### DIFF
--- a/net/usrsock/usrsock_connect.c
+++ b/net/usrsock/usrsock_connect.c
@@ -54,33 +54,29 @@ static uint16_t connect_event(FAR struct net_driver_s *dev,
       ninfo("socket aborted.\n");
 
       pstate->result = -ECONNABORTED;
+    }
+  else if (flags & USRSOCK_EVENT_REMOTE_CLOSED)
+    {
+      ninfo("remote closed.\n");
 
-      /* Stop further callbacks */
-
-      pstate->cb->flags = 0;
-      pstate->cb->priv  = NULL;
-      pstate->cb->event = NULL;
-
-      /* Wake up the waiting thread */
-
-      nxsem_post(&pstate->recvsem);
+      pstate->result = -ECONNREFUSED;
     }
   else
     {
       ninfo("request completed.\n");
 
       pstate->result = conn->resp.result;
-
-      /* Stop further callbacks */
-
-      pstate->cb->flags = 0;
-      pstate->cb->priv  = NULL;
-      pstate->cb->event = NULL;
-
-      /* Wake up the waiting thread */
-
-      nxsem_post(&pstate->recvsem);
     }
+
+  /* Stop further callbacks */
+
+  pstate->cb->flags = 0;
+  pstate->cb->priv  = NULL;
+  pstate->cb->event = NULL;
+
+  /* Wake up the waiting thread */
+
+  nxsem_post(&pstate->recvsem);
 
   return flags;
 }
@@ -199,6 +195,7 @@ int usrsock_connect(FAR struct socket *psock,
 
   ret = usrsock_setup_request_callback(conn, &state, connect_event,
                                        USRSOCK_EVENT_ABORT |
+                                       USRSOCK_EVENT_REMOTE_CLOSED |
                                        USRSOCK_EVENT_REQ_COMPLETE |
                                        USRSOCK_EVENT_SENDTO_READY);
   if (ret < 0)


### PR DESCRIPTION
## Summary

when usrsock client try to connect usrsock server local_loop socket with an invalid port, server cannot find a listener conn to handle this connet request, then it will response a TCP_RESET packet via nuttx existing processing, when before conn recv this RESET packet, it will trigger usrsock_rpmsg_server poll return and send REMOTE_CLOSE event to usrsock client.
so usrsock connect_event fucntion need handle this event.

## Impact
usrsock

## Testing
Internal test
