### PR TITLE
libc/stream: Remove \n special handle from syslogstream_putc

### DIFF
--- a/libs/libc/stream/lib_syslogstream.c
+++ b/libs/libc/stream/lib_syslogstream.c
@@ -125,15 +125,6 @@ static void syslogstream_putc(FAR struct lib_outstream_s *this, int ch)
 
       if (stream->iob != NULL)
         {
-          /* Is this a linefeed? */
-
-          if (ch == '\n')
-            {
-              /* Yes... pre-pend carriage return */
-
-              syslogstream_addchar(stream, '\r');
-            }
-
           /* Add the incoming character to the buffer */
 
           syslogstream_addchar(stream, ch);


### PR DESCRIPTION
## Summary
since \r\n process is already done in up_putc or serial driver level

## Impact
Make the behaviour same with/without iob

## Testing
Pass CI
