### PR TITLE
GD25 mtd issues

### DIFF
--- a/drivers/mtd/gd25.c
+++ b/drivers/mtd/gd25.c
@@ -141,7 +141,7 @@ struct gd25_dev_s
   uint16_t              nsectors;    /* Number of erase sectors */
   uint8_t               prev_instr;  /* Previous instruction given to GD25 device */
   bool                  addr_4byte;  /* True: Use Four-byte address */
-  uint8_t               memory;      /* memory type read from device */
+  uint8_t               memory;      /* memory type read from device*/
 };
 
 /***************************************************************************
@@ -310,9 +310,9 @@ static inline int gd25_readid(FAR struct gd25_dev_s *priv)
         {
           goto out;
         }
-
+      
       priv->memory = memory;
-
+      
       /* Capacity greater than 16MB, Enable four-byte address */
 
       if (priv->nsectors > GD25_NSECTORS_128MBIT)
@@ -427,10 +427,10 @@ static inline uint8_t gd25_rdsr(FAR struct gd25_dev_s *priv, uint32_t id)
 
 /***************************************************************************
  * Name:  gd25_4ben
- *
+ * 
  * Enable 4 byte memory addressing mode
  * Return success or not
- *
+ * 
  ***************************************************************************/
 
 static inline bool gd25_4ben(FAR struct gd25_dev_s *priv)
@@ -447,6 +447,8 @@ static inline bool gd25_4ben(FAR struct gd25_dev_s *priv)
       return ((gd25_rdsr(priv, 1) & GD25_SR1_EN4B) == GD25_SR1_EN4B);
     }
 }
+
+
 
 /***************************************************************************
  * Name:  gd25_wren

--- a/drivers/mtd/gd25.c
+++ b/drivers/mtd/gd25.c
@@ -141,7 +141,7 @@ struct gd25_dev_s
   uint16_t              nsectors;    /* Number of erase sectors */
   uint8_t               prev_instr;  /* Previous instruction given to GD25 device */
   bool                  addr_4byte;  /* True: Use Four-byte address */
-  uint8_t               memory;      /* memory type read from device*/
+  uint8_t               memory;      /* memory type read from device */
 };
 
 /***************************************************************************
@@ -310,9 +310,9 @@ static inline int gd25_readid(FAR struct gd25_dev_s *priv)
         {
           goto out;
         }
-      
+
       priv->memory = memory;
-      
+
       /* Capacity greater than 16MB, Enable four-byte address */
 
       if (priv->nsectors > GD25_NSECTORS_128MBIT)
@@ -427,10 +427,10 @@ static inline uint8_t gd25_rdsr(FAR struct gd25_dev_s *priv, uint32_t id)
 
 /***************************************************************************
  * Name:  gd25_4ben
- * 
+ *
  * Enable 4 byte memory addressing mode
  * Return success or not
- * 
+ *
  ***************************************************************************/
 
 static inline bool gd25_4ben(FAR struct gd25_dev_s *priv)
@@ -447,8 +447,6 @@ static inline bool gd25_4ben(FAR struct gd25_dev_s *priv)
       return ((gd25_rdsr(priv, 1) & GD25_SR1_EN4B) == GD25_SR1_EN4B);
     }
 }
-
-
 
 /***************************************************************************
  * Name:  gd25_wren

--- a/drivers/mtd/gd25.c
+++ b/drivers/mtd/gd25.c
@@ -107,6 +107,7 @@
 #define GD25_SR_WIP                 (1 << 0)  /* Bit 0: Write in Progress */
 #define GD25_SR_WEL                 (1 << 1)  /* Bit 1: Write Enable Latch */
 #define GD25_SR1_EN4B               (1 << 3)  /* Bit 3: Enable 4byte address */
+#define GD25Q_SR1_EN4B              (1 << 0)  /* Bit 0: Enable 4byte address */
 
 #define GD25_DUMMY                  0x00
 
@@ -140,6 +141,7 @@ struct gd25_dev_s
   uint16_t              nsectors;    /* Number of erase sectors */
   uint8_t               prev_instr;  /* Previous instruction given to GD25 device */
   bool                  addr_4byte;  /* True: Use Four-byte address */
+  uint8_t               memory;      /* memory type read from device*/
 };
 
 /***************************************************************************
@@ -170,7 +172,7 @@ static void gd25_pagewrite(FAR struct gd25_dev_s *priv,
     FAR const uint8_t *buffer, off_t address, size_t nbytes);
 #endif
 static inline uint8_t gd25_rdsr(FAR struct gd25_dev_s *priv, uint32_t id);
-static inline void gd25_4ben(FAR struct gd25_dev_s *priv);
+static inline bool gd25_4ben(FAR struct gd25_dev_s *priv);
 
 /* MTD driver methods */
 
@@ -308,14 +310,14 @@ static inline int gd25_readid(FAR struct gd25_dev_s *priv)
         {
           goto out;
         }
-
+      
+      priv->memory = memory;
+      
       /* Capacity greater than 16MB, Enable four-byte address */
 
       if (priv->nsectors > GD25_NSECTORS_128MBIT)
         {
-          gd25_4ben(priv);
-
-          if ((gd25_rdsr(priv, 1) & GD25_SR1_EN4B) != GD25_SR1_EN4B)
+          if (!gd25_4ben(priv))
             {
               ferr("ERROR: capacity %02x: Can't enable 4-byte mode!\n",
                    capacity);
@@ -425,14 +427,28 @@ static inline uint8_t gd25_rdsr(FAR struct gd25_dev_s *priv, uint32_t id)
 
 /***************************************************************************
  * Name:  gd25_4ben
+ * 
+ * Enable 4 byte memory addressing mode
+ * Return success or not
+ * 
  ***************************************************************************/
 
-static inline void gd25_4ben(FAR struct gd25_dev_s *priv)
+static inline bool gd25_4ben(FAR struct gd25_dev_s *priv)
 {
   SPI_SELECT(priv->spi, SPIDEV_FLASH(priv->spi_devid), true);
   SPI_SEND(priv->spi, GD25_4BEN);
   SPI_SELECT(priv->spi, SPIDEV_FLASH(priv->spi_devid), false);
+  if (priv->memory == GD25Q_JEDEC_MEMORY_TYPE)
+    {
+      return ((gd25_rdsr(priv, 1) & GD25Q_SR1_EN4B) == GD25Q_SR1_EN4B);
+    }
+  else
+    {
+      return ((gd25_rdsr(priv, 1) & GD25_SR1_EN4B) == GD25_SR1_EN4B);
+    }
 }
+
+
 
 /***************************************************************************
  * Name:  gd25_wren


### PR DESCRIPTION
## Summary
Added a 256Mbit GD25 device to the list of supported devices.
Discovered that the 4 byte status is in bit 0 not bit 3 for all the GD25Q devices I checked, so code added to check the correct bit depending on the discovered DEVICE ID.

See Issue #7670

## Impact
None

## Testing
Custom SAMA5D27 board fitted with GD25Q256ERIRR device which is now correctly identified and operating as required.

