### PR TITLE
net/icmpv6: Fix icmpv6_reply function

### DIFF
--- a/net/icmpv6/icmpv6_reply.c
+++ b/net/icmpv6/icmpv6_reply.c
@@ -88,6 +88,7 @@ void icmpv6_reply(FAR struct net_driver_s *dev, int type, int code, int data)
   FAR struct ipv6_hdr_s *ipv6 = IPv6BUF;
   FAR struct icmpv6_hdr_s *icmpv6 = (FAR struct icmpv6_hdr_s *)(ipv6 + 1);
   uint16_t datalen;
+  uint16_t paylen;
 
   if (net_ipv6addr_cmp(ipv6->destipaddr, g_ipv6_unspecaddr)
 #  ifdef CONFIG_NET_BROADCAST
@@ -111,6 +112,7 @@ void icmpv6_reply(FAR struct net_driver_s *dev, int type, int code, int data)
     }
 
   dev->d_len = ipicmplen + datalen;
+  paylen = dev->d_len - IPv6_HDRLEN;
 
   /* Copy fields from original packet */
 
@@ -121,8 +123,8 @@ void icmpv6_reply(FAR struct net_driver_s *dev, int type, int code, int data)
   ipv6->vtc      = 0x60;               /* Version/traffic class (MS) */
   ipv6->tcf      = 0;                  /* Traffic class(LS)/Flow label(MS) */
   ipv6->flow     = 0;                  /* Flow label (LS) */
-  ipv6->len[0]   = (dev->d_len >> 8);  /* Length excludes the IPv6 header */
-  ipv6->len[1]   = (dev->d_len & 0xff);
+  ipv6->len[0]   = (paylen >> 8);      /* Length excludes the IPv6 header */
+  ipv6->len[1]   = (paylen & 0xff);
   ipv6->proto    = IP_PROTO_ICMP6;     /* Next header */
   ipv6->ttl      = 255;                /* Hop limit */
 

--- a/net/icmpv6/icmpv6_reply.c
+++ b/net/icmpv6/icmpv6_reply.c
@@ -139,7 +139,7 @@ void icmpv6_reply(FAR struct net_driver_s *dev, int type, int code, int data)
   /* Calculate the ICMPv6 checksum over the ICMPv6 header and payload. */
 
   icmpv6->chksum = 0;
-  icmpv6->chksum = ~icmpv6_chksum(dev, datalen + sizeof(*icmpv6));
+  icmpv6->chksum = ~icmpv6_chksum(dev, IPv6_HDRLEN);
   if (icmpv6->chksum == 0)
     {
       icmpv6->chksum = 0xffff;

--- a/net/icmpv6/icmpv6_reply.c
+++ b/net/icmpv6/icmpv6_reply.c
@@ -99,9 +99,9 @@ void icmpv6_reply(FAR struct net_driver_s *dev, int type, int code, int data)
       return;
     }
 
-  /* Get the data size of the packet. */
+  /* Get the data (whole original packet) size of the packet. */
 
-  datalen = (ipv6->len[0] << 8) + ipv6->len[1];
+  datalen = (ipv6->len[0] << 8) + ipv6->len[1] + IPv6_HDRLEN;
 
   /* RFC says return as much as we can without exceeding 1280 bytes. */
 


### PR DESCRIPTION
## Summary
patches included:
- net/icmpv6: Fix `ipv6->len` in icmpv6_reply
  - The `ipv6->len` is the length excluding the IPv6 header, so need to be `dev->d_len - IPv6_HDRLEN`.
- net/icmpv6: Fix `datalen` in icmpv6_reply
  - The `datalen` indicates the whole len of original packet, which will become the payload inside icmpv6 packet.
- net/icmpv6: Fix icmpv6 checksum calculation in icmpv6_reply
  - The second param of icmpv6_chksum is `iplen`, which indicates `The size of the IPv6 header`.

## Impact
- Fix `icmpv6_reply` logic

## Testing
Manually tested when trying to implement TIME_EXCEEDED reply for ttl <= 0 (will create another pull request a few days later)