### PR TITLE
net/usrsock: fix get/setsockopt issue about usrsock protocol

### DIFF
--- a/net/socket/getsockopt.c
+++ b/net/socket/getsockopt.c
@@ -33,6 +33,7 @@
 #include <errno.h>
 
 #include "socket/socket.h"
+#include "usrsock/usrsock.h"
 #include "utils/utils.h"
 
 /****************************************************************************
@@ -123,9 +124,19 @@ static int psock_socketlevel_option(FAR struct socket *psock, int option,
 
           net_dsec2timeval(timeo, (struct timeval *)value);
           *value_len   = sizeof(struct timeval);
+          return OK;
         }
-        break;
+    }
 
+#ifdef CONFIG_NET_USRSOCK
+  if (psock->s_type == SOCK_USRSOCK_TYPE)
+    {
+      return -ENOPROTOOPT;
+    }
+#endif
+
+  switch (option)
+    {
       case SO_ACCEPTCONN: /* Reports whether socket listening is enabled */
         {
           if (*value_len < sizeof(int))

--- a/net/socket/setsockopt.c
+++ b/net/socket/setsockopt.c
@@ -38,6 +38,7 @@
 #include <netdev/netdev.h>
 
 #include "socket/socket.h"
+#include "usrsock/usrsock.h"
 #include "utils/utils.h"
 
 /****************************************************************************
@@ -130,9 +131,20 @@ static int psock_socketlevel_option(FAR struct socket *psock, int option,
             {
               _SO_SETOPT(conn->s_options, option);
             }
-        }
-        break;
 
+          return OK;
+        }
+    }
+
+#ifdef CONFIG_NET_USRSOCK
+  if (psock->s_type == SOCK_USRSOCK_TYPE)
+    {
+      return -ENOPROTOOPT;
+    }
+#endif
+
+  switch (option)
+    {
       case SO_BROADCAST:  /* Permits sending of broadcast messages */
       case SO_DEBUG:      /* Enables recording of debugging information */
       case SO_DONTROUTE:  /* Requests outgoing messages bypass standard routing */

--- a/net/usrsock/usrsock_getsockopt.c
+++ b/net/usrsock/usrsock_getsockopt.c
@@ -189,7 +189,7 @@ int usrsock_getsockopt(FAR struct socket *psock, int level, int option,
           *value_len = sizeof(int);
           return OK;
         }
-      else
+      else if (option == SO_RCVTIMEO || option == SO_SNDTIMEO)
         {
           return -ENOPROTOOPT;
         }

--- a/net/usrsock/usrsock_setsockopt.c
+++ b/net/usrsock/usrsock_setsockopt.c
@@ -174,10 +174,6 @@ int usrsock_setsockopt(FAR struct socket *psock, int level, int option,
         {
           return -ENOPROTOOPT;
         }
-      else
-        {
-          return -EINVAL;
-        }
     }
 
   net_lock();


### PR DESCRIPTION


## Summary
net/usrsock: fix get/setsockopt issue about usrsock protocol

Signed-off-by: dongjiuzhu1 <dongjiuzhu1@xiaomi.com>
## Impact
fix issue about https://github.com/apache/incubator-nuttx/pull/7651
## Testing
djz:nuttx$ ./nuttx 

NuttShell (NSH) NuttX-10.3.0
nsh> us
  usleep
  usrsocktest
nsh> usrsocktest
Starting unit-tests...
Testing group "char_dev" =>
        Group "char_dev": [OK]
Testing group "no_daemon" =>
        Group "no_daemon": [OK]
Testing group "basic_daemon" =>
        Group "basic_daemon": [OK]
Testing group "basic_connect" =>
        Group "basic_connect": [OK]
Testing group "basic_connect_delay" =>
        Group "basic_connect_delay": [OK]
Testing group "no_block_connect" =>
        Group "no_block_connect": [OK]
Testing group "basic_send" =>
        Group "basic_send": [OK]
Testing group "no_block_send" =>
        Group "no_block_send": [OK]
Testing group "block_send" =>
        Group "block_send": [OK]
Testing group "no_block_recv" =>
        Group "no_block_recv": [OK]
Testing group "block_recv" =>
        Group "block_recv": [OK]
Testing group "remote_disconnect" =>
        Group "remote_disconnect": [OK]
Testing group "basic_setsockopt" =>
        Group "basic_setsockopt": [OK]
Testing group "basic_getsockopt" =>
        Group "basic_getsockopt": [OK]
Testing group "basic_getsockname" =>
        Group "basic_getsockname": [OK]
Testing group "wake_with_signal" =>
        Group "wake_with_signal": [OK]
Testing group "multithread" =>
        Group "multithread": [OK]
Unit-test groups done... OK:17, FAILED:0, TOTAL:17
 -- number of checks made: 3589
HEAP BEFORE TESTS:
             total       used       free    largest
Mem:      67108224     284448   66823776   66823712
HEAP AFTER TESTS:
             total       used       free    largest
Mem:      67108224     624768   66483456   66481408
nsh> poweroff

