### PR TITLE
Sim V4L2 bridge and video driver enhancements

### DIFF
--- a/arch/sim/Kconfig
+++ b/arch/sim/Kconfig
@@ -265,6 +265,29 @@ endchoice
 
 endif
 
+config SIM_VIDEO
+	bool "Simulated video support"
+	depends on VIDEO
+	default y
+
+if SIM_VIDEO
+
+choice
+	prompt "Simulated video device type"
+	default SIM_VIDEO_V4L2
+
+config SIM_VIDEO_V4L2
+	bool "v4l2 camera support on sim"
+	depends on HOST_LINUX
+
+endchoice
+
+config HOST_VIDEO_DEV_PATH
+	string "host video device path"
+	default "/dev/video0"
+
+endif
+
 menu "Simulated Graphics/Input"
 
 config SIM_X11FB
@@ -462,10 +485,10 @@ config SIM_UART_NUMBER
 		Under simulation, a NuttX port can be bound to a serial
 		port on the host machine. This way NuttX can access the
 		host's hardware directly.
-				
+
 		There are two possibilities regarding the host's port:
 		it can be either a physical one, or a simulated one.
-		
+
 		In case of a physical port, NuttX will be able to open
 		this port and communicate with any actual hardware that
 		it is connected to. This is useful for testing code that
@@ -473,18 +496,18 @@ config SIM_UART_NUMBER
 		In order for this to work, NuttX port name must be set to
 		the same name that the host is using for this port (e.g.
 		/dev/ttyUSB0).
-		
+
 		Alternativelly, a "simulated" host port may be used to.
 		This is useful if you need to also simulate the external
 		hardware, or to have NuttX communicate with any other
 		software in your system.
 		You can create a "simulated" port in your host,
 		by running:
-		
+
 			socat PTY,link=/dev/ttySIM0 PTY,link=/dev/ttyNX0
 		 	stty -F /dev/ttySIM0 raw
 		 	stty -F /dev/ttyNX0 raw
-		
+
 		This will create two new ports on your system.
 		NuttX will use the ttySIM0 port, and another software
 		may open and use the ttyNX0 port.
@@ -498,7 +521,7 @@ config SIM_UART_BUFFER_SIZE
 	---help---
 		The size of the transmit and receive buffers of the
 		simulated UART ports.
-		
+
 		Note that all ports will have the same buffer size.
 
 config SIM_UART0_NAME
@@ -508,7 +531,7 @@ config SIM_UART0_NAME
 	---help---
 		This is the name of the simulated UART port.
 		The port will be mounted in NuttX under this name.
-		
+
 		A UART port must also exist on the host system
 		with the exact same name specified here.
 
@@ -519,7 +542,7 @@ config SIM_UART1_NAME
 	---help---
 		This is the name of the simulated UART port.
 		The port will be mounted in NuttX under this name.
-		
+
 		A UART port must also exist on the host system
 		with the exact same name specified here.
 
@@ -530,7 +553,7 @@ config SIM_UART2_NAME
 	---help---
 		This is the name of the simulated UART port.
 		The port will be mounted in NuttX under this name.
-		
+
 		A UART port must also exist on the host system
 		with the exact same name specified here.
 
@@ -541,7 +564,7 @@ config SIM_UART3_NAME
 	---help---
 		This is the name of the simulated UART port.
 		The port will be mounted in NuttX under this name.
-		
+
 		A UART port must also exist on the host system
 		with the exact same name specified here.
 

--- a/arch/sim/src/Makefile
+++ b/arch/sim/src/Makefile
@@ -203,6 +203,12 @@ ifeq ($(CONFIG_SIM_SOUND_ALSA),y)
   STDLIBS += -lasound
 endif
 
+ifeq ($(CONFIG_SIM_VIDEO_V4L2),y)
+  HOSTSRCS += up_video_host.c
+  CSRCS += up_video.c
+  STDLIBS += -lv4l2
+endif
+
 ifeq ($(CONFIG_SIM_HOSTFS),y)
   HOSTSRCS += sim_hostfs.c
 

--- a/arch/sim/src/sim/posix/up_video_host.c
+++ b/arch/sim/src/sim/posix/up_video_host.c
@@ -1,0 +1,328 @@
+/****************************************************************************
+ * arch/sim/src/sim/posix/up_video_host.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <string.h>
+#include <syslog.h>
+#include <unistd.h>
+#include <linux/videodev2.h>
+#include <sys/mman.h>
+#include <sys/ioctl.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define WARN(fmt, ...) \
+        syslog(LOG_WARNING, "up_video_host: " fmt "\n", ##__VA_ARGS__)
+
+/****************************************************************************
+ * Private Types
+ ****************************************************************************/
+
+typedef struct
+{
+  int fd;
+  int index;
+  unsigned int reqbuf_count;
+  struct v4l2_requestbuffers reqbuf;
+} video_host_dev_t;
+
+/****************************************************************************
+ * Private Function Prototypes
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+static video_host_dev_t priv;
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+static int xioctl(int fd, int request, void *arg)
+{
+  int r;
+  do
+    {
+      r = ioctl(fd, request, arg);
+    }
+  while (-1 == r && EINTR == errno);
+
+  return r;
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+bool video_host_is_available(const char *video_host_dev_path)
+{
+  if (access(video_host_dev_path, F_OK) == 0)
+    {
+      return true;
+    }
+
+  return false;
+}
+
+int video_host_init(const char *video_host_dev_path)
+{
+  int fd = open(video_host_dev_path, O_RDWR);
+  if (fd < 0)
+    {
+      perror(video_host_dev_path);
+      return -errno;
+    }
+
+  priv.fd = fd;
+  priv.index = 0;
+  return 0;
+}
+
+int video_host_enq_buf(uint8_t *addr, uint32_t size)
+{
+  struct v4l2_buffer buf;
+  memset(&buf, 0, sizeof(buf));
+  buf.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
+  buf.memory = V4L2_MEMORY_USERPTR;
+  buf.m.userptr = (uintptr_t)addr;
+  buf.length = size;
+  buf.index = priv.index;
+  priv.index = (priv.index + 1) % priv.reqbuf.count;
+  int ret = ioctl(priv.fd, VIDIOC_QBUF, (unsigned long)&buf);
+  if (ret < 0)
+    {
+      perror("VIDIOC_QBUF");
+      return ret;
+    }
+
+  return 0;
+}
+
+int video_host_set_buf(uint8_t *addr, uint32_t size)
+{
+  return 0;
+}
+
+int video_host_dq_buf(uint8_t **addr)
+{
+  struct v4l2_buffer buf;
+  memset(&buf, 0, sizeof(buf));
+  buf.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
+  buf.memory = V4L2_MEMORY_USERPTR;
+  *addr = NULL;
+
+  /* Dequeue a buffer */
+
+  if (-1 == xioctl(priv.fd, VIDIOC_DQBUF, &buf))
+    {
+      switch (errno)
+        {
+          case EAGAIN:
+
+            /* No buffer in the outgoing queue */
+
+            return 0;
+          case EIO:
+
+            /* fall through */
+
+          default:
+            perror("VIDIOC_DQBUF");
+            return -errno;
+        }
+    }
+
+  *addr = (uint8_t *)(uintptr_t)buf.m.userptr;
+
+  return 0;
+}
+
+int video_host_uninit(void)
+{
+  close(priv.fd);
+  return 0;
+}
+
+int video_host_data_init(void)
+{
+  return 0;
+}
+
+int video_host_start_capture(int reqbuf_count)
+{
+  int ret;
+
+  /* VIDIOC_REQBUFS initiate user pointer I/O */
+
+  priv.reqbuf.type   = V4L2_BUF_TYPE_VIDEO_CAPTURE;
+  priv.reqbuf.memory = V4L2_MEMORY_USERPTR;
+  priv.reqbuf.count  = reqbuf_count;
+
+  ret = ioctl(priv.fd, VIDIOC_REQBUFS,
+    (unsigned long)&priv.reqbuf);
+  if (ret < 0)
+    {
+      perror("VIDIOC_REQBUFS");
+      return ret;
+    }
+
+  if (priv.reqbuf.count < reqbuf_count)
+    {
+      errno = ENOMEM;
+      perror("Not enough buffers");
+      close(priv.fd);
+      return -ENOMEM;
+    }
+
+  enum v4l2_buf_type type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
+  if (-1 == xioctl(priv.fd, VIDIOC_STREAMON, &type))
+    {
+      perror("VIDIOC_STREAMON");
+      return -errno;
+    }
+
+  return 0;
+}
+
+int video_host_stop_capture(void)
+{
+  enum v4l2_buf_type type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
+  if (-1 == xioctl(priv.fd, VIDIOC_STREAMOFF, &type))
+    {
+      perror("VIDIOC_STREAMOFF");
+      return -errno;
+    }
+
+  return 0;
+}
+
+int video_host_set_fmt(uint16_t width, uint16_t height, uint32_t fmt,
+    uint32_t denom, uint32_t numer)
+{
+  struct v4l2_format v4l2_fmt =
+    {
+      0
+    };
+
+  v4l2_fmt.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
+
+  v4l2_fmt.fmt.pix.width = width;
+  v4l2_fmt.fmt.pix.height = height;
+  v4l2_fmt.fmt.pix.pixelformat = fmt;
+  v4l2_fmt.fmt.pix.field = V4L2_FIELD_NONE;
+
+  if (-1 == xioctl(priv.fd, VIDIOC_S_FMT, &v4l2_fmt))
+    {
+      perror("VIDIOC_S_FMT");
+      close(priv.fd);
+      return -errno;
+    }
+
+  struct v4l2_streamparm streamparm =
+    {
+      0
+    };
+
+  streamparm.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
+  if (-1 == xioctl(priv.fd, VIDIOC_G_PARM, &streamparm))
+    {
+      perror("VIDIOC_G_PARM");
+      close(priv.fd);
+      return -errno;
+    }
+
+  streamparm.parm.capture.capturemode |= V4L2_CAP_TIMEPERFRAME;
+  streamparm.parm.capture.timeperframe.numerator = numer;
+  streamparm.parm.capture.timeperframe.denominator = denom;
+  if (-1 == xioctl(priv.fd, VIDIOC_S_PARM, &streamparm))
+    {
+      perror("VIDIOC_S_PARM");
+      close(priv.fd);
+      return -errno;
+    }
+
+  return 0;
+}
+
+int video_host_try_fmt(uint16_t width, uint16_t height, uint32_t fmt,
+    uint32_t denom, uint32_t numer)
+{
+  struct v4l2_format v4l2_fmt =
+    {
+      0
+    };
+
+  v4l2_fmt.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
+
+  v4l2_fmt.fmt.pix.width = width;
+  v4l2_fmt.fmt.pix.height = height;
+  v4l2_fmt.fmt.pix.pixelformat = fmt;
+  v4l2_fmt.fmt.pix.field = V4L2_FIELD_NONE;
+
+  if (-1 == xioctl(priv.fd, VIDIOC_TRY_FMT, &v4l2_fmt))
+    {
+      perror("VIDIOC_TRY_FMT");
+      return -errno;
+    }
+
+  struct v4l2_frmivalenum v4l2_frmival =
+    {
+      0
+    };
+
+  v4l2_frmival.width = width;
+  v4l2_frmival.height = height;
+  v4l2_frmival.pixel_format = fmt;
+
+  /* Need not check frame interval for STILL type */
+
+  if (!denom)
+    {
+      while (xioctl(priv.fd, VIDIOC_ENUM_FRAMEINTERVALS,
+          &v4l2_frmival) == 0)
+        {
+          if (v4l2_frmival.type == V4L2_FRMSIZE_TYPE_DISCRETE &&
+              v4l2_frmival.discrete.denominator == denom &&
+              v4l2_frmival.discrete.numerator == numer)
+            {
+              return 0;
+            }
+
+          v4l2_frmival.index++;
+        }
+
+        WARN("Invalid frame interval, fallback to default");
+    }
+
+  return 0;
+}

--- a/arch/sim/src/sim/posix/up_video_host.c
+++ b/arch/sim/src/sim/posix/up_video_host.c
@@ -133,7 +133,7 @@ int video_host_set_buf(uint8_t *addr, uint32_t size)
   return 0;
 }
 
-int video_host_dq_buf(uint8_t **addr)
+int video_host_dq_buf(uint8_t **addr, struct timeval *ts)
 {
   struct v4l2_buffer buf;
   memset(&buf, 0, sizeof(buf));
@@ -163,6 +163,7 @@ int video_host_dq_buf(uint8_t **addr)
     }
 
   *addr = (uint8_t *)(uintptr_t)buf.m.userptr;
+  *ts = buf.timestamp;
 
   return 0;
 }

--- a/arch/sim/src/sim/sim_internal.h
+++ b/arch/sim/src/sim/sim_internal.h
@@ -357,6 +357,12 @@ struct spi_dev_s *sim_spi_initialize(const char *filename);
 int sim_spi_uninitialize(struct spi_dev_s *dev);
 #endif
 
+/* up_video.c ***************************************************************/
+
+#ifdef CONFIG_SIM_VIDEO
+int sim_camera_initialize(void);
+#endif
+
 /* Debug ********************************************************************/
 
 #ifdef CONFIG_STACK_COLORATION

--- a/arch/sim/src/sim/up_video.c
+++ b/arch/sim/src/sim/up_video.c
@@ -1,0 +1,373 @@
+/****************************************************************************
+ * arch/sim/src/sim/up_video.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <assert.h>
+#include <debug.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <arch/board/board.h>
+#include <nuttx/config.h>
+#include <nuttx/semaphore.h>
+#include <nuttx/signal.h>
+#include <nuttx/video/imgsensor.h>
+#include <nuttx/video/imgdata.h>
+#include <sys/mman.h>
+#include <sys/time.h>
+#include <sys/ioctl.h>
+
+#include "up_video_host.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define HOST_VIDEO_DEV_PATH  CONFIG_HOST_VIDEO_DEV_PATH
+#define HOST_VIDEO_BUF_NUM   30
+#define ENQUEUE(q, addr, size) (q).addr[q.num] = addr; \
+                               (q).size[q.num++] = size;
+
+/****************************************************************************
+ * Private Types
+ ****************************************************************************/
+
+typedef struct
+{
+  size_t num;
+  uint8_t *addr[HOST_VIDEO_BUF_NUM];
+  size_t size[HOST_VIDEO_BUF_NUM];
+} buf_queue_t;
+
+typedef struct
+{
+  imgdata_capture_t capture_cb;
+  uint32_t capture_size;
+  buf_queue_t buf_q;
+} video_priv_t;
+
+/****************************************************************************
+ * Private Function Prototypes
+ ****************************************************************************/
+
+/* video image sensor operations */
+
+static bool sim_camera_is_available(void);
+static int sim_camera_init(void);
+static int sim_camera_uninit(void);
+static FAR const char *sim_camera_get_driver_name(void);
+static int sim_camera_validate_frame_setting(imgsensor_stream_type_t type,
+                                         uint8_t nr_datafmt,
+                                         FAR imgsensor_format_t *datafmts,
+                                         FAR imgsensor_interval_t *interval);
+static int sim_camera_start_capture(imgsensor_stream_type_t type,
+                                uint8_t nr_datafmt,
+                                FAR imgsensor_format_t *datafmts,
+                                FAR imgsensor_interval_t *interval);
+static int sim_camera_stop_capture(imgsensor_stream_type_t type);
+static int sim_camera_get_supported_value(uint32_t id,
+                                     FAR imgsensor_supported_value_t *value);
+static int sim_camera_get_value(uint32_t id, uint32_t size,
+                            FAR imgsensor_value_t *value);
+static int sim_camera_set_value(uint32_t id, uint32_t size,
+                            imgsensor_value_t value);
+
+/* video image data operations */
+
+static int sim_camera_data_init(void);
+static int sim_camera_data_uninit(void);
+static int sim_camera_data_validate_frame_setting
+             (uint8_t nr_datafmt,
+              imgdata_format_t *datafmt,
+              imgdata_interval_t *interval);
+static int sim_camera_data_start_capture
+             (uint8_t nr_datafmt,
+              imgdata_format_t *datafmt,
+              imgdata_interval_t *interval,
+              imgdata_capture_t callback);
+static int sim_camera_data_stop_capture(void);
+static int sim_camera_data_validate_buf(uint8_t *addr, uint32_t size);
+static int sim_camera_data_set_buf(uint8_t *addr, uint32_t size);
+static int sim_camera_data_enq_buf(uint8_t *addr, uint32_t size);
+static int sim_camera_data_dq_buf(uint8_t **addr);
+
+static uint32_t imgsensor_fmt_to_v4l2(uint32_t pixelformat);
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+static struct imgsensor_ops_s g_sim_camera_ops =
+{
+  .is_available             = sim_camera_is_available,
+  .init                     = sim_camera_init,
+  .uninit                   = sim_camera_uninit,
+  .get_driver_name          = sim_camera_get_driver_name,
+  .validate_frame_setting   = sim_camera_validate_frame_setting,
+  .start_capture            = sim_camera_start_capture,
+  .stop_capture             = sim_camera_stop_capture,
+  .get_supported_value      = sim_camera_get_supported_value,
+  .get_value                = sim_camera_get_value,
+  .set_value                = sim_camera_set_value,
+};
+
+static struct imgdata_ops_s g_sim_camera_data_ops =
+  {
+    .init                   = sim_camera_data_init,
+    .uninit                 = sim_camera_data_uninit,
+    .validate_buf           = sim_camera_data_validate_buf,
+    .set_buf                = sim_camera_data_set_buf,
+    .dq_buf                 = sim_camera_data_dq_buf,
+    .enq_buf                = sim_camera_data_enq_buf,
+    .validate_frame_setting = sim_camera_data_validate_frame_setting,
+    .start_capture          = sim_camera_data_start_capture,
+    .stop_capture           = sim_camera_data_stop_capture,
+  };
+
+static video_priv_t priv;
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+static bool sim_camera_is_available()
+{
+  return video_host_is_available(HOST_VIDEO_DEV_PATH);
+}
+
+static int sim_camera_init()
+{
+  return video_host_init(HOST_VIDEO_DEV_PATH);
+}
+
+static int sim_camera_uninit()
+{
+  return video_host_uninit();
+}
+
+static FAR const char *sim_camera_get_driver_name(void)
+{
+  return "v4l2 nuttx sim driver";
+}
+
+static int sim_camera_get_supported_value(uint32_t id,
+                                     FAR imgsensor_supported_value_t *value)
+{
+  return 0;
+}
+
+static int sim_camera_get_value(uint32_t id, uint32_t size,
+                            FAR imgsensor_value_t *value)
+{
+  return 0;
+}
+
+static int sim_camera_set_value(uint32_t id, uint32_t size,
+                            imgsensor_value_t value)
+{
+  return 0;
+}
+
+static int validate_format(imgsensor_stream_type_t type, int nr_fmt,
+    FAR imgsensor_format_t *fmt, FAR imgsensor_interval_t *interval)
+{
+  if (nr_fmt > 1)
+    {
+      return -ENOTSUP;
+    }
+
+  uint32_t v4l2_fmt = imgsensor_fmt_to_v4l2(fmt->pixelformat);
+  if (type == IMGSENSOR_STREAM_TYPE_VIDEO)
+    {
+      return video_host_try_fmt(fmt->width, fmt->height,
+        v4l2_fmt, interval->denominator, interval->numerator);
+    }
+  else
+    {
+      return video_host_try_fmt(fmt->width, fmt->height, v4l2_fmt, 0, 0);
+    }
+}
+
+static int sim_camera_validate_frame_setting(imgsensor_stream_type_t type,
+                                         uint8_t nr_fmt,
+                                         FAR imgsensor_format_t *fmt,
+                                         FAR imgsensor_interval_t *interval)
+{
+  return validate_format(type, nr_fmt, fmt, interval);
+}
+
+static int sim_camera_start_capture(imgsensor_stream_type_t type,
+                                uint8_t nr_fmt,
+                                FAR imgsensor_format_t *fmt,
+                                FAR imgsensor_interval_t *interval)
+{
+  return video_host_set_fmt(fmt[IMGDATA_FMT_MAIN].width,
+    fmt[IMGDATA_FMT_MAIN].height,
+    imgsensor_fmt_to_v4l2(fmt[IMGDATA_FMT_MAIN].pixelformat),
+    interval->denominator, interval->numerator);
+}
+
+static int sim_camera_stop_capture(imgsensor_stream_type_t type)
+{
+  return video_host_stop_capture();
+}
+
+static int sim_camera_data_init()
+{
+  memset(&priv, 0, sizeof(priv));
+  return video_host_data_init();
+}
+
+static int sim_camera_data_uninit()
+{
+  return 0;
+}
+
+static int sim_camera_data_validate_frame_setting
+             (uint8_t nr_datafmt,
+              imgdata_format_t *datafmt,
+              imgdata_interval_t *interval)
+{
+  return 0;
+}
+
+static int sim_camera_data_start_capture
+             (uint8_t nr_datafmt,
+              imgdata_format_t *datafmt,
+              imgdata_interval_t *interval,
+              imgdata_capture_t callback)
+{
+  int i;
+  int ret;
+
+  priv.capture_cb = callback;
+  priv.capture_size = datafmt->width * datafmt->height * 2;
+  ret = video_host_start_capture(priv.buf_q.num);
+  if (ret < 0)
+    {
+      return ret;
+    }
+
+  for (i = 0; i < priv.buf_q.num; i++)
+    {
+      video_host_enq_buf(priv.buf_q.addr[i], priv.buf_q.size[i]);
+    }
+
+  return 0;
+}
+
+static int sim_camera_data_stop_capture()
+{
+  return 0;
+}
+
+static int sim_camera_data_validate_buf(uint8_t *addr, uint32_t size)
+{
+  if (!addr || (uintptr_t)(addr) & 0x1f)
+    {
+      return -EINVAL;
+    }
+
+  return 0;
+}
+
+static int sim_camera_data_set_buf(uint8_t *addr, uint32_t size)
+{
+  return 0;
+}
+
+static int sim_camera_data_enq_buf(uint8_t *addr, uint32_t size)
+{
+  int ret = sim_camera_data_validate_buf(addr, size);
+  if (ret != 0)
+    {
+      return ret;
+    }
+
+  if (priv.capture_cb)
+    {
+      video_host_enq_buf(addr, size);
+    }
+  else
+    {
+      ENQUEUE(priv.buf_q, addr, size);
+    }
+
+  return 0;
+}
+
+static int sim_camera_data_dq_buf(uint8_t **addr)
+{
+  int ret = video_host_dq_buf(addr);
+  priv.capture_cb(0, priv.capture_size);
+  return ret;
+}
+
+static uint32_t imgsensor_fmt_to_v4l2(uint32_t pixelformat)
+{
+  uint32_t fourcc;
+  switch (pixelformat)
+    {
+      case IMGSENSOR_PIX_FMT_JPEG_WITH_SUBIMG:
+        fourcc = V4L2_PIX_FMT_JPEG;
+        break;
+
+      case IMGSENSOR_PIX_FMT_JPEG:
+        fourcc = V4L2_PIX_FMT_JPEG;
+        break;
+
+      case IMGSENSOR_PIX_FMT_RGB565:
+        fourcc = V4L2_PIX_FMT_RGB565;
+        break;
+
+      case IMGSENSOR_PIX_FMT_UYVY:
+        fourcc = V4L2_PIX_FMT_UYVY;
+        break;
+
+      default:
+
+      /* Unsupported format */
+
+        fourcc = 0;
+    }
+
+  return fourcc;
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+int sim_camera_initialize(void)
+{
+  imgsensor_register(&g_sim_camera_ops);
+  imgdata_register(&g_sim_camera_data_ops);
+  return 0;
+}
+
+int sim_camera_uninitialize(void)
+{
+  return 0;
+}

--- a/arch/sim/src/sim/up_video.c
+++ b/arch/sim/src/sim/up_video.c
@@ -330,6 +330,10 @@ static uint32_t imgsensor_fmt_to_v4l2(uint32_t pixelformat)
   uint32_t fourcc;
   switch (pixelformat)
     {
+      case IMGSENSOR_PIX_FMT_YUYV:
+        fourcc = V4L2_PIX_FMT_YUYV;
+        break;
+
       case IMGSENSOR_PIX_FMT_JPEG_WITH_SUBIMG:
         fourcc = V4L2_PIX_FMT_JPEG;
         break;

--- a/arch/sim/src/sim/up_video.c
+++ b/arch/sim/src/sim/up_video.c
@@ -111,7 +111,7 @@ static int sim_camera_data_stop_capture(void);
 static int sim_camera_data_validate_buf(uint8_t *addr, uint32_t size);
 static int sim_camera_data_set_buf(uint8_t *addr, uint32_t size);
 static int sim_camera_data_enq_buf(uint8_t *addr, uint32_t size);
-static int sim_camera_data_dq_buf(uint8_t **addr);
+static int sim_camera_data_dq_buf(uint8_t **addr, struct timeval *ts);
 
 static uint32_t imgsensor_fmt_to_v4l2(uint32_t pixelformat);
 
@@ -318,9 +318,9 @@ static int sim_camera_data_enq_buf(uint8_t *addr, uint32_t size)
   return 0;
 }
 
-static int sim_camera_data_dq_buf(uint8_t **addr)
+static int sim_camera_data_dq_buf(uint8_t **addr, struct timeval *ts)
 {
-  int ret = video_host_dq_buf(addr);
+  int ret = video_host_dq_buf(addr, ts);
   priv.capture_cb(0, priv.capture_size);
   return ret;
 }

--- a/arch/sim/src/sim/up_video_host.h
+++ b/arch/sim/src/sim/up_video_host.h
@@ -1,0 +1,51 @@
+/****************************************************************************
+ * arch/sim/src/sim/up_video_host.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __ARCH_SIM_SRC_SIM_UP_VIDEO_HOST_H
+#define __ARCH_SIM_SRC_SIM_UP_VIDEO_HOST_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <errno.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <linux/videodev2.h>
+
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
+
+bool video_host_is_available(const char *video_host_dev_path);
+int video_host_init(const char *video_host_dev_path);
+int video_host_uninit(void);
+int video_host_data_init(void);
+int video_host_start_capture(int reqbuf_count);
+int video_host_stop_capture(void);
+int video_host_dq_buf(uint8_t **addr);
+int video_host_enq_buf(uint8_t *addr, uint32_t size);
+int video_host_set_buf(uint8_t *addr, uint32_t size);
+int video_host_set_fmt(uint16_t width, uint16_t height, uint32_t fmt,
+    uint32_t denom, uint32_t numer);
+int video_host_try_fmt(uint16_t width, uint16_t height, uint32_t fmt,
+    uint32_t denom, uint32_t numer);
+
+#endif /* __ARCH_SIM_SRC_SIM_UP_VIDEO_HOST_H */

--- a/arch/sim/src/sim/up_video_host.h
+++ b/arch/sim/src/sim/up_video_host.h
@@ -40,7 +40,7 @@ int video_host_uninit(void);
 int video_host_data_init(void);
 int video_host_start_capture(int reqbuf_count);
 int video_host_stop_capture(void);
-int video_host_dq_buf(uint8_t **addr);
+int video_host_dq_buf(uint8_t **addr, struct timeval *ts);
 int video_host_enq_buf(uint8_t *addr, uint32_t size);
 int video_host_set_buf(uint8_t *addr, uint32_t size);
 int video_host_set_fmt(uint16_t width, uint16_t height, uint32_t fmt,

--- a/boards/sim/sim/sim/src/sim_bringup.c
+++ b/boards/sim/sim/sim/src/sim_bringup.c
@@ -47,6 +47,7 @@
 #include <nuttx/serial/uart_rpmsg.h>
 #include <nuttx/timers/oneshot.h>
 #include <nuttx/video/fb.h>
+#include <nuttx/video/video.h>
 #include <nuttx/timers/oneshot.h>
 #include <nuttx/wireless/pktradio.h>
 #include <nuttx/wireless/bluetooth/bt_null.h>
@@ -289,6 +290,21 @@ int sim_bringup(void)
     {
       syslog(LOG_ERR, "ERROR: fb_register() failed: %d\n", ret);
     }
+#endif
+
+#ifdef CONFIG_SIM_VIDEO
+  /* Initialize and register the simulated framebuffer driver */
+
+  ret = video_initialize(CONFIG_VIDEO_DEV_PATH);
+  if (ret < 0)
+    {
+      syslog(LOG_ERR, "ERROR: video_initialize() failed: %d\n", ret);
+    }
+
+# ifdef CONFIG_SIM_VIDEO_V4L2
+  sim_camera_initialize();
+# endif
+
 #endif
 
 #ifdef CONFIG_LCD

--- a/drivers/video/Kconfig
+++ b/drivers/video/Kconfig
@@ -58,6 +58,10 @@ config VIDEO_STREAM
 
 if VIDEO_STREAM
 
+config VIDEO_HEAP_SIZE
+	int "Maximum Video heap size used by V4L2 mmap-ed buffer"
+	default 1843200
+
 config VIDEO_SCENE_BACKLIGHT
 	bool "Enable backlight scene"
 	default y

--- a/drivers/video/video.c
+++ b/drivers/video/video.c
@@ -222,7 +222,13 @@ static int validate_frame_setting(enum v4l2_buf_type type,
 
 /* internal function for each cmds of ioctl */
 
+static ssize_t video_read(FAR struct file *filep, FAR char *buffer,
+                          size_t buflen);
+static ssize_t video_write(FAR struct file *filep, FAR const char *buffer,
+                   size_t buflen);
 static int video_querycap(FAR struct v4l2_capability *cap);
+static int video_g_input(FAR int *num);
+static int video_enum_input(FAR struct v4l2_input *input);
 static int video_reqbufs(FAR struct video_mng_s *vmng,
                          FAR struct v4l2_requestbuffers *reqbufs);
 static int video_qbuf(FAR struct video_mng_s *vmng,
@@ -231,8 +237,14 @@ static int video_dqbuf(FAR struct video_mng_s *vmng,
                        FAR struct v4l2_buffer *buf);
 static int video_cancel_dqbuf(FAR struct video_mng_s *vmng,
                               enum v4l2_buf_type type);
+static int video_g_fmt(FAR struct video_mng_s *priv,
+                       FAR struct v4l2_format *fmt);
 static int video_s_fmt(FAR struct video_mng_s *priv,
                        FAR struct v4l2_format *fmt);
+static int video_try_fmt(FAR struct video_mng_s *priv,
+                         FAR struct v4l2_format *v4l2);
+static int video_g_parm(FAR struct video_mng_s *priv,
+                        FAR struct v4l2_streamparm *parm);
 static int video_s_parm(FAR struct video_mng_s *priv,
                         FAR struct v4l2_streamparm *parm);
 static int video_streamon(FAR struct video_mng_s *vmng,
@@ -270,8 +282,8 @@ static const struct file_operations g_video_fops =
 {
   video_open,               /* open */
   video_close,              /* close */
-  NULL,                     /* read */
-  NULL,                     /* write */
+  video_read,               /* read */
+  video_write,              /* write */
   NULL,                     /* seek */
   video_ioctl,              /* ioctl */
   NULL                      /* poll */
@@ -1071,6 +1083,18 @@ static int video_close(FAR struct file *filep)
   return ret;
 }
 
+static ssize_t video_read(FAR struct file *filep, FAR char *buffer,
+                          size_t buflen)
+{
+  return -ENOTSUP;
+}
+
+static ssize_t video_write(FAR struct file *filep, FAR const char *buffer,
+                   size_t buflen)
+{
+  return -ENOTSUP;
+}
+
 static int video_querycap(FAR struct v4l2_capability *cap)
 {
   FAR const char *name;
@@ -1094,6 +1118,30 @@ static int video_querycap(FAR struct v4l2_capability *cap)
   /* cap->driver needs to be NULL-terminated. */
 
   strlcpy((FAR char *)cap->driver, name, sizeof(cap->driver));
+  cap->capabilities = V4L2_CAP_VIDEO_CAPTURE | V4L2_CAP_STREAMING;
+
+  return OK;
+}
+
+static int video_g_input(FAR int *num)
+{
+  *num = 0;
+
+  return OK;
+}
+
+static int video_enum_input(FAR struct v4l2_input *input)
+{
+  FAR const char *name;
+
+  if (input->index > 0)
+    {
+      return -EINVAL;
+    }
+
+  name = g_video_sensor_ops->get_driver_name();
+  strlcpy((FAR char *)input->name, name, sizeof(input->name));
+  input->type = V4L2_INPUT_TYPE_CAMERA;
 
   return OK;
 }
@@ -1570,6 +1618,24 @@ static int video_try_fmt(FAR struct video_mng_s *priv,
                                 &type_inf->frame_interval);
 }
 
+static int video_g_fmt(FAR struct video_mng_s *priv,
+                       FAR struct v4l2_format *fmt)
+{
+  FAR video_type_inf_t *type_inf;
+
+  type_inf = get_video_type_inf(priv, fmt->type);
+  if (type_inf == NULL)
+    {
+      return -EINVAL;
+    }
+
+  fmt->fmt.pix.width = type_inf->fmt[VIDEO_FMT_MAIN].width;
+  fmt->fmt.pix.height = type_inf->fmt[VIDEO_FMT_MAIN].height;
+  fmt->fmt.pix.pixelformat = type_inf->fmt[VIDEO_FMT_MAIN].pixelformat;
+
+  return OK;
+}
+
 static int video_s_fmt(FAR struct video_mng_s *priv,
                        FAR struct v4l2_format *fmt)
 {
@@ -1687,6 +1753,7 @@ static int video_g_parm(FAR struct video_mng_s *vmng,
        */
 
       memset(&parm->parm, 0, sizeof(parm->parm));
+      parm->parm.capture.capability = V4L2_CAP_TIMEPERFRAME;
 
       ret = g_video_sensor_ops->get_frame_interval
               (parm->type,
@@ -2959,6 +3026,16 @@ static int video_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
 
         break;
 
+      case VIDIOC_G_INPUT:
+        ret = video_g_input((FAR int *)arg);
+
+        break;
+
+      case VIDIOC_ENUMINPUT:
+        ret = video_enum_input((FAR struct v4l2_input *)arg);
+
+        break;
+
       case VIDIOC_REQBUFS:
         ret = video_reqbufs(priv, (FAR struct v4l2_requestbuffers *)arg);
 
@@ -3019,6 +3096,11 @@ static int video_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
 
         break;
 
+      case VIDIOC_G_FMT:
+        ret = video_g_fmt(priv, (FAR struct v4l2_format *)arg);
+
+        break;
+
       case VIDIOC_S_FMT:
         ret = video_s_fmt(priv, (FAR struct v4l2_format *)arg);
 
@@ -3066,6 +3148,16 @@ static int video_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
 
       case VIDIOC_S_EXT_CTRLS:
         ret = video_s_ext_ctrls(priv, (FAR struct v4l2_ext_controls *)arg);
+
+        break;
+
+      case VIDIOC_G_STD:
+        ret = -ENODATA;
+
+        break;
+
+      case VIDIOC_S_STD:
+        ret = -EINVAL;
 
         break;
 

--- a/drivers/video/video.c
+++ b/drivers/video/video.c
@@ -1364,7 +1364,7 @@ static int video_dqbuf(FAR struct video_mng_s *vmng,
 
   if (g_video_data_ops->dq_buf)
     {
-      ret = g_video_data_ops->dq_buf(&dq_buf_addr);
+      ret = g_video_data_ops->dq_buf(&dq_buf_addr, &buf->timestamp);
       if (ret < 0)
         {
           return ret;

--- a/drivers/video/video.c
+++ b/drivers/video/video.c
@@ -500,6 +500,10 @@ static void convert_to_imgdatafmt(FAR video_format_t *video,
   data->height      = video->height;
   switch (video->pixelformat)
     {
+      case V4L2_PIX_FMT_YUYV :
+        data->pixelformat = IMGDATA_PIX_FMT_YUYV;
+        break;
+
       case V4L2_PIX_FMT_UYVY :
         data->pixelformat = IMGDATA_PIX_FMT_UYVY;
         break;
@@ -527,6 +531,10 @@ static void convert_to_imgsensorfmt(FAR video_format_t *video,
   sensor->height      = video->height;
   switch (video->pixelformat)
     {
+      case V4L2_PIX_FMT_YUYV :
+        sensor->pixelformat = IMGSENSOR_PIX_FMT_YUYV;
+        break;
+
       case V4L2_PIX_FMT_UYVY :
         sensor->pixelformat = IMGSENSOR_PIX_FMT_UYVY;
         break;
@@ -1540,6 +1548,7 @@ static int video_try_fmt(FAR struct video_mng_s *priv,
 
         break;
 
+      case V4L2_PIX_FMT_YUYV:
       case V4L2_PIX_FMT_UYVY:
       case V4L2_PIX_FMT_RGB565:
       case V4L2_PIX_FMT_JPEG:

--- a/include/nuttx/video/imgdata.h
+++ b/include/nuttx/video/imgdata.h
@@ -42,6 +42,7 @@
 #define IMGDATA_PIX_FMT_JPEG_WITH_SUBIMG (3)
 #define IMGDATA_PIX_FMT_SUBIMG_UYVY      (4)
 #define IMGDATA_PIX_FMT_SUBIMG_RGB565    (5)
+#define IMGDATA_PIX_FMT_YUYV             (6)
 
 /****************************************************************************
  * Public Types

--- a/include/nuttx/video/imgdata.h
+++ b/include/nuttx/video/imgdata.h
@@ -73,6 +73,8 @@ struct imgdata_ops_s
 
   CODE int (*validate_buf)(uint8_t *addr, uint32_t size);
   CODE int (*set_buf)(uint8_t *addr, uint32_t size);
+  CODE int (*enq_buf)(uint8_t *addr, uint32_t size);
+  CODE int (*dq_buf)(uint8_t **addr);
 
   CODE int (*validate_frame_setting)(uint8_t nr_datafmts,
                                      FAR imgdata_format_t *datafmts,

--- a/include/nuttx/video/imgdata.h
+++ b/include/nuttx/video/imgdata.h
@@ -26,6 +26,7 @@
  ****************************************************************************/
 
 #include <sys/types.h>
+#include <sys/time.h>
 
 /****************************************************************************
  * Pre-processor Definitions
@@ -75,7 +76,7 @@ struct imgdata_ops_s
   CODE int (*validate_buf)(uint8_t *addr, uint32_t size);
   CODE int (*set_buf)(uint8_t *addr, uint32_t size);
   CODE int (*enq_buf)(uint8_t *addr, uint32_t size);
-  CODE int (*dq_buf)(uint8_t **addr);
+  CODE int (*dq_buf)(uint8_t **addr, struct timeval *ts);
 
   CODE int (*validate_frame_setting)(uint8_t nr_datafmts,
                                      FAR imgdata_format_t *datafmts,

--- a/include/nuttx/video/imgdata.h
+++ b/include/nuttx/video/imgdata.h
@@ -44,6 +44,7 @@
 #define IMGDATA_PIX_FMT_SUBIMG_UYVY      (4)
 #define IMGDATA_PIX_FMT_SUBIMG_RGB565    (5)
 #define IMGDATA_PIX_FMT_YUYV             (6)
+#define IMGDATA_PIX_FMT_YUV420P          (7)
 
 /****************************************************************************
  * Public Types

--- a/include/nuttx/video/imgsensor.h
+++ b/include/nuttx/video/imgsensor.h
@@ -118,6 +118,7 @@
 #define IMGSENSOR_PIX_FMT_SUBIMG_UYVY      (4)
 #define IMGSENSOR_PIX_FMT_SUBIMG_RGB565    (5)
 #define IMGSENSOR_PIX_FMT_YUYV             (6)
+#define IMGSENSOR_PIX_FMT_YUV420P          (7)
 
 /****************************************************************************
  * Public Types

--- a/include/nuttx/video/imgsensor.h
+++ b/include/nuttx/video/imgsensor.h
@@ -101,7 +101,7 @@
 
 /* Status bit definition for IMGSENSOR_ID_3A_STATUS */
 
-#define IMGSENSOR_3A_STATUS_STABLE        (0) 
+#define IMGSENSOR_3A_STATUS_STABLE        (0)
 #define IMGSENSOR_3A_STATUS_AE_OPERATING  (1 << 0)
 #define IMGSENSOR_3A_STATUS_AWB_OPERATING (1 << 1)
 #define IMGSENSOR_3A_STATUS_AF_OPERATING  (1 << 2)
@@ -117,6 +117,7 @@
 #define IMGSENSOR_PIX_FMT_JPEG_WITH_SUBIMG (3)
 #define IMGSENSOR_PIX_FMT_SUBIMG_UYVY      (4)
 #define IMGSENSOR_PIX_FMT_SUBIMG_RGB565    (5)
+#define IMGSENSOR_PIX_FMT_YUYV             (6)
 
 /****************************************************************************
  * Public Types

--- a/include/nuttx/video/video.h
+++ b/include/nuttx/video/video.h
@@ -28,6 +28,7 @@
 #include <stdint.h>
 #include <nuttx/fs/ioctl.h>
 #include <nuttx/video/video_controls.h>
+#include <sys/time.h>
 
 #ifdef __cplusplus
 extern "C"
@@ -38,53 +39,177 @@ extern "C"
  * Pre-processor Definitions
  ****************************************************************************/
 
+/* Query device capability
+ * Address pointing to struct v4l2_capability
+ */
+
+#define VIDIOC_QUERYCAP               _VIDIOC(0x0000)
+
 /* Enumerate the formats supported by device */
 
-#define VIDIOC_ENUM_FMT               _VIDIOC(0x0001)
+#define VIDIOC_ENUM_FMT               _VIDIOC(0x0002)
 
-/* Enumerate the framesizes supported by device */
+/* Get the data format */
 
-#define VIDIOC_ENUM_FRAMESIZES        _VIDIOC(0x0002)
+#define VIDIOC_G_FMT                  _VIDIOC(0x0004)
 
-/* Enumerate the frameintervals supported by device */
-
-#define VIDIOC_ENUM_FRAMEINTERVALS    _VIDIOC(0x0003)
-
-/* Try format */
-
-#define VIDIOC_TRY_FMT                _VIDIOC(0x0004)
-
-/* Set the data format. */
+/* Set the data format */
 
 #define VIDIOC_S_FMT                  _VIDIOC(0x0005)
 
-/* Set the frame interval. */
-
-#define VIDIOC_S_PARM                 _VIDIOC(0x0006)
-
 /* Initiate user pointer I/O */
 
-#define VIDIOC_REQBUFS                _VIDIOC(0x0007)
+#define VIDIOC_REQBUFS                _VIDIOC(0x0008)
+
+/* Query the status of a buffer */
+
+#define VIDIOC_QUERYBUF               _VIDIOC(0x0009)
+
+/* Get frame buffer overlay parameters */
+
+#define VIDIOC_G_FBUF                 _VIDIOC(0x000a)
+
+/* Set frame buffer overlay parameters */
+
+#define VIDIOC_S_FBUF                 _VIDIOC(0x000b)
+
+/* Start or stop video overlay */
+
+#define VIDIOC_OVERLAY                _VIDIOC(0x000e)
 
 /* Enqueue an empty buffer */
 
-#define VIDIOC_QBUF                   _VIDIOC(0x0008)
+#define VIDIOC_QBUF                   _VIDIOC(0x000f)
+
+/* Export a buffer as a DMABUF file descriptor */
+
+#define VIDIOC_EXPBUF                 _VIDIOC(0x0010)
 
 /* Dequeue a filled buffer */
 
-#define VIDIOC_DQBUF                  _VIDIOC(0x0009)
+#define VIDIOC_DQBUF                  _VIDIOC(0x0011)
 
 /* Start streaming */
 
-#define VIDIOC_STREAMON               _VIDIOC(0x000A)
+#define VIDIOC_STREAMON               _VIDIOC(0x0012)
 
 /* Stop streaming */
 
-#define VIDIOC_STREAMOFF              _VIDIOC(0x000B)
+#define VIDIOC_STREAMOFF              _VIDIOC(0x0013)
+
+/* Get streaming parameters */
+
+#define VIDIOC_G_PARM                 _VIDIOC(0x0015)
+
+/* Set streaming parameters */
+
+#define VIDIOC_S_PARM                 _VIDIOC(0x0016)
+
+/* Query the video standard of the current input */
+
+#define VIDIOC_G_STD                  _VIDIOC(0x0017)
+
+/* Select the video standard of the current input */
+
+#define VIDIOC_S_STD                  _VIDIOC(0x0018)
+
+/* Enumerate supported video standards */
+
+#define VIDIOC_ENUMSTD                _VIDIOC(0x0019)
+
+/* Enumerate video inputs */
+
+#define VIDIOC_ENUMINPUT              _VIDIOC(0x001a)
+
+/* Get current control value.
+ *  This request is a special case of VIDIOC_G_EXT_CTRLS.
+ *  Address pointing to struct #v4l2_control
+ */
+
+#define VIDIOC_G_CTRL                 _VIDIOC(0x001b)
+
+/* Set control value.
+ *  This request is a special case of VIDIOC_S_EXT_CTRLS.
+ *  Address pointing to struct #v4l2_control
+ */
+
+#define VIDIOC_S_CTRL                 _VIDIOC(0x001c)
+
+/* Query control */
+
+#define VIDIOC_QUERYCTRL              _VIDIOC(0x0024)
+
+/* Query menu */
+
+#define VIDIOC_QUERYMENU              _VIDIOC(0x0025)
+
+/* Get video input */
+
+#define VIDIOC_G_INPUT                _VIDIOC(0x0026)
+
+/* Set video input */
+
+#define VIDIOC_S_INPUT                _VIDIOC(0x0027)
+
+/* Query video standard */
+
+#define VIDIOC_QUERYSTD               _VIDIOC(0x003f)
+
+/* Try format */
+
+#define VIDIOC_TRY_FMT                _VIDIOC(0x0040)
+
+/* Get current control value
+ *  Address pointing to struct #v4l2_ext_controls
+ */
+
+#define VIDIOC_G_EXT_CTRLS            _VIDIOC(0x0047)
+
+/* Set control value
+ *  Address pointing to struct #v4l2_ext_controls
+ */
+
+#define VIDIOC_S_EXT_CTRLS            _VIDIOC(0x0048)
+
+/* Try control value
+ *  Address pointing to struct #v4l2_ext_controls
+ */
+
+#define VIDIOC_TRY_EXT_CTRLS          _VIDIOC(0x0049)
+
+/* Enumerate the framesizes supported by device */
+
+#define VIDIOC_ENUM_FRAMESIZES        _VIDIOC(0x004a)
+
+/* Enumerate the frameintervals supported by device */
+
+#define VIDIOC_ENUM_FRAMEINTERVALS    _VIDIOC(0x004b)
+
+/* Get clip
+ * Address pointing to struct v4l2_selection
+ */
+
+#define VIDIOC_G_SELECTION            _VIDIOC(0x005e)
+
+/* Set clip
+ * Address pointing to struct v4l2_selection
+ */
+
+#define VIDIOC_S_SELECTION            _VIDIOC(0x005f)
+
+/* Query control */
+
+#define VIDIOC_QUERY_EXT_CTRL         _VIDIOC(0x00c0)
+
+/* Cancel DQBUF
+ *  enum #v4l2_buf_type
+ */
+
+#define VIDIOC_CANCEL_DQBUF           _VIDIOC(0x00c1)
 
 /* Do halfpush */
 
-#define VIDIOC_DO_HALFPUSH            _VIDIOC(0x000C)
+#define VIDIOC_DO_HALFPUSH            _VIDIOC(0x00c2)
 
 /* Start taking picture
  *
@@ -94,103 +219,35 @@ extern "C"
  * up to a specified number of times  or until VIDIOC_TAKEPICT_STOP.
  */
 
-#define VIDIOC_TAKEPICT_START         _VIDIOC(0x000D)
+#define VIDIOC_TAKEPICT_START         _VIDIOC(0x00c3)
 
 /* Stop taking picture */
 
-#define VIDIOC_TAKEPICT_STOP          _VIDIOC(0x000E)
-
-/* Query control */
-
-#define VIDIOC_QUERYCTRL              _VIDIOC(0x000F)
-
-/* Query control */
-
-#define VIDIOC_QUERY_EXT_CTRL         _VIDIOC(0x0010)
-
-/* Query menu */
-
-#define VIDIOC_QUERYMENU              _VIDIOC(0x0011)
-
-/* Get current control value.
- *  This request is a special case of VIDIOC_G_EXT_CTRLS.
- *  Address pointing to struct #v4l2_control
- */
-
-#define VIDIOC_G_CTRL                 _VIDIOC(0x0012)
-
-/* Set control value.
- *  This request is a special case of VIDIOC_S_EXT_CTRLS.
- *  Address pointing to struct #v4l2_control
- */
-
-#define VIDIOC_S_CTRL                 _VIDIOC(0x0013)
-
-/* Get current control value
- *  Address pointing to struct #v4l2_ext_controls
- */
-
-#define VIDIOC_G_EXT_CTRLS            _VIDIOC(0x0014)
-
-/* Set control value
- *  Address pointing to struct #v4l2_ext_controls
- */
-
-#define VIDIOC_S_EXT_CTRLS            _VIDIOC(0x0015)
-
-/* Cancel DQBUF
- *  enum #v4l2_buf_type
- */
-
-#define VIDIOC_CANCEL_DQBUF           _VIDIOC(0x0016)
+#define VIDIOC_TAKEPICT_STOP          _VIDIOC(0x00c4)
 
 /* Query control for scene parameter
  *  Address pointing to struct v4s_query_ext_ctrl_scene
  */
 
-#define V4SIOC_QUERY_EXT_CTRL_SCENE   _VIDIOC(0x0017)
+#define V4SIOC_QUERY_EXT_CTRL_SCENE   _VIDIOC(0x00c5)
 
 /* Query menu for scene parameter
  *  Address pointing to struct v4s_querymenu_scene
  */
 
-#define V4SIOC_QUERYMENU_SCENE        _VIDIOC(0x0018)
+#define V4SIOC_QUERYMENU_SCENE        _VIDIOC(0x00c6)
 
 /* Get current control value
  *  Address pointing to struct v4s_ext_controls_scene
  */
 
-#define V4SIOC_G_EXT_CTRLS_SCENE      _VIDIOC(0x0019)
+#define V4SIOC_G_EXT_CTRLS_SCENE      _VIDIOC(0x00c7)
 
 /* Set control value
  *  Address pointing to struct v4s_ext_controls_scene
  */
 
-#define V4SIOC_S_EXT_CTRLS_SCENE      _VIDIOC(0x001a)
-
-/* Query device capability
- * Address pointing to struct v4l2_capability
- */
-
-#define VIDIOC_QUERYCAP               _VIDIOC(0x001b)
-
-/* Set clip
- * Address pointing to struct v4l2_selection
- */
-
-#define VIDIOC_S_SELECTION            _VIDIOC(0x001c)
-
-/* Get clip
- * Address pointing to struct v4l2_selection
- */
-
-#define VIDIOC_G_SELECTION            _VIDIOC(0x001d)
-
-/* Get the frame interval.
- * Address pointing to struct v4l2_streamparm
- */
-
-#define VIDIOC_G_PARM                 _VIDIOC(0x001e)
+#define V4SIOC_S_EXT_CTRLS_SCENE      _VIDIOC(0x00c8)
 
 #define VIDEO_HSIZE_QVGA        (320)   /* QVGA    horizontal size */
 #define VIDEO_VSIZE_QVGA        (240)   /* QVGA    vertical   size */
@@ -214,19 +271,167 @@ extern "C"
   ((uint32_t)(c) << 16) | ((uint32_t)(d) << 24))
 #define v4l2_fourcc_be(a, b, c, d)    (v4l2_fourcc(a, b, c, d) | (1 << 31))
 
-/* YUV 4:2:2 */
+/* RGB formats */
 
-#define V4L2_PIX_FMT_UYVY v4l2_fourcc('U', 'Y', 'V', 'Y')
+#define V4L2_PIX_FMT_RGB332  v4l2_fourcc('R', 'G', 'B', '1')
+#define V4L2_PIX_FMT_RGB444  v4l2_fourcc('R', '4', '4', '4')
+#define V4L2_PIX_FMT_ARGB444 v4l2_fourcc('A', 'R', '1', '2')
+#define V4L2_PIX_FMT_XRGB444 v4l2_fourcc('X', 'R', '1', '2')
+#define V4L2_PIX_FMT_RGB555  v4l2_fourcc('R', 'G', 'B', 'O')
+#define V4L2_PIX_FMT_ARGB555 v4l2_fourcc('A', 'R', '1', '5')
+#define V4L2_PIX_FMT_XRGB555 v4l2_fourcc('X', 'R', '1', '5')
+#define V4L2_PIX_FMT_RGB565  v4l2_fourcc('R', 'G', 'B', 'P')
+#define V4L2_PIX_FMT_RGB555X v4l2_fourcc('R', 'G', 'B', 'Q')
+#define V4L2_PIX_FMT_ARGB555X v4l2_fourcc_be('A', 'R', '1', '5')
+#define V4L2_PIX_FMT_XRGB555X v4l2_fourcc_be('X', 'R', '1', '5')
+#define V4L2_PIX_FMT_RGB565X v4l2_fourcc('R', 'G', 'B', 'R')
+#define V4L2_PIX_FMT_BGR666  v4l2_fourcc('B', 'G', 'R', 'H')
+#define V4L2_PIX_FMT_BGR24   v4l2_fourcc('B', 'G', 'R', '3')
+#define V4L2_PIX_FMT_RGB24   v4l2_fourcc('R', 'G', 'B', '3')
+#define V4L2_PIX_FMT_BGR32   v4l2_fourcc('B', 'G', 'R', '4')
+#define V4L2_PIX_FMT_ABGR32  v4l2_fourcc('A', 'R', '2', '4')
+#define V4L2_PIX_FMT_XBGR32  v4l2_fourcc('X', 'R', '2', '4')
+#define V4L2_PIX_FMT_RGB32   v4l2_fourcc('R', 'G', 'B', '4')
+#define V4L2_PIX_FMT_ARGB32  v4l2_fourcc('B', 'A', '2', '4')
+#define V4L2_PIX_FMT_XRGB32  v4l2_fourcc('B', 'X', '2', '4')
 
-#define V4L2_PIX_FMT_YUYV v4l2_fourcc('Y', 'U', 'Y', 'V')
+/* Grey formats */
 
-/* RGB565 */
+#define V4L2_PIX_FMT_GREY    v4l2_fourcc('G', 'R', 'E', 'Y')
+#define V4L2_PIX_FMT_Y4      v4l2_fourcc('Y', '0', '4', ' ')
+#define V4L2_PIX_FMT_Y6      v4l2_fourcc('Y', '0', '6', ' ')
+#define V4L2_PIX_FMT_Y10     v4l2_fourcc('Y', '1', '0', ' ')
+#define V4L2_PIX_FMT_Y12     v4l2_fourcc('Y', '1', '2', ' ')
+#define V4L2_PIX_FMT_Y16     v4l2_fourcc('Y', '1', '6', ' ')
+#define V4L2_PIX_FMT_Y16_BE  v4l2_fourcc_be('Y', '1', '6', ' ')
 
-#define V4L2_PIX_FMT_RGB565 v4l2_fourcc('R', 'G', 'B', 'P')
+/* Grey bit-packed formats */
 
-/* JFIF JPEG */
+#define V4L2_PIX_FMT_Y10BPACK    v4l2_fourcc('Y', '1', '0', 'B')
 
-#define V4L2_PIX_FMT_JPEG v4l2_fourcc('J', 'P', 'E', 'G')
+/* Palette formats */
+
+#define V4L2_PIX_FMT_PAL8    v4l2_fourcc('P', 'A', 'L', '8')
+
+/* Chrominance formats */
+
+#define V4L2_PIX_FMT_UV8     v4l2_fourcc('U', 'V', '8', ' ')
+
+/* Luminance+Chrominance formats */
+
+#define V4L2_PIX_FMT_YUYV    v4l2_fourcc('Y', 'U', 'Y', 'V')
+#define V4L2_PIX_FMT_YYUV    v4l2_fourcc('Y', 'Y', 'U', 'V')
+#define V4L2_PIX_FMT_YVYU    v4l2_fourcc('Y', 'V', 'Y', 'U')
+#define V4L2_PIX_FMT_UYVY    v4l2_fourcc('U', 'Y', 'V', 'Y')
+#define V4L2_PIX_FMT_VYUY    v4l2_fourcc('V', 'Y', 'U', 'Y')
+#define V4L2_PIX_FMT_Y41P    v4l2_fourcc('Y', '4', '1', 'P')
+#define V4L2_PIX_FMT_YUV444  v4l2_fourcc('Y', '4', '4', '4')
+#define V4L2_PIX_FMT_YUV555  v4l2_fourcc('Y', 'U', 'V', 'O')
+#define V4L2_PIX_FMT_YUV565  v4l2_fourcc('Y', 'U', 'V', 'P')
+#define V4L2_PIX_FMT_YUV32   v4l2_fourcc('Y', 'U', 'V', '4')
+#define V4L2_PIX_FMT_HI240   v4l2_fourcc('H', 'I', '2', '4')
+#define V4L2_PIX_FMT_HM12    v4l2_fourcc('H', 'M', '1', '2')
+#define V4L2_PIX_FMT_M420    v4l2_fourcc('M', '4', '2', '0')
+
+/* two planes -- one Y, one Cr + Cb interleaved  */
+
+#define V4L2_PIX_FMT_NV12    v4l2_fourcc('N', 'V', '1', '2')
+#define V4L2_PIX_FMT_NV21    v4l2_fourcc('N', 'V', '2', '1')
+#define V4L2_PIX_FMT_NV16    v4l2_fourcc('N', 'V', '1', '6')
+#define V4L2_PIX_FMT_NV61    v4l2_fourcc('N', 'V', '6', '1')
+#define V4L2_PIX_FMT_NV24    v4l2_fourcc('N', 'V', '2', '4')
+#define V4L2_PIX_FMT_NV42    v4l2_fourcc('N', 'V', '4', '2')
+
+/* two non contiguous planes - one Y, one Cr + Cb interleaved  */
+
+#define V4L2_PIX_FMT_NV12M   v4l2_fourcc('N', 'M', '1', '2')
+#define V4L2_PIX_FMT_NV21M   v4l2_fourcc('N', 'M', '2', '1')
+#define V4L2_PIX_FMT_NV16M   v4l2_fourcc('N', 'M', '1', '6')
+#define V4L2_PIX_FMT_NV61M   v4l2_fourcc('N', 'M', '6', '1')
+#define V4L2_PIX_FMT_NV12MT  v4l2_fourcc('T', 'M', '1', '2')
+#define V4L2_PIX_FMT_NV12MT_16X16 v4l2_fourcc('V', 'M', '1', '2')
+
+/* three planes - Y Cb, Cr */
+
+#define V4L2_PIX_FMT_YUV410  v4l2_fourcc('Y', 'U', 'V', '9')
+#define V4L2_PIX_FMT_YVU410  v4l2_fourcc('Y', 'V', 'U', '9')
+#define V4L2_PIX_FMT_YUV411P v4l2_fourcc('4', '1', '1', 'P')
+#define V4L2_PIX_FMT_YUV420  v4l2_fourcc('Y', 'U', '1', '2')
+#define V4L2_PIX_FMT_YVU420  v4l2_fourcc('Y', 'V', '1', '2')
+#define V4L2_PIX_FMT_YUV422P v4l2_fourcc('4', '2', '2', 'P')
+
+/* three non contiguous planes - Y, Cb, Cr */
+
+#define V4L2_PIX_FMT_YUV420M v4l2_fourcc('Y', 'M', '1', '2')
+#define V4L2_PIX_FMT_YVU420M v4l2_fourcc('Y', 'M', '2', '1')
+#define V4L2_PIX_FMT_YUV422M v4l2_fourcc('Y', 'M', '1', '6')
+#define V4L2_PIX_FMT_YVU422M v4l2_fourcc('Y', 'M', '6', '1')
+#define V4L2_PIX_FMT_YUV444M v4l2_fourcc('Y', 'M', '2', '4')
+#define V4L2_PIX_FMT_YVU444M v4l2_fourcc('Y', 'M', '4', '2')
+
+/* Bayer formats - see http://www.siliconimaging.com/RGB%20Bayer.htm */
+
+#define V4L2_PIX_FMT_SBGGR8  v4l2_fourcc('B', 'A', '8', '1')
+#define V4L2_PIX_FMT_SGBRG8  v4l2_fourcc('G', 'B', 'R', 'G')
+#define V4L2_PIX_FMT_SGRBG8  v4l2_fourcc('G', 'R', 'B', 'G')
+#define V4L2_PIX_FMT_SRGGB8  v4l2_fourcc('R', 'G', 'G', 'B')
+#define V4L2_PIX_FMT_SBGGR10 v4l2_fourcc('B', 'G', '1', '0')
+#define V4L2_PIX_FMT_SGBRG10 v4l2_fourcc('G', 'B', '1', '0')
+#define V4L2_PIX_FMT_SGRBG10 v4l2_fourcc('B', 'A', '1', '0')
+#define V4L2_PIX_FMT_SRGGB10 v4l2_fourcc('R', 'G', '1', '0')
+
+/* 10bit raw bayer packed, 5 bytes for every 4 pixels */
+
+#define V4L2_PIX_FMT_SBGGR10P v4l2_fourcc('p', 'B', 'A', 'A')
+#define V4L2_PIX_FMT_SGBRG10P v4l2_fourcc('p', 'G', 'A', 'A')
+#define V4L2_PIX_FMT_SGRBG10P v4l2_fourcc('p', 'g', 'A', 'A')
+#define V4L2_PIX_FMT_SRGGB10P v4l2_fourcc('p', 'R', 'A', 'A')
+
+/* 10bit raw bayer a-law compressed to 8 bits */
+
+#define V4L2_PIX_FMT_SBGGR10ALAW8 v4l2_fourcc('a', 'B', 'A', '8')
+#define V4L2_PIX_FMT_SGBRG10ALAW8 v4l2_fourcc('a', 'G', 'A', '8')
+#define V4L2_PIX_FMT_SGRBG10ALAW8 v4l2_fourcc('a', 'g', 'A', '8')
+#define V4L2_PIX_FMT_SRGGB10ALAW8 v4l2_fourcc('a', 'R', 'A', '8')
+
+/* 10bit raw bayer DPCM compressed to 8 bits */
+
+#define V4L2_PIX_FMT_SBGGR10DPCM8 v4l2_fourcc('b', 'B', 'A', '8')
+#define V4L2_PIX_FMT_SGBRG10DPCM8 v4l2_fourcc('b', 'G', 'A', '8')
+#define V4L2_PIX_FMT_SGRBG10DPCM8 v4l2_fourcc('B', 'D', '1', '0')
+#define V4L2_PIX_FMT_SRGGB10DPCM8 v4l2_fourcc('b', 'R', 'A', '8')
+#define V4L2_PIX_FMT_SBGGR12 v4l2_fourcc('B', 'G', '1', '2')
+#define V4L2_PIX_FMT_SGBRG12 v4l2_fourcc('G', 'B', '1', '2')
+#define V4L2_PIX_FMT_SGRBG12 v4l2_fourcc('B', 'A', '1', '2')
+#define V4L2_PIX_FMT_SRGGB12 v4l2_fourcc('R', 'G', '1', '2')
+#define V4L2_PIX_FMT_SBGGR16 v4l2_fourcc('B', 'Y', 'R', '2')
+#define V4L2_PIX_FMT_SGBRG16 v4l2_fourcc('G', 'B', '1', '6')
+#define V4L2_PIX_FMT_SGRBG16 v4l2_fourcc('G', 'R', '1', '6')
+#define V4L2_PIX_FMT_SRGGB16 v4l2_fourcc('R', 'G', '1', '6')
+
+/* HSV formats */
+
+#define V4L2_PIX_FMT_HSV24 v4l2_fourcc('H', 'S', 'V', '3')
+#define V4L2_PIX_FMT_HSV32 v4l2_fourcc('H', 'S', 'V', '4')
+
+/* compressed formats */
+
+#define V4L2_PIX_FMT_MJPEG    v4l2_fourcc('M', 'J', 'P', 'G')
+#define V4L2_PIX_FMT_JPEG     v4l2_fourcc('J', 'P', 'E', 'G')
+#define V4L2_PIX_FMT_DV       v4l2_fourcc('d', 'v', 's', 'd')
+#define V4L2_PIX_FMT_MPEG     v4l2_fourcc('M', 'P', 'E', 'G')
+#define V4L2_PIX_FMT_H264     v4l2_fourcc('H', '2', '6', '4')
+#define V4L2_PIX_FMT_H264_NO_SC v4l2_fourcc('A', 'V', 'C', '1')
+#define V4L2_PIX_FMT_H264_MVC v4l2_fourcc('M', '2', '6', '4')
+#define V4L2_PIX_FMT_H263     v4l2_fourcc('H', '2', '6', '3')
+#define V4L2_PIX_FMT_MPEG1    v4l2_fourcc('M', 'P', 'G', '1')
+#define V4L2_PIX_FMT_MPEG2    v4l2_fourcc('M', 'P', 'G', '2')
+#define V4L2_PIX_FMT_MPEG4    v4l2_fourcc('M', 'P', 'G', '4')
+#define V4L2_PIX_FMT_XVID     v4l2_fourcc('X', 'V', 'I', 'D')
+#define V4L2_PIX_FMT_VC1_ANNEX_G v4l2_fourcc('V', 'C', '1', 'G')
+#define V4L2_PIX_FMT_VC1_ANNEX_L v4l2_fourcc('V', 'C', '1', 'L')
+#define V4L2_PIX_FMT_VP8      v4l2_fourcc('V', 'P', '8', '0')
+#define V4L2_PIX_FMT_VP9      v4l2_fourcc('V', 'P', '9', '0')
 
 /* JPEG + sub image */
 
@@ -274,6 +479,116 @@ struct v4l2_capability
   uint32_t device_caps;  /* Device capabilities of the opened device */
 };
 
+/* Values for 'capabilities' field */
+
+/* Is a video capture device */
+
+#define V4L2_CAP_VIDEO_CAPTURE              0x00000001
+
+/* Is a video output device */
+
+#define V4L2_CAP_VIDEO_OUTPUT                0x00000002
+
+/* Can do video overlay */
+
+#define V4L2_CAP_VIDEO_OVERLAY              0x00000004
+
+/* Is a raw VBI capture device */
+
+#define V4L2_CAP_VBI_CAPTURE                0x00000010
+
+/* Is a raw VBI output device */
+
+#define V4L2_CAP_VBI_OUTPUT                  0x00000020
+
+/* Is a sliced VBI capture device */
+
+#define V4L2_CAP_SLICED_VBI_CAPTURE        0x00000040
+
+/* Is a sliced VBI output device */
+
+#define V4L2_CAP_SLICED_VBI_OUTPUT        0x00000080
+
+/* RDS data capture */
+
+#define V4L2_CAP_RDS_CAPTURE                0x00000100
+
+/* Can do video output overlay */
+
+#define V4L2_CAP_VIDEO_OUTPUT_OVERLAY      0x00000200
+
+/* Can do hardware frequency seek  */
+
+#define V4L2_CAP_HW_FREQ_SEEK                0x00000400
+
+/* Is an RDS encoder */
+
+#define V4L2_CAP_RDS_OUTPUT                  0x00000800
+
+/* Is a video capture device that supports multiplanar formats */
+
+#define V4L2_CAP_VIDEO_CAPTURE_MPLANE      0x00001000
+
+/* Is a video output device that supports multiplanar formats */
+
+#define V4L2_CAP_VIDEO_OUTPUT_MPLANE      0x00002000
+
+/* Is a video mem-to-mem device that supports multiplanar formats */
+
+#define V4L2_CAP_VIDEO_M2M_MPLANE          0x00004000
+
+/* Is a video mem-to-mem device */
+
+#define V4L2_CAP_VIDEO_M2M                  0x00008000
+
+/* has a tuner */
+
+#define V4L2_CAP_TUNER                        0x00010000
+
+/* has audio support */
+
+#define V4L2_CAP_AUDIO                        0x00020000
+
+/* is a radio device */
+
+#define V4L2_CAP_RADIO                        0x00040000
+
+/* has a modulator */
+
+#define V4L2_CAP_MODULATOR                  0x00080000
+
+/* Is a SDR capture device */
+
+#define V4L2_CAP_SDR_CAPTURE                0x00100000
+
+/* Supports the extended pixel format */
+
+#define V4L2_CAP_EXT_PIX_FORMAT              0x00200000
+
+/* Is a SDR output device */
+
+#define V4L2_CAP_SDR_OUTPUT                  0x00400000
+
+/* read/write systemcalls */
+
+#define V4L2_CAP_READWRITE              0x01000000
+
+/* async I/O */
+
+#define V4L2_CAP_ASYNCIO                0x02000000
+
+/* streaming I/O ioctls */
+
+#define V4L2_CAP_STREAMING              0x04000000
+
+/* Is a touch device */
+
+#define V4L2_CAP_TOUCH                  0x10000000
+
+/* sets device capabilities field */
+
+#define V4L2_CAP_DEVICE_CAPS            0x80000000
+
 /* Rectangle information */
 
 struct v4l2_rect
@@ -295,6 +610,14 @@ struct v4l2_rect
   uint32_t height;
 };
 
+/* Fraction */
+
+struct v4l2_fract
+{
+  uint32_t numerator;                     /* numerator */
+  uint32_t denominator;                   /* denominator */
+};
+
 /* V4L2 selection info for VIDIOC_S_SELECTION and VIDIOC_G_SELECTION.
  * Currently, only member type and r are supported.
  */
@@ -305,6 +628,136 @@ struct v4l2_selection
   uint32_t target;
   uint32_t flags;
   struct v4l2_rect r;  /* The selection rectangle. */
+};
+
+typedef u_int64_t v4l2_std_id;
+
+/* one bit for each */
+#define V4L2_STD_PAL_B          ((v4l2_std_id)0x00000001)
+#define V4L2_STD_PAL_B1         ((v4l2_std_id)0x00000002)
+#define V4L2_STD_PAL_G          ((v4l2_std_id)0x00000004)
+#define V4L2_STD_PAL_H          ((v4l2_std_id)0x00000008)
+#define V4L2_STD_PAL_I          ((v4l2_std_id)0x00000010)
+#define V4L2_STD_PAL_D          ((v4l2_std_id)0x00000020)
+#define V4L2_STD_PAL_D1         ((v4l2_std_id)0x00000040)
+#define V4L2_STD_PAL_K          ((v4l2_std_id)0x00000080)
+
+#define V4L2_STD_PAL_M          ((v4l2_std_id)0x00000100)
+#define V4L2_STD_PAL_N          ((v4l2_std_id)0x00000200)
+#define V4L2_STD_PAL_Nc         ((v4l2_std_id)0x00000400)
+#define V4L2_STD_PAL_60         ((v4l2_std_id)0x00000800)
+
+#define V4L2_STD_NTSC_M         ((v4l2_std_id)0x00001000)    /* BTSC */
+#define V4L2_STD_NTSC_M_JP      ((v4l2_std_id)0x00002000)    /* EIA-J */
+#define V4L2_STD_NTSC_443       ((v4l2_std_id)0x00004000)
+#define V4L2_STD_NTSC_M_KR      ((v4l2_std_id)0x00008000)    /* FM A2 */
+
+#define V4L2_STD_SECAM_B        ((v4l2_std_id)0x00010000)
+#define V4L2_STD_SECAM_D        ((v4l2_std_id)0x00020000)
+#define V4L2_STD_SECAM_G        ((v4l2_std_id)0x00040000)
+#define V4L2_STD_SECAM_H        ((v4l2_std_id)0x00080000)
+#define V4L2_STD_SECAM_K        ((v4l2_std_id)0x00100000)
+#define V4L2_STD_SECAM_K1       ((v4l2_std_id)0x00200000)
+#define V4L2_STD_SECAM_L        ((v4l2_std_id)0x00400000)
+#define V4L2_STD_SECAM_LC       ((v4l2_std_id)0x00800000)
+
+/* ATSC/HDTV */
+#define V4L2_STD_ATSC_8_VSB     ((v4l2_std_id)0x01000000)
+#define V4L2_STD_ATSC_16_VSB    ((v4l2_std_id)0x02000000)
+
+/* Some macros to merge video standards in order to make live easier for the
+ * drivers and V4L2 applications
+ */
+
+/* "Common" NTSC/M - It should be noticed that V4L2_STD_NTSC_443 is
+ * Missing here.
+ */
+#define V4L2_STD_NTSC           (V4L2_STD_NTSC_M    |\
+                 V4L2_STD_NTSC_M_JP     |\
+                 V4L2_STD_NTSC_M_KR)
+/* Secam macros */
+#define V4L2_STD_SECAM_DK          (V4L2_STD_SECAM_D    |\
+                 V4L2_STD_SECAM_K    |\
+                 V4L2_STD_SECAM_K1)
+/* All Secam Standards */
+#define V4L2_STD_SECAM        (V4L2_STD_SECAM_B    |\
+                 V4L2_STD_SECAM_G    |\
+                 V4L2_STD_SECAM_H    |\
+                 V4L2_STD_SECAM_DK    |\
+                 V4L2_STD_SECAM_L       |\
+                 V4L2_STD_SECAM_LC)
+/* PAL macros */
+#define V4L2_STD_PAL_BG        (V4L2_STD_PAL_B        |\
+                 V4L2_STD_PAL_B1    |\
+                 V4L2_STD_PAL_G)
+#define V4L2_STD_PAL_DK        (V4L2_STD_PAL_D        |\
+                 V4L2_STD_PAL_D1    |\
+                 V4L2_STD_PAL_K)
+
+/* "Common" PAL - This macro is there to be compatible with the old
+ * V4L1 concept of "PAL": /BGDKHI.
+ * Several PAL standards are missing here: /M, /N and /Nc
+ */
+
+#define V4L2_STD_PAL        (V4L2_STD_PAL_BG    |\
+                 V4L2_STD_PAL_DK    |\
+                 V4L2_STD_PAL_H        |\
+                 V4L2_STD_PAL_I)
+
+/* Chroma "agnostic" standards */
+
+#define V4L2_STD_B        (V4L2_STD_PAL_B        |\
+                 V4L2_STD_PAL_B1    |\
+                 V4L2_STD_SECAM_B)
+#define V4L2_STD_G        (V4L2_STD_PAL_G        |\
+                 V4L2_STD_SECAM_G)
+#define V4L2_STD_H        (V4L2_STD_PAL_H        |\
+                 V4L2_STD_SECAM_H)
+#define V4L2_STD_L        (V4L2_STD_SECAM_L    |\
+                 V4L2_STD_SECAM_LC)
+#define V4L2_STD_GH        (V4L2_STD_G        |\
+                 V4L2_STD_H)
+#define V4L2_STD_DK        (V4L2_STD_PAL_DK    |\
+                 V4L2_STD_SECAM_DK)
+#define V4L2_STD_BG        (V4L2_STD_B        |\
+                 V4L2_STD_G)
+#define V4L2_STD_MN        (V4L2_STD_PAL_M        |\
+                 V4L2_STD_PAL_N        |\
+                 V4L2_STD_PAL_Nc    |\
+                 V4L2_STD_NTSC)
+
+/* Standards where MTS/BTSC stereo could be found */
+#define V4L2_STD_MTS        (V4L2_STD_NTSC_M    |\
+                 V4L2_STD_PAL_M        |\
+                 V4L2_STD_PAL_N        |\
+                 V4L2_STD_PAL_Nc)
+
+/* Standards for Countries with 60Hz Line frequency */
+#define V4L2_STD_525_60        (V4L2_STD_PAL_M        |\
+                 V4L2_STD_PAL_60    |\
+                 V4L2_STD_NTSC        |\
+                 V4L2_STD_NTSC_443)
+/* Standards for Countries with 50Hz Line frequency */
+#define V4L2_STD_625_50        (V4L2_STD_PAL        |\
+                 V4L2_STD_PAL_N        |\
+                 V4L2_STD_PAL_Nc    |\
+                 V4L2_STD_SECAM)
+
+#define V4L2_STD_ATSC           (V4L2_STD_ATSC_8_VSB    |\
+                 V4L2_STD_ATSC_16_VSB)
+/* Macros with none and all analog standards */
+#define V4L2_STD_UNKNOWN        0
+#define V4L2_STD_ALL            (V4L2_STD_525_60    |\
+                 V4L2_STD_625_50)
+
+struct v4l2_standard
+{
+    u_int32_t             index;
+    v4l2_std_id           id;
+    u_int8_t              name[24];
+    struct v4l2_fract     frameperiod; /* Frames, not fields */
+    u_int32_t             framelines;
+    u_int32_t             reserved[4];
 };
 
 /* Buffer type.
@@ -420,6 +873,7 @@ struct v4l2_buffer
   uint32_t             bytesused; /* Driver sets the image size */
   uint16_t             flags;     /* buffer flags. */
   uint16_t             field;     /* the field order of the image */
+  struct timeval       timestamp; /* frame timestamp */
   struct v4l2_timecode timecode;  /* frame timecode */
   uint16_t             sequence;  /* frame sequence number */
   uint16_t             memory;    /* enum #v4l2_memory */
@@ -443,6 +897,9 @@ struct v4l2_fmtdesc
   char     description[V4L2_FMT_DSC_MAX];   /* Description string */
   uint32_t pixelformat;                     /* Format fourcc      */
 };
+
+#define V4L2_FMT_FLAG_COMPRESSED 0x0001
+#define V4L2_FMT_FLAG_EMULATED   0x0002
 
 enum v4l2_frmsizetypes
 {
@@ -492,14 +949,6 @@ enum v4l2_frmivaltypes
   V4L2_FRMIVAL_TYPE_DISCRETE      = 1,   /* Discrete value */
   V4L2_FRMIVAL_TYPE_CONTINUOUS    = 2,   /* Continuous value */
   V4L2_FRMIVAL_TYPE_STEPWISE      = 3,   /* Step value */
-};
-
-/* Fraction */
-
-struct v4l2_fract
-{
-  uint32_t numerator;                     /* numerator */
-  uint32_t denominator;                   /* denominator */
 };
 
 /* frame interval enumeration with stepwise format */
@@ -569,6 +1018,11 @@ struct v4l2_captureparm
   uint32_t           extendedmode;  /*  Driver-specific extensions */
   uint32_t           readbuffers;   /*  # of buffers for read */
 };
+
+/*  Flags for 'capability' and 'capturemode' fields */
+
+#define V4L2_MODE_HIGHQUALITY    0x0001    /*  High quality imaging mode */
+#define V4L2_CAP_TIMEPERFRAME    0x1000    /*  timeperframe field is supported */
 
 struct v4l2_streamparm
 {
@@ -642,6 +1096,89 @@ struct v4l2_querymenu
     int64_t value;          /* value of menu */
   };
 };
+
+struct v4l2_input
+{
+    u_int32_t         index;       /*  Which input */
+    u_int8_t          name[32];    /*  Label */
+    u_int32_t         type;        /*  Type of input */
+    u_int32_t         audioset;    /*  Associated audios (bitfield) */
+    u_int32_t         tuner;       /*  enum v4l2_tuner_type */
+    v4l2_std_id  std;
+    u_int32_t         status;
+    u_int32_t         capabilities;
+    u_int32_t         reserved[3];
+};
+
+/*  Values for the 'type' field */
+
+#define V4L2_INPUT_TYPE_TUNER      1
+#define V4L2_INPUT_TYPE_CAMERA     2
+#define V4L2_INPUT_TYPE_TOUCH      3
+
+/* field 'status' - general */
+
+#define V4L2_IN_ST_NO_POWER    0x00000001  /* Attached device is off */
+#define V4L2_IN_ST_NO_SIGNAL   0x00000002
+#define V4L2_IN_ST_NO_COLOR    0x00000004
+
+/* field 'status' - sensor orientation */
+
+/* If sensor is mounted upside down set both bits */
+
+#define V4L2_IN_ST_HFLIP       0x00000010 /* Frames are flipped horizontally */
+#define V4L2_IN_ST_VFLIP       0x00000020 /* Frames are flipped vertically */
+
+/* field 'status' - analog */
+
+#define V4L2_IN_ST_NO_H_LOCK   0x00000100  /* No horizontal sync lock */
+#define V4L2_IN_ST_COLOR_KILL  0x00000200  /* Color killer is active */
+#define V4L2_IN_ST_NO_V_LOCK   0x00000400  /* No vertical sync lock */
+#define V4L2_IN_ST_NO_STD_LOCK 0x00000800  /* No standard format lock */
+
+/* field 'status' - digital */
+
+#define V4L2_IN_ST_NO_SYNC     0x00010000  /* No synchronization lock */
+#define V4L2_IN_ST_NO_EQU      0x00020000  /* No equalizer lock */
+#define V4L2_IN_ST_NO_CARRIER  0x00040000  /* Carrier recovery failed */
+
+/* field 'status' - VCR and set-top box */
+
+#define V4L2_IN_ST_MACROVISION 0x01000000  /* Macrovision detected */
+#define V4L2_IN_ST_NO_ACCESS   0x02000000  /* Conditional access denied */
+#define V4L2_IN_ST_VTR         0x04000000  /* VTR time constant */
+
+/* capabilities flags */
+
+#define V4L2_IN_CAP_DV_TIMINGS        0x00000002              /* Supports S_DV_TIMINGS */
+#define V4L2_IN_CAP_CUSTOM_TIMINGS    V4L2_IN_CAP_DV_TIMINGS  /* For compatibility */
+#define V4L2_IN_CAP_STD               0x00000004              /* Supports S_STD */
+#define V4L2_IN_CAP_NATIVE_SIZE       0x00000008              /* Supports setting native size */
+
+struct v4l2_output
+{
+    u_int32_t         index;           /*  Which output */
+    u_int8_t          name[32];        /*  Label */
+    u_int32_t         type;            /*  Type of output */
+    u_int32_t         audioset;        /*  Associated audios (bitfield) */
+    u_int32_t         modulator;       /*  Associated modulator */
+    v4l2_std_id  std;
+    u_int32_t         capabilities;
+    u_int32_t         reserved[3];
+};
+
+/*  Values for the 'type' field */
+
+#define V4L2_OUTPUT_TYPE_MODULATOR             1
+#define V4L2_OUTPUT_TYPE_ANALOG                2
+#define V4L2_OUTPUT_TYPE_ANALOGVGAOVERLAY      3
+
+/* capabilities flags */
+
+#define V4L2_OUT_CAP_DV_TIMINGS         0x00000002                /* Supports S_DV_TIMINGS */
+#define V4L2_OUT_CAP_CUSTOM_TIMINGS     V4L2_OUT_CAP_DV_TIMINGS   /* For compatibility */
+#define V4L2_OUT_CAP_STD                0x00000004                /* Supports S_STD */
+#define V4L2_OUT_CAP_NATIVE_SIZE        0x00000008                /* Supports setting native size */
 
 struct v4l2_control
 {

--- a/include/nuttx/video/video.h
+++ b/include/nuttx/video/video.h
@@ -218,6 +218,8 @@ extern "C"
 
 #define V4L2_PIX_FMT_UYVY v4l2_fourcc('U', 'Y', 'V', 'Y')
 
+#define V4L2_PIX_FMT_YUYV v4l2_fourcc('Y', 'U', 'Y', 'V')
+
 /* RGB565 */
 
 #define V4L2_PIX_FMT_RGB565 v4l2_fourcc('R', 'G', 'B', 'P')

--- a/include/sys/videoio.h
+++ b/include/sys/videoio.h
@@ -1,0 +1,1 @@
+#include <nuttx/video/video.h>

--- a/video/Kconfig
+++ b/video/Kconfig
@@ -13,6 +13,10 @@ config VIDEO
 
 if VIDEO
 
+config VIDEO_DEV_PATH
+	string "video device path"
+	default "/dev/video"
+
 source "video/videomode/Kconfig"
 
 endif # VIDEO


### PR DESCRIPTION
## Summary
Enhancement to the NuttX video drivers.

## Impact
Enabling NuttX simulator to capture video from the host camera (Linux v4l2 only)

## Testing
Works with some modifications on the camera app. A more comprehensive app called NXcamera will be submitted soon to the apps repository.
Virtual camera (using v4l2loopback module) is also supported.
