### PR TITLE
libc/obstack, mm/circbuf: Fix non-standard usage of void* arithmetics

### DIFF
--- a/libs/libc/obstack/lib_obstack_finish.c
+++ b/libs/libc/obstack/lib_obstack_finish.c
@@ -66,10 +66,10 @@ FAR void *obstack_finish(FAR struct obstack *h)
     {
       chsize = h->next_free - (FAR char *)h->chunk;
       h->chunk = lib_obstack_realloc(h->chunk, chsize);
-      h->chunk->limit = (FAR void *)h->chunk + chsize;
+      h->chunk->limit = (FAR char *)h->chunk + chsize;
       h->object_base = h->chunk->limit;
       h->next_free = h->chunk->limit;
-      return (FAR void *)h->chunk + sizeof(struct _obstack_chunk);
+      return (FAR char *)h->chunk + sizeof(struct _obstack_chunk);
     }
 
   return obstack_finish_norealloc(h);

--- a/libs/libc/obstack/lib_obstack_free.c
+++ b/libs/libc/obstack/lib_obstack_free.c
@@ -51,7 +51,8 @@ void obstack_free(FAR struct obstack *h, FAR void *object)
 
   while (h->chunk)
     {
-      if (object >= (FAR void *)&h->chunk + sizeof(struct _obstack_chunk)
+      if (object >=
+          (FAR void *)((FAR char *)&h->chunk + sizeof(struct _obstack_chunk))
           && object < (FAR void *)h->chunk->limit)
         {
           /* The object is in this chunk so just move object base.

--- a/mm/circbuf/circbuf.c
+++ b/mm/circbuf/circbuf.c
@@ -320,8 +320,8 @@ ssize_t circbuf_peekat(FAR struct circbuf_s *circ, size_t pos,
       len = bytes;
     }
 
-  memcpy(dst, circ->base + off, len);
-  memcpy(dst + len, circ->base, bytes - len);
+  memcpy(dst, (FAR char *)circ->base + off, len);
+  memcpy((FAR char *)dst + len, circ->base, bytes - len);
 
   return bytes;
 }
@@ -468,8 +468,8 @@ ssize_t circbuf_write(FAR struct circbuf_s *circ,
       space = bytes;
     }
 
-  memcpy(circ->base + off, src, space);
-  memcpy(circ->base, src + space, bytes - space);
+  memcpy((FAR char *)circ->base + off, src, space);
+  memcpy(circ->base, (FAR char *)src + space, bytes - space);
   circ->head += bytes;
 
   return bytes;
@@ -514,7 +514,7 @@ ssize_t circbuf_overwrite(FAR struct circbuf_s *circ,
 
   if (bytes > circ->size)
     {
-      src += bytes - circ->size;
+      src = (FAR const void *)((FAR char *)src + bytes - circ->size);
       bytes = circ->size;
     }
 
@@ -531,8 +531,8 @@ ssize_t circbuf_overwrite(FAR struct circbuf_s *circ,
       space = bytes;
     }
 
-  memcpy(circ->base + off, src, space);
-  memcpy(circ->base, src + space, bytes - space);
+  memcpy((FAR char *)circ->base + off, src, space);
+  memcpy(circ->base, (FAR char *)src + space, bytes - space);
   circ->head += bytes;
   circ->tail += overwrite;
 


### PR DESCRIPTION
## Summary
Using void pointers as arithmetic operators is a GCC extension i.e. non-standard. I'm not sure if this is allowed byt NuttX coding conventions but it creates a problem when the tool chain is explicitly told to detect this (results in build errors).

## Impact
Remove non-standard usage of void pointers to perform arithmetics

## Testing
Build succeeds, CI passes, local testing with gcc + test application to verify behavior
