### PR TITLE
stm32f7/stm32_bbsram.c: Fix build error due to changed include path

### DIFF
--- a/arch/arm/src/stm32f7/stm32_bbsram.c
+++ b/arch/arm/src/stm32f7/stm32_bbsram.c
@@ -39,7 +39,7 @@
 #include <errno.h>
 #include <unistd.h>
 #include <time.h>
-#include <mutex.h>
+#include <nuttx/mutex.h>
 #include <nuttx/fs/fs.h>
 #include <nuttx/crc32.h>
 


### PR DESCRIPTION
## Summary
Use correct path to include mutex.h

## Impact
Fixes:
chip/stm32_bbsram.c:42:10: fatal error: mutex.h: No such file or directory
   42 | #include <mutex.h>
      |          ^~~~~~~~~

## Testing
Out-of-tree target using stm32f7
