### PR TITLE
lib_libvsprintf: fix the float point print bug

### DIFF
--- a/libs/libc/stdio/lib_libvsprintf.c
+++ b/libs/libc/stdio/lib_libvsprintf.c
@@ -878,8 +878,32 @@ flt_oper:
                   ndigs += 1;
                 }
 
-              putc(ndigs, stream);
-              putc('0' + exp, stream);
+              /* Parse the ndigs if the value of it bigger than '9' */
+
+              while (1)
+                {
+                  if (ndigs >= 'd')
+                    {
+                      putc(((ndigs - '0') / 100) + '0', stream);
+                      ndigs = (ndigs - '0') % 100 + '0';
+                    }
+                  else if (ndigs >= ':')
+                    {
+                      putc(((ndigs - '0') / 10) + '0', stream);
+                      ndigs = (ndigs - '0') % 10 + '0';
+                    }
+                  else if(ndigs >= '0')
+                    {
+                      putc(ndigs, stream);
+                      break;
+                    }
+                  else
+                    {
+                      break;
+                    }
+                 }
+
+               putc('0' + exp, stream);
             }
 
           goto tail;


### PR DESCRIPTION
## Summary
such as code: double value = +0x1.000000000000080000000000p-600;
              printf("Hello, World!! %.7g:f64\n", value);
expected output : Hello, World!! 2.40992e-181:f64
but real output : Hello, World!! 2.40992e-B1:f64
the reason: we want printf "18", but the flag of character is 'B'
            and 'B' is '0'+18,so printf 'B';


Related issue: https://github.com/apache/incubator-nuttx/issues/7620

## Impact
float printf

## Testing
esp32c3 with test code
```c
double value = +0x1.000000000000080000000000p-600;
printf("Hello, World!! %.7g:f64\n", value);
```

