### PR TITLE
tools/ci/arm/llvm/clang: bump up LLVMEmbeddedToolchainForArm to release-15.0.2

### DIFF
--- a/tools/ci/cibuild.sh
+++ b/tools/ci/cibuild.sh
@@ -60,11 +60,11 @@ function arm-clang-toolchain {
 
   if [ ! -f "${prebuilt}/clang-arm-none-eabi/bin/clang" ]; then
     cd "${prebuilt}"
-    curl -O -L -s https://github.com/ARM-software/LLVM-embedded-toolchain-for-Arm/releases/download/release-14.0.0/LLVMEmbeddedToolchainForArm-14.0.0-linux.tar.gz
-    tar zxf LLVMEmbeddedToolchainForArm-14.0.0-linux.tar.gz
-    mv LLVMEmbeddedToolchainForArm-14.0.0 clang-arm-none-eabi
+    curl -O -L -s https://github.com/ARM-software/LLVM-embedded-toolchain-for-Arm/releases/download/release-15.0.2/LLVMEmbeddedToolchainForArm-15.0.2-Linux-x86_64.tar.gz
+    mkdir -p clang-arm-none-eabi
+    tar zxf LLVMEmbeddedToolchainForArm-15.0.2-Linux-x86_64.tar.gz -C clang-arm-none-eabi
     cp /usr/bin/clang-extdef-mapping-10 clang-arm-none-eabi/bin/clang-extdef-mapping
-    rm LLVMEmbeddedToolchainForArm-14.0.0-linux.tar.gz
+    rm LLVMEmbeddedToolchainForArm-15.0.2-Linux-x86_64.tar.gz
   fi
   clang --version
 }

--- a/tools/ci/docker/linux/Dockerfile
+++ b/tools/ci/docker/linux/Dockerfile
@@ -85,8 +85,8 @@ WORKDIR /tools
 FROM nuttx-toolchain-base AS nuttx-toolchain-arm
 # Download the latest ARM clang toolchain prebuilt by ARM
 RUN mkdir clang-arm-none-eabi && \
-  curl -s -L  "https://github.com/ARM-software/LLVM-embedded-toolchain-for-Arm/releases/download/release-14.0.0/LLVMEmbeddedToolchainForArm-14.0.0-linux.tar.gz" \
-  | tar -C clang-arm-none-eabi --strip-components 1 -xz
+  curl -s -L  "https://github.com/ARM-software/LLVM-embedded-toolchain-for-Arm/releases/download/release-15.0.2/LLVMEmbeddedToolchainForArm-15.0.2-Linux-x86_64.tar.gz" \
+  | tar -C clang-arm-none-eabi --strip-components 0 -xz
 
 # Download the latest ARM GCC toolchain prebuilt by ARM
 RUN mkdir gcc-arm-none-eabi && \


### PR DESCRIPTION
## Summary

tools/ci/arm/llvm/clang: bump up LLVMEmbeddedToolchainForArm to release-15.0.2

Upstream:
https://github.com/ARM-software/LLVM-embedded-toolchain-for-Arm/releases/tag/release-15.0.2

Signed-off-by: chao an <anchao@xiaomi.com>

## Impact

N/A

## Testing

ci check