### PR TITLE
stm32f7: Fix compliation of stm32_flash.c (add stm32_waste.c)

### DIFF
--- a/arch/arm/src/stm32f7/Make.defs
+++ b/arch/arm/src/stm32f7/Make.defs
@@ -29,7 +29,7 @@ include armv7-m/Make.defs
 
 CHIP_CSRCS  = stm32_allocateheap.c stm32_exti_gpio.c stm32_gpio.c
 CHIP_CSRCS += stm32_irq.c stm32_lowputc.c stm32_rcc.c stm32_serial.c
-CHIP_CSRCS += stm32_start.c stm32_capture.c stm32_uid.c
+CHIP_CSRCS += stm32_start.c stm32_capture.c stm32_uid.c stm32_waste.c
 
 ifneq ($(CONFIG_SCHED_TICKLESS),y)
 CHIP_CSRCS += stm32_timerisr.c

--- a/arch/arm/src/stm32f7/stm32_flash.c
+++ b/arch/arm/src/stm32f7/stm32_flash.c
@@ -61,6 +61,7 @@
 #include "barriers.h"
 
 #include "hardware/stm32_flash.h"
+#include "stm32_waste.h"
 #include "arm_internal.h"
 
 /****************************************************************************

--- a/arch/arm/src/stm32f7/stm32_waste.c
+++ b/arch/arm/src/stm32f7/stm32_waste.c
@@ -1,0 +1,42 @@
+/****************************************************************************
+ * arch/arm/src/stm32f7/stm32_waste.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+#include <stdint.h>
+#include "stm32_waste.h"
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+uint32_t g_waste_counter = 0;
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+void stm32_waste(void)
+{
+  g_waste_counter++;
+}

--- a/arch/arm/src/stm32f7/stm32_waste.h
+++ b/arch/arm/src/stm32f7/stm32_waste.h
@@ -1,0 +1,64 @@
+/****************************************************************************
+ * arch/arm/src/stm32f7/stm32_waste.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __ARCH_ARM_SRC_STM32_STM32_WASTE_H
+#define __ARCH_ARM_SRC_STM32_STM32_WASTE_H
+
+/* Waste CPU Time */
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#ifndef __ASSEMBLY__
+
+#undef EXTERN
+#if defined(__cplusplus)
+#define EXTERN extern "C"
+extern "C"
+{
+#else
+#define EXTERN extern
+#endif
+
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
+
+/** Waste CPU Time
+ *
+ *   stm32_waste() is the logic that will be executed when portions of kernel
+ *   or user-app is polling some register or similar, waiting for desired
+ *   status. This time is wasted away. This function offers a measure of
+ *   badly written piece of software or some undesired behavior.
+ *
+ *   At the same time this function adds to some IDLE time which portion
+ *   cannot be used for other purposes (yet).
+ **/
+
+void stm32_waste(void);
+
+#undef EXTERN
+#if defined(__cplusplus)
+}
+#endif
+
+#endif /* __ASSEMBLY__ */
+#endif /* __ARCH_ARM_SRC_STM32_STM32_WASTE_H */


### PR DESCRIPTION
## Summary
/arch/arm/src/libarch.a(stm32_flash.o): in function `up_progmem_write': /arch/arm/src/chip/stm32_flash.c:419: undefined reference to `stm32_waste'

Seems like the symbol definition + declaration were completely missing

## Impact
Fixes the build errors

## Testing
Out-of-tree target using stm32f7
