### PR TITLE
boards/citest: disable NET_ARP for usrsocktest

### DIFF
--- a/boards/arm/imx6/sabre-6quad/configs/citest/defconfig
+++ b/boards/arm/imx6/sabre-6quad/configs/citest/defconfig
@@ -5,6 +5,7 @@
 # You can then do "make savedefconfig" to generate a new defconfig file that includes your
 # modifications.
 #
+# CONFIG_NET_ARP is not set
 # CONFIG_NSH_CMDOPT_HEXDUMP is not set
 # CONFIG_NSH_NETINIT is not set
 CONFIG_ARCH="arm"

--- a/boards/risc-v/qemu-rv/rv-virt/configs/citest/defconfig
+++ b/boards/risc-v/qemu-rv/rv-virt/configs/citest/defconfig
@@ -6,6 +6,7 @@
 # modifications.
 #
 # CONFIG_DISABLE_OS_API is not set
+# CONFIG_NET_ARP is not set
 # CONFIG_NSH_DISABLE_LOSMART is not set
 # CONFIG_NSH_NETINIT is not set
 CONFIG_16550_ADDRWIDTH=0

--- a/boards/risc-v/qemu-rv/rv-virt/configs/citest64/defconfig
+++ b/boards/risc-v/qemu-rv/rv-virt/configs/citest64/defconfig
@@ -6,6 +6,7 @@
 # modifications.
 #
 # CONFIG_DISABLE_OS_API is not set
+# CONFIG_NET_ARP is not set
 # CONFIG_NSH_DISABLE_LOSMART is not set
 # CONFIG_NSH_NETINIT is not set
 CONFIG_16550_ADDRWIDTH=0

--- a/boards/sim/sim/sim/configs/citest/defconfig
+++ b/boards/sim/sim/sim/configs/citest/defconfig
@@ -5,6 +5,7 @@
 # You can then do "make savedefconfig" to generate a new defconfig file that includes your
 # modifications.
 #
+# CONFIG_NET_ARP is not set
 # CONFIG_NSH_CMDOPT_HEXDUMP is not set
 # CONFIG_NSH_NETINIT is not set
 CONFIG_ALLSYMS=y

--- a/boards/sim/sim/sim/configs/usrsocktest/defconfig
+++ b/boards/sim/sim/sim/configs/usrsocktest/defconfig
@@ -5,6 +5,7 @@
 # You can then do "make savedefconfig" to generate a new defconfig file that includes your
 # modifications.
 #
+# CONFIG_NET_ARP is not set
 CONFIG_ARCH="sim"
 CONFIG_ARCH_BOARD="sim"
 CONFIG_ARCH_BOARD_SIM=y


### PR DESCRIPTION
## Summary

boards/citest: disable NET_ARP for usrsocktest

usrsock network does not need arp support

Signed-off-by: chao an <anchao@xiaomi.com>

## Impact

N/A

## Testing

ci test