### PR TITLE
arm/llvm/clang: add support for LLVMEmbeddedToolchainForArm release-15.0.2

### DIFF
--- a/arch/arm/src/armv6-m/Toolchain.defs
+++ b/arch/arm/src/armv6-m/Toolchain.defs
@@ -26,7 +26,7 @@ TOOLCHAIN_MFLOAT := -mfloat-abi=soft
 # Clang Configuration files
 
 ifeq ($(CONFIG_ARM_TOOLCHAIN_CLANG),y)
-  TOOLCHAIN_MARCH := --config armv6m_soft_nofp_nosys
+  TOOLCHAIN_MARCH := --config armv6m_soft_nofp
 else ifeq ($(CONFIG_ARM_TOOLCHAIN_ARMCLANG),y)
   LDFLAGS += --cpu=Cortex-M0
 endif

--- a/arch/arm/src/armv7-m/Toolchain.defs
+++ b/arch/arm/src/armv7-m/Toolchain.defs
@@ -61,18 +61,18 @@ ifeq ($(CONFIG_ARM_TOOLCHAIN_CLANG),y)
 
   ifeq ($(CONFIG_ARCH_CORTEXM4),y)
     ifeq ($(CONFIG_ARCH_FPU),y)
-      TOOLCHAIN_MARCH += --config armv7em_hard_fpv4_sp_d16_nosys
+      TOOLCHAIN_MARCH += --config armv7em_hard_fpv4_sp_d16
     else
-      TOOLCHAIN_MARCH += --config armv7em_soft_nofp_nosys
+      TOOLCHAIN_MARCH += --config armv7em_soft_nofp
     endif
   else ifeq ($(CONFIG_ARCH_CORTEXM7),y)
     ifeq ($(CONFIG_ARCH_FPU),y)
-      TOOLCHAIN_MARCH += --config armv7em_hard_fpv5_d16_nosys
+      TOOLCHAIN_MARCH += --config armv7em_hard_fpv5_d16
     else
-      TOOLCHAIN_MARCH += --config armv7em_soft_nofp_nosys
+      TOOLCHAIN_MARCH += --config armv7em_soft_nofp
     endif
   else # ifeq ($(CONFIG_ARCH_CORTEXM3),y)
-      TOOLCHAIN_MARCH += --config armv7m_soft_nofp_nosys
+      TOOLCHAIN_MARCH += --config armv7m_soft_nofp
   endif
 
 else ifeq ($(CONFIG_ARM_TOOLCHAIN_ARMCLANG),y)

--- a/arch/arm/src/armv8-m/Toolchain.defs
+++ b/arch/arm/src/armv8-m/Toolchain.defs
@@ -63,24 +63,24 @@ endif
 ifeq ($(CONFIG_ARM_TOOLCHAIN_CLANG),y)
 
   ifeq ($(CONFIG_ARCH_CORTEXM23),y)
-    TOOLCHAIN_MARCH += --config armv8m.main_soft_nofp_nosys
+    TOOLCHAIN_MARCH += --config armv8m.main_soft_nofp
   else ifeq ($(CONFIG_ARCH_CORTEXM33),y)
     ifeq ($(CONFIG_ARCH_FPU),y)
-      TOOLCHAIN_MARCH += --config armv8m.main_hard_fp_nosys
+      TOOLCHAIN_MARCH += --config armv8m.main_hard_fp
     else
-      TOOLCHAIN_MARCH += --config armv8m.main_soft_nofp_nosys
+      TOOLCHAIN_MARCH += --config armv8m.main_soft_nofp
     endif
   else ifeq ($(CONFIG_ARCH_CORTEXM35P),y)
     ifeq ($(CONFIG_ARCH_FPU),y)
-      TOOLCHAIN_MARCH += --config armv8m.main_hard_fp_nosys
+      TOOLCHAIN_MARCH += --config armv8m.main_hard_fp
     else
-      TOOLCHAIN_MARCH += --config armv8m.main_soft_nofp_nosys
+      TOOLCHAIN_MARCH += --config armv8m.main_soft_nofp
     endif
   else ifeq ($(CONFIG_ARCH_CORTEXM55),y)
     ifeq ($(CONFIG_ARCH_FPU),y)
-      TOOLCHAIN_MARCH += --config armv8.1m.main_hard_fp_nosys
+      TOOLCHAIN_MARCH += --config armv8.1m.main_hard_fp
     else
-      TOOLCHAIN_MARCH += --config armv8.1m.main_soft_nofp_nomve_nosys
+      TOOLCHAIN_MARCH += --config armv8.1m.main_soft_nofp_nomve
     endif
   endif
 

--- a/arch/arm/src/tlsr82/Toolchain.defs
+++ b/arch/arm/src/tlsr82/Toolchain.defs
@@ -21,7 +21,7 @@
 # Clang Configuration files
 
 ifeq ($(CONFIG_ARM_TOOLCHAIN_CLANG),y)
-  TOOLCHAIN_MARCH := --config armv6m_soft_nofp_nosys
+  TOOLCHAIN_MARCH := --config armv6m_soft_nofp
 endif
 
 # Generic GNU EABI toolchain


### PR DESCRIPTION
## Summary

arm/llvm/clang: add support for LLVMEmbeddedToolchainForArm release-15.0.2

Upstream:
https://github.com/ARM-software/LLVM-embedded-toolchain-for-Arm/releases/tag/release-15.0.2

Signed-off-by: chao an <anchao@xiaomi.com>

## Impact

N/A

## Testing

lm3s6965-ek/qemu-flat