### PR TITLE
Revert "tools/ci/arm/llvm/clang: bump up LLVMEmbeddedToolchainForArm to release-15.0.2"

### DIFF
--- a/arch/arm/src/armv6-m/Toolchain.defs
+++ b/arch/arm/src/armv6-m/Toolchain.defs
@@ -26,7 +26,7 @@ TOOLCHAIN_MFLOAT := -mfloat-abi=soft
 # Clang Configuration files
 
 ifeq ($(CONFIG_ARM_TOOLCHAIN_CLANG),y)
-  TOOLCHAIN_MARCH := --config armv6m_soft_nofp
+  TOOLCHAIN_MARCH := --config armv6m_soft_nofp_nosys
 else ifeq ($(CONFIG_ARM_TOOLCHAIN_ARMCLANG),y)
   LDFLAGS += --cpu=Cortex-M0
 endif

--- a/arch/arm/src/armv7-m/Toolchain.defs
+++ b/arch/arm/src/armv7-m/Toolchain.defs
@@ -61,18 +61,18 @@ ifeq ($(CONFIG_ARM_TOOLCHAIN_CLANG),y)
 
   ifeq ($(CONFIG_ARCH_CORTEXM4),y)
     ifeq ($(CONFIG_ARCH_FPU),y)
-      TOOLCHAIN_MARCH += --config armv7em_hard_fpv4_sp_d16
+      TOOLCHAIN_MARCH += --config armv7em_hard_fpv4_sp_d16_nosys
     else
-      TOOLCHAIN_MARCH += --config armv7em_soft_nofp
+      TOOLCHAIN_MARCH += --config armv7em_soft_nofp_nosys
     endif
   else ifeq ($(CONFIG_ARCH_CORTEXM7),y)
     ifeq ($(CONFIG_ARCH_FPU),y)
-      TOOLCHAIN_MARCH += --config armv7em_hard_fpv5_d16
+      TOOLCHAIN_MARCH += --config armv7em_hard_fpv5_d16_nosys
     else
-      TOOLCHAIN_MARCH += --config armv7em_soft_nofp
+      TOOLCHAIN_MARCH += --config armv7em_soft_nofp_nosys
     endif
   else # ifeq ($(CONFIG_ARCH_CORTEXM3),y)
-      TOOLCHAIN_MARCH += --config armv7m_soft_nofp
+      TOOLCHAIN_MARCH += --config armv7m_soft_nofp_nosys
   endif
 
 else ifeq ($(CONFIG_ARM_TOOLCHAIN_ARMCLANG),y)

--- a/arch/arm/src/armv8-m/Toolchain.defs
+++ b/arch/arm/src/armv8-m/Toolchain.defs
@@ -63,24 +63,24 @@ endif
 ifeq ($(CONFIG_ARM_TOOLCHAIN_CLANG),y)
 
   ifeq ($(CONFIG_ARCH_CORTEXM23),y)
-    TOOLCHAIN_MARCH += --config armv8m.main_soft_nofp
+    TOOLCHAIN_MARCH += --config armv8m.main_soft_nofp_nosys
   else ifeq ($(CONFIG_ARCH_CORTEXM33),y)
     ifeq ($(CONFIG_ARCH_FPU),y)
-      TOOLCHAIN_MARCH += --config armv8m.main_hard_fp
+      TOOLCHAIN_MARCH += --config armv8m.main_hard_fp_nosys
     else
-      TOOLCHAIN_MARCH += --config armv8m.main_soft_nofp
+      TOOLCHAIN_MARCH += --config armv8m.main_soft_nofp_nosys
     endif
   else ifeq ($(CONFIG_ARCH_CORTEXM35P),y)
     ifeq ($(CONFIG_ARCH_FPU),y)
-      TOOLCHAIN_MARCH += --config armv8m.main_hard_fp
+      TOOLCHAIN_MARCH += --config armv8m.main_hard_fp_nosys
     else
-      TOOLCHAIN_MARCH += --config armv8m.main_soft_nofp
+      TOOLCHAIN_MARCH += --config armv8m.main_soft_nofp_nosys
     endif
   else ifeq ($(CONFIG_ARCH_CORTEXM55),y)
     ifeq ($(CONFIG_ARCH_FPU),y)
-      TOOLCHAIN_MARCH += --config armv8.1m.main_hard_fp
+      TOOLCHAIN_MARCH += --config armv8.1m.main_hard_fp_nosys
     else
-      TOOLCHAIN_MARCH += --config armv8.1m.main_soft_nofp_nomve
+      TOOLCHAIN_MARCH += --config armv8.1m.main_soft_nofp_nomve_nosys
     endif
   endif
 

--- a/arch/arm/src/tlsr82/Toolchain.defs
+++ b/arch/arm/src/tlsr82/Toolchain.defs
@@ -21,7 +21,7 @@
 # Clang Configuration files
 
 ifeq ($(CONFIG_ARM_TOOLCHAIN_CLANG),y)
-  TOOLCHAIN_MARCH := --config armv6m_soft_nofp
+  TOOLCHAIN_MARCH := --config armv6m_soft_nofp_nosys
 endif
 
 # Generic GNU EABI toolchain

--- a/tools/ci/cibuild.sh
+++ b/tools/ci/cibuild.sh
@@ -60,11 +60,11 @@ function arm-clang-toolchain {
 
   if [ ! -f "${prebuilt}/clang-arm-none-eabi/bin/clang" ]; then
     cd "${prebuilt}"
-    curl -O -L -s https://github.com/ARM-software/LLVM-embedded-toolchain-for-Arm/releases/download/release-15.0.2/LLVMEmbeddedToolchainForArm-15.0.2-Linux-x86_64.tar.gz
-    mkdir -p clang-arm-none-eabi
-    tar zxf LLVMEmbeddedToolchainForArm-15.0.2-Linux-x86_64.tar.gz -C clang-arm-none-eabi
+    curl -O -L -s https://github.com/ARM-software/LLVM-embedded-toolchain-for-Arm/releases/download/release-14.0.0/LLVMEmbeddedToolchainForArm-14.0.0-linux.tar.gz
+    tar zxf LLVMEmbeddedToolchainForArm-14.0.0-linux.tar.gz
+    mv LLVMEmbeddedToolchainForArm-14.0.0 clang-arm-none-eabi
     cp /usr/bin/clang-extdef-mapping-10 clang-arm-none-eabi/bin/clang-extdef-mapping
-    rm LLVMEmbeddedToolchainForArm-15.0.2-Linux-x86_64.tar.gz
+    rm LLVMEmbeddedToolchainForArm-14.0.0-linux.tar.gz
   fi
   clang --version
 }

--- a/tools/ci/docker/linux/Dockerfile
+++ b/tools/ci/docker/linux/Dockerfile
@@ -85,8 +85,8 @@ WORKDIR /tools
 FROM nuttx-toolchain-base AS nuttx-toolchain-arm
 # Download the latest ARM clang toolchain prebuilt by ARM
 RUN mkdir clang-arm-none-eabi && \
-  curl -s -L  "https://github.com/ARM-software/LLVM-embedded-toolchain-for-Arm/releases/download/release-15.0.2/LLVMEmbeddedToolchainForArm-15.0.2-Linux-x86_64.tar.gz" \
-  | tar -C clang-arm-none-eabi --strip-components 0 -xz
+  curl -s -L  "https://github.com/ARM-software/LLVM-embedded-toolchain-for-Arm/releases/download/release-14.0.0/LLVMEmbeddedToolchainForArm-14.0.0-linux.tar.gz" \
+  | tar -C clang-arm-none-eabi --strip-components 1 -xz
 
 # Download the latest ARM GCC toolchain prebuilt by ARM
 RUN mkdir gcc-arm-none-eabi && \


### PR DESCRIPTION
## Summary

Revert "tools/ci/arm/llvm/clang: bump up LLVMEmbeddedToolchainForArm to release-15.0.2"

This reverts commit b4bab51e86e74e5c0ac50c43c52cf7246ffb39a0.

Issue:
Builtin math symbols are missing on llvm 15.0.2(libm.a):
https://github.com/ARM-software/LLVM-embedded-toolchain-for-Arm/issues/158

Signed-off-by: chao an <anchao@xiaomi.com>

## Impact

N/A

## Testing

broken change:
viewtool-stm32f107/tcpblaster

```
ld.lld -m armelf --entry=__start -nostdlib --gc-sections --cref -Map=nuttx.map -Tboards/arm/stm32/viewtool-stm32f107/scripts/flash.ld.tmp  -L staging -L arch/arm/src/board  \
	-o nuttx   \
	--start-group -lsched -ldrivers -lboards -lc -lmm -larch -lapps -lnet -lfs -lbinfmt -lboard prebuilts/clang/linux/arm/bin/../lib/clang-runtimes/armv7m_soft_nofp/lib/libclang_rt.builtins-armv7m.a prebuilts/clang/linux/arm/bin/../lib/clang-runtimes/armv7m_soft_nofp/lib/libm.a --end-group
ld.lld: error: undefined symbol: __fpclassifyd
>>> referenced by lib_dtoa_engine.c
>>>               lib_dtoa_engine.o:(__dtoa_engine) in archive staging/libc.a
>>> referenced by lib_dtoa_engine.c
>>>               lib_dtoa_engine.o:(__dtoa_engine) in archive staging/libc.a
make[1]: *** [Makefile:174: nuttx] Error 1
make[1]: Leaving directory 'arch/arm/src'
```