### PR TITLE
tools/nuttx-gdbinit: restore the context at the end of each command

### DIFF
--- a/tools/nuttx-gdbinit
+++ b/tools/nuttx-gdbinit
@@ -415,6 +415,13 @@ define _switch_tcb_simx86
   set $pc  = $tcb.xcp.regs[5]
 end
 
+define _restore_current_tcb
+  # TODO: SMP
+  set $tcb = g_readytorun->head
+  _switch_tcb $tcb
+  set $_current_tcb = 0x0
+end
+
 define nxthread
   _examine_target
   _save_current_tcb
@@ -432,6 +439,7 @@ define nxthread
       end
     end
   end
+  _restore_current_tcb
 end
 
 define nxthread_all_bt
@@ -442,6 +450,7 @@ define nxthread_all_bt
     nxthread $i 1
     set $i = $i + 1
   end
+  _restore_current_tcb
 end
 
 define info_nxthreads
@@ -452,13 +461,11 @@ define info_nxthreads
     nxthread $i 0 0
     set $i = $i + 1
   end
+  _restore_current_tcb
 end
 
 define nxcontinue
   printf "nxcontinue\n"
-  # TODO: SMP
-  set $tcb = g_readytorun->head
-  _switch_tcb $tcb
-  set $_current_tcb = 0x0
+  _restore_current_tcb
   continue
 end


### PR DESCRIPTION
## Summary

tools/nuttx-gdbinit: restore the context at the end of each command

after executing commands such as nxthread_*, you can enter c to continue the program directly

Signed-off-by: chao an <anchao@xiaomi.com>

## Impact

N/A

## Testing

```
(gdb) nxthread_all_bt 
* 0 Thread 0x555b9c80  (Name: Idle Task, State: Running, Priority: 0, Stack: 0/69584) PC: 0xf7e501e4 in clock_nanosleep()
#0  0x00007ffff7e501e4 in __GI___clock_nanosleep (clock_id=<optimized out>, clock_id@entry=0, flags=flags@entry=0, req=req@entry=0x7fffffffe2e0, rem=rem@entry=0x0) at ../sysdeps/unix/sysv/linux/clock_nanosleep.c:78
#1  0x00007ffff7e55ef7 in __GI___nanosleep (requested_time=requested_time@entry=0x7fffffffe2e0, remaining=remaining@entry=0x0) at nanosleep.c:27
#2  0x00007ffff7e8888f in usleep (useconds=<optimized out>) at ../sysdeps/posix/usleep.c:32
#3  0x00005555555a0e6c in sim_host_sleepuntil (nsec=13280000000) at sim/posix/sim_hosttime.c:85
#4  0x000055555556af0b in sim_timer_update () at sim/sim_oneshot.c:445
#5  0x000055555556a1f4 in up_idle () at sim/sim_idle.c:81
#6  0x000055555555fae3 in nx_start () at init/nx_start.c:697
#7  0x000055555555f40b in main (argc=1, argv=0x7fffffffe4b8, envp=0x7fffffffe4c8) at sim/sim_head.c:130
saved current_tcb (pid=0)
  1 Thread 0xf3e723c0  (Name: loop_task, State: Waiting,Signal, Priority: 255, Stack: 0/67504) PC: 0x5556a5a1 in up_switch_context()
#0  0x000055555556a5a1 in up_switch_context (tcb=0x5555555b9c80 <g_idletcb>, rtcb=0x7ffff3e723c0) at 
...
(gdb) c 
nsh>
```
