### PR TITLE
tcp: recv returns 0 without set errno

### DIFF
--- a/net/tcp/tcp_recvfrom.c
+++ b/net/tcp/tcp_recvfrom.c
@@ -555,7 +555,7 @@ static ssize_t tcp_recvfrom_result(int result, struct tcp_recvfrom_s *pstate)
    * handler error is prioritized over any previous error.
    */
 
-  return (pstate->ir_result <= 0) ? pstate->ir_result : result;
+  return (pstate->ir_result < 0) ? pstate->ir_result : result;
 }
 
 /****************************************************************************


### PR DESCRIPTION
Issue:
recv return 0  means peer side has already closed the connection according to
man page's description.
0 is returned without set errno when TCP rx timeout happens with current
design.

Solution:
return result instead of ir_result when ir_result is 0, then -1 will be
returned with errno set to EAGAIN for tcp rx buffer empty case.

Signed-off-by: liangchaozhong <liangchaozhong@xiaomi.com>

## Summary

## Impact

## Testing

